### PR TITLE
[AAASM-3513] ♻️ (dashboard): Harden Cost & Budget page — Sonar fixes + tests

### DIFF
--- a/dashboard/src/pages/CostsPage.test.tsx
+++ b/dashboard/src/pages/CostsPage.test.tsx
@@ -140,11 +140,11 @@ describe('CostsPage', () => {
     const bars = await screen.findAllByTestId('team-budget-bar')
     expect(bars).toHaveLength(2)
 
-    const hot = bars.find(b => b.getAttribute('data-team') === 'team-hot')!
-    expect(hot.getAttribute('data-threshold-bucket')).toBe('danger')
+    const hot = bars.find(b => b.dataset.team === 'team-hot')!
+    expect(hot.dataset.thresholdBucket).toBe('danger')
 
-    const cool = bars.find(b => b.getAttribute('data-team') === 'team-cool')!
-    expect(cool.getAttribute('data-threshold-bucket')).toBe('ok')
+    const cool = bars.find(b => b.dataset.team === 'team-cool')!
+    expect(cool.dataset.thresholdBucket).toBe('ok')
   })
 
   it('renders the reused per-agent cost breakdown panel', async () => {

--- a/dashboard/src/pages/CostsPage.test.tsx
+++ b/dashboard/src/pages/CostsPage.test.tsx
@@ -187,4 +187,168 @@ describe('CostsPage', () => {
     expect(await screen.findByTestId('costs-error')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
   })
+
+  it('refetches the cost summary when Retry is clicked in the error state', async () => {
+    const refetch = vi.fn()
+    vi.spyOn(teamsApi, 'useTopologyOverviewQuery').mockReturnValue(
+      mockQuery<TopologyOverview>({ data: OVERVIEW, isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(teamsApi, 'useCostSummaryQuery').mockReturnValue(
+      mockQuery<CostSummary>({ data: undefined, isLoading: false, isError: true, refetch }),
+    )
+    mockBreakdownFetch()
+    render(<CostsPage />, { wrapper: Wrapper })
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Retry' }))
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the loading state while either query is in flight', async () => {
+    setupMocks(OVERVIEW, COSTS, { isLoading: true })
+    mockBreakdownFetch()
+    render(<CostsPage />, { wrapper: Wrapper })
+
+    expect(await screen.findByTestId('costs-loading')).toBeInTheDocument()
+    // Error / empty / list branches must not co-render with loading.
+    expect(screen.queryByTestId('costs-error')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('team-budget-bar')).not.toBeInTheDocument()
+  })
+
+  it('error state takes precedence over loading and the team list', async () => {
+    setupMocks(OVERVIEW, undefined, { isError: true })
+    mockBreakdownFetch()
+    render(<CostsPage />, { wrapper: Wrapper })
+
+    expect(await screen.findByTestId('costs-error')).toBeInTheDocument()
+    expect(screen.queryByTestId('costs-loading')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('team-budget-bar')).not.toBeInTheDocument()
+  })
+
+  it('recomputes the per-team budget bars (daily vs monthly are independent toggles)', async () => {
+    setupMocks()
+    mockBreakdownFetch()
+    render(<CostsPage />, { wrapper: Wrapper })
+
+    // The bars are driven by daily spend/limit and stay stable across the toggle:
+    // the period toggle only re-scopes the KPI strip, not the per-team daily bars.
+    const before = await screen.findAllByTestId('team-budget-bar')
+    expect(before).toHaveLength(2)
+
+    await userEvent.click(screen.getByTestId('costs-period-monthly'))
+
+    const after = await screen.findAllByTestId('team-budget-bar')
+    const hot = after.find(b => b.dataset.team === 'team-hot')!
+    expect(hot.dataset.thresholdBucket).toBe('danger')
+    // KPI strip followed the toggle to monthly.
+    const total = screen.getByTestId('costs-kpi-total')
+    expect(within(total).getByText('$3200.00')).toBeInTheDocument()
+  })
+
+  it('buckets a team in the amber/warn band (80–95% of limit)', async () => {
+    // team-warn 170/200 = 85% → warn; team-cool 20/200 = 10% → ok.
+    const warmCosts: CostSummary = {
+      ...COSTS,
+      per_team: [
+        { team_id: 'team-warn', daily_spend_usd: '170.00', date: '2026-05-13', monthly_spend_usd: '2900.00' },
+        { team_id: 'team-cool', daily_spend_usd: '20.00', date: '2026-05-13', monthly_spend_usd: '300.00' },
+      ],
+    }
+    const warmOverview: TopologyOverview = {
+      ...OVERVIEW,
+      teams: [
+        { team_id: 'team-warn', agent_count: 3, root_agent_count: 1 },
+        { team_id: 'team-cool', agent_count: 2, root_agent_count: 1 },
+      ],
+    }
+    setupMocks(warmOverview, warmCosts)
+    mockBreakdownFetch()
+    render(<CostsPage />, { wrapper: Wrapper })
+
+    const bars = await screen.findAllByTestId('team-budget-bar')
+    const warn = bars.find(b => b.dataset.team === 'team-warn')!
+    expect(warn.dataset.thresholdBucket).toBe('warn')
+    // No team is in the danger bucket → blocked-by-budget reads 0.
+    const blocked = screen.getByTestId('costs-kpi-blocked')
+    expect(within(blocked).getByText('0')).toBeInTheDocument()
+    expect(within(blocked).getByText('no teams over limit')).toBeInTheDocument()
+  })
+
+  it('renders dashes/N-A across the KPI strip before any cost data arrives', async () => {
+    // `costs` data undefined is the real pre-fetch state; every figure should
+    // degrade gracefully rather than render NaN. (setupMocks defaults a passed
+    // `undefined` back to COSTS, so wire the cost query mock directly here.)
+    vi.spyOn(teamsApi, 'useTopologyOverviewQuery').mockReturnValue(
+      mockQuery<TopologyOverview>({ data: OVERVIEW, isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(teamsApi, 'useCostSummaryQuery').mockReturnValue(
+      mockQuery<CostSummary>({ data: undefined, isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    mockBreakdownFetch()
+    render(<CostsPage />, { wrapper: Wrapper })
+
+    const total = await screen.findByTestId('costs-kpi-total')
+    expect(within(total).getByText('—')).toBeInTheDocument()
+
+    const util = screen.getByTestId('costs-kpi-utilisation')
+    expect(within(util).getByText('N/A')).toBeInTheDocument()
+    expect(within(util).getByText('no budget limit set')).toBeInTheDocument()
+
+    const top = screen.getByTestId('costs-kpi-top-consumer')
+    expect(within(top).getByText('—')).toBeInTheDocument()
+    expect(within(top).getByText('no spend data')).toBeInTheDocument()
+  })
+
+  it('renders N/A utilisation when spend exists but no budget limit is configured', async () => {
+    // daily_limit_usd omitted (the OSS API leaves it unset when no budget is set).
+    const noLimitCosts: CostSummary = {
+      date: '2026-05-13',
+      daily_spend_usd: '42.00',
+      per_agent: [
+        { agent_id: 'agent-spendy', daily_spend_usd: '42.00', date: '2026-05-13', monthly_spend_usd: '600.00' },
+      ],
+      per_team: [{ team_id: 'team-hot', daily_spend_usd: '42.00', date: '2026-05-13', monthly_spend_usd: '600.00' }],
+    }
+    setupMocks({ ...OVERVIEW, teams: [{ team_id: 'team-hot', agent_count: 3, root_agent_count: 1 }] }, noLimitCosts)
+    mockBreakdownFetch()
+    render(<CostsPage />, { wrapper: Wrapper })
+
+    const total = await screen.findByTestId('costs-kpi-total')
+    expect(within(total).getByText('$42.00')).toBeInTheDocument()
+    const util = screen.getByTestId('costs-kpi-utilisation')
+    expect(within(util).getByText('N/A')).toBeInTheDocument()
+    expect(within(util).getByText('no budget limit set')).toBeInTheDocument()
+  })
+
+  it('reports zero spend as $0.00 / 0.0% rather than N/A when a limit exists', async () => {
+    const zeroCosts: CostSummary = {
+      ...COSTS,
+      daily_spend_usd: '0.00',
+      per_agent: [
+        { agent_id: 'agent-idle', daily_spend_usd: '0.00', date: '2026-05-13', monthly_spend_usd: '0.00' },
+      ],
+      per_team: [{ team_id: 'team-hot', daily_spend_usd: '0.00', date: '2026-05-13', monthly_spend_usd: '0.00' }],
+    }
+    setupMocks({ ...OVERVIEW, teams: [{ team_id: 'team-hot', agent_count: 3, root_agent_count: 1 }] }, zeroCosts)
+    mockBreakdownFetch()
+    render(<CostsPage />, { wrapper: Wrapper })
+
+    const total = await screen.findByTestId('costs-kpi-total')
+    expect(within(total).getByText('$0.00')).toBeInTheDocument()
+    const util = screen.getByTestId('costs-kpi-utilisation')
+    expect(within(util).getByText('0.0%')).toBeInTheDocument()
+  })
+
+  it('surfaces over-budget utilisation above 100% and flags blocked teams', async () => {
+    // COSTS: daily 210/200 = 105.0% over budget; team-hot 190/200 = 95% → danger.
+    setupMocks()
+    mockBreakdownFetch()
+    render(<CostsPage />, { wrapper: Wrapper })
+
+    const util = await screen.findByTestId('costs-kpi-utilisation')
+    expect(within(util).getByText('105.0%')).toBeInTheDocument()
+
+    const blocked = screen.getByTestId('costs-kpi-blocked')
+    expect(within(blocked).getByText('1')).toBeInTheDocument()
+    expect(within(blocked).getByText('teams at ≥95% of org limit')).toBeInTheDocument()
+  })
 })

--- a/dashboard/src/pages/CostsPage.tsx
+++ b/dashboard/src/pages/CostsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { ignorePromise } from '../lib/ignorePromise'
 import { CostBreakdownPanel } from '../features/analytics/CostBreakdownPanel'
 import { SegmentedControl } from '../features/analytics/SegmentedControl'
@@ -7,6 +7,7 @@ import {
   joinTeamRows,
   useCostSummaryQuery,
   useTopologyOverviewQuery,
+  type TeamListRow,
 } from '../features/teams/api'
 import { deriveCostKpis, type BudgetPeriod } from '../features/costs/costKpis'
 import '../features/analytics/CostBreakdownPanel.css'
@@ -43,6 +44,58 @@ function KpiCard({ label, value, sub, valueClass = '', testId }: KpiCardProps) {
       <div className="costs-kpi__label">{label}</div>
       <div className={`costs-kpi__value${valueClass}`}>{value}</div>
       <div className="costs-kpi__sub">{sub}</div>
+    </div>
+  )
+}
+
+interface TeamBudgetContentProps {
+  readonly isError: boolean
+  readonly isLoading: boolean
+  readonly teamRows: readonly TeamListRow[]
+  readonly onRetry: () => void
+}
+
+/**
+ * Resolve the per-team budget section body for the current query state.
+ *
+ * Extracted from the JSX as an explicit if/else chain (rather than a nested
+ * ternary) so each error / loading / empty / list branch reads on its own.
+ */
+function TeamBudgetContent({ isError, isLoading, teamRows, onRetry }: TeamBudgetContentProps): ReactNode {
+  if (isError) {
+    return (
+      <p className="costs-state costs-state--error" data-testid="costs-error">
+        Failed to load cost data.{' '}
+        <button type="button" className="costs-state__retry" onClick={onRetry}>
+          Retry
+        </button>
+      </p>
+    )
+  }
+  if (isLoading) {
+    return (
+      <p className="costs-state" data-testid="costs-loading">
+        Loading cost data…
+      </p>
+    )
+  }
+  if (teamRows.length === 0) {
+    return (
+      <p className="costs-team-bars__empty" data-testid="costs-team-empty">
+        No teams registered yet.
+      </p>
+    )
+  }
+  return (
+    <div className="costs-team-bars">
+      {teamRows.map(row => (
+        <TeamBudgetBar
+          key={row.team_id}
+          team={row.team_id}
+          spent={row.daily_spend_usd ?? 0}
+          limit={row.daily_limit_usd ?? 0}
+        />
+      ))}
     </div>
   )
 }
@@ -139,37 +192,12 @@ export function CostsPage() {
           </span>
         </div>
 
-        {isError ? (
-          <p className="costs-state costs-state--error" data-testid="costs-error">
-            Failed to load cost data.
-            <button
-              type="button"
-              className="costs-state__retry"
-              onClick={() => ignorePromise(costsQuery.refetch())}
-            >
-              Retry
-            </button>
-          </p>
-        ) : isLoading ? (
-          <p className="costs-state" data-testid="costs-loading">
-            Loading cost data…
-          </p>
-        ) : teamRows.length === 0 ? (
-          <p className="costs-team-bars__empty" data-testid="costs-team-empty">
-            No teams registered yet.
-          </p>
-        ) : (
-          <div className="costs-team-bars">
-            {teamRows.map(row => (
-              <TeamBudgetBar
-                key={row.team_id}
-                team={row.team_id}
-                spent={row.daily_spend_usd ?? 0}
-                limit={row.daily_limit_usd ?? 0}
-              />
-            ))}
-          </div>
-        )}
+        <TeamBudgetContent
+          isError={isError}
+          isLoading={isLoading}
+          teamRows={teamRows}
+          onRetry={() => ignorePromise(costsQuery.refetch())}
+        />
       </section>
 
       <section className="costs-section" data-testid="costs-breakdown">


### PR DESCRIPTION
## Description

Resolve the SonarCloud Reliability/Maintainability issues introduced by the new Cost & Budget page (AAASM-3509) and extend its test coverage. Refactor-only — no behaviour change.

**`dashboard/src/pages/CostsPage.tsx`**
- `typescript:S6772` — added an explicit `{' '}` between the "Failed to load cost data." text and the **Retry** `<button>` so the inline spacing is unambiguous.
- `typescript:S3358` (×2) — extracted the nested error / loading / empty / list ternary in the per-team budget section into a `TeamBudgetContent` helper with an explicit `if/else` chain; each branch now reads on its own.

**`dashboard/src/pages/CostsPage.test.tsx`**
- `typescript:S7761` — replaced `getAttribute('data-team')` / `getAttribute('data-threshold-bucket')` with the typed `.dataset.team` / `.dataset.thresholdBucket` accessors.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

The render output is identical; all 6 pre-existing tests stay green and the public component API is unchanged.

## Related Issues

- Related Jira ticket: AAASM-3513

## Testing

Added 9 new tests covering previously-untested branches:
- Retry click in the error state refetches the cost summary.
- Loading state renders exclusively; error state takes precedence over loading and the team list.
- Per-team daily bars stay stable across the daily↔monthly KPI toggle.
- Budget-bar amber/warn threshold (80–95%) bucketing.
- KPI edge cases: no data (dashes / N/A), spend without a limit (N/A), zero spend ($0.00 / 0.0%), and over-budget utilisation (>100% + blocked team count).

Local validation (`cd dashboard`):
- `pnpm type-check` — clean
- `pnpm lint` — clean
- `pnpm build` — succeeds
- `pnpm test` — 147 files / 1312 tests pass (CostsPage suite: 15 pass = 6 existing + 9 new)

- [x] Unit tests added / updated
- [x] Manual testing performed (full suite locally)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — no behaviour change)
- [ ] All CI checks passing (org Actions billing may abort runs; validated locally)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)