### PR TITLE
[AAASM-3406] 📝 (docs): Fix SDK production-mode prose to gRPC/UDS via aa-sdk-client

### DIFF
--- a/docs/src/operations/sandbox-dry-run.md
+++ b/docs/src/operations/sandbox-dry-run.md
@@ -155,13 +155,19 @@ The flag is **exclusive**: by default `aasm audit list` HIDES shadow events so o
 
 All three SDKs expose the same posture surface. Pass an `enforcement_mode` (Python / Go) or `enforcementMode` (Node.js) at agent registration:
 
+The SDK never talks to the core over HTTP. The public API delegates to the native
+`aa-sdk-client` shim, which speaks gRPC (over a Unix domain socket by default, or
+TCP for cross-host) to `aa-gateway` — see [ADR 0004](../adr/0004-governance-enforcement-flow.md).
+`gateway_url` / `gatewayUrl` / `WithGatewayURL` is therefore the gateway's gRPC
+endpoint as `host:port` (no scheme); the OSS local default is `localhost:7391`.
+
 ### Python
 
 ```python
 from agent_assembly import init_assembly
 
 ctx = init_assembly(
-    gateway_url="http://localhost:8080",
+    gateway_url="localhost:7391",   # gRPC endpoint, host:port (no scheme)
     api_key="...",
     agent_id="experimental-agent-001",
     enforcement_mode="observe",   # "enforce" | "observe" | "disabled"
@@ -176,7 +182,7 @@ The parameter is keyword-only; the type is `Literal["enforce", "observe", "disab
 import { initAssembly, type EnforcementMode } from "@agent-assembly/sdk";
 
 const ctx = await initAssembly({
-  gatewayUrl: "http://localhost:8080",
+  gatewayUrl: "localhost:7391",   // gRPC endpoint, host:port (no scheme)
   apiKey: "...",
   agentId: "experimental-agent-001",
   enforcementMode: "observe",   // 'enforce' | 'observe' | 'disabled'
@@ -191,7 +197,7 @@ The `EnforcementMode` union narrows at compile time; runtime validation catches 
 import "github.com/agent-assembly/go-sdk/assembly"
 
 a, err := assembly.Init(ctx,
-    assembly.WithGatewayURL("http://localhost:8080"),
+    assembly.WithGatewayURL("localhost:7391"),   // gRPC endpoint, host:port (no scheme)
     assembly.WithAPIKey("..."),
     assembly.WithSelfAgentID("experimental-agent-001"),
     assembly.WithEnforcementMode(assembly.EnforcementModeObserve),


### PR DESCRIPTION
## Description

The SDK usage snippets in the Sandbox / Dry-Run guide
(`docs/src/operations/sandbox-dry-run.md`) initialised all three SDKs with
`gateway_url="http://localhost:8080"`. That implies the SDK calls the core
directly over HTTP, which is wrong.

Per [ADR 0004](https://github.com/ai-agent-assembly/agent-assembly/blob/master/docs/src/adr/0004-governance-enforcement-flow.md):
the SDK public API **never** calls a core or REST endpoint directly — it
delegates to the native `aa-sdk-client` shim, which speaks **gRPC** (over a
Unix domain socket by default, or TCP for cross-host) to `aa-gateway`. The
`gateway_url` / `gatewayUrl` / `WithGatewayURL` value is the gateway's gRPC
endpoint as `host:port` with **no scheme** (per `docs/src/compatibility.md`),
and the OSS local default is `localhost:7391` — not the HTTP control-plane
API port `8080`.

Changes (one file, surgical):
- Corrected the Python / Node / Go init snippets to `localhost:7391`
  (host:port, no scheme) with an inline "gRPC endpoint" comment.
- Added a short clarifying note under **SDK usage** describing the
  SDK → aa-sdk-client → core (gRPC/UDS) flow and linking ADR 0004.

Scope note: the many other `:8080` references in `cli/`, `quick-start/`,
`usage-guide/` are about the CLI/dashboard **HTTP control-plane API** (which
legitimately runs on 8080) and are correct — left untouched. Only the SDK
init snippets were wrong.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3406

Closes AAASM-3406

## Testing

- [x] Manual testing performed — `mdbook build` runs clean (no broken-link
  errors; only the unrelated mdbook-mermaid version warning). The new
  relative link `../adr/0004-governance-enforcement-flow.md` resolves; the
  page is in `SUMMARY.md`.
- [x] No tests required (docs-only prose/snippet correction)

## Checklist

- [x] Code follows project style guidelines (docs-only; lefthook fmt/clippy/deny skipped — no staged Rust)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention
