### PR TITLE
[AAASM-3499] 🐛 (aa-gateway): Route --policy directory to load_cascade_from_dir

### DIFF
--- a/aa-cli/src/commands/gateway/start.rs
+++ b/aa-cli/src/commands/gateway/start.rs
@@ -323,6 +323,44 @@ mod tests {
         assert_eq!(resolve_policy(&args), Some(PathBuf::from("/tmp/policy.yaml")));
     }
 
+    /// AAASM-3499 — `--policy` must accept a cascade *directory*, forwarded
+    /// verbatim to `aa-gateway --policy` (which routes a directory to the
+    /// multi-document cascade loader). Before the fix the dir was usable from
+    /// Rust test code only; the operator path rejected it.
+    #[test]
+    fn resolve_policy_accepts_directory_via_flag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        let args = StartArgs {
+            policy: Some(dir.clone()),
+            listen: DEFAULT_LISTEN.to_string(),
+            socket: None,
+            no_detach: false,
+            log_file: None,
+        };
+        let resolved = resolve_policy(&args).expect("a directory must resolve");
+        assert_eq!(resolved, dir);
+        assert!(resolved.is_dir(), "the resolved policy path is a directory");
+    }
+
+    /// `$AA_POLICY` pointing at a directory resolves too (the env-var path uses
+    /// `.exists()`, which is true for directories).
+    #[test]
+    fn resolve_policy_accepts_directory_via_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        let _guard = PolicyEnvGuard::set(dir.to_str().unwrap());
+
+        let args = StartArgs {
+            policy: None,
+            listen: DEFAULT_LISTEN.to_string(),
+            socket: None,
+            no_detach: false,
+            log_file: None,
+        };
+        assert_eq!(resolve_policy(&args), Some(dir));
+    }
+
     #[test]
     fn resolve_policy_uses_env_when_no_flag_and_file_exists() {
         let tmp = tempfile::NamedTempFile::new().unwrap();

--- a/aa-cli/src/commands/gateway/start.rs
+++ b/aa-cli/src/commands/gateway/start.rs
@@ -17,7 +17,9 @@ const READINESS_POLL: Duration = Duration::from_millis(200);
 /// Arguments for `aasm gateway start`.
 #[derive(Debug, Args)]
 pub struct StartArgs {
-    /// Path to the policy YAML file (overrides $AA_POLICY and default locations).
+    /// Path to the policy YAML file, or a directory of scoped `*.yaml`
+    /// documents for the multi-document cascade (AAASM-3499). Overrides
+    /// $AA_POLICY and the default locations.
     #[arg(long)]
     pub policy: Option<PathBuf>,
 
@@ -55,9 +57,10 @@ pub fn dispatch(args: StartArgs) -> ExitCode {
         Some(p) => p,
         None => {
             eprintln!(
-                "error: no policy file found.\n\
-                 Tried: $AA_POLICY, ~/.aasm/policy.yaml, /etc/aasm/policy.yaml\n\
-                 Use --policy FILE to specify a path."
+                "error: no policy file or directory found.\n\
+                 Tried: $AA_POLICY, ~/.aasm/policy.yaml, ~/.aasm/policies/, \
+                 /etc/aasm/policy.yaml, /etc/aasm/policies/\n\
+                 Use --policy FILE or --policy DIR to specify a path."
             );
             return ExitCode::FAILURE;
         }
@@ -201,10 +204,16 @@ fn is_executable(path: &std::path::Path) -> bool {
     path.exists()
 }
 
-/// Resolve the policy file path.
+/// Resolve the policy path — a single file or a cascade directory.
 ///
 /// Resolution order: `--policy` flag → `$AA_POLICY` → `~/.aasm/policy.yaml` →
-/// `/etc/aasm/policy.yaml`.
+/// `~/.aasm/policies/` → `/etc/aasm/policy.yaml` → `/etc/aasm/policies/`.
+///
+/// AAASM-3499 — the `--policy` flag and `$AA_POLICY` accept either a file or a
+/// directory (forwarded verbatim to `aa-gateway --policy`, which routes a
+/// directory to the multi-document cascade loader). The default `policies/`
+/// directory locations let an operator drop scoped `*.yaml` documents into a
+/// well-known path without any flag.
 pub fn resolve_policy(args: &StartArgs) -> Option<PathBuf> {
     if let Some(ref p) = args.policy {
         return Some(p.clone());
@@ -218,14 +227,22 @@ pub fn resolve_policy(args: &StartArgs) -> Option<PathBuf> {
         }
     }
     if let Some(home) = dirs::home_dir() {
-        let p = home.join(".aasm").join("policy.yaml");
-        if p.exists() {
-            return Some(p);
+        let file = home.join(".aasm").join("policy.yaml");
+        if file.exists() {
+            return Some(file);
+        }
+        let dir = home.join(".aasm").join("policies");
+        if dir.is_dir() {
+            return Some(dir);
         }
     }
-    let system = PathBuf::from("/etc/aasm/policy.yaml");
-    if system.exists() {
-        return Some(system);
+    let system_file = PathBuf::from("/etc/aasm/policy.yaml");
+    if system_file.exists() {
+        return Some(system_file);
+    }
+    let system_dir = PathBuf::from("/etc/aasm/policies");
+    if system_dir.is_dir() {
+        return Some(system_dir);
     }
     None
 }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -244,6 +244,22 @@ enum CredentialScanOutcome {
     Continue(Option<String>, Vec<aa_security::CredentialFinding>),
 }
 
+/// Parsed result of reading a cascade directory, before a budget tracker is
+/// chosen. Shared between [`PolicyEngine::load_cascade_from_dir`] (fresh
+/// tracker) and [`PolicyEngine::load_cascade_from_dir_with_budget`]
+/// (externally-restored tracker) so the parse path stays identical.
+struct ParsedCascade {
+    scope_index: ScopeIndex,
+    /// First Global-scoped document, if any — becomes the primary slot.
+    primary: Option<PolicyDocument>,
+    compiled_patterns: Vec<regex::Regex>,
+    budget_tz: chrono_tz::Tz,
+    daily_limit: Option<rust_decimal::Decimal>,
+    monthly_limit: Option<rust_decimal::Decimal>,
+    org_daily_limit: Option<rust_decimal::Decimal>,
+    org_monthly_limit: Option<rust_decimal::Decimal>,
+}
+
 impl PolicyEngine {
     /// Load a policy from a YAML file, parse it, validate it, and start the filesystem watcher.
     ///
@@ -375,6 +391,48 @@ impl PolicyEngine {
         dir: &Path,
         budget_alert_tx: tokio::sync::broadcast::Sender<crate::budget::BudgetAlert>,
     ) -> Result<Self, PolicyLoadError> {
+        let parsed = Self::read_cascade_dir(dir)?;
+
+        // The Global-scoped document supplies the budget limits; build a
+        // fresh tracker around them. (The `_with_budget` sibling instead
+        // adopts an externally-restored tracker — see
+        // [`load_cascade_from_dir_with_budget`].)
+        let mut budget_tracker = BudgetTracker::new_with_alert_sender(
+            crate::budget::PricingTable::default_table(),
+            parsed.daily_limit,
+            parsed.monthly_limit,
+            parsed.budget_tz,
+            budget_alert_tx,
+        );
+        if let Some(limit) = parsed.org_daily_limit {
+            budget_tracker = budget_tracker.with_org_daily_limit(limit);
+        }
+        if let Some(limit) = parsed.org_monthly_limit {
+            budget_tracker = budget_tracker.with_org_monthly_limit(limit);
+        }
+        Ok(Self::assemble_cascade(parsed, Arc::new(budget_tracker)))
+    }
+
+    /// Directory-cascade loader that adopts a **pre-built** budget tracker —
+    /// the multi-document analogue of [`load_from_file_with_budget`].
+    ///
+    /// The shipped `aa-gateway` binary uses this so the gateway's
+    /// persistence loop (background writer + shutdown flush) owns the same
+    /// `Arc<BudgetTracker>` it restored from disk, exactly as it does for the
+    /// single-file path. Scope-index population and primary-doc selection are
+    /// identical to [`load_cascade_from_dir`]; only the budget-tracker
+    /// ownership differs. No filesystem watcher is attached (the watcher is
+    /// single-file only — see [`load_cascade_from_dir`] semantics).
+    pub fn load_cascade_from_dir_with_budget(dir: &Path, budget: Arc<BudgetTracker>) -> Result<Self, PolicyLoadError> {
+        let parsed = Self::read_cascade_dir(dir)?;
+        Ok(Self::assemble_cascade(parsed, budget))
+    }
+
+    /// Read and parse every `*.yaml` file in `dir` (alphabetical order) into
+    /// a populated [`ScopeIndex`] plus the budget/pattern config drawn from
+    /// the first Global-scoped document. Shared by both cascade loaders so
+    /// the parse semantics stay identical regardless of budget ownership.
+    fn read_cascade_dir(dir: &Path) -> Result<ParsedCascade, PolicyLoadError> {
         // Collect *.yaml entries in alphabetical order so the cascade is
         // deterministic across runs and filesystems with different
         // dir-iteration orders.
@@ -445,20 +503,27 @@ impl PolicyEngine {
             scope_index.insert(doc);
         }
 
-        let mut budget_tracker = BudgetTracker::new_with_alert_sender(
-            crate::budget::PricingTable::default_table(),
+        Ok(ParsedCascade {
+            scope_index,
+            primary,
+            compiled_patterns,
+            budget_tz,
             daily_limit,
             monthly_limit,
-            budget_tz,
-            budget_alert_tx,
-        );
-        if let Some(limit) = org_daily_limit {
-            budget_tracker = budget_tracker.with_org_daily_limit(limit);
-        }
-        if let Some(limit) = org_monthly_limit {
-            budget_tracker = budget_tracker.with_org_monthly_limit(limit);
-        }
-        let budget = Arc::new(budget_tracker);
+            org_daily_limit,
+            org_monthly_limit,
+        })
+    }
+
+    /// Assemble a [`PolicyEngine`] from a [`ParsedCascade`] and the budget
+    /// tracker the caller chose to own (freshly built or externally restored).
+    fn assemble_cascade(parsed: ParsedCascade, budget: Arc<BudgetTracker>) -> Self {
+        let ParsedCascade {
+            scope_index,
+            primary,
+            compiled_patterns,
+            ..
+        } = parsed;
 
         let primary_doc = primary.unwrap_or_else(|| PolicyDocument {
             name: None,
@@ -476,7 +541,7 @@ impl PolicyEngine {
         });
         let policy_arc = Arc::new(ArcSwap::new(Arc::new(primary_doc)));
 
-        Ok(PolicyEngine {
+        PolicyEngine {
             policy: policy_arc,
             scanner: aa_security::CredentialScanner::new(),
             compiled_patterns,
@@ -488,7 +553,7 @@ impl PolicyEngine {
             policy_epoch: Arc::new(AtomicU64::new(0)),
             invalidation_hub: None,
             decision_cache: DecisionCache::new(100_000),
-        })
+        }
     }
 
     /// Load a policy from a YAML file using a pre-built budget tracker.

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2644,6 +2644,117 @@ mod tests {
         );
     }
 
+    // ── Directory-cascade binary-loader regression (AAASM-3499) ───────────────
+
+    /// Build a `ctx` for a distinct agent (`agent_byte`) whose lineage
+    /// `org_id` is `org`, mirroring the metadata `convert.rs` deposits on the
+    /// live gRPC path. Distinct agent ids matter: the decision cache is keyed
+    /// by `agent_id` (different orgs run different agents in production), so a
+    /// test must not reuse one agent id across two orgs.
+    fn make_ctx_in_org(agent_byte: u8, org: &str) -> AgentContext {
+        let mut ctx = make_ctx();
+        ctx.agent_id = AgentId::from_bytes([agent_byte; 16]);
+        ctx.metadata.insert("org_id".to_string(), org.to_string());
+        ctx
+    }
+
+    /// AAASM-3499 — the directory cascade must be reachable through the loader
+    /// the shipped `aa-gateway` binary calls (`load_cascade_from_dir_with_budget`),
+    /// not just the test-only `load_cascade_from_dir`. Mirrors the ST-org-4 QA
+    /// fixtures: a Global allow-all baseline plus an org-alpha-scoped `bash`
+    /// deny. The narrower org-scoped deny must override the Global allow for an
+    /// org-alpha agent, while an org-beta agent falls through to the allow.
+    #[test]
+    fn binary_loader_cascades_org_scoped_deny_over_global_allow() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Global baseline — empty tools = allow-by-default.
+        std::fs::write(
+            tmp.path().join("000-global-allow-all.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: reg-global-allow-all\n  version: \"0.1.0\"\n\
+             spec:\n  tools: {}\n",
+        )
+        .unwrap();
+        // Org-alpha-scoped deny of `bash`. `scope:` lives INSIDE `spec:`.
+        std::fs::write(
+            tmp.path().join("100-org-alpha-deny-bash.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: reg-org-alpha-deny-bash\n  version: \"0.1.0\"\n\
+             spec:\n  scope: org:org-alpha\n  tools:\n    bash:\n      allow: false\n",
+        )
+        .unwrap();
+
+        let (alert_tx, _alert_rx) = tokio::sync::broadcast::channel::<crate::budget::BudgetAlert>(8);
+        let budget = Arc::new(BudgetTracker::new(
+            crate::budget::PricingTable::default_table(),
+            None,
+            None,
+            chrono_tz::UTC,
+        ));
+        // The binary path: a pre-built tracker is adopted, scope_index populated.
+        let engine = PolicyEngine::load_cascade_from_dir_with_budget(tmp.path(), budget)
+            .expect("cascade directory loads via the binary loader");
+        let _ = alert_tx; // budget alerts unused in this assertion
+
+        let bash = tool_call("bash", "");
+
+        // org-alpha → the org-scoped deny fires and overrides the Global allow.
+        assert_eq!(
+            engine.evaluate(&make_ctx_in_org(0xaa, "org-alpha"), &bash).decision,
+            PolicyResult::Deny {
+                reason: "tool denied by policy".into()
+            },
+            "org-alpha bash must be denied by the narrower org-scoped document"
+        );
+
+        // org-beta → the org-alpha doc is filtered out; falls through to allow.
+        assert_eq!(
+            engine.evaluate(&make_ctx_in_org(0xbb, "org-beta"), &bash).decision,
+            PolicyResult::Allow,
+            "org-beta bash must pass through to the Global allow-all default"
+        );
+    }
+
+    /// The single-file loader must keep the same `scope_index`-empty,
+    /// primary-only behaviour (back-compat) — a directory and a file are not
+    /// interchangeable through the same loader, but routing on
+    /// `path.is_dir()` (in `server::load_policy_engine`) is what selects them.
+    #[test]
+    fn binary_loader_cascade_populates_scope_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("000-global.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: reg-global\n  version: \"0.1.0\"\n\
+             spec:\n  tools: {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("100-org.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: reg-org\n  version: \"0.1.0\"\n\
+             spec:\n  scope: org:acme\n  tools:\n    bash:\n      allow: false\n",
+        )
+        .unwrap();
+
+        let budget = Arc::new(BudgetTracker::new(
+            crate::budget::PricingTable::default_table(),
+            None,
+            None,
+            chrono_tz::UTC,
+        ));
+        let engine = PolicyEngine::load_cascade_from_dir_with_budget(tmp.path(), budget).expect("loads");
+        // A populated scope_index is what routes evaluate() through the cascade.
+        assert!(
+            !engine.scope_index.is_empty(),
+            "directory loader must populate the scope_index (cascade active)"
+        );
+    }
+
     // ── approval_escalation_overrides tests ───────────────────────────────────
 
     #[test]

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -62,8 +62,10 @@ struct Cli {
     #[arg(long, value_enum)]
     mode: Option<Mode>,
 
-    /// Path to the policy YAML file. Required by `legacy-grpc`; ignored by
-    /// `remote` and `local` modes.
+    /// Path to the policy YAML file, or a directory of scoped `*.yaml`
+    /// documents. A directory activates the multi-document Global/Org/Team/
+    /// Agent cascade (AAASM-3499); a file preserves single-policy behaviour.
+    /// Required by `legacy-grpc`; ignored by `remote` and `local` modes.
     #[arg(long)]
     policy: Option<PathBuf>,
 

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -611,3 +611,116 @@ pub async fn serve_uds(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_core::identity::{AgentId, SessionId};
+    use aa_core::time::Timestamp;
+    use aa_core::{AgentContext, GovernanceAction, PolicyResult};
+    use std::collections::BTreeMap;
+
+    fn new_tracker() -> Arc<BudgetTracker> {
+        Arc::new(BudgetTracker::new(
+            crate::budget::PricingTable::default_table(),
+            None,
+            None,
+            chrono_tz::UTC,
+        ))
+    }
+
+    fn ctx_in_org(agent_byte: u8, org: &str) -> AgentContext {
+        let mut metadata = BTreeMap::new();
+        metadata.insert("org_id".to_string(), org.to_string());
+        AgentContext {
+            agent_id: AgentId::from_bytes([agent_byte; 16]),
+            session_id: SessionId::from_bytes([2u8; 16]),
+            pid: 1,
+            started_at: Timestamp::from_nanos(0),
+            metadata,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: None,
+        }
+    }
+
+    fn bash_call() -> GovernanceAction {
+        GovernanceAction::ToolCall {
+            name: "bash".to_string(),
+            args: String::new(),
+        }
+    }
+
+    fn write_cascade_dir() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("000-global.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: srv-global\n  version: \"0.1.0\"\n\
+             spec:\n  tools: {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("100-org.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: srv-org\n  version: \"0.1.0\"\n\
+             spec:\n  scope: org:acme\n  tools:\n    bash:\n      allow: false\n",
+        )
+        .unwrap();
+        tmp
+    }
+
+    /// AAASM-3499 — `load_policy_engine` must route a *directory* to the
+    /// multi-document cascade loader, making the documented Org/Team/Agent
+    /// cascade reachable from the shipped `aa-gateway` binary. Asserted
+    /// behaviourally: the org-acme `bash` deny overrides the Global allow for
+    /// an org-acme agent, while a different org falls through to allow.
+    #[test]
+    fn load_policy_engine_routes_directory_to_cascade() {
+        let tmp = write_cascade_dir();
+        let engine = load_policy_engine(tmp.path(), new_tracker()).expect("directory loads");
+
+        assert_eq!(
+            engine.evaluate(&ctx_in_org(0xac, "acme"), &bash_call()).decision,
+            PolicyResult::Deny {
+                reason: "tool denied by policy".into()
+            },
+            "org-acme bash must be denied by the cascade loaded from the directory"
+        );
+        assert_eq!(
+            engine.evaluate(&ctx_in_org(0x07, "other"), &bash_call()).decision,
+            PolicyResult::Allow,
+            "a non-matching org must fall through to the Global allow-all"
+        );
+    }
+
+    /// A single file preserves the long-standing single-policy behaviour: with
+    /// no cascade loaded, the same org-acme agent is not subject to any
+    /// org-scoped deny (the directory document is never consulted).
+    #[test]
+    fn load_policy_engine_routes_file_to_single_policy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("policy.yaml");
+        std::fs::write(
+            &file,
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: srv-single\n  version: \"0.1.0\"\n\
+             spec:\n  tools: {}\n",
+        )
+        .unwrap();
+
+        let engine = load_policy_engine(&file, new_tracker()).expect("file loads");
+        assert_eq!(
+            engine.evaluate(&ctx_in_org(0xac, "acme"), &bash_call()).decision,
+            PolicyResult::Allow,
+            "single-file load must not apply any org-scoped cascade deny"
+        );
+    }
+}

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -104,6 +104,36 @@ async fn setup_audit(
     Ok((audit_tx, audit_drops, initial_hash, initial_seq))
 }
 
+/// Return the YAML of the first Global-scoped `*.yaml` document in a cascade
+/// directory (alphabetical order), or empty string if none parses as Global.
+///
+/// AAASM-3499 — the budget tracker the gateway's persistence loop owns must
+/// reflect the same limits `load_cascade_from_dir` derives, which come from
+/// the Global-scoped document. Returning empty on absence makes the limits
+/// default to `None`, identical to the cascade loader's own behaviour.
+fn read_global_doc_yaml(dir: &Path) -> String {
+    let mut entries: Vec<PathBuf> = match std::fs::read_dir(dir) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("yaml"))
+            .collect(),
+        Err(_) => return String::new(),
+    };
+    entries.sort();
+    for path in &entries {
+        let Ok(yaml) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if let Ok(output) = crate::policy::PolicyValidator::from_yaml(&yaml) {
+            if matches!(output.document.scope, crate::policy::scope::PolicyScope::Global) {
+                return yaml;
+            }
+        }
+    }
+    String::new()
+}
+
 /// Load persisted budget state from `~/.aa/budget.json`, construct a
 /// [`BudgetTracker`] pre-populated with the restored spend totals, and
 /// return it wrapped in `Arc` alongside the budget file path.
@@ -123,8 +153,14 @@ fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAle
     });
 
     // Extract limits and rollover window from the policy YAML so the tracker
-    // enforces them.
-    let yaml = std::fs::read_to_string(policy_path).unwrap_or_default();
+    // enforces them. For a cascade directory (AAASM-3499) the limits live in
+    // the first Global-scoped document, mirroring `load_cascade_from_dir`;
+    // for a single file we read it directly.
+    let yaml = if policy_path.is_dir() {
+        read_global_doc_yaml(policy_path)
+    } else {
+        std::fs::read_to_string(policy_path).unwrap_or_default()
+    };
     let (daily_limit, monthly_limit, window) = if let Ok(output) = crate::policy::PolicyValidator::from_yaml(&yaml) {
         let daily = output
             .document
@@ -163,6 +199,26 @@ fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAle
     tracing::info!(path = %budget_path.display(), "budget state loaded");
 
     (tracker, budget_path)
+}
+
+/// Build the [`PolicyEngine`] from `policy_path`, routing on whether the path
+/// is a directory.
+///
+/// AAASM-3499 — a directory activates the multi-document Global/Org/Team/Agent
+/// cascade via [`PolicyEngine::load_cascade_from_dir_with_budget`]; a single
+/// file preserves the long-standing [`PolicyEngine::load_from_file_with_budget`]
+/// behaviour unchanged (back-compat). Both adopt the pre-built `tracker` so the
+/// gateway's persistence loop owns the same budget state either way.
+fn load_policy_engine(
+    policy_path: &Path,
+    tracker: Arc<BudgetTracker>,
+) -> Result<PolicyEngine, crate::engine::PolicyLoadError> {
+    if policy_path.is_dir() {
+        tracing::info!(dir = %policy_path.display(), "loading policy cascade from directory");
+        PolicyEngine::load_cascade_from_dir_with_budget(policy_path, tracker)
+    } else {
+        PolicyEngine::load_from_file_with_budget(policy_path, tracker)
+    }
 }
 
 /// Spawn a periodic flush task when the tracker is configured with a
@@ -402,7 +458,7 @@ pub async fn serve_tcp(
     let _budget_flush = maybe_spawn_window_flush(Arc::clone(&tracker));
     let invalidation_hub = InvalidationHub::new();
     let engine = Arc::new(
-        PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
+        load_policy_engine(policy_path, Arc::clone(&tracker))
             .map_err(|e| format!("failed to load policy: {e:?}"))?
             .with_invalidation_hub(Arc::clone(&invalidation_hub)),
     );
@@ -485,7 +541,7 @@ pub async fn serve_uds(
     let _budget_flush = maybe_spawn_window_flush(Arc::clone(&tracker));
     let invalidation_hub = InvalidationHub::new();
     let engine = Arc::new(
-        PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
+        load_policy_engine(policy_path, Arc::clone(&tracker))
             .map_err(|e| format!("failed to load policy: {e:?}"))?
             .with_invalidation_hub(Arc::clone(&invalidation_hub)),
     );

--- a/docs/src/operations/policy-cascade-loader.md
+++ b/docs/src/operations/policy-cascade-loader.md
@@ -33,6 +33,27 @@ Filename prefixes are convention only — the loader sorts alphabetically
 so the cascade order is deterministic across filesystems. Use numeric
 prefixes to make precedence visually obvious.
 
+## Activating the cascade on the gateway (AAASM-3499)
+
+Point `--policy` at the **directory** instead of a single file — the
+shipped binaries detect a directory and route it through the cascade
+loader; a file path keeps the long-standing single-policy behaviour.
+
+```bash
+# aa-gateway binary
+aa-gateway --policy /etc/aa-gateway/policies/ --listen 127.0.0.1:50051
+
+# via the operator CLI
+aasm gateway start --policy /etc/aa-gateway/policies/
+```
+
+`aasm gateway start` also accepts a directory through `$AA_POLICY`, and
+falls back to the well-known directories `~/.aasm/policies/` and
+`/etc/aasm/policies/` (after the `policy.yaml` file locations) when no
+`--policy` flag is given. The budget limits and `data.sensitive_patterns`
+the gateway enforces are taken from the first Global-scoped document in
+the directory, identical to the programmatic loader below.
+
 ## Scope field placement (gotcha)
 
 When using the envelope format (`apiVersion` / `kind` / `metadata` /


### PR DESCRIPTION
## Description

`PolicyEngine::load_cascade_from_dir` (the documented multi-tenant Global/Org/Team/Agent cascade loader) had **no non-test caller** — every shipped/operator path loaded a single file, so passing a directory failed with `Is a directory (os error 21)` and the cascade could only be exercised from Rust test code.

This PR makes `--policy` directory-aware on the shipped binaries:

- **`aa-gateway`** (`serve_tcp`/`serve_uds`): a new `load_policy_engine` detects a directory `--policy` and routes it to the cascade loader; a single file keeps the long-standing behaviour. `setup_budget` reads budget limits / `data.sensitive_patterns` from the directory's first Global-scoped document.
- **Engine**: added `PolicyEngine::load_cascade_from_dir_with_budget` (the multi-document analogue of `load_from_file_with_budget`) so the gateway's persistence loop owns the same pre-built `BudgetTracker`. The directory read + scope-index build is shared with the existing `load_cascade_from_dir` via a `ParsedCascade`/`read_cascade_dir`/`assemble_cascade` trio.
- **`aasm gateway start`**: `resolve_policy` forwards a `--policy`/`$AA_POLICY` directory verbatim and adds `~/.aasm/policies/` + `/etc/aasm/policies/` directory fallbacks.

Single-file behaviour is unchanged (back-compat).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Single-file `--policy` behaviour is fully preserved; directory support is purely additive.

## Related Issues

- Related Jira ticket: AAASM-3499

## Testing

- [x] Unit tests added / updated

New regression tests (each its own commit):

- `aa-gateway engine::tests::binary_loader_cascades_org_scoped_deny_over_global_allow` — scoped `*.yaml` loaded through `load_cascade_from_dir_with_budget` (the binary path); a narrower org-scoped `bash` deny overrides the Global allow for the matching org while a non-matching org falls through to allow.
- `aa-gateway server::tests::load_policy_engine_routes_directory_to_cascade` / `..._routes_file_to_single_policy` — directory routes to the cascade, a file does not.
- `aa-cli ...::resolve_policy_accepts_directory_via_flag` / `..._via_env` — `--policy` and `$AA_POLICY` accept a directory.

`cargo nextest run -p aa-gateway -p aa-cli` → **1744 passed, 0 failed**. `cargo fmt`, `cargo clippy --all-targets -D warnings`, and `cargo deny check` all clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
