### PR TITLE
[AAASM-3396] ✨ (aa-sdk-client): Gateway Register + credential_token for live-core enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "prost",
  "sha2 0.11.0",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,9 +464,12 @@ dependencies = [
  "aa-proto",
  "aa-security",
  "bs58",
+ "ed25519-dalek",
+ "hex",
  "prost",
  "sha2 0.11.0",
  "tokio",
+ "tonic",
  "tracing",
 ]
 

--- a/aa-sdk-client/Cargo.toml
+++ b/aa-sdk-client/Cargo.toml
@@ -16,8 +16,15 @@ aa-proto = { path = "../aa-proto" }
 aa-security = { path = "../aa-security", optional = true }
 # did:key derivation for gateway registration identity (AAASM-3387).
 bs58 = "0.5"
+# Deterministic Ed25519 keypair backing the registration did:key + public_key
+# (AAASM-3396); the gateway validates public_key as a real Ed25519 verifying key.
+ed25519-dalek = { version = "2", features = ["std"] }
+hex = { workspace = true }
 prost = { workspace = true }
 sha2 = { workspace = true }
+# Direct gateway gRPC Register client (AAASM-3396). CheckAction stays via the
+# runtime UDS forward; only AgentLifecycleService.Register is called directly.
+tonic = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "sync", "time", "io-util", "macros"] }
 tracing = { workspace = true }
 

--- a/aa-sdk-client/Cargo.toml
+++ b/aa-sdk-client/Cargo.toml
@@ -37,7 +37,9 @@ default = ["preflight"]
 preflight = ["dep:aa-security"]
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util", "rt", "sync", "macros", "net", "io-util"] }
+tokio = { workspace = true, features = ["test-util", "rt", "rt-multi-thread", "sync", "macros", "net", "io-util"] }
+# Mock gateway gRPC server for the with-core register+check test (AAASM-3398).
+tokio-stream = { workspace = true }
 
 [lints]
 workspace = true

--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -10,7 +10,9 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Duration;
 
+use crate::config::AssemblyConfig;
 use crate::error::SdkClientError;
+use crate::gateway::{build_register_request, GatewayRegistrationClient};
 use crate::ipc::{IpcCommand, IpcHandle};
 #[cfg(feature = "preflight")]
 use crate::preflight::Preflight;
@@ -28,6 +30,10 @@ const QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct AssemblyClient {
     inner: Mutex<Option<IpcHandle>>,
     detected_frameworks: Vec<String>,
+    /// Credential token issued by the gateway at [`register`](Self::register).
+    /// `None` until registration succeeds; attached to every `CheckActionRequest`
+    /// so the gateway's `validate_credential_token` does not deny the call.
+    credential_token: Mutex<Option<String>>,
     #[cfg(feature = "preflight")]
     preflight: Option<Preflight>,
 }
@@ -39,6 +45,7 @@ impl AssemblyClient {
         Self {
             inner: Mutex::new(Some(ipc_handle)),
             detected_frameworks,
+            credential_token: Mutex::new(None),
             #[cfg(feature = "preflight")]
             preflight: Some(Preflight::new()),
         }
@@ -57,6 +64,7 @@ impl AssemblyClient {
         Self {
             inner: Mutex::new(Some(ipc_handle)),
             detected_frameworks,
+            credential_token: Mutex::new(None),
             preflight,
         }
     }
@@ -75,6 +83,43 @@ impl AssemblyClient {
     #[cfg(not(feature = "preflight"))]
     fn apply_preflight(&self, details: String) -> String {
         details
+    }
+
+    /// Register this agent with the governance gateway over a direct gRPC call
+    /// and store the issued `credential_token`.
+    ///
+    /// Per ADR 0004 this is the *only* direct SDK→gateway call; `CheckAction`
+    /// continues to flow through the `aa-runtime` UDS forward. The stored token
+    /// is then attached to every [`query_policy`](Self::query_policy) request so
+    /// the gateway's `validate_credential_token` does not deny a registered
+    /// agent.
+    ///
+    /// `config` supplies the agent identity (its `agent_id` is derived into a
+    /// `did:key` + a consistent Ed25519 `public_key`) and the gateway gRPC
+    /// endpoint. Returns the assigned policy id from the gateway on success.
+    pub async fn register(
+        &self,
+        config: &AssemblyConfig,
+        name: String,
+        framework: String,
+    ) -> Result<String, SdkClientError> {
+        let endpoint = config.resolve_gateway_endpoint();
+        let request = build_register_request(config, name, framework);
+
+        let mut client = GatewayRegistrationClient::connect(endpoint).await?;
+        let response = client.register(request).await?;
+
+        {
+            let mut guard = self.credential_token.lock().map_err(|_| SdkClientError::LockPoisoned)?;
+            *guard = Some(response.credential_token);
+        }
+
+        Ok(response.assigned_policy)
+    }
+
+    /// Return the stored gateway credential token, if registration has run.
+    pub fn credential_token(&self) -> Option<String> {
+        self.credential_token.lock().ok().and_then(|g| g.clone())
     }
 
     /// Enqueue an already-built event onto the IPC command channel.

--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -219,8 +219,18 @@ impl AssemblyClient {
     /// release it around this call, since it blocks the calling thread.
     pub fn query_policy(
         &self,
-        request: aa_proto::assembly::policy::v1::CheckActionRequest,
+        mut request: aa_proto::assembly::policy::v1::CheckActionRequest,
     ) -> Result<aa_proto::assembly::policy::v1::CheckActionResponse, SdkClientError> {
+        // Attach the credential token issued at registration so the gateway's
+        // `validate_credential_token` does not deny a registered agent. Only
+        // fill it when the caller did not supply one, so an explicitly-set
+        // token still wins. The check is forwarded verbatim by the runtime.
+        if request.credential_token.is_empty() {
+            if let Some(token) = self.credential_token() {
+                request.credential_token = token;
+            }
+        }
+
         let (resp_tx, resp_rx) = std::sync::mpsc::channel();
 
         // Enqueue under the lock, then release it before blocking on the

--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -423,6 +423,62 @@ mod tests {
         }
     }
 
+    /// Test-only seam: set the stored credential token without a live gateway.
+    /// The end-to-end registered path is covered by the with-core gateway test.
+    impl AssemblyClient {
+        fn set_credential_token_for_test(&self, token: &str) {
+            *self.credential_token.lock().unwrap() = Some(token.to_string());
+        }
+    }
+
+    #[test]
+    fn query_policy_attaches_stored_credential_token() {
+        use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse};
+
+        let (client, mut rx) = test_client(vec![]);
+        client.set_credential_token_for_test("tok-abc");
+
+        // Run query_policy on a thread and answer it from the test thread so the
+        // blocking recv_timeout does not deadlock.
+        let handle = std::thread::spawn(move || {
+            client.query_policy(CheckActionRequest::default()).unwrap();
+        });
+
+        match rx.blocking_recv().expect("should receive a command") {
+            IpcCommand::QueryPolicy { request, resp } => {
+                assert_eq!(request.credential_token, "tok-abc");
+                resp.send(CheckActionResponse::default()).unwrap();
+            }
+            other => panic!("expected QueryPolicy, got {other:?}"),
+        }
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn query_policy_keeps_explicit_credential_token() {
+        use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse};
+
+        let (client, mut rx) = test_client(vec![]);
+        client.set_credential_token_for_test("stored-tok");
+
+        let explicit = CheckActionRequest {
+            credential_token: "explicit-tok".to_string(),
+            ..Default::default()
+        };
+        let handle = std::thread::spawn(move || {
+            client.query_policy(explicit).unwrap();
+        });
+
+        match rx.blocking_recv().expect("should receive a command") {
+            IpcCommand::QueryPolicy { request, resp } => {
+                assert_eq!(request.credential_token, "explicit-tok");
+                resp.send(CheckActionResponse::default()).unwrap();
+            }
+            other => panic!("expected QueryPolicy, got {other:?}"),
+        }
+        handle.join().unwrap();
+    }
+
     #[cfg(feature = "preflight")]
     #[test]
     fn report_event_with_preflight_disabled_passes_details_through() {

--- a/aa-sdk-client/src/config.rs
+++ b/aa-sdk-client/src/config.rs
@@ -6,6 +6,12 @@
 use std::env;
 use std::path::PathBuf;
 
+/// Default gateway gRPC endpoint, matching `aa-runtime`'s
+/// `AA_GATEWAY_ENDPOINT` default. This is the **gRPC** port (`:50051`) that
+/// serves `AgentLifecycleService` / `PolicyService` — *not* the gateway's
+/// `:8080` HTTP/OpenAPI surface that some docs reference for REST.
+pub const DEFAULT_GATEWAY_ENDPOINT: &str = "http://127.0.0.1:50051";
+
 /// Configuration for connecting to `aa-runtime`.
 #[derive(Debug, Clone)]
 pub struct AssemblyConfig {
@@ -13,6 +19,9 @@ pub struct AssemblyConfig {
     pub agent_id: String,
     /// Explicit socket path override. When `None`, resolved from env or default.
     pub socket_path: Option<String>,
+    /// Explicit gateway gRPC endpoint override (e.g. `"http://127.0.0.1:50051"`).
+    /// When `None`, resolved from env or [`DEFAULT_GATEWAY_ENDPOINT`].
+    pub gateway_endpoint: Option<String>,
 }
 
 impl AssemblyConfig {
@@ -36,6 +45,32 @@ impl AssemblyConfig {
         PathBuf::from(format!("/tmp/aa-runtime-{}.sock", self.agent_id))
     }
 
+    /// Resolve the gateway gRPC endpoint to use for registration.
+    ///
+    /// Resolution order:
+    /// 1. Explicit `gateway_endpoint` if provided
+    /// 2. `AA_GATEWAY_ENDPOINT` environment variable (the same knob
+    ///    `aa-runtime` reads)
+    /// 3. Default: [`DEFAULT_GATEWAY_ENDPOINT`] (`http://127.0.0.1:50051`)
+    ///
+    /// Note this is the gRPC `:50051` endpoint, not the gateway's `:8080`
+    /// HTTP/OpenAPI URL.
+    pub fn resolve_gateway_endpoint(&self) -> String {
+        if let Some(ref endpoint) = self.gateway_endpoint {
+            if !endpoint.is_empty() {
+                return endpoint.clone();
+            }
+        }
+
+        if let Ok(env_endpoint) = env::var("AA_GATEWAY_ENDPOINT") {
+            if !env_endpoint.is_empty() {
+                return env_endpoint;
+            }
+        }
+
+        DEFAULT_GATEWAY_ENDPOINT.to_string()
+    }
+
     /// Return the agent identity to send on gateway registration.
     ///
     /// The gateway's `AgentLifecycleService.Register` rejects a plain
@@ -56,6 +91,7 @@ mod tests {
         AssemblyConfig {
             agent_id: agent_id.to_string(),
             socket_path: socket_path.map(|s| s.to_string()),
+            gateway_endpoint: None,
         }
     }
 
@@ -74,6 +110,23 @@ mod tests {
             config.resolve_socket_path(),
             PathBuf::from("/tmp/aa-runtime-my-agent.sock")
         );
+    }
+
+    #[test]
+    fn resolve_gateway_uses_explicit_endpoint() {
+        let config = AssemblyConfig {
+            agent_id: "a".into(),
+            socket_path: None,
+            gateway_endpoint: Some("http://gw.example:50051".into()),
+        };
+        assert_eq!(config.resolve_gateway_endpoint(), "http://gw.example:50051");
+    }
+
+    #[test]
+    fn resolve_gateway_falls_back_to_default() {
+        env::remove_var("AA_GATEWAY_ENDPOINT");
+        let config = make_config("a", None);
+        assert_eq!(config.resolve_gateway_endpoint(), DEFAULT_GATEWAY_ENDPOINT);
     }
 
     #[test]

--- a/aa-sdk-client/src/error.rs
+++ b/aa-sdk-client/src/error.rs
@@ -19,6 +19,11 @@ pub enum SdkClientError {
     /// within the timeout, or the IPC connection closed before a response
     /// arrived. Callers should treat this as *fail-open* (the SDK is advisory).
     QueryFailed,
+    /// The gateway gRPC endpoint could not be reached for registration.
+    GatewayUnreachable,
+    /// The gateway rejected the `Register` call. Carries the gRPC status message
+    /// (e.g. an invalid did:key or public_key).
+    RegisterFailed(String),
 }
 
 impl std::fmt::Display for SdkClientError {
@@ -33,6 +38,12 @@ impl std::fmt::Display for SdkClientError {
             }
             SdkClientError::QueryFailed => {
                 write!(f, "policy query failed: runtime did not respond in time")
+            }
+            SdkClientError::GatewayUnreachable => {
+                write!(f, "gateway gRPC endpoint is unreachable for registration")
+            }
+            SdkClientError::RegisterFailed(msg) => {
+                write!(f, "gateway rejected registration: {msg}")
             }
         }
     }

--- a/aa-sdk-client/src/gateway.rs
+++ b/aa-sdk-client/src/gateway.rs
@@ -1,0 +1,105 @@
+//! Direct gateway gRPC client for agent registration (AAASM-3396).
+//!
+//! Per ADR 0004, the SDK enforcement path is SDK → `aa-sdk-client` → core.
+//! `CheckAction` reaches the gateway via the `aa-runtime` UDS forward and stays
+//! that way. The one gap this module closes is **registration**: nothing on the
+//! SDK path called `AgentLifecycleService.Register`, so the gateway never issued
+//! a `credential_token` — and a registered agent's later `CheckAction` would be
+//! denied by the gateway's `validate_credential_token` for lacking one.
+//!
+//! This module gives `aa-sdk-client` a *direct* gRPC client to the gateway's
+//! `AgentLifecycleService.Register` RPC. The returned `credential_token` is held
+//! by the [`AssemblyClient`](crate::client::AssemblyClient) and attached to
+//! subsequent `CheckActionRequest`s (see `query_policy`).
+
+use aa_proto::assembly::agent::v1::agent_lifecycle_service_client::AgentLifecycleServiceClient;
+use aa_proto::assembly::agent::v1::{RegisterRequest, RegisterResponse};
+use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
+use tonic::transport::Channel;
+
+use crate::config::AssemblyConfig;
+use crate::error::SdkClientError;
+use crate::keypair::AgentKeypair;
+
+/// Thin wrapper over the generated `AgentLifecycleServiceClient`, scoped to the
+/// SDK's only direct gateway call: `Register`.
+pub struct GatewayRegistrationClient {
+    client: AgentLifecycleServiceClient<Channel>,
+}
+
+impl GatewayRegistrationClient {
+    /// Connect to the gateway gRPC endpoint (e.g. `"http://127.0.0.1:50051"`).
+    pub async fn connect(endpoint: String) -> Result<Self, SdkClientError> {
+        let client = AgentLifecycleServiceClient::connect(endpoint)
+            .await
+            .map_err(|_| SdkClientError::GatewayUnreachable)?;
+        Ok(Self { client })
+    }
+
+    /// Call `AgentLifecycleService.Register` and return the response.
+    pub async fn register(&mut self, request: RegisterRequest) -> Result<RegisterResponse, SdkClientError> {
+        let resp = self
+            .client
+            .register(request)
+            .await
+            .map_err(|status| SdkClientError::RegisterFailed(status.message().to_string()))?;
+        Ok(resp.into_inner())
+    }
+}
+
+/// Build the `RegisterRequest` the gateway requires from the SDK config.
+///
+/// Derives a deterministic [`AgentKeypair`] from `config.agent_id` so the
+/// `agent_id` did:key and the `public_key` hex encode the *same* valid Ed25519
+/// key — both of which the gateway validates at registration.
+pub fn build_register_request(config: &AssemblyConfig, name: String, framework: String) -> RegisterRequest {
+    let keypair = AgentKeypair::derive(&config.agent_id);
+
+    RegisterRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: String::new(),
+            team_id: String::new(),
+            agent_id: config.registration_did(),
+        }),
+        name,
+        framework,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        public_key: keypair.public_key_hex(),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(agent_id: &str) -> AssemblyConfig {
+        AssemblyConfig {
+            agent_id: agent_id.to_string(),
+            socket_path: None,
+            gateway_endpoint: None,
+        }
+    }
+
+    #[test]
+    fn register_request_carries_did_and_consistent_public_key() {
+        let config = cfg("my-agent");
+        let req = build_register_request(&config, "My Agent".into(), "custom".into());
+
+        let agent_id = req.agent_id.expect("agent_id must be set");
+        assert!(agent_id.agent_id.starts_with("did:key:z"), "got {}", agent_id.agent_id);
+        assert_eq!(req.name, "My Agent");
+        assert_eq!(req.framework, "custom");
+
+        // public_key must be 64 hex chars (32-byte Ed25519 key) — the gateway
+        // rejects anything else.
+        assert_eq!(req.public_key.len(), 64);
+
+        // The did:key and the public_key must encode the same key.
+        let pk_bytes = hex::decode(&req.public_key).unwrap();
+        let did_payload = bs58::decode(agent_id.agent_id.strip_prefix("did:key:z").unwrap())
+            .into_vec()
+            .unwrap();
+        assert_eq!(&did_payload[2..], pk_bytes.as_slice());
+    }
+}

--- a/aa-sdk-client/src/identity.rs
+++ b/aa-sdk-client/src/identity.rs
@@ -9,29 +9,31 @@
 //!
 //! The derivation is **deterministic**: the same input always yields the same
 //! DID, so an agent keeps a stable identity across process restarts without
-//! having to persist a keypair. Bytes are produced by hashing the input with
-//! SHA-256, then wrapped as an Ed25519 `did:key` (multicodec `0xed 0x01`,
-//! base58btc multibase). The resulting DID has the canonical `did:key:z6Mk…`
-//! shape and passes the gateway's syntactic `did:key` validation.
+//! having to persist a keypair. The DID encodes a real Ed25519 verifying key
+//! deterministically derived from the input (see [`crate::keypair`]), wrapped
+//! as an Ed25519 `did:key` (multicodec `0xed 0x01`, base58btc multibase). The
+//! resulting DID has the canonical `did:key:z6Mk…` shape, passes the gateway's
+//! syntactic `did:key` validation, and is bound to the same key the gateway
+//! receives in the `public_key` field at registration (AAASM-3396).
 
-use sha2::{Digest, Sha256};
-
-/// Multicodec prefix for an Ed25519 public key (`0xed`), varint-encoded as
-/// the two bytes `0xed 0x01`. A `did:key` for Ed25519 is the base58btc
-/// multibase encoding of these two bytes followed by the 32-byte key.
-const ED25519_MULTICODEC_PREFIX: [u8; 2] = [0xed, 0x01];
+use crate::keypair::AgentKeypair;
 
 /// Length, in bytes, of an Ed25519 public key.
+#[cfg(test)]
 const ED25519_PUBLIC_KEY_LEN: usize = 32;
+
+/// Multicodec prefix for an Ed25519 public key, used by the tests below.
+#[cfg(test)]
+const ED25519_MULTICODEC_PREFIX: [u8; 2] = [0xed, 0x01];
 
 /// Derive a deterministic, conformant Ed25519 `did:key` DID from a plain agent
 /// identifier.
 ///
 /// The returned string has the shape `did:key:z<base58btc>` where the decoded
-/// multibase value is `[0xed, 0x01]` followed by 32 deterministic bytes derived
-/// from `identity`. This is accepted by the gateway's `did:key` validation,
-/// which checks the `did:key:` prefix, the `z` base58btc multibase marker, and
-/// that the value decodes to non-empty bytes.
+/// multibase value is `[0xed, 0x01]` followed by the 32-byte Ed25519 verifying
+/// key deterministically derived from `identity`. This is accepted by the
+/// gateway's `did:key` validation and binds the DID to the same key that
+/// [`AgentKeypair::public_key_hex`] supplies as the registration `public_key`.
 ///
 /// If `identity` is already a `did:key` DID (it starts with `did:key:`), it is
 /// returned unchanged so callers can pass through an explicitly-provisioned DID.
@@ -40,19 +42,7 @@ pub fn agent_id_to_did_key(identity: &str) -> String {
         return identity.to_string();
     }
 
-    // Derive a stable 32-byte value to stand in for an Ed25519 public key. No
-    // keypair is provisioned at this layer, so the DID identifies the agent by
-    // its configured identifier rather than by a verifiable signing key.
-    let digest = Sha256::digest(identity.as_bytes());
-    let mut key_bytes = [0u8; ED25519_PUBLIC_KEY_LEN];
-    key_bytes.copy_from_slice(&digest[..ED25519_PUBLIC_KEY_LEN]);
-
-    let mut multicodec = Vec::with_capacity(ED25519_MULTICODEC_PREFIX.len() + ED25519_PUBLIC_KEY_LEN);
-    multicodec.extend_from_slice(&ED25519_MULTICODEC_PREFIX);
-    multicodec.extend_from_slice(&key_bytes);
-
-    let multibase = bs58::encode(&multicodec).into_string();
-    format!("did:key:z{multibase}")
+    AgentKeypair::derive(identity).did_key()
 }
 
 #[cfg(test)]

--- a/aa-sdk-client/src/keypair.rs
+++ b/aa-sdk-client/src/keypair.rs
@@ -1,0 +1,122 @@
+//! Deterministic Ed25519 keypair derivation for gateway registration.
+//!
+//! The gateway's `AgentLifecycleService.Register` requires *both* a
+//! syntactically-valid `did:key` agent identity *and* a real Ed25519
+//! `public_key` (32 bytes, hex-encoded — see
+//! `aa-gateway/src/service/lifecycle_service.rs`, which calls
+//! `VerifyingKey::from_bytes` on the decoded hex). A bare SHA-256 hash is not a
+//! valid Ed25519 verifying key, so the registration identity and the
+//! `public_key` field must both come from one real keypair to stay consistent.
+//!
+//! SDKs configure agents with a human-readable identifier rather than a
+//! provisioned keypair, so this module derives a **deterministic** keypair from
+//! that identifier: the same agent id always yields the same keypair, giving a
+//! stable identity across process restarts without persisting key material. The
+//! seed is `SHA-256(identifier)`, fed to [`SigningKey::from_bytes`]; the
+//! resulting [`VerifyingKey`] backs both the `did:key` and the `public_key`.
+
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+/// Multicodec prefix for an Ed25519 public key (`0xed`), varint-encoded as the
+/// two bytes `0xed 0x01`. An Ed25519 `did:key` is the base58btc multibase
+/// encoding of these two bytes followed by the 32-byte verifying key.
+const ED25519_MULTICODEC_PREFIX: [u8; 2] = [0xed, 0x01];
+
+/// A deterministic Ed25519 keypair derived from an agent identifier.
+///
+/// Holds the signing key purely so the verifying key (and the identity values
+/// derived from it) are guaranteed to come from a genuine, valid Ed25519
+/// keypair that the gateway will accept.
+pub struct AgentKeypair {
+    verifying_key: VerifyingKey,
+}
+
+impl AgentKeypair {
+    /// Derive the deterministic keypair for `identifier`.
+    ///
+    /// The seed is `SHA-256(identifier)` (always 32 bytes), which is a valid
+    /// Ed25519 secret scalar seed, so derivation never fails.
+    pub fn derive(identifier: &str) -> Self {
+        let seed: [u8; 32] = Sha256::digest(identifier.as_bytes()).into();
+        let signing_key = SigningKey::from_bytes(&seed);
+        Self {
+            verifying_key: signing_key.verifying_key(),
+        }
+    }
+
+    /// The 32-byte Ed25519 verifying (public) key.
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.verifying_key.to_bytes()
+    }
+
+    /// The verifying key hex-encoded, as the gateway's `public_key` field
+    /// expects (64 lowercase hex chars).
+    pub fn public_key_hex(&self) -> String {
+        hex::encode(self.public_key_bytes())
+    }
+
+    /// The canonical Ed25519 `did:key` for this keypair: the base58btc
+    /// multibase (`z` prefix) of `0xed 0x01` followed by the 32-byte verifying
+    /// key. Passes the gateway's `did:key` validation and binds the DID to the
+    /// same key as [`public_key_hex`](Self::public_key_hex).
+    pub fn did_key(&self) -> String {
+        let mut multicodec = Vec::with_capacity(ED25519_MULTICODEC_PREFIX.len() + 32);
+        multicodec.extend_from_slice(&ED25519_MULTICODEC_PREFIX);
+        multicodec.extend_from_slice(&self.public_key_bytes());
+        let multibase = bs58::encode(&multicodec).into_string();
+        format!("did:key:z{multibase}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derivation_is_deterministic() {
+        assert_eq!(
+            AgentKeypair::derive("agent-a").public_key_hex(),
+            AgentKeypair::derive("agent-a").public_key_hex()
+        );
+    }
+
+    #[test]
+    fn distinct_identifiers_yield_distinct_keys() {
+        assert_ne!(
+            AgentKeypair::derive("agent-a").public_key_hex(),
+            AgentKeypair::derive("agent-b").public_key_hex()
+        );
+    }
+
+    #[test]
+    fn public_key_hex_is_64_chars() {
+        let hex = AgentKeypair::derive("any").public_key_hex();
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn public_key_is_a_valid_ed25519_verifying_key() {
+        // Mirror the gateway's acceptance check: decode hex and parse as a key.
+        let kp = AgentKeypair::derive("gateway-accepts-me");
+        let bytes = hex::decode(kp.public_key_hex()).unwrap();
+        let arr: [u8; 32] = bytes.try_into().unwrap();
+        VerifyingKey::from_bytes(&arr).expect("public_key must be a valid Ed25519 key");
+    }
+
+    #[test]
+    fn did_key_uses_canonical_ed25519_prefix() {
+        let did = AgentKeypair::derive("anything").did_key();
+        assert!(did.starts_with("did:key:z6Mk"), "got {did}");
+    }
+
+    #[test]
+    fn did_key_and_public_key_encode_the_same_key() {
+        let kp = AgentKeypair::derive("consistency");
+        let encoded = kp.did_key().strip_prefix("did:key:z").unwrap().to_string();
+        let decoded = bs58::decode(encoded).into_vec().unwrap();
+        // Strip the 0xed 0x01 multicodec prefix; the rest must equal the pubkey.
+        assert_eq!(&decoded[2..], &kp.public_key_bytes());
+    }
+}

--- a/aa-sdk-client/src/lib.rs
+++ b/aa-sdk-client/src/lib.rs
@@ -29,6 +29,7 @@ pub mod client;
 pub mod codec;
 pub mod config;
 pub mod error;
+pub mod gateway;
 pub mod identity;
 pub mod ipc;
 pub mod keypair;

--- a/aa-sdk-client/src/lib.rs
+++ b/aa-sdk-client/src/lib.rs
@@ -31,6 +31,7 @@ pub mod config;
 pub mod error;
 pub mod identity;
 pub mod ipc;
+pub mod keypair;
 #[cfg(feature = "preflight")]
 pub mod preflight;
 
@@ -38,5 +39,6 @@ pub use client::AssemblyClient;
 pub use config::AssemblyConfig;
 pub use error::SdkClientError;
 pub use identity::agent_id_to_did_key;
+pub use keypair::AgentKeypair;
 #[cfg(feature = "preflight")]
 pub use preflight::Preflight;

--- a/aa-sdk-client/tests/gateway_register_with_core.rs
+++ b/aa-sdk-client/tests/gateway_register_with_core.rs
@@ -1,0 +1,192 @@
+//! AAASM-3398 with-core acceptance: `AssemblyClient::register` against a live
+//! (mock) gateway gRPC `AgentLifecycleService` issues a `credential_token`, and
+//! that token is carried on a subsequent `CheckAction` so the gateway can
+//! authenticate the registered agent and surface a `DENY`.
+//!
+//! This exercises the full ADR 0004 path the SDK is responsible for: the direct
+//! SDK→gateway Register call (real tonic), the token being stored, and the token
+//! riding on the `CheckActionRequest` that the runtime forwards to the gateway's
+//! `PolicyService`. The runtime is represented by a forwarder task that relays
+//! the `IpcCommand::QueryPolicy` request to the mock gateway and returns its
+//! response — the same hop a real `aa-runtime` performs.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::{
+    AgentLifecycleService, AgentLifecycleServiceServer,
+};
+use aa_proto::assembly::agent::v1::{
+    ControlCommand, ControlStreamRequest, DeregisterRequest, DeregisterResponse, HeartbeatRequest, HeartbeatResponse,
+    RegisterRequest, RegisterResponse,
+};
+use aa_proto::assembly::common::v1::Decision;
+use aa_proto::assembly::policy::v1::policy_service_server::{PolicyService, PolicyServiceServer};
+use aa_proto::assembly::policy::v1::{
+    BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse, OpControlMessage,
+    OpControlSubscribeRequest,
+};
+use aa_sdk_client::ipc::{IpcCommand, IpcHandle};
+use aa_sdk_client::{AssemblyClient, AssemblyConfig};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
+use tonic::{Request, Response, Status};
+
+const ISSUED_TOKEN: &str = "issued-credential-token-xyz";
+
+/// Mock gateway `AgentLifecycleService` — validates the inbound did:key +
+/// public_key (mirroring the real gateway) and issues a fixed token.
+#[derive(Default)]
+struct MockLifecycle;
+
+#[tonic::async_trait]
+impl AgentLifecycleService for MockLifecycle {
+    async fn register(&self, request: Request<RegisterRequest>) -> Result<Response<RegisterResponse>, Status> {
+        let req = request.into_inner();
+        let agent_id = req
+            .agent_id
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing agent_id"))?;
+        if !agent_id.agent_id.starts_with("did:key:z") {
+            return Err(Status::invalid_argument("agent_id is not a did:key"));
+        }
+        // The real gateway requires a 32-byte (64 hex char) Ed25519 key.
+        if req.public_key.len() != 64 || hex::decode(&req.public_key).is_err() {
+            return Err(Status::invalid_argument("public_key must be 64 hex chars"));
+        }
+        Ok(Response::new(RegisterResponse {
+            credential_token: ISSUED_TOKEN.to_string(),
+            assigned_policy: "default-policy".to_string(),
+            heartbeat_interval_sec: 30,
+            ..Default::default()
+        }))
+    }
+
+    async fn heartbeat(&self, _: Request<HeartbeatRequest>) -> Result<Response<HeartbeatResponse>, Status> {
+        Err(Status::unimplemented("not used in this test"))
+    }
+
+    async fn deregister(&self, _: Request<DeregisterRequest>) -> Result<Response<DeregisterResponse>, Status> {
+        Err(Status::unimplemented("not used in this test"))
+    }
+
+    type ControlStreamStream = ReceiverStream<Result<ControlCommand, Status>>;
+
+    async fn control_stream(
+        &self,
+        _: Request<ControlStreamRequest>,
+    ) -> Result<Response<Self::ControlStreamStream>, Status> {
+        Err(Status::unimplemented("not used in this test"))
+    }
+}
+
+/// Mock gateway `PolicyService` — records the credential token it sees and
+/// denies every action, standing in for an authenticated deny decision.
+struct MockPolicy {
+    seen_token: Arc<StdMutex<Option<String>>>,
+}
+
+#[tonic::async_trait]
+impl PolicyService for MockPolicy {
+    async fn check_action(
+        &self,
+        request: Request<CheckActionRequest>,
+    ) -> Result<Response<CheckActionResponse>, Status> {
+        let req = request.into_inner();
+        *self.seen_token.lock().unwrap() = Some(req.credential_token.clone());
+        Ok(Response::new(CheckActionResponse {
+            decision: Decision::Deny as i32,
+            reason: "denied by mock policy".to_string(),
+            ..Default::default()
+        }))
+    }
+
+    async fn batch_check(&self, _: Request<BatchCheckRequest>) -> Result<Response<BatchCheckResponse>, Status> {
+        Err(Status::unimplemented("not used in this test"))
+    }
+
+    type OpControlStreamStream = ReceiverStream<Result<OpControlMessage, Status>>;
+
+    async fn op_control_stream(
+        &self,
+        _: Request<OpControlSubscribeRequest>,
+    ) -> Result<Response<Self::OpControlStreamStream>, Status> {
+        Err(Status::unimplemented("not used in this test"))
+    }
+}
+
+/// Start both mock gateway services on one ephemeral port.
+async fn start_gateway(seen_token: Arc<StdMutex<Option<String>>>) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let policy = MockPolicy { seen_token };
+
+    tokio::spawn(async move {
+        let incoming = TcpListenerStream::new(listener);
+        tonic::transport::Server::builder()
+            .add_service(AgentLifecycleServiceServer::new(MockLifecycle))
+            .add_service(PolicyServiceServer::new(policy))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+    addr
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn register_then_check_carries_token_and_surfaces_deny() {
+    let seen_token = Arc::new(StdMutex::new(None));
+    let addr = start_gateway(seen_token.clone()).await;
+    let endpoint = format!("http://{addr}");
+
+    // Build a client over an in-process IPC channel that a forwarder task drains
+    // (the "runtime" hop). query_policy blocking-sends onto this channel.
+    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<IpcCommand>(16);
+    let ipc = IpcHandle { cmd_tx, thread: None };
+    let client = Arc::new(AssemblyClient::new(ipc, vec![]));
+
+    let config = AssemblyConfig {
+        agent_id: "with-core-agent".to_string(),
+        socket_path: None,
+        gateway_endpoint: Some(endpoint.clone()),
+    };
+
+    // 1) Register directly against the mock gateway — issues + stores the token.
+    let assigned = client
+        .register(&config, "with-core-agent".into(), "custom".into())
+        .await
+        .expect("register against live gateway should succeed");
+    assert_eq!(assigned, "default-policy");
+    assert_eq!(client.credential_token().as_deref(), Some(ISSUED_TOKEN));
+
+    // 2) Forwarder task: drain one QueryPolicy command and relay it to the mock
+    //    gateway PolicyService over gRPC, mirroring the aa-runtime forward.
+    let forwarder = tokio::spawn(async move {
+        if let Some(IpcCommand::QueryPolicy { request, resp }) = cmd_rx.recv().await {
+            let mut gw = aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient::connect(endpoint)
+                .await
+                .unwrap();
+            let decision = gw.check_action(*request).await.unwrap().into_inner();
+            resp.send(decision).unwrap();
+        }
+    });
+
+    // 3) Run the blocking query_policy on a worker thread; the stored token is
+    //    attached automatically.
+    let client_for_check = client.clone();
+    let response = tokio::task::spawn_blocking(move || client_for_check.query_policy(CheckActionRequest::default()))
+        .await
+        .unwrap()
+        .expect("query_policy should return the gateway decision");
+
+    forwarder.await.unwrap();
+
+    // The gateway saw the registration token on the CheckAction request …
+    assert_eq!(seen_token.lock().unwrap().as_deref(), Some(ISSUED_TOKEN));
+    // … and the DENY decision surfaced back through query_policy.
+    assert_eq!(response.decision, Decision::Deny as i32);
+    assert_eq!(response.reason, "denied by mock policy");
+}

--- a/docs/src/adr/0004-governance-enforcement-flow.md
+++ b/docs/src/adr/0004-governance-enforcement-flow.md
@@ -90,6 +90,23 @@ Concretely:
 | REST is non-SDK only | A REST `/api/v1/policy/check`, **if it is ever added**, exists solely for non-SDK consumers (dashboard, operators, CLI data commands). It is never on the SDK path. |
 | Identity on Register | Registration through `aa-sdk-client` carries the `did:key` identity requirement; an out-of-band REST call would not, which is another reason the SDK path must stay on the boundary. |
 
+### Decision (Register transport)
+
+`aa-sdk-client` owns a **direct gateway gRPC client for `AgentLifecycleService.Register`**.
+On registration it derives a deterministic Ed25519 keypair from the agent identifier,
+sends the `did:key` agent id plus the matching `public_key`, and **stores the returned
+`credential_token`**. That token is then attached to every subsequent
+`CheckActionRequest`, so the gateway's `validate_credential_token` does not deny a
+registered agent.
+
+`CheckAction` itself stays on the **UDS / IPC forward through `aa-runtime`** (the mandatory
+chokepoint) — it is **not** sent directly to the gateway. This keeps the fast-path single
+chokepoint intact while closing the gap that nothing on the SDK path called `Register`
+(so no `credential_token` was ever issued or carried). Both transports still live inside
+`aa-sdk-client`, behind one API. See [AAASM-3396](https://lightning-dust-mite.atlassian.net/browse/AAASM-3396),
+[AAASM-3397](https://lightning-dust-mite.atlassian.net/browse/AAASM-3397),
+[AAASM-3398](https://lightning-dust-mite.atlassian.net/browse/AAASM-3398).
+
 ---
 
 ## Rationale / Consequences


### PR DESCRIPTION
## Description

Closes the SDK→core enforcement gap from ADR 0004: nothing on the SDK path called the gateway's `AgentLifecycleService.Register`, so no `credential_token` was ever issued, and a registered agent's later `CheckAction` would be denied by the gateway's `validate_credential_token`. This adds a **direct gateway gRPC Register client** to `aa-sdk-client`, stores the issued token, and **attaches it to every forwarded `CheckActionRequest`**. `CheckAction` itself still flows via the `aa-runtime` UDS forward (unchanged) — only Register is direct.

One branch/PR covers three sequential, same-crate tickets:

- **AAASM-3396 (T1)** — `tonic` + `ed25519-dalek` + `hex` deps; `gateway` module wrapping `AgentLifecycleServiceClient`; `AssemblyClient::register()` building a `RegisterRequest` with the `did:key` `agent_id` and a **consistent** Ed25519 `public_key` (both derived from one deterministic `AgentKeypair`, since the gateway validates `public_key` as a real Ed25519 verifying key); `AssemblyConfig::resolve_gateway_endpoint()` (env `AA_GATEWAY_ENDPOINT`, default `http://127.0.0.1:50051` — the gRPC port, not the `:8080` HTTP/OpenAPI URL).
- **AAASM-3397 (T2)** — `query_policy()` attaches the stored `credential_token` (when the caller left it empty) so post-Register checks are authenticated.
- **AAASM-3398 (T4)** — a with-core test spinning a mock gateway (`AgentLifecycleService` + `PolicyService`): `register()` issues+stores the token, a forwarded `CheckAction` carries it, and a gateway `DENY` surfaces.
- **ADR addendum** — records the Register-transport decision in `docs/src/adr/0004-governance-enforcement-flow.md`.

Note: `agent_id_to_did_key` was refactored to encode a real (deterministic) Ed25519 verifying key so the DID and `public_key` are bound to the same key; the existing gateway acceptance test (`register_with_sdk_derived_did_key_is_accepted`) and all identity tests still pass.

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

`AssemblyConfig` gained a `gateway_endpoint` field; all in-tree constructors are updated. The external FFI shims construct it via the public struct and will set the new field when they adopt `register()`.

## Related Issues

- Closes AAASM-3396
- Closes AAASM-3397
- Closes AAASM-3398

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`cargo build -p aa-sdk-client` and `cargo nextest run -p aa-sdk-client` — **46 tests pass** (incl. the with-core gateway test). `cargo fmt -p aa-sdk-client` + `cargo clippy -p aa-sdk-client --all-targets` clean. `aa-gateway::register_with_sdk_derived_did_key_is_accepted` re-verified green against the changed DID derivation. Root `Cargo.toml` untouched (no `compat-matrix-check` impact). QA evidence: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
