### PR TITLE
[AAASM-3559] 🐛 (docs): Add GA tag to the core agent-assembly root redirect stub

### DIFF
--- a/docs/site-root-index.html
+++ b/docs/site-root-index.html
@@ -8,6 +8,30 @@
 -->
 <html lang="en">
   <head>
+    <!-- Google Analytics 4 (gtag.js) + Consent Mode v2. The Measurement ID is
+         public (embedded client-side), not a secret. Analytics storage is denied
+         by default and only enabled after explicit opt-in. Mirrors the content-page
+         tag in docs/theme/head.hbs so the bare site root is tagged too — AAASM-3559. -->
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      // Consent Mode v2 — deny analytics/ads storage until the visitor opts in.
+      gtag('consent', 'default', {
+        'analytics_storage': 'denied',
+        'ad_storage': 'denied',
+        'ad_user_data': 'denied',
+        'ad_personalization': 'denied'
+      });
+      // Re-apply a stored opt-in before the first hit fires.
+      try {
+        if (window.localStorage && localStorage.getItem('aa-analytics-consent') === 'granted') {
+          gtag('consent', 'update', { 'analytics_storage': 'granted' });
+        }
+      } catch (e) {}
+      gtag('js', new Date());
+      gtag('config', 'G-EV2FPGTJJB', { 'anonymize_ip': true });
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-EV2FPGTJJB"></script>
     <meta charset="utf-8">
     <meta name="robots" content="noindex">
     <title>agent-assembly documentation</title>


### PR DESCRIPTION
## Description

The bare-root published URL `https://ai-agent-assembly.github.io/agent-assembly/` is a version-redirect stub (`docs/site-root-index.html`, copied verbatim to `_site/index.html` by `.github/workflows/docs.yml`). It forwards to the highest-priority channel (stable → pre-release → latest) but carried **no GA tag**, so Google Analytics' "Test your website" on the root reported the tag as not detected. GA only loaded on real content pages (`/latest/...`) via `docs/theme/head.hbs`.

This injects the same GA4 `gtag.js` + Consent Mode v2 default-denied snippet from `head.hbs` (Measurement ID `G-EV2FPGTJJB`) into the stub's `<head>`, so the bare root is now tagged. The redirect to `latest/` (JS `location.replace` + `<noscript>` meta refresh) and the denied-by-default consent posture are unchanged.

This is the **core (agent-assembly) half** of AAASM-3559; the go-sdk root stub is handled separately.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3559

## Testing

- [x] Manual testing performed
- [x] No tests required (explain why)

Reproduced the workflow assembly step (`cp docs/site-root-index.html _site/index.html`) and confirmed the produced bare-root `index.html`:
- contains `gtag/js?id=G-EV2FPGTJJB`, `gtag('config', 'G-EV2FPGTJJB', ...)`, and the `analytics_storage: 'denied'` consent default
- still redirects to `latest/` via both `window.location.replace` and the `<noscript>` `<meta http-equiv="refresh" ... url=latest/>`

HTML parses cleanly; `<script>`/`</script>` tags balance (3/3). No SRI on the gtag.js loader by design — it mirrors `head.hbs` exactly and Google's unversioned loader cannot carry a static integrity hash.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention