### PR TITLE
[AAASM-3375] 🔖 (release): Cut v0.0.1-beta.3 (version bump + docs sync)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aa-api"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "aa-cache"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-cache",
  "aa-core",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aa-cli"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aa-core"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-security",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-claude-code"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-codex"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-copilot"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-saas"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-sample-myeditor"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-windsurf"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-ebpf-common",
@@ -249,11 +249,11 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf-common"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 
 [[package]]
 name = "aa-gateway"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "aa-integration-tests"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-api",
  "aa-core",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "prost",
  "tonic",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proxy"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aa-runtime"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-ebpf",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "aa-sandbox"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "thiserror 2.0.18",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "aa-sdk-client"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "aa-security"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-memory"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-storage",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-postgres"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-storage",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-redis"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-storage",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-sqlite-buffer"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "aa-wasm"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "wasm-bindgen",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 dependencies = [
  "aa-core",
  "aa-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ exclude = ["node-sdk"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ai-agent-assembly/agent-assembly"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The installer script lives at [`scripts/install-cli.sh`](scripts/install-cli.sh)
 
 ```sh
 # Pin a specific version
-AASM_VERSION=v0.0.1-beta.2 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
+AASM_VERSION=v0.0.1-beta.3 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 
 # Custom install directory
 AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
@@ -120,8 +120,8 @@ These two are built by `aa-ebpf/build.rs` (via `aya-build`) for the BPF target â
 public API and wire protocol are **not** stable; do not use in production.
 
 Releases are published as GitHub pre-releases â€” latest
-[`v0.0.1-beta.2`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.2)
-(2026-06-13). The coordinated release tag also publishes the CLI, crates, SDK
+[`v0.0.1-beta.3`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.3)
+(2026-06-20). The coordinated release tag also publishes the CLI, crates, SDK
 packages, and container image:
 
 | Channel | Status |

--- a/docs/release/v0.0.1-beta.3.md
+++ b/docs/release/v0.0.1-beta.3.md
@@ -1,0 +1,105 @@
+# v0.0.1-beta.3 — anomaly detection wiring + audit lineage + SDK gateway register
+
+> **Operator note** — this file is the source-controlled draft of the
+> GitHub Release description for the `v0.0.1-beta.3` tag. The
+> `prerelease: true` flag is applied automatically by `release.yml`.
+
+---
+
+## v0.0.1-beta.3 — forward-roll beta with governance + audit enrichment
+
+Third pre-release in the v0.0.1 beta channel. This is a **forward-roll**
+beta cut on top of `v0.0.1-beta.2` (no channel promotion, no scope
+expansion) carrying a large body of master content merged since beta.2 —
+anomaly-detector wiring into `serve`, audit trace/lineage enrichment and
+persistence, `aa-sdk-client` gateway register with credential-token
+attachment, rate-limit env honoring, and a CodeQL hardening pass.
+
+> **Not for production use.** Beta still carries no API/ABI/wire-protocol
+> stability commitment at 0.x.y SemVer.
+
+### agent-assembly content riding this tag
+
+Highlights of master content merged since `v0.0.1-beta.2`:
+
+- **Anomaly detection** (AAASM-3378 / AAASM-3384) — the anomaly detector
+  is now wired into and enabled in `serve`, with anomaly outcomes
+  enforced through the governance flow.
+- **Audit lineage + trace enrichment** (AAASM-3376 / AAASM-3377 /
+  AAASM-3415) — audit events are enriched with trace/lineage data and
+  persisted; `aa-sdk-client` forwards `team_id` / `parent_agent_id` on
+  native Register.
+- **SDK gateway register** (AAASM-3396) — `AssemblyClient::register`
+  stores the credential token and attaches it on `query_policy`;
+  with-core test coverage added.
+- **`aa-api` hardening** (AAASM-3369) — server hardening pass; retention
+  cron loop added (AAASM-3383); `AA_RATE_LIMIT_RPM` is now honored in the
+  `serve_local` live limiter (AAASM-3441).
+- **`aa-cli` fixes** (AAASM-3442 / AAASM-3374) — `policy get` resolves the
+  active policy when no version is given; CLI health-probe target fixed.
+- **CodeQL hardening** (AAASM-3432 / AAASM-3438 / AAASM-3440 / AAASM-3443)
+  — added the CodeQL workflow with push-to-master coverage, scan docs
+  theme JS, and fixed `js/xss-through-dom` findings in the docs version
+  switcher.
+- **Release tooling** (AAASM-3449 / AAASM-3453) — refreshed the
+  release-tag-cut / release-validate-channels skills for the beta cadence
+  and added the `release-docs-sync` runbook + `check-docs-versions.sh`
+  verifier so version-dependent docs can no longer go stale on a cut.
+- **Docs version-drift fix** (AAASM-3372) — corrected stale version refs
+  in the compatibility matrix and install examples.
+- **Dependency bumps** — redis 1.2.4, ratatui 0.30.2, bytes 1.12.0,
+  cron 0.17.0, undici 7.28.0, dompurify 3.4.11, plus several GitHub
+  Actions bumps (checkout 7, action-gh-release 3.0.1).
+
+### Coordinated SDK publishes driven by this tag
+
+- `@agent-assembly/sdk@0.0.1-beta.3` (npm) — via `repository_dispatch` → `release-node.yml`.
+- `agent-assembly==0.0.1b3` (PyPI) — via `repository_dispatch` → `release-python.yml`.
+- `github.com/ai-agent-assembly/go-sdk@v0.0.1-beta.3` (Go module) — tagged
+  directly on go-sdk (it owns its own release trajectory; not part of the
+  agent-assembly fan-out).
+
+### Expected post-tag sequence
+
+1. `release.yml` → builds binaries → GH Release → `publish-crates`
+   re-publishes all publishable crates at `0.0.1-beta.3`.
+2. `docker.yml` → ghcr.io images at the new tag.
+3. `notify-downstream` → `repository_dispatch` to node-sdk + python-sdk.
+4. node-sdk publishes `@agent-assembly/sdk@0.0.1-beta.3` + runtime sub-packages.
+5. python-sdk publishes `agent-assembly==0.0.1b3`.
+6. `update-homebrew-tap` opens a tap PR.
+7. go-sdk `v0.0.1-beta.3` tag (pushed separately) → goreleaser + Go module proxy.
+
+### Install
+
+```bash
+# Native binaries
+brew install ai-agent-assembly/homebrew-agent-assembly/aasm
+curl -L https://github.com/ai-agent-assembly/agent-assembly/releases/download/v0.0.1-beta.3/aasm-aarch64-apple-darwin.tar.gz | tar xz
+
+# crates.io
+cargo install aasm --version 0.0.1-beta.3
+
+# Container images
+docker pull ghcr.io/ai-agent-assembly/aa-runtime:v0.0.1-beta.3
+
+# Language SDKs
+pip install --pre agent-assembly==0.0.1b3
+npm install @agent-assembly/sdk@0.0.1-beta.3
+go get github.com/ai-agent-assembly/go-sdk@v0.0.1-beta.3
+```
+
+### Behaviour delta on the crates.io `aasm` binary
+
+Unchanged from `v0.0.1-beta.2`. The published `aasm` binary omits the
+`aasm run <tool>` and `aasm tools` subcommands while the dev-tool
+subsystem is being finished. Local source builds (`cargo build -p aa-cli`)
+expose the full surface unchanged.
+
+### Refs
+
+- This tag's prep: `AAASM-3375`
+- Predecessor: `AAASM-3004` (beta.2)
+- Anomaly detection: `AAASM-3378`, `AAASM-3384`
+- Audit lineage: `AAASM-3376`, `AAASM-3377`, `AAASM-3415`
+- SDK gateway register: `AAASM-3396`

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -76,6 +76,7 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 | v0.0.1 | v0.0.1 ✓ | v0.0.1 ✓ | v0.0.1 ✓ | protocol/v1 |
 | v0.0.1-beta.1 | v0.0.1-beta.1 (PyPI `0.0.1b1`) ✓ | v0.0.1-beta.1 ✓ | v0.0.1-beta.1 ✓ | protocol/v1 |
 | v0.0.1-beta.2 | v0.0.1-beta.2 (PyPI `0.0.1b2`) ✓ | v0.0.1-beta.2 ✓ | v0.0.1-beta.2 ✓ | protocol/v1 |
+| v0.0.1-beta.3 | v0.0.1-beta.3 (PyPI `0.0.1b3`) ✓ | v0.0.1-beta.3 ✓ | v0.0.1-beta.3 ✓ | protocol/v1 |
 
 **Legend:**
 - ✓ Compatible — fully supported
@@ -94,6 +95,9 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 | Python SDK (`aa-ffi-python`) v0.0.1-beta.2 | aa-runtime v0.0.1-beta.1 |
 | Node.js SDK (`aa-ffi-node`) v0.0.1-beta.2 | aa-runtime v0.0.1-beta.1 |
 | Go SDK (`aa-ffi-go`) v0.0.1-beta.2 | aa-runtime v0.0.1-beta.1 |
+| Python SDK (`aa-ffi-python`) v0.0.1-beta.3 | aa-runtime v0.0.1-beta.1 |
+| Node.js SDK (`aa-ffi-node`) v0.0.1-beta.3 | aa-runtime v0.0.1-beta.1 |
+| Go SDK (`aa-ffi-go`) v0.0.1-beta.3 | aa-runtime v0.0.1-beta.1 |
 
 ---
 
@@ -109,6 +113,7 @@ A runtime version may support multiple protocol versions to allow SDK upgrades w
 | v0.0.1 | protocol/v1 |
 | v0.0.1-beta.1 | protocol/v1 |
 | v0.0.1-beta.2 | protocol/v1 |
+| v0.0.1-beta.3 | protocol/v1 |
 
 ---
 

--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -46,7 +46,7 @@ The installer honors these environment variables:
 
 ```sh
 # Install a specific release tag (default: latest)
-AASM_VERSION=v0.0.1-beta.2 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
+AASM_VERSION=v0.0.1-beta.3 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 
 # Install to a custom directory
 AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
@@ -96,7 +96,7 @@ publishes per-platform tarballs plus a `SHA256SUMS` file and a
 To install and verify by hand:
 
 ```sh
-VERSION=v0.0.1-beta.2
+VERSION=v0.0.1-beta.3
 ASSET=aasm-aarch64-apple-darwin.tar.gz   # adjust for your platform
 BASE="https://github.com/ai-agent-assembly/agent-assembly/releases/download/${VERSION}"
 
@@ -147,7 +147,7 @@ Confirm the binary is on your `PATH` and runs:
 
 ```console
 $ aasm --version
-aasm 0.0.1-beta.2
+aasm 0.0.1-beta.3
 ```
 
 A fuller report — the CLI version plus whether a gateway and API are reachable —
@@ -159,7 +159,7 @@ $ aasm version
 +-----------+---------------+-------------+
 | COMPONENT | VERSION       | STATUS      |
 +=========================================+
-| cli       | 0.0.1-beta.2  | -           |
+| cli       | 0.0.1-beta.3  | -           |
 |-----------+---------------+-------------|
 | gateway   | -             | unreachable |
 |-----------+---------------+-------------|


### PR DESCRIPTION
## Description

Cuts the **core** beta release **v0.0.1-beta.3** (forward-roll after `v0.0.1-beta.2`). This is the **version-bump PR only** — it bumps the Cargo workspace version, regenerates `Cargo.lock`, adds the release notes, and syncs every version-dependent doc. **No git tag is created in this PR.** After this PR merges, the operator pushes the `v0.0.1-beta.3` tag from `master`, which triggers `release.yml` (GitHub Release, `cargo publish`, downstream SDK `repository_dispatch` fan-out, Homebrew tap PR).

This is the **lead** of the coordinated release.

## Type of Change

- [x] 🚀 Release

## Breaking Changes

- [x] No

Beta still carries no API/ABI/wire-protocol stability commitment at 0.x.y SemVer; this is a same-channel forward-roll (no promotion, no scope expansion).

## Related Issues

- Related Jira ticket: AAASM-3375 (version-skew reconcile / beta.3 cut)

## Testing

- [x] Manual testing performed
- [x] No tests required (release version bump)

Validation performed:
- `release-tag-cut.sh 0.0.1-beta.2 0.0.1-beta.3` — bumped the workspace `version` literal + regenerated `Cargo.lock`; no `0.0.1-beta.2` literal remains in any `Cargo.toml`.
- `cargo metadata` — all workspace crates report `0.0.1-beta.3`.
- `cargo build -p aa-core` — compiles clean with the new versions.
- `scripts/check-docs-versions.sh 0.0.1-beta.3` — **exit 0** (installation.md AASM_VERSION/VERSION/--version/version-table, compatibility.md matrix row, README AASM_VERSION + Project Status line all on `v0.0.1-beta.3`).

## What changed

- `Cargo.toml` — `[workspace.package] version` → `0.0.1-beta.3`.
- `Cargo.lock` — regenerated.
- `docs/release/v0.0.1-beta.3.md` — new release notes (highlights since beta.2: anomaly-detector wiring/enforcement, audit lineage + trace enrichment + persistence, `aa-sdk-client` gateway register w/ credential token, `AA_RATE_LIMIT_RPM` honoring, `aa-cli` policy-get / health-probe fixes, CodeQL hardening, release-docs-sync tooling, dependency bumps).
- `docs/src/compatibility.md` — new `v0.0.1-beta.3` rows in Compatibility Matrix, Minimum Supported Runtime per SDK, and Supported Protocol Versions.
- `docs/src/quick-start/installation.md` + `README.md` — version-dependent live install examples bumped to `v0.0.1-beta.3` (release-docs-sync).

## Post-merge (operator)

1. Tag `v0.0.1-beta.3` on `master` → triggers `release.yml`.
2. Run `/release-validate-channels v0.0.1-beta.3` once the workflow is green.
3. `/homebrew-tap-merge` the bot's tap PR.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
