### PR TITLE
[AAASM-3457] 🔧 (sonar): Lowercase org naming to ai-agent-assembly (projectKey + refs)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,7 +99,7 @@ cargo doc --workspace --no-deps        # checked on push by hooks
 ## Project policy
 
 - **JIRA:** project AAASM; set **Component** (`customfield_10041`) to the repo
-  (`AI-agent-assembly/agent-assembly`); Team (`customfield_10001`) = Pioneer.
+  (`ai-agent-assembly/agent-assembly`); Team (`customfield_10001`) = Pioneer.
   Epic → Story → Subtask (one Subtask ≈ one commit) + a `Verify …` subtask per Story.
 - **Self-hosted deployment is out of scope** product-wide — don't propose
   Helm/Terraform/air-gapped/migration work even if the spec mentions it.

--- a/.claude/skills/release-docs-sync/SKILL.md
+++ b/.claude/skills/release-docs-sync/SKILL.md
@@ -115,8 +115,8 @@ uses **static** shields.io badges that do NOT self-update:
   `0.0.1-beta.x`" prose. Otherwise nothing to bump.
 - **go-sdk** — badges are static `docs-live` only; the install snippet is
   `go get github.com/<org>/go-sdk` with no version. **Nothing version-bump to
-  do.** (Note: the README's `go get` path uses mixed-case org `AI-agent-assembly`;
-  the canonical org id is lowercase `ai-agent-assembly` — a casing fix, tracked
+  do.** (Note: the canonical org id is lowercase `ai-agent-assembly`; if a
+  README's `go get` path ever uses mixed case, that is a casing fix tracked
   separately, not part of version-sync.)
 
 **Net for SDKs:** on a same-channel forward-roll, the SDK READMEs need **no**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -559,9 +559,10 @@ jobs:
         run: |
           set -euo pipefail
           cd sdk
-          # Rewrite the rev for each of the three shared crates. The host
-          # casing varies (`AI-agent-assembly` vs `ai-agent-assembly`) across
-          # historical edits, so the regex tolerates `[^"]*` for the URL.
+          # Rewrite the rev for each of the three shared crates. The host org
+          # casing has varied across historical edits (the canonical id is the
+          # lowercase `ai-agent-assembly`), so the regex tolerates `[^"]*` for
+          # the URL.
           for crate in aa-core aa-proto aa-sdk-client; do
             sed -i -E "s|(${crate} = \{ git = \"[^\"]*\", rev = )\"[0-9a-f]{40}\"|\\1\"${NEW_SHA}\"|" \
               native/aa-ffi-python/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/ai-agent-assembly/agent-assembly?include_prereleases&sort=semver&logo=github&label=release)](https://github.com/ai-agent-assembly/agent-assembly/releases)
 [![crates.io](https://img.shields.io/crates/v/aa-cli?logo=rust&label=crates.io)](https://crates.io/crates/aa-cli)
 [![Coverage](https://img.shields.io/codecov/c/github/ai-agent-assembly/agent-assembly?logo=codecov&logoColor=white)](https://codecov.io/gh/ai-agent-assembly/agent-assembly)
-[![Quality Gate](https://img.shields.io/sonar/quality_gate/AI-agent-assembly_agent-assembly?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud)](https://sonarcloud.io/project/overview?id=AI-agent-assembly_agent-assembly)
+[![Quality Gate](https://img.shields.io/sonar/quality_gate/ai-agent-assembly_agent-assembly?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud)](https://sonarcloud.io/project/overview?id=ai-agent-assembly_agent-assembly)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-%E2%89%A51.75-orange?logo=rust)](https://www.rust-lang.org)
 [![Style](https://img.shields.io/badge/style-rustfmt-000?logo=rust)](https://github.com/rust-lang/rustfmt)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.host.url=https://sonarcloud.io
-sonar.projectKey=AI-agent-assembly_agent-assembly
+sonar.projectKey=ai-agent-assembly_agent-assembly
 sonar.organization=ai-agent-assembly
 
 sonar.projectName=agent-assembly


### PR DESCRIPTION
## Description

Align repo config with the canonical lowercase org id `ai-agent-assembly`. The
live SonarCloud project was renamed `AI-agent-assembly_agent-assembly` →
`ai-agent-assembly_agent-assembly` (AAASM-3456); `sonar-project.properties` still
carried the stale uppercase `sonar.projectKey`, so a labeled Sonar scan would have
reported to the now-renamed-away key. This PR makes the config match the renamed
project — this PR's own scan (if it runs) reads the lowercase config and reports to
the correct project.

Lowercased every tracked `AI-agent-assembly` occurrence (5 files):
- `sonar-project.properties` — `sonar.projectKey` (load-bearing)
- `README.md` — SonarCloud Quality Gate badge + project-overview link
- `.claude/CLAUDE.md` — JIRA Component org reference
- `.github/workflows/release.yml` — SDK-pin comment (reworded; behavior unchanged)
- `.claude/skills/release-docs-sync/SKILL.md` — casing note (reworded)

`git grep -n 'AI-agent-assembly'` is now empty.

## Type of Change

- [x] 🔧 Configuration / CI change
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3457 (aligns config after the rename in AAASM-3456)

## Testing

- [x] No tests required (explain why)

Config/docs/comment-only change with no source behavior change. No Cargo git URLs
were modified (the only git-dep URL reference is a comment), so no build verification
was needed; the pre-push `cargo doc` gate passed.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3457
