### PR TITLE
[AAASM-3369] 🔒 (aa-api): Harden aa-api-server (API-key auth + real audit/retention/alerts)

### DIFF
--- a/aa-api/src/alerts/rules/evaluator.rs
+++ b/aa-api/src/alerts/rules/evaluator.rs
@@ -37,6 +37,42 @@ impl MetricSource for NullMetricSource {
     }
 }
 
+/// Metric source backed by the live [`BudgetTracker`] (AAASM-3369).
+///
+/// Supplies a real `BudgetSpentPct` observation — the global daily spend as a
+/// percentage of the configured daily limit — so budget alert rules actually
+/// fire in the local single-process entrypoint instead of being a no-op against
+/// [`NullMetricSource`]. Non-budget metrics (anomaly / approval-age / violation)
+/// stay `None`; their sources remain follow-ups to AAASM-1386.
+pub struct BudgetMetricSource {
+    tracker: std::sync::Arc<aa_gateway::budget::tracker::BudgetTracker>,
+}
+
+impl BudgetMetricSource {
+    /// Build a metric source reading from `tracker`.
+    pub fn new(tracker: std::sync::Arc<aa_gateway::budget::tracker::BudgetTracker>) -> Self {
+        Self { tracker }
+    }
+}
+
+impl MetricSource for BudgetMetricSource {
+    fn current_value(&self, metric: RuleMetric) -> Option<f64> {
+        match metric {
+            RuleMetric::BudgetSpentPct => {
+                let limit = self.tracker.daily_limit_usd()?;
+                if limit.is_zero() {
+                    return None;
+                }
+                let spent = self.tracker.global_state().spent_usd;
+                let pct = (spent / limit) * rust_decimal::Decimal::from(100);
+                use rust_decimal::prelude::ToPrimitive;
+                pct.to_f64()
+            }
+            _ => None,
+        }
+    }
+}
+
 /// Returns true when the current metric `value` satisfies the rule's
 /// `operator` ⟂ `threshold` condition.
 pub fn evaluate(rule: &AlertRule, value: f64) -> bool {
@@ -249,6 +285,49 @@ mod tests {
 
         let fired = evaluate_once(&rules, &FixedMetric(95.0), &alerts);
         assert_eq!(fired, 0);
+    }
+
+    #[test]
+    fn budget_metric_source_reports_spent_pct() {
+        use aa_core::identity::AgentId;
+        use aa_gateway::budget::tracker::BudgetTracker;
+        use aa_gateway::budget::PricingTable;
+        use rust_decimal::Decimal;
+
+        let tracker = std::sync::Arc::new(BudgetTracker::new(
+            PricingTable::default_table(),
+            Some(Decimal::from(100)),
+            None,
+            chrono_tz::UTC,
+        ));
+        let source = BudgetMetricSource::new(tracker.clone());
+
+        // No spend yet -> 0%.
+        assert_eq!(source.current_value(RuleMetric::BudgetSpentPct), Some(0.0));
+        // Non-budget metrics stay None.
+        assert_eq!(source.current_value(RuleMetric::AnomalyScore), None);
+
+        // Spend $40 of the $100 daily limit -> 40%.
+        tracker.record_raw_spend(AgentId::from_bytes([1u8; 16]), None, None, Decimal::from(40));
+        let pct = source
+            .current_value(RuleMetric::BudgetSpentPct)
+            .expect("budget metric must be present");
+        assert!((pct - 40.0).abs() < 1e-6, "expected 40%, got {pct}");
+    }
+
+    #[test]
+    fn budget_metric_source_none_without_limit() {
+        use aa_gateway::budget::tracker::BudgetTracker;
+        use aa_gateway::budget::PricingTable;
+
+        let tracker = std::sync::Arc::new(BudgetTracker::new(
+            PricingTable::default_table(),
+            None,
+            None,
+            chrono_tz::UTC,
+        ));
+        let source = BudgetMetricSource::new(tracker);
+        assert_eq!(source.current_value(RuleMetric::BudgetSpentPct), None);
     }
 
     #[test]

--- a/aa-api/src/auth/api_key.rs
+++ b/aa-api/src/auth/api_key.rs
@@ -110,6 +110,18 @@ pub struct ApiKeyStore {
 }
 
 impl ApiKeyStore {
+    /// Build a store directly from in-memory entries.
+    ///
+    /// Used by the local single-process entrypoint (AAASM-3369), which seeds a
+    /// single admin key from the environment (or a generated one) without a
+    /// keys-on-disk file.
+    pub fn from_entries(entries: Vec<ApiKeyEntry>) -> Self {
+        Self {
+            entries,
+            revoked_ids: DashMap::new(),
+        }
+    }
+
     /// Load API key entries from a JSON file.
     ///
     /// Returns an empty store if the file does not exist.

--- a/aa-api/src/bin/aa-api-server.rs
+++ b/aa-api/src/bin/aa-api-server.rs
@@ -1,20 +1,31 @@
 //! Shipped entrypoint that serves the full `/api/v1/*` REST surface from a
-//! single in-memory process (AAASM-3360).
+//! single-process, locally-backed `AppState` (AAASM-3360, hardened by
+//! AAASM-3369).
 //!
 //! Usage:
 //! ```text
-//! cargo run -p aa-api --bin aa-api-server          # binds 127.0.0.1:7700
+//! cargo run -p aa-api --bin aa-api-server          # binds 127.0.0.1:7700, API-key auth
 //! AA_API_ADDR=127.0.0.1:8080 \
 //!   cargo run -p aa-api --bin aa-api-server         # custom bind address
+//! AASM_API_KEY=aa_… cargo run -p aa-api --bin aa-api-server   # use a fixed key
+//! AASM_API_AUTH=off cargo run -p aa-api --bin aa-api-server   # disable auth (dev only)
 //! ```
 //!
-//! Every route registered by `aa_api::routes::v1_router()` is served. Auth is
-//! disabled in this mode, so protected routes (e.g. `/api/v1/agents`,
-//! `/api/v1/policies`) are reachable without a bearer credential. See
-//! `aa_api::AppState::local_in_memory` for the documented limitations of the
-//! in-memory wiring.
+//! Auth posture (AAASM-3369):
+//! * By default the protected `/api/v1/*` surface requires
+//!   `Authorization: Bearer aa_…`. A key is read from `AASM_API_KEY`, or a
+//!   random admin key is generated and printed on startup.
+//! * `AASM_API_AUTH=off` disables auth entirely (every request is admin) — for
+//!   throwaway local development only.
+//! * `/healthz` and `/api/v1/health` are always reachable without a key.
+//!
+//! Audit and retention are backed by a per-process local SQLite store, so
+//! `/api/v1/audit/*`, `/api/v1/logs/*`, and `/api/v1/admin/retention*` return
+//! real data instead of 503.
 
 use std::net::SocketAddr;
+
+use aa_api::LocalAuth;
 
 /// Default bind address when `AA_API_ADDR` is unset.
 const DEFAULT_ADDR: &str = "127.0.0.1:7700";
@@ -31,6 +42,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DEFAULT_ADDR.parse().expect("default address is valid")
     });
 
-    eprintln!("aa-api serving full /api/v1/* REST surface (in-memory, auth disabled) on http://{addr}");
-    aa_api::serve_local(addr).await
+    let (auth, generated) = LocalAuth::from_env();
+    match &auth {
+        LocalAuth::Off => {
+            eprintln!(
+                "aa-api serving full /api/v1/* REST surface on http://{addr} \
+                 (AUTH DISABLED via AASM_API_AUTH=off — do not expose this)"
+            );
+        }
+        LocalAuth::ApiKey { key } => {
+            if generated {
+                eprintln!("aa-api: generated admin API key (set AASM_API_KEY to reuse): {key}");
+            } else {
+                eprintln!("aa-api: using admin API key from AASM_API_KEY");
+            }
+            eprintln!(
+                "aa-api serving full /api/v1/* REST surface on http://{addr} \
+                 (API-key auth; send `Authorization: Bearer {prefix}…`)",
+                prefix = &key[..key.len().min(6)]
+            );
+        }
+    }
+
+    aa_api::serve_local(addr, auth).await
 }

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -34,5 +34,5 @@ pub use models::{EventType, GovernanceEvent};
 pub use openapi::ApiDoc;
 pub use replay::ReplayBuffer;
 pub use server::{build_app, run_server, serve_local};
-pub use state::{AppState, LocalStateError};
+pub use state::{AppState, LocalAuth, LocalStateError};
 pub use trace_store::{InMemoryTraceStore, TraceStore};

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -33,22 +33,27 @@ pub fn build_app(state: AppState) -> Router {
     apply_middleware(app)
 }
 
-/// Serve the full `/api/v1/*` REST surface from an in-memory, single-process
-/// `AppState` (AAASM-3360).
+/// Serve the full `/api/v1/*` REST surface from a hardened, single-process
+/// `AppState` (AAASM-3360 / AAASM-3369).
 ///
 /// This is the shipped entrypoint that makes the entire REST surface reachable
-/// without the operator hand-wiring ~30 subsystems: it builds an
-/// [`AppState::local_in_memory`], constructs an [`ApiConfig`] bound to `addr`
-/// with auth disabled, and delegates to [`run_server`]. The process blocks
-/// until a shutdown signal (SIGTERM/SIGINT) arrives.
+/// without the operator hand-wiring ~30 subsystems. It builds an
+/// [`AppState::local_hardened`] with the supplied [`LocalAuth`] posture,
+/// constructs an [`ApiConfig`] bound to `addr`, and delegates to [`run_server`].
+/// The process blocks until a shutdown signal (SIGTERM/SIGINT) arrives.
 ///
-/// All routes registered by [`routes::v1_router`] are served. Because auth is
-/// off, protected routes (e.g. `/api/v1/agents`, `/api/v1/policies`) respond
-/// without a bearer credential. See [`AppState::local_in_memory`] for the
-/// documented limitations of the in-memory wiring (audit pipeline + retention
-/// engine respond 503; alert rules never fire).
-pub async fn serve_local(addr: std::net::SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
-    let state = AppState::local_in_memory()?;
+/// Unlike the original AAASM-3360 wiring, the protected routes require an API key
+/// by default ([`LocalAuth::ApiKey`]) and the audit / retention seams are backed
+/// by a local SQLite store, so `/api/v1/audit/*`, `/api/v1/logs/*` and
+/// `/api/v1/admin/retention*` return real data instead of 503. `/api/v1/health`
+/// stays public.
+///
+/// [`LocalAuth`]: crate::state::LocalAuth
+pub async fn serve_local(
+    addr: std::net::SocketAddr,
+    auth: crate::state::LocalAuth,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state = AppState::local_hardened(auth).await?;
     let config = ApiConfig {
         bind_addr: addr,
         auth: (*state.auth_config).clone(),
@@ -79,13 +84,15 @@ pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dy
         state.alert_store.clone(),
     );
 
-    // Spawn the MVP alert-rule evaluator (AAASM-1386). The NullMetricSource
-    // returns None for every metric, so the loop is a no-op against today's
-    // wiring — production-grade hooks for budget / anomaly / approval-age /
-    // policy-violation metrics are tracked as follow-ups in the Story.
+    // Spawn the MVP alert-rule evaluator (AAASM-1386). AAASM-3369 wires the
+    // real `BudgetMetricSource` (global daily spend vs. limit) so budget rules
+    // fire against live spend; anomaly / approval-age / policy-violation metrics
+    // still return None and stay follow-ups in the Story.
     let _rule_evaluator_handle = crate::alerts::rules::evaluator::spawn_rule_evaluator(
         state.alert_rule_store.clone(),
-        std::sync::Arc::new(crate::alerts::rules::evaluator::NullMetricSource),
+        std::sync::Arc::new(crate::alerts::rules::evaluator::BudgetMetricSource::new(
+            state.budget_tracker.clone(),
+        )),
         state.alert_store.clone(),
         std::time::Duration::from_secs(60),
     );

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -151,15 +151,67 @@ pub enum LocalStateError {
     /// Loading the bundled minimal policy into a [`PolicyEngine`] failed.
     #[error("failed to load bootstrap policy: {0}")]
     PolicyLoad(String),
+    /// Opening / migrating the local SQLite storage backend failed.
+    #[error("failed to open local storage backend: {0}")]
+    Storage(String),
+    /// Constructing the audit writer over the local audit directory failed.
+    #[error("failed to start local audit writer: {0}")]
+    Audit(String),
+}
+
+/// Resolved authentication posture for the local single-process entrypoint
+/// (AAASM-3369).
+///
+/// The shipped `aa-api-server` binary serves the *protected* `/api/v1/*` surface
+/// over the loopback interface. Defaulting to [`AuthMode::Off`] there shipped an
+/// unauthenticated admin surface; [`LocalAuth`] lets the binary require a real
+/// API key by default while keeping an explicit opt-out for throwaway local dev.
+#[derive(Debug, Clone)]
+pub enum LocalAuth {
+    /// Authentication is bypassed — every request is treated as admin. Only for
+    /// throwaway local dev; selected via `AASM_API_AUTH=off`.
+    Off,
+    /// Require an `Authorization: Bearer aa_…` API key. The single seeded key has
+    /// admin scope. The plaintext is surfaced to the operator on startup.
+    ApiKey {
+        /// The plaintext admin API key callers must present.
+        key: String,
+    },
+}
+
+impl LocalAuth {
+    /// Resolve the local auth posture from the environment.
+    ///
+    /// * `AASM_API_AUTH=off` → [`LocalAuth::Off`] (explicit opt-out).
+    /// * `AASM_API_KEY=aa_…` → [`LocalAuth::ApiKey`] using the supplied key.
+    /// * otherwise → [`LocalAuth::ApiKey`] with a freshly generated admin key.
+    ///
+    /// Returns the resolved posture and whether the key was generated (so the
+    /// caller can print it prominently on first boot).
+    pub fn from_env() -> (Self, bool) {
+        if matches!(std::env::var("AASM_API_AUTH").as_deref(), Ok("off") | Ok("OFF")) {
+            return (LocalAuth::Off, false);
+        }
+        match std::env::var("AASM_API_KEY") {
+            Ok(key) if !key.is_empty() => (LocalAuth::ApiKey { key }, false),
+            _ => {
+                let key = crate::auth::api_key::ApiKey::generate().as_str().to_string();
+                (LocalAuth::ApiKey { key }, true)
+            }
+        }
+    }
 }
 
 impl AppState {
     /// Build a fully-wired `AppState` backed entirely by in-memory / default
     /// implementations (AAASM-3360).
     ///
-    /// This is the production seam that lets a single shipped entrypoint serve
-    /// the full `/api/v1/*` REST surface in local / single-process mode without
-    /// the operator wiring ~30 subsystems by hand. Every store is the same
+    /// This is the unauthenticated base wiring. The shipped `aa-api-server`
+    /// entrypoint builds on it via [`local_hardened`](Self::local_hardened),
+    /// which adds API-key auth and SQLite-backed audit / retention. It lets a
+    /// single process serve the full `/api/v1/*` REST surface in local /
+    /// single-process mode without the operator wiring ~30 subsystems by hand.
+    /// Every store is the same
     /// in-memory implementation the gateway already uses for ephemeral state;
     /// nothing here touches a remote database, NATS, or the network.
     ///
@@ -312,5 +364,104 @@ impl AppState {
             secrets_store: Arc::new(aa_gateway::secrets::InMemorySecretsStore::new()),
             tool_registry: ToolRegistry::new(),
         })
+    }
+
+    /// Build a hardened local `AppState` for the shipped `aa-api-server`
+    /// entrypoint (AAASM-3369).
+    ///
+    /// This is [`local_in_memory`](Self::local_in_memory) plus the wiring that
+    /// turns the documented 503 / no-op seams into real behaviour for a local
+    /// single-process deployment:
+    ///
+    /// * **Auth** — when `auth` is [`LocalAuth::ApiKey`], the protected
+    ///   `/api/v1/*` surface requires an `Authorization: Bearer aa_…` key
+    ///   ([`AuthMode::On`]); the single seeded key carries admin scope. With
+    ///   [`LocalAuth::Off`] it stays bypassed exactly like `local_in_memory`.
+    /// * **Audit + retention** — a SQLite [`StorageBackend`] is opened under a
+    ///   per-process temp directory. An [`AuditWriter`] is spawned in dual-sink
+    ///   mode (JSONL + SQLite) and its sender is threaded into `audit_sender`, so
+    ///   audit-emitting handlers persist instead of returning 503. A
+    ///   [`RetentionEngine`] over the same backend backs the
+    ///   `/api/v1/admin/retention-policy` handlers (get / put / run-once) instead
+    ///   of 503. The audit *reader* points at the same JSONL directory.
+    ///
+    /// The alert-rule evaluator metric source is still wired by `run_server`; see
+    /// [`crate::alerts::rules::evaluator::BudgetMetricSource`] for the real
+    /// budget-spent source this entrypoint installs.
+    pub async fn local_hardened(auth: LocalAuth) -> Result<Self, LocalStateError> {
+        use std::sync::atomic::AtomicUsize;
+
+        let mut state = Self::local_in_memory()?;
+
+        // --- Auth: require an API key unless explicitly opted out. ---
+        match &auth {
+            LocalAuth::Off => { /* keep the AuthMode::Off wiring from local_in_memory */ }
+            LocalAuth::ApiKey { key } => {
+                let parsed = crate::auth::api_key::ApiKey::parse(key)
+                    .map_err(|e| LocalStateError::PolicyLoad(format!("invalid AASM_API_KEY: {e}")))?;
+                let key_hash = parsed
+                    .hash()
+                    .map_err(|e| LocalStateError::PolicyLoad(format!("failed to hash AASM_API_KEY: {e}")))?;
+                let entry = crate::auth::api_key::ApiKeyEntry {
+                    id: "local-admin".to_string(),
+                    key_hash,
+                    scopes: vec![
+                        crate::auth::scope::Scope::Read,
+                        crate::auth::scope::Scope::Write,
+                        crate::auth::scope::Scope::Admin,
+                    ],
+                    created_at: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                    label: Some("local single-process admin key".to_string()),
+                    team_id: None,
+                    org_id: None,
+                };
+                state.auth_config = Arc::new(AuthConfig {
+                    mode: AuthMode::On,
+                    jwt_secret: state.auth_config.jwt_secret.clone(),
+                    api_keys_path: state.auth_config.api_keys_path.clone(),
+                    rate_limit_rpm: state.auth_config.rate_limit_rpm,
+                });
+                state.key_store = Arc::new(ApiKeyStore::from_entries(vec![entry]));
+            }
+        }
+
+        // --- Audit + retention: open a local SQLite backend and wire the
+        // dual-sink writer + retention engine over it. ---
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let uniq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let pid = std::process::id();
+        let storage_dir = std::env::temp_dir().join(format!("aa-api-local-storage-{pid}-{uniq}"));
+        std::fs::create_dir_all(&storage_dir).map_err(|source| LocalStateError::PolicyWrite {
+            path: storage_dir.clone(),
+            source,
+        })?;
+        let db_path = storage_dir.join("local.db");
+        let storage = aa_gateway::storage::open_sqlite_backend(&db_path)
+            .await
+            .map_err(|e| LocalStateError::Storage(format!("{e}")))?;
+
+        // Audit writer (dual-sink) over a dedicated JSONL directory; the reader
+        // points at the same directory so reads see what the writer persists.
+        let audit_jsonl_dir = storage_dir.join("audit");
+        let (audit_tx, audit_rx) = mpsc::channel::<AuditEntry>(4096);
+        let writer = aa_gateway::audit::AuditWriter::new(audit_jsonl_dir.clone(), "local", "local", audit_rx)
+            .await
+            .map_err(|e| LocalStateError::Audit(format!("{e}")))?
+            .with_storage(storage.clone());
+        tokio::spawn(writer.run());
+        state.audit_sender = Some(audit_tx);
+        state.audit_reader = Arc::new(AuditReader::new(audit_jsonl_dir));
+
+        // Retention engine over the same backend, using aa-core's validated
+        // default policy (daily 03:00 UTC). Constructed directly — the admin
+        // REST handlers drive run_once / hot_reload on demand, so the cron
+        // background loop is not required for the local entrypoint.
+        let retention_cfg = aa_gateway::storage::RetentionConfig::default();
+        state.retention_engine = Some(Arc::new(RetentionEngine::new(storage, retention_cfg)));
+
+        Ok(state)
     }
 }

--- a/aa-api/tests/serve_local_hardened.rs
+++ b/aa-api/tests/serve_local_hardened.rs
@@ -1,0 +1,126 @@
+//! Tests for the hardened local entrypoint (AAASM-3369).
+//!
+//! `AppState::local_hardened` upgrades the AAASM-3360 in-memory entrypoint so
+//! that the shipped `aa-api-server` binary (a) requires an API key on the
+//! protected `/api/v1/*` surface by default, leaving `/api/v1/health` public,
+//! and (b) backs audit / retention with a local SQLite store so those handlers
+//! return real data instead of 503.
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+const TEST_KEY: &str = "aa_00112233445566778899aabbccddeeff";
+
+/// Build the hardened app with API-key auth seeded from a fixed key.
+async fn hardened_app_with_key() -> axum::Router {
+    let state = aa_api::AppState::local_hardened(aa_api::LocalAuth::ApiKey {
+        key: TEST_KEY.to_string(),
+    })
+    .await
+    .expect("local_hardened must construct");
+    aa_api::build_app(state)
+}
+
+/// Build the hardened app with auth explicitly disabled.
+async fn hardened_app_auth_off() -> axum::Router {
+    let state = aa_api::AppState::local_hardened(aa_api::LocalAuth::Off)
+        .await
+        .expect("local_hardened must construct");
+    aa_api::build_app(state)
+}
+
+async fn status_of(app: axum::Router, uri: &str, bearer: Option<&str>) -> StatusCode {
+    let mut builder = Request::builder().uri(uri);
+    if let Some(token) = bearer {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    let response = app
+        .oneshot(builder.body(Body::empty()).expect("build request"))
+        .await
+        .expect("router.oneshot");
+    response.status()
+}
+
+#[tokio::test]
+async fn protected_route_rejected_without_key() {
+    let status = status_of(hardened_app_with_key().await, "/api/v1/agents", None).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "protected route must be 401 without an API key"
+    );
+}
+
+#[tokio::test]
+async fn protected_route_rejected_with_bad_key() {
+    let bad = "aa_ffffffffffffffffffffffffffffffff";
+    let status = status_of(hardened_app_with_key().await, "/api/v1/agents", Some(bad)).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "protected route must be 401 with an unknown API key"
+    );
+}
+
+#[tokio::test]
+async fn protected_route_allowed_with_key() {
+    let status = status_of(hardened_app_with_key().await, "/api/v1/agents", Some(TEST_KEY)).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "protected route must be 200 with the seeded API key"
+    );
+}
+
+#[tokio::test]
+async fn health_is_public_without_key() {
+    let status = status_of(hardened_app_with_key().await, "/api/v1/health", None).await;
+    assert_eq!(status, StatusCode::OK, "health probe must stay public");
+}
+
+#[tokio::test]
+async fn auth_off_leaves_protected_route_open() {
+    let status = status_of(hardened_app_auth_off().await, "/api/v1/agents", None).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "AASM_API_AUTH=off must leave protected routes reachable"
+    );
+}
+
+#[tokio::test]
+async fn retention_policy_returns_real_data_not_503() {
+    let app = hardened_app_with_key().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/admin/retention-policy")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router.oneshot");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "retention engine must be wired (real data, not 503)"
+    );
+    let bytes = to_bytes(response.into_body(), 64 * 1024).await.expect("read body");
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json");
+    // Default policy: hot=30d, warm=90d, 6-field daily-3am schedule.
+    assert_eq!(body["hot_days"], 30);
+    assert_eq!(body["schedule"], "0 0 3 * * *");
+}
+
+#[tokio::test]
+async fn logs_endpoint_returns_real_data_not_503() {
+    let app = hardened_app_with_key().await;
+    let status = status_of(app, "/api/v1/logs", Some(TEST_KEY)).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "logs endpoint must serve real (empty) data, not 503"
+    );
+}


### PR DESCRIPTION
## Description

Hardens the shipped `aa-api-server` entrypoint (AAASM-3360 / `AppState::local_in_memory`) so the served `/api/v1/*` surface is no longer an unauthenticated admin surface with 503-stub audit/retention.

- **Auth** — new `LocalAuth` posture + `AppState::local_hardened`. By default the protected `/api/v1/*` routes require `Authorization: Bearer aa_…`. The key is read from `AASM_API_KEY`, or a random admin key is generated and printed on startup. `AASM_API_AUTH=off` is the explicit dev opt-out. `/healthz` and `/api/v1/health` stay public. JWT/RBAC remain available (the existing `AuthMode::On` gate + JWT verifier are unchanged).
- **Audit + retention** — `local_hardened` opens a per-process local SQLite `StorageBackend` (`open_sqlite_backend`), spawns an `AuditWriter` in dual-sink mode (JSONL + SQLite) and threads its sender into `audit_sender`, and constructs a `RetentionEngine` over the same backend. So `/api/v1/audit/*`, `/api/v1/logs/*`, and `/api/v1/admin/retention*` return real data instead of 503.
- **Alerts** — new `BudgetMetricSource` (global daily spend vs. configured daily limit) replaces `NullMetricSource` in `run_server`, so budget alert rules evaluate against live spend. Non-budget metric sources (anomaly / approval-age / violation) remain follow-ups to AAASM-1386.

The unauthenticated, no-storage `AppState::local_in_memory()` is kept as the base builder (still used by the existing smoke test); `local_hardened` layers on top of it.

### Deferred to follow-up
- `aasm --mode local` spawning this entrypoint (Scope item 4) — not wired here; the binary is run directly via `cargo run -p aa-api --bin aa-api-server` / `AASM_API_KEY=…`.
- Retention cron background loop is not started (the on-demand admin REST handlers — get/put/run-once — do not need it); avoids pulling `tokio-util` into `aa-api`.
- Non-budget alert metric sources remain follow-ups to AAASM-1386.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

(Primarily a security hardening — 🔒 — of an existing entrypoint.)

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

`aa_api::serve_local` now takes a second `LocalAuth` argument. Its only caller is the `aa-api-server` binary (updated in this PR). The shipped binary now requires an API key by default; set `AASM_API_AUTH=off` to restore the previous unauthenticated behaviour.

## Related Issues

- Related Jira ticket: AAASM-3369
- Related GitHub issues: builds on #1131 (AAASM-3360)

## Testing

- [x] Unit tests added / updated (`BudgetMetricSource` percentage + no-limit cases)
- [x] Integration tests added / updated (`aa-api/tests/serve_local_hardened.rs`: 401 without/bad key, 200 with key, public health, auth-off bypass, retention + logs not-503)
- [x] Manual testing performed (see below)
- [ ] No tests required

`cargo build -p aa-api -p aa-gateway` — clean. `cargo nextest run -p aa-api` — 581 passed, 0 failed. `cargo fmt -p aa-api` + `cargo clippy -p aa-api --all-targets` — clean.

Manual curl proof against the running `aa-api-server` (`AASM_API_KEY=aa_00112233445566778899aabbccddeeff`):

```
GET /api/v1/agents  (no key)                 -> 401
GET /api/v1/agents  (Bearer <key>)           -> 200
GET /api/v1/health  (no key)                 -> 200
GET /api/v1/admin/retention-policy (key)     -> 200 {"hot_days":30,"schedule":"0 0 3 * * *",...}
GET /api/v1/logs    (key)                    -> 200
```
Generated-key mode (no env) and `AASM_API_AUTH=off` (no-key -> 200) also verified.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on the new/changed items)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3369
