### PR TITLE
[AAASM-3554] 🍪 (docs): Add GDPR cookie-consent gating to the mdBook docs

### DIFF
--- a/docs/theme/head.hbs
+++ b/docs/theme/head.hbs
@@ -22,3 +22,68 @@
   gtag('config', 'G-EV2FPGTJJB', { 'anonymize_ip': true });
 </script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-EV2FPGTJJB"></script>
+
+<!-- Opt-in cookie-consent banner (vanilla JS, no external request) — AAASM-3554. -->
+<style>
+  .aa-consent { position: fixed; left: 1rem; right: 1rem; bottom: 1rem; z-index: 2147483647;
+    max-width: 42rem; margin: 0 auto; padding: 1rem 1.25rem; border-radius: 8px;
+    background: #1f2430; color: #e7eaf0; box-shadow: 0 4px 24px rgba(0, 0, 0, .35);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  .aa-consent p { margin: 0 0 .75rem; }
+  .aa-consent a { color: #8ab4f8; }
+  .aa-consent__actions { display: flex; gap: .5rem; flex-wrap: wrap; }
+  .aa-consent button { cursor: pointer; border: 0; border-radius: 6px; padding: .45rem .9rem;
+    font-size: 14px; font-weight: 600; }
+  .aa-consent__accept { background: #8ab4f8; color: #14161b; }
+  .aa-consent__reject { background: transparent; color: #e7eaf0; border: 1px solid #4a5160; }
+</style>
+<script>
+  (function () {
+    var KEY = 'aa-analytics-consent';
+    function stored() {
+      try { return window.localStorage && localStorage.getItem(KEY); } catch (e) { return null; }
+    }
+    if (stored()) { return; } // visitor already chose — no banner
+    function choose(value) {
+      try { localStorage.setItem(KEY, value); } catch (e) {}
+      if (value === 'granted' && typeof gtag === 'function') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+      var box = document.querySelector('.aa-consent');
+      if (box && box.parentNode) { box.parentNode.removeChild(box); }
+    }
+    function build() {
+      if (stored() || document.querySelector('.aa-consent')) { return; }
+      var box = document.createElement('div');
+      box.className = 'aa-consent';
+      box.setAttribute('role', 'dialog');
+      box.setAttribute('aria-live', 'polite');
+      box.setAttribute('aria-label', 'Cookie consent');
+      var text = document.createElement('p');
+      text.textContent = 'We use Google Analytics to understand documentation usage. '
+        + 'Analytics cookies are only set if you accept.';
+      var actions = document.createElement('div');
+      actions.className = 'aa-consent__actions';
+      var accept = document.createElement('button');
+      accept.type = 'button';
+      accept.className = 'aa-consent__accept';
+      accept.textContent = 'Accept';
+      accept.addEventListener('click', function () { choose('granted'); });
+      var reject = document.createElement('button');
+      reject.type = 'button';
+      reject.className = 'aa-consent__reject';
+      reject.textContent = 'Reject';
+      reject.addEventListener('click', function () { choose('denied'); });
+      actions.appendChild(accept);
+      actions.appendChild(reject);
+      box.appendChild(text);
+      box.appendChild(actions);
+      document.body.appendChild(box);
+    }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', build);
+    } else {
+      build();
+    }
+  })();
+</script>

--- a/docs/theme/head.hbs
+++ b/docs/theme/head.hbs
@@ -1,9 +1,24 @@
-<!-- Google Analytics 4 (gtag.js). The Measurement ID is public (embedded
-     client-side), not a secret. Core agent-assembly docs — AAASM-3552. -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-EV2FPGTJJB"></script>
+<!-- Google Analytics 4 (gtag.js) + Consent Mode v2. The Measurement ID is
+     public (embedded client-side), not a secret. Analytics storage is denied
+     by default and only enabled after explicit opt-in. Core agent-assembly
+     docs — AAASM-3552 / AAASM-3554. -->
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag() { dataLayer.push(arguments); }
+  // Consent Mode v2 — deny analytics/ads storage until the visitor opts in.
+  gtag('consent', 'default', {
+    'analytics_storage': 'denied',
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied'
+  });
+  // Re-apply a stored opt-in before the first hit fires.
+  try {
+    if (window.localStorage && localStorage.getItem('aa-analytics-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
   gtag('js', new Date());
-  gtag('config', 'G-EV2FPGTJJB', { anonymize_ip: true });
+  gtag('config', 'G-EV2FPGTJJB', { 'anonymize_ip': true });
 </script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-EV2FPGTJJB"></script>


### PR DESCRIPTION
## Description

Adds GDPR cookie-consent gating to the **core agent-assembly mdBook docs site**, the fast-follow to the GA4 analytics wiring landed in AAASM-3552 (#1201). Until now this site loaded Google Analytics with no consent gate, so analytics cookies were set before the visitor opted in.

This change implements **Google Consent Mode v2** in `docs/theme/head.hbs`:
- Sets the Consent Mode default to **`denied`** for `analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization` **before `gtag.js` loads**, and re-applies a stored opt-in from `localStorage` (`aa-analytics-consent`) before the first hit — so **no analytics cookie is set until the visitor accepts**.
- Adds a lightweight, dependency-free **opt-in banner** (Accept / Reject), built with `createElement`/`textContent` (no `innerHTML`), appended to the body after DOM-ready, non-modal and keyboard-accessible. Accept → `gtag('consent','update',{analytics_storage:'granted'})` + persist; Reject → persist denied; the banner does not reappear once a choice is stored.

This brings the core site to parity with the python-sdk mkdocs site's native `extra.consent` behaviour (opt-in, denied by default). The Measurement ID (`G-EV2FPGTJJB`, public) is unchanged.

## Type of Change

- [x] ✨ New feature (privacy/consent gating)
- [x] 📝 Documentation update (docs-site theme)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3554 (Part of — core agent-assembly site; sibling PRs cover node-sdk, go-sdk, agent-assembly-docs)
- Follows up: AAASM-3552

## Testing

- [x] Manual testing performed — verified the consent-default script precedes the `gtag.js` loader in `head.hbs`; banner built via DOM API only.
- [x] No tests required — static docs-theme `head.hbs`; no Rust/runtime code touched, so no unit/integration tests apply. Behaviour is verifiable in a browser (Application → Cookies shows no `_ga` until Accept; Network shows no `collect` hit until Accept).

## Checklist

- [x] Code follows project style guidelines (no Rust touched; `cargo fmt`/`clippy` N/A)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (will confirm on the PR — expect `Build mdBook` green)
- [x] Commits are small and follow the Gitmoji convention (2 commits: consent-mode default, then banner)