### PR TITLE
[AAASM-3526] 🐛 (docker): Fix base-image registry org (agent-assembly → ai-agent-assembly)

### DIFF
--- a/docker/Dockerfile.go-1.24-alpine
+++ b/docker/Dockerfile.go-1.24-alpine
@@ -7,7 +7,7 @@
 # governance on first run with no extra install step.
 #
 # Use:
-#   FROM ghcr.io/agent-assembly/go:1.24-alpine
+#   FROM ghcr.io/ai-agent-assembly/go:1.24-alpine
 #
 # Transitional install path (will simplify once this Story ships):
 #   * `aasm` is built from source until AAASM-1201 publishes a curl|sh

--- a/docker/Dockerfile.go-1.25-alpine
+++ b/docker/Dockerfile.go-1.25-alpine
@@ -7,7 +7,7 @@
 # governance on first run with no extra install step.
 #
 # Use:
-#   FROM ghcr.io/agent-assembly/go:1.25-alpine
+#   FROM ghcr.io/ai-agent-assembly/go:1.25-alpine
 #
 # Transitional install path (will simplify once this Story ships):
 #   * `aasm` is built from source until AAASM-1201 publishes a curl|sh

--- a/docker/Dockerfile.go-1.26-alpine
+++ b/docker/Dockerfile.go-1.26-alpine
@@ -7,7 +7,7 @@
 # governance on first run with no extra install step.
 #
 # Use:
-#   FROM ghcr.io/agent-assembly/go:1.26-alpine
+#   FROM ghcr.io/ai-agent-assembly/go:1.26-alpine
 #
 # Transitional install path (will simplify once this Story ships):
 #   * `aasm` is built from source until AAASM-1201 publishes a curl|sh

--- a/docker/Dockerfile.node-20-slim
+++ b/docker/Dockerfile.node-20-slim
@@ -7,7 +7,7 @@
 # governance on first run with no extra install step.
 #
 # Use:
-#   FROM ghcr.io/agent-assembly/node:20-slim
+#   FROM ghcr.io/ai-agent-assembly/node:20-slim
 #
 # Transitional install paths (will simplify once these Stories ship):
 #   * `aasm` is built from source until AAASM-1201 publishes a curl|sh

--- a/docker/Dockerfile.node-22-slim
+++ b/docker/Dockerfile.node-22-slim
@@ -7,7 +7,7 @@
 # governance on first run with no extra install step.
 #
 # Use:
-#   FROM ghcr.io/agent-assembly/node:22-slim
+#   FROM ghcr.io/ai-agent-assembly/node:22-slim
 #
 # Transitional install paths (will simplify once these Stories ship):
 #   * `aasm` is built from source until AAASM-1201 publishes a curl|sh

--- a/docker/Dockerfile.node-24-slim
+++ b/docker/Dockerfile.node-24-slim
@@ -7,7 +7,7 @@
 # governance on first run with no extra install step.
 #
 # Use:
-#   FROM ghcr.io/agent-assembly/node:24-slim
+#   FROM ghcr.io/ai-agent-assembly/node:24-slim
 #
 # Transitional install paths (will simplify once these Stories ship):
 #   * `aasm` is built from source until AAASM-1201 publishes a curl|sh

--- a/docker/Dockerfile.python-3.12-slim
+++ b/docker/Dockerfile.python-3.12-slim
@@ -7,7 +7,7 @@
 # run with no extra install step.
 #
 # Use:
-#   FROM ghcr.io/agent-assembly/python:3.12-slim
+#   FROM ghcr.io/ai-agent-assembly/python:3.12-slim
 #
 # Transitional install paths (will simplify once these Stories ship):
 #   * `aasm` is built from source until AAASM-1201 publishes a curl|sh

--- a/docker/Dockerfile.python-3.13-slim
+++ b/docker/Dockerfile.python-3.13-slim
@@ -7,7 +7,7 @@
 # run with no extra install step.
 #
 # Use:
-#   FROM ghcr.io/agent-assembly/python:3.13-slim
+#   FROM ghcr.io/ai-agent-assembly/python:3.13-slim
 #
 # Transitional install paths (will simplify once these Stories ship):
 #   * `aasm` is built from source until AAASM-1201 publishes a curl|sh

--- a/docker/Dockerfile.python-3.14-slim
+++ b/docker/Dockerfile.python-3.14-slim
@@ -7,7 +7,7 @@
 # run with no extra install step.
 #
 # Use:
-#   FROM ghcr.io/agent-assembly/python:3.14-slim
+#   FROM ghcr.io/ai-agent-assembly/python:3.14-slim
 #
 # Transitional install paths (will simplify once these Stories ship):
 #   * `aasm` is built from source until AAASM-1201 publishes a curl|sh


### PR DESCRIPTION
## Description

The 9 base-image Dockerfile header comments referenced the wrong GHCR org `ghcr.io/agent-assembly/...` (missing the `ai-` prefix). The canonical org is `ai-agent-assembly`, so the published images live at `ghcr.io/ai-agent-assembly/...`. The wrong spelling would point users at a non-existent registry path.

This replaces every `ghcr.io/agent-assembly/` → `ghcr.io/ai-agent-assembly/` in the 9 `docker/Dockerfile.*` base images (python 3.12/3.13/3.14-slim, node 20/22/24-slim, go 1.24/1.25/1.26-alpine). All 9 occurrences are in `#   FROM ...` usage-example comments — no real `FROM`/build line depended on the wrong spelling. Only `docker/Dockerfile.*` is touched; other `docker/` files are owned by a parallel ticket.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3526

## Testing

- [x] Manual testing performed
- [x] No tests required (explain why)

`git grep "ghcr.io/agent-assembly/" -- docker/Dockerfile.*` returns 0 matches after the fix (was 9 before). Sanity-checked one image builds: `docker build -f docker/Dockerfile.go-1.24-alpine .` completed successfully (exit 0).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3526