### PR TITLE
[AAASM-3441] 🐛 (aa-api): Honor AA_RATE_LIMIT_RPM in shipped server's live limiter

### DIFF
--- a/aa-api/src/auth/config.rs
+++ b/aa-api/src/auth/config.rs
@@ -78,10 +78,7 @@ impl AuthConfig {
         let api_keys_path = std::env::var("AA_API_KEYS_PATH").unwrap_or_else(|_| DEFAULT_API_KEYS_PATH.to_string());
         let api_keys_path = expand_tilde(&api_keys_path);
 
-        let rate_limit_rpm = match std::env::var("AA_RATE_LIMIT_RPM") {
-            Ok(val) => val.parse::<u32>().map_err(|_| AuthConfigError::InvalidRateLimit(val))?,
-            Err(_) => DEFAULT_RATE_LIMIT_RPM,
-        };
+        let rate_limit_rpm = resolve_rate_limit_rpm()?;
 
         Ok(Self {
             mode,
@@ -89,6 +86,19 @@ impl AuthConfig {
             api_keys_path,
             rate_limit_rpm,
         })
+    }
+}
+
+/// Resolve the per-key requests-per-minute limit from `AA_RATE_LIMIT_RPM`.
+///
+/// Returns [`DEFAULT_RATE_LIMIT_RPM`] when the variable is unset, and an
+/// [`AuthConfigError::InvalidRateLimit`] when it is set to a non-`u32` value.
+/// Shared by [`AuthConfig::from_env`] and the local-mode entrypoint so the
+/// shipped server honours `AA_RATE_LIMIT_RPM` in its live rate limiter.
+pub fn resolve_rate_limit_rpm() -> Result<u32, AuthConfigError> {
+    match std::env::var("AA_RATE_LIMIT_RPM") {
+        Ok(val) => val.parse::<u32>().map_err(|_| AuthConfigError::InvalidRateLimit(val)),
+        Err(_) => Ok(DEFAULT_RATE_LIMIT_RPM),
     }
 }
 

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -157,6 +157,9 @@ pub enum LocalStateError {
     /// Constructing the audit writer over the local audit directory failed.
     #[error("failed to start local audit writer: {0}")]
     Audit(String),
+    /// `AA_RATE_LIMIT_RPM` was set to an invalid (non-`u32`) value.
+    #[error("invalid AA_RATE_LIMIT_RPM: {0}")]
+    RateLimit(String),
 }
 
 /// Resolved authentication posture for the local single-process entrypoint
@@ -392,6 +395,20 @@ impl AppState {
         use std::sync::atomic::AtomicUsize;
 
         let mut state = Self::local_in_memory()?;
+
+        // --- Rate limiting: honour AA_RATE_LIMIT_RPM in the live limiter. ---
+        // `local_in_memory` hard-codes 1000; the shipped binary resolves the
+        // operator-configured limit here so the live `rate_limiter` (and the
+        // advertised `auth_config.rate_limit_rpm`) reflect the env (AAASM-3441).
+        let rate_limit_rpm =
+            crate::auth::config::resolve_rate_limit_rpm().map_err(|e| LocalStateError::RateLimit(format!("{e}")))?;
+        state.rate_limiter = Arc::new(RateLimiter::new(rate_limit_rpm));
+        state.auth_config = Arc::new(AuthConfig {
+            mode: state.auth_config.mode,
+            jwt_secret: state.auth_config.jwt_secret.clone(),
+            api_keys_path: state.auth_config.api_keys_path.clone(),
+            rate_limit_rpm,
+        });
 
         // --- Auth: require an API key unless explicitly opted out. ---
         match &auth {

--- a/aa-api/tests/serve_local_hardened.rs
+++ b/aa-api/tests/serve_local_hardened.rs
@@ -6,11 +6,17 @@
 //! and (b) backs audit / retention with a local SQLite store so those handlers
 //! return real data instead of 503.
 
+use std::sync::Mutex;
+
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
 
 const TEST_KEY: &str = "aa_00112233445566778899aabbccddeeff";
+
+/// Serializes the env-var-dependent rate-limit tests so a concurrent test does
+/// not observe a half-set `AA_RATE_LIMIT_RPM`.
+static RATE_LIMIT_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 /// Build the hardened app with API-key auth seeded from a fixed key.
 async fn hardened_app_with_key() -> axum::Router {
@@ -112,6 +118,62 @@ async fn retention_policy_returns_real_data_not_503() {
     // Default policy: hot=30d, warm=90d, 6-field daily-3am schedule.
     assert_eq!(body["hot_days"], 30);
     assert_eq!(body["schedule"], "0 0 3 * * *");
+}
+
+// These two tests are plain `#[test]`s (not `#[tokio::test]`): they mutate the
+// process-global `AA_RATE_LIMIT_RPM` under a std `Mutex` and drive the async
+// `local_hardened` on a private current-thread runtime, so the lock is never
+// held across an `.await` (clippy `await_holding_lock`).
+#[test]
+fn rate_limit_rpm_env_is_honoured_in_live_limiter() {
+    // AAASM-3441: the shipped `serve_local`/`local_hardened` path must build the
+    // live limiter from AA_RATE_LIMIT_RPM, not a hard-coded 1000.
+    let _guard = RATE_LIMIT_ENV_LOCK.lock().unwrap();
+    std::env::set_var("AA_RATE_LIMIT_RPM", "7");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime");
+    let state = rt
+        .block_on(aa_api::AppState::local_hardened(aa_api::LocalAuth::ApiKey {
+            key: TEST_KEY.to_string(),
+        }))
+        .expect("local_hardened must construct");
+    std::env::remove_var("AA_RATE_LIMIT_RPM");
+
+    assert_eq!(
+        state.auth_config.rate_limit_rpm, 7,
+        "auth_config must reflect AA_RATE_LIMIT_RPM"
+    );
+    // The live limiter must enforce the same value: 7 ok, 8th rejected.
+    for i in 0..7 {
+        assert!(
+            state.rate_limiter.check("local-admin").is_ok(),
+            "request {i} should be allowed under rpm=7"
+        );
+    }
+    assert!(
+        state.rate_limiter.check("local-admin").is_err(),
+        "8th request must be rate-limited when rpm=7"
+    );
+}
+
+#[test]
+fn rate_limit_rpm_defaults_to_1000_when_unset() {
+    // With the env unset the live limiter keeps the documented default.
+    let _guard = RATE_LIMIT_ENV_LOCK.lock().unwrap();
+    std::env::remove_var("AA_RATE_LIMIT_RPM");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime");
+    let state = rt
+        .block_on(aa_api::AppState::local_hardened(aa_api::LocalAuth::Off))
+        .expect("local_hardened must construct");
+    assert_eq!(
+        state.auth_config.rate_limit_rpm, 1000,
+        "default rpm must be 1000 when AA_RATE_LIMIT_RPM is unset"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description

The shipped `aa-api-server` `serve_local` path builds `AppState::local_hardened`, which is layered on `AppState::local_in_memory`. The latter hard-codes `RateLimiter::new(1000)` and `auth_config.rate_limit_rpm: 1000`, and neither path reads `AA_RATE_LIMIT_RPM`. As a result the env var was silently ignored at runtime — the live limiter always ran at 1000 rpm.

This PR resolves `AA_RATE_LIMIT_RPM` in `local_hardened` (the path the shipped binary uses) and rebuilds **both** the live `rate_limiter` and the advertised `auth_config.rate_limit_rpm` from it. The default (1000) is preserved when the env var is unset; an invalid value surfaces a clear `LocalStateError::RateLimit`.

The env-parse logic is extracted into a shared `resolve_rate_limit_rpm()` helper so `AuthConfig::from_env` and the local entrypoint use the exact same parsing.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3441

## Testing

- [x] Integration tests added / updated

Added `rate_limit_rpm_env_is_honoured_in_live_limiter` (sets `AA_RATE_LIMIT_RPM=7`, asserts `auth_config.rate_limit_rpm == 7` and that the live limiter rejects the 8th request) and `rate_limit_rpm_defaults_to_1000_when_unset`. Validated with `cargo nextest run -p aa-api` (serve_local_hardened + auth_rate_limit + auth::config), `cargo clippy -p aa-api --all-targets`, `cargo fmt`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
