### PR TITLE
[AAASM-3391] ♻️ (dashboard): Reduce SonarCloud smells under 5

### DIFF
--- a/dashboard/src/features/alerts/index.ts
+++ b/dashboard/src/features/alerts/index.ts
@@ -1,4 +1,15 @@
 // Alerts feature — see AAASM-118.
-// Public surface kept minimal until subsequent Subtasks add hooks, drawer,
-// and rule builder.
-export {}
+// Barrel for the feature's public surface. Re-export named specifiers (not a
+// bare `export {}`) so the module advertises a real API; consumers may import
+// from here or from the individual modules directly.
+export { AlertList } from './AlertList'
+export { AlertFilterBar } from './AlertFilterBar'
+export { AlertsTabs, type AlertsTab } from './AlertsTabs'
+export { AlertDetailDrawer } from './AlertDetailDrawer'
+export { AlertDetailContent } from './AlertDetailContent'
+export { AlertRuleForm } from './AlertRuleForm'
+export { AlertRulesTable } from './AlertRulesTable'
+export { DestinationManager } from './DestinationManager'
+export { useAlertsQuery, useAlertRulesQuery } from './api'
+export { useAlertsStream } from './useAlertsStream'
+export type { Alert, AlertFilters, AlertRule } from './types'

--- a/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
+++ b/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
@@ -45,7 +45,7 @@ export function CapabilityMatrixGrid({
   const templateColumns = `260px repeat(${resources.length}, minmax(110px, 1fr))`
 
   function sortIndicator(resourceId: string): string {
-    if (!sort || sort.resourceId !== resourceId || !sort.direction) return '↕'
+    if (sort?.resourceId !== resourceId || !sort.direction) return '↕'
     return sort.direction === 'desc' ? '↓' : '↑'
   }
 

--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -42,10 +42,8 @@ export function CapabilityPage() {
     })
   }
 
-  const toggleSelectAll = (next: boolean) => {
-    if (next) setSelected(new Set(visibleAgents.map((a) => a.id)))
-    else setSelected(new Set())
-  }
+  const selectAllAgents = () => setSelected(new Set(visibleAgents.map((a) => a.id)))
+  const clearSelectedAgents = () => setSelected(new Set())
 
   const handleBulkApply = async ({
     resourceId,
@@ -211,7 +209,7 @@ export function CapabilityPage() {
             onCellClick={setInspected}
             selectedIds={selected}
             onToggleSelect={toggleSelect}
-            onToggleSelectAll={toggleSelectAll}
+            onToggleSelectAll={(next) => (next ? selectAllAgents() : clearSelectedAgents())}
           />
         )}
         {tab === 'resource' && matrix && (

--- a/dashboard/src/test/mockWebSocket.ts
+++ b/dashboard/src/test/mockWebSocket.ts
@@ -25,7 +25,7 @@
  * the `MockWebSocket.instances` registry doesn't leak across cases.
  */
 export class MockWebSocket {
-  static instances: MockWebSocket[] = []
+  static readonly instances: MockWebSocket[] = []
   static readonly OPEN = 1
   static readonly CLOSED = 3
 
@@ -76,5 +76,7 @@ export class MockWebSocket {
  * Call this in `beforeEach` to prevent cross-test pollution.
  */
 export function resetMockWebSockets(): void {
-  MockWebSocket.instances = []
+  // Mutate in place rather than reassigning so `instances` can stay readonly
+  // (the registry identity is stable; only its contents are cleared).
+  MockWebSocket.instances.length = 0
 }

--- a/dashboard/src/theme/useTheme.ts
+++ b/dashboard/src/theme/useTheme.ts
@@ -53,19 +53,19 @@ export interface UseThemeResult {
 }
 
 export function useTheme(): UseThemeResult {
-  const [theme, setThemeState] = useState<Theme>(getInitialTheme)
+  const [activeTheme, setActiveTheme] = useState<Theme>(getInitialTheme)
 
   // Keep the document root in sync with the active theme.
   useEffect(() => {
-    applyTheme(theme)
-  }, [theme])
+    applyTheme(activeTheme)
+  }, [activeTheme])
 
   // Follow OS changes only while the user has NOT made an explicit choice.
   useEffect(() => {
     if (typeof globalThis === 'undefined' || typeof globalThis.matchMedia !== 'function') return
     const mq = globalThis.matchMedia('(prefers-color-scheme: dark)')
     const onChange = (e: MediaQueryListEvent) => {
-      if (readStored() === null) setThemeState(e.matches ? 'dark' : 'light')
+      if (readStored() === null) setActiveTheme(e.matches ? 'dark' : 'light')
     }
     mq.addEventListener('change', onChange)
     return () => mq.removeEventListener('change', onChange)
@@ -77,12 +77,12 @@ export function useTheme(): UseThemeResult {
     } catch {
       /* storage unavailable (private mode) — theme still applies for the session */
     }
-    setThemeState(next)
+    setActiveTheme(next)
   }
 
   return {
-    theme,
+    theme: activeTheme,
     setTheme: persist,
-    toggleTheme: () => persist(theme === 'dark' ? 'light' : 'dark'),
+    toggleTheme: () => persist(activeTheme === 'dark' ? 'light' : 'dark'),
   }
 }


### PR DESCRIPTION
## Description

Resolves the 5 dashboard TypeScript SonarCloud code smells so the project drops from 8 → 3 open code smells (under the <5 target for AAASM-3391, Epic AAASM-3388). All changes are behaviour-preserving and confined to `dashboard/`.

| Rule | File:line | Fix |
|---|---|---|
| `typescript:S6754` | `dashboard/src/theme/useTheme.ts:56` | Rename raw `useState` pair to `activeTheme`/`setActiveTheme` so the value+setter convention holds; public hook API unchanged |
| `typescript:S1444` | `dashboard/src/test/mockWebSocket.ts:28` | Make static `instances` registry `readonly`; clear in place (`length = 0`) instead of reassigning |
| `typescript:S6582` | `dashboard/src/features/capability/CapabilityMatrixGrid.tsx:48` | Use an optional chain (`sort?.resourceId`) instead of `!sort` guard + member access |
| `typescript:S2301` | `dashboard/src/pages/CapabilityPage.tsx:46` | Split boolean-flag `toggleSelectAll` into `selectAllAgents`/`clearSelectedAgents`; dispatch the checkbox boolean at the prop boundary |
| `typescript:S7787` | `dashboard/src/features/alerts/index.ts:4` | Replace bare `export {}` placeholder with named re-exports of the feature's public surface |

The remaining 3 smells are all `rust:S3776` (cognitive complexity) in the policy engine (`aa-gateway`, `aa-proxy`, `aa-api`) — intentionally left untouched to avoid conflict with the parallel Rust bug-fix workstream. 3 < 5 ✅.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-3391 (Epic AAASM-3388)
- Related GitHub issues: N/A

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (behaviour-preserving refactors; existing suite covers the touched code)

Validation run in `dashboard/` — all green:
- `pnpm type-check` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (143 files, 1262 tests passed)
- `pnpm build` ✅

## Checklist

- [x] Code follows project style guidelines (TS lint/type-check clean)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
