### PR TITLE
[AAASM-3515] 📝 (docs): Link Examples page to per-SDK example docs

### DIFF
--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -16,3 +16,13 @@ scenarios:
 - **Python** — [examples-repo/python](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/python)
 - **Go** — [examples-repo/go](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/go)
 - **Scenarios** (cross-cutting: approval-gates, audit-trace, budget-limits, policy-enforcement, sidecar-runtime) — [examples-repo/scenarios](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/scenarios)
+
+## Per-SDK example docs
+
+Each language SDK also publishes its examples as rendered documentation, with the
+governance walkthrough alongside the code. These are the same scenarios as the
+repo links above, presented in the SDK's own docs site:
+
+- **Python** — [python-sdk examples](https://ai-agent-assembly.github.io/python-sdk/pre-release/examples/)
+- **Node** — [node-sdk examples](https://ai-agent-assembly.github.io/node-sdk/examples/)
+- **Go** — [go-sdk examples](https://ai-agent-assembly.github.io/go-sdk/pre-release/examples/)


### PR DESCRIPTION
## Description

Adds a **Per-SDK example docs** subsection to the mdBook Examples page
(`docs/src/usage-guide/examples.md`). The page previously linked only to the
`agent-assembly-examples` GitHub repo per language; it now also links to the
rendered per-SDK example documentation sites so readers can browse the examples
with their governance walkthrough in each SDK's own docs site.

Added links (all verified live, HTTP 200):

- Python — https://ai-agent-assembly.github.io/python-sdk/pre-release/examples/
- Node — https://ai-agent-assembly.github.io/node-sdk/examples/
- Go — https://ai-agent-assembly.github.io/go-sdk/pre-release/examples/

All existing content is preserved; only this file was changed.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3515 (QA-review follow-up under Epic AAASM-3198)

## Testing

- [x] Manual testing performed
- [x] No tests required (docs-only change)

Verification:
- `mdbook build docs` succeeds (only a benign mdbook-mermaid version-mismatch warning).
- The 3 SDK example-docs URLs resolve (HTTP 200).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Refs AAASM-3515