### PR TITLE
[AAASM-3442] 🐛 (aa-cli): Resolve active policy for 'policy get' with no version

### DIFF
--- a/aa-cli/src/commands/policy/get.rs
+++ b/aa-cli/src/commands/policy/get.rs
@@ -4,68 +4,69 @@ use std::process::ExitCode;
 
 use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig, PolicyHistoryStore};
 use clap::Args;
+use serde::Deserialize;
+
+use crate::config::ResolvedContext;
 
 /// Arguments for `aasm policy get`.
 #[derive(Args)]
 pub struct GetArgs {
     /// Version identifier (SHA-256 prefix) to retrieve.
-    /// Shows the latest active policy when omitted.
+    /// Shows the currently active policy when omitted.
     #[arg(long)]
     pub version: Option<String>,
 }
 
-/// Execute the `aasm policy get` command.
-///
-/// When `--version` is provided, retrieves that specific policy version.
-/// Otherwise, retrieves the most recently applied (active) policy.
-pub fn run(args: GetArgs) -> ExitCode {
-    run_with_config(args, HistoryConfig::default_config())
+/// Response from `GET /api/v1/policies/active`. Only the YAML is consumed here.
+#[derive(Debug, Deserialize)]
+struct ActivePolicyResponse {
+    /// Raw YAML content of the currently active governance policy.
+    policy_yaml: String,
 }
 
-/// Inner implementation that accepts a [`HistoryConfig`] for testability.
-fn run_with_config(args: GetArgs, config: HistoryConfig) -> ExitCode {
+/// Execute the `aasm policy get` command.
+///
+/// When `--version` is provided, retrieves that specific policy version from
+/// the local version-history store. Otherwise, resolves the currently active
+/// policy from the gateway (the same source `apply` and `list` use), so a
+/// policy that was just applied is found instead of reporting "no versions".
+pub fn run(args: GetArgs, ctx: &ResolvedContext) -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async {
-        let store = FsHistoryStore::new(config);
-
-        if let Some(ref version) = args.version {
-            match store.get(version).await {
-                Ok(snapshot) => {
-                    print!("{}", snapshot.yaml_content);
-                    ExitCode::SUCCESS
-                }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    ExitCode::FAILURE
-                }
-            }
-        } else {
-            match store.list(1).await {
-                Ok(versions) if versions.is_empty() => {
-                    eprintln!("No policy versions found.");
-                    ExitCode::FAILURE
-                }
-                Ok(versions) => {
-                    let latest = &versions[0];
-                    let version_id = &latest.sha256;
-                    match store.get(version_id).await {
-                        Ok(snapshot) => {
-                            print!("{}", snapshot.yaml_content);
-                            ExitCode::SUCCESS
-                        }
-                        Err(e) => {
-                            eprintln!("error: {e}");
-                            ExitCode::FAILURE
-                        }
-                    }
-                }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    ExitCode::FAILURE
-                }
-            }
+        match args.version {
+            Some(version) => get_by_version(&version, HistoryConfig::default_config()).await,
+            None => get_active(ctx).await,
         }
     })
+}
+
+/// Resolve the currently active policy from the gateway and print its YAML.
+async fn get_active(ctx: &ResolvedContext) -> ExitCode {
+    match crate::client::get_json::<ActivePolicyResponse>(ctx, "/api/v1/policies/active").await {
+        Ok(resp) => {
+            print!("{}", resp.policy_yaml);
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Retrieve a specific policy version from the local history store.
+async fn get_by_version(version: &str, config: HistoryConfig) -> ExitCode {
+    let store = FsHistoryStore::new(config);
+    match store.get(version).await {
+        Ok(snapshot) => {
+            print!("{}", snapshot.yaml_content);
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
 }
 
 #[cfg(test)]
@@ -80,42 +81,25 @@ mod tests {
     }
 
     #[test]
-    fn get_no_versions_exits_failure() {
-        let tmp = tempfile::tempdir().unwrap();
-        let config = test_config(tmp.path());
-        let args = GetArgs { version: None };
-        assert_eq!(run_with_config(args, config), ExitCode::FAILURE);
-    }
-
-    #[test]
-    fn get_latest_after_apply_exits_success() {
+    fn get_by_version_after_save_exits_success() {
         let tmp = tempfile::tempdir().unwrap();
         let config = test_config(tmp.path());
 
-        // Apply a policy first
         let rt = tokio::runtime::Runtime::new().unwrap();
         let store = FsHistoryStore::new(config.clone());
         let yaml = "tier: low\nrules:\n  - id: r1\n    description: test\n    match:\n      actions: [\"*\"]\n    effect: allow\n    audit: true\n";
         let meta = rt.block_on(store.save(yaml, Some("test"))).unwrap();
 
-        // Now get latest
-        let args = GetArgs { version: None };
-        assert_eq!(run_with_config(args, config.clone()), ExitCode::SUCCESS);
-
-        // Get by specific version
-        let args = GetArgs {
-            version: Some(meta.sha256[..12].to_string()),
-        };
-        assert_eq!(run_with_config(args, config), ExitCode::SUCCESS);
+        let exit = rt.block_on(get_by_version(&meta.sha256[..12], config));
+        assert_eq!(exit, ExitCode::SUCCESS);
     }
 
     #[test]
     fn get_unknown_version_exits_failure() {
         let tmp = tempfile::tempdir().unwrap();
         let config = test_config(tmp.path());
-        let args = GetArgs {
-            version: Some("nonexistent123".to_string()),
-        };
-        assert_eq!(run_with_config(args, config), ExitCode::FAILURE);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let exit = rt.block_on(get_by_version("nonexistent123", config));
+        assert_eq!(exit, ExitCode::FAILURE);
     }
 }

--- a/aa-cli/src/commands/policy/mod.rs
+++ b/aa-cli/src/commands/policy/mod.rs
@@ -53,7 +53,7 @@ pub fn dispatch(args: PolicyArgs, ctx: &ResolvedContext, output: OutputFormat) -
         PolicyCommands::Diff(diff_args) => history::run_diff(diff_args),
         PolicyCommands::Simulate(sim_args) => simulate::run(sim_args),
         PolicyCommands::Validate(val_args) => validate::run(val_args),
-        PolicyCommands::Get(get_args) => get::run(get_args),
+        PolicyCommands::Get(get_args) => get::run(get_args, ctx),
         PolicyCommands::List(list_args) => list::run(list_args, ctx, output),
         PolicyCommands::Show(show_args) => show::run(show_args, ctx, output),
     }

--- a/aa-integration-tests/tests/cli_policy.rs
+++ b/aa-integration-tests/tests/cli_policy.rs
@@ -1,8 +1,8 @@
 //! CLI integration tests for `aasm policy` (AAASM-1261 / F121 Phase A ST-3).
 //!
 //! Exercises every `aasm policy <leaf>` subcommand against a live in-process
-//! gateway booted via `CliFixture`. Three leaves (`list`, `show`) hit the
-//! gateway via HTTP; the other three (`get`, `history`, `simulate`) are
+//! gateway booted via `CliFixture`. `list`, `show`, and no-arg `get` hit the
+//! gateway via HTTP; `get --version`, `history`, and `simulate` are
 //! filesystem-only and read from `AA_DATA_DIR` (defaulting via
 //! `HistoryConfig::default_config()`). `CliFixture::cmd()` automatically
 //! sets `AA_DATA_DIR` to a per-fixture TempDir so these tests don't
@@ -13,6 +13,7 @@
 //! | Leaf | Args | Backend | Notes |
 //! | --- | --- | --- | --- |
 //! | list     | —                                    | GET `/api/v1/policies`                                          | PaginatedResponse |
+//! | get      | (none)                                | GET `/api/v1/policies/active`                                   | raw active YAML to stdout |
 //! | get      | `--version`                           | filesystem (`AA_DATA_DIR/policy-history`)                       | raw YAML to stdout |
 //! | show     | `<agent_id> --show-permissions --show-budget` | GET `/api/v1/policies/agents/{id}/permissions` + `/budget` | `{permissions, budget}` |
 //! | history  | `-n / --limit`                        | filesystem (`AA_DATA_DIR/policy-history`)                       | table |
@@ -108,11 +109,15 @@ async fn policy_list_succeeds_for_every_output_format(#[case] fmt: &str) {
 // =============================================================================
 
 #[tokio::test(flavor = "multi_thread")]
-async fn policy_get_with_empty_data_dir_exits_failure() {
+async fn policy_get_no_version_resolves_active_policy() {
     let fixture = CliFixture::start().await.expect("fixture should start");
-    // AA_DATA_DIR is set to the fixture's empty TempDir, so no policy
-    // history exists — `policy get` should report "No policy versions
-    // found" and exit non-zero.
+    // No-arg `policy get` resolves the currently active policy from the
+    // gateway (`GET /api/v1/policies/active`), not the local history store
+    // — so a just-applied policy is found instead of "no versions". Seed
+    // an active policy first to make the assertion deterministic.
+    let yaml =
+        std::fs::read_to_string(CliFixture::fixture_path("policies/allow_all.yaml")).expect("read allow_all fixture");
+    fixture.seed_policy(&yaml).await.expect("seed_policy");
 
     let out = fixture
         .cmd()
@@ -120,9 +125,14 @@ async fn policy_get_with_empty_data_dir_exits_failure() {
         .output()
         .expect("aasm policy get should execute");
     assert!(
-        !out.status.success(),
-        "empty history should fail; stdout:\n{}\nstderr:\n{}",
+        out.status.success(),
+        "no-arg get should resolve the active policy and exit 0; stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        !out.stdout.is_empty(),
+        "no-arg get should print the active policy YAML; stderr:\n{}",
         String::from_utf8_lossy(&out.stderr),
     );
 }


### PR DESCRIPTION
## Description

After a successful `aasm policy apply` (which reports `Active: true`) and with `aasm policy list` showing the active version, `aasm policy get` with no `--version` returned **"No policy versions found."**

Root cause: `apply` and `list` both talk to the **gateway** over HTTP (`/api/v1/policies`), where `active` is a server-side property. But `policy get` (no arg) read the **local** `FsHistoryStore` — a different source that `apply` never populates — so it was always empty for the typical apply-then-get flow.

Fix: `policy get` with no `--version` now resolves the currently active policy from the gateway via `GET /api/v1/policies/active` (the same source `apply`/`list` use) and prints its `policy_yaml`. This also makes the command's own doc comment ("Show the currently active policy") accurate. The `--version <id>` path continues to read the local history store, since the gateway exposes no by-version retrieval endpoint.

Design choice: **active-resolve** (preferred UX), not a required-arg error — the gateway already exposes the active policy, and `get.rs`'s documented intent was always "show the currently active (or a specific) policy".

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

`policy get` with no `--version` previously failed for the apply-then-get flow; it now succeeds. The CLI surface (flags) is unchanged.

## Related Issues

- Related Jira ticket: AAASM-3442

## Testing

- [x] Unit tests added / updated

`get.rs` tests now cover the `--version` (local-store) success and unknown-version failure paths against a real `FsHistoryStore`. The no-arg active path is an HTTP call to the gateway (covered by the existing API `get_active_policy` route). Validated with `cargo nextest run -p aa-cli commands::policy` (28 passed), `cargo clippy -p aa-cli --all-targets`, `cargo fmt`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
