### PR TITLE
[AAASM-3506] 🐛 (dashboard): Theme the violations-heatmap tooltip (dark-mode legibility)

### DIFF
--- a/dashboard/src/components/ViolationHeatmap.tsx
+++ b/dashboard/src/components/ViolationHeatmap.tsx
@@ -193,11 +193,16 @@ export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Readonly<Props>) {
       {/* Tooltip */}
       {tooltip && (
         <div
+          data-testid="heatmap-tooltip"
           style={{
             position: "absolute",
             left: tooltip.x + 60,
             top: tooltip.y + 10,
-            background: "white",
+            // Theme tokens (not hardcoded white) so the tooltip stays legible
+            // in dark mode — a bare `white` background inherits the light
+            // foreground and produces light-on-white text (AAASM-3506).
+            background: "var(--paper-2)",
+            color: "var(--ink)",
             border: "1px solid var(--line-2)",
             borderRadius: 6,
             padding: "8px 12px",

--- a/dashboard/src/components/__tests__/ViolationHeatmap.test.tsx
+++ b/dashboard/src/components/__tests__/ViolationHeatmap.test.tsx
@@ -139,6 +139,23 @@ describe("ViolationHeatmap", () => {
     expect(screen.queryByText("Top policies:")).not.toBeInTheDocument();
   });
 
+  it("themes the tooltip via CSS tokens instead of hardcoded white (AAASM-3506)", () => {
+    // Regression guard: the tooltip previously hardcoded `background: "white"`
+    // with no `color`, so in dark mode it inherited the light foreground and
+    // rendered light-on-white. It must use theme tokens that invert per theme.
+    const nodes = makeFiftyEntryNodes();
+    render(<ViolationHeatmap nodes={nodes} />);
+
+    const target = screen.getByTestId("heatmap-node-aaaa0000000000000000000000000001");
+    fireEvent.mouseEnter(target);
+
+    const tooltip = screen.getByTestId("heatmap-tooltip");
+    expect(tooltip.style.background).toBe("var(--paper-2)");
+    expect(tooltip.style.color).toBe("var(--ink)");
+    // Must not fall back to the hardcoded light-mode background.
+    expect(tooltip.style.background).not.toBe("white");
+  });
+
   it("hides team/depth/top-policies tooltip fields when not set", () => {
     const onlyAgent = makeNode({
       agent_id: "cccc0000000000000000000000000001",


### PR DESCRIPTION
## Description

The `ViolationHeatmap` hover tooltip (route `/audit/violations`) hardcoded `background: "white"` with no explicit `color`. In **dark mode** the tooltip therefore inherited the light theme foreground, rendering near-invisible light-text-on-white (fails WCAG contrast). Light mode was unaffected.

This swaps the hardcoded color for the dashboard's CSS theme tokens so the tooltip inverts correctly in both themes:

- `background: "white"` → `background: "var(--paper-2)"` (light `#ffffff` → dark `#1c1a16`)
- adds `color: "var(--ink)"` (light `#0e0e0e` → dark `#f0ede4`)

The existing `1px solid var(--line-2)` border already themes correctly and is unchanged. **Only the colors changed** — tooltip positioning, content, and hover/leave behavior are untouched. A `data-testid="heatmap-tooltip"` was added to anchor the regression test.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3506

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

Added a `ViolationHeatmap` unit test that hovers a node and asserts the tooltip background resolves to `var(--paper-2)` and color to `var(--ink)` (and is not hardcoded `white`). Local validation in `dashboard/`:

- `pnpm vitest run` (ViolationHeatmap) — 12/12 pass
- `pnpm type-check` — clean
- `pnpm lint` — clean
- `pnpm build` — succeeds (only pre-existing chunk-size / dynamic-import warnings, unrelated)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — token swap)
- [ ] All CI checks passing (org Actions may be billing-blocked; validated locally)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)