### PR TITLE
[AAASM-3564] 🔒 (multi-tenant): DB-enforced RLS + per-tenant isolation

### DIFF
--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -137,6 +137,25 @@ impl AuthenticatedCaller {
         }
         self.tenant.org_id.as_deref() == Some(org)
     }
+
+    /// The verified tenant org that scopes this caller's storage access, if any.
+    ///
+    /// AAASM-3596: this is the single, honest source for the `app.tenant_id` GUC
+    /// the storage layer's Row-Level Security filters on (AAASM-3595). It is
+    /// taken *only* from [`Self::tenant`] — the verified JWT `org_id` claim or
+    /// the authenticated API-key entry — and never from a request `Query`,
+    /// header, or body. A client cannot redirect it by sending a different
+    /// `?org_id` / `X-Org-Id`, because nothing here reads request input.
+    ///
+    /// Returns `None` for a caller with no tenant scope (an admin / cross-tenant
+    /// caller). Such a caller must run the storage connection with NO
+    /// `app.tenant_id` GUC — i.e. via a dedicated RLS-bypass admin DB role — and
+    /// must *never* synthesize a tenant from a client-chosen value. Feeding a
+    /// `None` here into the GUC seam yields a fail-closed (zero-row) connection,
+    /// not a full-table read.
+    pub fn storage_tenant_org(&self) -> Option<&str> {
+        self.tenant.org_id.as_deref()
+    }
 }
 
 /// Prefix used by API keys (`aa_`).
@@ -239,5 +258,60 @@ where
             .map_err(|retry_after_secs| AuthError::RateLimited { retry_after_secs })?;
 
         Ok(caller)
+    }
+}
+
+#[cfg(test)]
+mod tenant_guard_tests {
+    use super::*;
+
+    fn caller_with_org(org: Option<&str>, scopes: Vec<Scope>) -> AuthenticatedCaller {
+        AuthenticatedCaller {
+            key_id: "key-1".to_string(),
+            scopes,
+            tenant: Tenant {
+                team_id: None,
+                org_id: org.map(str::to_string),
+            },
+        }
+    }
+
+    /// AAASM-3596: the value feeding the storage `app.tenant_id` GUC is the
+    /// caller's verified org and nothing else.
+    #[test]
+    fn storage_tenant_org_is_the_verified_org() {
+        let caller = caller_with_org(Some("org-verified"), vec![Scope::Read]);
+        assert_eq!(caller.storage_tenant_org(), Some("org-verified"));
+    }
+
+    /// AAASM-3596 (the spoof case): a request might carry any `?org_id` /
+    /// `X-Org-Id`, but `storage_tenant_org` reads none of that — it only ever
+    /// returns the verified tenant, so a client-supplied org cannot redirect or
+    /// widen a caller's storage scope.
+    #[test]
+    fn client_supplied_org_cannot_redirect_storage_scope() {
+        // The caller is verified as org-A. A spoofed request body/header asking
+        // for "org-victim" is irrelevant: the seam never consults request input.
+        let caller = caller_with_org(Some("org-A"), vec![Scope::Read]);
+        let spoofed_client_org = "org-victim";
+        assert_ne!(
+            caller.storage_tenant_org(),
+            Some(spoofed_client_org),
+            "a client-chosen org must not become the storage tenant"
+        );
+        assert_eq!(
+            caller.storage_tenant_org(),
+            Some("org-A"),
+            "the storage tenant is provably the verified org only"
+        );
+    }
+
+    /// A caller with no verified tenant scope yields None — which the storage
+    /// GUC seam maps to a fail-closed (zero-row) connection, never a synthesized
+    /// client-chosen tenant.
+    #[test]
+    fn no_tenant_scope_yields_none_not_a_client_value() {
+        let caller = caller_with_org(None, vec![Scope::Read, Scope::Admin]);
+        assert_eq!(caller.storage_tenant_org(), None);
     }
 }

--- a/aa-storage-postgres/migrations/0006_tenant_columns.sql
+++ b/aa-storage-postgres/migrations/0006_tenant_columns.sql
@@ -26,6 +26,11 @@ UPDATE policies p
  WHERE p.agent_id = a.id
    AND a.org_id IS NOT NULL;
 UPDATE policies SET org_id = '00000000-0000-0000-0000-000000000000' WHERE org_id IS NULL;
+-- DEFAULT the reserved system org so the legacy (non-tenant-aware) trait-impl
+-- writes — which do not supply org_id — land under the reserved tenant rather
+-- than violating NOT NULL. Tenant-aware writes (the *_for_tenant methods) supply
+-- the verified org explicitly and override this default.
+ALTER TABLE policies ALTER COLUMN org_id SET DEFAULT '00000000-0000-0000-0000-000000000000';
 ALTER TABLE policies ALTER COLUMN org_id SET NOT NULL;
 ALTER TABLE policies ADD CONSTRAINT policies_org_id_fkey FOREIGN KEY (org_id) REFERENCES orgs(id);
 -- Tenant-prefixed analogue of idx_policies_agent_version, so RLS-scoped reads of
@@ -41,6 +46,7 @@ UPDATE audit_logs l
  WHERE l.agent_id = a.id
    AND a.org_id IS NOT NULL;
 UPDATE audit_logs SET org_id = '00000000-0000-0000-0000-000000000000' WHERE org_id IS NULL;
+ALTER TABLE audit_logs ALTER COLUMN org_id SET DEFAULT '00000000-0000-0000-0000-000000000000';
 ALTER TABLE audit_logs ALTER COLUMN org_id SET NOT NULL;
 -- No FK to orgs: keep audit append-only and fail-proof, matching the existing
 -- no-FK-on-agent_id rationale (0004). Metadata-only invariant preserved — no
@@ -52,6 +58,7 @@ CREATE INDEX idx_audit_logs_org_agent_ts ON audit_logs(org_id, agent_id, ts DESC
 -- get the reserved system org. New rows carry the writer's verified org.
 ALTER TABLE credentials ADD COLUMN org_id UUID;
 UPDATE credentials SET org_id = '00000000-0000-0000-0000-000000000000' WHERE org_id IS NULL;
+ALTER TABLE credentials ALTER COLUMN org_id SET DEFAULT '00000000-0000-0000-0000-000000000000';
 ALTER TABLE credentials ALTER COLUMN org_id SET NOT NULL;
 ALTER TABLE credentials ADD CONSTRAINT credentials_org_id_fkey FOREIGN KEY (org_id) REFERENCES orgs(id);
 CREATE INDEX idx_credentials_org_key ON credentials(org_id, key);

--- a/aa-storage-postgres/migrations/0006_tenant_columns.sql
+++ b/aa-storage-postgres/migrations/0006_tenant_columns.sql
@@ -1,0 +1,57 @@
+-- Tenant-discriminator columns (AAASM-3593): give `policies`, `audit_logs`, and
+-- `credentials` the per-row `org_id` that Row-Level Security filters on.
+--
+-- Today only `agents` carries `org_id` (and nullably). The three child tables key
+-- solely on `agent_id`/`key`, so the database has nothing to filter a tenant on
+-- and RLS (0007) cannot be enforced. This migration adds that column to every
+-- tenant-owned table and backfills it so the boundary is non-null going forward.
+--
+-- Tenant boundary is `orgs.id` (0001). Legacy rows that predate per-row tenant
+-- tagging — and rows with no join path to an org — are assigned the reserved
+-- system org below so the NOT NULL constraint can be made unconditional; RLS
+-- then isolates them under a tenant no real customer is ever assigned.
+
+-- Reserved system org for legacy/unassignable rows. The all-zeroes UUID is never
+-- handed to a real tenant, so RLS confines these rows to a tenant that no caller
+-- can set `app.tenant_id` to.
+INSERT INTO orgs (id, name)
+VALUES ('00000000-0000-0000-0000-000000000000', 'system (reserved)')
+ON CONFLICT (id) DO NOTHING;
+
+-- policies: backfill from the owning agent's org via the existing agent_id FK.
+ALTER TABLE policies ADD COLUMN org_id UUID;
+UPDATE policies p
+   SET org_id = a.org_id
+  FROM agents a
+ WHERE p.agent_id = a.id
+   AND a.org_id IS NOT NULL;
+UPDATE policies SET org_id = '00000000-0000-0000-0000-000000000000' WHERE org_id IS NULL;
+ALTER TABLE policies ALTER COLUMN org_id SET NOT NULL;
+ALTER TABLE policies ADD CONSTRAINT policies_org_id_fkey FOREIGN KEY (org_id) REFERENCES orgs(id);
+-- Tenant-prefixed analogue of idx_policies_agent_version, so RLS-scoped reads of
+-- the latest policy version stay index-served.
+CREATE INDEX idx_policies_org_agent_version ON policies(org_id, agent_id, policy_version DESC);
+
+-- audit_logs: agent_id is TEXT joinable to agents.id (no FK by design — the sink
+-- must never fail on a missing agent). Backfill where the agent row exists.
+ALTER TABLE audit_logs ADD COLUMN org_id UUID;
+UPDATE audit_logs l
+   SET org_id = a.org_id
+  FROM agents a
+ WHERE l.agent_id = a.id
+   AND a.org_id IS NOT NULL;
+UPDATE audit_logs SET org_id = '00000000-0000-0000-0000-000000000000' WHERE org_id IS NULL;
+ALTER TABLE audit_logs ALTER COLUMN org_id SET NOT NULL;
+-- No FK to orgs: keep audit append-only and fail-proof, matching the existing
+-- no-FK-on-agent_id rationale (0004). Metadata-only invariant preserved — no
+-- payload column added.
+-- Tenant-prefixed analogue of idx_audit_logs_agent_ts.
+CREATE INDEX idx_audit_logs_org_agent_ts ON audit_logs(org_id, agent_id, ts DESC);
+
+-- credentials: no join path to an org (keyed only by `key`), so existing rows
+-- get the reserved system org. New rows carry the writer's verified org.
+ALTER TABLE credentials ADD COLUMN org_id UUID;
+UPDATE credentials SET org_id = '00000000-0000-0000-0000-000000000000' WHERE org_id IS NULL;
+ALTER TABLE credentials ALTER COLUMN org_id SET NOT NULL;
+ALTER TABLE credentials ADD CONSTRAINT credentials_org_id_fkey FOREIGN KEY (org_id) REFERENCES orgs(id);
+CREATE INDEX idx_credentials_org_key ON credentials(org_id, key);

--- a/aa-storage-postgres/migrations/0007_enable_rls.sql
+++ b/aa-storage-postgres/migrations/0007_enable_rls.sql
@@ -10,9 +10,12 @@
 --   * FORCE ROW LEVEL SECURITY — applies the policy even to the table owner, so a
 --     query run by the owning role is still tenant-confined (without FORCE, the
 --     owner bypasses RLS).
---   * `current_setting('app.tenant_id', true)` — the `true` (missing_ok) form
---     yields NULL when the GUC is unset rather than raising. `org_id = NULL` is
---     never true, so an unset connection sees ZERO rows: fail-closed, not
+--   * `NULLIF(current_setting('app.tenant_id', true), '')::uuid` — the `true`
+--     (missing_ok) form yields NULL when the GUC is unset rather than raising,
+--     and the `NULLIF(…, '')` collapses an empty-string residue (which a pooled
+--     connection or a bare `SET app.tenant_id = ''` can leave) to NULL too, so
+--     it never reaches the `::uuid` cast as `''`. `org_id = NULL` is never true,
+--     so an unset OR empty connection sees ZERO rows: fail-closed, not
 --     fail-open. This is what makes a forgotten `SET app.tenant_id` deny-all.
 --   * WITH CHECK mirrors USING so a write cannot insert/relabel a row into
 --     another tenant.
@@ -39,18 +42,18 @@ ALTER TABLE credentials FORCE  ROW LEVEL SECURITY;
 -- NULL org_id row is still denied to every real tenant.
 CREATE POLICY tenant_isolation ON agents
     USING (COALESCE(org_id, '00000000-0000-0000-0000-000000000000')
-           = current_setting('app.tenant_id', true)::uuid)
+           = NULLIF(current_setting('app.tenant_id', true), '')::uuid)
     WITH CHECK (COALESCE(org_id, '00000000-0000-0000-0000-000000000000')
-           = current_setting('app.tenant_id', true)::uuid);
+           = NULLIF(current_setting('app.tenant_id', true), '')::uuid);
 
 CREATE POLICY tenant_isolation ON policies
-    USING (org_id = current_setting('app.tenant_id', true)::uuid)
-    WITH CHECK (org_id = current_setting('app.tenant_id', true)::uuid);
+    USING (org_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (org_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid);
 
 CREATE POLICY tenant_isolation ON audit_logs
-    USING (org_id = current_setting('app.tenant_id', true)::uuid)
-    WITH CHECK (org_id = current_setting('app.tenant_id', true)::uuid);
+    USING (org_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (org_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid);
 
 CREATE POLICY tenant_isolation ON credentials
-    USING (org_id = current_setting('app.tenant_id', true)::uuid)
-    WITH CHECK (org_id = current_setting('app.tenant_id', true)::uuid);
+    USING (org_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (org_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid);

--- a/aa-storage-postgres/migrations/0007_enable_rls.sql
+++ b/aa-storage-postgres/migrations/0007_enable_rls.sql
@@ -1,0 +1,56 @@
+-- DB-enforced tenant isolation (AAASM-3594): the core control of AAASM-3564.
+--
+-- Enable Row-Level Security and a `tenant_isolation` policy on every tenant-owned
+-- table so the database itself rejects any row whose `org_id` does not match the
+-- connection's verified tenant (`app.tenant_id`, set per checkout in 0595). This
+-- sits below the ORM: "application code WILL someday forget a tenant_id filter —
+-- the DB must be the backstop."
+--
+-- Design choices:
+--   * FORCE ROW LEVEL SECURITY — applies the policy even to the table owner, so a
+--     query run by the owning role is still tenant-confined (without FORCE, the
+--     owner bypasses RLS).
+--   * `current_setting('app.tenant_id', true)` — the `true` (missing_ok) form
+--     yields NULL when the GUC is unset rather than raising. `org_id = NULL` is
+--     never true, so an unset connection sees ZERO rows: fail-closed, not
+--     fail-open. This is what makes a forgotten `SET app.tenant_id` deny-all.
+--   * WITH CHECK mirrors USING so a write cannot insert/relabel a row into
+--     another tenant.
+--
+-- ROLE SPLIT (operational, not enforced here): the migration runner and any
+-- admin/cross-tenant maintenance must use a role that is BYPASSRLS (or table
+-- owner without FORCE-defeating privileges) — NOT the application row-access
+-- role. FORCE RLS means even the table owner is policy-bound, so migrations and
+-- backfills run as a privileged role; the runtime connection pool authenticates
+-- as the unprivileged row-access role that IS subject to this policy. Mixing the
+-- two would let the app role bypass isolation or block migrations.
+
+ALTER TABLE agents      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agents      FORCE  ROW LEVEL SECURITY;
+ALTER TABLE policies    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE policies    FORCE  ROW LEVEL SECURITY;
+ALTER TABLE audit_logs  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_logs  FORCE  ROW LEVEL SECURITY;
+ALTER TABLE credentials ENABLE ROW LEVEL SECURITY;
+ALTER TABLE credentials FORCE  ROW LEVEL SECURITY;
+
+-- agents.org_id is nullable (LifecycleStore::register carries no org context), so
+-- its policy also admits the reserved system org for untagged liveness rows; a
+-- NULL org_id row is still denied to every real tenant.
+CREATE POLICY tenant_isolation ON agents
+    USING (COALESCE(org_id, '00000000-0000-0000-0000-000000000000')
+           = current_setting('app.tenant_id', true)::uuid)
+    WITH CHECK (COALESCE(org_id, '00000000-0000-0000-0000-000000000000')
+           = current_setting('app.tenant_id', true)::uuid);
+
+CREATE POLICY tenant_isolation ON policies
+    USING (org_id = current_setting('app.tenant_id', true)::uuid)
+    WITH CHECK (org_id = current_setting('app.tenant_id', true)::uuid);
+
+CREATE POLICY tenant_isolation ON audit_logs
+    USING (org_id = current_setting('app.tenant_id', true)::uuid)
+    WITH CHECK (org_id = current_setting('app.tenant_id', true)::uuid);
+
+CREATE POLICY tenant_isolation ON credentials
+    USING (org_id = current_setting('app.tenant_id', true)::uuid)
+    WITH CHECK (org_id = current_setting('app.tenant_id', true)::uuid);

--- a/aa-storage-postgres/src/audit_sink.rs
+++ b/aa-storage-postgres/src/audit_sink.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::pool::PostgresPool;
-use crate::support::{agent_id_to_text, backend_err};
+use crate::support::{agent_id_to_text, backend_err, SYSTEM_ORG};
 
 /// A fully-resolved `audit_logs` row, ready to INSERT verbatim.
 ///
@@ -52,16 +52,17 @@ impl PgAuditSink {
         Self { pool }
     }
 
-    /// INSERT a pre-resolved [`AuditLogRecord`], deduplicating on its primary key.
+    /// INSERT a pre-resolved [`AuditLogRecord`] under the verified tenant
+    /// `org_id`, via an RLS-scoped connection that stamps the row's `org_id`.
     ///
-    /// Returns `Ok(true)` when a new row was written and `Ok(false)` when the
-    /// `event_id` already existed (`ON CONFLICT (event_id) DO NOTHING` matched
-    /// zero rows). The async audit consumer uses the boolean to count duplicates
-    /// without a second round-trip.
-    pub async fn insert_audit_log(&self, record: &AuditLogRecord) -> Result<bool> {
+    /// `org_id` must be the verified tenant of the event (never client input).
+    /// Returns `Ok(true)` when a new row was written and `Ok(false)` on an
+    /// `event_id` conflict, matching [`Self::insert_audit_log`].
+    pub async fn insert_audit_log_for_tenant(&self, org_id: Uuid, record: &AuditLogRecord) -> Result<bool> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
         let result = sqlx::query(
-            "INSERT INTO audit_logs (event_id, agent_id, tool_name, decision, latency_ms, ts) \
-             VALUES ($1, $2, $3, $4, $5, $6) \
+            "INSERT INTO audit_logs (event_id, agent_id, tool_name, decision, latency_ms, ts, org_id) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7) \
              ON CONFLICT (event_id) DO NOTHING",
         )
         .bind(record.event_id)
@@ -70,10 +71,24 @@ impl PgAuditSink {
         .bind(&record.decision)
         .bind(record.latency_ms)
         .bind(record.ts)
-        .execute(self.pool.pool())
+        .bind(org_id)
+        .execute(&mut *tx)
         .await
         .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
         Ok(result.rows_affected() == 1)
+    }
+
+    /// INSERT a pre-resolved [`AuditLogRecord`], deduplicating on its primary key.
+    ///
+    /// Returns `Ok(true)` when a new row was written and `Ok(false)` when the
+    /// `event_id` already existed (`ON CONFLICT (event_id) DO NOTHING` matched
+    /// zero rows). The async audit consumer uses the boolean to count duplicates
+    /// without a second round-trip.
+    pub async fn insert_audit_log(&self, record: &AuditLogRecord) -> Result<bool> {
+        // Org-less insert scopes to the reserved system org (org_id defaults to
+        // it); tenant callers use `insert_audit_log_for_tenant`.
+        self.insert_audit_log_for_tenant(SYSTEM_ORG, record).await
     }
 
     /// Batch-INSERT audit rows in a single multi-row statement, deduplicating by
@@ -107,7 +122,11 @@ impl PgAuditSink {
         });
         builder.push(" ON CONFLICT (event_id) DO NOTHING");
 
-        let result = builder.build().execute(self.pool.pool()).await.map_err(backend_err)?;
+        // Org-less batch scopes to the reserved system org (org_id column
+        // defaults to it); rows are written under that tenant.
+        let mut tx = self.pool.begin_for_tenant(SYSTEM_ORG).await.map_err(backend_err)?;
+        let result = builder.build().execute(&mut *tx).await.map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
         Ok(result.rows_affected())
     }
 }
@@ -153,6 +172,11 @@ impl AuditSink for PgAuditSink {
         let ts = chrono::DateTime::from_timestamp((ns / 1_000_000_000) as i64, (ns % 1_000_000_000) as u32)
             .unwrap_or_default();
 
+        // The AuditSink trait carries no org; the event scopes to the reserved
+        // system org (org_id column defaults to it). Tenant-aware audit writes
+        // use `insert_audit_log_for_tenant`. Scoped through the system-org GUC so
+        // the write passes FORCE RLS.
+        let mut tx = self.pool.begin_for_tenant(SYSTEM_ORG).await.map_err(backend_err)?;
         sqlx::query(
             "INSERT INTO audit_logs (event_id, agent_id, tool_name, decision, latency_ms, ts) \
              VALUES ($1, $2, $3, $4, $5, $6) \
@@ -164,9 +188,10 @@ impl AuditSink for PgAuditSink {
         .bind(decision_label(event.event_type()))
         .bind(None::<i32>)
         .bind(ts)
-        .execute(self.pool.pool())
+        .execute(&mut *tx)
         .await
         .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
         Ok(())
     }
 }

--- a/aa-storage-postgres/src/credential_store.rs
+++ b/aa-storage-postgres/src/credential_store.rs
@@ -2,9 +2,10 @@
 
 use aa_storage::{CredentialStore, Result, StorageError};
 use async_trait::async_trait;
+use uuid::Uuid;
 
 use crate::pool::PostgresPool;
-use crate::support::backend_err;
+use crate::support::{backend_err, SYSTEM_ORG};
 
 /// Postgres-backed [`CredentialStore`]. Secrets are stored verbatim as opaque
 /// ciphertext in the `credentials.ciphertext` column; the driver never sees or
@@ -19,42 +20,68 @@ impl PgCredentialStore {
     pub fn new(pool: PostgresPool) -> Self {
         Self { pool }
     }
-}
 
-#[async_trait]
-impl CredentialStore for PgCredentialStore {
-    async fn get_secret(&self, key: &str) -> Result<Vec<u8>> {
+    /// Fetch a secret for `key` under the verified tenant `org_id`, via an
+    /// RLS-scoped connection. A key owned by another tenant is RLS-invisible and
+    /// reads as [`StorageError::NotFound`].
+    pub async fn get_secret_for_tenant(&self, org_id: Uuid, key: &str) -> Result<Vec<u8>> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
         let row: Option<(Vec<u8>,)> = sqlx::query_as("SELECT ciphertext FROM credentials WHERE key = $1")
             .bind(key)
-            .fetch_optional(self.pool.pool())
+            .fetch_optional(&mut *tx)
             .await
             .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
 
         let (ciphertext,) = row.ok_or_else(|| StorageError::NotFound(key.to_owned()))?;
         Ok(ciphertext)
     }
 
-    async fn put_secret(&self, key: &str, value: Vec<u8>) -> Result<()> {
+    /// Store a secret for `key` under the verified tenant `org_id`, stamping the
+    /// row with that tenant. The RLS `WITH CHECK` rejects any attempt to write a
+    /// row for a different tenant than the connection's GUC.
+    pub async fn put_secret_for_tenant(&self, org_id: Uuid, key: &str, value: Vec<u8>) -> Result<()> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
         sqlx::query(
-            "INSERT INTO credentials (key, ciphertext, updated_at) \
-             VALUES ($1, $2, now()) \
+            "INSERT INTO credentials (key, ciphertext, org_id, updated_at) \
+             VALUES ($1, $2, $3, now()) \
              ON CONFLICT (key) DO UPDATE SET ciphertext = EXCLUDED.ciphertext, updated_at = now()",
         )
         .bind(key)
         .bind(value)
-        .execute(self.pool.pool())
+        .bind(org_id)
+        .execute(&mut *tx)
         .await
         .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl CredentialStore for PgCredentialStore {
+    async fn get_secret(&self, key: &str) -> Result<Vec<u8>> {
+        // Org-less trait read scopes to the reserved system org; tenant callers
+        // use `get_secret_for_tenant`.
+        self.get_secret_for_tenant(SYSTEM_ORG, key).await
+    }
+
+    async fn put_secret(&self, key: &str, value: Vec<u8>) -> Result<()> {
+        // Org-less trait write scopes to the reserved system org; tenant callers
+        // use `put_secret_for_tenant`.
+        self.put_secret_for_tenant(SYSTEM_ORG, key, value).await
     }
 
     async fn delete_secret(&self, key: &str) -> Result<()> {
-        // Idempotent: deleting an absent key affects zero rows and still succeeds.
+        // Idempotent: deleting an absent (or RLS-invisible) key affects zero rows
+        // and still succeeds. Scoped to the reserved system org under FORCE RLS.
+        let mut tx = self.pool.begin_for_tenant(SYSTEM_ORG).await.map_err(backend_err)?;
         sqlx::query("DELETE FROM credentials WHERE key = $1")
             .bind(key)
-            .execute(self.pool.pool())
+            .execute(&mut *tx)
             .await
             .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
         Ok(())
     }
 }

--- a/aa-storage-postgres/src/lifecycle_store.rs
+++ b/aa-storage-postgres/src/lifecycle_store.rs
@@ -3,9 +3,10 @@
 use aa_storage::{AgentId, LifecycleStore, Result, StorageError};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use uuid::Uuid;
 
 use crate::pool::PostgresPool;
-use crate::support::{agent_id_to_text, backend_err};
+use crate::support::{agent_id_to_text, backend_err, SYSTEM_ORG};
 
 /// Postgres-backed [`LifecycleStore`]. Liveness is tracked in the `agents`
 /// table's `status` and `last_heartbeat` columns.
@@ -20,6 +21,28 @@ impl PgLifecycleStore {
         Self { pool }
     }
 
+    /// Register an agent under the verified tenant `org_id`, stamping its row
+    /// with that tenant so RLS confines it.
+    ///
+    /// `org_id` must be the verified caller's tenant (never client input). The
+    /// RLS `WITH CHECK` rejects an attempt to register an agent into a different
+    /// tenant than the connection's GUC.
+    pub async fn register_for_tenant(&self, org_id: Uuid, agent_id: &AgentId) -> Result<()> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
+        sqlx::query(
+            "INSERT INTO agents (id, org_id, status, registered_at, last_heartbeat) \
+             VALUES ($1, $2, 'registered', now(), now()) \
+             ON CONFLICT (id) DO UPDATE SET org_id = EXCLUDED.org_id, status = 'registered', last_heartbeat = now()",
+        )
+        .bind(agent_id_to_text(agent_id))
+        .bind(org_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
+        Ok(())
+    }
+
     /// Record a heartbeat "last seen" for a raw agent-id string without
     /// requiring the agent row to exist.
     ///
@@ -29,12 +52,14 @@ impl PgLifecycleStore {
     /// heartbeat must never fail the consumer's ack path. `ts` falls back to
     /// `now()` when the event carried no timestamp.
     pub async fn touch_last_heartbeat(&self, agent_id: &str, ts: Option<DateTime<Utc>>) -> Result<()> {
+        let mut tx = self.pool.begin_for_tenant(SYSTEM_ORG).await.map_err(backend_err)?;
         sqlx::query("UPDATE agents SET last_heartbeat = COALESCE($2, now()) WHERE id = $1")
             .bind(agent_id)
             .bind(ts)
-            .execute(self.pool.pool())
+            .execute(&mut *tx)
             .await
             .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
         Ok(())
     }
 }
@@ -42,26 +67,33 @@ impl PgLifecycleStore {
 #[async_trait]
 impl LifecycleStore for PgLifecycleStore {
     async fn register(&self, agent_id: &AgentId) -> Result<()> {
-        // Upsert so a re-registration overwrites a stale row's status/heartbeat.
+        // The org-less trait register carries no org context (org_id stays NULL,
+        // which the agents RLS policy COALESCEs to the system org); tenant
+        // callers use `register_for_tenant`. Scoped through the system-org GUC so
+        // the write passes FORCE RLS.
+        let mut tx = self.pool.begin_for_tenant(SYSTEM_ORG).await.map_err(backend_err)?;
         sqlx::query(
             "INSERT INTO agents (id, status, registered_at, last_heartbeat) \
              VALUES ($1, 'registered', now(), now()) \
              ON CONFLICT (id) DO UPDATE SET status = 'registered', last_heartbeat = now()",
         )
         .bind(agent_id_to_text(agent_id))
-        .execute(self.pool.pool())
+        .execute(&mut *tx)
         .await
         .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
         Ok(())
     }
 
     async fn heartbeat(&self, agent_id: &AgentId) -> Result<()> {
         let id = agent_id_to_text(agent_id);
+        let mut tx = self.pool.begin_for_tenant(SYSTEM_ORG).await.map_err(backend_err)?;
         let result = sqlx::query("UPDATE agents SET last_heartbeat = now() WHERE id = $1")
             .bind(&id)
-            .execute(self.pool.pool())
+            .execute(&mut *tx)
             .await
             .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
 
         if result.rows_affected() == 0 {
             return Err(StorageError::NotFound(id));
@@ -71,12 +103,14 @@ impl LifecycleStore for PgLifecycleStore {
 
     async fn deregister(&self, agent_id: &AgentId) -> Result<()> {
         // Idempotent: marking an absent agent offline affects zero rows and
-        // still succeeds.
+        // still succeeds. Scoped through the system-org GUC under FORCE RLS.
+        let mut tx = self.pool.begin_for_tenant(SYSTEM_ORG).await.map_err(backend_err)?;
         sqlx::query("UPDATE agents SET status = 'deregistered' WHERE id = $1")
             .bind(agent_id_to_text(agent_id))
-            .execute(self.pool.pool())
+            .execute(&mut *tx)
             .await
             .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
         Ok(())
     }
 }

--- a/aa-storage-postgres/src/policy_store.rs
+++ b/aa-storage-postgres/src/policy_store.rs
@@ -2,9 +2,10 @@
 
 use aa_storage::{AgentId, PolicyDocument, PolicyStore, Result, StorageError};
 use async_trait::async_trait;
+use uuid::Uuid;
 
 use crate::pool::PostgresPool;
-use crate::support::{agent_id_to_text, backend_err};
+use crate::support::{agent_id_to_text, backend_err, SYSTEM_ORG};
 
 /// Postgres-backed [`PolicyStore`]. Reads the highest-versioned policy row for
 /// an agent and deserializes its JSONB `body` into a [`PolicyDocument`].
@@ -18,23 +19,40 @@ impl PgPolicyStore {
     pub fn new(pool: PostgresPool) -> Self {
         Self { pool }
     }
-}
 
-#[async_trait]
-impl PolicyStore for PgPolicyStore {
-    async fn get_policy(&self, agent_id: &AgentId) -> Result<PolicyDocument> {
+    /// Read the highest-versioned policy for `agent_id` under the verified
+    /// tenant `org_id`, running through an RLS-scoped connection.
+    ///
+    /// `org_id` must be the verified caller's tenant (never client input). The
+    /// `tenant_isolation` policy already confines rows to `org_id`, so this is
+    /// the DB-backstopped read: even with the `WHERE org_id` predicate dropped,
+    /// RLS returns only this tenant's rows.
+    pub async fn get_policy_for_tenant(&self, org_id: Uuid, agent_id: &AgentId) -> Result<PolicyDocument> {
         let id = agent_id_to_text(agent_id);
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
         let row: Option<(serde_json::Value,)> = sqlx::query_as(
             "SELECT body FROM policies WHERE agent_id = $1 \
              ORDER BY policy_version DESC LIMIT 1",
         )
         .bind(&id)
-        .fetch_optional(self.pool.pool())
+        .fetch_optional(&mut *tx)
         .await
         .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
 
         let (body,) = row.ok_or(StorageError::NotFound(id))?;
         serde_json::from_value(body).map_err(|e| StorageError::Serialization(e.to_string()))
+    }
+}
+
+#[async_trait]
+impl PolicyStore for PgPolicyStore {
+    async fn get_policy(&self, agent_id: &AgentId) -> Result<PolicyDocument> {
+        // The org-less trait method scopes to the reserved system org; callers
+        // that carry a verified tenant use `get_policy_for_tenant`. Under FORCE
+        // RLS an unscoped read would see zero rows, so this routes through the
+        // system-org GUC rather than the bare pool.
+        self.get_policy_for_tenant(SYSTEM_ORG, agent_id).await
     }
 
     async fn invalidate(&self, _agent_id: &AgentId) -> Result<()> {

--- a/aa-storage-postgres/src/pool.rs
+++ b/aa-storage-postgres/src/pool.rs
@@ -2,8 +2,10 @@
 //! embedded migrations.
 
 use sqlx::migrate::Migrator;
+use sqlx::pool::PoolConnection;
 use sqlx::postgres::PgPoolOptions;
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, Transaction};
+use uuid::Uuid;
 
 use crate::config::PostgresPoolConfig;
 
@@ -52,9 +54,55 @@ impl PostgresPool {
         &self.pool
     }
 
+    /// Acquire a connection bound to `org_id` for the duration of a transaction,
+    /// returning that open transaction.
+    ///
+    /// The tenant is bound by `SET LOCAL app.tenant_id` (via `set_config(…, true)`),
+    /// which the `tenant_isolation` RLS policy (migration 0007) reads to confine
+    /// every row to this tenant. `is_local = true` ties the GUC to *this*
+    /// transaction, so when the connection returns to the pool the setting is
+    /// rolled back and cannot bleed into the next tenant's checkout — the
+    /// connection-pool cross-tenant leak vector RLS designs must guard against.
+    ///
+    /// `org_id` MUST be the verified caller's tenant (the JWT `org_id` claim via
+    /// [`crate`]'s gateway seam), never a client-supplied value. Run the store
+    /// query through the returned transaction and commit it; on drop without
+    /// commit the work — and the GUC — are discarded.
+    pub async fn begin_for_tenant(&self, org_id: Uuid) -> Result<Transaction<'static, Postgres>, sqlx::Error> {
+        // `pool.begin()` returns a transaction that owns its pooled connection for
+        // its lifetime, so the GUC and the checkout share a scope.
+        let mut tx = self.pool.begin().await?;
+        set_tenant_guc(&mut tx, org_id).await?;
+        Ok(tx)
+    }
+
+    /// Acquire a raw pooled connection with no tenant GUC set.
+    ///
+    /// Under FORCE RLS a connection with no `app.tenant_id` sees zero tenant rows
+    /// (fail-closed). Used only by privileged/admin paths that intentionally run
+    /// without a tenant scope.
+    pub async fn acquire(&self) -> Result<PoolConnection<Postgres>, sqlx::Error> {
+        self.pool.acquire().await
+    }
+
     /// Apply every embedded migration. Idempotent: already-applied migrations
     /// are skipped, so it is safe to call on every startup.
     pub async fn migrate(&self) -> Result<(), sqlx::migrate::MigrateError> {
         MIGRATOR.run(&self.pool).await
     }
+}
+
+/// Bind the open transaction to `org_id` via the transaction-local
+/// `app.tenant_id` GUC the `tenant_isolation` RLS policy filters on.
+///
+/// `set_config(name, value, is_local = true)` scopes the setting to the
+/// surrounding transaction, so it never survives the connection's return to the
+/// pool. The UUID is rendered to its canonical string and re-parsed by the
+/// policy's `::uuid` cast.
+async fn set_tenant_guc(tx: &mut Transaction<'static, Postgres>, org_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query("SELECT set_config('app.tenant_id', $1, true)")
+        .bind(org_id.to_string())
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
 }

--- a/aa-storage-postgres/src/support.rs
+++ b/aa-storage-postgres/src/support.rs
@@ -1,6 +1,15 @@
 //! Shared helpers for the trait implementations: id encoding and error mapping.
 
 use aa_storage::{AgentId, StorageError};
+use uuid::Uuid;
+
+/// The reserved system org (all-zeroes UUID) used for rows with no verified
+/// tenant: legacy data and the non-tenant-aware trait-impl paths.
+///
+/// Under FORCE RLS every write needs a matching `app.tenant_id`, so the legacy
+/// trait impls scope themselves to this reserved tenant. No real customer is
+/// ever assigned it, so its rows stay isolated from every tenant scope.
+pub const SYSTEM_ORG: Uuid = Uuid::nil();
 
 /// Encode an [`AgentId`] for a `TEXT` agent-id column as its canonical
 /// hyphenated UUID string (the same encoding the gateway driver uses).

--- a/aa-storage-postgres/tests/conformance_pg.rs
+++ b/aa-storage-postgres/tests/conformance_pg.rs
@@ -129,13 +129,22 @@ async fn policy_store_satisfies_conformance() {
     };
     let body = serde_json::to_value(&doc).expect("serialize policy");
     let agent_text = uuid::Uuid::from_bytes(*present.as_bytes()).to_string();
+    // Under FORCE RLS (0007) a bare-pool insert with no app.tenant_id is denied,
+    // so seed the policy under the reserved system org the trait-impl read path
+    // (PgPolicyStore::get_policy) scopes to. The org_id column defaults to the
+    // system org, so this matches the GUC the read uses.
+    let mut tx = pool
+        .begin_for_tenant(uuid::Uuid::nil())
+        .await
+        .expect("begin system-org tx");
     sqlx::query("INSERT INTO policies (agent_id, policy_version, body) VALUES ($1, $2, $3)")
         .bind(&agent_text)
         .bind(1_i64)
         .bind(body)
-        .execute(pool.pool())
+        .execute(&mut *tx)
         .await
         .expect("seed policy row");
+    tx.commit().await.expect("commit seed");
 
     let store = PgPolicyStore::new(pool.clone());
     // Coerces to `&dyn PolicyStore`, exercising object-safety too.

--- a/aa-storage-postgres/tests/rls_isolation_pg.rs
+++ b/aa-storage-postgres/tests/rls_isolation_pg.rs
@@ -1,0 +1,172 @@
+//! RLS regression suite (AAASM-3598) — the executable contract for AAASM-3564.
+//!
+//! Proves the DB backstop holds even when the application layer misbehaves:
+//!   1. A raw query with the app-layer tenant predicate REMOVED still returns
+//!      zero of another tenant's rows (RLS filters them).
+//!   2. A connection with no `app.tenant_id` set returns zero rows (fail-closed).
+//!   3. A pooled connection reused across tenants carries no stale GUC
+//!      (`set_config(..., is_local = true)` correctness).
+//!   4. A client-supplied org differing from the GUC cannot widen results.
+//!
+//! Each case runs against a real Postgres via `testcontainers-modules`, mirroring
+//! `conformance_pg.rs`. Requires a working Docker daemon.
+
+use aa_storage_postgres::{PostgresPool, PostgresPoolConfig};
+use sqlx::Row;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
+use uuid::Uuid;
+
+const TENANT_A: Uuid = Uuid::from_u128(0x0a);
+const TENANT_B: Uuid = Uuid::from_u128(0x0b);
+
+/// Start a fresh Postgres 18 container, connect a pool, and run migrations.
+async fn setup_pg() -> (ContainerAsync<Postgres>, PostgresPool) {
+    let container = Postgres::default()
+        .with_db_name("aasm")
+        .with_user("aasm")
+        .with_password("secret")
+        .with_tag("18-alpine")
+        .start()
+        .await
+        .expect("start postgres testcontainer (is Docker running?)");
+
+    let host = container.get_host().await.expect("container host");
+    let port = container.get_host_port_ipv4(5432).await.expect("container port");
+    let url = format!("postgres://aasm:secret@{host}:{port}/aasm");
+
+    let pool = PostgresPool::connect(&PostgresPoolConfig {
+        url,
+        // A single connection makes the pooled-reuse test deterministic: the
+        // second checkout is guaranteed to be the same physical connection.
+        max_connections: 1,
+        statement_timeout_ms: 0,
+    })
+    .await
+    .expect("connect pool");
+    pool.migrate().await.expect("run migrations");
+
+    (container, pool)
+}
+
+/// Seed one org row plus one audit_logs row stamped with that org, under a
+/// tenant-scoped transaction so the RLS WITH CHECK admits the write.
+async fn seed_tenant_audit(pool: &PostgresPool, org: Uuid, agent: &str) {
+    // The org FK lives only on policies/credentials, not audit_logs, but seed the
+    // org so any future FK-bearing seed reuses the same helper. Insert it under a
+    // bypass path: orgs has no RLS, so the bare pool can write it.
+    sqlx::query("INSERT INTO orgs (id, name) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING")
+        .bind(org)
+        .bind(format!("tenant-{org}"))
+        .execute(pool.pool())
+        .await
+        .expect("seed org");
+
+    let mut tx = pool.begin_for_tenant(org).await.expect("begin tenant tx");
+    sqlx::query(
+        "INSERT INTO audit_logs (event_id, agent_id, tool_name, decision, ts, org_id) \
+         VALUES ($1, $2, 'fs.read', 'allow', now(), $3)",
+    )
+    .bind(Uuid::new_v4())
+    .bind(agent)
+    .bind(org)
+    .execute(&mut *tx)
+    .await
+    .expect("seed audit row");
+    tx.commit().await.expect("commit seed");
+}
+
+/// AC#1: a query with NO tenant predicate, run under tenant A's GUC, returns
+/// only A's rows — RLS filters B's even though the app forgot the WHERE.
+#[tokio::test]
+async fn dropped_filter_still_excludes_other_tenant_rows() {
+    let (_pg, pool) = setup_pg().await;
+    seed_tenant_audit(&pool, TENANT_A, "agent-a").await;
+    seed_tenant_audit(&pool, TENANT_B, "agent-b").await;
+
+    let mut tx = pool.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
+    // Deliberately NO `WHERE org_id = …` — the app-layer filter is dropped.
+    let rows = sqlx::query("SELECT org_id, agent_id FROM audit_logs")
+        .fetch_all(&mut *tx)
+        .await
+        .expect("select without predicate");
+    tx.commit().await.expect("commit");
+
+    assert_eq!(rows.len(), 1, "RLS must hide tenant B's rows even with no predicate");
+    let org: Uuid = rows[0].get("org_id");
+    assert_eq!(org, TENANT_A, "the only visible row must belong to tenant A");
+}
+
+/// AC#1 (fail-closed): a connection with no `app.tenant_id` set sees zero rows
+/// from every tenant table — an unset tenant denies all, never dumps all.
+#[tokio::test]
+async fn unset_guc_returns_zero_rows() {
+    let (_pg, pool) = setup_pg().await;
+    seed_tenant_audit(&pool, TENANT_A, "agent-a").await;
+    seed_tenant_audit(&pool, TENANT_B, "agent-b").await;
+
+    // The bare pool sets no app.tenant_id; FORCE RLS + missing_ok current_setting
+    // makes the policy predicate NULL → no row matches.
+    for table in ["audit_logs", "agents", "policies", "credentials"] {
+        let count: i64 = sqlx::query_scalar(&format!("SELECT COUNT(*) FROM {table}"))
+            .fetch_one(pool.pool())
+            .await
+            .unwrap_or_else(|e| panic!("count {table}: {e}"));
+        assert_eq!(count, 0, "unset app.tenant_id must see zero rows from {table}");
+    }
+}
+
+/// AC#3 of the test plan: reusing a pooled connection across tenants must not
+/// carry tenant A's GUC into tenant B's checkout. With max_connections = 1 the
+/// second `begin_for_tenant` reuses the same physical connection, so a leak of
+/// `is_local = false` semantics would show A's row under B's scope.
+#[tokio::test]
+async fn pooled_connection_reuse_does_not_bleed_guc() {
+    let (_pg, pool) = setup_pg().await;
+    seed_tenant_audit(&pool, TENANT_A, "agent-a").await;
+    seed_tenant_audit(&pool, TENANT_B, "agent-b").await;
+
+    // First checkout: tenant A, then return the connection to the pool.
+    {
+        let mut tx = pool.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
+        let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_logs")
+            .fetch_one(&mut *tx)
+            .await
+            .expect("count under A");
+        assert_eq!(n, 1, "A sees exactly its own row");
+        tx.commit().await.expect("commit A");
+    }
+
+    // Second checkout: same physical connection, tenant B. It must see only B's
+    // row — never A's leftover GUC — and the count must be B's, not A's+B's.
+    let mut tx = pool.begin_for_tenant(TENANT_B).await.expect("tenant B tx");
+    let rows = sqlx::query("SELECT org_id FROM audit_logs")
+        .fetch_all(&mut *tx)
+        .await
+        .expect("count under B");
+    tx.commit().await.expect("commit B");
+    assert_eq!(rows.len(), 1, "B must see exactly one row (no GUC bleed from A)");
+    let org: Uuid = rows[0].get("org_id");
+    assert_eq!(org, TENANT_B, "the visible row must belong to tenant B, not A");
+}
+
+/// AC#2: a "spoof" — a query that hard-codes another tenant's id in its WHERE —
+/// cannot widen results past the connection's GUC. Tenant A asks for B's rows by
+/// id; RLS still returns nothing because the row is invisible under A's scope.
+#[tokio::test]
+async fn client_supplied_org_cannot_widen_past_guc() {
+    let (_pg, pool) = setup_pg().await;
+    seed_tenant_audit(&pool, TENANT_A, "agent-a").await;
+    seed_tenant_audit(&pool, TENANT_B, "agent-b").await;
+
+    let mut tx = pool.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
+    // Tenant A explicitly asks for tenant B's rows (the spoof attempt).
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_logs WHERE org_id = $1")
+        .bind(TENANT_B)
+        .fetch_one(&mut *tx)
+        .await
+        .expect("spoof query");
+    tx.commit().await.expect("commit");
+    assert_eq!(count, 0, "a client-chosen org cannot reach past the connection's GUC");
+}

--- a/aa-storage-postgres/tests/rls_isolation_pg.rs
+++ b/aa-storage-postgres/tests/rls_isolation_pg.rs
@@ -3,13 +3,18 @@
 //! Proves the DB backstop holds even when the application layer misbehaves:
 //!   1. A raw query with the app-layer tenant predicate REMOVED still returns
 //!      zero of another tenant's rows (RLS filters them).
-//!   2. A connection with no `app.tenant_id` set returns zero rows (fail-closed).
+//!   2. A connection with no `app.tenant_id` set returns zero rows (fail-closed),
+//!      and an empty-string GUC residue is treated the same (NULLIF guard).
 //!   3. A pooled connection reused across tenants carries no stale GUC
 //!      (`set_config(..., is_local = true)` correctness).
 //!   4. A client-supplied org differing from the GUC cannot widen results.
 //!
-//! Each case runs against a real Postgres via `testcontainers-modules`, mirroring
-//! `conformance_pg.rs`. Requires a working Docker daemon.
+//! Critical harness note: the container's bootstrap superuser BYPASSES RLS
+//! (FORCE RLS binds the table *owner*, never a superuser). So the migrations are
+//! applied as the superuser, but the RLS assertions run through a second pool
+//! connected as a restricted, non-superuser, RLS-bound `app_user` role — exactly
+//! the role split the production deployment uses (privileged migrator vs.
+//! unprivileged row-access). Requires a working Docker daemon.
 
 use aa_storage_postgres::{PostgresPool, PostgresPoolConfig};
 use sqlx::Row;
@@ -21,8 +26,10 @@ use uuid::Uuid;
 const TENANT_A: Uuid = Uuid::from_u128(0x0a);
 const TENANT_B: Uuid = Uuid::from_u128(0x0b);
 
-/// Start a fresh Postgres 18 container, connect a pool, and run migrations.
-async fn setup_pg() -> (ContainerAsync<Postgres>, PostgresPool) {
+/// Start a fresh Postgres 18 container. Returns the container guard, the
+/// superuser pool (migrations + seeding, bypasses RLS), and an `app_user` pool
+/// (restricted, RLS-bound — the pool every assertion reads through).
+async fn setup_pg() -> (ContainerAsync<Postgres>, PostgresPool, PostgresPool) {
     let container = Postgres::default()
         .with_db_name("aasm")
         .with_user("aasm")
@@ -34,58 +41,79 @@ async fn setup_pg() -> (ContainerAsync<Postgres>, PostgresPool) {
 
     let host = container.get_host().await.expect("container host");
     let port = container.get_host_port_ipv4(5432).await.expect("container port");
-    let url = format!("postgres://aasm:secret@{host}:{port}/aasm");
 
-    let pool = PostgresPool::connect(&PostgresPoolConfig {
-        url,
-        // A single connection makes the pooled-reuse test deterministic: the
-        // second checkout is guaranteed to be the same physical connection.
+    // Superuser pool: applies migrations and seeds rows (RLS does not bind it).
+    let admin_url = format!("postgres://aasm:secret@{host}:{port}/aasm");
+    let admin = PostgresPool::connect(&PostgresPoolConfig {
+        url: admin_url,
+        max_connections: 5,
+        statement_timeout_ms: 0,
+    })
+    .await
+    .expect("connect admin pool");
+    admin.migrate().await.expect("run migrations");
+
+    // Create the restricted row-access role and grant it table DML.
+    for stmt in [
+        "CREATE ROLE app_user LOGIN PASSWORD 'app'",
+        "GRANT USAGE ON SCHEMA public TO app_user",
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user",
+    ] {
+        sqlx::query(stmt)
+            .execute(admin.pool())
+            .await
+            .unwrap_or_else(|e| panic!("grant setup `{stmt}`: {e}"));
+    }
+
+    // app_user pool: non-superuser, so FORCE RLS applies — every assertion below
+    // runs through this pool, the way the runtime row-access role would.
+    let app_url = format!("postgres://app_user:app@{host}:{port}/aasm");
+    let app = PostgresPool::connect(&PostgresPoolConfig {
+        url: app_url,
+        // One connection makes the pooled-reuse test deterministic.
         max_connections: 1,
         statement_timeout_ms: 0,
     })
     .await
-    .expect("connect pool");
-    pool.migrate().await.expect("run migrations");
+    .expect("connect app_user pool");
 
-    (container, pool)
+    (container, admin, app)
 }
 
-/// Seed one org row plus one audit_logs row stamped with that org, under a
-/// tenant-scoped transaction so the RLS WITH CHECK admits the write.
-async fn seed_tenant_audit(pool: &PostgresPool, org: Uuid, agent: &str) {
-    // The org FK lives only on policies/credentials, not audit_logs, but seed the
-    // org so any future FK-bearing seed reuses the same helper. Insert it under a
-    // bypass path: orgs has no RLS, so the bare pool can write it.
+/// Seed an org + one audit row stamped with that org, AS the superuser (bypasses
+/// RLS, so the cross-tenant seed needs no per-row GUC dance).
+async fn seed_tenant_audit(admin: &PostgresPool, org: Uuid, agent: &str, event_id: Uuid) {
     sqlx::query("INSERT INTO orgs (id, name) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING")
         .bind(org)
         .bind(format!("tenant-{org}"))
-        .execute(pool.pool())
+        .execute(admin.pool())
         .await
         .expect("seed org");
-
-    let mut tx = pool.begin_for_tenant(org).await.expect("begin tenant tx");
     sqlx::query(
         "INSERT INTO audit_logs (event_id, agent_id, tool_name, decision, ts, org_id) \
          VALUES ($1, $2, 'fs.read', 'allow', now(), $3)",
     )
-    .bind(Uuid::new_v4())
+    .bind(event_id)
     .bind(agent)
     .bind(org)
-    .execute(&mut *tx)
+    .execute(admin.pool())
     .await
     .expect("seed audit row");
-    tx.commit().await.expect("commit seed");
+}
+
+async fn seed_two_tenants(admin: &PostgresPool) {
+    seed_tenant_audit(admin, TENANT_A, "agent-a", Uuid::from_u128(0xa1)).await;
+    seed_tenant_audit(admin, TENANT_B, "agent-b", Uuid::from_u128(0xb1)).await;
 }
 
 /// AC#1: a query with NO tenant predicate, run under tenant A's GUC, returns
 /// only A's rows — RLS filters B's even though the app forgot the WHERE.
 #[tokio::test]
 async fn dropped_filter_still_excludes_other_tenant_rows() {
-    let (_pg, pool) = setup_pg().await;
-    seed_tenant_audit(&pool, TENANT_A, "agent-a").await;
-    seed_tenant_audit(&pool, TENANT_B, "agent-b").await;
+    let (_pg, admin, app) = setup_pg().await;
+    seed_two_tenants(&admin).await;
 
-    let mut tx = pool.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
+    let mut tx = app.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
     // Deliberately NO `WHERE org_id = …` — the app-layer filter is dropped.
     let rows = sqlx::query("SELECT org_id, agent_id FROM audit_logs")
         .fetch_all(&mut *tx)
@@ -98,38 +126,48 @@ async fn dropped_filter_still_excludes_other_tenant_rows() {
     assert_eq!(org, TENANT_A, "the only visible row must belong to tenant A");
 }
 
-/// AC#1 (fail-closed): a connection with no `app.tenant_id` set sees zero rows
-/// from every tenant table — an unset tenant denies all, never dumps all.
+/// AC#1 (fail-closed): the restricted role with no `app.tenant_id` set sees zero
+/// rows; an empty-string GUC residue is treated identically (NULLIF guard).
 #[tokio::test]
-async fn unset_guc_returns_zero_rows() {
-    let (_pg, pool) = setup_pg().await;
-    seed_tenant_audit(&pool, TENANT_A, "agent-a").await;
-    seed_tenant_audit(&pool, TENANT_B, "agent-b").await;
+async fn unset_or_empty_guc_returns_zero_rows() {
+    let (_pg, admin, app) = setup_pg().await;
+    seed_two_tenants(&admin).await;
 
-    // The bare pool sets no app.tenant_id; FORCE RLS + missing_ok current_setting
-    // makes the policy predicate NULL → no row matches.
+    // Never-set GUC, via the bare app_user pool.
     for table in ["audit_logs", "agents", "policies", "credentials"] {
         let count: i64 = sqlx::query_scalar(&format!("SELECT COUNT(*) FROM {table}"))
-            .fetch_one(pool.pool())
+            .fetch_one(app.pool())
             .await
             .unwrap_or_else(|e| panic!("count {table}: {e}"));
         assert_eq!(count, 0, "unset app.tenant_id must see zero rows from {table}");
     }
+
+    // Empty-string GUC must also deny (the NULLIF(…, '') guard), not error on
+    // the `::uuid` cast.
+    let mut tx = app.pool().begin().await.expect("begin");
+    sqlx::query("SELECT set_config('app.tenant_id', '', true)")
+        .execute(&mut *tx)
+        .await
+        .expect("set empty guc");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_logs")
+        .fetch_one(&mut *tx)
+        .await
+        .expect("count under empty guc");
+    tx.commit().await.expect("commit");
+    assert_eq!(count, 0, "empty-string app.tenant_id must see zero rows (fail-closed)");
 }
 
-/// AC#3 of the test plan: reusing a pooled connection across tenants must not
-/// carry tenant A's GUC into tenant B's checkout. With max_connections = 1 the
-/// second `begin_for_tenant` reuses the same physical connection, so a leak of
-/// `is_local = false` semantics would show A's row under B's scope.
+/// Reusing a pooled connection across tenants must not carry tenant A's GUC into
+/// tenant B's checkout. With max_connections = 1 the second `begin_for_tenant`
+/// reuses the same physical connection, so an `is_local = false` leak would show
+/// A's row under B's scope.
 #[tokio::test]
 async fn pooled_connection_reuse_does_not_bleed_guc() {
-    let (_pg, pool) = setup_pg().await;
-    seed_tenant_audit(&pool, TENANT_A, "agent-a").await;
-    seed_tenant_audit(&pool, TENANT_B, "agent-b").await;
+    let (_pg, admin, app) = setup_pg().await;
+    seed_two_tenants(&admin).await;
 
-    // First checkout: tenant A, then return the connection to the pool.
     {
-        let mut tx = pool.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
+        let mut tx = app.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
         let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_logs")
             .fetch_one(&mut *tx)
             .await
@@ -138,9 +176,7 @@ async fn pooled_connection_reuse_does_not_bleed_guc() {
         tx.commit().await.expect("commit A");
     }
 
-    // Second checkout: same physical connection, tenant B. It must see only B's
-    // row — never A's leftover GUC — and the count must be B's, not A's+B's.
-    let mut tx = pool.begin_for_tenant(TENANT_B).await.expect("tenant B tx");
+    let mut tx = app.begin_for_tenant(TENANT_B).await.expect("tenant B tx");
     let rows = sqlx::query("SELECT org_id FROM audit_logs")
         .fetch_all(&mut *tx)
         .await
@@ -156,12 +192,10 @@ async fn pooled_connection_reuse_does_not_bleed_guc() {
 /// id; RLS still returns nothing because the row is invisible under A's scope.
 #[tokio::test]
 async fn client_supplied_org_cannot_widen_past_guc() {
-    let (_pg, pool) = setup_pg().await;
-    seed_tenant_audit(&pool, TENANT_A, "agent-a").await;
-    seed_tenant_audit(&pool, TENANT_B, "agent-b").await;
+    let (_pg, admin, app) = setup_pg().await;
+    seed_two_tenants(&admin).await;
 
-    let mut tx = pool.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
-    // Tenant A explicitly asks for tenant B's rows (the spoof attempt).
+    let mut tx = app.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_logs WHERE org_id = $1")
         .bind(TENANT_B)
         .fetch_one(&mut *tx)
@@ -169,4 +203,35 @@ async fn client_supplied_org_cannot_widen_past_guc() {
         .expect("spoof query");
     tx.commit().await.expect("commit");
     assert_eq!(count, 0, "a client-chosen org cannot reach past the connection's GUC");
+}
+
+/// The RLS WITH CHECK rejects a write that would stamp a row with a tenant other
+/// than the connection's GUC — a forged-tenant INSERT cannot land.
+#[tokio::test]
+async fn write_with_mismatched_tenant_is_rejected() {
+    let (_pg, _admin, app) = setup_pg().await;
+
+    // orgs carries no RLS, so the app_user pool can seed tenant B's org row
+    // directly to satisfy any FK; audit_logs itself has no FK to orgs but this
+    // keeps the fixture honest for the cross-tenant write attempt.
+    sqlx::query("INSERT INTO orgs (id, name) VALUES ($1, 'B') ON CONFLICT (id) DO NOTHING")
+        .bind(TENANT_B)
+        .execute(app.pool())
+        .await
+        .expect("seed org B");
+
+    // Under tenant A's GUC, try to write a row tagged for tenant B.
+    let mut tx = app.begin_for_tenant(TENANT_A).await.expect("tenant A tx");
+    let result = sqlx::query(
+        "INSERT INTO audit_logs (event_id, agent_id, tool_name, decision, ts, org_id) \
+         VALUES ($1, 'x', 'y', 'allow', now(), $2)",
+    )
+    .bind(Uuid::from_u128(0xc1))
+    .bind(TENANT_B)
+    .execute(&mut *tx)
+    .await;
+    assert!(
+        result.is_err(),
+        "WITH CHECK must reject inserting a row for a tenant other than the GUC"
+    );
 }

--- a/verification-reports/AAASM-3600.md
+++ b/verification-reports/AAASM-3600.md
@@ -1,0 +1,105 @@
+# AAASM-3600 — Verify DB-enforced RLS + per-tenant isolation
+
+**Story:** AAASM-3564 — DB-enforced Postgres RLS + per-tenant runtime/memory isolation
+**Date:** 2026-06-23
+**Verifier:** dev (local, real Postgres 18 + TimescaleDB pg16 via testcontainers)
+
+This report records evidence that the three acceptance criteria of AAASM-3564
+hold across `agent-assembly` (`aa-storage-postgres`, `aa-api`) and
+`agent-assembly-cloud` (`aa-cloud-persistence`, `aa-cloud-control-plane`).
+
+## AC#1 — An intentionally-removed app-layer filter cannot leak cross-tenant rows
+
+**Mechanism:** FORCE ROW LEVEL SECURITY + a `tenant_isolation` policy on every
+tenant table, keyed on `app.tenant_id` set per connection (migrations
+`aa-storage-postgres/migrations/0006_tenant_columns.sql`,
+`0007_enable_rls.sql`; cloud `aa-cloud-persistence/migrations/0013_audit_logs_rls.sql`).
+
+**Evidence — agent-assembly** (`cargo nextest run -p aa-storage-postgres`):
+- `rls_isolation_pg::dropped_filter_still_excludes_other_tenant_rows` — a
+  `SELECT … FROM audit_logs` with NO `WHERE org_id` predicate, under tenant A's
+  GUC, returns exactly 1 row (A's), not 2. PASS.
+- `rls_isolation_pg::unset_or_empty_guc_returns_zero_rows` — a connection with no
+  `app.tenant_id`, and one with an empty-string GUC, both return 0 rows from
+  every tenant table (fail-closed via `NULLIF(current_setting(…, true), '')`). PASS.
+- `rls_isolation_pg::pooled_connection_reuse_does_not_bleed_guc` — with
+  `max_connections = 1`, a tenant-B checkout reusing tenant A's physical
+  connection sees only B's row (`set_config(..., is_local = true)`). PASS.
+- `rls_isolation_pg::write_with_mismatched_tenant_is_rejected` — a cross-tenant
+  INSERT under the wrong GUC is rejected by the policy `WITH CHECK`. PASS.
+
+Full suite result: **15 tests run, 15 passed** (10 conformance + 5 RLS; legacy
+trait paths unaffected — they route through the reserved system org).
+
+**Evidence — cloud** (`cargo nextest run -p aa-cloud-persistence`):
+- `rls_isolation::{dropped_filter_still_excludes_other_tenant_rows,
+  unset_or_empty_guc_returns_zero_rows, pooled_connection_reuse_does_not_bleed_guc,
+  client_supplied_tenant_cannot_widen_past_guc}` — all PASS on real TimescaleDB.
+- `migrations::retention_policy_is_registered_and_compression_is_traded_for_rls`
+  — confirms FORCE RLS is on `audit_logs` and the retention policy is kept. PASS.
+
+Full suite result: **78 tests run, 78 passed**.
+
+**Harness note (important):** RLS does not bind a PostgreSQL superuser, and the
+testcontainer bootstrap user IS a superuser. The RLS assertions therefore run
+through a second pool connected as a restricted, non-superuser `app_user` role —
+the same migrator-vs-row-access role split the production deployment uses (and
+which migrations `0007` / `0013` document as an operational requirement).
+
+## AC#2 — tenant_id cannot be spoofed by the client (set only from the verified JWT)
+
+**Mechanism:** the value feeding the storage `app.tenant_id` GUC comes only from
+the verified identity. In `aa-api`, `AuthenticatedCaller::storage_tenant_org()`
+reads only `caller.tenant.org_id` (verified JWT claim / API-key entry), never a
+request `Query`/header/body. In cloud, `Tenanted<T>` is only constructible from a
+verified-mTLS `AuthenticatedTenant`.
+
+**Evidence:**
+- `aa-api auth::tenant_guard_tests::{storage_tenant_org_is_the_verified_org,
+  client_supplied_org_cannot_redirect_storage_scope,
+  no_tenant_scope_yields_none_not_a_client_value}` — 3 tests run, 3 passed: a
+  client-chosen org cannot become the storage tenant; no scope yields `None`
+  (fail-closed), never a synthesized client value.
+- DB-level corroboration:
+  `rls_isolation_pg::client_supplied_org_cannot_widen_past_guc` (agent-assembly)
+  and `rls_isolation::client_supplied_tenant_cannot_widen_past_guc` (cloud) — a
+  query hard-coding another tenant's id in its WHERE still returns 0 rows under
+  the connection's GUC. PASS.
+
+## AC#3 — High-tier tenants get OS-process-level memory isolation
+
+**Mechanism:** the isolation-tier design (`agent-assembly-cloud/docs/architecture/
+isolation-tiers.md`) defines the high tier as a dedicated `aa-runtime` OS process
+per tenant (no shared address space → no residual-memory/cache side-channel) plus
+a per-tenant Postgres schema; the standard tier is shared runtime + shared schema
++ RLS. The tier is a selectable property: `IsolationTier{Standard,High}` in
+`aa-cloud-control-plane`, with `IsolationTier::High.has_process_isolation() == true`.
+
+**Evidence:**
+- `aa-cloud-control-plane isolation::tests::*` + `config::tests::default_isolation_tier_is_standard`
+  — 6 + relevant config tests pass: default is `Standard`, only `High` reports
+  process isolation, parsing round-trips, the control-plane `Config` carries a
+  `default_isolation_tier`.
+- ADR merged in the cloud PR describing both tiers, tradeoffs, and assignment.
+
+> Scope note: this Story delivers the design + config surface for the high tier
+> (AC#3 as specified by subtask AAASM-3599 — "design + config only, no runtime
+> orchestration"). The orchestration that physically spins up a dedicated
+> process/schema per high-tier tenant is explicitly out of scope here.
+
+## Discovered constraints (handled, not deferred)
+
+1. **Superuser bypasses RLS** — tests connect as a restricted role (above).
+2. **TimescaleDB: RLS ⊥ columnstore** — on pg16, enabling RLS on a hypertable
+   with columnstore, or re-enabling columnstore on an RLS table, both error
+   (`0A000`). The Story makes RLS the required control, so cloud migration `0013`
+   removes the `0012` compression setting + policy and keeps the retention
+   policy. Recorded in the migration header and the migrations test.
+3. **Empty-string GUC** — a pooled-connection GUC residue can be `''`, which
+   errors on `::uuid`. All policies use `NULLIF(current_setting(…, true), '')`
+   so empty is treated as NULL (fail-closed), verified by the unset/empty test.
+
+## Conclusion
+
+All three acceptance criteria are verified with passing tests on real
+Postgres/TimescaleDB. No gaps requiring new bug subtasks were found.


### PR DESCRIPTION
## Description

DB-enforced multi-tenant isolation for `aa-storage-postgres` (Story AAASM-3564). PostgreSQL Row-Level Security is the backstop below the ORM, so a forgotten app-layer `WHERE org_id` cannot leak cross-tenant rows.

- **0006** adds a non-null `org_id` tenant column to `policies`, `audit_logs`, `credentials` (backfilled from the owning agent's org; reserved system org for unassignable legacy rows; tenant-prefixed indexes).
- **0007** `ENABLE`+`FORCE ROW LEVEL SECURITY` + a `tenant_isolation` policy on every tenant table, keyed on `app.tenant_id`. `NULLIF(current_setting('app.tenant_id', true), '')::uuid` makes both an unset and an empty-string GUC deny all rows (fail-closed).
- **pool seam** `PostgresPool::begin_for_tenant(org_id)` sets the GUC transaction-locally (`is_local = true` → no pooled-connection bleed) and `*_for_tenant` store methods thread the verified org. Legacy org-less trait impls route through the reserved system org so they pass FORCE RLS.
- **anti-spoof** `AuthenticatedCaller::storage_tenant_org()` (aa-api) is the only source for the storage GUC — verified JWT org only, never client `Query`/header/body.

## Type of Change

- [x] ✨ New feature (security control)
- [x] 🔧 Configuration / CI change (migrations)

## Breaking Changes

- [x] No — existing storage trait contract unchanged; legacy paths scope to a reserved system org.

## Related Issues

- Related Jira ticket: AAASM-3564 (subtasks AAASM-3593/3594/3595/3596/3598/3600)

## Testing

- [x] Integration tests added — `aa-storage-postgres/tests/rls_isolation_pg.rs` (5 cases: dropped-filter, unset/empty GUC, pooled-reuse no-bleed, spoof WHERE, mismatched-tenant write) + 3 anti-spoof unit tests in `aa-api`.
- [x] `cargo nextest run -p aa-storage-postgres` → **15 passed** (10 conformance + 5 RLS) on real Postgres 18. `aa-api auth::tenant_guard_tests` → 3 passed.

Note: the RLS assertions run through a restricted non-superuser role because a Postgres superuser bypasses RLS — this mirrors the production migrator-vs-row-access role split that migration 0007 documents.

## Checklist

- [x] `cargo fmt` / `cargo clippy` clean (only pre-existing Cargo.toml warnings)
- [x] Self-review of the diff completed
- [x] Documentation updated (migration headers document the role split + fail-closed design)
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3593, AAASM-3594, AAASM-3595, AAASM-3596, AAASM-3598

🤖 Generated with [Claude Code](https://claude.com/claude-code)
