### PR TITLE
[AAASM-3377] 🐛 (aa-gateway): Persist agent lineage in the audit event payload

### DIFF
--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -801,49 +801,6 @@ impl PolicyServiceImpl {
         let timestamp_ns = Timestamp::from(SystemTime::now()).as_nanos();
         let seq = self.seq.fetch_add(1, Ordering::Relaxed);
 
-        // AAASM-3376 — the session_id stored on the entry is SHA256(trace_id)[:16],
-        // which is one-way: the raw trace_id and the per-action span_id are lost
-        // once the entry is persisted. Carry both in the payload JSON so they
-        // survive to the JSONL log / DB and let `/api/v1/traces/{trace_id}`
-        // reconstruct spans. (A first-class column on `AuditEntry` is the proto /
-        // core-type follow-up — see PR body.)
-        let trace_id_str: Option<&str> = (!req.trace_id.is_empty()).then_some(req.trace_id.as_str());
-        let span_id_str: Option<&str> = (!req.span_id.is_empty()).then_some(req.span_id.as_str());
-        let payload = match shadow {
-            Some(s) => serde_json::json!({
-                "action_type": req.action_type,
-                "decision": response.decision,
-                "reason": &response.reason,
-                "policy_rule": &response.policy_rule,
-                "latency_us": response.decision_latency_us,
-                "dry_run": true,
-                "shadow_decision": &s.shadow_decision,
-                "shadow_reason": &s.reason,
-                "caller_agent_id": caller_agent_id_str,
-                "callee_agent_id": caller_agent_id_str.map(|_| proto_agent.agent_id.as_str()),
-                "trace_id": trace_id_str,
-                "span_id": span_id_str,
-            }),
-            None => serde_json::json!({
-                "action_type": req.action_type,
-                "decision": response.decision,
-                "reason": &response.reason,
-                "policy_rule": &response.policy_rule,
-                "latency_us": response.decision_latency_us,
-                "caller_agent_id": caller_agent_id_str,
-                "callee_agent_id": caller_agent_id_str.map(|_| proto_agent.agent_id.as_str()),
-                "trace_id": trace_id_str,
-                "span_id": span_id_str,
-            }),
-        }
-        .to_string();
-
-        let mut last_hash = self.last_hash.lock().await;
-
-        // When the credential scanner produced findings, attach them (and the
-        // redacted payload) to the audit entry via the redaction-aware constructor.
-        // Both fields carry the [REDACTED:<kind>] form only — the raw secret bytes
-        // never reach the audit pipeline.
         // AAASM-2008 — resolve the agent's org_id from the registry so the
         // audit entry carries it in the Lineage. Lets `/api/v1/logs?org_id=…`
         // and `aasm audit compliance-export` filter by tenant. Falls back to
@@ -868,6 +825,74 @@ impl PolicyServiceImpl {
             })
             .unwrap_or_default();
 
+        // AAASM-3377 — the lineage above is persisted as top-level `AuditEntry`
+        // fields, but consumers that read only the inner `payload` JSON (e.g.
+        // `/api/v1/logs`, JSONL replay tooling) never saw the delegation chain.
+        // Mirror the delegation lineage into the payload — alongside org/team —
+        // so a child agent's persisted JSONL `payload` carries root / parent /
+        // depth / delegation_reason / spawned_by_tool. Hex-encode the AgentId
+        // fields so the payload value is a stable, human-readable string rather
+        // than the raw byte array the top-level field serializes to.
+        let root_agent_id_hex = lineage.root_agent_id.map(|id| hex::encode(id.as_bytes()));
+        let parent_agent_id_hex = lineage.parent_agent_id.map(|id| hex::encode(id.as_bytes()));
+
+        // AAASM-3376 — the session_id stored on the entry is SHA256(trace_id)[:16],
+        // which is one-way: the raw trace_id and the per-action span_id are lost
+        // once the entry is persisted. Carry both in the payload JSON so they
+        // survive to the JSONL log / DB and let `/api/v1/traces/{trace_id}`
+        // reconstruct spans. (A first-class column on `AuditEntry` is the proto /
+        // core-type follow-up — see PR body.)
+        let trace_id_str: Option<&str> = (!req.trace_id.is_empty()).then_some(req.trace_id.as_str());
+        let span_id_str: Option<&str> = (!req.span_id.is_empty()).then_some(req.span_id.as_str());
+        let payload = match shadow {
+            Some(s) => serde_json::json!({
+                "action_type": req.action_type,
+                "decision": response.decision,
+                "reason": &response.reason,
+                "policy_rule": &response.policy_rule,
+                "latency_us": response.decision_latency_us,
+                "dry_run": true,
+                "shadow_decision": &s.shadow_decision,
+                "shadow_reason": &s.reason,
+                "caller_agent_id": caller_agent_id_str,
+                "callee_agent_id": caller_agent_id_str.map(|_| proto_agent.agent_id.as_str()),
+                "trace_id": trace_id_str,
+                "span_id": span_id_str,
+                "org_id": &lineage.org_id,
+                "team_id": &lineage.team_id,
+                "root_agent_id": &root_agent_id_hex,
+                "parent_agent_id": &parent_agent_id_hex,
+                "depth": lineage.depth,
+                "delegation_reason": &lineage.delegation_reason,
+                "spawned_by_tool": &lineage.spawned_by_tool,
+            }),
+            None => serde_json::json!({
+                "action_type": req.action_type,
+                "decision": response.decision,
+                "reason": &response.reason,
+                "policy_rule": &response.policy_rule,
+                "latency_us": response.decision_latency_us,
+                "caller_agent_id": caller_agent_id_str,
+                "callee_agent_id": caller_agent_id_str.map(|_| proto_agent.agent_id.as_str()),
+                "trace_id": trace_id_str,
+                "span_id": span_id_str,
+                "org_id": &lineage.org_id,
+                "team_id": &lineage.team_id,
+                "root_agent_id": &root_agent_id_hex,
+                "parent_agent_id": &parent_agent_id_hex,
+                "depth": lineage.depth,
+                "delegation_reason": &lineage.delegation_reason,
+                "spawned_by_tool": &lineage.spawned_by_tool,
+            }),
+        }
+        .to_string();
+
+        let mut last_hash = self.last_hash.lock().await;
+
+        // When the credential scanner produced findings, attach them (and the
+        // redacted payload) to the audit entry via the redaction-aware constructor.
+        // Both fields carry the [REDACTED:<kind>] form only — the raw secret bytes
+        // never reach the audit pipeline.
         let entry = if eval.credential_findings.is_empty() {
             AuditEntry::new_with_lineage(
                 seq,

--- a/aa-gateway/tests/audit_lineage_persisted_test.rs
+++ b/aa-gateway/tests/audit_lineage_persisted_test.rs
@@ -1,0 +1,172 @@
+//! AAASM-3377 — full delegation lineage in the PERSISTED audit `payload`.
+//!
+//! Regression: a child agent's CheckAction lineage (root / parent / depth /
+//! delegation_reason / spawned_by_tool) was carried only on the top-level
+//! `AuditEntry` fields. Consumers that read the inner `payload` JSON never saw
+//! the delegation chain. The earlier in-memory-struct test passed while the
+//! persisted `payload` was still empty, so this test drives the *real persist
+//! path*: it wires the live `AuditWriter` to a temp JSONL file, runs a
+//! CheckAction for a depth-1 child, then reads the JSONL back and asserts the
+//! lineage fields are present inside the persisted `payload`.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::io::Write;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use aa_core::AuditEntry;
+use aa_gateway::audit::AuditWriter;
+use aa_gateway::registry::store::AgentRecord;
+use aa_gateway::registry::{AgentRegistry, AgentStatus};
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId};
+use aa_proto::assembly::policy::v1::action_context::Action;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
+use aa_proto::assembly::policy::v1::{ActionContext, CheckActionRequest, LlmCallContext};
+use sha2::{Digest, Sha256};
+use tokio::sync::mpsc;
+use tonic::Request;
+
+const ALLOW_ALL_YAML: &str = "version: \"1\"\n";
+
+/// Mirror `registry::convert::proto_agent_id_to_key` so the registered record
+/// is keyed the same way the service looks it up.
+fn key_for(org: &str, team: &str, agent: &str) -> [u8; 16] {
+    let composite = format!("{org}/{team}/{agent}");
+    let digest = Sha256::digest(composite.as_bytes());
+    let mut out = [0u8; 16];
+    out.copy_from_slice(&digest[..16]);
+    out
+}
+
+fn child_record(key: [u8; 16], parent_key: [u8; 16], root_key: [u8; 16]) -> AgentRecord {
+    AgentRecord {
+        agent_id: key,
+        name: "child".into(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "pk".into(),
+        credential_token: "child-token".into(),
+        metadata: BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: vec![],
+        recent_events: VecDeque::new(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: Some("parent".into()),
+        team_id: Some("team".into()),
+        depth: 1,
+        delegation_reason: Some("summarise results".into()),
+        spawned_by_tool: Some("langgraph.subgraph".into()),
+        root_agent_id: Some(root_key),
+        children: vec![],
+        parent_key: Some(parent_key),
+        enforcement_mode: None,
+        org_id: Some("org".into()),
+    }
+}
+
+fn llm_request() -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "org".into(),
+            team_id: "team".into(),
+            agent_id: "child".into(),
+        }),
+        action_type: ActionType::LlmCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::LlmCall(LlmCallContext {
+                model: "gpt-4o".into(),
+                prompt_tokens: 10,
+                contains_pii: false,
+            })),
+        }),
+        trace_id: "trace-lineage".into(),
+        span_id: "span-lineage".into(),
+        credential_token: "child-token".into(),
+        caller_agent_id: None,
+    }
+}
+
+#[tokio::test]
+async fn persisted_jsonl_payload_carries_full_lineage() {
+    let registry = Arc::new(AgentRegistry::new());
+
+    let parent_key = key_for("org", "team", "parent");
+    let child_key = key_for("org", "team", "child");
+    let root_key = parent_key; // depth-1 child: parent is the root.
+
+    registry
+        .register(child_record(child_key, parent_key, root_key))
+        .expect("register child");
+
+    // Wire the *real* AuditWriter to a temp JSONL file — this is the persist
+    // path that QA inspects, not an in-memory struct check.
+    let audit_dir = tempfile::tempdir().expect("tempdir");
+    let (audit_tx, audit_rx) = mpsc::channel::<AuditEntry>(16);
+    let writer = AuditWriter::new(audit_dir.path().to_path_buf(), "org", "sess", audit_rx)
+        .await
+        .expect("audit writer");
+    let writer_handle = tokio::spawn(writer.run());
+
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", ALLOW_ALL_YAML).unwrap();
+    tmp.flush().unwrap();
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap();
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::with_registry(Arc::new(engine), registry, audit_tx, audit_drops, [0u8; 32]);
+
+    service
+        .check_action(Request::new(llm_request()))
+        .await
+        .expect("check_action ok");
+
+    // Drop the service so its `audit_tx` closes; the writer then flushes and exits.
+    drop(service);
+    writer_handle.await.expect("writer task join");
+
+    let jsonl_path = audit_dir.path().join("org-sess.jsonl");
+    let content = std::fs::read_to_string(&jsonl_path).expect("read persisted jsonl");
+    let line = content.trim();
+    assert!(!line.is_empty(), "persisted JSONL must not be empty");
+
+    let entry: serde_json::Value = serde_json::from_str(line).expect("parse persisted entry");
+    let payload_str = entry
+        .get("payload")
+        .and_then(|p| p.as_str())
+        .expect("persisted entry has a payload string");
+    let payload: serde_json::Value = serde_json::from_str(payload_str).expect("parse persisted payload");
+
+    assert_eq!(payload["org_id"], "org", "org_id persisted in payload");
+    assert_eq!(payload["team_id"], "team", "team_id persisted in payload");
+    assert_eq!(
+        payload["root_agent_id"],
+        serde_json::json!(hex::encode(root_key)),
+        "root_agent_id persisted in payload"
+    );
+    assert_eq!(
+        payload["parent_agent_id"],
+        serde_json::json!(hex::encode(parent_key)),
+        "parent_agent_id persisted in payload"
+    );
+    assert_eq!(payload["depth"], 1, "depth persisted in payload");
+    assert_eq!(
+        payload["delegation_reason"], "summarise results",
+        "delegation_reason persisted in payload"
+    );
+    assert_eq!(
+        payload["spawned_by_tool"], "langgraph.subgraph",
+        "spawned_by_tool persisted in payload"
+    );
+}


### PR DESCRIPTION
## Description

QA re-verification of AAASM-3377 on merged `master` found that the **persisted JSONL `payload`** for a child agent's `ToolCallIntercepted` / `PolicyViolation` audit entry still omitted the delegation lineage. The prior PR (#1138) correctly sourced the full lineage from `AgentRegistry::lineage()` and attached it to the top-level `AuditEntry` fields — but consumers that read only the inner `payload` JSON (e.g. `/api/v1/logs`, JSONL replay tooling) never saw `root_agent_id` / `parent_agent_id` / `depth` / `delegation_reason` / `spawned_by_tool`. The earlier regression test asserted only the in-memory `AuditEntry` getters, so it passed while the persisted `payload` was still empty.

This PR mirrors the registry-sourced lineage — alongside `org_id` / `team_id` — into the persisted `payload` JSON in `PolicyServiceImpl::record_audit` (`aa-gateway/src/service/policy_service.rs`). `AgentId` fields are hex-encoded so the payload value is a stable, human-readable string rather than the raw byte array the top-level field serializes to. The single registry `lineage()` lookup is reused (moved above the payload construction) — no extra registry call. This mirrors how #1138 already duplicated `trace_id` / `span_id` into the payload despite `session_id` existing at the top level.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Additive only — new keys appear inside the audit `payload` JSON. The audit entry hash chain is unaffected (the hash is computed over the typed `Lineage` struct + payload string; payload content already participates and remains internally consistent).

## Related Issues

- Related Jira ticket: AAASM-3377
- Follows up: #1138

Closes AAASM-3377

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed

**End-to-end persisted-JSONL proof** (the key gap — verified via the real persist path, not an in-memory struct):

A new test `aa-gateway/tests/audit_lineage_persisted_test.rs` registers a depth-1 child agent (parent/root keys, `delegation_reason`, `spawned_by_tool`), wires the **live `AuditWriter`** to a temp JSONL file, drives an ALLOW `CheckAction` as the child, then reads the JSONL back and parses the inner `payload`.

Before this fix, the persisted `payload` keys were:
```
[action_type, callee_agent_id, caller_agent_id, decision, latency_us, policy_rule, reason, span_id, trace_id]
```

After this fix the persisted JSONL `payload` contains the lineage:
```
[action_type, callee_agent_id, caller_agent_id, decision, delegation_reason, depth,
 latency_us, org_id, parent_agent_id, policy_rule, reason, root_agent_id, span_id,
 spawned_by_tool, team_id, trace_id]
```
with concrete values e.g. `"depth":1`, `"delegation_reason":"summarise results"`, `"spawned_by_tool":"langgraph.subgraph"`, `"parent_agent_id":"f3519e43587cd9df458116d38f661fcd"`, `"root_agent_id":"f3519e43587cd9df458116d38f661fcd"`.

- `cargo build -p aa-gateway` — OK
- `cargo nextest run -p aa-gateway` — **1138 passed, 0 failed**
- `cargo fmt -p aa-gateway` + `cargo clippy -p aa-gateway --all-targets` — clean

**Follow-up (documented, not in scope):** the lineage is currently carried both as top-level `AuditEntry` fields and (now) inside the `payload` string. Promoting the lineage to first-class proto / `AuditEntry` columns consumed uniformly by all readers (so duplication into `payload` is no longer needed) is the proper proto-level follow-up — `proto/` is intentionally untouched here.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
