### PR TITLE
[AAASM-3555] 👍 (docs): Add "Was this page helpful?" feedback widget to the mdBook docs

### DIFF
--- a/docs/theme/head.hbs
+++ b/docs/theme/head.hbs
@@ -87,3 +87,16 @@
     }
   })();
 </script>
+
+<!-- "Was this page helpful?" feedback widget (vanilla JS) — AAASM-3555. -->
+<style>
+  .aa-feedback { margin: 3rem 0 1rem; padding-top: 1.25rem; border-top: 1px solid rgba(127, 127, 127, .25);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  .aa-feedback__q { font-weight: 600; margin: 0 0 .5rem; }
+  .aa-feedback__actions { display: flex; gap: .5rem; align-items: center; }
+  .aa-feedback__btn { cursor: pointer; border: 1px solid rgba(127, 127, 127, .4); background: transparent;
+    color: inherit; border-radius: 6px; padding: .35rem .75rem; font-size: 14px; line-height: 1; }
+  .aa-feedback__btn:hover { border-color: #8ab4f8; }
+  .aa-feedback__msg { margin: .5rem 0 0; }
+  .aa-feedback__msg a { color: #8ab4f8; }
+</style>

--- a/docs/theme/head.hbs
+++ b/docs/theme/head.hbs
@@ -100,3 +100,68 @@
   .aa-feedback__msg { margin: .5rem 0 0; }
   .aa-feedback__msg a { color: #8ab4f8; }
 </style>
+<script>
+  (function () {
+    // Per-site repo for the "tell us what to improve" pre-filled issue link.
+    var REPO = 'agent-assembly';
+    function sendFeedback(value) {
+      // Consent Mode (AAASM-3554) governs whether this hit is stored; fire either way.
+      if (typeof gtag === 'function') {
+        gtag('event', 'feedback', { 'value': value, 'page_path': location.pathname });
+      }
+    }
+    function issueUrl() {
+      var title = 'Docs feedback: ' + location.pathname;
+      var body = 'Page: ' + location.href + '\n\nWhat could be improved?\n';
+      return 'https://github.com/ai-agent-assembly/' + REPO + '/issues/new?labels=docs,feedback'
+        + '&title=' + encodeURIComponent(title) + '&body=' + encodeURIComponent(body);
+    }
+    function build() {
+      var main = document.querySelector('main');
+      if (!main || document.querySelector('.aa-feedback')) { return; }
+      var box = document.createElement('div');
+      box.className = 'aa-feedback';
+      var q = document.createElement('p');
+      q.className = 'aa-feedback__q';
+      q.textContent = 'Was this page helpful?';
+      var actions = document.createElement('div');
+      actions.className = 'aa-feedback__actions';
+      var msg = document.createElement('p');
+      msg.className = 'aa-feedback__msg';
+      function done(text, withLink) {
+        if (actions.parentNode) { actions.parentNode.removeChild(actions); }
+        msg.textContent = text;
+        if (withLink) {
+          msg.appendChild(document.createTextNode(' '));
+          var a = document.createElement('a');
+          a.href = issueUrl();
+          a.target = '_blank';
+          a.rel = 'noopener';
+          a.textContent = 'Tell us what we can improve →';
+          msg.appendChild(a);
+        }
+      }
+      var yes = document.createElement('button');
+      yes.type = 'button';
+      yes.className = 'aa-feedback__btn';
+      yes.textContent = '👍 Yes';
+      yes.addEventListener('click', function () { sendFeedback(1); done('Thanks for your feedback!', false); });
+      var no = document.createElement('button');
+      no.type = 'button';
+      no.className = 'aa-feedback__btn';
+      no.textContent = '👎 No';
+      no.addEventListener('click', function () { sendFeedback(0); done('Thanks — sorry this page missed the mark.', true); });
+      actions.appendChild(yes);
+      actions.appendChild(no);
+      box.appendChild(q);
+      box.appendChild(actions);
+      box.appendChild(msg);
+      main.appendChild(box);
+    }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', build);
+    } else {
+      build();
+    }
+  })();
+</script>


### PR DESCRIPTION
## Description

Adds a **"Was this page helpful? 👍 / 👎"** feedback widget to the bottom of every page on the **core agent-assembly mdBook docs site**, reporting the rating to GA4. Builds on the analytics (AAASM-3552) + consent (AAASM-3554) work already merged.

Single-file change to `docs/theme/head.hbs` (appended after the existing GA/consent block):
- A vanilla-JS widget appended to the page `<main>` after DOM-ready: 👍 **Yes** / 👎 **No** buttons under a "Was this page helpful?" heading.
- A click fires a GA4 event `gtag('event', 'feedback', { value: 1|0, page_path })` — the existing Consent Mode governs whether the hit is stored.
- The 👎 path reveals a link to a **pre-filled GitHub issue** in `ai-agent-assembly/agent-assembly` (page URL baked into title+body, labelled `docs`/`feedback`) — **no free-text reason is sent to GA** (GA no-PII compliance).
- Built with `createElement`/`textContent` (**no `innerHTML`** → CodeQL-clean), real `<button>` elements (keyboard-accessible), theme-neutral CSS (reads in light + dark). No dependency, no code touched.

## Type of Change

- [x] ✨ New feature (docs-site feedback widget)
- [x] 📝 Documentation update (docs-site theme)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3555 (Part of — core agent-assembly site; sibling PRs cover python-sdk, node-sdk, go-sdk, agent-assembly-docs)
- Builds on: AAASM-3552 (analytics), AAASM-3554 (consent)

## Testing

- [x] Manual testing performed — widget appends to `<main>`; 👍/👎 fire the `feedback` event; 👎 reveals the pre-filled issue link; built with DOM API only.
- [x] No tests required — static docs-theme `head.hbs`; no Rust/runtime code touched. Verifiable in-browser (GA DebugView shows the `feedback` event; the 👎 link opens a pre-filled issue).

## Checklist

- [x] Code follows project style guidelines (no Rust touched)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (will confirm on the PR — expect `Build mdBook` green)
- [x] Commits are small and follow the Gitmoji convention (2 commits: styles, then widget)