### PR TITLE
[AAASM-3491] 🐛 (aa-runtime): Consume OpControlStream — enforce live terminate/pause

### DIFF
--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -15,6 +15,21 @@ pub struct RuntimeConfig {
     /// Used to name the Unix socket: `/tmp/aa-runtime-<agent_id>.sock`.
     pub agent_id: String,
 
+    /// Team component of this agent's composite identity.
+    ///
+    /// Read from `AA_AGENT_TEAM_ID` (default empty). Combined with
+    /// [`agent_org_id`](Self::agent_org_id) and [`agent_id`](Self::agent_id) to
+    /// build the `AgentId` triple the runtime uses to subscribe to the
+    /// gateway's `OpControlStream`, which the gateway routes by the full
+    /// `(org_id, team_id, agent_id)` triple (AAASM-3491).
+    pub agent_team_id: String,
+
+    /// Org component of this agent's composite identity.
+    ///
+    /// Read from `AA_AGENT_ORG_ID` (default empty). See
+    /// [`agent_team_id`](Self::agent_team_id).
+    pub agent_org_id: String,
+
     /// Number of Tokio worker threads.
     ///
     /// Read from `AA_RUNTIME_WORKER_THREADS`. Defaults to `0`, which tells
@@ -157,6 +172,8 @@ impl RuntimeConfig {
     /// | `AA_AUDIT_BUFFER_PATH` | `PathBuf` | `<temp>/aa-audit-buffer-<agent_id>.db` |
     /// | `AA_ENFORCEMENT_MAX_FIELD_BYTES` | `usize` | `65536` (64 KiB) |
     /// | `AA_GATEWAY_FAIL_CLOSED` | `bool` | `true` (deny on gateway unreachable) |
+    /// | `AA_AGENT_TEAM_ID` | `String` | `""` (op-control subscription identity) |
+    /// | `AA_AGENT_ORG_ID` | `String` | `""` (op-control subscription identity) |
     pub fn from_env() -> Result<Self, String> {
         let agent_id = std::env::var("AA_AGENT_ID").map_err(|_| "AA_AGENT_ID is required but not set".to_string())?;
 
@@ -167,6 +184,12 @@ impl RuntimeConfig {
         if agent_id.contains('/') || agent_id.contains("..") {
             return Err("AA_AGENT_ID must not contain path separators ('/' or '..')".to_string());
         }
+
+        // Optional composite-identity components — empty when the agent is not
+        // scoped to a team/org. Used only to address the OpControlStream
+        // subscription (AAASM-3491).
+        let agent_team_id = std::env::var("AA_AGENT_TEAM_ID").unwrap_or_default();
+        let agent_org_id = std::env::var("AA_AGENT_ORG_ID").unwrap_or_default();
 
         let worker_threads = std::env::var("AA_RUNTIME_WORKER_THREADS")
             .ok()
@@ -255,6 +278,8 @@ impl RuntimeConfig {
 
         Ok(Self {
             agent_id,
+            agent_team_id,
+            agent_org_id,
             worker_threads,
             shutdown_timeout_secs,
             ipc_max_connections,

--- a/aa-runtime/src/correlation/config.rs
+++ b/aa-runtime/src/correlation/config.rs
@@ -65,6 +65,8 @@ mod tests {
     fn from_runtime_config_maps_fields() {
         let rc = crate::config::RuntimeConfig {
             agent_id: "test".to_string(),
+            agent_team_id: String::new(),
+            agent_org_id: String::new(),
             worker_threads: 0,
             shutdown_timeout_secs: 30,
             ipc_max_connections: 64,

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -657,6 +657,7 @@ mod tests {
             pipeline_router,
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(std::sync::atomic::AtomicU64::new(0)),
         ));
 
@@ -751,6 +752,7 @@ mod tests {
             pipeline_router,
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(std::sync::atomic::AtomicU64::new(0)),
         ));
 
@@ -852,6 +854,7 @@ mod tests {
             pipeline_router,
             approval_queue,
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(std::sync::atomic::AtomicU64::new(0)),
         ));
 

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -18,6 +18,7 @@ pub mod ipc;
 pub mod l1_cache;
 pub mod layer;
 pub mod lifecycle;
+pub mod op_control;
 pub mod pipeline;
 pub mod policy;
 pub mod runtime;

--- a/aa-runtime/src/op_control.rs
+++ b/aa-runtime/src/op_control.rs
@@ -1,0 +1,163 @@
+//! Runtime-side consumer of the gateway's op-control kill switch
+//! (`PolicyService.OpControlStream`, AAASM-3491).
+//!
+//! # Why this exists
+//!
+//! The gateway can already *publish* pause/resume/terminate signals for an
+//! in-flight op (`aa-gateway/src/ops`), but before this module **no client on
+//! the agent's execution path subscribed to them** — an operator terminate
+//! flipped the gateway registry to `Terminated` and broadcast into a channel
+//! with no listener, so the running agent kept executing (a silent no-op /
+//! allow-through of the documented kill switch; QA `qa3464-ops-registry-control`).
+//!
+//! [`OpControlClient`] is the missing consumer. It opens the
+//! `OpControlStream` for this agent's composite id, and records each signal in
+//! a shared [`OpControlStore`] keyed by `op_id` (`"{trace_id}:{span_id}"`, the
+//! same form the gateway and dashboard use). The runtime's per-tool policy
+//! check (`pipeline::handle_policy_query`) consults the store before allowing
+//! an action, so a terminate **fast-fails** the in-flight action and a pause
+//! **blocks** it until resume.
+//!
+//! # Fail-closed
+//!
+//! An op the operator has terminated is denied; a paused op is held. The store
+//! is the authoritative runtime-side record — once a terminate is observed it
+//! is sticky (`Terminated` is never cleared by a later pause/resume), so the
+//! kill switch cannot be undone by a racing signal.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::sync::Notify;
+
+use aa_proto::assembly::policy::v1::OpControlSignal;
+
+/// The runtime-observed lifecycle state of a single op.
+///
+/// Derived from the most recent [`OpControlSignal`] the gateway pushed for the
+/// op's `op_id`. Absence from the [`OpControlStore`] means "no control signal
+/// seen" — the op runs normally.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpState {
+    /// Operator paused the op: the next per-tool check must block until a
+    /// `Resume` (or `Terminate`) arrives.
+    Paused,
+    /// Operator (or a policy deny) terminated the op: every further per-tool
+    /// check must fast-fail. Terminal and sticky — never downgraded.
+    Terminated,
+}
+
+/// Shared, lock-light record of op-control state keyed by `op_id`.
+///
+/// Written by the [`OpControlClient`] background subscriber; read by the
+/// runtime pipeline on every per-tool policy check. Cheap to clone (`Arc`).
+#[derive(Clone, Default)]
+pub struct OpControlStore {
+    /// `op_id` → latest non-`Resume` state. A `Resume` removes the entry so a
+    /// resumed op reads as "runnable" again.
+    states: Arc<DashMap<String, OpState>>,
+    /// Woken whenever a signal is applied, so a check parked on a paused op
+    /// re-evaluates promptly instead of polling.
+    changed: Arc<Notify>,
+}
+
+impl OpControlStore {
+    /// Construct an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Apply one `OpControlSignal` for `op_id`, returning the resulting state
+    /// (`None` once the op is runnable again, i.e. after a `Resume`).
+    ///
+    /// `Terminate` is sticky: once recorded it overrides a later `Pause` or
+    /// `Resume` so the kill switch cannot be lifted by a racing signal.
+    /// `Unspecified` is a malformed message and is ignored.
+    pub fn apply(&self, op_id: &str, signal: OpControlSignal) -> Option<OpState> {
+        let result = match signal {
+            OpControlSignal::Terminate => {
+                self.states.insert(op_id.to_owned(), OpState::Terminated);
+                Some(OpState::Terminated)
+            }
+            OpControlSignal::Pause => {
+                // Never undo a terminate.
+                if matches!(self.states.get(op_id).as_deref(), Some(OpState::Terminated)) {
+                    Some(OpState::Terminated)
+                } else {
+                    self.states.insert(op_id.to_owned(), OpState::Paused);
+                    Some(OpState::Paused)
+                }
+            }
+            OpControlSignal::Resume => {
+                // A terminated op stays terminated; otherwise resume clears it.
+                if matches!(self.states.get(op_id).as_deref(), Some(OpState::Terminated)) {
+                    Some(OpState::Terminated)
+                } else {
+                    self.states.remove(op_id);
+                    None
+                }
+            }
+            OpControlSignal::Unspecified => self.states.get(op_id).as_deref().copied(),
+        };
+        self.changed.notify_waiters();
+        result
+    }
+
+    /// Current state of `op_id`, or `None` if no control signal is in effect.
+    pub fn state(&self, op_id: &str) -> Option<OpState> {
+        self.states.get(op_id).as_deref().copied()
+    }
+
+    /// Await the next signal application. Used by a check parked on a paused op
+    /// to wake the moment a resume/terminate lands rather than busy-polling.
+    pub async fn changed(&self) {
+        self.changed.notified().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminate_records_terminated_state() {
+        let store = OpControlStore::new();
+        assert_eq!(store.apply("t:s", OpControlSignal::Terminate), Some(OpState::Terminated));
+        assert_eq!(store.state("t:s"), Some(OpState::Terminated));
+    }
+
+    #[test]
+    fn pause_then_resume_clears_state() {
+        let store = OpControlStore::new();
+        assert_eq!(store.apply("t:s", OpControlSignal::Pause), Some(OpState::Paused));
+        assert_eq!(store.apply("t:s", OpControlSignal::Resume), None);
+        assert_eq!(store.state("t:s"), None);
+    }
+
+    #[test]
+    fn terminate_is_sticky_against_later_pause_and_resume() {
+        let store = OpControlStore::new();
+        store.apply("t:s", OpControlSignal::Terminate);
+        // A racing pause or resume must not lift the kill switch.
+        assert_eq!(store.apply("t:s", OpControlSignal::Pause), Some(OpState::Terminated));
+        assert_eq!(store.apply("t:s", OpControlSignal::Resume), Some(OpState::Terminated));
+        assert_eq!(store.state("t:s"), Some(OpState::Terminated));
+    }
+
+    #[test]
+    fn unspecified_signal_is_ignored() {
+        let store = OpControlStore::new();
+        assert_eq!(store.apply("t:s", OpControlSignal::Unspecified), None);
+        assert_eq!(store.state("t:s"), None);
+    }
+
+    #[test]
+    fn distinct_ops_are_independent() {
+        let store = OpControlStore::new();
+        store.apply("a:1", OpControlSignal::Terminate);
+        store.apply("b:2", OpControlSignal::Pause);
+        assert_eq!(store.state("a:1"), Some(OpState::Terminated));
+        assert_eq!(store.state("b:2"), Some(OpState::Paused));
+        assert_eq!(store.state("c:3"), None);
+    }
+}

--- a/aa-runtime/src/op_control.rs
+++ b/aa-runtime/src/op_control.rs
@@ -117,10 +117,15 @@ impl OpControlStore {
         self.states.get(op_id).as_deref().copied()
     }
 
-    /// Await the next signal application. Used by a check parked on a paused op
-    /// to wake the moment a resume/terminate lands rather than busy-polling.
-    pub async fn changed(&self) {
-        self.changed.notified().await;
+    /// A future that resolves on the next signal application.
+    ///
+    /// Returned (not awaited) so a caller parked on a paused op can register
+    /// interest **before** re-reading [`state`](Self::state) — closing the race
+    /// where a resume/terminate lands between the state read and the await.
+    /// `notify_waiters` only wakes already-registered waiters, so registering
+    /// first is required for correctness.
+    pub fn changed(&self) -> tokio::sync::futures::Notified<'_> {
+        self.changed.notified()
     }
 }
 
@@ -212,7 +217,10 @@ mod tests {
     #[test]
     fn terminate_records_terminated_state() {
         let store = OpControlStore::new();
-        assert_eq!(store.apply("t:s", OpControlSignal::Terminate), Some(OpState::Terminated));
+        assert_eq!(
+            store.apply("t:s", OpControlSignal::Terminate),
+            Some(OpState::Terminated)
+        );
         assert_eq!(store.state("t:s"), Some(OpState::Terminated));
     }
 

--- a/aa-runtime/src/op_control.rs
+++ b/aa-runtime/src/op_control.rs
@@ -26,11 +26,20 @@
 //! kill switch cannot be undone by a racing signal.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use dashmap::DashMap;
 use tokio::sync::Notify;
+use tokio::task::JoinHandle;
 
-use aa_proto::assembly::policy::v1::OpControlSignal;
+use aa_proto::assembly::common::v1::AgentId;
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::{OpControlSignal, OpControlSubscribeRequest};
+
+/// First reconnect delay; doubles on each consecutive failure.
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+/// Upper bound on the reconnect delay (1s → 2 → 4 → … → 32s cap).
+const MAX_BACKOFF: Duration = Duration::from_secs(32);
 
 /// The runtime-observed lifecycle state of a single op.
 ///
@@ -115,9 +124,90 @@ impl OpControlStore {
     }
 }
 
+/// Next reconnect delay: double the current one, capped at [`MAX_BACKOFF`].
+fn next_backoff(current: Duration) -> Duration {
+    (current * 2).min(MAX_BACKOFF)
+}
+
+/// Background subscriber that keeps an [`OpControlStore`] fresh from the
+/// gateway's `PolicyService.OpControlStream`.
+///
+/// Mirrors [`crate::invalidation_client::InvalidationClient`]: it opens the
+/// stream keyed by this agent's composite id, applies each pushed signal to the
+/// store, and reconnects forever with exponential backoff. The gateway filters
+/// the broadcast so only this agent's ops arrive.
+pub struct OpControlClient;
+
+impl OpControlClient {
+    /// Spawn the subscribe loop on the Tokio runtime and return its handle.
+    ///
+    /// `gateway_url` is the same endpoint the policy-check path forwards to;
+    /// `agent_id` must match the `agent_id` on this agent's `CheckActionRequest`s
+    /// so the gateway routes the right signals. Abort the returned
+    /// [`JoinHandle`] to stop the subscriber.
+    pub fn start(gateway_url: String, agent_id: AgentId, store: OpControlStore) -> JoinHandle<()> {
+        tokio::spawn(async move { run(gateway_url, agent_id, store).await })
+    }
+}
+
+/// Reconnect loop: subscribe, apply signals, and on disconnect back off
+/// exponentially before resubscribing.
+async fn run(gateway_url: String, agent_id: AgentId, store: OpControlStore) {
+    let mut backoff = INITIAL_BACKOFF;
+    loop {
+        match subscribe_once(&gateway_url, &agent_id, &store).await {
+            // The gateway closed the stream cleanly — reconnect promptly.
+            Ok(()) => backoff = INITIAL_BACKOFF,
+            Err(err) => {
+                metrics::counter!("aa_op_control_reconnects_total").increment(1);
+                tracing::warn!(
+                    error = %err,
+                    backoff_secs = backoff.as_secs(),
+                    "op-control stream dropped; reconnecting after backoff"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = next_backoff(backoff);
+            }
+        }
+    }
+}
+
+/// Open one `OpControlStream` and apply messages to the store until it ends or
+/// errors.
+async fn subscribe_once(
+    gateway_url: &str,
+    agent_id: &AgentId,
+    store: &OpControlStore,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut client = PolicyServiceClient::connect(gateway_url.to_owned()).await?;
+    let request = OpControlSubscribeRequest {
+        agent_id: Some(agent_id.clone()),
+    };
+    let response = client.op_control_stream(request).await?;
+    let mut inbound = response.into_inner();
+
+    while let Some(message) = inbound.message().await? {
+        let signal = message.signal();
+        tracing::debug!(op_id = %message.op_id, ?signal, "op-control signal received");
+        store.apply(&message.op_id, signal);
+        metrics::counter!("aa_op_control_signals_total").increment(1);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn backoff_doubles_then_caps_at_32s() {
+        let schedule: Vec<u64> = std::iter::successors(Some(INITIAL_BACKOFF), |&d| Some(next_backoff(d)))
+            .take(7)
+            .map(|d| d.as_secs())
+            .collect();
+        assert_eq!(schedule, vec![1, 2, 4, 8, 16, 32, 32]);
+    }
 
     #[test]
     fn terminate_records_terminated_state() {

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -497,6 +497,8 @@ mod tests {
     fn from_runtime_config_maps_size_cap_and_keeps_fail_closed_policy() {
         let rc = RuntimeConfig {
             agent_id: "test".to_string(),
+            agent_team_id: String::new(),
+            agent_org_id: String::new(),
             worker_threads: 0,
             shutdown_timeout_secs: 30,
             ipc_max_connections: 64,

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -428,7 +428,11 @@ async fn op_control_halts(
             }
             Some(OpState::Paused) => {
                 ::metrics::counter!("aa_op_control_pauses_total").increment(1);
-                tracing::info!(connection_id, op_id, "op paused by operator — blocking action until resume");
+                tracing::info!(
+                    connection_id,
+                    op_id,
+                    "op paused by operator — blocking action until resume"
+                );
                 // Wait for the next signal, then re-evaluate. A resume removes
                 // the entry (loop reads `None` → runnable); a terminate upgrades
                 // it (loop fast-fails on the next pass).

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -640,6 +640,7 @@ mod tests {
     use super::*;
     use crate::policy::PolicyRules;
     use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, PolicyViolation};
+    use aa_proto::assembly::policy::v1::OpControlSignal;
 
     /// Unwrap a `PipelineEvent::Audit` variant, panicking if it is a different variant.
     fn unwrap_audit(event: PipelineEvent) -> EnrichedEvent {
@@ -1511,6 +1512,141 @@ mod tests {
 
         if let IpcResponse::PolicyResponse(r) = resp {
             assert_eq!(r.decision, Decision::Deny as i32);
+        } else {
+            panic!("expected PolicyResponse, got {resp:?}");
+        }
+        token.cancel();
+    }
+
+    /// Build a per-tool PolicyQuery tagged with the trace/span that compose
+    /// `op_id` ("{trace_id}:{span_id}"), so the op-control store can address it.
+    fn policy_query_frame_for_op(
+        action_type: aa_proto::assembly::common::v1::ActionType,
+        trace_id: &str,
+        span_id: &str,
+    ) -> IpcFrame {
+        IpcFrame::PolicyQuery(aa_proto::assembly::policy::v1::CheckActionRequest {
+            action_type: action_type as i32,
+            trace_id: trace_id.to_string(),
+            span_id: span_id.to_string(),
+            ..Default::default()
+        })
+    }
+
+    /// AAASM-3491: a gateway terminate for the running op must **halt** the
+    /// agent — the in-flight per-tool check fast-fails with `OpTerminatedError`
+    /// even though no policy rule blocks the action. This is the core
+    /// regression: before the op-control consumer, terminate was a silent
+    /// allow-through.
+    #[tokio::test]
+    async fn op_control_terminate_halts_running_agent_tool_call() {
+        use aa_proto::assembly::common::v1::{ActionType, Decision};
+
+        let config = test_config(100, 10_000);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, _rx) = broadcast::channel::<PipelineEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+        let (router, mut resp_rx) = make_router_with_receiver();
+        let approval_queue = crate::approval::ApprovalQueue::new();
+        let op_control = crate::op_control::OpControlStore::new();
+
+        // Operator terminates the op via the gateway kill switch; the
+        // subscriber records it in the store before the next tool check.
+        op_control.apply("trace-1:span-1", OpControlSignal::Terminate);
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics,
+            token.clone(),
+            // Empty policy: nothing here would deny — only the kill switch does.
+            Arc::new(PolicyRules::default()),
+            router,
+            approval_queue,
+            None,
+            op_control,
+            Arc::new(AtomicU64::new(0)),
+        ));
+
+        tx.send((0, policy_query_frame_for_op(ActionType::ToolCall, "trace-1", "span-1")))
+            .await
+            .unwrap();
+
+        let resp = tokio::time::timeout(Duration::from_millis(200), resp_rx.recv())
+            .await
+            .expect("response timed out")
+            .expect("channel closed");
+
+        if let IpcResponse::PolicyResponse(r) = resp {
+            assert_eq!(r.decision, Decision::Deny as i32, "terminated op must be denied");
+            assert!(
+                r.reason.contains("OpTerminatedError"),
+                "deny reason must name OpTerminatedError, got: {}",
+                r.reason
+            );
+        } else {
+            panic!("expected PolicyResponse, got {resp:?}");
+        }
+        token.cancel();
+    }
+
+    /// AAASM-3491: a paused op blocks the per-tool check; once the operator
+    /// resumes it, the same check completes (here: allowed by the empty policy).
+    /// Proves cooperative pause/resume reaches the running agent.
+    #[tokio::test]
+    async fn op_control_pause_blocks_then_resume_releases_tool_call() {
+        use aa_proto::assembly::common::v1::{ActionType, Decision};
+
+        let config = test_config(100, 10_000);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, _rx) = broadcast::channel::<PipelineEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+        let (router, mut resp_rx) = make_router_with_receiver();
+        let approval_queue = crate::approval::ApprovalQueue::new();
+        let op_control = crate::op_control::OpControlStore::new();
+
+        op_control.apply("trace-2:span-2", OpControlSignal::Pause);
+        let store_for_resume = op_control.clone();
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics,
+            token.clone(),
+            Arc::new(PolicyRules::default()),
+            router,
+            approval_queue,
+            None,
+            op_control,
+            Arc::new(AtomicU64::new(0)),
+        ));
+
+        tx.send((0, policy_query_frame_for_op(ActionType::ToolCall, "trace-2", "span-2")))
+            .await
+            .unwrap();
+
+        // While paused, the check must NOT have answered yet.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), resp_rx.recv())
+                .await
+                .is_err(),
+            "paused op must block the tool check until resume"
+        );
+
+        // Operator resumes; the blocked check should now complete.
+        store_for_resume.apply("trace-2:span-2", OpControlSignal::Resume);
+
+        let resp = tokio::time::timeout(Duration::from_millis(500), resp_rx.recv())
+            .await
+            .expect("resume did not release the blocked check")
+            .expect("channel closed");
+
+        if let IpcResponse::PolicyResponse(r) = resp {
+            assert_eq!(r.decision, Decision::Allow as i32, "resumed op must proceed");
         } else {
             panic!("expected PolicyResponse, got {resp:?}");
         }

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -78,6 +78,7 @@ pub async fn run(
     response_router: ResponseRouter,
     approval_queue: Arc<ApprovalQueue>,
     gateway_client: Option<Arc<Mutex<GatewayClient>>>,
+    op_control: crate::op_control::OpControlStore,
     seq: Arc<AtomicU64>,
 ) {
     let mut batch: Vec<EnrichedEvent> = Vec::with_capacity(config.batch_size);
@@ -134,6 +135,7 @@ pub async fn run(
                             &approval_queue,
                             &response_router,
                             &gateway_client,
+                            &op_control,
                             config.gateway_fail_closed,
                             &broadcast_tx,
                             &seq,
@@ -275,10 +277,24 @@ async fn handle_policy_query(
     approval_queue: &Arc<ApprovalQueue>,
     response_router: &ResponseRouter,
     gateway_client: &Option<Arc<Mutex<GatewayClient>>>,
+    op_control: &crate::op_control::OpControlStore,
     fail_closed: bool,
     broadcast_tx: &broadcast::Sender<PipelineEvent>,
     sequence_counter: &AtomicU64,
 ) {
+    // ── Op-control kill switch (AAASM-3491) ─────────────────────────────
+    // Consult the operator-driven op lifecycle BEFORE any policy evaluation:
+    // a terminated op must fast-fail and a paused op must block, regardless of
+    // what the policy would otherwise decide. The op_id mirrors the gateway's
+    // form ("{trace_id}:{span_id}"); an empty trace_id means the request is not
+    // part of a tracked op, so there is nothing to halt.
+    if !req.trace_id.is_empty() {
+        let op_id = format!("{}:{}", req.trace_id, req.span_id);
+        if op_control_halts(connection_id, &op_id, op_control, response_router).await {
+            return;
+        }
+    }
+
     // ── Gateway forwarding path ─────────────────────────────────────────
     match try_gateway_forward(
         connection_id,
@@ -369,6 +385,58 @@ async fn handle_policy_query(
         response_router,
     )
     .await;
+}
+
+/// Enforce the op-control kill switch for `op_id` before the action proceeds.
+///
+/// Returns `true` when the action was **halted** and a response already sent —
+/// the caller must stop processing. Returns `false` when the op is runnable
+/// (no signal, or a pause that was subsequently resumed).
+///
+/// - **Terminated:** fast-fail the in-flight action with a `Deny`
+///   (`OpTerminatedError`); the kill switch reached the agent.
+/// - **Paused:** cooperatively block until the gateway pushes a resume (op
+///   leaves the store) or a terminate. This parks the per-tool check on the
+///   store's change notification rather than busy-polling, so a paused agent
+///   makes no further progress until the operator resumes it.
+async fn op_control_halts(
+    connection_id: u64,
+    op_id: &str,
+    op_control: &crate::op_control::OpControlStore,
+    response_router: &ResponseRouter,
+) -> bool {
+    use crate::op_control::OpState;
+    loop {
+        // Register interest before reading state so a resume/terminate that
+        // lands during this iteration cannot be missed (see `changed`).
+        let changed = op_control.changed();
+        match op_control.state(op_id) {
+            Some(OpState::Terminated) => {
+                ::metrics::counter!("aa_op_control_terminations_total").increment(1);
+                tracing::warn!(connection_id, op_id, "op terminated by operator — fast-failing action");
+                send_ipc_response(
+                    connection_id,
+                    IpcResponse::PolicyResponse(CheckActionResponse {
+                        decision: Decision::Deny as i32,
+                        reason: "OpTerminatedError: operator terminated this op via the live kill switch".to_string(),
+                        ..Default::default()
+                    }),
+                    response_router,
+                )
+                .await;
+                return true;
+            }
+            Some(OpState::Paused) => {
+                ::metrics::counter!("aa_op_control_pauses_total").increment(1);
+                tracing::info!(connection_id, op_id, "op paused by operator — blocking action until resume");
+                // Wait for the next signal, then re-evaluate. A resume removes
+                // the entry (loop reads `None` → runnable); a terminate upgrades
+                // it (loop fast-fails on the next pass).
+                changed.await;
+            }
+            None => return false,
+        }
+    }
 }
 
 /// Outcome of attempting to forward a policy check to the gateway.
@@ -753,6 +821,8 @@ mod tests {
     fn from_runtime_config_copies_all_fields() {
         let runtime_config = RuntimeConfig {
             agent_id: "test-agent".to_string(),
+            agent_team_id: String::new(),
+            agent_org_id: String::new(),
             worker_threads: 0,
             shutdown_timeout_secs: 30,
             ipc_max_connections: 64,
@@ -857,6 +927,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -894,6 +965,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -931,6 +1003,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -967,6 +1040,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1022,6 +1096,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1067,6 +1142,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1121,6 +1197,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1171,6 +1248,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1217,6 +1295,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1287,6 +1366,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1368,6 +1448,7 @@ mod tests {
             router,
             approval_queue,
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1417,6 +1498,7 @@ mod tests {
             router,
             approval_queue,
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1465,6 +1547,7 @@ mod tests {
             router,
             approval_queue,
             Some(gateway),
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1517,6 +1600,7 @@ mod tests {
             router,
             approval_queue,
             Some(gateway),
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1572,6 +1656,7 @@ mod tests {
             router,
             approval_queue,
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1630,6 +1715,7 @@ mod tests {
             router,
             approval_queue,
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1723,6 +1809,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 
@@ -1770,6 +1857,7 @@ mod tests {
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
             None,
+            crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
         ));
 

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -679,6 +679,27 @@ pub async fn run(config: RuntimeConfig) {
         }
     };
 
+    // AAASM-3491: shared op-control store + subscriber. The store records the
+    // gateway's pause/resume/terminate signals; the pipeline consults it on
+    // every per-tool check so a terminate fast-fails and a pause blocks the
+    // running agent. Without a configured gateway there is no kill-switch
+    // channel to subscribe to, so the store simply stays empty (no op control).
+    let op_control = crate::op_control::OpControlStore::new();
+    if let Some(endpoint) = &config.gateway_endpoint {
+        let subscriber_agent = aa_proto::assembly::common::v1::AgentId {
+            org_id: config.agent_org_id.clone(),
+            team_id: config.agent_team_id.clone(),
+            agent_id: config.agent_id.clone(),
+        };
+        let handle = crate::op_control::OpControlClient::start(endpoint.clone(), subscriber_agent, op_control.clone());
+        tracker.spawn(async move {
+            let _ = handle.await;
+        });
+        tracing::info!(endpoint, "op-control subscriber spawned — live kill switch active");
+    } else {
+        tracing::info!("no gateway endpoint configured — op-control kill switch inactive");
+    }
+
     // Spawn the event aggregation pipeline task.
     {
         let pipeline_token = token.clone();
@@ -687,6 +708,7 @@ pub async fn run(config: RuntimeConfig) {
         let pipeline_router = std::sync::Arc::clone(&response_router);
         let pipeline_approval_queue = std::sync::Arc::clone(&approval_queue);
         let pipeline_seq = std::sync::Arc::clone(&seq);
+        let pipeline_op_control = op_control.clone();
         tracker.spawn(async move {
             crate::pipeline::run(
                 inbound_rx,
@@ -698,6 +720,7 @@ pub async fn run(config: RuntimeConfig) {
                 pipeline_router,
                 pipeline_approval_queue,
                 gateway_client,
+                pipeline_op_control,
                 pipeline_seq,
             )
             .await;
@@ -1243,6 +1266,8 @@ mod tests {
     fn audit_test_config(nats_config_path: Option<std::path::PathBuf>) -> crate::config::RuntimeConfig {
         crate::config::RuntimeConfig {
             agent_id: "audit-test".to_string(),
+            agent_team_id: String::new(),
+            agent_org_id: String::new(),
             worker_threads: 0,
             shutdown_timeout_secs: 30,
             ipc_max_connections: 64,

--- a/aa-runtime/tests/aaasm_2568_gate_verification.rs
+++ b/aa-runtime/tests/aaasm_2568_gate_verification.rs
@@ -79,6 +79,7 @@ async fn drive_one(policy: PolicyRules) -> PipelineEvent {
         new_response_router(),
         ApprovalQueue::new(),
         None,
+        aa_runtime::op_control::OpControlStore::new(),
         Arc::new(AtomicU64::new(0)),
     ));
 
@@ -146,6 +147,7 @@ async fn configured_size_cap_redacts_oversized_field_through_run() {
         new_response_router(),
         ApprovalQueue::new(),
         None,
+        aa_runtime::op_control::OpControlStore::new(),
         Arc::new(AtomicU64::new(0)),
     ));
 


### PR DESCRIPTION
## Description

Wires a consumer for the gateway's live op-control kill switch (`PolicyService.OpControlStream`) into the authoritative runtime, so an operator terminate/pause actually reaches a running agent. Before this, the gateway broadcast pause/resume/terminate into a channel with **no listener** on any agent's execution path — a silent no-op / allow-through (QA `qa3464-ops-registry-control.md`).

What lands here (scoped first-pass — the core path):
- `aa-runtime/src/op_control.rs`: `OpControlStore` (op-state keyed by `op_id = "{trace_id}:{span_id}"`, terminate is sticky/fail-closed) + `OpControlClient` background subscriber that opens `OpControlStream` for the agent's composite id and applies each signal (mirrors `InvalidationClient`).
- `aa-runtime/src/pipeline/mod.rs`: `handle_policy_query` consults the store **before** policy evaluation — a terminated op fast-fails the in-flight tool check with `OpTerminatedError`; a paused op blocks (cooperatively, race-free via `Notify`) until resume.
- `aa-runtime/src/runtime.rs` + `config.rs`: spawn the subscriber at startup when a gateway endpoint is configured; read the team/org composite-id components (`AA_AGENT_TEAM_ID` / `AA_AGENT_ORG_ID`) the gateway routes by.

The Python SDK companion (honoring the same signal in the SDK tool path) is in `ai-agent-assembly/python-sdk` PR — see below. Node/Go are deferred to follow-up subtasks (their `OpControlSubscriber` consumers already exist but are dead/unexported): **AAASM-3500** (node-sdk), **AAASM-3501** (go-sdk).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3491
- Cross-repo: ai-agent-assembly/python-sdk PR `[AAASM-3491] 🐛 (python-sdk): Honor live op-control signal in tool path`
- Follow-ups: AAASM-3500 (node-sdk), AAASM-3501 (go-sdk)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Two pipeline integration tests drive `run()` end-to-end: a gateway terminate fast-fails the in-flight tool check with `OpTerminatedError` under an empty policy (the core regression), and a pause blocks the check until a resume releases it. Plus `OpControlStore` unit tests (sticky terminate, pause/resume, signal independence) and a subscriber backoff test.

`cargo nextest run -p aa-runtime -p aa-sdk-client` → 347 passed. `cargo fmt --check`, `cargo clippy -p aa-runtime --all-targets -D warnings`, `cargo deny check` all clean. (Org CI is billing-blocked; validated locally per repo practice.)

QA evidence: `verification-reports/base-branch-2026-06/qa3464-ops-registry-control.md`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-3491]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ