### PR TITLE
[AAASM-3570] 🔒 (aa-sdk-client): SDK credential/token hygiene & log-leak prevention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/aa-sdk-client/Cargo.toml
+++ b/aa-sdk-client/Cargo.toml
@@ -27,6 +27,9 @@ sha2 = { workspace = true }
 tonic = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "sync", "time", "io-util", "macros"] }
 tracing = { workspace = true }
+# Zeroizes the gateway `credential_token` from process memory on drop so it does
+# not linger in a heap/core-dump readable by a host attacker (AAASM-3629).
+zeroize = { workspace = true }
 
 [features]
 default = ["preflight"]

--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -471,6 +471,44 @@ mod tests {
     }
 
     #[test]
+    fn credential_token_never_appears_in_any_debug_output() {
+        // Regression guard for the token-hygiene contract (AAASM-3638): a unique
+        // sentinel token set on the client must not surface in the Debug output
+        // of the client or any IpcCommand carrying it, while the public accessor
+        // still round-trips it (positive control).
+        use aa_proto::assembly::policy::v1::CheckActionRequest;
+
+        const SENTINEL: &str = "SENTINEL-TOK-DO-NOT-LOG";
+
+        let (client, _rx) = test_client(vec![]);
+        client.set_credential_token_for_test(SENTINEL);
+
+        // (1) `AssemblyClient` deliberately derives no `Debug`, so there is no
+        // `{:?}` path on the client itself that could print the token. The IPC
+        // command below is the only structured path the token reaches.
+        //
+        // (2) An IpcCommand carrying the token must not leak it via Debug.
+        let request = CheckActionRequest {
+            credential_token: client.credential_token().unwrap(),
+            ..Default::default()
+        };
+        let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
+        let cmd = IpcCommand::QueryPolicy {
+            request: Box::new(request),
+            resp: resp_tx,
+        };
+        let cmd_debug = format!("{cmd:?}");
+        assert!(
+            !cmd_debug.contains(SENTINEL),
+            "IpcCommand Debug must not contain the sentinel token, got: {cmd_debug}"
+        );
+
+        // (3) Positive control: the accessor still returns the real token, so
+        // the redaction above is not a false pass from the value being absent.
+        assert_eq!(client.credential_token().as_deref(), Some(SENTINEL));
+    }
+
+    #[test]
     fn query_policy_attaches_stored_credential_token() {
         use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse};
 

--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -443,6 +443,31 @@ mod tests {
         fn set_credential_token_for_test(&self, token: &str) {
             *self.credential_token.lock().unwrap() = Some(Zeroizing::new(token.to_string()));
         }
+
+        /// Test-only: clear the stored token, dropping (and thus zeroizing) the
+        /// `Zeroizing<String>` it held.
+        fn clear_credential_token_for_test(&self) {
+            *self.credential_token.lock().unwrap() = None;
+        }
+    }
+
+    #[test]
+    fn credential_token_is_zeroizing_and_clears_on_take() {
+        // The slot is backed by a zeroizing wrapper (AAASM-3629): on drop the
+        // plaintext heap copy is overwritten rather than lingering for a core
+        // dump. Functionally we assert the value round-trips while held and is
+        // gone once the slot is cleared (which drops/zeroizes the wrapper).
+        let (client, _rx) = test_client(vec![]);
+        client.set_credential_token_for_test("tok-zero");
+        assert_eq!(client.credential_token().as_deref(), Some("tok-zero"));
+
+        client.clear_credential_token_for_test();
+        assert_eq!(client.credential_token(), None);
+
+        // Compile-time guard: the field is a `Zeroizing<String>`, so this
+        // type annotation must hold (a plain `String` would fail to compile).
+        let guard = client.credential_token.lock().unwrap();
+        let _typed: &Option<Zeroizing<String>> = &guard;
     }
 
     #[test]

--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Duration;
 
+use zeroize::Zeroizing;
+
 use crate::config::AssemblyConfig;
 use crate::error::SdkClientError;
 use crate::gateway::{build_register_request, GatewayRegistrationClient};
@@ -33,7 +35,12 @@ pub struct AssemblyClient {
     /// Credential token issued by the gateway at [`register`](Self::register).
     /// `None` until registration succeeds; attached to every `CheckActionRequest`
     /// so the gateway's `validate_credential_token` does not deny the call.
-    credential_token: Mutex<Option<String>>,
+    ///
+    /// Held in [`Zeroizing`] so the plaintext heap copy is overwritten when the
+    /// client drops (or the token is replaced) rather than lingering in a core
+    /// dump readable by a host attacker (AAASM-3629). The plaintext is only
+    /// cloned out transiently when attached to an outgoing request.
+    credential_token: Mutex<Option<Zeroizing<String>>>,
     #[cfg(feature = "preflight")]
     preflight: Option<Preflight>,
 }
@@ -111,15 +118,22 @@ impl AssemblyClient {
 
         {
             let mut guard = self.credential_token.lock().map_err(|_| SdkClientError::LockPoisoned)?;
-            *guard = Some(response.credential_token);
+            *guard = Some(Zeroizing::new(response.credential_token));
         }
 
         Ok(response.assigned_policy)
     }
 
     /// Return the stored gateway credential token, if registration has run.
+    ///
+    /// Clones the plaintext out of its zeroizing wrapper transiently for the
+    /// caller — used only to attach the token to an outgoing `CheckActionRequest`
+    /// immediately before send (AAASM-3629).
     pub fn credential_token(&self) -> Option<String> {
-        self.credential_token.lock().ok().and_then(|g| g.clone())
+        self.credential_token
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().map(|t| t.to_string()))
     }
 
     /// Enqueue an already-built event onto the IPC command channel.
@@ -427,7 +441,7 @@ mod tests {
     /// The end-to-end registered path is covered by the with-core gateway test.
     impl AssemblyClient {
         fn set_credential_token_for_test(&self, token: &str) {
-            *self.credential_token.lock().unwrap() = Some(token.to_string());
+            *self.credential_token.lock().unwrap() = Some(Zeroizing::new(token.to_string()));
         }
     }
 

--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -17,7 +17,12 @@ use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse};
 use crate::codec;
 
 /// Commands sent from the calling thread to the background IPC thread.
-#[derive(Debug)]
+///
+/// `Debug` is hand-written (not derived) so the `QueryPolicy` variant never
+/// prints its `CheckActionRequest.credential_token` — a derived `Debug` would
+/// emit the gateway auth token verbatim into any `{:?}`/`tracing` log at
+/// `RUST_LOG=debug` (AAASM-3634). Only the non-sensitive `action_type` shape is
+/// shown; the token (and the rest of the request body) is elided.
 pub enum IpcCommand {
     /// Send an audit event to the runtime.
     SendEvent(Box<aa_proto::assembly::audit::v1::AuditEvent>),
@@ -30,6 +35,24 @@ pub enum IpcCommand {
     },
     /// Gracefully shut down the IPC connection.
     Shutdown,
+}
+
+impl std::fmt::Debug for IpcCommand {
+    /// Scrubbing `Debug`: prints the variant + non-sensitive shape only and
+    /// never the `credential_token` carried by the `QueryPolicy` request
+    /// (AAASM-3634).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IpcCommand::SendEvent(event) => {
+                f.debug_tuple("SendEvent").field(&event.event_id).finish()
+            }
+            IpcCommand::QueryPolicy { request, .. } => f
+                .debug_struct("QueryPolicy")
+                .field("action_type", &request.action_type)
+                .finish_non_exhaustive(),
+            IpcCommand::Shutdown => f.write_str("Shutdown"),
+        }
+    }
 }
 
 /// Response senders awaiting a synchronous policy decision, in FIFO order.

--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -261,6 +261,33 @@ mod tests {
         assert_eq!(format!("{:?}", cmd), "Shutdown");
     }
 
+    #[test]
+    fn query_policy_debug_does_not_leak_credential_token() {
+        // Redaction guard (AAASM-3634): the QueryPolicy variant carries the
+        // gateway credential_token, but its Debug must never print it — only
+        // the variant name + non-sensitive action_type shape.
+        let sentinel = "SENTINEL-TOK-DO-NOT-LOG";
+        let request = CheckActionRequest {
+            credential_token: sentinel.to_string(),
+            ..Default::default()
+        };
+        let (resp_tx, _resp_rx) = blocking_mpsc::channel();
+        let cmd = IpcCommand::QueryPolicy {
+            request: Box::new(request),
+            resp: resp_tx,
+        };
+
+        let debug = format!("{cmd:?}");
+        assert!(
+            !debug.contains(sentinel),
+            "IpcCommand Debug must not contain the credential token, got: {debug}"
+        );
+        assert!(
+            debug.contains("QueryPolicy"),
+            "Debug should still name the variant, got: {debug}"
+        );
+    }
+
     /// The agent id the mock-server tests handshake as.
     const TEST_AGENT_ID: &str = "test-agent";
 

--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -43,9 +43,7 @@ impl std::fmt::Debug for IpcCommand {
     /// (AAASM-3634).
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IpcCommand::SendEvent(event) => {
-                f.debug_tuple("SendEvent").field(&event.event_id).finish()
-            }
+            IpcCommand::SendEvent(event) => f.debug_tuple("SendEvent").field(&event.event_id).finish(),
             IpcCommand::QueryPolicy { request, .. } => f
                 .debug_struct("QueryPolicy")
                 .field("action_type", &request.action_type)


### PR DESCRIPTION
## Description

Hardens the shared `aa-sdk-client` runtime-client so the gateway `credential_token` can never leak via logs, structured `Debug`/`tracing` output, or a core dump (Story AAASM-3570, subtasks 3629/3634/3638).

- **AAASM-3629** — `AssemblyClient.credential_token` now holds `zeroize::Zeroizing<String>` instead of a long-lived plaintext `String`, so the heap copy is overwritten on drop/replace rather than lingering for a crash dump. Plaintext is cloned out only transiently when attached to an outgoing `CheckActionRequest`.
- **AAASM-3634** — Replaced the derived `Debug` on `IpcCommand` with a hand-written scrubbing impl: the `QueryPolicy` variant carried the token, so any `{:?}`/`tracing` log at `RUST_LOG=debug` would have emitted it verbatim. The new impl prints only the variant + non-sensitive `action_type` shape.
- **AAASM-3638** — Added a no-token-in-logs regression test (unique sentinel never appears in any `IpcCommand` Debug output; accessor still round-trips as a positive control).

## Type of Change

- [x] 🔧 Configuration / CI change (added `zeroize` dependency)
- [x] ♻️ Refactoring (token storage type, `Debug` impl)

## Breaking Changes

- [x] No

`credential_token()`'s public signature (`Option<String>`) is unchanged; the zeroizing wrapper is internal.

## Related Issues

- Related Jira ticket: AAASM-3570 (subtasks AAASM-3629, AAASM-3634, AAASM-3638)
- Relates to AAASM-3562 (proxy credential hygiene)

## Testing

- [x] Unit tests added / updated
- [x] No tests required for the dependency add

Run locally (macOS, `RUSTUP_TOOLCHAIN=stable`):
- `cargo build -p aa-sdk-client` — clean
- `cargo nextest run -p aa-sdk-client` — 53 passed, 0 skipped (incl. existing `query_policy_attaches_stored_credential_token`, `query_policy_keeps_explicit_credential_token`, `register_then_check_carries_token_and_surfaces_deny`, plus new `credential_token_is_zeroizing_and_clears_on_take`, `query_policy_debug_does_not_leak_credential_token`, `credential_token_never_appears_in_any_debug_output`)
- `cargo clippy -p aa-sdk-client --all-targets -- -D warnings` — clean
- `cargo fmt -p aa-sdk-client --check` — clean

Full-workspace CI is the reviewer's gate.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc-comments on the field + Debug impl)
- [ ] All CI checks passing (to be verified by CI)
- [x] Commits are small and follow the Gitmoji convention

⚠️ No hard-coded crypto secrets: tests use redaction sentinels only; no value flows into a crypto sink.
