### PR TITLE
[AAASM-3443] 🔧 (ci): CodeQL — stop ignoring docs/** (docs theme has executable JS)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,15 +8,14 @@ name: CodeQL
 # Mirrors the known-good go-sdk codeql.yml, adapted for this Rust + TS/JS repo.
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - "**/*.md"
-      - "docs/**"
       - "LICENSE"
   push:
     paths-ignore:
       - "**/*.md"
-      - "docs/**"
       - "LICENSE"
     branches:
       - master


### PR DESCRIPTION
## Description

The committed `.github/workflows/codeql.yml` had `docs/**` in `paths-ignore` on BOTH the `pull_request` and `push` triggers. But `docs/theme/index.hbs` contains executable JavaScript (the version switcher — the source of the AAASM-3440 XSS). Consequences:

- Docs-only security fixes never trigger CodeQL, so the default-branch security analysis never re-evaluates docs JS. AAASM-3440's XSS fix is merged + PR-verified clean, yet the master code-scanning dashboard still shows the HIGH `js/xss-through-dom` (last master analysis is the pre-fix commit `fc0b40b7d`; it would otherwise only clear on the weekly `cron`).
- Going forward, any future vuln introduced in the docs theme JS would be missed on docs-only changes.

This PR removes `docs/**` from `paths-ignore` under both triggers so docs code/template changes are scanned by CodeQL again. `**/*.md` and `LICENSE` are kept so pure-markdown / license-only changes still skip. Also adds `workflow_dispatch:` so a master CodeQL scan can be run on demand.

CI-config only — no source or other workflow changed.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-3443 (follow-up to AAASM-3440 / Epic AAASM-3431)
- Related GitHub issues: N/A

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

`actionlint .github/workflows/codeql.yml` → clean. Re-read confirms `docs/**` removed from both `paths-ignore` blocks while `**/*.md` and `LICENSE` remain.

**Intended side effect (post-merge):** merging this touches `.github/workflows/codeql.yml` (a non-ignored path) → triggers a master CodeQL run that re-scans the fixed `docs/theme/index.hbs` → code-scanning alert #1 (`js/xss-through-dom`) should auto-close on master (`gh api repos/ai-agent-assembly/agent-assembly/code-scanning/alerts/1` → state resolved/fixed).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — N/A, CI-config only
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — N/A
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
