### PR TITLE
[AAASM-3535] 📝 (docs): Add 5 Python frameworks to compatibility hub

### DIFF
--- a/docs/src/reference/framework-compatibility.md
+++ b/docs/src/reference/framework-compatibility.md
@@ -21,7 +21,7 @@ compatibility page:
 
 | SDK | Frameworks (high level) | Authoritative compatibility doc |
 |---|---|---|
-| **Python** (`agent-assembly`) | LangChain · LangGraph · Pydantic AI · CrewAI · Google ADK · MCP · OpenAI Agents | [python-sdk → Framework compatibility](https://ai-agent-assembly.github.io/python-sdk/stable/compatibility/frameworks/) |
+| **Python** (`agent-assembly`) | LangChain · LangGraph · Pydantic AI · CrewAI · Google ADK · MCP · OpenAI Agents · LlamaIndex · Agno · Microsoft Agent Framework · Smolagents · Haystack | [python-sdk → Framework compatibility](https://ai-agent-assembly.github.io/python-sdk/stable/compatibility/frameworks/) |
 | **Node / TypeScript** (`@agent-assembly/sdk`) | LangChain.js · LangGraph.js · Vercel AI SDK · Mastra · OpenAI Agents | [node-sdk → Framework compatibility](https://ai-agent-assembly.github.io/node-sdk/stable/compatibility-versioning/compatibility/) |
 | **Go** (`go-sdk`) | LangChainGo (+ generic tool wrapping) | [go-sdk → Framework compatibility](https://ai-agent-assembly.github.io/go-sdk/stable/compatibility/) |
 
@@ -39,6 +39,10 @@ An SDK lists a framework as supported when it has both:
    [AAASM-3525](https://lightning-dust-mite.atlassian.net/browse/AAASM-3525) — a
    minimal agent on that framework, wired to the SDK + core (`aa-runtime` /
    gateway), exercised end-to-end against a real runtime.
+
+The Python list was expanded with LlamaIndex, Agno, Microsoft Agent Framework,
+Smolagents, and Haystack under
+[AAASM-3535](https://lightning-dust-mite.atlassian.net/browse/AAASM-3535).
 
 The exact **supported version range** and the **tested version** live in each
 per-SDK doc above — anchored to that adapter's real constraints and the


### PR DESCRIPTION
## What

Adds **LlamaIndex, Agno, Microsoft Agent Framework, Smolagents, and Haystack** to the Python row of the core per-SDK framework-compatibility hub (`docs/src/reference/framework-compatibility.md`), and records the provenance of the expansion (AAASM-3535) in the "What supported means" section.

## Why

These 5 adapters are being added to the Python SDK under Story **AAASM-3535** (subtasks AAASM-3536…3540). This is the **central reconciliation** of the shared core-docs hub: the 5 per-framework PRs in `python-sdk` / `agent-assembly-integration-tests` / `agent-assembly-examples` deliberately did **not** touch this file, to avoid a 5-way merge conflict. This single PR updates it once.

Per **AAASM-3530**, the hub stays a *thin index* — high-level framework names only. The authoritative version ranges (`get_supported_versions()`) stay in the python-sdk compatibility docs, where the adapters live.

## How to verify

- The Python row now lists all 12 frameworks (7 existing + 5 new).
- No version-matrix detail was added here (by design — it lives per-SDK).
- mdBook builds the page unchanged in structure.

## Related

Part of **AAASM-3535**. Companion PRs (per framework, base `master`):
- python-sdk: #160 (Haystack) · #161 (Smolagents) · #162 (Agno) · #163 (LlamaIndex) · #164 (MS Agent Framework)
- integration-tests: #106 · #107 · #108 · #109 · #110
- examples: #149 · #150 · #151 · #152 · #153

Refs AAASM-3535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)