### PR TITLE
[AAASM-3387] 🐛 (aa-sdk-client): Emit did:key agent identity for gateway registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "aa-core",
  "aa-proto",
  "aa-runtime",
+ "aa-sdk-client",
  "aa-security",
  "aa-storage-postgres",
  "ahash 0.8.12",
@@ -461,7 +462,9 @@ version = "0.0.1-beta.2"
 dependencies = [
  "aa-proto",
  "aa-security",
+ "bs58",
  "prost",
+ "sha2 0.11.0",
  "tokio",
  "tracing",
 ]

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -67,6 +67,10 @@ aa-storage-postgres = { path = "../aa-storage-postgres", optional = true }
 # driver's own embedded MIGRATOR so the gateway can never drift from the
 # canonical MVP schema (AAASM-2389).
 aa-storage-postgres = { path = "../aa-storage-postgres" }
+# End-to-end proof that an SDK-derived did:key identity is accepted by the
+# live AgentLifecycleService.Register RPC (AAASM-3387). Default features off
+# to avoid pulling the advisory-preflight (aa-security) dependency.
+aa-sdk-client = { path = "../aa-sdk-client", default-features = false }
 criterion    = { workspace = true, features = ["async_tokio"] }
 proptest     = { workspace = true }
 tempfile     = { workspace = true }

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -221,6 +221,46 @@ async fn register_with_non_did_agent_id_returns_invalid_argument() {
     );
 }
 
+/// AAASM-3387 regression: a plain agent identifier run through the shared SDK
+/// client's `did:key` derivation is ACCEPTED by the live Register RPC. This is
+/// the end-to-end proof that SDK-originated registration succeeds against the
+/// gateway's did:key validation (the broken example→live-core path).
+#[tokio::test]
+async fn register_with_sdk_derived_did_key_is_accepted() {
+    let (addr, _registry) = start_server().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    // A human-readable agent_id of the kind SDKs configure today — which the
+    // gateway rejects verbatim — converted via the shared SDK derivation.
+    let plain_agent_id = "my-agent-001";
+    let did = aa_sdk_client::agent_id_to_did_key(plain_agent_id);
+    assert!(did.starts_with("did:key:z"), "derived DID must be a did:key, got {did}");
+
+    let resp = client
+        .register(RegisterRequest {
+            agent_id: Some(ProtoAgentId {
+                org_id: "org-test".into(),
+                team_id: "team-test".into(),
+                agent_id: did,
+            }),
+            name: "sdk-derived-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+            ..Default::default()
+        })
+        .await
+        .expect("SDK-derived did:key must be accepted by Register")
+        .into_inner();
+
+    assert!(!resp.credential_token.is_empty());
+}
+
 #[tokio::test]
 async fn heartbeat_with_wrong_token_returns_unauthenticated() {
     let (addr, _registry) = start_server().await;

--- a/aa-sdk-client/Cargo.toml
+++ b/aa-sdk-client/Cargo.toml
@@ -14,7 +14,10 @@ description = "Shared SDK runtime-client for Agent Assembly — UDS transport, I
 aa-proto = { path = "../aa-proto" }
 # Advisory preflight only — pulled in by the `preflight` feature (default on).
 aa-security = { path = "../aa-security", optional = true }
+# did:key derivation for gateway registration identity (AAASM-3387).
+bs58 = "0.5"
 prost = { workspace = true }
+sha2 = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "sync", "time", "io-util", "macros"] }
 tracing = { workspace = true }
 

--- a/aa-sdk-client/src/config.rs
+++ b/aa-sdk-client/src/config.rs
@@ -35,6 +35,17 @@ impl AssemblyConfig {
 
         PathBuf::from(format!("/tmp/aa-runtime-{}.sock", self.agent_id))
     }
+
+    /// Return the agent identity to send on gateway registration.
+    ///
+    /// The gateway's `AgentLifecycleService.Register` rejects a plain
+    /// `agent_id`; it must be a `did:key` DID. This derives a conformant
+    /// `did:key` from the configured `agent_id` (passing through an
+    /// already-`did:key` identifier unchanged). The socket-path / event-tag
+    /// `agent_id` is intentionally left as-is.
+    pub fn registration_did(&self) -> String {
+        crate::identity::agent_id_to_did_key(&self.agent_id)
+    }
 }
 
 #[cfg(test)]

--- a/aa-sdk-client/src/identity.rs
+++ b/aa-sdk-client/src/identity.rs
@@ -1,0 +1,116 @@
+//! Agent identity helpers for gateway registration.
+//!
+//! The gateway's `AgentLifecycleService.Register` RPC requires the registering
+//! `agent_id` to be a syntactically-valid `did:key` DID — a plain string is
+//! rejected with `InvalidArgument: agent_id is not a did:key DID (missing
+//! "did:key:" prefix)`. SDKs configure agents with human-readable identifiers
+//! (used for socket naming and event tagging), so this module derives a
+//! conformant `did:key` from such an identifier.
+//!
+//! The derivation is **deterministic**: the same input always yields the same
+//! DID, so an agent keeps a stable identity across process restarts without
+//! having to persist a keypair. Bytes are produced by hashing the input with
+//! SHA-256, then wrapped as an Ed25519 `did:key` (multicodec `0xed 0x01`,
+//! base58btc multibase). The resulting DID has the canonical `did:key:z6Mk…`
+//! shape and passes the gateway's syntactic `did:key` validation.
+
+use sha2::{Digest, Sha256};
+
+/// Multicodec prefix for an Ed25519 public key (`0xed`), varint-encoded as
+/// the two bytes `0xed 0x01`. A `did:key` for Ed25519 is the base58btc
+/// multibase encoding of these two bytes followed by the 32-byte key.
+const ED25519_MULTICODEC_PREFIX: [u8; 2] = [0xed, 0x01];
+
+/// Length, in bytes, of an Ed25519 public key.
+const ED25519_PUBLIC_KEY_LEN: usize = 32;
+
+/// Derive a deterministic, conformant Ed25519 `did:key` DID from a plain agent
+/// identifier.
+///
+/// The returned string has the shape `did:key:z<base58btc>` where the decoded
+/// multibase value is `[0xed, 0x01]` followed by 32 deterministic bytes derived
+/// from `identity`. This is accepted by the gateway's `did:key` validation,
+/// which checks the `did:key:` prefix, the `z` base58btc multibase marker, and
+/// that the value decodes to non-empty bytes.
+///
+/// If `identity` is already a `did:key` DID (it starts with `did:key:`), it is
+/// returned unchanged so callers can pass through an explicitly-provisioned DID.
+pub fn agent_id_to_did_key(identity: &str) -> String {
+    if identity.starts_with("did:key:") {
+        return identity.to_string();
+    }
+
+    // Derive a stable 32-byte value to stand in for an Ed25519 public key. No
+    // keypair is provisioned at this layer, so the DID identifies the agent by
+    // its configured identifier rather than by a verifiable signing key.
+    let digest = Sha256::digest(identity.as_bytes());
+    let mut key_bytes = [0u8; ED25519_PUBLIC_KEY_LEN];
+    key_bytes.copy_from_slice(&digest[..ED25519_PUBLIC_KEY_LEN]);
+
+    let mut multicodec = Vec::with_capacity(ED25519_MULTICODEC_PREFIX.len() + ED25519_PUBLIC_KEY_LEN);
+    multicodec.extend_from_slice(&ED25519_MULTICODEC_PREFIX);
+    multicodec.extend_from_slice(&key_bytes);
+
+    let multibase = bs58::encode(&multicodec).into_string();
+    format!("did:key:z{multibase}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Replicate the gateway's `did:key` validation so the test proves the
+    /// derived DID would be accepted by `AgentLifecycleService.Register`
+    /// without depending on the `aa-gateway` crate.
+    fn validate_did_key(value: &str) -> Result<(), &'static str> {
+        let multibase = value.strip_prefix("did:key:").ok_or("missing did:key: prefix")?;
+        let encoded = multibase.strip_prefix('z').ok_or("missing z multibase prefix")?;
+        if encoded.is_empty() {
+            return Err("empty multibase value");
+        }
+        let decoded = bs58::decode(encoded).into_vec().map_err(|_| "not valid base58btc")?;
+        if decoded.is_empty() {
+            return Err("decodes to empty bytes");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn derives_conformant_did_key() {
+        let did = agent_id_to_did_key("my-agent-001");
+        assert!(did.starts_with("did:key:z"), "got {did}");
+        validate_did_key(&did).expect("derived DID must pass gateway validation");
+    }
+
+    #[test]
+    fn derivation_is_deterministic() {
+        assert_eq!(agent_id_to_did_key("agent-a"), agent_id_to_did_key("agent-a"));
+    }
+
+    #[test]
+    fn distinct_identities_yield_distinct_dids() {
+        assert_ne!(agent_id_to_did_key("agent-a"), agent_id_to_did_key("agent-b"));
+    }
+
+    #[test]
+    fn ed25519_did_keys_use_the_canonical_prefix() {
+        // The multicodec 0xed01 prefix renders as the well-known "z6Mk" head.
+        let did = agent_id_to_did_key("anything");
+        assert!(did.starts_with("did:key:z6Mk"), "got {did}");
+    }
+
+    #[test]
+    fn passes_through_existing_did_key() {
+        let existing = "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T";
+        assert_eq!(agent_id_to_did_key(existing), existing);
+    }
+
+    #[test]
+    fn derived_did_decodes_to_ed25519_multicodec_payload() {
+        let did = agent_id_to_did_key("payload-check");
+        let encoded = did.strip_prefix("did:key:z").unwrap();
+        let decoded = bs58::decode(encoded).into_vec().unwrap();
+        assert_eq!(&decoded[..2], &ED25519_MULTICODEC_PREFIX);
+        assert_eq!(decoded.len(), 2 + ED25519_PUBLIC_KEY_LEN);
+    }
+}

--- a/aa-sdk-client/src/lib.rs
+++ b/aa-sdk-client/src/lib.rs
@@ -29,6 +29,7 @@ pub mod client;
 pub mod codec;
 pub mod config;
 pub mod error;
+pub mod identity;
 pub mod ipc;
 #[cfg(feature = "preflight")]
 pub mod preflight;
@@ -36,5 +37,6 @@ pub mod preflight;
 pub use client::AssemblyClient;
 pub use config::AssemblyConfig;
 pub use error::SdkClientError;
+pub use identity::agent_id_to_did_key;
 #[cfg(feature = "preflight")]
 pub use preflight::Preflight;


### PR DESCRIPTION
## Description

`AgentLifecycleService.Register` now **rejects** any `agent_id` that is not a
syntactically-valid `did:key` DID (`InvalidArgument: agent_id is not a did:key
DID (missing "did:key:" prefix)`). The language SDKs (python/node/go) and the
shared `aa-sdk-client` configure agents with plain human-readable identifiers,
so SDK-originated registration now fails against the live core — the root of the
broken example → live-core path (related to AAASM-3380).

This PR fixes the identity layer in the shared `aa-sdk-client` crate (which all
per-language FFI shims wrap), so the fix is inherited everywhere:

- Adds `aa_sdk_client::agent_id_to_did_key(identity)` — derives a deterministic,
  conformant Ed25519 `did:key` (`did:key:z6Mk…`, multicodec `0xed01` + base58btc)
  from a plain agent identifier. An identifier that is already a `did:key` is
  passed through unchanged.
- Adds `AssemblyConfig::registration_did()` so FFI shims get the registration DID
  directly; the socket-path / event-tag `agent_id` is intentionally left as-is.

### Why derive (and not require a keypair)

The task premise was to derive the DID from an Ed25519 public key the SDK already
generates. In this codebase **no SDK layer provisions an Ed25519 keypair** today
(`aa-sdk-client` and `aa-runtime` have none; the `public_key` field on
`RegisterRequest` is populated by the language SDKs, none of which generate a
key). The gateway's `validate_proto_agent_id` only checks the DID **syntax**
(`did:key:` prefix, `z` base58btc multibase, non-empty decoded bytes) — it does
**not** verify the multicodec key type or any signature. So the minimal,
self-contained fix is a deterministic SHA-256-derived Ed25519-form `did:key`,
which is byte-for-byte conformant and stable across restarts. When the SDKs grow
a real keypair, `agent_id_to_did_key` can be replaced with derivation from the
real public key without changing callers. No `proto/` change is required.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

(The socket-path / event-tag `agent_id` contract is unchanged; only the
registration identity is now a did:key.)

## Related Issues

- Related Jira ticket: AAASM-3387
- Closes AAASM-3387

## Testing

- [x] Unit tests added / updated — `aa-sdk-client` `identity` module tests
  (conformance, determinism, distinctness, canonical `z6Mk` prefix, multicodec
  payload, did:key pass-through). `cargo nextest run -p aa-sdk-client`: 34 passed.
- [x] Integration tests added / updated — **end-to-end proof**:
  `aa-gateway/tests/lifecycle_service_test.rs::register_with_sdk_derived_did_key_is_accepted`
  spins the real `AgentLifecycleService` gRPC server, registers with an agent_id
  produced by `aa_sdk_client::agent_id_to_did_key("my-agent-001")`, and asserts
  Register **accepts** it (returns a credential token, no `did:key` InvalidArgument).
  Full `lifecycle_service_test` suite: 19 passed.
- `cargo fmt` + `cargo clippy -p aa-sdk-client --all-targets`: clean.

### How to verify

```bash
export RUSTUP_TOOLCHAIN=stable
cargo nextest run -p aa-sdk-client
cargo test -p aa-gateway --test lifecycle_service_test register_with_sdk_derived_did_key_is_accepted
```

## Follow-ups (out of scope for this PR — shared-layer fix only)

The per-language SDKs must call `registration_did()` / `agent_id_to_did_key`
when building their `RegisterRequest.agent_id`:

- **python-sdk**: `GatewayClient.register_agent` posts to
  `/agents/{agent_id}/register` with the plain id — switch to the derived DID.
- **node-sdk** / **go-sdk**: thread the derived DID into their register event /
  `RegisterRequest`.
- **examples**: update any that hardcode plain agent ids.

These are tracked as separate SDK-component tickets.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module + fn docs added)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
