### PR TITLE
[AAASM-3446] 🔧 (ci): Run eBPF/three-layer suite on master via schedule + dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,15 @@ on:
       - "!**/*.gif"
       - "!**/*.webp"
       - "!**/*.ico"
+  # AAASM-3446: the per-PR / per-push path-filter above gates the slow eBPF
+  # jobs (ebpf-build, e2e-ebpf-linux) to aa-ebpf*/** changes for cost control,
+  # which means the Layer 3 (eBPF) / three-layer suite is normally SKIPPED on
+  # master. A weekly schedule + on-demand dispatch restores standing master
+  # coverage for the AAASM-1520/1522/1523 suites at ~1 run/week without
+  # adding per-PR eBPF cost. The eBPF jobs' `if:` opt in to these events.
+  schedule:
+    - cron: "0 3 * * 1" # Mondays 03:00 UTC
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -677,8 +686,10 @@ jobs:
 
   ebpf-build:
     needs: [changes]
-    # AAASM-2580: only run when aa-ebpf* (or this workflow) changed.
-    if: needs.changes.outputs.ebpf == 'true'
+    # AAASM-2580: per-PR/push, only run when aa-ebpf* (or this workflow) changed.
+    # AAASM-3446: also run on the weekly schedule and on manual dispatch so the
+    # Layer 3 suite keeps standing master coverage despite the path-filter.
+    if: needs.changes.outputs.ebpf == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: eBPF probes build (Linux nightly)
     runs-on: ubuntu-latest
     defaults:
@@ -758,8 +769,10 @@ jobs:
 
   e2e-ebpf-linux:
     needs: [changes]
-    # AAASM-2580: only run when aa-ebpf* (or this workflow) changed.
-    if: needs.changes.outputs.ebpf == 'true'
+    # AAASM-2580: per-PR/push, only run when aa-ebpf* (or this workflow) changed.
+    # AAASM-3446: also run on the weekly schedule and on manual dispatch so the
+    # Layer 3 e2e suite keeps standing master coverage despite the path-filter.
+    if: needs.changes.outputs.ebpf == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     # AAASM-1520 / F116 ST-H — Layer 3 (eBPF) end-to-end interception suite.
     # Linux-only, runs as root for CAP_BPF + CAP_PERFMON; the test source is
     # `#[cfg(all(target_os = "linux", feature = "integration-test"))]` so it


### PR DESCRIPTION
## Description

PR #913 (AAASM-2580) gated the `ebpf-build` and `e2e — Layer 3 eBPF (Linux)` (`e2e-ebpf-linux`) jobs on the `aa-ebpf*/**` dorny path-filter (`needs.changes.outputs.ebpf == 'true'`) for cost control. As a side effect, the Layer 3 (eBPF) / three-layer interception suite — AAASM-1520 `e2e_ebpf`, AAASM-1522 `e2e_file_monitoring`, AAASM-1523 `e2e_three_layers_together` (no-double-count / consistent-decision) plus the `ebpf-build` probe build + multi-layer runtime test — has been **skipped on every master run** since 2026-05-24 (last green: run 26336987822, PR #770). That is a standing-coverage regression and blocks verifying AAASM-3249 (three-layer interception).

This restores standing master coverage at **low cost**:

- Adds a weekly `schedule:` (`cron: 0 3 * * 1`, Mondays 03:00 UTC) and `workflow_dispatch:` trigger to `ci.yml`.
- Opts both eBPF jobs into those events:
  `if: needs.changes.outputs.ebpf == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`

The existing per-PR / per-push path-gating is **unchanged** — the eBPF jobs still do not run on ordinary PRs/pushes that don't touch `aa-ebpf*/**`. Net added cost is ~1 scheduled eBPF run/week plus on-demand dispatch. The `CI Success` gate already treats skipped jobs as non-blocking, so this does not change PR gating behaviour.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3446 (restores PR #913 regression); produces evidence for AAASM-3249 (3261 eBPF leg, 3263 no-double-count)

Closes AAASM-3446

## Testing

- [x] No tests required (explain why)

CI-config-only change. Validated locally with `actionlint .github/workflows/ci.yml` (clean) and a YAML parse. The eBPF suite itself is unchanged; this PR only controls when it runs. A `workflow_dispatch` run on this branch exercises the new trigger.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (inline `ci.yml` comments)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
