### PR TITLE
[AAASM-3483] 🐛 (aa-api): Scope topology & audit-log endpoints to caller tenant

### DIFF
--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -124,6 +124,19 @@ impl AuthenticatedCaller {
         }
         self.tenant.team_id.as_deref() == Some(team)
     }
+
+    /// Whether this caller may see data for `org` without a separate admin gate.
+    ///
+    /// AAASM-3483: the org-tier analogue of [`Self::can_access_team`], used by
+    /// the topology and audit-log surfaces. An admin sees every org; a
+    /// tenant-scoped caller sees only its own org. A caller with no org scope
+    /// (and no admin) sees no per-org data.
+    pub fn can_access_org(&self, org: &str) -> bool {
+        if self.scopes.contains(&Scope::Admin) {
+            return true;
+        }
+        self.tenant.org_id.as_deref() == Some(org)
+    }
 }
 
 /// Prefix used by API keys (`aa_`).

--- a/aa-api/src/models/topology.rs
+++ b/aa-api/src/models/topology.rs
@@ -43,7 +43,7 @@ pub(crate) fn status_str(status: &AgentStatus) -> &'static str {
 ///   "standalone_root_agents": []
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
 #[schema(example = json!({
     "team_count": 2,
     "root_agent_count": 3,

--- a/aa-api/src/routes/logs.rs
+++ b/aa-api/src/routes/logs.rs
@@ -6,6 +6,7 @@ use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
+use crate::auth::scope::{RequireRead, Scope};
 use crate::pagination::{PaginatedResponse, PaginationParams};
 use crate::state::AppState;
 
@@ -46,22 +47,44 @@ pub struct LogFilterParams {
 ///
 /// Query the paginated audit log of governance events.
 /// Supports optional filtering by agent ID and event type.
+///
+/// Per-tenant scoping (AAASM-3483): the audit log is per-tenant data. An admin
+/// caller may read any org's audit (honouring an explicit `?org_id`); a
+/// tenant-scoped caller has the `org_id` filter forced to its own org, so it
+/// can neither read another org's audit nor omit the filter to enumerate every
+/// org. A non-admin caller with no org scope receives an empty page rather than
+/// a cross-tenant dump.
 #[utoipa::path(
     get,
     path = "/api/v1/logs",
     params(PaginationParams, LogFilterParams),
     responses(
-        (status = 200, description = "Paginated audit log entries", body = Vec<LogEntry>)
+        (status = 200, description = "Paginated audit log entries", body = Vec<LogEntry>),
+        (status = 401, description = "Missing or invalid credentials")
     ),
     tag = "logs"
 )]
 pub async fn list_logs(
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     axum::extract::Query(params): axum::extract::Query<PaginationParams>,
     axum::extract::Query(filters): axum::extract::Query<LogFilterParams>,
 ) -> impl IntoResponse {
     let limit = params.per_page() as usize;
     let offset = params.offset();
+
+    // AAASM-3483 — bind the `org_id` filter to the caller's tenant. An admin
+    // honours the caller-supplied `?org_id`; a tenant-scoped caller is forced to
+    // its own org; a non-admin with no org scope is given a sentinel that the
+    // `AuditReader` org filter never matches (entries with `org_id = None` never
+    // match an explicit filter), yielding an empty page instead of every org's
+    // audit.
+    let is_admin = caller.scopes.contains(&Scope::Admin);
+    let effective_org: Option<&str> = if is_admin {
+        filters.org_id.as_deref()
+    } else {
+        Some(caller.tenant.org_id.as_deref().unwrap_or("\0__no_tenant_scope__"))
+    };
 
     let (entries, total) = state
         .audit_reader
@@ -70,7 +93,7 @@ pub async fn list_logs(
             offset,
             filters.agent_id.as_deref(),
             filters.event_type.as_deref(),
-            filters.org_id.as_deref(),
+            effective_org,
         )
         .await
         .unwrap_or_default();

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -13,9 +13,10 @@ use axum::{Extension, Json};
 use serde::Deserialize;
 use utoipa::IntoParams;
 
-use aa_gateway::registry::{AgentRegistry, AgentStatus};
+use aa_gateway::registry::{AgentRecord, AgentRegistry, AgentStatus};
 
-use crate::auth::scope::RequireRead;
+use crate::auth::scope::{RequireRead, Scope};
+use crate::auth::AuthenticatedCaller;
 use crate::error::ProblemDetail;
 use crate::models::topology::{format_id, status_str};
 pub use crate::models::topology::{
@@ -48,6 +49,67 @@ fn matches_status_filter(status: &AgentStatus, filter: &str) -> bool {
         "deregistered" => matches!(status, AgentStatus::Deregistered),
         _ => true,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Tenant scoping (AAASM-3483)
+// ---------------------------------------------------------------------------
+//
+// The topology surface is per-tenant data, but the org/team/agent selector is
+// caller-controlled. Without scoping, any read-scoped caller can read another
+// tenant's topology, or omit the filter to enumerate every tenant. Mirror the
+// cost / agent-budget reference pattern (AAASM-3139): admin bypasses; a
+// tenant-scoped caller is confined to its own org / team; a non-admin caller
+// with no tenant scope at all sees nothing (deny / empty, never a cross-tenant
+// dump).
+
+/// Whether a single record is visible to `caller` under tenant scoping.
+///
+/// Admin sees every record. A non-admin caller only sees a record whose
+/// `org_id` matches its org scope (when it has one) AND whose `team_id` matches
+/// its team scope (when it has one). A record carrying no `org_id` / `team_id`
+/// never matches a scoped non-admin caller — untagged records are not exposed
+/// across the tenant boundary.
+fn record_visible_to(caller: &AuthenticatedCaller, record: &AgentRecord) -> bool {
+    if caller.scopes.contains(&Scope::Admin) {
+        return true;
+    }
+    // A non-admin caller with no tenant scope at all can never be confined to a
+    // tenant, so it sees nothing (fail-closed; never a cross-tenant dump).
+    if caller.tenant.org_id.is_none() && caller.tenant.team_id.is_none() {
+        return false;
+    }
+    if let Some(org) = caller.tenant.org_id.as_deref() {
+        if record.org_id.as_deref() != Some(org) {
+            return false;
+        }
+    }
+    if let Some(team) = caller.tenant.team_id.as_deref() {
+        if record.team_id.as_deref() != Some(team) {
+            return false;
+        }
+    }
+    true
+}
+
+/// A non-admin caller with neither an org nor a team scope can never be
+/// confined to a tenant, so it must not receive any per-tenant topology data.
+fn caller_has_no_tenant_scope(caller: &AuthenticatedCaller) -> bool {
+    !caller.scopes.contains(&Scope::Admin) && caller.tenant.org_id.is_none() && caller.tenant.team_id.is_none()
+}
+
+/// Cache-key fragment that makes a cached topology response specific to the
+/// caller's tenant scope, so a tenant-scoped response is never served to a
+/// caller from a different tenant.
+fn tenant_cache_tag(caller: &AuthenticatedCaller) -> String {
+    if caller.scopes.contains(&Scope::Admin) {
+        return "admin".to_string();
+    }
+    format!(
+        "org={}|team={}",
+        caller.tenant.org_id.as_deref().unwrap_or(""),
+        caller.tenant.team_id.as_deref().unwrap_or(""),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -146,12 +208,31 @@ fn build_tree(
     tag = "topology"
 )]
 pub async fn get_overview(
-    _auth: RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     Query(params): Query<TopologyFilterParams>,
 ) -> (StatusCode, Json<TopologyOverview>) {
+    // AAASM-3483 — a non-admin caller with no tenant scope receives an empty
+    // overview rather than a cross-tenant dump.
+    if caller_has_no_tenant_scope(&caller) {
+        return (StatusCode::OK, Json(TopologyOverview::default()));
+    }
+
+    // AAASM-3483 — a tenant-scoped caller is confined to its own org; an
+    // explicit `?org_id` selector outside that scope yields no agents. Force
+    // the effective org filter to the caller's own org for non-admins.
+    let is_admin = caller.scopes.contains(&Scope::Admin);
+    let effective_org: Option<String> = if is_admin {
+        params.org_id.clone()
+    } else {
+        caller.tenant.org_id.clone()
+    };
+
+    // AAASM-3483 — the tenant tag scopes the cache entry to the caller's tenant
+    // so a tenant-scoped response is never served to a different tenant.
     let cache_key = format!(
-        "{}|{}|{}",
+        "{}|{}|{}|{}",
+        tenant_cache_tag(&caller),
         params.status.as_deref().unwrap_or(""),
         params.min_depth.unwrap_or(0),
         params.show_budget.unwrap_or(false),
@@ -162,7 +243,7 @@ pub async fn get_overview(
 
     // AAASM-2008 — when org_id is set, scope to that org's members
     // (O(members) lookup). Otherwise list all agents.
-    let all = match params.org_id.as_deref() {
+    let all: Vec<AgentRecord> = match effective_org.as_deref() {
         Some(oid) => {
             let keys = state.agent_registry.org_members(oid);
             keys.into_iter().filter_map(|k| state.agent_registry.get(&k)).collect()
@@ -173,6 +254,9 @@ pub async fn get_overview(
 
     let filtered: Vec<_> = all
         .iter()
+        // AAASM-3483 — confine the result to records the caller's tenant may see
+        // (team-tier scoping; org-tier handled by `effective_org` above).
+        .filter(|r| record_visible_to(&caller, r))
         .filter(|r| {
             params
                 .status
@@ -260,7 +344,7 @@ pub async fn get_overview(
     tag = "topology"
 )]
 pub async fn get_tree(
-    _auth: RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     Path(root_id): Path<String>,
     Query(params): Query<TreeParams>,
@@ -269,8 +353,24 @@ pub async fn get_tree(
     let max_depth = params.depth.unwrap_or(MAX_TREE_DEPTH).min(MAX_TREE_DEPTH);
     let show_budget = params.show_budget.unwrap_or(false);
 
+    // AAASM-3483 — a non-admin caller with no tenant scope sees no per-tenant
+    // topology; report 404 (not 403) so it cannot probe agent existence.
+    if caller_has_no_tenant_scope(&caller) {
+        return Err(
+            ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {root_id}"))
+        );
+    }
+
     // Validate the starting agent exists and is a root before hitting the cache.
     if let Some(record) = state.agent_registry.get(&agent_id) {
+        // AAASM-3483 — a root outside the caller's tenant is reported as not
+        // found, so the tree of another tenant's agent never leaks and the
+        // 404-vs-422 distinction cannot be used to enumerate cross-tenant roots.
+        if !record_visible_to(&caller, &record) {
+            return Err(
+                ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {root_id}"))
+            );
+        }
         if record.depth > 0 {
             return Err(ProblemDetail::from_status(StatusCode::UNPROCESSABLE_ENTITY)
                 .with_detail(format!("Agent {root_id} is not a root agent (depth {})", record.depth)));
@@ -282,7 +382,8 @@ pub async fn get_tree(
     }
 
     let cache_key = format!(
-        "{}|{}|{}|{}",
+        "{}|{}|{}|{}|{}",
+        tenant_cache_tag(&caller),
         root_id,
         max_depth,
         params.status.as_deref().unwrap_or(""),
@@ -329,13 +430,22 @@ pub async fn get_tree(
     tag = "topology"
 )]
 pub async fn get_team(
-    _auth: RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     Path(team_id): Path<String>,
     Query(params): Query<TopologyFilterParams>,
 ) -> Result<(StatusCode, Json<TeamTopology>), ProblemDetail> {
+    // AAASM-3483 — a tenant-scoped caller may only read its own team; any other
+    // team (and an unscoped non-admin caller) is denied, so a team's membership
+    // never leaks across the tenant boundary.
+    if !caller.can_access_team(&team_id) {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("Reading a team's topology requires admin scope or membership in that team"));
+    }
+
     let cache_key = format!(
-        "{}|{}|{}|{}",
+        "{}|{}|{}|{}|{}",
+        tenant_cache_tag(&caller),
         team_id,
         params.status.as_deref().unwrap_or(""),
         params.min_depth.unwrap_or(0),
@@ -353,6 +463,9 @@ pub async fn get_team(
     let mut members: Vec<AgentNode> = member_ids
         .iter()
         .filter_map(|id| state.agent_registry.get(id))
+        // AAASM-3483 — apply org-tier scoping too: a caller scoped to both an
+        // org and a team must not see a same-named team's members in another org.
+        .filter(|r| record_visible_to(&caller, r))
         .filter(|r| {
             params
                 .status
@@ -403,11 +516,20 @@ pub async fn get_team(
     tag = "topology"
 )]
 pub async fn get_lineage(
-    _auth: RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     Path(agent_id_str): Path<String>,
 ) -> Result<(StatusCode, Json<AgentLineage>), ProblemDetail> {
-    if let Some(cached) = state.topology_lineage_cache.get(&agent_id_str).await {
+    // AAASM-3483 — a non-admin caller with no tenant scope sees no per-tenant
+    // topology; report 404 so it cannot probe agent existence.
+    if caller_has_no_tenant_scope(&caller) {
+        return Err(
+            ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {agent_id_str}"))
+        );
+    }
+
+    let cache_key = format!("{}|{}", tenant_cache_tag(&caller), agent_id_str);
+    if let Some(cached) = state.topology_lineage_cache.get(&cache_key).await {
         return Ok((StatusCode::OK, Json((*cached).clone())));
     }
 
@@ -416,6 +538,14 @@ pub async fn get_lineage(
     let record = state.agent_registry.get(&agent_id).ok_or_else(|| {
         ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {agent_id_str}"))
     })?;
+
+    // AAASM-3483 — an agent outside the caller's tenant is reported as not found
+    // so its delegation lineage (and that of its ancestors) never leaks.
+    if !record_visible_to(&caller, &record) {
+        return Err(
+            ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {agent_id_str}"))
+        );
+    }
 
     // ancestors_of returns parent-first (direct parent at [0], root at end).
     // Reverse to root-first, then append the requested agent as the final element.
@@ -450,7 +580,7 @@ pub async fn get_lineage(
     };
     state
         .topology_lineage_cache
-        .insert(agent_id_str, Arc::new(lineage.clone()))
+        .insert(cache_key, Arc::new(lineage.clone()))
         .await;
     Ok((StatusCode::OK, Json(lineage)))
 }
@@ -468,12 +598,25 @@ pub async fn get_lineage(
     ),
     tag = "topology"
 )]
-pub async fn get_stats(_auth: RequireRead, Extension(state): Extension<AppState>) -> (StatusCode, Json<TopologyStats>) {
-    if let Some(cached) = state.topology_stats_cache.get("stats").await {
+pub async fn get_stats(
+    RequireRead(caller): RequireRead,
+    Extension(state): Extension<AppState>,
+) -> (StatusCode, Json<TopologyStats>) {
+    // AAASM-3483 — stats aggregate the whole registry, so without tenant scoping
+    // they leak every tenant's agent counts. The tenant tag scopes the cache and
+    // the visibility filter below confines the aggregation to the caller's tenant
+    // (a non-admin with no tenant scope aggregates over an empty set → zeros).
+    let cache_key = format!("stats|{}", tenant_cache_tag(&caller));
+    if let Some(cached) = state.topology_stats_cache.get(&cache_key).await {
         return (StatusCode::OK, Json((*cached).clone()));
     }
 
-    let all = state.agent_registry.list();
+    let all: Vec<AgentRecord> = state
+        .agent_registry
+        .list()
+        .into_iter()
+        .filter(|r| record_visible_to(&caller, r))
+        .collect();
 
     let mut root_agent_count = 0usize;
     let mut max_depth = 0u32;
@@ -546,7 +689,7 @@ pub async fn get_stats(_auth: RequireRead, Extension(state): Extension<AppState>
     };
     state
         .topology_stats_cache
-        .insert("stats", Arc::new(stats.clone()))
+        .insert(cache_key, Arc::new(stats.clone()))
         .await;
     (StatusCode::OK, Json(stats))
 }

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -92,7 +92,7 @@ pub struct AppState {
     /// Short-lived cache for GET /topology/lineage/{agent_id} responses (5 s TTL).
     pub topology_lineage_cache: moka::future::Cache<String, Arc<AgentLineage>>,
     /// Short-lived cache for GET /topology/stats responses (10 s TTL).
-    pub topology_stats_cache: moka::future::Cache<&'static str, Arc<TopologyStats>>,
+    pub topology_stats_cache: moka::future::Cache<String, Arc<TopologyStats>>,
     /// Dashboard Capability Matrix store (AAASM-1366).
     pub capability_store: Arc<CapabilityStore>,
     /// Dashboard Identity & Access — IAM API key management (AAASM-1397).

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -265,3 +265,20 @@ pub fn generate_test_jwt_for_team(key_id: &str, scopes: &[Scope], team_id: &str)
         .sign_with_tenant(key_id, scopes, Some(team_id.to_string()), None)
         .expect("signing should succeed")
 }
+
+/// Generate a test JWT scoped to an arbitrary (team, org) tenant (AAASM-3483).
+///
+/// Mirrors the bug repro's `sign_with_tenant(.., team, org)`, letting tests
+/// mint org-scoped callers for the topology / audit-log isolation checks.
+#[allow(dead_code)]
+pub fn generate_test_jwt_for_tenant(
+    key_id: &str,
+    scopes: &[Scope],
+    team_id: Option<&str>,
+    org_id: Option<&str>,
+) -> String {
+    let signer = JwtSigner::new(TEST_SECRET);
+    signer
+        .sign_with_tenant(key_id, scopes, team_id.map(str::to_string), org_id.map(str::to_string))
+        .expect("signing should succeed")
+}

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -25,6 +25,11 @@ fn bearer(uri: &str, token: &str) -> Request<Body> {
 }
 
 fn agent_with_team(id_byte: u8, team: &str) -> AgentRecord {
+    agent_with_tenant(id_byte, Some(team), None)
+}
+
+/// Build a root `AgentRecord` tagged with an optional team and org (AAASM-3483).
+fn agent_with_tenant(id_byte: u8, team: Option<&str>, org: Option<&str>) -> AgentRecord {
     AgentRecord {
         agent_id: [id_byte; 16],
         name: format!("agent-{id_byte}"),
@@ -48,7 +53,7 @@ fn agent_with_team(id_byte: u8, team: &str) -> AgentRecord {
         layer: None,
         governance_level: aa_core::GovernanceLevel::default(),
         parent_agent_id: None,
-        team_id: Some(team.to_string()),
+        team_id: team.map(str::to_string),
         depth: 0,
         delegation_reason: None,
         spawned_by_tool: None,
@@ -56,7 +61,7 @@ fn agent_with_team(id_byte: u8, team: &str) -> AgentRecord {
         children: Vec::new(),
         parent_key: None,
         enforcement_mode: None,
-        org_id: None,
+        org_id: org.map(str::to_string),
     }
 }
 
@@ -153,4 +158,219 @@ async fn agent_budget_cross_tenant_read_is_403() {
         StatusCode::FORBIDDEN,
         "cross-tenant budget read is denied"
     );
+}
+
+// ---------------------------------------------------------------------------
+// AAASM-3483 — topology & audit-log cross-tenant isolation (security
+// regression). Reproduces the four leaks the QA harness flagged on base SHA
+// ebc4d7dc (verification-reports/base-branch-2026-06/AAASM-3463-org-isolation.md
+// + verification-reports/qa3463/): an `acme`/`alpha`-scoped caller must not read
+// `globex`/`beta` topology or audit, and a missing filter must not become an
+// all-tenant dump.
+// ---------------------------------------------------------------------------
+
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&body).unwrap()
+}
+
+/// TC1 — a tenant-scoped caller cannot read another org's topology overview
+/// even with an explicit `?org_id` selector for that org.
+#[tokio::test]
+async fn topology_overview_cross_org_explicit_filter_is_empty() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state
+        .agent_registry
+        .register(agent_with_tenant(0x11, Some("research"), Some("globex")))
+        .unwrap();
+    let app = aa_api::build_app(state);
+
+    // Caller scoped to org "acme" asks for globex's overview.
+    let token = common::generate_test_jwt_for_tenant("u", &[Scope::Read], None, Some("acme"));
+    let response = app
+        .oneshot(bearer("/api/v1/topology/overview?org_id=globex", &token))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["total_agent_count"], 0,
+        "an acme-scoped caller must not see globex's agents via ?org_id=globex"
+    );
+    assert!(json["teams"].as_array().unwrap().is_empty());
+}
+
+/// TC1b — omitting the org filter must not dump every tenant's topology.
+#[tokio::test]
+async fn topology_overview_no_filter_does_not_dump_all_orgs() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state
+        .agent_registry
+        .register(agent_with_tenant(0x21, Some("eng"), Some("acme")))
+        .unwrap();
+    state
+        .agent_registry
+        .register(agent_with_tenant(0x22, Some("research"), Some("globex")))
+        .unwrap();
+    let app = aa_api::build_app(state);
+
+    // No ?org_id — an acme-scoped caller must still see only acme's one agent.
+    let token = common::generate_test_jwt_for_tenant("u", &[Scope::Read], None, Some("acme"));
+    let response = app.oneshot(bearer("/api/v1/topology/overview", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["total_agent_count"], 1,
+        "a tenant-scoped caller must see only its own org, not every org"
+    );
+    let teams = json["teams"].as_array().unwrap();
+    assert_eq!(teams.len(), 1);
+    assert_eq!(teams[0]["team_id"], "eng");
+}
+
+/// A non-admin caller with no tenant scope at all gets an empty overview, never
+/// a cross-tenant dump.
+#[tokio::test]
+async fn topology_overview_unscoped_caller_sees_nothing() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state
+        .agent_registry
+        .register(agent_with_tenant(0x31, Some("eng"), Some("acme")))
+        .unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[Scope::Read]);
+    let response = app.oneshot(bearer("/api/v1/topology/overview", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["total_agent_count"], 0);
+}
+
+/// TC3 — a team-scoped caller cannot read another team's topology.
+#[tokio::test]
+async fn topology_team_cross_team_read_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x41, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let response = app.oneshot(bearer("/api/v1/topology/team/beta", &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "an alpha-scoped caller must not read team beta's membership"
+    );
+}
+
+/// A team-scoped caller may still read its own team's topology.
+#[tokio::test]
+async fn topology_team_own_team_read_is_ok() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x51, "alpha")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let response = app
+        .oneshot(bearer("/api/v1/topology/team/alpha", &token))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["agent_count"], 1);
+}
+
+/// TC4 — a team-scoped caller cannot read another team's agent lineage; the
+/// out-of-tenant agent is reported as not found (no existence oracle).
+#[tokio::test]
+async fn topology_lineage_cross_tenant_read_is_404() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x61, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/topology/lineage/{}", hex_id(0x61));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "a beta agent's lineage must not leak to an alpha caller"
+    );
+}
+
+/// The tree endpoint reports another tenant's root as not found.
+#[tokio::test]
+async fn topology_tree_cross_tenant_read_is_404() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x71, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/topology/tree/{}", hex_id(0x71));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// Stats aggregate only the caller's own tenant, never every tenant's counts.
+#[tokio::test]
+async fn topology_stats_are_scoped_to_caller_tenant() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state
+        .agent_registry
+        .register(agent_with_tenant(0x81, Some("eng"), Some("acme")))
+        .unwrap();
+    state
+        .agent_registry
+        .register(agent_with_tenant(0x82, Some("research"), Some("globex")))
+        .unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_tenant("u", &[Scope::Read], None, Some("acme"));
+    let response = app.oneshot(bearer("/api/v1/topology/stats", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["total_agents"], 1,
+        "stats must count only the caller's own org, not every org"
+    );
+}
+
+/// The audit-log endpoint requires authentication (it previously had none).
+#[tokio::test]
+async fn logs_endpoint_requires_authentication() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/logs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "the audit-log endpoint must reject an unauthenticated caller"
+    );
+}
+
+/// A tenant-scoped caller's audit query is pinned to its own org: an explicit
+/// `?org_id` for another org returns an empty page, not that org's audit.
+#[tokio::test]
+async fn logs_cross_org_explicit_filter_is_empty() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_tenant("u", &[Scope::Read], None, Some("acme"));
+    let response = app.oneshot(bearer("/api/v1/logs?org_id=globex", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["total"], 0,
+        "an acme-scoped caller must not read globex's audit via ?org_id=globex"
+    );
+    assert!(json["items"].as_array().unwrap().is_empty());
 }

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -927,6 +927,13 @@ export interface paths {
          * `GET /api/v1/logs` — paginated audit log query.
          * @description Query the paginated audit log of governance events.
          *     Supports optional filtering by agent ID and event type.
+         *
+         *     Per-tenant scoping (AAASM-3483): the audit log is per-tenant data. An admin
+         *     caller may read any org's audit (honouring an explicit `?org_id`); a
+         *     tenant-scoped caller has the `org_id` filter forced to its own org, so it
+         *     can neither read another org's audit nor omit the filter to enumerate every
+         *     org. A non-admin caller with no org scope receives an empty page rather than
+         *     a cross-tenant dump.
          */
         get: operations["list_logs"];
         put?: never;
@@ -5182,6 +5189,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["LogEntry"][];
                 };
+            };
+            /** @description Missing or invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1595,6 +1595,13 @@ paths:
       description: |-
         Query the paginated audit log of governance events.
         Supports optional filtering by agent ID and event type.
+
+        Per-tenant scoping (AAASM-3483): the audit log is per-tenant data. An admin
+        caller may read any org's audit (honouring an explicit `?org_id`); a
+        tenant-scoped caller has the `org_id` filter forced to its own org, so it
+        can neither read another org's audit nor omit the filter to enumerate every
+        org. A non-admin caller with no org scope receives an empty page rather than
+        a cross-tenant dump.
       operationId: list_logs
       parameters:
       - name: page
@@ -1657,6 +1664,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/LogEntry'
+        '401':
+          description: Missing or invalid credentials
   /api/v1/ops:
     get:
       tags:


### PR DESCRIPTION
## Description

Highest-priority security fix for a cross-tenant IDOR / missing object-level authorization (multi-tenant **read** leak) on the topology and audit-log HTTP surfaces.

**What changed**

- `topology.rs` — `get_overview` / `get_team` / `get_lineage` / `get_tree` / `get_stats` bound `RequireRead` but discarded `caller.tenant`, so the org/team/agent selector was caller-controlled. They now adopt the AAASM-3139 cost/agent-budget reference pattern: admin bypasses; a tenant-scoped caller is confined to its own org/team (via `can_access_team` + a record-visibility filter); a non-admin caller with **no** tenant scope gets an empty/`404` response, never a cross-tenant dump. Out-of-tenant team reads return `403`; out-of-tenant agent/tree/lineage reads return `404` (no existence oracle). Each topology cache key is tenant-tagged so a tenant-scoped response is never served to a different tenant.
- `logs.rs::list_logs` — had **no auth extractor at all** and took `org_id` as a free query param. It now binds `RequireRead` and forces the `org_id` filter to the caller's tenant: an admin honours an explicit `?org_id`; a tenant-scoped caller is pinned to its own org; a non-admin with no org scope gets a sentinel the `AuditReader` filter never matches (empty page).
- Supporting: `AuthenticatedCaller::can_access_org` (org-tier analogue of `can_access_team`); `TopologyOverview: Default`; `topology_stats_cache` re-keyed to `String` so its entry can be tenant-tagged.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

API responses are unchanged for admin / bypass-mode callers; tenant-scoped callers now correctly see only their own tenant's data (previously they over-saw, which was the defect).

## Related Issues

- Related Jira ticket: AAASM-3483 (Bug), verified under AAASM-3463 (org-isolation Story)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Extended `aa-api/tests/tenant_scope.rs` with 10 regression tests that reproduce the four leaks QA flagged on base SHA `ebc4d7dc` and assert the new denial behavior:

| Probe | Caller scope | Before (leak) | After |
| --- | --- | --- | --- |
| `GET /topology/overview?org_id=globex` | org=acme | 200 + globex data | 200 empty |
| `GET /topology/overview` (no filter) | org=acme | 200 + all orgs | 200 only acme |
| `GET /topology/team/beta` | team=alpha | 200 + beta member | 403 |
| `GET /topology/lineage/<beta-agent>` | team=alpha | 200 + lineage | 404 |
| `GET /topology/tree/<beta-root>` | team=alpha | 200 | 404 |
| `GET /topology/stats` | org=acme | all-tenant counts | acme-only |
| `GET /logs` (no auth) | — | 200 | 401 |
| `GET /logs?org_id=globex` | org=acme | globex audit | 200 empty |

**How to verify:** `cargo nextest run -p aa-api -E 'binary(tenant_scope)'` — 14 pass (4 pre-existing cost/budget control cases + 10 new). Full `cargo nextest run -p aa-api`: 604 pass. `cargo clippy -p aa-api --all-targets -- -D warnings` clean.

QA evidence this fix addresses: `verification-reports/base-branch-2026-06/AAASM-3463-org-isolation.md` and `verification-reports/qa3463/` (in the QA-verify repo).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

Closes nothing yet — verified post-merge under AAASM-3463

🤖 Generated with [Claude Code](https://claude.com/claude-code)