### PR TITLE
[AAASM-3424] ⬆️ (deps): bump undici 7.28.0 + dompurify 3.4.11 (Dependabot)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -66,9 +66,10 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "^7.29.7",
-      "dompurify": "^3.4.10",
+      "dompurify": "^3.4.11",
       "esbuild": "^0.28.1",
-      "js-yaml": "^4.2.0"
+      "js-yaml": "^4.2.0",
+      "undici": "^7.28.0"
     }
   }
 }

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -6,9 +6,10 @@ settings:
 
 overrides:
   '@babel/core': ^7.29.7
-  dompurify: ^3.4.10
+  dompurify: ^3.4.11
   esbuild: ^0.28.1
   js-yaml: ^4.2.0
+  undici: ^7.28.0
 
 importers:
 
@@ -1548,8 +1549,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
@@ -2499,8 +2500,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unplugin@2.3.11:
@@ -3969,7 +3970,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -4327,7 +4328,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4473,7 +4474,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       marked: 14.0.0
 
   ms@2.1.3: {}
@@ -4932,7 +4933,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unplugin@2.3.11:
     dependencies:


### PR DESCRIPTION
## Description

Remediates three Dependabot alerts on the `master` default branch, all transitive
dependencies declared in `dashboard/pnpm-lock.yaml`:

- **#23 [HIGH]** `undici` `>=7.23.0,<7.28.0` → **7.28.0**
- **#22 [MED]** `undici` `>=7.0.0,<7.28.0` → **7.28.0** (same bump fixes both)
- **#21 [MED]** `dompurify` `<=3.4.10` → **3.4.11**

Both are transitive (undici via `vitest`→`jsdom`; dompurify via
`@monaco-editor/react`→`monaco-editor`), so they are pinned through
`dashboard/package.json` `pnpm.overrides` (`undici: ^7.28.0`,
`dompurify: ^3.4.11`) and applied via `pnpm install`. No bare `>=` ranges.

## Type of Change

- [x] ⬆️ Dependency upgrade

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3424
- Related GitHub issues: Dependabot alerts #21, #22, #23

## Testing

Describe the testing performed for this PR:

- [x] Manual testing performed
- [x] No tests required (dependency-only bump; existing suite re-run for regression)

Local validation in `dashboard/`:

- `pnpm install` — clean
- `pnpm build` — succeeds (vite 8.0.16; only pre-existing chunk-size advisories)
- `pnpm test` — **143 test files / 1262 tests passed**
- `pnpm why undici` → resolves **7.28.0**; `pnpm why dompurify` → resolves **3.4.11**

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — N/A, lockfile-only
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
