### PR TITLE
[AAASM-3523] 📝 (docs): Standardize reference links to latest stable channel

### DIFF
--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -26,8 +26,19 @@ scenarios:
 
 Each language SDK also publishes its examples as rendered documentation, with the
 governance walkthrough alongside the code. These are the same scenarios as the
-repo links above, presented in the SDK's own docs site:
+repo links above, presented in the SDK's own docs site.
 
-- **Python** — [python-sdk examples](https://ai-agent-assembly.github.io/python-sdk/pre-release/examples/)
-- **Node** — [node-sdk examples](https://ai-agent-assembly.github.io/node-sdk/examples/)
-- **Go** — [go-sdk examples](https://ai-agent-assembly.github.io/go-sdk/pre-release/examples/)
+<!--
+  Link convention: we point at each SDK's channel-agnostic documentation root, not
+  a pinned version and not a hardcoded `pre-release`/`latest` segment. Per the docs
+  versioning model the root auto-redirects to the latest *stable* channel when one
+  exists (falling back to the best-available channel while the products are still in
+  beta). A `/stable/examples/` deep link does not resolve yet (the stable channel has
+  no published version during `0.0.1-beta.x`), so we link the SDK doc root — which
+  always tracks stable and returns HTTP 200 — and let its navigation surface the
+  examples section. Revisit deep `/stable/examples/` links once a stable release ships.
+-->
+
+- **Python** — [python-sdk examples](https://ai-agent-assembly.github.io/python-sdk/)
+- **Node** — [node-sdk examples](https://ai-agent-assembly.github.io/node-sdk/)
+- **Go** — [go-sdk examples](https://ai-agent-assembly.github.io/go-sdk/)

--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -9,7 +9,10 @@ testable on its own, while these pages stay focused on the concepts.
 > **Want to stand up the infrastructure itself?** The
 > [Self-hosting guide](self-hosting.md) walks through the open-source Docker Compose
 > stack — its architecture, which containers run (and who each is for), and how to
-> set up, run, and maintain the program's infra locally.
+> set up, run, and maintain the program's infra locally. For the wiring diagram
+> behind that stack — how a single agent action travels across every hop and the
+> real config knob at each one — see the
+> [Infrastructure overview](../architecture/infra-overview.md).
 
 Every example is governed by the same three-layer interception model described
 in [Choosing interception layers](interception-layers.md): a gateway as the


### PR DESCRIPTION
## Description

Standardizes every documentation reference link pointing at the 5 GitHub-Pages
docs sites (core, python-sdk, node-sdk, go-sdk, docs-hub) to the **channel-agnostic
root** form — never `pre-release`, never `latest`, never a pinned version.

Concretely, the per-SDK example links in `docs/src/usage-guide/examples.md` were
the only non-conforming references and are repointed:

| Before | After |
|---|---|
| `python-sdk/pre-release/examples/` | `python-sdk/` |
| `node-sdk/examples/` | `node-sdk/` |
| `go-sdk/pre-release/examples/` | `go-sdk/` |

The links in `overview.md` and `README.md` were already in the standardized root
form (no change needed). The single `go-sdk/v0.0.1-alpha.5/` occurrence in
`docs/release/v0.0.1-alpha.7.md` is a **historical release note** describing a past
event — left untouched so the record stays accurate.

This PR also adds the **deferred AAASM-3517 cross-link**: the runnable-examples
self-hosting callout now links to the architecture **Infrastructure overview** page
(`architecture/infra-overview.md`).

### Chosen link convention + why

I verified what actually resolves today (`curl -sL -o /dev/null -w "%{http_code}"`),
because the products are in `0.0.1-beta.x` and a `/stable/` deep segment can 404:

**Root pages (the chosen form) — all 200:**
```
200  python-sdk/        200  node-sdk/        200  go-sdk/
200  agent-assembly/    200  agent-assembly-docs/
```
The root is the only form that is (a) consistent across all 5 sites, (b) auto-tracks
the latest **stable** channel per the docs versioning model (root redirects
stable→pre-release→latest, best-available), and (c) returns 200 everywhere today.

**Does `/stable/` resolve? Mixed, and `/stable/examples/` 404s on every SDK:**
```
python-sdk/stable/         200    python-sdk/stable/examples/   404
go-sdk/stable/             404    go-sdk/stable/examples/       404
node-sdk/stable/           404    node-sdk/stable/examples/     404
```
The deep example pages only resolve under `pre-release`/`latest` (python, go) or
un-channeled (node) — none of which "track stable." So a `/stable/examples/`
deep link would introduce a 404. Per the ticket's guidance for that judgment call,
the example links point at the **stable-tracking SDK doc root** (200, tracks stable)
and let each site's navigation surface its examples section. A code comment in
`examples.md` records this convention and a note to revisit deep `/stable/examples/`
links once a stable release ships.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3523 (QA follow-up under Epic AAASM-3198)
- Also lands deferred cross-link from AAASM-3517

## Testing

- [x] Manual testing performed
- [x] No tests required (docs-only link standardization)

Verification:
- Re-curled every changed/added link → HTTP 200.
- `mdbook build docs` exits 0.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated
- [x] Commits are small and follow the Gitmoji convention

Refs AAASM-3523