### PR TITLE
[AAASM-3512] ♻️ (dashboard): Harden Overview page — Sonar fixes + tests

### DIFF
--- a/dashboard/src/pages/OverviewPage.kpis.test.ts
+++ b/dashboard/src/pages/OverviewPage.kpis.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import type { FleetAgent } from '../features/agents/fleetTypes'
+import type { Alert } from '../features/alerts/types'
+import { compareBySeverity, deriveOverviewKpis } from './OverviewPage.kpis'
+
+function makeFleetAgent(overrides: Partial<FleetAgent> = {}): FleetAgent {
+  return {
+    source: {} as FleetAgent['source'],
+    id: 'agent-1',
+    name: 'research-bot',
+    framework: 'langgraph',
+    status: 'active',
+    owner: null,
+    mode: 'enforce',
+    flagged: false,
+    lastSeen: null,
+    trust: null,
+    blocked24h: null,
+    scrubbed24h: null,
+    note: null,
+    ...overrides,
+  }
+}
+
+function makeAlert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    id: 'alert-1',
+    ruleId: 'rule-1',
+    ruleName: 'shell.exec blocked',
+    severity: 'CRITICAL',
+    status: 'FIRING',
+    agentId: 'research-bot',
+    firstFiredAt: '2026-01-01T14:02:08Z',
+    resolvedAt: null,
+    destinationIds: [],
+    ...overrides,
+  }
+}
+
+describe('compareBySeverity', () => {
+  it('orders CRITICAL before HIGH before MEDIUM before LOW', () => {
+    const alerts = [
+      makeAlert({ id: 'lo', severity: 'LOW' }),
+      makeAlert({ id: 'med', severity: 'MEDIUM' }),
+      makeAlert({ id: 'crit', severity: 'CRITICAL' }),
+      makeAlert({ id: 'hi', severity: 'HIGH' }),
+    ]
+    const sorted = [...alerts].sort(compareBySeverity).map((a) => a.id)
+    expect(sorted).toEqual(['crit', 'hi', 'med', 'lo'])
+  })
+
+  it('treats equal severities as equal (returns 0)', () => {
+    expect(compareBySeverity(makeAlert({ severity: 'HIGH' }), makeAlert({ severity: 'HIGH' }))).toBe(
+      0,
+    )
+  })
+})
+
+describe('deriveOverviewKpis', () => {
+  it('returns full-score posture for an empty fleet (total === 0 branch)', () => {
+    const kpis = deriveOverviewKpis([], [])
+    expect(kpis.total).toBe(0)
+    expect(kpis.flagged).toBe(0)
+    expect(kpis.identityScore).toBe(100)
+    expect(kpis.capabilityScore).toBe(100)
+    expect(kpis.scrubScore).toBe(91)
+    // (100 + 100 + 91) / 3 → 97 (rounded).
+    expect(kpis.overallScore).toBe(97)
+    expect(kpis.topAlert).toBeUndefined()
+    expect(kpis.firingAlerts).toEqual([])
+  })
+
+  it('counts modes and flags across the fleet', () => {
+    const kpis = deriveOverviewKpis(
+      [
+        makeFleetAgent({ id: 'a', mode: 'enforce' }),
+        makeFleetAgent({ id: 'b', mode: 'enforce' }),
+        makeFleetAgent({ id: 'c', mode: 'shadow' }),
+        makeFleetAgent({ id: 'd', mode: 'off' }),
+        makeFleetAgent({ id: 'e', mode: 'enforce', flagged: true }),
+      ],
+      [],
+    )
+    expect(kpis.total).toBe(5)
+    expect(kpis.enforcing).toBe(3)
+    expect(kpis.shadow).toBe(1)
+    expect(kpis.flagged).toBe(1)
+  })
+
+  it('degrades identity and capability scores as agents are flagged', () => {
+    // 1 of 4 flagged: identity = 100 - 1*3 = 97; capability = round(100 - (1/4)*100*0.5) = 88.
+    const kpis = deriveOverviewKpis(
+      [
+        makeFleetAgent({ id: 'a', flagged: true }),
+        makeFleetAgent({ id: 'b' }),
+        makeFleetAgent({ id: 'c' }),
+        makeFleetAgent({ id: 'd' }),
+      ],
+      [],
+    )
+    expect(kpis.flagged).toBe(1)
+    expect(kpis.identityScore).toBe(97)
+    expect(kpis.capabilityScore).toBe(88)
+  })
+
+  it('clamps the identity score at zero when many agents are flagged', () => {
+    // 40 flagged → 100 - 40*3 = -20 → clamped to 0.
+    const fleet = Array.from({ length: 40 }, (_, i) =>
+      makeFleetAgent({ id: `a${i}`, flagged: true }),
+    )
+    const kpis = deriveOverviewKpis(fleet, [])
+    expect(kpis.flagged).toBe(40)
+    expect(kpis.identityScore).toBe(0)
+  })
+
+  it('sums blocked and scrubbed counts, treating null metrics as zero', () => {
+    const kpis = deriveOverviewKpis(
+      [
+        makeFleetAgent({ id: 'a', blocked24h: 3, scrubbed24h: 10 }),
+        makeFleetAgent({ id: 'b', blocked24h: null, scrubbed24h: null }),
+        makeFleetAgent({ id: 'c', blocked24h: 2, scrubbed24h: 5 }),
+      ],
+      [],
+    )
+    expect(kpis.blocked).toBe(5)
+    expect(kpis.scrubbed).toBe(15)
+  })
+
+  it('keeps only FIRING alerts and picks the most-severe as the top alert', () => {
+    const kpis = deriveOverviewKpis(
+      [makeFleetAgent()],
+      [
+        makeAlert({ id: 'resolved-crit', severity: 'CRITICAL', status: 'RESOLVED' }),
+        makeAlert({ id: 'firing-med', severity: 'MEDIUM', status: 'FIRING' }),
+        makeAlert({ id: 'firing-crit', severity: 'CRITICAL', status: 'FIRING' }),
+        makeAlert({ id: 'suppressed-hi', severity: 'HIGH', status: 'SUPPRESSED' }),
+      ],
+    )
+    expect(kpis.firingAlerts.map((a) => a.id)).toEqual(['firing-med', 'firing-crit'])
+    expect(kpis.topAlert?.id).toBe('firing-crit')
+  })
+
+  it('leaves the top alert undefined when nothing is firing', () => {
+    const kpis = deriveOverviewKpis(
+      [makeFleetAgent()],
+      [makeAlert({ status: 'RESOLVED' }), makeAlert({ status: 'SUPPRESSED' })],
+    )
+    expect(kpis.firingAlerts).toEqual([])
+    expect(kpis.topAlert).toBeUndefined()
+  })
+})

--- a/dashboard/src/pages/OverviewPage.kpis.ts
+++ b/dashboard/src/pages/OverviewPage.kpis.ts
@@ -1,0 +1,77 @@
+import type { FleetAgent } from '../features/agents/fleetTypes'
+import type { Alert } from '../features/alerts/types'
+
+/**
+ * Pure KPI derivation for the Overview page, kept in a plain module (not the
+ * component file) so it can be unit-tested directly and so `OverviewPage.tsx`
+ * stays a components-only module (react-refresh `only-export-components`).
+ */
+
+/** Severity ordering used to pick the single most-urgent firing alert. */
+const SEVERITY_RANK = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 } as const
+
+/** Sort comparator: most-severe alert first. */
+export function compareBySeverity(a: Alert, b: Alert): number {
+  return SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]
+}
+
+export interface OverviewKpis {
+  readonly total: number
+  readonly flagged: number
+  readonly enforcing: number
+  readonly shadow: number
+  readonly blocked: number
+  readonly scrubbed: number
+  readonly firingAlerts: readonly Alert[]
+  readonly topAlert: Alert | undefined
+  readonly identityScore: number
+  readonly capabilityScore: number
+  readonly scrubScore: number
+  readonly overallScore: number
+}
+
+/**
+ * Project the live query results onto the scalar KPIs and derived collections
+ * the page renders. Pure and side-effect free — extracted from the component
+ * body to keep `OverviewPage`'s cognitive complexity within budget and to make
+ * the headline-number derivations independently testable.
+ *
+ * Posture scores are a deterministic projection of live counts: identity is
+ * healthy until an agent is flagged; capability degrades with the flagged
+ * ratio; scrub stays high while nothing leaks. They are headline indicators,
+ * not the authoritative per-layer audit (that lives on each layer's page).
+ */
+export function deriveOverviewKpis(
+  fleet: readonly FleetAgent[],
+  alerts: readonly Alert[],
+): OverviewKpis {
+  const total = fleet.length
+  const flagged = fleet.filter((a) => a.flagged).length
+  const enforcing = fleet.filter((a) => a.mode === 'enforce').length
+  const shadow = fleet.filter((a) => a.mode === 'shadow').length
+  const blocked = fleet.reduce((sum, a) => sum + (a.blocked24h ?? 0), 0)
+  const scrubbed = fleet.reduce((sum, a) => sum + (a.scrubbed24h ?? 0), 0)
+
+  const firingAlerts = alerts.filter((a) => a.status === 'FIRING')
+  const topAlert = [...firingAlerts].sort(compareBySeverity)[0]
+
+  const capabilityScore = total > 0 ? Math.round(100 - (flagged / total) * 100 * 0.5) : 100
+  const identityScore = total > 0 ? Math.max(0, 100 - flagged * 3) : 100
+  const scrubScore = 91
+  const overallScore = Math.round((identityScore + capabilityScore + scrubScore) / 3)
+
+  return {
+    total,
+    flagged,
+    enforcing,
+    shadow,
+    blocked,
+    scrubbed,
+    firingAlerts,
+    topAlert,
+    identityScore,
+    capabilityScore,
+    scrubScore,
+    overallScore,
+  }
+}

--- a/dashboard/src/pages/OverviewPage.test.tsx
+++ b/dashboard/src/pages/OverviewPage.test.tsx
@@ -159,6 +159,150 @@ describe('OverviewPage', () => {
     expect(sevenDay.className).toContain('is-active')
   })
 
+  it('defaults the window to 24h and reflects it in the subtitle', () => {
+    setup()
+    renderPage()
+    expect(screen.getByTestId('overview-window-24h').className).toContain('is-active')
+    expect(screen.getByText(/last 24h\./)).toBeInTheDocument()
+  })
+
+  it.each(['1h', '24h', '7d', '30d'] as const)(
+    'activates the %s window button on click and drops the previous one',
+    (win) => {
+      setup()
+      renderPage()
+      const target = screen.getByTestId(`overview-window-${win}`)
+      fireEvent.click(target)
+      expect(target.className).toContain('is-active')
+      // Exactly one window button is active at a time.
+      const active = ['1h', '24h', '7d', '30d'].filter((w) =>
+        screen.getByTestId(`overview-window-${w}`).className.includes('is-active'),
+      )
+      expect(active).toEqual([win])
+      // The subtitle echoes the selected window.
+      expect(screen.getByText(new RegExp(`last ${win}\\.`))).toBeInTheDocument()
+    },
+  )
+
+  it('renders the singular over-permissioned hero message for one flagged agent', () => {
+    setup({
+      agents: [
+        makeAgent({ id: 'a1', name: 'ok-bot' }),
+        makeAgent({ id: 'a2', name: 'bad-bot', policy_violations_count: 99 }),
+      ],
+    })
+    renderPage()
+    expect(screen.getByText(/1 agent over-permissioned\./)).toBeInTheDocument()
+  })
+
+  it('pluralises the over-permissioned hero message for multiple flagged agents', () => {
+    setup({
+      agents: [
+        makeAgent({ id: 'a1', name: 'bad-1', policy_violations_count: 60 }),
+        makeAgent({ id: 'a2', name: 'bad-2', policy_violations_count: 70 }),
+      ],
+    })
+    renderPage()
+    expect(screen.getByText(/2 agents over-permissioned\./)).toBeInTheDocument()
+  })
+
+  it('shows the healthy hero message when no agent is flagged', () => {
+    setup({ agents: [makeAgent()] })
+    renderPage()
+    expect(
+      screen.getByText('Enforcement is healthy across all layers.'),
+    ).toBeInTheDocument()
+  })
+
+  it('derives the fleet snapshot counts from agent modes and flags', () => {
+    setup({
+      agents: [
+        makeAgent({ id: 'e1', name: 'enf-1', metadata: { mode: 'enforce' } }),
+        makeAgent({ id: 'e2', name: 'enf-2', metadata: { mode: 'enforce' } }),
+        makeAgent({ id: 's1', name: 'shadow-1', metadata: { mode: 'shadow' } }),
+        makeAgent({
+          id: 'f1',
+          name: 'flag-1',
+          metadata: { mode: 'enforce' },
+          policy_violations_count: 80,
+        }),
+      ],
+    })
+    renderPage()
+    const snapshot = screen.getByTestId('overview-snapshot')
+    // total agents heading.
+    expect(snapshot).toHaveTextContent('4 agents')
+    // 3 enforcing, 1 shadow, 1 flagged surfaced as snapshot tiles.
+    expect(snapshot.querySelector('.overview-snapshot__num.is-ok')).toHaveTextContent('3')
+    expect(snapshot.querySelector('.overview-snapshot__num.is-warn')).toHaveTextContent('1')
+    expect(snapshot.querySelector('.overview-snapshot__num.is-danger')).toHaveTextContent('1')
+  })
+
+  it('renders recent decisions mapped from firing-alert severities', () => {
+    setup({
+      agents: [makeAgent()],
+      alerts: [
+        makeAlert({ id: 'c', severity: 'CRITICAL', ruleName: 'shell.exec', agentId: 'bot-x' }),
+        makeAlert({ id: 'h', severity: 'HIGH', ruleName: 'net.egress', agentId: null }),
+        makeAlert({ id: 'm', severity: 'MEDIUM', ruleName: 'fs.read', agentId: 'bot-y' }),
+      ],
+    })
+    renderPage()
+    const recent = screen.getByTestId('overview-recent')
+    // CRITICAL → deny, HIGH → narrow, MEDIUM (and below) → scrub.
+    expect(recent).toHaveTextContent('deny')
+    expect(recent).toHaveTextContent('narrow')
+    expect(recent).toHaveTextContent('scrub')
+    // agentId is rendered when present, "fleet" when null.
+    expect(recent).toHaveTextContent('bot-x')
+    expect(recent).toHaveTextContent('fleet')
+  })
+
+  it('shows the empty recent-decisions note when nothing is firing', () => {
+    setup({
+      agents: [makeAgent()],
+      alerts: [makeAlert({ status: 'RESOLVED' })],
+    })
+    renderPage()
+    expect(
+      screen.getByText('No enforcement events in this window.'),
+    ).toBeInTheDocument()
+  })
+
+  it('reports a clear approvals queue when there are no pending approvals', () => {
+    setup({ agents: [makeAgent()], approvals: [] })
+    renderPage()
+    const approvals = screen.getByTestId('overview-approvals')
+    expect(approvals).toHaveTextContent('0')
+    expect(approvals).toHaveTextContent('queue clear')
+  })
+
+  it('reports awaiting-decision copy when approvals are pending', () => {
+    setup({
+      agents: [makeAgent()],
+      approvals: [{ id: 'ap-1' }, { id: 'ap-2' }, { id: 'ap-3' }] as unknown as Approval[],
+    })
+    renderPage()
+    const approvals = screen.getByTestId('overview-approvals')
+    expect(approvals).toHaveTextContent('3')
+    expect(approvals).toHaveTextContent('awaiting operator decision')
+  })
+
+  it('surfaces a fleet-wide top issue and active-policy count for a null agentId alert', () => {
+    setup({
+      agents: [makeAgent()],
+      policies: [{ name: 'p-1' }, { name: 'p-2' }] as unknown as Policy[],
+      alerts: [makeAlert({ agentId: null, ruleName: 'budget breach' })],
+    })
+    renderPage()
+    const issue = screen.getByTestId('overview-top-issue')
+    expect(issue).toHaveTextContent('budget breach')
+    expect(issue).toHaveTextContent('fleet-wide')
+    // Active policies KPI reflects the mocked policy set.
+    expect(screen.getByText('active policies')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
   // Theme safety: the page must rely on CSS theme tokens so it inverts under
   // :root[data-theme="dark"]. Hardcoded hex / white / black colours would
   // break dark mode — guard against reintroducing that class of bug.

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAgentsQuery } from '../features/agents/api'
 import { toFleetAgent } from '../features/agents/fleetTypes'
-import type { FleetAgent } from '../features/agents/fleetTypes'
 import { useApprovalsQuery } from '../features/approvals/api'
 import { usePoliciesQuery } from '../features/policies/api'
 import { useAlertsQuery } from '../features/alerts/api'
@@ -11,6 +10,7 @@ import { LoadingState } from '../components/LoadingState'
 import { EmptyState } from '../components/EmptyState'
 import { ErrorState } from '../components/ErrorState'
 import { ignorePromise } from '../lib/ignorePromise'
+import { deriveOverviewKpis } from './OverviewPage.kpis'
 import './OverviewPage.css'
 
 /**
@@ -169,75 +169,6 @@ function shortTime(iso: string): string {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-}
-
-/** Severity ordering used to pick the single most-urgent firing alert. */
-const SEVERITY_RANK = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 } as const
-
-/** Sort comparator: most-severe alert first. */
-function compareBySeverity(a: Alert, b: Alert): number {
-  return SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]
-}
-
-interface OverviewKpis {
-  readonly total: number
-  readonly flagged: number
-  readonly enforcing: number
-  readonly shadow: number
-  readonly blocked: number
-  readonly scrubbed: number
-  readonly firingAlerts: readonly Alert[]
-  readonly topAlert: Alert | undefined
-  readonly identityScore: number
-  readonly capabilityScore: number
-  readonly scrubScore: number
-  readonly overallScore: number
-}
-
-/**
- * Project the live query results onto the scalar KPIs and derived collections
- * the page renders. Pure and side-effect free — extracted from the component
- * body to keep `OverviewPage`'s cognitive complexity within budget and to make
- * the headline-number derivations independently testable.
- *
- * Posture scores are a deterministic projection of live counts: identity is
- * healthy until an agent is flagged; capability degrades with the flagged
- * ratio; scrub stays high while nothing leaks. They are headline indicators,
- * not the authoritative per-layer audit (that lives on each layer's page).
- */
-function deriveOverviewKpis(
-  fleet: readonly FleetAgent[],
-  alerts: readonly Alert[],
-): OverviewKpis {
-  const total = fleet.length
-  const flagged = fleet.filter((a) => a.flagged).length
-  const enforcing = fleet.filter((a) => a.mode === 'enforce').length
-  const shadow = fleet.filter((a) => a.mode === 'shadow').length
-  const blocked = fleet.reduce((sum, a) => sum + (a.blocked24h ?? 0), 0)
-  const scrubbed = fleet.reduce((sum, a) => sum + (a.scrubbed24h ?? 0), 0)
-
-  const firingAlerts = alerts.filter((a) => a.status === 'FIRING')
-  const topAlert = [...firingAlerts].sort(compareBySeverity)[0]
-
-  const capabilityScore = total > 0 ? Math.round(100 - (flagged / total) * 100 * 0.5) : 100
-  const identityScore = total > 0 ? Math.max(0, 100 - flagged * 3) : 100
-  const scrubScore = 91
-  const overallScore = Math.round((identityScore + capabilityScore + scrubScore) / 3)
-
-  return {
-    total,
-    flagged,
-    enforcing,
-    shadow,
-    blocked,
-    scrubbed,
-    firingAlerts,
-    topAlert,
-    identityScore,
-    capabilityScore,
-    scrubScore,
-    overallScore,
-  }
 }
 
 /** One row in the "recent decisions" list. */

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -126,12 +126,15 @@ function LayerCard({
         <span className="overview-chip">open ↗</span>
       </div>
       <div className="overview-layer__stats">
-        {stats.map((s) => (
-          <div key={s.label}>
-            <div className={`overview-stat__v${s.tone ? ` ${TONE_CLASS[s.tone]}` : ''}`}>{s.value}</div>
-            <div className="overview-stat__l">{s.label}</div>
-          </div>
-        ))}
+        {stats.map((s) => {
+          const toneClass = s.tone ? ` ${TONE_CLASS[s.tone]}` : ''
+          return (
+            <div key={s.label}>
+              <div className={`overview-stat__v${toneClass}`}>{s.value}</div>
+              <div className="overview-stat__l">{s.label}</div>
+            </div>
+          )
+        })}
       </div>
       <div className="overview-layer__footer">{footer}</div>
     </button>

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -9,6 +9,7 @@ import type { Alert, AlertFilters } from '../features/alerts/types'
 import { LoadingState } from '../components/LoadingState'
 import { EmptyState } from '../components/EmptyState'
 import { ErrorState } from '../components/ErrorState'
+import { ignorePromise } from '../lib/ignorePromise'
 import './OverviewPage.css'
 
 /**
@@ -191,7 +192,7 @@ export function OverviewPage() {
     return (
       <ErrorState
         kind="generic"
-        onRetry={() => void agentsQuery.refetch()}
+        onRetry={() => ignorePromise(agentsQuery.refetch())}
         onSecondary={() => navigate('/audit')}
       />
     )

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -238,7 +238,7 @@ export function OverviewPage() {
       <header className="overview-head">
         <div>
           <h1 className="overview-title">
-            Overview
+            Overview{' '}
             <span className="overview-title-zh">· 治理態勢儀表</span>
           </h1>
           <p className="overview-sub">

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAgentsQuery } from '../features/agents/api'
 import { toFleetAgent } from '../features/agents/fleetTypes'
+import type { FleetAgent } from '../features/agents/fleetTypes'
 import { useApprovalsQuery } from '../features/approvals/api'
 import { usePoliciesQuery } from '../features/policies/api'
 import { useAlertsQuery } from '../features/alerts/api'
@@ -170,6 +171,91 @@ function shortTime(iso: string): string {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
+/** Severity ordering used to pick the single most-urgent firing alert. */
+const SEVERITY_RANK = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 } as const
+
+/** Sort comparator: most-severe alert first. */
+function compareBySeverity(a: Alert, b: Alert): number {
+  return SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]
+}
+
+interface OverviewKpis {
+  readonly total: number
+  readonly flagged: number
+  readonly enforcing: number
+  readonly shadow: number
+  readonly blocked: number
+  readonly scrubbed: number
+  readonly firingAlerts: readonly Alert[]
+  readonly topAlert: Alert | undefined
+  readonly identityScore: number
+  readonly capabilityScore: number
+  readonly scrubScore: number
+  readonly overallScore: number
+}
+
+/**
+ * Project the live query results onto the scalar KPIs and derived collections
+ * the page renders. Pure and side-effect free — extracted from the component
+ * body to keep `OverviewPage`'s cognitive complexity within budget and to make
+ * the headline-number derivations independently testable.
+ *
+ * Posture scores are a deterministic projection of live counts: identity is
+ * healthy until an agent is flagged; capability degrades with the flagged
+ * ratio; scrub stays high while nothing leaks. They are headline indicators,
+ * not the authoritative per-layer audit (that lives on each layer's page).
+ */
+function deriveOverviewKpis(
+  fleet: readonly FleetAgent[],
+  alerts: readonly Alert[],
+): OverviewKpis {
+  const total = fleet.length
+  const flagged = fleet.filter((a) => a.flagged).length
+  const enforcing = fleet.filter((a) => a.mode === 'enforce').length
+  const shadow = fleet.filter((a) => a.mode === 'shadow').length
+  const blocked = fleet.reduce((sum, a) => sum + (a.blocked24h ?? 0), 0)
+  const scrubbed = fleet.reduce((sum, a) => sum + (a.scrubbed24h ?? 0), 0)
+
+  const firingAlerts = alerts.filter((a) => a.status === 'FIRING')
+  const topAlert = [...firingAlerts].sort(compareBySeverity)[0]
+
+  const capabilityScore = total > 0 ? Math.round(100 - (flagged / total) * 100 * 0.5) : 100
+  const identityScore = total > 0 ? Math.max(0, 100 - flagged * 3) : 100
+  const scrubScore = 91
+  const overallScore = Math.round((identityScore + capabilityScore + scrubScore) / 3)
+
+  return {
+    total,
+    flagged,
+    enforcing,
+    shadow,
+    blocked,
+    scrubbed,
+    firingAlerts,
+    topAlert,
+    identityScore,
+    capabilityScore,
+    scrubScore,
+    overallScore,
+  }
+}
+
+/** One row in the "recent decisions" list. */
+function RecentDecisionRow({ alert }: Readonly<{ alert: Alert }>) {
+  const decision = alertDecision(alert.severity)
+  return (
+    <div className="overview-recent__row">
+      <span className="overview-recent__time">{shortTime(alert.firstFiredAt)}</span>
+      <span className="overview-recent__decision" style={{ color: decisionTone(decision) }}>
+        {decision}
+      </span>
+      <span className="overview-recent__target">
+        {alert.agentId ?? 'fleet'} <span>· {alert.ruleName}</span>
+      </span>
+    </div>
+  )
+}
+
 export function OverviewPage() {
   const navigate = useNavigate()
   const [windowSel, setWindowSel] = useState<Window>('24h')
@@ -207,30 +293,24 @@ export function OverviewPage() {
     )
   }
 
-  const total = fleet.length
-  const flagged = fleet.filter((a) => a.flagged).length
-  const enforcing = fleet.filter((a) => a.mode === 'enforce').length
-  const shadow = fleet.filter((a) => a.mode === 'shadow').length
-  const blocked = fleet.reduce((sum, a) => sum + (a.blocked24h ?? 0), 0)
-  const scrubbed = fleet.reduce((sum, a) => sum + (a.scrubbed24h ?? 0), 0)
-
   const approvals = approvalsQuery.data ?? []
   const policies = policiesQuery.data ?? []
   const alerts = alertsQuery.data ?? []
-  const firingAlerts = alerts.filter((a) => a.status === 'FIRING')
-  const topAlert = [...firingAlerts].sort((a, b) => {
-    const order = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 } as const
-    return order[a.severity] - order[b.severity]
-  })[0]
 
-  // Posture scores are a deterministic projection of live counts: identity is
-  // healthy until an agent is flagged; capability degrades with the flagged
-  // ratio; scrub stays high while nothing leaks. They are headline indicators,
-  // not the authoritative per-layer audit (that lives on each layer's page).
-  const capabilityScore = total > 0 ? Math.round(100 - (flagged / total) * 100 * 0.5) : 100
-  const identityScore = total > 0 ? Math.max(0, 100 - flagged * 3) : 100
-  const scrubScore = 91
-  const overallScore = Math.round((identityScore + capabilityScore + scrubScore) / 3)
+  const {
+    total,
+    flagged,
+    enforcing,
+    shadow,
+    blocked,
+    scrubbed,
+    firingAlerts,
+    topAlert,
+    identityScore,
+    capabilityScore,
+    scrubScore,
+    overallScore,
+  } = deriveOverviewKpis(fleet, alerts)
 
   const recent = firingAlerts.slice(0, 5)
 
@@ -460,23 +540,7 @@ export function OverviewPage() {
             {recent.length === 0 ? (
               <p className="overview-empty-note">No enforcement events in this window.</p>
             ) : (
-              recent.map((a) => {
-                const decision = alertDecision(a.severity)
-                return (
-                  <div key={a.id} className="overview-recent__row">
-                    <span className="overview-recent__time">{shortTime(a.firstFiredAt)}</span>
-                    <span
-                      className="overview-recent__decision"
-                      style={{ color: decisionTone(decision) }}
-                    >
-                      {decision}
-                    </span>
-                    <span className="overview-recent__target">
-                      {a.agentId ?? 'fleet'} <span>· {a.ruleName}</span>
-                    </span>
-                  </div>
-                )
-              })
+              recent.map((a) => <RecentDecisionRow key={a.id} alert={a} />)
             )}
           </section>
 


### PR DESCRIPTION
## Description

Refactor-only hardening of the dashboard **Overview** page to clear the four
SonarCloud Reliability/Maintainability issues flagged on
`dashboard/src/pages/OverviewPage.tsx`, plus broader test coverage. No behaviour
change to the page — rendered output is identical.

**SonarCloud rules fixed:**

| Line | Rule | Fix |
|---|---|---|
| L131 | `typescript:S4624` (nested template literals) | Hoisted the inner `${TONE_CLASS[...]}` template into a named `toneClass` const in `LayerCard`. |
| L169 | `typescript:S3776` (Cognitive Complexity 18 > 15) | Extracted the pure KPI/score/alert derivations into `deriveOverviewKpis` + `compareBySeverity` in a sibling `OverviewPage.kpis.ts` module, and pulled the recent-decisions row into a `RecentDecisionRow` component. The component now destructures one helper result. |
| L191 | `typescript:S3735` (`void` operator) | Replaced `void agentsQuery.refetch()` with the repo's existing `ignorePromise(...)` helper (already used by every other page) — satisfies `no-floating-promises`, swallows unexpected rejections, tolerates the test mock's `undefined` return. |
| L239 | `typescript:S6772` (ambiguous JSX spacing) | Added explicit `{' '}` between "Overview" and the zh subtitle `<span>` in the `<h1>`. |

> Note: the helper was placed in a sibling `.ts` module (matching the repo's
> `fleetTypes` / `fleetFilters` pattern) rather than exported from the component
> file, because `react-refresh/only-export-components` forbids non-component
> exports there. This also makes the pure derivation directly unit-testable.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3512

## Testing

- [x] Unit tests added / updated

**Tests added:**
- `OverviewPage.kpis.test.ts` (new, 9 cases) — `deriveOverviewKpis` branches:
  empty-fleet `total === 0` full-score posture, mode/flag counting, identity &
  capability score degradation, identity clamp-at-zero, blocked/scrubbed
  null-as-zero summation, FIRING-only filtering + most-severe top-alert,
  no-firing undefined case; plus `compareBySeverity` ordering and the
  equal-severity (0) branch.
- `OverviewPage.test.tsx` (extended, +14 cases) — default 24h window + all four
  window-toggle states (1h/24h/7d/30d) asserting single-active + subtitle echo;
  singular/plural/healthy hero posture messages; fleet-snapshot mode/flag tile
  derivations; recent-decisions severity→decision mapping (deny/narrow/scrub)
  with agentId-vs-fleet rendering; empty recent note; approvals clear-vs-awaiting
  copy; fleet-wide top-issue with active-policy count. (loading/error/empty
  states were already covered and remain green.)

**Local validation (all green):**
- `pnpm type-check` — clean
- `pnpm lint` (`--max-warnings 0`) — clean
- `pnpm build` — succeeds (pre-existing chunk-size warnings only)
- `pnpm test` — **148 files / 1326 tests passed** (Overview suite: 22 + KPI suite: 9)

## Checklist

- [x] Self-review of the diff completed
- [x] All local checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
