### PR TITLE
[AAASM-3430] 🐛 (aa-runtime): Wire gateway client so per-tool deny fires e2e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "moka",
  "portpicker",
+ "prost",
  "reqwest 0.12.28",
  "rstest",
  "rust_decimal",

--- a/aa-integration-tests/Cargo.toml
+++ b/aa-integration-tests/Cargo.toml
@@ -69,6 +69,7 @@ bytes        = { workspace = true }
 libc        = { workspace = true }
 moka        = { workspace = true, features = ["future"] }
 portpicker  = "0.1"
+prost       = { workspace = true }
 reqwest     = { workspace = true, features = ["json", "rustls-tls"] }
 rustls      = { workspace = true, features = ["ring"] }
 tokio-rustls = { workspace = true }

--- a/aa-integration-tests/tests/common/live_gateway.rs
+++ b/aa-integration-tests/tests/common/live_gateway.rs
@@ -40,15 +40,21 @@ impl LiveGateway {
     /// (`"127.0.0.1:<port>"`). Waits up to 30 s for the listener to
     /// accept TCP connections.
     pub fn spawn() -> Result<Self> {
+        Self::spawn_with_policy(
+            "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nspec:\n  budget:\n    daily_limit_usd: 1000.0\n",
+        )
+    }
+
+    /// Spawn `aa-gateway` exactly as [`spawn`](Self::spawn) but with a
+    /// caller-supplied policy YAML body. Used by the AAASM-3430 regression
+    /// test, which needs a section-based tool-deny policy so the gateway
+    /// returns a real `Deny` for a deny-listed tool.
+    pub fn spawn_with_policy(policy_yaml: &str) -> Result<Self> {
         let bin = locate_gateway_binary().context("locating aa-gateway binary for LiveGateway::spawn")?;
         let home_tmp = tempfile::tempdir().context("creating HOME tempdir")?;
         let policy_tmp = tempfile::tempdir().context("creating policy tempdir")?;
         let policy_path = policy_tmp.path().join("policy.yaml");
-        std::fs::write(
-            &policy_path,
-            "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nspec:\n  budget:\n    daily_limit_usd: 1000.0\n",
-        )
-        .context("writing minimal policy YAML")?;
+        std::fs::write(&policy_path, policy_yaml).context("writing policy YAML")?;
 
         let port = free_port().context("picking a free TCP port")?;
         let addr = format!("127.0.0.1:{port}");

--- a/aa-integration-tests/tests/e2e_runtime_gateway_deny.rs
+++ b/aa-integration-tests/tests/e2e_runtime_gateway_deny.rs
@@ -1,0 +1,242 @@
+//! AAASM-3430 — runtime→gateway per-tool deny enforcement E2E.
+//!
+//! Regression guard for the bug where `aa-runtime` ignored its configured
+//! `AA_GATEWAY_ENDPOINT` and evaluated every policy check locally (always
+//! allowing), so a per-tool `deny` held by the gateway never fired end-to-end
+//! (the AAASM-3407 symptom: `delete_file` returned ALLOW through the real
+//! SDK→runtime→gateway chain).
+//!
+//! The loss point was `aa-runtime::runtime::run`, which passed `None` for the
+//! pipeline's gateway client unconditionally. The fix constructs a
+//! `GatewayClient` from the configured endpoint so checks are forwarded to the
+//! authoritative gateway.
+//!
+//! This test spawns a real `aa-gateway` (with a section-based tool-deny policy)
+//! and a real `aa-runtime` configured to forward to it, then sends two
+//! `CheckActionRequest`s over the runtime's Unix-socket IPC — exactly the wire
+//! the SDK uses — and asserts the gateway's per-tool decision is honoured:
+//! `read_file` → Allow, `delete_file` → Deny.
+//!
+//! It skips cleanly when the `aa-gateway` / `aa-runtime` binaries are not built,
+//! mirroring the existing `e2e_sdk_node` pattern, so a single-crate test run
+//! without a prior workspace build does not fail.
+
+mod common;
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use aa_proto::assembly::common::v1::{ActionType, AgentId, Decision};
+use aa_proto::assembly::policy::v1::action_context::Action;
+use aa_proto::assembly::policy::v1::{ActionContext, CheckActionRequest, CheckActionResponse, ToolCallContext};
+use common::live_gateway::{gateway_binary_locatable, LiveGateway};
+use prost::Message;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+/// Section-based policy: deny the `delete_file` tool, allow `read_file`.
+/// Tool deny is keyed by tool name and is agent-independent, so the check
+/// fires for an unregistered agent (the gateway skips credential validation
+/// for agents it has never seen).
+const TOOL_DENY_POLICY: &str = "\
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: aaasm-3430-tool-deny
+  version: \"0.1.0\"
+spec:
+  tools:
+    read_file:
+      allow: true
+    delete_file:
+      allow: false
+";
+
+/// Inbound IPC tag for a policy query (SDK → runtime). Mirrors
+/// `aa-runtime::ipc::codec::TAG_POLICY_QUERY`.
+const TAG_POLICY_QUERY: u8 = 1;
+/// Outbound IPC tag for a policy response (runtime → SDK). Mirrors
+/// `aa-runtime::ipc::codec::TAG_POLICY_RESPONSE`.
+const TAG_POLICY_RESPONSE: u8 = 1;
+
+/// Locate the `aa-runtime` binary the same way `live_gateway` finds the gateway.
+fn locate_runtime_binary() -> Option<PathBuf> {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let workspace_root = Path::new(&manifest).parent()?;
+    for profile in ["debug", "release"] {
+        let candidate = workspace_root.join("target").join(profile).join("aa-runtime");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// A spawned `aa-runtime` sidecar pointed at a gateway endpoint. Killed on drop.
+struct LiveRuntime {
+    child: Option<Child>,
+    socket_path: PathBuf,
+    _home: tempfile::TempDir,
+}
+
+impl LiveRuntime {
+    /// Spawn `aa-runtime` with `AA_GATEWAY_ENDPOINT` set so it forwards policy
+    /// checks to the gateway. Policy enforcement is disabled on disk
+    /// (`AA_POLICY_PATH=""`) so the only authority is the gateway — exactly the
+    /// configuration that exposed the bug.
+    fn spawn(binary: &Path, agent_id: &str, gateway_endpoint: &str, metrics_port: u16) -> std::io::Result<Self> {
+        let home = tempfile::tempdir()?;
+        let socket_path = PathBuf::from(format!("/tmp/aa-runtime-{agent_id}.sock"));
+        let child = Command::new(binary)
+            .env("HOME", home.path())
+            .env("AA_AGENT_ID", agent_id)
+            .env("AA_POLICY_PATH", "")
+            .env("AA_GATEWAY_ENDPOINT", gateway_endpoint)
+            .env("AA_METRICS_ADDR", format!("127.0.0.1:{metrics_port}"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        Ok(Self {
+            child: Some(child),
+            socket_path,
+            _home: home,
+        })
+    }
+
+    /// Block until the runtime's UDS accepts a connection.
+    async fn await_ready(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if UnixStream::connect(&self.socket_path).await.is_ok() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        false
+    }
+}
+
+impl Drop for LiveRuntime {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+/// Build a tool-call `CheckActionRequest` for `tool_name`.
+fn tool_call_request(agent_id: &str, tool_name: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(AgentId {
+            org_id: "test-org".to_string(),
+            team_id: "test-team".to_string(),
+            agent_id: agent_id.to_string(),
+        }),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: tool_name.to_string(),
+                tool_source: "function".to_string(),
+                ..Default::default()
+            })),
+        }),
+        ..Default::default()
+    }
+}
+
+/// Write a varint length prefix then the payload (prost length-delimited).
+async fn write_varint(stream: &mut UnixStream, mut value: u64) -> std::io::Result<()> {
+    loop {
+        let byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value == 0 {
+            stream.write_u8(byte).await?;
+            return Ok(());
+        }
+        stream.write_u8(byte | 0x80).await?;
+    }
+}
+
+/// Read a prost-style unsigned varint.
+async fn read_varint(stream: &mut UnixStream) -> std::io::Result<u64> {
+    let mut result = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = stream.read_u8().await?;
+        result |= ((byte & 0x7F) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(result);
+        }
+        shift += 7;
+    }
+}
+
+/// Send one `CheckActionRequest` over the runtime UDS and return the gateway's
+/// decision as relayed back in the `CheckActionResponse`.
+async fn check_tool(socket_path: &Path, req: &CheckActionRequest) -> CheckActionResponse {
+    let mut stream = UnixStream::connect(socket_path).await.expect("connect to runtime UDS");
+
+    let payload = req.encode_to_vec();
+    stream.write_u8(TAG_POLICY_QUERY).await.expect("write tag");
+    write_varint(&mut stream, payload.len() as u64)
+        .await
+        .expect("write len");
+    stream.write_all(&payload).await.expect("write payload");
+    stream.flush().await.expect("flush");
+
+    let tag = stream.read_u8().await.expect("read response tag");
+    assert_eq!(tag, TAG_POLICY_RESPONSE, "expected a PolicyResponse frame");
+    let len = read_varint(&mut stream).await.expect("read response len") as usize;
+    let mut buf = vec![0u8; len];
+    stream.read_exact(&mut buf).await.expect("read response payload");
+    CheckActionResponse::decode(buf.as_ref()).expect("decode CheckActionResponse")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn runtime_forwards_per_tool_deny_to_gateway() {
+    let Some(runtime_bin) = locate_runtime_binary() else {
+        eprintln!("skipping: aa-runtime binary not built — run `cargo build -p aa-runtime`");
+        return;
+    };
+    if !gateway_binary_locatable() {
+        eprintln!("skipping: aa-gateway binary not built — run `cargo build -p aa-gateway`");
+        return;
+    }
+
+    // Real gateway holding the per-tool deny policy.
+    let gateway = LiveGateway::spawn_with_policy(TOOL_DENY_POLICY).expect("spawn aa-gateway");
+    let endpoint = format!("http://{}", gateway.addr());
+
+    // Real runtime, configured to forward checks to that gateway.
+    let agent_id = format!("aaasm3430-{}", std::process::id());
+    let metrics_port = portpicker::pick_unused_port().expect("free metrics port");
+    let runtime = LiveRuntime::spawn(&runtime_bin, &agent_id, &endpoint, metrics_port).expect("spawn aa-runtime");
+    assert!(
+        runtime.await_ready(Duration::from_secs(30)).await,
+        "aa-runtime did not bind its UDS in time"
+    );
+
+    // Allow path: the gateway permits `read_file`.
+    let allow = check_tool(&runtime.socket_path, &tool_call_request(&agent_id, "read_file")).await;
+    assert_eq!(
+        allow.decision,
+        Decision::Allow as i32,
+        "read_file must be ALLOWED end-to-end (got reason: {})",
+        allow.reason
+    );
+
+    // Deny path (the regression): the gateway denies `delete_file`, and the
+    // runtime MUST forward the check and relay the Deny — not short-circuit to
+    // a local allow.
+    let deny = check_tool(&runtime.socket_path, &tool_call_request(&agent_id, "delete_file")).await;
+    assert_eq!(
+        deny.decision,
+        Decision::Deny as i32,
+        "delete_file must be DENIED end-to-end via the gateway — a local allow \
+         here is the AAASM-3430 regression (got reason: {})",
+        deny.reason
+    );
+}

--- a/aa-runtime/src/gateway_client.rs
+++ b/aa-runtime/src/gateway_client.rs
@@ -41,4 +41,39 @@ impl GatewayClient {
             client: PolicyServiceClient::new(channel),
         }
     }
+
+    /// Build a client over a **lazy** channel to an owned `endpoint` without
+    /// connecting eagerly (AAASM-3430).
+    ///
+    /// Used by the runtime when the gateway endpoint is configured but the
+    /// initial eager [`connect`](Self::connect) fails: the runtime must not
+    /// silently fall back to permissive local evaluation. A lazy client lets
+    /// the pipeline's fail-closed path (AAASM-3110) deny checks while the
+    /// gateway is unreachable, and recover automatically once it comes up.
+    ///
+    /// Returns `None` if `endpoint` is not a valid URI.
+    pub fn connect_lazy_owned(endpoint: &str) -> Option<Self> {
+        let channel = Channel::from_shared(endpoint.to_string()).ok()?.connect_lazy();
+        Some(Self {
+            client: PolicyServiceClient::new(channel),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn connect_lazy_owned_accepts_valid_uri() {
+        // `connect_lazy` requires a tokio reactor in scope.
+        assert!(GatewayClient::connect_lazy_owned("http://127.0.0.1:50051").is_some());
+    }
+
+    #[test]
+    fn connect_lazy_owned_rejects_invalid_uri() {
+        // An empty endpoint is not a valid URI and must not yield a client —
+        // the runtime must surface None rather than degrade to local allow.
+        assert!(GatewayClient::connect_lazy_owned("").is_none());
+    }
 }

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -649,6 +649,36 @@ pub async fn run(config: RuntimeConfig) {
         spawn_ebpf_exec_tracepoints(&tracker, &broadcast_tx, &token, &mut degraded_layers);
     }
 
+    // AAASM-3430: build the gateway client when an endpoint is configured so
+    // policy checks are forwarded to the authoritative governance gateway. When
+    // no endpoint is set the pipeline falls back to local evaluation. Without
+    // this, the pipeline always received `None` and every per-tool deny held by
+    // the gateway was silently dropped to a permissive local allow.
+    let gateway_client = match &config.gateway_endpoint {
+        Some(endpoint) => match crate::gateway_client::GatewayClient::connect(endpoint).await {
+            Ok(client) => {
+                tracing::info!(endpoint, "gateway client connected — forwarding policy checks");
+                Some(std::sync::Arc::new(tokio::sync::Mutex::new(client)))
+            }
+            Err(e) => {
+                // Construction failure must not silently degrade to local allow.
+                // Build a lazy client so the pipeline's fail-closed path
+                // (AAASM-3110) governs the unreachable case at check time.
+                tracing::warn!(
+                    endpoint,
+                    error = %e,
+                    "gateway client initial connect failed — using lazy channel (checks fail-closed when unreachable)"
+                );
+                crate::gateway_client::GatewayClient::connect_lazy_owned(endpoint)
+                    .map(|client| std::sync::Arc::new(tokio::sync::Mutex::new(client)))
+            }
+        },
+        None => {
+            tracing::info!("no gateway endpoint configured — policy checks evaluated locally");
+            None
+        }
+    };
+
     // Spawn the event aggregation pipeline task.
     {
         let pipeline_token = token.clone();
@@ -667,7 +697,7 @@ pub async fn run(config: RuntimeConfig) {
                 pipeline_policy,
                 pipeline_router,
                 pipeline_approval_queue,
-                None,
+                gateway_client,
                 pipeline_seq,
             )
             .await;


### PR DESCRIPTION
## Description

`aa-runtime` ignored its configured `AA_GATEWAY_ENDPOINT` and evaluated every
policy check locally — always allowing — so a per-tool `deny` held by the
gateway never fired end-to-end. This is the AAASM-3407 symptom: with a real
gateway + real `aa-runtime` + real Python SDK and a section policy
(`read_file` allow / `delete_file` deny), `delete_file` returned **allow**.

**Loss point:** `aa-runtime/src/runtime.rs` — `runtime::run()` called
`pipeline::run(...)` with `None` for the `gateway_client` argument
unconditionally (was line 670). The runtime crate already had a working
`GatewayClient` (`gateway_client.rs`), a forwarding path
(`pipeline::try_gateway_forward → check_action`), and a fail-closed path
(AAASM-3110), but the client was never constructed, so the gateway was never
consulted and `try_local_approval` fell through to a permissive local allow.

**Fix:** construct the `GatewayClient` from `config.gateway_endpoint` and pass
it into `pipeline::run`. When the endpoint is unset, behaviour is unchanged
(local evaluation). When set but the initial connect fails, a lazy client is
used so the existing fail-closed path governs the unreachable case rather than
silently degrading to local allow.

The gateway itself was already correct (a direct gRPC `CheckAction` probe
denies `delete_file` for a registered agent); no `proto/` or gateway changes.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3430 (Closes); references AAASM-3407
- Prior: AAASM-3021 (SDK check wired), AAASM-3000 (IPC deadlock), AAASM-3110 (fail-closed)

## Testing

- [x] Unit tests added / updated — `connect_lazy_owned` URI validation.
- [x] Integration tests added / updated — new `e2e_runtime_gateway_deny.rs`
  spawns a real `aa-gateway` (tool-deny policy) and a real `aa-runtime`
  forwarding to it, sends `CheckActionRequest`s over the runtime's UDS, and
  asserts `read_file` → Allow, `delete_file` → Deny. Verified it goes **red**
  with the fix reverted (`delete_file` returned allow) and **green** with the
  fix.
- `cargo nextest run -p aa-runtime` — 291 passed.
- `cargo fmt` / `cargo clippy` clean on touched crates.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3430
