### PR TITLE
[AAASM-3449] 📝 (skills): Refresh agent-assembly release skills

### DIFF
--- a/.claude/skills/release-tag-cut/SKILL.md
+++ b/.claude/skills/release-tag-cut/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-tag-cut
-description: Cut a coordinated agent-assembly release tag: bump every workspace Cargo version literal, regenerate Cargo.lock, create the annotated tag, and push it to trigger release.yml. Use when an operator is ready to cut a new alpha-series agent-assembly release (e.g. 0.0.1-alpha.N) on a green master and wants the version bump, tag, release-notes, and downstream fan-out handled in the correct order.
+description: Cut a coordinated agent-assembly release tag: bump every workspace Cargo version literal, regenerate Cargo.lock, create the annotated tag, and push it to trigger release.yml. Use when an operator is ready to cut a new pre-release agent-assembly tag (the current cadence is the 0.0.1-beta.N series; earlier cuts were 0.0.1-alpha.N) on a green master and wants the version bump, tag, release-notes, and downstream fan-out handled in the correct order.
 ---
 
 # release-tag-cut
@@ -12,6 +12,30 @@ Executable contract for cutting an agent-assembly release tag from a clean
 gates, and downstream channel matrix live in
 [`docs/release/RUNBOOK.md`](../../../docs/release/RUNBOOK.md).
 
+## Release-flow index (cut → fan-out → validate → tap-merge)
+
+A full release is a four-stage relay across three sibling skills. WHY this is
+split: each stage has a different write-authority and a different owner, so
+collapsing them invites an LLM to "fix" downstream channels from inside the
+cut. Run them in order:
+
+1. **`release-tag-cut`** (this skill, write) — bump the workspace version, tag,
+   push the tag. Ends the moment `git push remote v<X>` fires `release.yml`.
+2. **fan-out** (automatic, owned by `release.yml`) — the pushed tag triggers
+   GitHub Release + cosign signing, `cargo publish` of the workspace,
+   `notify-downstream` `repository_dispatch` to node-sdk + python-sdk, the
+   `update-{node,python,go}-sdk-ffi-pin` auto-bump PRs, and the
+   `update-homebrew-tap` bot PR. The operator runs none of these by hand.
+3. **`/release-validate-channels v<X>`** (read-only) — once `release.yml` is
+   green, confirm every channel actually caught up. Emits a green/red matrix.
+4. **`/homebrew-tap-merge <PR>`** (write, on the tap repo) — verify the bot's
+   sha256s against the release `SHA256SUMS` and merge the tap PR so
+   `brew install aasm` serves the new version.
+
+The cadence is currently the `0.0.1-beta.N` pre-release series (the latest cut
+is `v0.0.1-beta.2`); the same relay served the earlier `0.0.1-alpha.N` cuts and
+is version-string-agnostic — the operator always supplies the exact literal.
+
 > This skill ends at `git push remote v<X>`. The post-tag verification loop
 > (Homebrew tap PR merge, crates.io / PyPI / npm propagation, ghcr.io image
 > push) is owned by `/release-validate-channels`, invoked by the operator once
@@ -22,7 +46,8 @@ gates, and downstream channel matrix live in
 Pick this skill when **all** of the following hold:
 
 - The operator has decided agent-assembly is ready for a new pre-release tag
-  in the alpha series (e.g. cutting `0.0.1-alpha.10` after `0.0.1-alpha.9`).
+  (current cadence: the beta series, e.g. cutting `0.0.1-beta.3` after
+  `0.0.1-beta.2`; the same path served the earlier `0.0.1-alpha.N` cuts).
 - The most recent CI run on `master` is green.
 - Draft release notes exist (or the operator is prepared to write them inline
   during step 5).
@@ -30,19 +55,20 @@ Pick this skill when **all** of the following hold:
 
 The triggering operator phrasing is typically:
 
-> "Cut alpha-N+1", "Tag v0.0.1-alpha.10", "Release the next alpha".
+> "Cut beta-N+1", "Tag v0.0.1-beta.3", "Release the next beta".
 
 ## When NOT to use
 
-This skill is **alpha-series, agent-assembly-monorepo, full-fanout** specific.
-Pick a different path in any of the following cases:
+This skill is **pre-release-series, agent-assembly-monorepo, full-fanout**
+specific. Pick a different path in any of the following cases:
 
 - **SDK-only release** — use `/sdk-only-release` in the target SDK repo.
   Cutting an `agent-assembly` tag for an SDK-only change wastes a full
   crates.io publish cycle.
-- **GA or non-pre-release tag** (`v1.0.0`, `v0.1.0`, etc.) — this skill is
-  intentionally scoped to the alpha pre-release cadence; a GA cut needs the
-  release-readiness checklist + manual review, not this autopilot path.
+- **GA or non-pre-release tag** (`v1.0.0`, `v0.1.0`, etc. — any tag with no
+  `-alpha`/`-beta`/`-rc` suffix) — this skill is intentionally scoped to the
+  pre-release cadence; a GA cut needs the release-readiness checklist + manual
+  review, not this autopilot path.
 - **Hotfix to an already-tagged release** — use the SDK-only path or a
   follow-up patch tag coordinated via the RUNBOOK; do not re-cut the same tag.
 - **Pre-conditions not met** — if `master` is dirty, behind `remote/master`,

--- a/.claude/skills/release-validate-channels/EXAMPLES.md
+++ b/.claude/skills/release-validate-channels/EXAMPLES.md
@@ -32,13 +32,17 @@ gh release view v0.0.1-alpha.9 --repo ai-agent-assembly/agent-assembly \
 ```
 
 - `isDraft = false`, `isPrerelease = true`
-- 6 assets:
+- 8 assets (current `release.yml` uploads the detached cosign `.sig`/`.pem`
+  alongside the self-contained `.cosign.bundle`; the very earliest cuts
+  predated the detached pair and showed 6):
   - `aasm-aarch64-apple-darwin.tar.gz`
   - `aasm-x86_64-apple-darwin.tar.gz`
   - `aasm-aarch64-unknown-linux-gnu.tar.gz`
   - `aasm-x86_64-unknown-linux-gnu.tar.gz`
   - `SHA256SUMS`
   - `SHA256SUMS.cosign.bundle`
+  - `SHA256SUMS.sig`
+  - `SHA256SUMS.pem`
 
 ### 2. crates.io (sparse-index)
 
@@ -120,7 +124,7 @@ Release validation for v0.0.1-alpha.9:
 
 | Channel              | Status | Detail                                                            |
 |----------------------|--------|-------------------------------------------------------------------|
-| GitHub Release       | ✓      | 6 assets, isPrerelease=true                                       |
+| GitHub Release       | ✓      | 8 assets, isPrerelease=true                                       |
 | crates.io (9 crates) | ✓      | all sparse-index vers = 0.0.1-alpha.9                             |
 | npm (5 packages)     | ✓      | sdk + 4 runtime sub-packages (linux-{arm64,x64}, no -gnu)         |
 | PyPI                 | ✓      | 0.0.1a9 active, 4 wheels + 1 sdist; soft note: 0.0.2 yanked shadow|

--- a/.claude/skills/release-validate-channels/REFERENCE.md
+++ b/.claude/skills/release-validate-channels/REFERENCE.md
@@ -8,7 +8,7 @@ detailed Level-3 reference it links to.
 ## Contents
 
 - [The channel matrix](#the-channel-matrix)
-  - [1. GitHub Release — 6 assets, isPrerelease](#1-github-release--6-assets-isprerelease)
+  - [1. GitHub Release — 8 assets, isPrerelease](#1-github-release--8-assets-isprerelease)
   - [2. crates.io — sparse-index probe per crate](#2-cratesio--sparse-index-probe-per-crate)
   - [3. npm — sdk + 4 runtime sub-packages](#3-npm--sdk--4-runtime-sub-packages)
   - [4. PyPI — wheels + sdist, distinguishing yanked from active](#4-pypi--wheels--sdist-distinguishing-yanked-from-active)
@@ -31,7 +31,7 @@ literal output so the operator can paste back into a follow-up ticket.
 
 | # | Channel              | Check |
 |---|----------------------|-------|
-| 1 | GitHub Release       | `gh release view <TAG>` exposes the 6 expected assets and `isPrerelease=true` |
+| 1 | GitHub Release       | `gh release view <TAG>` exposes the 8 expected assets and `isPrerelease=true` |
 | 2 | crates.io            | Each workspace-published crate's sparse-index latest line `vers` matches `$VERSION` |
 | 3 | npm                  | `@agent-assembly/sdk@$VERSION` + 4 platform runtime sub-packages exist |
 | 4 | PyPI                 | `agent-assembly==$PEP440` exists with 4 wheels + 1 sdist; no yanked higher version shadows |
@@ -41,7 +41,7 @@ literal output so the operator can paste back into a follow-up ticket.
 | 8 | Docs sites           | `Docs` workflow on agent-assembly + `pages-build-deployment` on python-sdk / node-sdk all succeeded post-tag |
 | 9 | GHCR                 | `ghcr.io/ai-agent-assembly/{python,go}:$VERSION` manifests exist |
 
-### 1. GitHub Release — 6 assets, isPrerelease
+### 1. GitHub Release — 8 assets, isPrerelease
 
 ```bash
 gh release view "$TAG" \
@@ -52,14 +52,17 @@ gh release view "$TAG" \
 Pass criteria:
 
 - `isDraft = false`
-- `isPrerelease = true` (every `v0.0.1-alpha.*` tag is a pre-release)
-- `assets` array has **6 entries**, exactly:
+- `isPrerelease = true` (every tag with a `-alpha`/`-beta`/`-rc` suffix is a
+  pre-release — `release.yml` sets `prerelease: contains(ref_name, '-')`)
+- `assets` array has **8 entries**, exactly:
   - `aasm-aarch64-apple-darwin.tar.gz`
   - `aasm-x86_64-apple-darwin.tar.gz`
   - `aasm-aarch64-unknown-linux-gnu.tar.gz`
   - `aasm-x86_64-unknown-linux-gnu.tar.gz`
   - `SHA256SUMS`
   - `SHA256SUMS.cosign.bundle`
+  - `SHA256SUMS.sig`
+  - `SHA256SUMS.pem`
 
 If asset count or names diverge, report the exact `assets[].name` list and
 flag the release run URL.
@@ -304,11 +307,13 @@ skill does not relearn them every cut.
    agent-assembly==$PEP440` is unaffected because yanked versions are
    excluded from resolution unless explicitly pinned.
 
-2. **go-sdk is out of scope by design.** The Go SDK cuts its own
-   `goreleaser`-driven tag on its own cadence and is decoupled from the
-   `agent-assembly` release. Per `docs/release/RUNBOOK.md` section 7, do
-   NOT flag go-sdk as a missing channel. There is no `release-go.yml`
-   fanout to probe.
+2. **go-sdk has no published channel to validate here.** The Go SDK ships
+   via the Go module proxy off its own `goreleaser`-driven tag on its own
+   cadence. Per `docs/release/RUNBOOK.md` section 7, do NOT flag go-sdk as a
+   missing channel; there is no `release-go.yml` binary fanout to probe.
+   (`release.yml` does open an `update-go-sdk-ffi-pin` auto-bump PR per tag —
+   AAASM-3006 — but that is a source-pin PR on go-sdk, confirmed by merging
+   the PR, not a registry channel in this read-only matrix.)
 
 3. **crates.io public REST is rate-limited.** Sustained polling of
    `https://crates.io/api/v1/crates/<name>` returns 429. Use the

--- a/.claude/skills/release-validate-channels/SKILL.md
+++ b/.claude/skills/release-validate-channels/SKILL.md
@@ -86,13 +86,14 @@ this skill.
 
 ## The nine channels
 
-`VERSION="${TAG#v}"`; `PEP440`: `0.0.1-alpha.N` → `0.0.1aN` (canonical sed in
+`VERSION="${TAG#v}"`; `PEP440`: `-alpha.N`→`aN`, `-beta.N`→`bN`, `-rc.N`→`rcN`
+(e.g. current cadence `0.0.1-beta.2` → `0.0.1b2`; canonical sed in
 `scripts/check-release.sh` `to_pep440()`). Probe in this order, recording
 green / red per channel:
 
 | # | Channel              | One-line check |
 |---|----------------------|----------------|
-| 1 | GitHub Release       | 6 expected assets present, `isPrerelease=true`, `isDraft=false` |
+| 1 | GitHub Release       | 8 expected assets present, `isPrerelease=true`, `isDraft=false` |
 | 2 | crates.io            | All 9 published crates' sparse-index latest `vers` = `$VERSION` |
 | 3 | npm                  | `@agent-assembly/sdk` + 4 runtime sub-packages exist at `$VERSION` |
 | 4 | PyPI                 | `agent-assembly==$PEP440` active with 4 wheels + 1 sdist; no yanked higher shadow |
@@ -117,7 +118,7 @@ Release validation for <TAG>:
 
 | Channel              | Status | Detail                                          |
 |----------------------|--------|-------------------------------------------------|
-| GitHub Release       | ✓      | 6 assets, isPrerelease=true                     |
+| GitHub Release       | ✓      | 8 assets, isPrerelease=true                     |
 | crates.io (9 crates) | ✓      | all latest line vers = <VERSION>                |
 | npm (5 packages)     | ✓      | sdk + 4 runtime sub-packages at <VERSION>       |
 | PyPI                 | ✓      | <PEP440> active, 4 wheels + 1 sdist, no shadows |
@@ -174,10 +175,15 @@ tempted to "fix" things from inside the validation loop.
   job.** That aggregator decides whether the cut itself succeeded; this skill
   is the *external* cross-channel confirmation that runs after it. The two
   complement each other; the skill does not block the workflow.
-- **go-sdk is out of scope by design.** The Go SDK cuts its own
-  `goreleaser`-driven tag on its own cadence (RUNBOOK § 7). Do **not** flag
-  go-sdk as a missing channel, probe a non-existent `release-go.yml`, or add
-  it to the matrix. The 9-channel matrix is complete as-is.
+- **go-sdk has no distribution channel to validate here.** The Go SDK ships
+  via the Go module proxy off its own `goreleaser`-driven tag on its own
+  cadence (RUNBOOK § 7), so there is no `release-go.yml` binary fan-out and no
+  registry row to probe. Do **not** add go-sdk to the matrix or flag it as a
+  missing channel — the 9-channel matrix is complete as-is. (Note: go-sdk's
+  `aa-sdk-client` source pin IS now kept in lockstep with each tag via
+  `release.yml`'s `update-go-sdk-ffi-pin` auto-bump PR, AAASM-3006 — but that
+  is a source-pin PR on go-sdk, not a published channel, so it is verified by
+  merging the bump PR, not by this read-only channel matrix.)
 
 If a fix is required, exit with the matrix, then invoke the appropriate
 write-side skill or RUNBOOK procedure separately, and re-run this skill to


### PR DESCRIPTION
## Description

Refresh the three checked-in release skills (`release-tag-cut`,
`release-validate-channels`, `homebrew-tap-merge`) under
`.claude/skills/` so they match the **current** release pipeline and can drive a
real release. Cross-checked every command / path / job name against
`.github/workflows/release.yml`, the workspace version literals, and
`scripts/check-release.sh`.

Key staleness fixed (WHY, not just WHAT):

- **Cadence drift (alpha → beta).** Both `release-tag-cut` and
  `release-validate-channels` were framed as alpha-series-only, but the release
  cadence has moved to the `0.0.1-beta.N` series (latest cut `v0.0.1-beta.2`).
  An operator cutting a beta was steered toward the GA-exclusion path.
  Generalized the descriptions / when-to-use / GA-exclusion / PEP440 example to
  the version-agnostic pre-release cadence (`-alpha`/`-beta`/`-rc`).
- **GitHub Release asset count wrong (6 → 8).** `release.yml`'s cosign step now
  uploads the detached `SHA256SUMS.sig` + `SHA256SUMS.pem` alongside the
  `.cosign.bundle`, so a release carries 8 assets. The old "exactly 6"
  pass-criterion would false-red every current release; fixed the count + asset
  list across SKILL / REFERENCE / EXAMPLES.
- **go-sdk fan-out note half-stale.** `release.yml` now opens an
  `update-go-sdk-ffi-pin` auto-bump PR per tag (AAASM-3006). Clarified that
  go-sdk still has no published *channel* to probe in the read-only matrix, but
  its `aa-sdk-client` source pin IS now coordinated per tag (confirmed by
  merging the bump PR).
- Added a four-stage **release-flow index** (cut → fan-out → validate →
  tap-merge) to `release-tag-cut` so a fresh session understands the relay
  across the three release skills.

`homebrew-tap-merge` needed no functional change — its plan already matches the
`update-homebrew-tap` job exactly (bot/aasm-<version> branch, base master, 4
sha256s, peter-evans PR).

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3449

## Testing

- [x] No tests required (docs-only skill refresh; `markdownlint-cli2` clean,
  0 errors on all changed files; SKILL frontmatter `name`/`description` intact)

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3449
