### PR TITLE
[AAASM-3523] 📝 (docs): Use stable channel for SDK/hub reference links

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -6,7 +6,7 @@ This book is the contributor and operator reference for the core. If you build *
 
 New here? Start with the **[Introduction](introduction/README.md)** — it explains what Agent Assembly is, the problem it solves, the core concepts, and the three-layer interception model. Then move on to the [Quick Start](quick-start/requirements.md).
 
-> **Other docs:** [Docs Hub](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/)
+> **Other docs:** [Docs Hub](https://ai-agent-assembly.github.io/agent-assembly-docs/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
 
 ## Run it locally
 

--- a/docs/src/introduction/overview.md
+++ b/docs/src/introduction/overview.md
@@ -90,6 +90,6 @@ This book is the reference for **contributors and operators of the
 `agent-assembly` core** — people running the gateway, writing policy, and
 deploying the interception layers. If you are instead building an application
 *with* a language SDK, start from the per-SDK guides: [Python
-SDK](https://ai-agent-assembly.github.io/python-sdk/), [Node
-SDK](https://ai-agent-assembly.github.io/node-sdk/), [Go
-SDK](https://ai-agent-assembly.github.io/go-sdk/).
+SDK](https://ai-agent-assembly.github.io/python-sdk/stable/), [Node
+SDK](https://ai-agent-assembly.github.io/node-sdk/stable/), [Go
+SDK](https://ai-agent-assembly.github.io/go-sdk/stable/).

--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -32,16 +32,16 @@ governance walkthrough alongside the code. These are the same scenarios as the
 repo links above, presented in the SDK's own docs site.
 
 <!--
-  Link convention: we point at each SDK's channel-agnostic documentation root, not
-  a pinned version and not a hardcoded `pre-release`/`latest` segment. Per the docs
-  versioning model the root auto-redirects to the latest *stable* channel when one
-  exists (falling back to the best-available channel while the products are still in
-  beta). A `/stable/examples/` deep link does not resolve yet (the stable channel has
-  no published version during `0.0.1-beta.x`), so we link the SDK doc root — which
-  always tracks stable and returns HTTP 200 — and let its navigation surface the
-  examples section. Revisit deep `/stable/examples/` links once a stable release ships.
+  Link convention: always point at the **stable** documentation channel — never a
+  hardcoded `pre-release`/`latest` segment and never a pinned version. These links
+  intentionally use `/stable/`, which 404s while the products are still in
+  `0.0.1-beta.x` (the stable channel has no published version yet). That 404 is
+  expected and correct: as soon as a stable release ships, every link resolves to
+  the right stable page with no further edits. (mdBook does not validate external
+  links and the docs CI has no link-checker, so the temporary 404 does not break the
+  build.) Do NOT "fix" these by switching to pre-release/latest.
 -->
 
-- **Python** — [python-sdk examples](https://ai-agent-assembly.github.io/python-sdk/)
-- **Node** — [node-sdk examples](https://ai-agent-assembly.github.io/node-sdk/)
-- **Go** — [go-sdk examples](https://ai-agent-assembly.github.io/go-sdk/)
+- **Python** — [python-sdk examples](https://ai-agent-assembly.github.io/python-sdk/stable/examples/)
+- **Node** — [node-sdk examples](https://ai-agent-assembly.github.io/node-sdk/stable/examples/)
+- **Go** — [go-sdk examples](https://ai-agent-assembly.github.io/go-sdk/stable/examples/)


### PR DESCRIPTION
## What
Follow-up to the merged #1190/#1194 docs work: switch every SDK / docs-hub reference link from the channel-agnostic **root** form to the explicit **stable** channel (`/stable/…`).

- `usage-guide/examples.md` — per-SDK example links → `/<sdk>/stable/examples/`
- `introduction/overview.md` — per-SDK guide links → `/<sdk>/stable/`
- `README.md` — "Other docs" nav (Docs Hub + 3 SDKs) → `/stable/`

## Why
Per owner direction (AAASM-3523): reference links must point at the **latest stable** channel — never `pre-release`/`latest`/pinned, and not the auto-routing root. These links intentionally **404 while the products are in `0.0.1-beta.x`** (no stable release yet); that is expected and resolves automatically at the first GA. mdBook does not validate external links and the docs CI has no link-checker, so the temporary 404 does not break the build. A comment in `examples.md` documents the convention so it is not "fixed" back to pre-release.

## Verify
- `mdbook build docs` succeeds.
- Every changed link uses `/stable/`.

Refs AAASM-3523