### PR TITLE
[AAASM-3432] 🔧 (ci): run CodeQL on push to master (default-branch coverage)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,67 @@
+name: CodeQL
+
+# Why a dedicated workflow (AAASM-3432): the agent-assembly default branch
+# recorded ZERO CodeQL analyses (code-scanning/analyses -> 404, default-setup
+# not-configured). Code scanning only updates the repo's security tab when an
+# analysis is uploaded from a `push` to the default branch, so this workflow
+# triggers on push to master (not just pull_request) plus a weekly schedule.
+# Mirrors the known-good go-sdk codeql.yml, adapted for this Rust + TS/JS repo.
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+  push:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+    branches:
+      - master
+  schedule:
+    - cron: "0 3 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # build-mode: none — CodeQL extracts source directly without a full
+          # workspace build. Keeps the analysis cheap and avoids the eBPF /
+          # cross-target build complexity that the main CI handles separately.
+          - language: rust
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Description

The agent-assembly default branch recorded **zero CodeQL analyses** — `GET /repos/ai-agent-assembly/agent-assembly/code-scanning/analyses` returns HTTP 404 "no analysis found" and `code-scanning/default-setup` is `not-configured`. The repo had **no CodeQL configuration at all** (no `github/codeql-action` usage in any workflow; the only "CodeQL" strings in `ci.yml` are `rm -rf` of the toolcache for disk space).

Code scanning only populates the repo's Security tab when an analysis is uploaded from a **push to the default branch**. This PR adds a dedicated `.github/workflows/codeql.yml` that triggers on push to `master`, pull_request, and a weekly schedule, mirroring the known-good `go-sdk/.github/workflows/codeql.yml` and adapted for this Rust + TS/JS repo.

Key points:
- Triggers: `push: { branches: [master] }`, `pull_request`, `schedule: cron "0 3 * * 1"` — so SARIF is uploaded on master and default-branch coverage is achieved.
- `permissions: security-events: write` (+ `contents: read`, `actions: read`) so the SARIF upload succeeds.
- Language matrix `rust` + `javascript-typescript`, `build-mode: none` (CodeQL extracts source without a full workspace build — avoids eBPF/cross-target build complexity already handled by the main CI).
- Action SHAs pinned (init/analyze `codeql-bundle-v2.25.2`, checkout v6.0.3), matching go-sdk.

`ci.yml` and all other jobs are left **unchanged** — this is CI-config only, no source changes.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3432

## Testing

- [x] No tests required (explain why)

CI-config only. Validated with `actionlint .github/workflows/codeql.yml` (exit 0, clean). Full CodeQL execution cannot be run locally; trigger/permission logic verified by inspection against the go-sdk reference. master coverage will be confirmed by the first push-triggered run recording in `code-scanning/analyses` after merge.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
