### PR TITLE
[AAASM-3394] ✅ (aa-api): De-flake L1 policy-invalidation test (tolerance-based)

### DIFF
--- a/aa-api/tests/http_policy_invalidation.rs
+++ b/aa-api/tests/http_policy_invalidation.rs
@@ -4,14 +4,20 @@
 //! Proves the production wiring contract: when the aa-api `create_policy` HTTP
 //! handler and the gateway `InvalidationService` share ONE hub-attached
 //! `PolicyEngine`, a real `POST /api/v1/policies` causes a subscribed Assembly's
-//! L1 cache to be invalidated within 100 ms — with no direct `apply_yaml`/hub
-//! call in the test. The composition root (which shares the hub) is the only
-//! thing a real deployment must provide; this test stands it up in-process.
+//! L1 cache to be invalidated — with no direct `apply_yaml`/hub call in the
+//! test. The composition root (which shares the hub) is the only thing a real
+//! deployment must provide; this test stands it up in-process.
+//!
+//! Correctness, not latency, is what this test guards: it asserts the
+//! invalidation DOES propagate to the subscriber. A generous, CI-load-tolerant
+//! timeout bounds the wait so a genuinely broken wiring fails fast; it is not a
+//! tight wall-clock budget (that flaked under parallel-CPU contention,
+//! AAASM-3394).
 
 mod common;
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -24,7 +30,7 @@ use aa_runtime::invalidation_client::{InvalidationClient, InvalidationSink};
 use aa_runtime::l1_cache::PolicyL1Cache;
 
 #[tokio::test]
-async fn http_policy_mutation_invalidates_subscribed_l1_within_100ms() {
+async fn http_policy_mutation_invalidates_subscribed_l1() {
     // ── aa-api HTTP app on a hub-attached engine ────────────────────────────
     let state = common::test_state();
     // The composition root shares this exact hub between the HTTP engine and
@@ -73,7 +79,6 @@ async fn http_policy_mutation_invalidates_subscribed_l1_within_100ms() {
             serde_json::json!({ "policy_yaml": "tools:\n  bash:\n    allow: false\n" }).to_string(),
         ))
         .expect("build create_policy request");
-    let start = Instant::now();
     let response = app.oneshot(request).await.expect("create_policy request");
     assert_eq!(
         response.status(),
@@ -81,15 +86,17 @@ async fn http_policy_mutation_invalidates_subscribed_l1_within_100ms() {
         "create_policy should return 201"
     );
 
-    // The subscribed L1 entry must disappear within 100 ms of the HTTP mutation.
-    tokio::time::timeout(Duration::from_millis(100), async {
+    // Correctness assertion: the subscribed L1 entry MUST be invalidated as a
+    // result of the HTTP mutation. The timeout is generous so this stays
+    // deterministic under CI parallel-CPU contention; it bounds the wait only so
+    // a genuinely broken push-invalidation wiring fails fast rather than hanging.
+    tokio::time::timeout(Duration::from_secs(5), async {
         while cache.contains("agent-x") {
             tokio::time::sleep(Duration::from_millis(1)).await;
         }
     })
     .await
-    .expect("HTTP policy mutation invalidated the subscribed L1 within 100 ms");
-    assert!(start.elapsed() < Duration::from_millis(100));
+    .expect("HTTP policy mutation must invalidate the subscribed L1 cache");
 
     client.abort();
     server.abort();


### PR DESCRIPTION
## Description

The `aa-api` integration test `http_policy_invalidation::http_policy_mutation_invalidates_subscribed_l1_within_100ms` asserted a hardcoded `<100ms` wall-clock budget on how fast an HTTP policy mutation propagated through the push-invalidation channel to a subscribed Assembly's L1 cache. It passed in isolation but flaked repeatedly under CI parallel-CPU contention (observed across multiple PRs).

This PR de-flakes the test while keeping its real intent — "a policy mutation invalidates the subscribed L1 cache" — strongly asserted. Changes:

- Replace the tight 100ms timeout + hard `assert!(start.elapsed() < 100ms)` with a deterministic poll-until-invalidated check bounded by a generous, CI-load-tolerant 5s timeout. The test still fails fast if the wiring is genuinely broken; it no longer fails on a latency budget that parallel-CPU contention can violate.
- Drop the now-unused `Instant` import and the wall-clock measurement.
- Rename the test to `http_policy_mutation_invalidates_subscribed_l1` (the `_within_100ms` suffix was misleading).
- Update the module doc comment to state the test guards correctness, not latency.

The correctness assertion (invalidation does occur, propagated through the real gRPC `InvalidationService` over loopback) is unchanged in strength.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

(Test-stability fix; closest category is CI.)

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-3394

Closes AAASM-3394

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

- `cargo build -p aa-api` — green.
- `cargo fmt -p aa-api` + `cargo clippy -p aa-api --all-targets` — clean.
- Ran the test 5× in isolation: 5/5 pass.
- Ran the test 8× under full 16-core CPU saturation (`yes` on every core) to reproduce the parallel-contention condition that caused the flake: 8/8 pass. The previous tight 100ms budget would have flaked under this load.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
