### PR TITLE
[AAASM-3438] 🔒 (sec): fix DOM XSS in docs theme (CodeQL js/xss-through-dom)

### DIFF
--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -476,7 +476,15 @@
                 }
 
                 select.addEventListener("change", function () {
-                    window.location.href = siteRoot + select.value + "/";
+                    // select.value comes from versions.json (a fetched, hence
+                    // untrusted, document). Constrain it to a safe version-subpath
+                    // shape before building a navigation URL so a crafted value
+                    // cannot smuggle in a "javascript:" scheme, "//host" authority,
+                    // or path traversal. Legitimate ids/targets (e.g. "latest",
+                    // "v0.0.1-alpha.5", "v0.1.0") only use these characters.
+                    var subpath = select.value;
+                    if (!/^[A-Za-z0-9._-]+$/.test(subpath)) { return; }
+                    window.location.href = siteRoot + subpath + "/";
                 });
                 label.classList.remove("hidden");
             }


### PR DESCRIPTION
## Description

Fixes CodeQL code-scanning alert **#1** (`js/xss-through-dom`, **HIGH**) at `docs/theme/index.hbs:479`.

The mdBook docs theme version selector navigated via:

```js
window.location.href = siteRoot + select.value + "/";
```

`select.value` is read back from a `<select>` populated from `versions.json`, a document **fetched at runtime** and therefore treated as untrusted by CodeQL's taint tracking. A crafted value could smuggle a `javascript:` scheme, a `//host` authority, or path traversal into the navigation URL.

The fix constrains the value to a safe version-subpath shape before building the URL:

```js
var subpath = select.value;
if (!/^[A-Za-z0-9._-]+$/.test(subpath)) { return; }
window.location.href = siteRoot + subpath + "/";
```

Legitimate channel ids/targets and archived version ids (`latest`, `v0.0.1-alpha.5`, `v0.1.0`) all match this allowlist, so navigation is **identical for every real version**; anything else is rejected. This both hardens the sink and breaks the CodeQL taint flow.

## Type of Change

- [x] 🐛 Bug fix (security hardening)

## Breaking Changes

- [x] No

Navigation behaviour is unchanged for all valid version subpaths.

## Related Issues

- Related Jira ticket: AAASM-3438
- Resolves CodeQL code-scanning alert #1

## Testing

- [x] Manual testing performed
- [x] No tests required (explain why)

The docs theme is a Handlebars HTML template with no unit-test harness. Validation performed:
- Extracted the edited IIFE and parsed it with `new Function(...)` — JS is syntactically valid.
- `mdbook build` succeeds; the guarded navigation (regex allowlist) renders into every generated HTML page.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — behaviour preserved; rationale captured in an inline why-comment)
- [ ] All CI checks passing (org Actions may be billing-blocked; validated locally)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
