### PR TITLE
[AAASM-3415] 🐛 (aa-sdk-client): Forward team_id/parent_agent_id on native Register

### DIFF
--- a/aa-sdk-client/src/config.rs
+++ b/aa-sdk-client/src/config.rs
@@ -22,6 +22,14 @@ pub struct AssemblyConfig {
     /// Explicit gateway gRPC endpoint override (e.g. `"http://127.0.0.1:50051"`).
     /// When `None`, resolved from env or [`DEFAULT_GATEWAY_ENDPOINT`].
     pub gateway_endpoint: Option<String>,
+    /// Team the agent belongs to. Forwarded on gateway registration as the
+    /// `team_id` of the composite `AgentId` so the gateway can attribute the
+    /// agent's spend to the correct team budget. `None` leaves it unset.
+    pub team_id: Option<String>,
+    /// UUID of the parent agent that spawned this one. Forwarded on gateway
+    /// registration so the gateway can build the topology / delegation graph.
+    /// `None` marks the agent as a root agent.
+    pub parent_agent_id: Option<String>,
 }
 
 impl AssemblyConfig {
@@ -92,6 +100,8 @@ mod tests {
             agent_id: agent_id.to_string(),
             socket_path: socket_path.map(|s| s.to_string()),
             gateway_endpoint: None,
+            team_id: None,
+            parent_agent_id: None,
         }
     }
 
@@ -118,6 +128,8 @@ mod tests {
             agent_id: "a".into(),
             socket_path: None,
             gateway_endpoint: Some("http://gw.example:50051".into()),
+            team_id: None,
+            parent_agent_id: None,
         };
         assert_eq!(config.resolve_gateway_endpoint(), "http://gw.example:50051");
     }

--- a/aa-sdk-client/src/gateway.rs
+++ b/aa-sdk-client/src/gateway.rs
@@ -58,13 +58,14 @@ pub fn build_register_request(config: &AssemblyConfig, name: String, framework: 
     RegisterRequest {
         agent_id: Some(ProtoAgentId {
             org_id: String::new(),
-            team_id: String::new(),
+            team_id: config.team_id.clone().unwrap_or_default(),
             agent_id: config.registration_did(),
         }),
         name,
         framework,
         version: env!("CARGO_PKG_VERSION").to_string(),
         public_key: keypair.public_key_hex(),
+        parent_agent_id: config.parent_agent_id.clone(),
         ..Default::default()
     }
 }
@@ -78,6 +79,8 @@ mod tests {
             agent_id: agent_id.to_string(),
             socket_path: None,
             gateway_endpoint: None,
+            team_id: None,
+            parent_agent_id: None,
         }
     }
 
@@ -101,5 +104,29 @@ mod tests {
             .into_vec()
             .unwrap();
         assert_eq!(&did_payload[2..], pk_bytes.as_slice());
+    }
+
+    #[test]
+    fn register_request_forwards_team_id_and_parent_agent_id() {
+        let mut config = cfg("child-agent");
+        config.team_id = Some("team-payments".into());
+        config.parent_agent_id = Some("11111111-2222-3333-4444-555555555555".into());
+
+        let req = build_register_request(&config, "Child".into(), "custom".into());
+
+        assert_eq!(req.agent_id.expect("agent_id must be set").team_id, "team-payments");
+        assert_eq!(
+            req.parent_agent_id.as_deref(),
+            Some("11111111-2222-3333-4444-555555555555")
+        );
+    }
+
+    #[test]
+    fn register_request_omits_lineage_when_unset() {
+        let config = cfg("root-agent");
+        let req = build_register_request(&config, "Root".into(), "custom".into());
+
+        assert_eq!(req.agent_id.expect("agent_id must be set").team_id, "");
+        assert_eq!(req.parent_agent_id, None);
     }
 }

--- a/aa-sdk-client/tests/gateway_register_with_core.rs
+++ b/aa-sdk-client/tests/gateway_register_with_core.rs
@@ -152,6 +152,8 @@ async fn register_then_check_carries_token_and_surfaces_deny() {
         agent_id: "with-core-agent".to_string(),
         socket_path: None,
         gateway_endpoint: Some(endpoint.clone()),
+        team_id: None,
+        parent_agent_id: None,
     };
 
     // 1) Register directly against the mock gateway — issues + stores the token.


### PR DESCRIPTION
## Description

When the SDKs moved to native gRPC `Register` (Epic AAASM-3395), the native register path stopped forwarding the lineage/team fields the old REST register sent. `team_id` drives team-budget attribution; `parent_agent_id` drives the topology graph.

This restores forwarding in `aa-sdk-client`:

- `AssemblyConfig` gains optional `team_id` and `parent_agent_id` fields.
- `build_register_request` sets the composite `AgentId.team_id` and the `RegisterRequest.parent_agent_id` from those fields. When unset, `team_id` stays empty and `parent_agent_id` stays `None` (root agent), preserving current behaviour.

The proto (`proto/agent.proto`) **already** carries `parent_agent_id` (field 9) and `team_id` (in the composite `AgentId`), so this is pure plumbing — no proto change, no wire-format change.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

`AssemblyConfig` is constructed by the FFI shims; the two new fields are additive (`Option`) and default to `None`.

## Related Issues

- Related Jira ticket: AAASM-3415

Closes AAASM-3415

## Testing

- [x] Unit tests added / updated

`cargo nextest run -p aa-sdk-client` → 48 passed (incl. 2 new: `register_request_forwards_team_id_and_parent_agent_id`, `register_request_omits_lineage_when_unset`). `cargo clippy -p aa-sdk-client --all-targets --all-features -- -D warnings` clean; `cargo fmt` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

## Follow-up

- **go-sdk / `aa-ffi-go`** lineage forwarding is a deferred follow-up — go-sdk is being edited concurrently by AAASM-3404, so it was left out of this change to avoid collision.
- The python-sdk and node-sdk shims must bump their `aa-sdk-client` git-SHA pin to this PR's merge commit to consume the new `AssemblyConfig` fields (separate PRs, referencing AAASM-3415).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
