### PR TITLE
[AAASM-3502] 📝 (release-validate-channels): Fix expected release asset count 8→6

### DIFF
--- a/.claude/skills/release-validate-channels/EXAMPLES.md
+++ b/.claude/skills/release-validate-channels/EXAMPLES.md
@@ -32,17 +32,14 @@ gh release view v0.0.1-alpha.9 --repo ai-agent-assembly/agent-assembly \
 ```
 
 - `isDraft = false`, `isPrerelease = true`
-- 8 assets (current `release.yml` uploads the detached cosign `.sig`/`.pem`
-  alongside the self-contained `.cosign.bundle`; the very earliest cuts
-  predated the detached pair and showed 6):
+- 6 assets (`release.yml` signs `SHA256SUMS` with a single self-contained
+  `.cosign.bundle` — there are no detached `.sig`/`.pem` files):
   - `aasm-aarch64-apple-darwin.tar.gz`
   - `aasm-x86_64-apple-darwin.tar.gz`
   - `aasm-aarch64-unknown-linux-gnu.tar.gz`
   - `aasm-x86_64-unknown-linux-gnu.tar.gz`
   - `SHA256SUMS`
   - `SHA256SUMS.cosign.bundle`
-  - `SHA256SUMS.sig`
-  - `SHA256SUMS.pem`
 
 ### 2. crates.io (sparse-index)
 
@@ -124,7 +121,7 @@ Release validation for v0.0.1-alpha.9:
 
 | Channel              | Status | Detail                                                            |
 |----------------------|--------|-------------------------------------------------------------------|
-| GitHub Release       | ✓      | 8 assets, isPrerelease=true                                       |
+| GitHub Release       | ✓      | 6 assets, isPrerelease=true                                       |
 | crates.io (9 crates) | ✓      | all sparse-index vers = 0.0.1-alpha.9                             |
 | npm (5 packages)     | ✓      | sdk + 4 runtime sub-packages (linux-{arm64,x64}, no -gnu)         |
 | PyPI                 | ✓      | 0.0.1a9 active, 4 wheels + 1 sdist; soft note: 0.0.2 yanked shadow|

--- a/.claude/skills/release-validate-channels/REFERENCE.md
+++ b/.claude/skills/release-validate-channels/REFERENCE.md
@@ -8,7 +8,7 @@ detailed Level-3 reference it links to.
 ## Contents
 
 - [The channel matrix](#the-channel-matrix)
-  - [1. GitHub Release — 8 assets, isPrerelease](#1-github-release--8-assets-isprerelease)
+  - [1. GitHub Release — 6 assets, isPrerelease](#1-github-release--6-assets-isprerelease)
   - [2. crates.io — sparse-index probe per crate](#2-cratesio--sparse-index-probe-per-crate)
   - [3. npm — sdk + 4 runtime sub-packages](#3-npm--sdk--4-runtime-sub-packages)
   - [4. PyPI — wheels + sdist, distinguishing yanked from active](#4-pypi--wheels--sdist-distinguishing-yanked-from-active)
@@ -31,7 +31,7 @@ literal output so the operator can paste back into a follow-up ticket.
 
 | # | Channel              | Check |
 |---|----------------------|-------|
-| 1 | GitHub Release       | `gh release view <TAG>` exposes the 8 expected assets and `isPrerelease=true` |
+| 1 | GitHub Release       | `gh release view <TAG>` exposes the 6 expected assets and `isPrerelease=true` |
 | 2 | crates.io            | Each workspace-published crate's sparse-index latest line `vers` matches `$VERSION` |
 | 3 | npm                  | `@agent-assembly/sdk@$VERSION` + 4 platform runtime sub-packages exist |
 | 4 | PyPI                 | `agent-assembly==$PEP440` exists with 4 wheels + 1 sdist; no yanked higher version shadows |
@@ -41,7 +41,7 @@ literal output so the operator can paste back into a follow-up ticket.
 | 8 | Docs sites           | `Docs` workflow on agent-assembly + `pages-build-deployment` on python-sdk / node-sdk all succeeded post-tag |
 | 9 | GHCR                 | `ghcr.io/ai-agent-assembly/{python,go}:$VERSION` manifests exist |
 
-### 1. GitHub Release — 8 assets, isPrerelease
+### 1. GitHub Release — 6 assets, isPrerelease
 
 ```bash
 gh release view "$TAG" \
@@ -54,15 +54,13 @@ Pass criteria:
 - `isDraft = false`
 - `isPrerelease = true` (every tag with a `-alpha`/`-beta`/`-rc` suffix is a
   pre-release — `release.yml` sets `prerelease: contains(ref_name, '-')`)
-- `assets` array has **8 entries**, exactly:
+- `assets` array has **6 entries**, exactly:
   - `aasm-aarch64-apple-darwin.tar.gz`
   - `aasm-x86_64-apple-darwin.tar.gz`
   - `aasm-aarch64-unknown-linux-gnu.tar.gz`
   - `aasm-x86_64-unknown-linux-gnu.tar.gz`
   - `SHA256SUMS`
   - `SHA256SUMS.cosign.bundle`
-  - `SHA256SUMS.sig`
-  - `SHA256SUMS.pem`
 
 If asset count or names diverge, report the exact `assets[].name` list and
 flag the release run URL.

--- a/.claude/skills/release-validate-channels/SKILL.md
+++ b/.claude/skills/release-validate-channels/SKILL.md
@@ -93,7 +93,7 @@ green / red per channel:
 
 | # | Channel              | One-line check |
 |---|----------------------|----------------|
-| 1 | GitHub Release       | 8 expected assets present, `isPrerelease=true`, `isDraft=false` |
+| 1 | GitHub Release       | 6 expected assets present, `isPrerelease=true`, `isDraft=false` |
 | 2 | crates.io            | All 9 published crates' sparse-index latest `vers` = `$VERSION` |
 | 3 | npm                  | `@agent-assembly/sdk` + 4 runtime sub-packages exist at `$VERSION` |
 | 4 | PyPI                 | `agent-assembly==$PEP440` active with 4 wheels + 1 sdist; no yanked higher shadow |
@@ -118,7 +118,7 @@ Release validation for <TAG>:
 
 | Channel              | Status | Detail                                          |
 |----------------------|--------|-------------------------------------------------|
-| GitHub Release       | ✓      | 8 assets, isPrerelease=true                     |
+| GitHub Release       | ✓      | 6 assets, isPrerelease=true                     |
 | crates.io (9 crates) | ✓      | all latest line vers = <VERSION>                |
 | npm (5 packages)     | ✓      | sdk + 4 runtime sub-packages at <VERSION>       |
 | PyPI                 | ✓      | <PEP440> active, 4 wheels + 1 sdist, no shadows |


### PR DESCRIPTION
## Description

The `release-validate-channels` skill expected **8** assets on the agent-assembly GitHub Release. The real release has **6**: 4 platform tarballs (`aasm-{aarch64,x86_64}-{apple-darwin,unknown-linux-gnu}.tar.gz`) + `SHA256SUMS` + `SHA256SUMS.cosign.bundle`. Cosign uses a single self-contained bundle, not separate detached `.sig`/`.pem` files.

The wrong count was introduced by **AAASM-3449 / PR #1169**, which assumed `release.yml` uploads a detached cosign `.sig`/`.pem` pair. It does not. With the skill expecting 8, channel validation falsely fails on every real release.

This PR reverts the expected count from 8 back to **6** across `SKILL.md`, `REFERENCE.md`, and `EXAMPLES.md`, and corrects the accompanying text/asset lists to describe the single `SHA256SUMS.cosign.bundle` instead of separate `.sig`/`.pem` files.

**Verified** against the live **v0.0.1-beta.3** GitHub Release, which has exactly 6 assets.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3502
- Closes AAASM-3502

## Testing

- [x] No tests required (documentation-only change; values cross-checked against the live v0.0.1-beta.3 release which has 6 assets)

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention
