### PR TITLE
[AAASM-3511] 🔧 (ci): Run SonarCloud analysis on dashboard PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1157,7 +1157,7 @@ jobs:
   sonar:
     name: SonarCloud analysis
     needs: [changes, coverage, dashboard-test]
-    if: ${{ !cancelled() && needs.changes.result == 'success' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-coverage')) }}
+    if: ${{ !cancelled() && needs.changes.result == 'success' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-coverage') || needs.changes.outputs.dashboard == 'true') }}
     runs-on: ubuntu-latest
     # AAASM-3197: actions:read lets `gh run download` pull the last successful
     # master LCOV when a coverage producer was skipped this run (see fallback


### PR DESCRIPTION
## Description

The `sonar` job ("SonarCloud analysis") in `.github/workflows/ci.yml` was gated
to run only on `push` events or PRs carrying the manual `run-coverage` label.
As a result, **dashboard-only PRs received no SonarCloud report** — the dashboard
JS changes were never analyzed unless someone remembered to apply the label.

This PR adds `needs.changes.outputs.dashboard == 'true'` to the job's `if:`
condition so dashboard PRs are analyzed automatically:

```diff
-    if: ${{ !cancelled() && needs.changes.result == 'success' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-coverage')) }}
+    if: ${{ !cancelled() && needs.changes.result == 'success' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-coverage') || needs.changes.outputs.dashboard == 'true') }}
```

`dashboard` is a real output of the `changes` job (the `dorny/paths-filter`
`dashboard` filter). The sonar job already declares `needs: [changes, coverage,
dashboard-test]` and backfills the last successful master Rust LCOV when the
`coverage` producer is skipped, so on a dashboard PR (coverage skipped,
dashboard-test runs) it scans with just the dashboard JS LCOV — no extra test
runs required.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3511

## Testing

- [x] No tests required (explain why)

CI-config-only change to a single job-level `if:` gate. Validated locally with
`actionlint .github/workflows/ci.yml` (clean, no findings) and a `yaml.safe_load`
parse check. The fix takes effect on the next dashboard PR's CI run.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)