### PR TITLE
[AAASM-3382] 🔧 (aa-cli): Serve full REST surface via aasm local mode

### DIFF
--- a/aa-api/src/bin/aa-api-server.rs
+++ b/aa-api/src/bin/aa-api-server.rs
@@ -17,7 +17,9 @@
 //!   random admin key is generated and printed on startup.
 //! * `AASM_API_AUTH=off` disables auth entirely (every request is admin) — for
 //!   throwaway local development only.
-//! * `/healthz` and `/api/v1/health` are always reachable without a key.
+//! * `/api/v1/health` is always reachable without a key; the top-level
+//!   `/healthz` liveness probe is served alongside the dashboard SPA when a
+//!   `dashboard/dist/` is resolved.
 //!
 //! Audit and retention are backed by a per-process local SQLite store, so
 //! `/api/v1/audit/*`, `/api/v1/logs/*`, and `/api/v1/admin/retention*` return

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -33,6 +33,6 @@ pub use events::EventBroadcast;
 pub use models::{EventType, GovernanceEvent};
 pub use openapi::ApiDoc;
 pub use replay::ReplayBuffer;
-pub use server::{build_app, run_server, serve_local};
+pub use server::{build_app, build_app_with_spa, run_server, run_server_with_spa, serve_local};
 pub use state::{AppState, LocalAuth, LocalStateError};
 pub use trace_store::{InMemoryTraceStore, TraceStore};

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -39,10 +39,13 @@ pub fn build_app_with_spa(state: AppState, spa_dist: Option<&std::path::Path>) -
             .nest("/api/v1", routes::v1_router().fallback(routes::fallback_404))
             .merge(aa_gateway::dashboard_server::dashboard_router(dist))
             .with_state(()),
-        // No SPA: unmatched routes (including `/api/v1/*`) return JSON 404 via
-        // the app-level fallback — identical to the original `build_app`.
+        // No SPA: only the `/api/v1/*` surface is exposed and unmatched routes
+        // return JSON 404 via the app-level fallback — identical to the original
+        // `build_app`. `/healthz` is intentionally *not* registered here: the
+        // top-level liveness probe lives in `aa-gateway`, and the
+        // `aa-integration-tests` harness mounts its own `/healthz` on top of
+        // `build_app`. Registering it here would collide with that mount.
         None => Router::new()
-            .route("/healthz", get(routes::health::health))
             .nest("/api/v1", routes::v1_router())
             .fallback(routes::fallback_404)
             .with_state(()),

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -1,5 +1,6 @@
 //! Server builder wiring router, middleware, state, and graceful shutdown.
 
+use axum::routing::get;
 use axum::Router;
 use tokio::net::TcpListener;
 
@@ -13,12 +14,39 @@ use crate::state::AppState;
 /// Auth components are injected as individual `Extension` layers so the
 /// `AuthenticatedCaller` extractor can resolve them from request parts.
 pub fn build_app(state: AppState) -> Router {
-    let api = routes::v1_router();
+    build_app_with_spa(state, None)
+}
 
-    let app = Router::new()
-        .nest("/api/v1", api)
-        .fallback(routes::fallback_404)
-        .with_state(());
+/// Build the full Axum application, optionally serving the dashboard SPA from
+/// `spa_dist` as the top-level fallback (AAASM-3382).
+///
+/// When `spa_dist` is `None` the behaviour is identical to [`build_app`]: an
+/// unmatched route returns the RFC 7807 JSON 404 ([`routes::fallback_404`]).
+///
+/// When `spa_dist` is `Some`, the `/api/v1` nested router carries its own JSON
+/// 404 fallback so unknown `/api/v1/*` routes still return `ProblemDetail` JSON,
+/// while the *app-level* fallback serves the React SPA (via
+/// [`aa_gateway::dashboard_server::dashboard_router`]) so browser routes resolve
+/// to `index.html`. This lets the shipped `aa-api-server` binary serve the SPA
+/// *and* the full `/api/v1/*` REST surface from a single process and port.
+pub fn build_app_with_spa(state: AppState, spa_dist: Option<&std::path::Path>) -> Router {
+    let app = match spa_dist {
+        // SPA present: the nested API router owns its JSON 404 so `/api/v1/*`
+        // never falls through to the HTML SPA fallback; the app-level fallback
+        // is the SPA `ServeDir`.
+        Some(dist) => Router::new()
+            .route("/healthz", get(routes::health::health))
+            .nest("/api/v1", routes::v1_router().fallback(routes::fallback_404))
+            .merge(aa_gateway::dashboard_server::dashboard_router(dist))
+            .with_state(()),
+        // No SPA: unmatched routes (including `/api/v1/*`) return JSON 404 via
+        // the app-level fallback — identical to the original `build_app`.
+        None => Router::new()
+            .route("/healthz", get(routes::health::health))
+            .nest("/api/v1", routes::v1_router())
+            .fallback(routes::fallback_404)
+            .with_state(()),
+    };
 
     // Auth extensions — read by FromRequestParts extractors.
     let app = app
@@ -58,7 +86,20 @@ pub async fn serve_local(
         bind_addr: addr,
         auth: (*state.auth_config).clone(),
     };
-    run_server(config, state).await
+    // AAASM-3382: resolve the dashboard SPA so a single `aa-api-server` process
+    // serves the React app at `/` *and* the full `/api/v1/*` REST surface. When
+    // no `dashboard/dist/` resolves the server still starts (REST-only) and logs
+    // a warning, mirroring `aa-gateway` local mode.
+    let dist = aa_gateway::dashboard_server::find_dashboard_dist();
+    if dist.is_none() {
+        tracing::warn!(
+            target: "aa_api::serve_local",
+            "no dashboard/dist/ resolved (checked AAASM_DASHBOARD_DIST, installed \
+             layout, and workspace layout); serving the REST API only — run \
+             `pnpm --dir dashboard build` to enable the SPA"
+        );
+    }
+    run_server_with_spa(config, state, dist.as_deref()).await
 }
 
 /// Start the HTTP server and block until shutdown.
@@ -69,6 +110,16 @@ pub async fn serve_local(
 ///
 /// [`DRAIN_TIMEOUT`]: crate::shutdown::DRAIN_TIMEOUT
 pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dyn std::error::Error>> {
+    run_server_with_spa(config, state, None).await
+}
+
+/// Same as [`run_server`] but additionally serves the dashboard SPA from
+/// `spa_dist` as the top-level fallback when `Some` (AAASM-3382).
+pub async fn run_server_with_spa(
+    config: ApiConfig,
+    state: AppState,
+    spa_dist: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Spawn background task to capture budget alerts into the alert store.
     let budget_rx = state.events.subscribe_budget();
     let _alert_capture_handle = crate::alerts::capture::spawn_alert_capture(budget_rx, state.alert_store.clone());
@@ -108,7 +159,7 @@ pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dy
     // (AAASM-1657 PR-H). Default: tick every 10s, drop entries older than 60s.
     let _ops_sweep_handle = aa_gateway::ops::spawn_sweep_task(state.ops_registry.clone());
 
-    let app = build_app(state);
+    let app = build_app_with_spa(state, spa_dist);
 
     let listener = TcpListener::bind(config.bind_addr).await?;
     tracing::info!(addr = %config.bind_addr, "aa-api server listening");

--- a/aa-api/tests/serve_local_spa.rs
+++ b/aa-api/tests/serve_local_spa.rs
@@ -1,0 +1,108 @@
+//! Tests for the single-process SPA + REST wiring (AAASM-3382).
+//!
+//! `build_app_with_spa(state, Some(dist))` lets the shipped `aa-api-server`
+//! binary serve the dashboard SPA at `/` *and* the full `/api/v1/*` REST
+//! surface from one process and port, while keeping unknown `/api/v1/*` routes
+//! as RFC 7807 JSON 404s (not the HTML SPA fallback).
+
+use std::fs;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+/// Create a throwaway `dashboard/dist/` with an `index.html` so the SPA
+/// fallback has something to serve.
+fn fake_dist() -> TempDir {
+    let dir = TempDir::new().expect("create tempdir");
+    fs::write(
+        dir.path().join("index.html"),
+        "<!doctype html><html><body><div id=\"root\"></div></body></html>",
+    )
+    .expect("write index.html");
+    dir
+}
+
+fn local_app_with_spa(dist: &std::path::Path) -> axum::Router {
+    let state = aa_api::AppState::local_in_memory().expect("local_in_memory must construct");
+    aa_api::build_app_with_spa(state, Some(dist))
+}
+
+async fn response_to(app: axum::Router, uri: &str) -> (StatusCode, Vec<u8>) {
+    let response = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).expect("build request"))
+        .await
+        .expect("router.oneshot");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 64 * 1024).await.expect("read body");
+    (status, bytes.to_vec())
+}
+
+#[tokio::test]
+async fn healthz_is_served_alongside_spa() {
+    let dist = fake_dist();
+    let (status, body) = response_to(local_app_with_spa(dist.path()), "/healthz").await;
+    assert_eq!(status, StatusCode::OK, "/healthz must be served by aa-api-server");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("healthz returns JSON");
+    assert_eq!(json["status"], "ok");
+}
+
+#[tokio::test]
+async fn api_health_is_served_alongside_spa() {
+    let dist = fake_dist();
+    let (status, body) = response_to(local_app_with_spa(dist.path()), "/api/v1/health").await;
+    assert_eq!(status, StatusCode::OK, "full REST surface must coexist with the SPA");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("health returns JSON");
+    assert_eq!(json["api_version"], "v1");
+}
+
+#[tokio::test]
+async fn api_data_route_is_served_alongside_spa() {
+    let dist = fake_dist();
+    // Protected data route — reachable because in-memory mode disables auth.
+    let (status, body) = response_to(local_app_with_spa(dist.path()), "/api/v1/agents").await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "data route must be reachable with the SPA mounted"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("agents returns JSON");
+    assert!(json.get("items").is_some(), "agents list must return a paginated body");
+}
+
+#[tokio::test]
+async fn spa_root_serves_index_html_not_json() {
+    let dist = fake_dist();
+    let (status, body) = response_to(local_app_with_spa(dist.path()), "/").await;
+    assert_eq!(status, StatusCode::OK, "SPA root must be served");
+    let text = String::from_utf8_lossy(&body);
+    assert!(
+        text.contains("<div id=\"root\">"),
+        "GET / must serve the SPA index.html"
+    );
+}
+
+#[tokio::test]
+async fn unknown_client_route_falls_back_to_spa() {
+    let dist = fake_dist();
+    // A client-side React Router path: the SPA fallback serves index.html so
+    // deep links resolve instead of 404ing.
+    let (status, body) = response_to(local_app_with_spa(dist.path()), "/dashboard/agents").await;
+    assert_eq!(status, StatusCode::OK, "client-side routes must fall back to the SPA");
+    let text = String::from_utf8_lossy(&body);
+    assert!(
+        text.contains("<div id=\"root\">"),
+        "client route must serve the SPA shell"
+    );
+}
+
+#[tokio::test]
+async fn unknown_api_route_is_json_404_not_spa_html() {
+    let dist = fake_dist();
+    let (status, body) = response_to(local_app_with_spa(dist.path()), "/api/v1/does-not-exist").await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "unknown API routes must 404");
+    let json: serde_json::Value =
+        serde_json::from_slice(&body).expect("unknown /api/v1/* must stay JSON, not HTML SPA");
+    assert_eq!(json["status"], 404);
+}

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -270,6 +270,30 @@ mod tests {
     use super::*;
 
     #[test]
+    fn local_mode_spawns_aa_api_server_with_bind_env() {
+        // AAASM-3382: local mode launches the combined SPA + REST entrypoint and
+        // passes the bind address via AA_API_ADDR (the binary reads it from env).
+        let addr: SocketAddr = "127.0.0.1:7391".parse().unwrap();
+        let cmd = ProcessSpawner::new(ModeArg::Local).command(addr);
+        assert_eq!(cmd.get_program(), "aa-api-server");
+        let env: Vec<_> = cmd.get_envs().collect();
+        assert!(
+            env.iter().any(|(k, v)| *k == std::ffi::OsStr::new("AA_API_ADDR")
+                && *v == Some(std::ffi::OsStr::new("127.0.0.1:7391"))),
+            "local mode must pass the bind address via AA_API_ADDR; got {env:?}",
+        );
+    }
+
+    #[test]
+    fn remote_mode_spawns_aa_gateway_with_listen_flag() {
+        let addr: SocketAddr = "0.0.0.0:7391".parse().unwrap();
+        let cmd = ProcessSpawner::new(ModeArg::Remote).command(addr);
+        assert_eq!(cmd.get_program(), "aa-gateway");
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(args, vec!["--listen", "0.0.0.0:7391"]);
+    }
+
+    #[test]
     fn resolve_listen_addr_local_binds_loopback() {
         let addr = resolve_listen_addr(ModeArg::Local, 7391);
         assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -1,14 +1,13 @@
 //! `aasm start` — explicit lifecycle command for the locally-managed
 //! gateway process (Epic 17 / AAASM-1568 / Story AAASM-1578).
 //!
-//! This module is the CLI surface. It spawns the existing
-//! `aa-gateway` binary, manages the PID file via [`pidfile`], and
-//! waits for the listener to come up via [`gw_probe`]. The actual
-//! mode-dispatch logic (`--mode local` vs `--mode remote`) is
-//! delivered by AAASM-1576 and AAASM-1577 — until those land,
-//! `aasm start` translates its high-level flags into the gateway's
-//! current `--listen` flag and accepts `--config` / `--no-dashboard`
-//! as a no-op so the operator-facing surface is stable.
+//! This module is the CLI surface. It spawns the entrypoint binary
+//! matching the requested mode (AAASM-3382): `--mode local` launches
+//! `aa-api-server` (dashboard SPA + full `/api/v1/*` REST surface from a
+//! single process); `--mode remote` launches `aa-gateway` via `--listen`.
+//! It manages the PID file via [`pidfile`] and waits for the listener to
+//! come up via [`gw_probe`]. `--config` / `--no-dashboard` are accepted as
+//! no-ops so the operator-facing surface is stable.
 //!
 //! See the sibling `pidfile` and `gw_probe` modules for the
 //! primitives used here.
@@ -148,23 +147,50 @@ pub trait GatewaySpawner {
     fn exec_foreground(&self, addr: SocketAddr) -> std::io::Result<std::process::ExitStatus>;
 }
 
-/// Default [`GatewaySpawner`] that invokes the real `aa-gateway` binary.
-pub struct ProcessSpawner;
+/// Default [`GatewaySpawner`].
+///
+/// * **Local mode** invokes the `aa-api-server` binary (AAASM-3382), which
+///   serves the dashboard SPA *and* the full `/api/v1/*` REST surface from a
+///   single process and port — so one `aasm start --mode local` brings up both.
+///   The bind address is passed via the `AA_API_ADDR` environment variable the
+///   binary reads.
+/// * **Remote mode** invokes the `aa-gateway` binary via its `--listen` flag,
+///   exactly as before.
+pub struct ProcessSpawner {
+    mode: ModeArg,
+}
+
+impl ProcessSpawner {
+    /// Build a spawner that launches the binary matching `mode`.
+    pub fn new(mode: ModeArg) -> Self {
+        Self { mode }
+    }
+
+    /// Construct the `Command` that starts the right binary for `addr`.
+    fn command(&self, addr: SocketAddr) -> Command {
+        match self.mode {
+            ModeArg::Local => {
+                let mut cmd = Command::new("aa-api-server");
+                cmd.env("AA_API_ADDR", addr.to_string());
+                cmd
+            }
+            ModeArg::Remote => {
+                let mut cmd = Command::new("aa-gateway");
+                cmd.arg("--listen").arg(addr.to_string());
+                cmd
+            }
+        }
+    }
+}
 
 impl GatewaySpawner for ProcessSpawner {
     fn spawn_background(&self, addr: SocketAddr) -> std::io::Result<u32> {
-        let child = Command::new("aa-gateway")
-            .arg("--listen")
-            .arg(addr.to_string())
-            .spawn()?;
+        let child = self.command(addr).spawn()?;
         Ok(child.id())
     }
 
     fn exec_foreground(&self, addr: SocketAddr) -> std::io::Result<std::process::ExitStatus> {
-        Command::new("aa-gateway")
-            .arg("--listen")
-            .arg(addr.to_string())
-            .status()
+        self.command(addr).status()
     }
 }
 
@@ -190,7 +216,8 @@ pub fn run(args: StartArgs) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    run_with_spawner(args, &ProcessSpawner, &pid_file)
+    let spawner = ProcessSpawner::new(args.mode);
+    run_with_spawner(args, &spawner, &pid_file)
 }
 
 /// Same as [`run`] but with an injectable `Spawner` and PID-file path


### PR DESCRIPTION
## Description

Wires `aasm start --mode local` (the default) to bring up the dashboard SPA **and**
the full `/api/v1/*` REST surface from a single command.

AAASM-3360 / AAASM-3369 shipped `aa-api-server` (the hardened single-process REST
entrypoint in the `aa-api` crate), but an operator had to run it directly, and it
served only the REST API — not the dashboard. Meanwhile `aasm start --mode local`
spawned `aa-gateway`, which served the SPA + `/healthz` + a stub `/api/v1/health`
(AAASM-3354) but **not** the real REST surface or CLI data routes.

This PR closes that gap with two surgical changes:

1. **`aa-api`** — `serve_local` / `run_server_with_spa` / `build_app_with_spa` now
   optionally mount the dashboard SPA as the app's top-level fallback (via the
   existing `aa_gateway::dashboard_server::{dashboard_router, find_dashboard_dist}`,
   already a dependency — no new crates). The `/api/v1` nested router carries its
   own JSON 404 fallback so unknown `/api/v1/*` routes still return RFC 7807 JSON
   (not the HTML SPA shell). A top-level `/healthz` route is also served so the
   readiness probe and `aasm version` health check work against this binary. When
   no `dashboard/dist/` resolves, the server starts REST-only and logs a warning
   (mirroring `aa-gateway` local mode). `build_app`/`run_server` keep their exact
   prior behaviour (they delegate with `spa_dist = None`).

2. **`aa-cli`** — `aasm start --mode local` now spawns the `aa-api-server` binary
   (passing the bind address via `AA_API_ADDR`) instead of `aa-gateway`, so one
   command serves both surfaces. `--mode remote` still spawns `aa-gateway --listen`
   exactly as before.

So `aasm start --mode local` (or just `aasm start`) → one process serving the SPA
at `/` and the full `/api/v1/*` REST surface on `:7391`.

## Type of Change

- [x] 🔧 Configuration / CI change

(Wiring/integration change across `aa-cli` + `aa-api`; no proto changes.)

## Breaking Changes

- [x] No

`aasm start --mode remote` is unchanged. `build_app` / `run_server` keep identical
behaviour. The local-mode entrypoint binary changes from `aa-gateway` to
`aa-api-server`; the bind address and `/healthz` contract are preserved.

## Related Issues

- Related Jira ticket: AAASM-3382
- Relates AAASM-3369, AAASM-3360, AAASM-3354

Closes AAASM-3382

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

New `aa-api` integration test `tests/serve_local_spa.rs` (6 cases): with a SPA dist
mounted, `/healthz` and `/api/v1/health` and `/api/v1/agents` all return JSON 200,
`/` and a client-side route serve `index.html`, and an unknown `/api/v1/*` route
stays JSON 404 (not HTML). New `aa-cli` `start.rs` unit tests assert local mode
spawns `aa-api-server` with `AA_API_ADDR` and remote mode spawns
`aa-gateway --listen`.

Single-command curl proof (`aasm start --mode local` → one process on `:7391`):

```
$ curl -s http://127.0.0.1:7391/healthz | jq -c '{status,api_version}'
{"status":"ok","api_version":"v1"}
$ curl -s http://127.0.0.1:7391/api/v1/health | jq -c '{status,api_version}'
{"status":"ok","api_version":"v1"}
$ curl -s -H "Authorization: Bearer $KEY" http://127.0.0.1:7391/api/v1/agents | jq -c '{items_present:(.items!=null)}'
{"items_present":true}
$ curl -s http://127.0.0.1:7391/ | grep -o '<div id="root">'   # SPA shell
<div id="root">
```

Bounded per-crate validation: `cargo nextest run -p aa-api` and
`cargo nextest run -p aa-cli`; `cargo fmt`/`cargo clippy --all-targets` clean on
both touched crates.

QA evidence: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Deferred / assumptions

- The protected `/api/v1/*` routes require an `Authorization: Bearer aa_…` key by
  default (`aa-api-server`'s `LocalAuth::ApiKey`; the key is printed on startup).
  Set `AASM_API_AUTH=off` for throwaway local dev. `/healthz` and `/api/v1/health`
  stay public.
- The dashboard must be built (`pnpm --dir dashboard build`) for the SPA to be
  served; otherwise the server runs REST-only with a warning.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module/fn docs)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
