### PR TITLE
[AAASM-3514] ♻️ (dashboard): Harden Audit Log page — Sonar fixes + tests

### DIFF
--- a/dashboard/src/features/audit/logs.test.tsx
+++ b/dashboard/src/features/audit/logs.test.tsx
@@ -33,6 +33,18 @@ describe('extractDecision', () => {
   it('returns null for malformed JSON', () => {
     expect(extractDecision('not-json')).toBeNull()
   })
+
+  it('ignores an empty-string decision and falls through to null', () => {
+    expect(extractDecision('{"decision":""}')).toBeNull()
+  })
+
+  it('ignores a non-string decision and falls back to shadow_decision', () => {
+    expect(extractDecision('{"decision":1,"shadow_decision":"redact"}')).toBe('REDACT')
+  })
+
+  it('returns null for a non-object JSON payload', () => {
+    expect(extractDecision('"just-a-string"')).toBeNull()
+  })
 })
 
 describe('payloadSummary', () => {
@@ -66,11 +78,69 @@ describe('payloadSummary', () => {
   it('returns an em dash for malformed payloads', () => {
     expect(payloadSummary('LLMCall', 'not-json')).toBe('—')
   })
+
+  it('upper-cases a FileOp operation and renders a MB size suffix', () => {
+    const s = payloadSummary(
+      'FileOp',
+      '{"operation":"write","path":"/tmp/out.bin","bytes":2097152}',
+    )
+    expect(s).toBe('WRITE /tmp/out.bin · 2.0 MB')
+  })
+
+  it('omits the size suffix for a FileOp with no byte count', () => {
+    const s = payloadSummary('FileOp', '{"operation":"read","path":"/etc/hosts"}')
+    expect(s).toBe('READ /etc/hosts')
+  })
+
+  it('coerces a non-string FileOp operation to an empty verb (no [object Object])', () => {
+    const s = payloadSummary('FileOp', '{"operation":{"verb":"x"},"path":"/p"}')
+    expect(s).not.toContain('[object Object]')
+    expect(s).toBe(' /p')
+  })
+
+  it('renders an empty verb for a missing FileOp operation', () => {
+    const s = payloadSummary('FileOp', '{"path":"/p"}')
+    expect(s).toBe(' /p')
+  })
+
+  it('summarises a ToolCall with an error marker when it did not succeed', () => {
+    const s = payloadSummary(
+      'ToolCall',
+      '{"tool_name":"db_query","tool_source":"mcp","succeeded":false,"latency_ms":12}',
+    )
+    expect(s).toBe('db_query (mcp) · ✕ error · 12ms')
+  })
+
+  it('summarises a NetworkCall as protocol://host → status', () => {
+    const s = payloadSummary(
+      'NetworkCall',
+      '{"protocol":"https","host":"api.example.com","status_code":200,"latency_ms":54}',
+    )
+    expect(s).toBe('https://api.example.com → 200 · 54ms')
+  })
+
+  it('summarises an ApprovalEvent as rejected when not approved', () => {
+    const s = payloadSummary(
+      'ApprovalEvent',
+      '{"approval_id":"ap-1","approved":false,"approver_id":"u-9","wait_time_ms":4200}',
+    )
+    expect(s).toBe('ap-1 rejected by u-9 after 4s')
+  })
+
+  it('truncates an oversized unknown-type dump to 100 chars', () => {
+    const big = JSON.stringify({ note: 'x'.repeat(200) })
+    const s = payloadSummary('Mystery', big)
+    expect(s).toHaveLength(100)
+  })
 })
 
 describe('auditEventHref', () => {
   it('builds the stable /audit/event/:seq detail path', () => {
     expect(auditEventHref(1048)).toBe('/audit/event/1048')
+  })
+
+  it('handles a zero seq without dropping the segment', () => {
+    expect(auditEventHref(0)).toBe('/audit/event/0')
   })
 })
 

--- a/dashboard/src/features/audit/logs.ts
+++ b/dashboard/src/features/audit/logs.ts
@@ -89,8 +89,11 @@ export function payloadSummary(eventType: string, payload: string): string {
         return `${p.model} · ${p.prompt_tokens}+${p.completion_tokens} tok · ${p.latency_ms}ms${p.pii_detected ? ' · ⚠ PII detected' : ''}`
       case 'ToolCall':
         return `${p.tool_name} (${p.tool_source}) · ${p.succeeded ? '✓ ok' : '✕ error'} · ${p.latency_ms}ms`
-      case 'FileOp':
-        return `${String(p.operation ?? '').toUpperCase()} ${p.path}${p.bytes ? ` · ${(Number(p.bytes) / 1048576).toFixed(1)} MB` : ''}`
+      case 'FileOp': {
+        const operation = typeof p.operation === 'string' ? p.operation : ''
+        const sizeSuffix = p.bytes ? ` · ${(Number(p.bytes) / 1048576).toFixed(1)} MB` : ''
+        return `${operation.toUpperCase()} ${p.path}${sizeSuffix}`
+      }
       case 'NetworkCall':
         return `${p.protocol}://${p.host} → ${p.status_code} · ${p.latency_ms}ms`
       case 'PolicyViolation':

--- a/dashboard/src/pages/AuditLogPage.test.tsx
+++ b/dashboard/src/pages/AuditLogPage.test.tsx
@@ -180,4 +180,73 @@ describe('AuditLogPage', () => {
     expect(await screen.findByTestId('audit-error')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
   })
+
+  it('renders the allow decision chip for a non-violation row', async () => {
+    renderPage()
+    const row = await screen.findByTestId('audit-row-1047')
+    expect(within(row).getByText('allow')).toBeInTheDocument()
+  })
+
+  it('renders an em-dash decision chip when the payload carries no verdict', async () => {
+    get.mockResolvedValue({
+      data: [entry({ seq: 900, event_type: 'LLMCall', payload: '{"model":"gpt-4o"}' })],
+    })
+    renderPage()
+    const row = await screen.findByTestId('audit-row-900')
+    expect(within(row).getByText('—')).toBeInTheDocument()
+  })
+
+  it('falls back to the raw event-type label for an unknown type', async () => {
+    get.mockResolvedValue({
+      data: [entry({ seq: 901, event_type: 'MysteryEvent', payload: '{}' })],
+    })
+    renderPage()
+    const row = await screen.findByTestId('audit-row-901')
+    expect(within(row).getByText(/MysteryEvent/)).toBeInTheDocument()
+  })
+
+  it('lists one agent-select option per distinct agent plus "all"', async () => {
+    renderPage()
+    await screen.findByTestId('audit-row-1048')
+    const options = within(screen.getByTestId('audit-agent-filter')).getAllByRole('option')
+    expect(options.map((o) => o.getAttribute('value'))).toEqual([
+      'all',
+      'research-bot-04',
+      'support-triage',
+    ])
+  })
+
+  it('combines the type filter with free-text search', async () => {
+    renderPage()
+    await screen.findByTestId('audit-row-1048')
+
+    fireEvent.click(screen.getByTestId('audit-stat-ToolCall'))
+    await waitFor(() => expect(screen.queryByTestId('audit-row-1048')).toBeNull())
+
+    fireEvent.change(screen.getByTestId('audit-search'), {
+      target: { value: 'no-match' },
+    })
+    expect(await screen.findByTestId('audit-empty')).toBeInTheDocument()
+    expect(screen.getByTestId('audit-count')).toHaveTextContent('0 / 3')
+  })
+
+  it('shows the loading state before the query resolves', async () => {
+    let resolve: (v: { data: LogEntry[] }) => void = () => {}
+    get.mockReturnValue(
+      new Promise<{ data: LogEntry[] }>((r) => {
+        resolve = r
+      }),
+    )
+    renderPage()
+    expect(await screen.findByTestId('audit-loading')).toBeInTheDocument()
+    resolve({ data: ENTRIES })
+    await screen.findByTestId('audit-table')
+  })
+
+  it('navigates to the agent detail view from the agent link', async () => {
+    renderPage()
+    const row = await screen.findByTestId('audit-row-1044')
+    const agentLink = within(row).getByTestId('audit-agent-link-1044')
+    expect(agentLink).toHaveTextContent('support-triage')
+  })
 })

--- a/dashboard/src/pages/AuditLogPage.tsx
+++ b/dashboard/src/pages/AuditLogPage.tsx
@@ -100,6 +100,166 @@ export function AuditLogPage() {
     })),
   ]
 
+  // Pick the body section with an explicit branch rather than a nested ternary
+  // (error → loading → table), keeping the render tree readable.
+  let body: React.ReactNode
+  if (isError) {
+    body = (
+      <div className="audit-state audit-state--error" data-testid="audit-error">
+        <p>Failed to load audit log.</p>
+        <button type="button" className="audit-btn" onClick={() => ignorePromise(refetch())}>
+          Retry
+        </button>
+      </div>
+    )
+  } else if (isLoading) {
+    body = (
+      <div className="audit-state" data-testid="audit-loading">
+        Loading…
+      </div>
+    )
+  } else {
+    body = (
+      <div className="audit-table-wrap">
+        <table className="audit-table" data-testid="audit-table">
+          <thead>
+            <tr>
+              <th style={{ width: 52 }}>seq</th>
+              <th style={{ width: 100 }}>time</th>
+              <th style={{ width: 150 }}>agent</th>
+              <th style={{ width: 150 }}>event type</th>
+              <th style={{ width: 84 }}>decision</th>
+              <th>summary</th>
+              <th style={{ width: 90 }}>session</th>
+              <th style={{ width: 64 }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="audit-empty-cell" data-testid="audit-empty">
+                  no entries match
+                </td>
+              </tr>
+            ) : (
+              filtered.map((e) => {
+                const meta = EVENT_META[e.event_type] ?? {
+                  label: e.event_type,
+                  chip: '',
+                  icon: '·',
+                }
+                const decision = extractDecision(e.payload)
+                const dm = (decision && DECISION_META[decision]) || {
+                  chip: '',
+                  label: decision ? decision.toLowerCase() : '—',
+                }
+                const summary = payloadSummary(e.event_type, e.payload)
+                const isExp = expanded === e.seq
+                const isViolation = e.event_type === 'PolicyViolation'
+                const rowCls = [
+                  'audit-row',
+                  isExp ? 'audit-row--expanded' : '',
+                  !isExp && isViolation ? 'audit-row--violation' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')
+
+                return (
+                  <Fragment key={e.seq}>
+                    <tr
+                      className={rowCls}
+                      data-testid={`audit-row-${e.seq}`}
+                      onClick={() => setExpanded(isExp ? null : e.seq)}
+                    >
+                      <td className="audit-mono audit-session">{e.seq}</td>
+                      <td>
+                        <div className="audit-cell-time">{e.timestamp.slice(11, 19)}</div>
+                        <div className="audit-cell-date">{e.timestamp.slice(0, 10)}</div>
+                      </td>
+                      <td>
+                        <button
+                          type="button"
+                          className="audit-agent-link"
+                          data-testid={`audit-agent-link-${e.seq}`}
+                          onClick={(ev) => {
+                            ev.stopPropagation()
+                            navigate(`/agents/${e.agent_id}`)
+                          }}
+                        >
+                          {e.agent_id}
+                        </button>
+                      </td>
+                      <td>
+                        <span className={chipClass(meta.chip)}>
+                          {meta.icon} {meta.label}
+                        </span>
+                      </td>
+                      <td>
+                        <span className={chipClass(dm.chip)}>{dm.label}</span>
+                      </td>
+                      <td>
+                        <span
+                          className={[
+                            'audit-summary',
+                            isViolation ? 'audit-summary--violation' : '',
+                            MONO_SUMMARY_TYPES.has(e.event_type) ? 'audit-summary--mono' : '',
+                          ]
+                            .filter(Boolean)
+                            .join(' ')}
+                        >
+                          {summary}
+                        </span>
+                      </td>
+                      <td className="audit-session">{e.session_id}</td>
+                      <td>
+                        <Link
+                          to={auditEventHref(e.seq)}
+                          className="audit-event-link"
+                          data-testid={`audit-event-link-${e.seq}`}
+                          onClick={(ev) => ev.stopPropagation()}
+                        >
+                          View →
+                        </Link>
+                      </td>
+                    </tr>
+
+                    {isExp && (
+                      <tr>
+                        <td colSpan={8} className="audit-detail-cell">
+                          <div className="audit-detail" data-testid={`audit-detail-${e.seq}`}>
+                            <div>
+                              <div className="audit-detail__section-title">metadata</div>
+                              <div className="audit-kv">
+                                <span className="audit-kv__k">seq</span>
+                                <span className="audit-kv__v">{e.seq}</span>
+                                <span className="audit-kv__k">timestamp</span>
+                                <span className="audit-kv__v">{e.timestamp}</span>
+                                <span className="audit-kv__k">session</span>
+                                <span className="audit-kv__v">{e.session_id}</span>
+                                <span className="audit-kv__k">decision</span>
+                                <span className="audit-kv__v">
+                                  <span className={chipClass(dm.chip)}>{dm.label}</span>
+                                </span>
+                              </div>
+                            </div>
+                            <div>
+                              <div className="audit-detail__section-title">payload</div>
+                              <pre className="audit-payload">{prettyPayload(e.payload)}</pre>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+
   return (
     <div className="audit-page" data-testid="audit-log-page">
       <header className="audit-head">
@@ -178,156 +338,7 @@ export function AuditLogPage() {
         </span>
       </div>
 
-      {isError ? (
-        <div className="audit-state audit-state--error" data-testid="audit-error">
-          <p>Failed to load audit log.</p>
-          <button type="button" className="audit-btn" onClick={() => ignorePromise(refetch())}>
-            Retry
-          </button>
-        </div>
-      ) : isLoading ? (
-        <div className="audit-state" data-testid="audit-loading">
-          Loading…
-        </div>
-      ) : (
-        <div className="audit-table-wrap">
-          <table className="audit-table" data-testid="audit-table">
-            <thead>
-              <tr>
-                <th style={{ width: 52 }}>seq</th>
-                <th style={{ width: 100 }}>time</th>
-                <th style={{ width: 150 }}>agent</th>
-                <th style={{ width: 150 }}>event type</th>
-                <th style={{ width: 84 }}>decision</th>
-                <th>summary</th>
-                <th style={{ width: 90 }}>session</th>
-                <th style={{ width: 64 }}></th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.length === 0 ? (
-                <tr>
-                  <td colSpan={8} className="audit-empty-cell" data-testid="audit-empty">
-                    no entries match
-                  </td>
-                </tr>
-              ) : (
-                filtered.map((e) => {
-                  const meta = EVENT_META[e.event_type] ?? {
-                    label: e.event_type,
-                    chip: '',
-                    icon: '·',
-                  }
-                  const decision = extractDecision(e.payload)
-                  const dm = (decision && DECISION_META[decision]) || {
-                    chip: '',
-                    label: decision ? decision.toLowerCase() : '—',
-                  }
-                  const summary = payloadSummary(e.event_type, e.payload)
-                  const isExp = expanded === e.seq
-                  const isViolation = e.event_type === 'PolicyViolation'
-                  const rowCls = [
-                    'audit-row',
-                    isExp ? 'audit-row--expanded' : '',
-                    !isExp && isViolation ? 'audit-row--violation' : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' ')
-
-                  return (
-                    <Fragment key={e.seq}>
-                      <tr
-                        className={rowCls}
-                        data-testid={`audit-row-${e.seq}`}
-                        onClick={() => setExpanded(isExp ? null : e.seq)}
-                      >
-                        <td className="audit-mono audit-session">{e.seq}</td>
-                        <td>
-                          <div className="audit-cell-time">{e.timestamp.slice(11, 19)}</div>
-                          <div className="audit-cell-date">{e.timestamp.slice(0, 10)}</div>
-                        </td>
-                        <td>
-                          <button
-                            type="button"
-                            className="audit-agent-link"
-                            data-testid={`audit-agent-link-${e.seq}`}
-                            onClick={(ev) => {
-                              ev.stopPropagation()
-                              navigate(`/agents/${e.agent_id}`)
-                            }}
-                          >
-                            {e.agent_id}
-                          </button>
-                        </td>
-                        <td>
-                          <span className={chipClass(meta.chip)}>
-                            {meta.icon} {meta.label}
-                          </span>
-                        </td>
-                        <td>
-                          <span className={chipClass(dm.chip)}>{dm.label}</span>
-                        </td>
-                        <td>
-                          <span
-                            className={[
-                              'audit-summary',
-                              isViolation ? 'audit-summary--violation' : '',
-                              MONO_SUMMARY_TYPES.has(e.event_type) ? 'audit-summary--mono' : '',
-                            ]
-                              .filter(Boolean)
-                              .join(' ')}
-                          >
-                            {summary}
-                          </span>
-                        </td>
-                        <td className="audit-session">{e.session_id}</td>
-                        <td>
-                          <Link
-                            to={auditEventHref(e.seq)}
-                            className="audit-event-link"
-                            data-testid={`audit-event-link-${e.seq}`}
-                            onClick={(ev) => ev.stopPropagation()}
-                          >
-                            View →
-                          </Link>
-                        </td>
-                      </tr>
-
-                      {isExp && (
-                        <tr>
-                          <td colSpan={8} className="audit-detail-cell">
-                            <div className="audit-detail" data-testid={`audit-detail-${e.seq}`}>
-                              <div>
-                                <div className="audit-detail__section-title">metadata</div>
-                                <div className="audit-kv">
-                                  <span className="audit-kv__k">seq</span>
-                                  <span className="audit-kv__v">{e.seq}</span>
-                                  <span className="audit-kv__k">timestamp</span>
-                                  <span className="audit-kv__v">{e.timestamp}</span>
-                                  <span className="audit-kv__k">session</span>
-                                  <span className="audit-kv__v">{e.session_id}</span>
-                                  <span className="audit-kv__k">decision</span>
-                                  <span className="audit-kv__v">
-                                    <span className={chipClass(dm.chip)}>{dm.label}</span>
-                                  </span>
-                                </div>
-                              </div>
-                              <div>
-                                <div className="audit-detail__section-title">payload</div>
-                                <pre className="audit-payload">{prettyPayload(e.payload)}</pre>
-                              </div>
-                            </div>
-                          </td>
-                        </tr>
-                      )}
-                    </Fragment>
-                  )
-                })
-              )}
-            </tbody>
-          </table>
-        </div>
-      )}
+      {body}
     </div>
   )
 }


### PR DESCRIPTION
## Description

Fixes the SonarCloud Reliability/Maintainability issues reported on the dashboard
**Audit Log** page and broadens its test coverage. Refactor-only — no behaviour
change for the existing (string-valued) payload inputs.

SonarCloud fixes:
- `dashboard/src/features/audit/logs.ts` L93 — `typescript:S6551`: `p.operation ?? ''`
  could stringify a non-string `operation` as `[object Object]`. Now narrowed to
  `typeof p.operation === 'string' ? p.operation : ''` before `.toUpperCase()`.
- `dashboard/src/features/audit/logs.ts` L93 — `typescript:S4624`: the nested
  byte-size template literal is lifted into a named `sizeSuffix` const.
- `dashboard/src/pages/AuditLogPage.tsx` L188 — `typescript:S3358`: the nested
  `isError ? … : isLoading ? … : <table>` ternary is replaced by a `body`
  `ReactNode` chosen with an explicit `if`/`else` chain before the return.

Tests:
- `logs.test.tsx` — `payloadSummary` FileOp coverage (object-valued / missing /
  non-string `operation`, MB suffix on/off), ToolCall error / NetworkCall /
  ApprovalEvent branches, oversized-dump truncation; `extractDecision`
  non-string / empty / non-object payloads; zero-seq `auditEventHref`.
- `AuditLogPage.test.tsx` — allow / em-dash decision chips, unknown event-type
  label fallback, agent-select option set, combined type + search filtering,
  loading state, agent link.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

For string `operation` values the summary output is byte-for-byte identical;
only previously-malformed non-string inputs change from `[OBJECT OBJECT]` to an
empty verb.

## Related Issues

- Related Jira ticket: AAASM-3514

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

Validation (in `dashboard/`): `pnpm type-check`, `pnpm lint`, `pnpm build`, and
`pnpm test` (147 files / 1322 tests) all green.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — no behaviour change)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
