### PR TITLE
[AAASM-3527] 🐛 (aa-runtime): Fix Docker image entrypoint (/aa-runtime was a directory)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Keep the Docker build context lean. The aa-runtime image build (context: .)
+# only needs the Cargo workspace sources; everything below is rebuilt inside the
+# image or is irrelevant to it. Excluding target/ in particular avoids shipping a
+# host-built (wrong-arch, non-musl) artifact into the build and bloating context.
+target/
+**/target/
+.git/
+.github/
+dashboard/node_modules/
+**/node_modules/
+*.log

--- a/aa-runtime/Dockerfile
+++ b/aa-runtime/Dockerfile
@@ -50,12 +50,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     TARGET=$(cat /tmp/rust_target) && \
     cargo build --release --target "$TARGET" -p aa-runtime && \
     strip "target/$TARGET/release/aa-runtime" && \
-    cp "target/$TARGET/release/aa-runtime" /app/aa-runtime
+    cp "target/$TARGET/release/aa-runtime" /aa-runtime-bin
 
 # Final stage: minimal distroless image running as non-root.
 FROM gcr.io/distroless/static:nonroot AS runtime
 
-COPY --from=builder /app/aa-runtime /aa-runtime
+COPY --from=builder /aa-runtime-bin /aa-runtime
 
 LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="aa-runtime sidecar — AI agent assembly runtime" \


### PR DESCRIPTION
## Description

`aa-runtime/Dockerfile` produced an image whose `ENTRYPOINT ["/aa-runtime"]` resolved to a **directory** instead of the binary, so the published sidecar could not start:

```
exec /aa-runtime: is a directory
```

**Root cause.** The image builds with `context: .` (repo root). `COPY . .` brings the repo's `aa-runtime/` **source directory** into the builder as `/app/aa-runtime`. The builder step then ran `cp target/$TARGET/release/aa-runtime /app/aa-runtime` — but `/app/aa-runtime` already existed **as a directory**, so the binary was placed *inside* it as `/app/aa-runtime/aa-runtime`. The final stage's `COPY --from=builder /app/aa-runtime /aa-runtime` therefore copied that **directory** into the runtime image, and the entrypoint pointed at a directory.

**Fix.** Copy the built binary to `/aa-runtime-bin` (outside `/app`), a path that no source directory in the build context can shadow, and `COPY` that single file into the final image. Also added a root `.dockerignore` (excludes `target/`, `.git/`, `.github/`, `node_modules/`) as defense-in-depth so the context stays lean and a host-built artifact can never be pulled in.

### Before / after evidence

Built `docker build -f aa-runtime/Dockerfile -t aa-runtime-test .` from the repo root, then inspected the final image filesystem (distroless, no shell) via `docker export`:

```
$ docker export $(docker create aa-runtime-test) | tar -tvf - | grep aa-runtime
-rwxr-xr-x  0 0 0  9339280 21 Jun 22:31 aa-runtime
```

The `/aa-runtime` entry is now a **regular executable file** (`-rwxr-xr-x`, 9.3 MB) — before the fix it was a directory (`d...`).

Running the container executes the binary (no `is a directory`):

```
$ docker run --rm aa-runtime-test            # entrypoint runs the binary
thread 'main' panicked at aa-runtime/src/main.rs:15: "AA_AGENT_ID is required but not set"

$ docker run --rm -e AA_AGENT_ID=test-agent -e AA_POLICY_PATH="" aa-runtime-test
# boots and keeps running (timeout-killed) — no exec error
```

The runtime reaches its own `main.rs` config-loading logic, proving the entrypoint is the executable.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3527

Closes AAASM-3527

## Testing

- [x] Manual testing performed (real `docker build` + filesystem inspection + container start, see evidence above)
- [x] No unit tests required (Dockerfile/build-packaging change; correctness proven by building and running the image)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
