### PR TITLE
[AAASM-3519] ✨ (examples/docs): Limited-function self-host Docker Compose example + docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -48,6 +48,7 @@
   - [Team budgets and cost](usage-guide/team-budgets.md)
   - [Observe in the dashboard](usage-guide/observe-in-dashboard.md)
   - [Choosing interception layers](usage-guide/interception-layers.md)
+  - [Self-hosting (limited function)](usage-guide/self-hosting.md)
   - [Runnable examples](usage-guide/examples.md)
   - [Troubleshooting](usage-guide/troubleshooting.md)
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -48,7 +48,7 @@
   - [Team budgets and cost](usage-guide/team-budgets.md)
   - [Observe in the dashboard](usage-guide/observe-in-dashboard.md)
   - [Choosing interception layers](usage-guide/interception-layers.md)
-  - [Self-hosting (limited function)](usage-guide/self-hosting.md)
+  - [Self-hosting (open source)](usage-guide/self-hosting.md)
   - [Runnable examples](usage-guide/examples.md)
   - [Troubleshooting](usage-guide/troubleshooting.md)
 

--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -6,6 +6,11 @@ it, the framework-specific, end-to-end examples live in the dedicated
 repository rather than in this book — that keeps the runnable code versioned and
 testable on its own, while these pages stay focused on the concepts.
 
+> **Want to stand up the infrastructure itself?** The
+> [Self-hosting guide](self-hosting.md) walks through the open-source Docker Compose
+> stack — its architecture, which containers run (and who each is for), and how to
+> set up, run, and maintain the program's infra locally.
+
 Every example is governed by the same three-layer interception model described
 in [Choosing interception layers](interception-layers.md): a gateway as the
 brain, at least one interception layer (SDK shim, `aa-proxy` sidecar, or eBPF),

--- a/docs/src/usage-guide/self-hosting.md
+++ b/docs/src/usage-guide/self-hosting.md
@@ -17,10 +17,78 @@ exact configuration, and how to bring it up.
 
 ## Infrastructure architecture
 
-The example stack is a single-host Compose project. Your agent runs alongside an
-`aa-runtime` enforcement sidecar; they share a Unix-domain-socket volume; an
-optional `aa-proxy` adds code-free egress interception. Local policy comes from a
-bind-mounted `policy.toml`.
+The full self-host topology is a short, end-to-end chain. Operators work in the
+**dashboard**; the dashboard reads everything through the **REST API** (`aa-api`);
+the API fronts the **gateway** (the brain), which evaluates policy and saves
+governance records to **persistence**; and your **agents run co-located with an
+`aa-runtime` enforcement sidecar**, which checks every action with the gateway. So
+the very actions your agents take are recorded in persistence and surface back in
+the dashboard:
+
+`you ⇄ dashboard ⇄ aa-api ⇄ aa-gateway ⇄ persistence ⇆ aa-runtime ⇄ your agents`
+
+```mermaid
+flowchart TB
+    user(["Operator — you, in a browser"])
+
+    subgraph present["Observe and manage"]
+        dash["dashboard<br/>single container · React / Vite"]
+        api["aa-api<br/>REST / OpenAPI :7700"]
+    end
+
+    gw["aa-gateway<br/>registry · policy · budgets · audit<br/>gRPC :50051"]
+    db[("persistence — you run and manage<br/>Postgres / TimescaleDB + cache")]
+
+    subgraph workload["Your workload — agent + program, co-located"]
+        agent["your agent(s)"]
+        rt["aa-runtime<br/>enforcement sidecar · :8080"]
+    end
+
+    user -->|HTTPS| dash
+    dash <-->|HTTP / WS :7700| api
+    api <-->|read model| gw
+    gw <-->|audit and state| db
+    agent <-->|IPC over UDS socket| rt
+    rt -->|CheckAction gRPC :50051| gw
+    gw -->|Allow / Deny| rt
+    gw -->|save governance records| db
+```
+
+Two things to read from it:
+
+- **The observability loop.** Your agents + `aa-runtime` produce the governance data
+  (decisions, audit, budget usage); the gateway persists it; the dashboard reads it
+  back through the API. That is how what your agents do shows up on screen.
+- **What runs where.** The **dashboard is a single container**; **persistence is a
+  standard datastore you run and manage** (e.g. Postgres / TimescaleDB); the
+  **gateway + API** are the control plane; and **each agent runs next to its own
+  `aa-runtime`** sidecar, sharing a Unix-domain socket.
+
+### Containers — for whom, for what
+
+| Container | Image / build today | For whom | For what |
+|---|---|---|---|
+| `dashboard` | build from source (`pnpm --dir dashboard build`); image pending | operators | **Single-container** web UI to observe governance and manage agents, policies and budgets — reads everything via the REST API. |
+| `aa-api` | build from source (`cargo build -p aa-api`); image pending | operators (via dashboard) + tools | The REST / OpenAPI surface on `:7700` the dashboard reads; fronts the gateway read model. |
+| `aa-gateway` | build from source (`cargo build -p aa-gateway`); image pending | the deployment | The brain — registry, policy evaluation, budgets, audit; decides each action and saves governance records to persistence. gRPC `:50051`. |
+| persistence | **you run / manage** a standard `postgres` / `timescaledb` image | the deployment | Durable audit history + state that the dashboard displays. |
+| `aa-runtime` | `ghcr.io/ai-agent-assembly/aa-runtime:latest` (pulled) | every agent | Enforcement sidecar **co-located with the agent** — the authoritative chokepoint that checks each action with the gateway. Serves health/metrics on `:8080`. |
+| your agent(s) | your image | you | The workload being governed — runs beside its runtime, sharing the UDS socket. |
+| `aa-proxy` (optional) | build from `aa-proxy/Dockerfile` (`proxy` profile) | teams wanting code-free egress control | MitM-intercepts outbound HTTPS to apply network-egress policy without touching agent code. |
+
+Everything above is **open source in this repository**. Today `aa-runtime` ships a
+published image and `aa-proxy` builds from a Dockerfile; `aa-gateway`, `aa-api` and
+`dashboard` you build from source (first-class images are tracked as follow-up); and
+persistence is any standard Postgres / TimescaleDB you run. The hosted **SaaS
+edition** runs this whole stack managed for you and adds the cloud / enterprise
+control-plane features that live outside this repo.
+
+## What the example Compose wires today
+
+The sample `docker-compose.yml` starts the subset that ships container images out of
+the box — your agent placeholder, its `aa-runtime` sidecar, and the optional egress
+proxy — so you see enforcement working immediately, then grow toward the full
+topology above by adding persistence, gateway, API and dashboard.
 
 ```mermaid
 flowchart LR
@@ -37,33 +105,6 @@ flowchart LR
     stub -.->|outbound HTTPS| proxy
     proxy -.->|decisions| rt
 ```
-
-### Containers — for whom, for what
-
-| Container | Image / build | For whom | For what |
-|---|---|---|---|
-| `aa-runtime` | `ghcr.io/ai-agent-assembly/aa-runtime:latest` (pulled) | everyone self-hosting | The authoritative enforcement sidecar. Re-scans, redacts and enforces every agent action against your `policy.toml`, and serves health/metrics on `:8080`. This is the one container you always run. |
-| `agent-stub` | `alpine:latest` placeholder | developers integrating an agent | A stand-in for **your** agent process. Swap in your own image, keep the same `AA_AGENT_ID`, and share the socket volume — that is all the wiring an agent needs. |
-| `aa-proxy` | built from `aa-proxy/Dockerfile` (`proxy` profile) | teams wanting code-free egress control | Optional sidecar that MitM-intercepts outbound HTTPS to apply network-egress policy without touching agent code. |
-
-### Completing the stack
-
-The example focuses on the **enforcement data plane** (runtime + optional proxy),
-because those ship a ready container image. The **control plane** — `aa-gateway`
-(registry · policy service · budgets), `aa-api` (HTTP/OpenAPI), and the operator
-`dashboard` — is **also open source in this repository**; it simply does not ship a
-published container image *yet*, so to run it yourself today you build it from
-source (`cargo build -p aa-gateway -p aa-api`, `pnpm --dir dashboard build`).
-Publishing first-class images for these is tracked as follow-up work. The hosted
-**SaaS edition** runs the complete control plane managed for you.
-
-| Plane | Components | In this example | Run it yourself |
-|---|---|---|---|
-| Enforcement (data plane) | `aa-runtime`, `aa-proxy` | ✅ container images | pull / `--profile proxy` build |
-| Control plane | `aa-gateway`, `aa-api`, `dashboard` | not yet (no published image) | open source in this repo — build from source; images pending |
-| Managed cloud / enterprise | hosted multi-tenant persistence, SSO, compliance | — | hosted **SaaS edition** |
-
-## What the stack runs
 
 The compose file (`examples/docker-compose/docker-compose.yml`) defines these
 services. Values below are taken directly from that file.

--- a/docs/src/usage-guide/self-hosting.md
+++ b/docs/src/usage-guide/self-hosting.md
@@ -1,33 +1,67 @@
-# Self-hosting (limited function)
+# Self-hosting the open-source stack
 
-You can self-host Agent Assembly's open-source enforcement services with the
-sample Docker Compose stack in [`examples/docker-compose/`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/examples/docker-compose).
-This page explains what that stack does, what it deliberately does **not** do, and
-how to bring it up.
+Agent Assembly is open source. You can **self-host it yourself** — stand the
+infrastructure up, run it, and maintain it — using the sample Docker Compose stack
+in [`examples/docker-compose/`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/examples/docker-compose).
+This page is the quick path for developers: it shows the **infrastructure
+architecture** (which containers exist, who each is for, and what each does), the
+exact configuration, and how to bring it up.
 
-## Limited function, by design
+> **"Open source" here means scope, not a crippled build.** Self-hosting runs the
+> components that live in this open-source repository. The hosted **SaaS edition**
+> additionally runs everything *for* you as a managed, multi-tenant service and adds
+> the cloud/enterprise control-plane features that live outside this repo (managed
+> persistence, SSO, compliance reporting). Nothing here is deliberately
+> feature-limited — the example simply starts with the components that already ship
+> a container image today.
 
-> **Complete functionality is SaaS-only.** Self-hosting via the open-source images
-> is supported for the enforcement *data plane* only. The **control plane** — the
-> gateway brain, persistence, the HTTP/OpenAPI API, the operator dashboard, the
-> central agent registry, and team budgets — is provided exclusively through the
-> hosted (SaaS) product.
+## Infrastructure architecture
 
-What this means in practice:
+The example stack is a single-host Compose project. Your agent runs alongside an
+`aa-runtime` enforcement sidecar; they share a Unix-domain-socket volume; an
+optional `aa-proxy` adds code-free egress interception. Local policy comes from a
+bind-mounted `policy.toml`.
 
-| Capability | Self-host (this stack) | SaaS-only |
-|---|---|---|
-| In-process / sidecar enforcement (`aa-runtime`) | ✅ | |
-| Local policy-file enforcement | ✅ | |
-| Egress-interception proxy (`aa-proxy`, optional) | ✅ (demo) | |
-| Gateway brain, central registry, policy evaluation service | | ✅ |
-| Persistence (audit history, durable state) | | ✅ |
-| HTTP/OpenAPI API + operator dashboard | | ✅ |
-| Team budgets and cost tracking | | ✅ |
+```mermaid
+flowchart LR
+    subgraph compose["docker compose — your machine or CI"]
+        stub["agent-stub<br/>(replace with your agent)"]
+        rt["aa-runtime<br/>enforcement sidecar<br/>:8080 health and metrics"]
+        proxy["aa-proxy<br/>egress MitM :8899<br/>optional · proxy profile"]
+        pol[/"policy.toml<br/>bind mount"/]
+        sock(["aa-runtime-socket<br/>shared UDS volume"])
+    end
+    stub <-->|IPC over shared UDS socket| sock
+    rt <--> sock
+    pol -->|AA_POLICY_PATH| rt
+    stub -.->|outbound HTTPS| proxy
+    proxy -.->|decisions| rt
+```
 
-The control-plane services have **no open-source container image**, so the sample
-stack intentionally omits them. It runs only the services this repository ships an
-image or build context for.
+### Containers — for whom, for what
+
+| Container | Image / build | For whom | For what |
+|---|---|---|---|
+| `aa-runtime` | `ghcr.io/ai-agent-assembly/aa-runtime:latest` (pulled) | everyone self-hosting | The authoritative enforcement sidecar. Re-scans, redacts and enforces every agent action against your `policy.toml`, and serves health/metrics on `:8080`. This is the one container you always run. |
+| `agent-stub` | `alpine:latest` placeholder | developers integrating an agent | A stand-in for **your** agent process. Swap in your own image, keep the same `AA_AGENT_ID`, and share the socket volume — that is all the wiring an agent needs. |
+| `aa-proxy` | built from `aa-proxy/Dockerfile` (`proxy` profile) | teams wanting code-free egress control | Optional sidecar that MitM-intercepts outbound HTTPS to apply network-egress policy without touching agent code. |
+
+### Completing the stack
+
+The example focuses on the **enforcement data plane** (runtime + optional proxy),
+because those ship a ready container image. The **control plane** — `aa-gateway`
+(registry · policy service · budgets), `aa-api` (HTTP/OpenAPI), and the operator
+`dashboard` — is **also open source in this repository**; it simply does not ship a
+published container image *yet*, so to run it yourself today you build it from
+source (`cargo build -p aa-gateway -p aa-api`, `pnpm --dir dashboard build`).
+Publishing first-class images for these is tracked as follow-up work. The hosted
+**SaaS edition** runs the complete control plane managed for you.
+
+| Plane | Components | In this example | Run it yourself |
+|---|---|---|---|
+| Enforcement (data plane) | `aa-runtime`, `aa-proxy` | ✅ container images | pull / `--profile proxy` build |
+| Control plane | `aa-gateway`, `aa-api`, `dashboard` | not yet (no published image) | open source in this repo — build from source; images pending |
+| Managed cloud / enterprise | hosted multi-tenant persistence, SSO, compliance | — | hosted **SaaS edition** |
 
 ## What the stack runs
 
@@ -36,7 +70,7 @@ services. Values below are taken directly from that file.
 
 | Service | Image / build | Compose profile | Published port | Role |
 |---|---|---|---|---|
-| `aa-runtime` | `ghcr.io/ai-agent-assembly/aa-runtime:latest` | default | `8080:8080` | Authoritative in-process enforcement sidecar (health + metrics) |
+| `aa-runtime` | `ghcr.io/ai-agent-assembly/aa-runtime:latest` | default | `8080:8080` | Authoritative enforcement sidecar (health + metrics) |
 | `agent-stub` | `alpine:latest` (placeholder) | default | — | Stand-in agent sharing the runtime IPC socket |
 | `aa-proxy` | built from `../../aa-proxy/Dockerfile` (context = repo root) | `proxy` | `8899:8899` | Optional egress-interception (MitM HTTPS) proxy |
 
@@ -56,14 +90,14 @@ services. Values below are taken directly from that file.
 | `AA_AGENT_ID` | `my-agent-001` | Agent identity; **must match** `agent-stub`. Names the IPC socket. |
 | `AA_POLICY_PATH` | `/etc/aa/policy.toml` | Path to the mounted local policy file. |
 | `AA_METRICS_ADDR` | `0.0.0.0:8080` (default) | Bind address for the health/metrics HTTP server. |
-| `AA_GATEWAY_ENDPOINT` | _(unset)_ | Left unset for standalone, gateway-less enforcement. Set it to call a (SaaS) gateway instead. |
+| `AA_GATEWAY_ENDPOINT` | _(unset)_ | Left unset for standalone, gateway-less enforcement. Set it to call a gateway (self-hosted from source, or the SaaS endpoint) instead. |
 
 `agent-stub`:
 
 | Variable | Value in the stack | Meaning |
 |---|---|---|
 | `AA_AGENT_ID` | `my-agent-001` | Must equal the runtime's `AA_AGENT_ID`. |
-| `AA_GATEWAY_URL` | `https://api.agentassembly.io` | SaaS gateway URL a real agent SDK would use. |
+| `AA_GATEWAY_URL` | `https://api.agentassembly.io` | Gateway URL a real agent SDK would use (SaaS endpoint shown; point it at your self-hosted gateway if you run one). |
 | `AA_API_KEY` | `${AA_API_KEY}` | Read from your shell environment. |
 
 `aa-proxy` (only under the `proxy` profile):
@@ -72,8 +106,8 @@ services. Values below are taken directly from that file.
 |---|---|---|
 | `AA_PROXY_ADDR` | `0.0.0.0:8899` | Proxy listen address. |
 | `AA_PROXY_LLM_ONLY` | `false` | Intercept all egress, not just LLM calls. |
-| `AA_PROXY_MCP_FAIL_OPEN` | `1` | **Demo only** — lets the proxy start without a gateway. The proxy normally fails **closed** when its gateway is unreachable. |
-| `AA_PROXY_GATEWAY_ENDPOINT` | _(unset)_ | Set to a gateway endpoint (SaaS-only) to enforce through it. |
+| `AA_PROXY_MCP_FAIL_OPEN` | `1` | **Demo only** — lets the proxy start without a reachable gateway. The proxy normally fails **closed** when its gateway is unreachable. |
+| `AA_PROXY_GATEWAY_ENDPOINT` | _(unset)_ | Set to a gateway endpoint (self-hosted or SaaS) to enforce through it. |
 
 ## Quickstart
 
@@ -118,9 +152,9 @@ image, keep `AA_AGENT_ID` identical to `aa-runtime`, and keep the
 [README](https://github.com/ai-agent-assembly/agent-assembly/blob/master/examples/docker-compose/README.md)
 for details.
 
-## When you need the full product
+## When you want it fully managed
 
-If you need the control-plane capabilities listed above — durable audit history,
-the operator dashboard, central registry, team budgets, the HTTP/OpenAPI surface —
-use the hosted (SaaS) product. Those services are not available as self-hostable
-open-source images.
+If you would rather not run and maintain the infrastructure yourself — and want the
+managed, multi-tenant control plane with durable audit history, the operator
+dashboard, central registry, team budgets, SSO and compliance reporting — use the
+hosted **SaaS edition**, which runs the complete stack for you.

--- a/docs/src/usage-guide/self-hosting.md
+++ b/docs/src/usage-guide/self-hosting.md
@@ -1,0 +1,126 @@
+# Self-hosting (limited function)
+
+You can self-host Agent Assembly's open-source enforcement services with the
+sample Docker Compose stack in [`examples/docker-compose/`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/examples/docker-compose).
+This page explains what that stack does, what it deliberately does **not** do, and
+how to bring it up.
+
+## Limited function, by design
+
+> **Complete functionality is SaaS-only.** Self-hosting via the open-source images
+> is supported for the enforcement *data plane* only. The **control plane** — the
+> gateway brain, persistence, the HTTP/OpenAPI API, the operator dashboard, the
+> central agent registry, and team budgets — is provided exclusively through the
+> hosted (SaaS) product.
+
+What this means in practice:
+
+| Capability | Self-host (this stack) | SaaS-only |
+|---|---|---|
+| In-process / sidecar enforcement (`aa-runtime`) | ✅ | |
+| Local policy-file enforcement | ✅ | |
+| Egress-interception proxy (`aa-proxy`, optional) | ✅ (demo) | |
+| Gateway brain, central registry, policy evaluation service | | ✅ |
+| Persistence (audit history, durable state) | | ✅ |
+| HTTP/OpenAPI API + operator dashboard | | ✅ |
+| Team budgets and cost tracking | | ✅ |
+
+The control-plane services have **no open-source container image**, so the sample
+stack intentionally omits them. It runs only the services this repository ships an
+image or build context for.
+
+## What the stack runs
+
+The compose file (`examples/docker-compose/docker-compose.yml`) defines these
+services. Values below are taken directly from that file.
+
+| Service | Image / build | Compose profile | Published port | Role |
+|---|---|---|---|---|
+| `aa-runtime` | `ghcr.io/ai-agent-assembly/aa-runtime:latest` | default | `8080:8080` | Authoritative in-process enforcement sidecar (health + metrics) |
+| `agent-stub` | `alpine:latest` (placeholder) | default | — | Stand-in agent sharing the runtime IPC socket |
+| `aa-proxy` | built from `../../aa-proxy/Dockerfile` (context = repo root) | `proxy` | `8899:8899` | Optional egress-interception (MitM HTTPS) proxy |
+
+### Volumes
+
+| Volume | Mounted at | Purpose |
+|---|---|---|
+| `aa-runtime-socket` | `/tmp` (in `aa-runtime` and `agent-stub`) | Shared Unix domain socket — the IPC channel lives at `/tmp/aa-runtime-<AA_AGENT_ID>.sock` |
+| `../policy.toml` (bind) | `/etc/aa/policy.toml` (read-only) in `aa-runtime` | Local enforcement policy |
+
+### Environment variables
+
+`aa-runtime`:
+
+| Variable | Value in the stack | Meaning |
+|---|---|---|
+| `AA_AGENT_ID` | `my-agent-001` | Agent identity; **must match** `agent-stub`. Names the IPC socket. |
+| `AA_POLICY_PATH` | `/etc/aa/policy.toml` | Path to the mounted local policy file. |
+| `AA_METRICS_ADDR` | `0.0.0.0:8080` (default) | Bind address for the health/metrics HTTP server. |
+| `AA_GATEWAY_ENDPOINT` | _(unset)_ | Left unset for standalone, gateway-less enforcement. Set it to call a (SaaS) gateway instead. |
+
+`agent-stub`:
+
+| Variable | Value in the stack | Meaning |
+|---|---|---|
+| `AA_AGENT_ID` | `my-agent-001` | Must equal the runtime's `AA_AGENT_ID`. |
+| `AA_GATEWAY_URL` | `https://api.agentassembly.io` | SaaS gateway URL a real agent SDK would use. |
+| `AA_API_KEY` | `${AA_API_KEY}` | Read from your shell environment. |
+
+`aa-proxy` (only under the `proxy` profile):
+
+| Variable | Value in the stack | Meaning |
+|---|---|---|
+| `AA_PROXY_ADDR` | `0.0.0.0:8899` | Proxy listen address. |
+| `AA_PROXY_LLM_ONLY` | `false` | Intercept all egress, not just LLM calls. |
+| `AA_PROXY_MCP_FAIL_OPEN` | `1` | **Demo only** — lets the proxy start without a gateway. The proxy normally fails **closed** when its gateway is unreachable. |
+| `AA_PROXY_GATEWAY_ENDPOINT` | _(unset)_ | Set to a gateway endpoint (SaaS-only) to enforce through it. |
+
+## Quickstart
+
+From a clone of the repository:
+
+```bash
+cd examples/docker-compose
+
+# Runtime sidecar path (default profile: aa-runtime + agent-stub)
+AA_API_KEY=dev-local-key docker compose up
+```
+
+`aa-runtime` starts, enforces locally from `../policy.toml`, exposes the IPC socket
+at `/tmp/aa-runtime-my-agent-001.sock`, and serves health/metrics on `:8080`:
+
+```bash
+curl http://localhost:8080/ready
+curl http://localhost:8080/health
+curl http://localhost:8080/metrics
+```
+
+To additionally build and run the optional egress proxy on `:8899`:
+
+```bash
+AA_API_KEY=dev-local-key docker compose --profile proxy up
+```
+
+Tear down when finished:
+
+```bash
+docker compose down
+# or, if you started the proxy profile:
+docker compose --profile proxy down
+```
+
+## Replacing the agent stub
+
+`agent-stub` is an `alpine` placeholder (the Python SDK is not yet published —
+tracked in AAASM-55). To run a real agent, replace its `image:` with your agent
+image, keep `AA_AGENT_ID` identical to `aa-runtime`, and keep the
+`aa-runtime-socket` volume mounted at `/tmp`. See the example's
+[README](https://github.com/ai-agent-assembly/agent-assembly/blob/master/examples/docker-compose/README.md)
+for details.
+
+## When you need the full product
+
+If you need the control-plane capabilities listed above — durable audit history,
+the operator dashboard, central registry, team budgets, the HTTP/OpenAPI surface —
+use the hosted (SaaS) product. Those services are not available as self-hostable
+open-source images.

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,21 +1,60 @@
-# aa-runtime docker-compose example
+# Limited-function self-host — docker-compose example
 
-Demonstrates running `aa-runtime` as a sidecar alongside an agent container,
-connected via a shared Unix domain socket.
+A sample **limited-function** self-host stack for Agent Assembly. It runs the
+open-source enforcement services that ship a real image or build context in this
+repository, wired to reflect the sidecar-interception dataflow.
+
+> **Limited function, by design.** Per the owner policy (2026-06-21), self-hosting
+> the open-source services is supported, but **complete functionality — the gateway
+> brain, persistence, the HTTP/OpenAPI API, the operator dashboard, central agent
+> registry, and team budgets — is SaaS-only.** This stack does not (and cannot)
+> stand those up; they have no open-source image. See
+> [`docs/src/usage-guide/self-hosting.md`](../../docs/src/usage-guide/self-hosting.md)
+> for the full story.
+
+## What this stack runs
+
+| Service | Image / build | Profile | Port | Role |
+|---|---|---|---|---|
+| `aa-runtime` | `ghcr.io/ai-agent-assembly/aa-runtime:latest` | default | `8080` | Authoritative in-process enforcement sidecar |
+| `agent-stub` | `alpine:latest` (placeholder) | default | — | Stand-in agent sharing the runtime's IPC socket |
+| `aa-proxy` | built from `../../aa-proxy/Dockerfile` | `proxy` | `8899` | Optional egress-interception (MitM HTTPS) proxy |
+
+Services that are **SaaS-only** (`aa-gateway`, `aa-api`, persistence, dashboard)
+are intentionally absent — they have no open-source container image.
 
 ## Prerequisites
 
 - Docker and Docker Compose v2
-- An Agent Assembly API key (`AA_API_KEY`)
+- An Agent Assembly API key (`AA_API_KEY`) — used by the agent stub
 
 ## Running the example
+
+Default (runtime sidecar path):
 
 ```bash
 AA_API_KEY=<your-key> docker compose up
 ```
 
-`aa-runtime` will start, expose the IPC socket at `/tmp/aa-runtime-my-agent-001.sock`,
-and serve health/metrics at `http://localhost:8080`.
+`aa-runtime` starts, enforces locally from the mounted `../policy.toml`, exposes the
+IPC socket at `/tmp/aa-runtime-my-agent-001.sock`, and serves health/metrics at
+`http://localhost:8080`.
+
+With the optional egress proxy:
+
+```bash
+AA_API_KEY=<your-key> docker compose --profile proxy up
+```
+
+This additionally **builds** `aa-proxy` from `../../aa-proxy/Dockerfile` and listens
+on `:8899`.
+
+## Local enforcement (no gateway)
+
+In this limited-function stack `aa-runtime` runs with **no central gateway**. It
+enforces from the policy file mounted at `/etc/aa/policy.toml` (`../policy.toml`).
+To point it at a gateway instead, set `AA_GATEWAY_ENDPOINT` on the `aa-runtime`
+service. See `../policy.toml` for the rule format.
 
 ## Agent placeholder
 
@@ -32,16 +71,13 @@ To swap in your own agent:
 3. Keep the `aa-runtime-socket` volume mount at `/tmp` — the IPC socket lives at
    `/tmp/aa-runtime-<AA_AGENT_ID>.sock`.
 
-## Policy enforcement (optional)
+## About the optional `aa-proxy` profile
 
-Uncomment the policy volume mount in `docker-compose.yml` to load a policy file:
-
-```yaml
-volumes:
-  - ./policy.toml:/etc/aa/policy.toml:ro
-```
-
-See `../policy.toml` for an example policy.
+`aa-proxy` forwards governance decisions to the gateway and **fails closed** when
+the gateway is unreachable. Because this stack has no open-source gateway image,
+the proxy service sets `AA_PROXY_MCP_FAIL_OPEN=1` so it can start standalone for a
+demo of the egress path. Remove that variable and set `AA_PROXY_GATEWAY_ENDPOINT`
+to enforce through a (SaaS) gateway.
 
 ## Health check
 
@@ -49,4 +85,11 @@ See `../policy.toml` for an example policy.
 curl http://localhost:8080/health
 curl http://localhost:8080/ready
 curl http://localhost:8080/metrics
+```
+
+## Tear down
+
+```bash
+docker compose down            # default profile
+docker compose --profile proxy down
 ```

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,16 +1,19 @@
-# Limited-function self-host — docker-compose example
+# Open-source self-host — docker-compose example
 
-A sample **limited-function** self-host stack for Agent Assembly. It runs the
-open-source enforcement services that ship a real image or build context in this
+A sample **open-source** self-host stack for Agent Assembly — a quick way for
+developers to set up, run, and maintain the program's infrastructure locally. It
+runs the components that already ship a container image or build context in this
 repository, wired to reflect the sidecar-interception dataflow.
 
-> **Limited function, by design.** Per the owner policy (2026-06-21), self-hosting
-> the open-source services is supported, but **complete functionality — the gateway
-> brain, persistence, the HTTP/OpenAPI API, the operator dashboard, central agent
-> registry, and team budgets — is SaaS-only.** This stack does not (and cannot)
-> stand those up; they have no open-source image. See
+> **"Open source" is about scope, not a crippled build.** This stack starts the
+> enforcement data plane (`aa-runtime` + optional `aa-proxy`), which ship images
+> today. The control plane (`aa-gateway`, `aa-api`, the operator dashboard) is
+> **also open source in this repository** — it just has no published container image
+> *yet*, so you currently build it from source; images are a tracked follow-up. The
+> hosted **SaaS edition** runs the complete stack managed for you and adds the
+> cloud/enterprise control-plane features that live outside this repo. See
 > [`docs/src/usage-guide/self-hosting.md`](../../docs/src/usage-guide/self-hosting.md)
-> for the full story.
+> for the full architecture.
 
 ## What this stack runs
 
@@ -20,8 +23,10 @@ repository, wired to reflect the sidecar-interception dataflow.
 | `agent-stub` | `alpine:latest` (placeholder) | default | — | Stand-in agent sharing the runtime's IPC socket |
 | `aa-proxy` | built from `../../aa-proxy/Dockerfile` | `proxy` | `8899` | Optional egress-interception (MitM HTTPS) proxy |
 
-Services that are **SaaS-only** (`aa-gateway`, `aa-api`, persistence, dashboard)
-are intentionally absent — they have no open-source container image.
+The control-plane components (`aa-gateway`, `aa-api`, dashboard) are open source in
+this repo but have no published container image yet, so they are not in this
+example; build them from source to run them yourself, or use the hosted SaaS
+edition for the complete managed stack.
 
 ## Prerequisites
 
@@ -51,7 +56,7 @@ on `:8899`.
 
 ## Local enforcement (no gateway)
 
-In this limited-function stack `aa-runtime` runs with **no central gateway**. It
+In this example stack `aa-runtime` runs with **no central gateway**. It
 enforces from the policy file mounted at `/etc/aa/policy.toml` (`../policy.toml`).
 To point it at a gateway instead, set `AA_GATEWAY_ENDPOINT` on the `aa-runtime`
 service. See `../policy.toml` for the rule format.
@@ -74,10 +79,10 @@ To swap in your own agent:
 ## About the optional `aa-proxy` profile
 
 `aa-proxy` forwards governance decisions to the gateway and **fails closed** when
-the gateway is unreachable. Because this stack has no open-source gateway image,
-the proxy service sets `AA_PROXY_MCP_FAIL_OPEN=1` so it can start standalone for a
-demo of the egress path. Remove that variable and set `AA_PROXY_GATEWAY_ENDPOINT`
-to enforce through a (SaaS) gateway.
+the gateway is unreachable. Because no gateway runs in this example stack (it has
+no published image yet), the proxy service sets `AA_PROXY_MCP_FAIL_OPEN=1` so it can
+start standalone for a demo of the egress path. Remove that variable and set
+`AA_PROXY_GATEWAY_ENDPOINT` to enforce through a gateway (self-hosted or SaaS).
 
 ## Health check
 

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,22 +1,44 @@
-# aa-runtime sidecar — docker-compose example
+# Agent Assembly — limited-function self-host stack (Docker Compose)
+#
+# Owner policy (2026-06-21): limited-function self-hosting via open source is
+# acceptable. FULL functionality (gateway brain, persistence, HTTP/OpenAPI API,
+# operator dashboard, team budgets, central registry) remains SaaS-only.
+#
+# This stack therefore stands up only the open-source services that ship a real
+# container image or build context in this repository:
+#
+#   * aa-runtime  — the authoritative in-process enforcement sidecar
+#                   (published image: ghcr.io/ai-agent-assembly/aa-runtime)
+#   * agent-stub  — a placeholder agent wired to the runtime over the IPC socket
+#   * aa-proxy    — the egress-interception proxy (built locally from
+#                   ../../aa-proxy/Dockerfile; OPTIONAL, see the `proxy` profile)
+#
+# Services that are SaaS-only and have NO open-source image/build context are
+# intentionally NOT defined here: aa-gateway, aa-api, persistence, dashboard.
 #
 # Usage:
-#   AA_API_KEY=<your-key> docker-compose up
+#   AA_API_KEY=<your-key> docker compose up                  # runtime sidecar path (default)
+#   AA_API_KEY=<your-key> docker compose --profile proxy up  # + optional egress proxy
 #
 # The agent and runtime share a Unix domain socket volume.
 # AA_AGENT_ID must be identical in both services.
 
 services:
   aa-runtime:
+    # The only Agent Assembly service published as a container image. It is the
+    # authoritative enforcement point for the SDK/sidecar interception path.
     image: ghcr.io/ai-agent-assembly/aa-runtime:latest
     restart: unless-stopped               # restart if the process exits unexpectedly
     environment:
       AA_AGENT_ID: "my-agent-001"
+      # Limited-function self-host: run with no central gateway. The runtime
+      # enforces locally from the mounted policy file instead of calling the
+      # SaaS gateway. Leaving AA_GATEWAY_ENDPOINT unset keeps it standalone.
+      AA_POLICY_PATH: "/etc/aa/policy.toml"
       # AA_METRICS_ADDR: "0.0.0.0:8080"   # default shown for reference
     volumes:
       - aa-runtime-socket:/tmp            # socket path hardcoded to /tmp/aa-runtime-<agent_id>.sock
-      # Uncomment to mount a policy file:
-      # - ./policy.toml:/etc/aa/policy.toml:ro
+      - ../policy.toml:/etc/aa/policy.toml:ro   # local enforcement policy (see ../policy.toml)
     ports:
       - "8080:8080"                       # health + metrics
     # Note: requires a health-check-capable image or override; distroless images have no shell.
@@ -50,6 +72,28 @@ services:
       AA_API_KEY: "${AA_API_KEY}"
     volumes:
       - aa-runtime-socket:/tmp      # IPC socket: /tmp/aa-runtime-my-agent-001.sock
+
+  aa-proxy:
+    # OPTIONAL egress-interception layer. Built locally from this repo (no
+    # published image yet). Enabled only under the `proxy` profile because, in
+    # production, the proxy forwards governance decisions to the SaaS gateway and
+    # fails CLOSED when that gateway is unreachable.
+    #
+    # AA_PROXY_MCP_FAIL_OPEN=1 below lets it start WITHOUT a gateway so you can
+    # exercise the egress path in this limited-function, gateway-less self-host
+    # demo. Remove it (and set AA_PROXY_GATEWAY_ENDPOINT) to enforce via a gateway.
+    build:
+      context: ../..
+      dockerfile: aa-proxy/Dockerfile
+    profiles: ["proxy"]
+    restart: unless-stopped
+    environment:
+      AA_PROXY_ADDR: "0.0.0.0:8899"
+      AA_PROXY_LLM_ONLY: "false"
+      AA_PROXY_MCP_FAIL_OPEN: "1"   # demo only: start without a gateway (fails open)
+      # AA_PROXY_GATEWAY_ENDPOINT: "http://aa-gateway:50051"  # SaaS-only; no OSS image
+    ports:
+      - "8899:8899"                 # MitM HTTPS proxy listener
 
 volumes:
   aa-runtime-socket:


### PR DESCRIPTION
## Description

Provides a sample **limited-function** self-host Docker Compose stack and a
reflecting docs page, per the revised owner policy (2026-06-21): limited-function
self-hosting via open source is acceptable, while **complete functionality remains
SaaS-only**.

- Expanded `examples/docker-compose/docker-compose.yml`: kept the default
  `aa-runtime` + `agent-stub` sidecar path, mounted `../policy.toml` for
  gateway-less local enforcement, and added an **optional** `aa-proxy` egress
  service behind a `proxy` profile (built from the real `aa-proxy/Dockerfile`).
- Rewrote `examples/docker-compose/README.md` to state the SaaS-only boundary and
  document services/ports/volumes/env/profiles.
- New docs page `docs/src/usage-guide/self-hosting.md` with the same story plus a
  copy-pasteable quickstart, registered in `docs/src/SUMMARY.md` under the
  **Usage Guide** section only.

Only services with a real image or build context in this repo are included —
`aa-runtime` (published GHCR image) and `aa-proxy` (local build context). The
SaaS-only control-plane services (`aa-gateway`, `aa-api`, persistence, dashboard)
have no open-source image and are intentionally omitted; inventing images for them
was explicitly out of scope.

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

The default `docker compose up` still launches `aa-runtime` + `agent-stub` exactly
as before (`aa-proxy` is opt-in via `--profile proxy`), so the existing
`docs/src/quick-start/first-run.md` reference is unaffected.

## Related Issues

- Related Jira ticket: AAASM-3519 (QA follow-up under Epic AAASM-3198)

## Testing

- [x] Manual testing performed
- [x] No tests required (sample stack + docs)

Validated:
- `docker compose -f examples/docker-compose/docker-compose.yml config` — **passes** (default profile).
- `... --profile proxy config` — **passes**; `aa-proxy` build context resolves to the repo root where `aa-proxy/Dockerfile` exists.
- `mdbook build docs` — **exits 0**; `self-hosting.html` renders and is linked in the sidebar.

Could **not** validate a full `docker compose up`: the `ghcr.io/ai-agent-assembly/aa-runtime:latest` image is not pullable in this sandboxed environment (no egress to GHCR), so the stack could not be brought up end-to-end here. The documented commands are otherwise verified by the config parse.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Refs AAASM-3519