### PR TITLE
[AAASM-3571] 🔒 (aa-runtime): SDK bypass/tamper observability in audit

### DIFF
--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -541,6 +541,7 @@ mod tests {
             connection_id: 0,
             sequence_number: 42,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         }))
     }
 
@@ -793,6 +794,7 @@ mod tests {
             connection_id: 0,
             sequence_number: 42,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         }));
         let stack = extract_call_stack(build_violation_payload(&ev)).expect("call_stack");
         assert_eq!(stack.len(), 1);

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -540,6 +540,7 @@ mod tests {
             agent_id: "support-agent".into(),
             connection_id: 0,
             sequence_number: 42,
+            observed_sdk_identity: Default::default(),
         }))
     }
 
@@ -791,6 +792,7 @@ mod tests {
             agent_id: "support-agent".into(),
             connection_id: 0,
             sequence_number: 42,
+            observed_sdk_identity: Default::default(),
         }));
         let stack = extract_call_stack(build_violation_payload(&ev)).expect("call_stack");
         assert_eq!(stack.len(), 1);

--- a/aa-api/tests/ws_streaming.rs
+++ b/aa-api/tests/ws_streaming.rs
@@ -54,6 +54,7 @@ async fn ws_receives_pipeline_event() {
         connection_id: 0,
         sequence_number: 0,
         observed_sdk_identity: Default::default(),
+        tamper: None,
     }));
     tx.send(event).unwrap();
 
@@ -90,6 +91,7 @@ async fn ws_type_filter_excludes_non_matching() {
         connection_id: 0,
         sequence_number: 0,
         observed_sdk_identity: Default::default(),
+        tamper: None,
     }));
     tx.send(event).unwrap();
 
@@ -164,6 +166,7 @@ async fn ws_100_simultaneous_clients_all_receive_event() {
         connection_id: 0,
         sequence_number: 0,
         observed_sdk_identity: Default::default(),
+        tamper: None,
     }));
     tx.send(event).unwrap();
 
@@ -207,6 +210,7 @@ async fn ws_client_disconnect_cleanup() {
         connection_id: 0,
         sequence_number: 0,
         observed_sdk_identity: Default::default(),
+        tamper: None,
     }));
     // send may return Err if no receivers remain, which is fine.
     let _ = tx.send(event);
@@ -223,6 +227,7 @@ async fn ws_client_disconnect_cleanup() {
         connection_id: 0,
         sequence_number: 1,
         observed_sdk_identity: Default::default(),
+        tamper: None,
     }));
     tx.send(event2).unwrap();
 
@@ -262,6 +267,7 @@ async fn ws_cli_logs_follow_integration() {
             connection_id: 1,
             sequence_number: 0,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         })))
         .unwrap();
 

--- a/aa-api/tests/ws_streaming.rs
+++ b/aa-api/tests/ws_streaming.rs
@@ -53,6 +53,7 @@ async fn ws_receives_pipeline_event() {
         agent_id: "agent-1".to_string(),
         connection_id: 0,
         sequence_number: 0,
+        observed_sdk_identity: Default::default(),
     }));
     tx.send(event).unwrap();
 
@@ -88,6 +89,7 @@ async fn ws_type_filter_excludes_non_matching() {
         agent_id: "agent-1".to_string(),
         connection_id: 0,
         sequence_number: 0,
+        observed_sdk_identity: Default::default(),
     }));
     tx.send(event).unwrap();
 
@@ -161,6 +163,7 @@ async fn ws_100_simultaneous_clients_all_receive_event() {
         agent_id: "fan-out-agent".to_string(),
         connection_id: 0,
         sequence_number: 0,
+        observed_sdk_identity: Default::default(),
     }));
     tx.send(event).unwrap();
 
@@ -203,6 +206,7 @@ async fn ws_client_disconnect_cleanup() {
         agent_id: "post-disconnect".to_string(),
         connection_id: 0,
         sequence_number: 0,
+        observed_sdk_identity: Default::default(),
     }));
     // send may return Err if no receivers remain, which is fine.
     let _ = tx.send(event);
@@ -218,6 +222,7 @@ async fn ws_client_disconnect_cleanup() {
         agent_id: "after-cleanup".to_string(),
         connection_id: 0,
         sequence_number: 1,
+        observed_sdk_identity: Default::default(),
     }));
     tx.send(event2).unwrap();
 
@@ -256,6 +261,7 @@ async fn ws_cli_logs_follow_integration() {
             agent_id: "agent-cli-test".to_string(),
             connection_id: 1,
             sequence_number: 0,
+            observed_sdk_identity: Default::default(),
         })))
         .unwrap();
 

--- a/aa-integration-tests/tests/api_ws.rs
+++ b/aa-integration-tests/tests/api_ws.rs
@@ -55,6 +55,7 @@ fn make_pipeline_event(agent_id: &str) -> PipelineEvent {
         connection_id: 0,
         sequence_number: 0,
         observed_sdk_identity: Default::default(),
+        tamper: None,
     }))
 }
 

--- a/aa-integration-tests/tests/api_ws.rs
+++ b/aa-integration-tests/tests/api_ws.rs
@@ -54,6 +54,7 @@ fn make_pipeline_event(agent_id: &str) -> PipelineEvent {
         agent_id: agent_id.to_string(),
         connection_id: 0,
         sequence_number: 0,
+        observed_sdk_identity: Default::default(),
     }))
 }
 

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -1106,6 +1106,7 @@ mod runtime_bypass {
             agent_id: "bypass-test-agent".to_string(),
             connection_id: 0,
             sequence_number: 0,
+            observed_sdk_identity: Default::default(),
         }
     }
 
@@ -1175,6 +1176,7 @@ mod runtime_bypass {
             agent_id: "lying-sdk".to_string(),
             connection_id: 0,
             sequence_number: 0,
+            observed_sdk_identity: Default::default(),
         };
 
         let outcome = scanner.enforce(&mut event);

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -1107,6 +1107,7 @@ mod runtime_bypass {
             connection_id: 0,
             sequence_number: 0,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         }
     }
 
@@ -1177,6 +1178,7 @@ mod runtime_bypass {
             connection_id: 0,
             sequence_number: 0,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         };
 
         let outcome = scanner.enforce(&mut event);

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -191,6 +191,7 @@ impl Interceptor {
             sequence_number: 0,
             // Proxy-sourced events carry no SDK identity claim.
             observed_sdk_identity: aa_security::sdk_identity::ObservedSdkIdentity::missing(),
+            tamper: None,
         };
 
         // send() returns Err only when there are zero receivers — normal for
@@ -297,6 +298,7 @@ impl Interceptor {
             sequence_number: 0,
             // Proxy-sourced events carry no SDK identity claim.
             observed_sdk_identity: aa_security::sdk_identity::ObservedSdkIdentity::missing(),
+            tamper: None,
         };
 
         let _ = self.event_tx.send(PipelineEvent::Audit(Box::new(enriched)));
@@ -404,6 +406,7 @@ impl Interceptor {
             sequence_number: 0,
             // Proxy-sourced events carry no SDK identity claim.
             observed_sdk_identity: aa_security::sdk_identity::ObservedSdkIdentity::missing(),
+            tamper: None,
         };
 
         PipelineEvent::Audit(Box::new(enriched))

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -189,6 +189,8 @@ impl Interceptor {
             agent_id: String::new(),
             connection_id: 0,
             sequence_number: 0,
+            // Proxy-sourced events carry no SDK identity claim.
+            observed_sdk_identity: aa_security::sdk_identity::ObservedSdkIdentity::missing(),
         };
 
         // send() returns Err only when there are zero receivers — normal for
@@ -293,6 +295,8 @@ impl Interceptor {
             agent_id: String::new(),
             connection_id: 0,
             sequence_number: 0,
+            // Proxy-sourced events carry no SDK identity claim.
+            observed_sdk_identity: aa_security::sdk_identity::ObservedSdkIdentity::missing(),
         };
 
         let _ = self.event_tx.send(PipelineEvent::Audit(Box::new(enriched)));
@@ -398,6 +402,8 @@ impl Interceptor {
             agent_id: event.agent_id.clone().unwrap_or_default(),
             connection_id: 0,
             sequence_number: 0,
+            // Proxy-sourced events carry no SDK identity claim.
+            observed_sdk_identity: aa_security::sdk_identity::ObservedSdkIdentity::missing(),
         };
 
         PipelineEvent::Audit(Box::new(enriched))

--- a/aa-runtime/src/audit_publisher/conversion.rs
+++ b/aa-runtime/src/audit_publisher/conversion.rs
@@ -174,20 +174,31 @@ fn parse_optional_agent_id(raw: &str) -> Option<AgentId> {
 /// only metadata fields (tool names, paths, hosts) — never raw `args_json`
 /// bytes, which the producer is contractually required to scan/redact and which
 /// this audit tier must not re-expand.
+///
+/// When the event carries a tamper signal (AAASM-3637), an `sdk_identity`
+/// section records the server-recomputed verdict and the count of stripped
+/// forged trust markers so the bypass/tamper trail is queryable.
 fn build_payload(event: &EnrichedEvent) -> String {
     let proto = &event.inner;
     let action = ActionType::try_from(proto.action_type)
         .unwrap_or(ActionType::ActionUnspecified)
         .as_str_name();
     let detail = detail_summary(&proto.detail);
-    serde_json::json!({
+    let mut payload = serde_json::json!({
         "event_id": proto.event_id,
         "action_type": action,
         "source": source_label(&event.source),
         "decision": proto.decision,
         "detail": detail,
-    })
-    .to_string()
+    });
+    if let Some(tamper) = &event.tamper {
+        payload["sdk_identity"] = serde_json::json!({
+            "tamper_suspected": true,
+            "verdict": tamper.verdict.as_str(),
+            "forged_trust_markers": tamper.forged_trust_markers,
+        });
+    }
+    payload.to_string()
 }
 
 /// Summarise the proto detail oneof as a small JSON object, copying only
@@ -274,6 +285,7 @@ mod tests {
             connection_id: 1,
             sequence_number: 7,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         }
     }
 

--- a/aa-runtime/src/audit_publisher/conversion.rs
+++ b/aa-runtime/src/audit_publisher/conversion.rs
@@ -471,4 +471,29 @@ mod tests {
         let entry = enriched_to_audit_entry(&enriched(ActionType::ToolCall, None, EventSource::Sdk));
         assert!(entry.verify_integrity());
     }
+
+    #[test]
+    fn payload_has_no_sdk_identity_section_without_tamper() {
+        let entry = enriched_to_audit_entry(&enriched(ActionType::ToolCall, None, EventSource::Sdk));
+        let p = payload_json(&entry);
+        assert!(
+            p.get("sdk_identity").is_none(),
+            "ordinary events carry no sdk_identity section"
+        );
+    }
+
+    #[test]
+    fn payload_carries_tamper_verdict_and_forged_count() {
+        use crate::pipeline::event::TamperSignal;
+        let mut event = enriched(ActionType::ToolCall, None, EventSource::Sdk);
+        event.tamper = Some(TamperSignal {
+            verdict: aa_security::sdk_identity::SdkIdentityVerdict::Missing,
+            forged_trust_markers: 2,
+        });
+        let entry = enriched_to_audit_entry(&event);
+        let p = payload_json(&entry);
+        assert_eq!(p["sdk_identity"]["tamper_suspected"], true);
+        assert_eq!(p["sdk_identity"]["verdict"], "missing");
+        assert_eq!(p["sdk_identity"]["forged_trust_markers"], 2);
+    }
 }

--- a/aa-runtime/src/audit_publisher/conversion.rs
+++ b/aa-runtime/src/audit_publisher/conversion.rs
@@ -273,6 +273,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             connection_id: 1,
             sequence_number: 7,
+            observed_sdk_identity: Default::default(),
         }
     }
 

--- a/aa-runtime/src/correlation/mod.rs
+++ b/aa-runtime/src/correlation/mod.rs
@@ -117,6 +117,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             connection_id: 1,
             sequence_number: 0,
+            observed_sdk_identity: Default::default(),
         }
     }
 

--- a/aa-runtime/src/correlation/mod.rs
+++ b/aa-runtime/src/correlation/mod.rs
@@ -118,6 +118,7 @@ mod tests {
             connection_id: 1,
             sequence_number: 0,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         }
     }
 

--- a/aa-runtime/src/ebpf_bridge.rs
+++ b/aa-runtime/src/ebpf_bridge.rs
@@ -114,6 +114,8 @@ pub fn enrich_ebpf(event: AuditEvent, agent_id: &str, seq: &Arc<AtomicU64>) -> E
         agent_id: agent_id.to_string(),
         connection_id: 0,
         sequence_number,
+        // eBPF-sourced events carry no SDK identity claim.
+        observed_sdk_identity: aa_security::sdk_identity::ObservedSdkIdentity::missing(),
     }
 }
 

--- a/aa-runtime/src/ebpf_bridge.rs
+++ b/aa-runtime/src/ebpf_bridge.rs
@@ -116,6 +116,7 @@ pub fn enrich_ebpf(event: AuditEvent, agent_id: &str, seq: &Arc<AtomicU64>) -> E
         sequence_number,
         // eBPF-sourced events carry no SDK identity claim.
         observed_sdk_identity: aa_security::sdk_identity::ObservedSdkIdentity::missing(),
+        tamper: None,
     }
 }
 

--- a/aa-runtime/src/ipc/mod.rs
+++ b/aa-runtime/src/ipc/mod.rs
@@ -24,3 +24,20 @@ pub type ResponseRouter = Arc<RwLock<HashMap<u64, mpsc::Sender<IpcResponse>>>>;
 pub fn new_response_router() -> ResponseRouter {
     Arc::new(RwLock::new(HashMap::new()))
 }
+
+/// Shared map from connection ID to the SDK identity the AAASM-3569 session
+/// handshake *verified* for that connection.
+///
+/// Populated by the IPC server when a connection completes the authenticated
+/// handshake (the peer proved possession of the agent's Ed25519 key) and
+/// removed when the connection closes — the same lifecycle as
+/// [`ResponseRouter`]. The pipeline reads it by `connection_id` to recompute
+/// the SDK-identity verdict (AAASM-3640) against a trusted reference instead of
+/// the attacker-controlled observed claim. When a connection has no entry (no
+/// handshake / unsupported), the classifier falls back to `Unverifiable`.
+pub type VerifiedIdentityStore = Arc<RwLock<HashMap<u64, aa_security::sdk_identity::VerifiedSdkIdentity>>>;
+
+/// Create an empty [`VerifiedIdentityStore`].
+pub fn new_verified_identity_store() -> VerifiedIdentityStore {
+    Arc::new(RwLock::new(HashMap::new()))
+}

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -111,6 +111,7 @@ impl IpcServer {
         inbound_tx: mpsc::Sender<(u64, IpcFrame)>,
         active_connections: Arc<AtomicI64>,
         response_router: ResponseRouter,
+        verified_identities: crate::ipc::VerifiedIdentityStore,
     ) {
         let semaphore = Arc::new(Semaphore::new(self.config.max_connections));
         let listener = self.listener;
@@ -193,6 +194,7 @@ impl IpcServer {
                             // succeeds — an unauthenticated peer is never wired
                             // into the dispatch path.
                             let conn_router = Arc::clone(&response_router);
+                            let conn_verified = Arc::clone(&verified_identities);
                             let conn_active = Arc::clone(&active_connections);
                             spawn_connection(
                                 &tracker,
@@ -203,6 +205,7 @@ impl IpcServer {
                                 conn_active,
                                 connection_id,
                                 conn_router,
+                                conn_verified,
                                 expected_key,
                                 inbound_channel_capacity,
                             );
@@ -243,6 +246,7 @@ pub(super) fn spawn_connection(
     active_connections: Arc<AtomicI64>,
     connection_id: u64,
     response_router: ResponseRouter,
+    verified_identities: crate::ipc::VerifiedIdentityStore,
     expected_key: ed25519_dalek::VerifyingKey,
     inbound_channel_capacity: usize,
 ) {
@@ -254,16 +258,17 @@ pub(super) fn spawn_connection(
 
         // AAASM-3585: challenge the peer and verify its signed proof before any
         // application frame is served. Bounded by HANDSHAKE_TIMEOUT.
-        match tokio::time::timeout(
+        let verified_identity = match tokio::time::timeout(
             HANDSHAKE_TIMEOUT,
             perform_handshake(&mut read_half, &mut write_half, &expected_key),
         )
         .await
         {
-            Ok(true) => {
+            Ok(Some(identity)) => {
                 tracing::debug!(connection_id, "IPC handshake succeeded");
+                identity
             }
-            Ok(false) => {
+            Ok(None) => {
                 tracing::warn!(connection_id, "IPC handshake failed — dropping connection");
                 return;
             }
@@ -271,11 +276,17 @@ pub(super) fn spawn_connection(
                 tracing::warn!(connection_id, "IPC handshake timed out — dropping connection");
                 return;
             }
-        }
+        };
 
         // Handshake passed: now wire this connection into the dispatch path.
         let (resp_tx, resp_rx) = mpsc::channel::<IpcResponse>(inbound_channel_capacity);
         response_router.write().await.insert(connection_id, resp_tx.clone());
+        // AAASM-3640: record the handshake-verified identity for this connection
+        // so the pipeline can recompute the SDK-identity verdict against it.
+        verified_identities
+            .write()
+            .await
+            .insert(connection_id, verified_identity);
         active_connections.fetch_add(1, Ordering::Relaxed);
 
         // Reader task: decode frames from socket → inbound channel.
@@ -288,6 +299,7 @@ pub(super) fn spawn_connection(
                 active_connections,
                 connection_id,
                 response_router,
+                verified_identities,
             )
             .await;
         });
@@ -304,13 +316,18 @@ pub(super) fn spawn_connection(
 /// Run the runtime side of the session handshake: send a fresh nonce challenge,
 /// await the SDK's `HandshakeProof`, and verify it against `expected_key`.
 ///
-/// Returns `true` only on a valid proof. Any I/O error, a non-handshake first
-/// frame, or a signature that does not verify returns `false` (fail-closed).
+/// Returns `Some(VerifiedSdkIdentity)` only on a valid proof — the identity the
+/// authenticated channel established (AAASM-3640 consumes it). The current
+/// handshake proof authenticates the agent's Ed25519 key possession but carries
+/// no SDK version on the wire, so the returned identity has `version: None`
+/// (a present-but-not-versioned attestation). Any I/O error, a non-handshake
+/// first frame, or a signature that does not verify returns `None`
+/// (fail-closed).
 pub(super) async fn perform_handshake(
     read_half: &mut tokio::net::unix::OwnedReadHalf,
     write_half: &mut tokio::net::unix::OwnedWriteHalf,
     expected_key: &ed25519_dalek::VerifyingKey,
-) -> bool {
+) -> Option<aa_security::sdk_identity::VerifiedSdkIdentity> {
     use crate::ipc::handshake;
     use aa_proto::assembly::ipc::v1::HandshakeChallenge;
 
@@ -319,7 +336,7 @@ pub(super) async fn perform_handshake(
     let challenge = IpcResponse::HandshakeChallenge(HandshakeChallenge { nonce: nonce.to_vec() });
     if let Err(e) = super::codec::write_response(write_half, challenge).await {
         tracing::warn!(error = %e, "failed to send handshake challenge");
-        return false;
+        return None;
     }
 
     // 2. Await the proof. The first frame MUST be a HandshakeProof — anything
@@ -328,10 +345,12 @@ pub(super) async fn perform_handshake(
     match super::codec::read_frame(read_half).await {
         Ok(IpcFrame::HandshakeProof(proof)) => {
             if handshake::verify_proof(&nonce, &proof, expected_key) {
-                true
+                // Authenticated. The proof carries no version, so the verified
+                // reference is present-without-version (version: None).
+                Some(aa_security::sdk_identity::VerifiedSdkIdentity::none())
             } else {
                 tracing::warn!("handshake proof did not verify against the expected agent key");
-                false
+                None
             }
         }
         Ok(other) => {
@@ -339,11 +358,11 @@ pub(super) async fn perform_handshake(
                 frame = ?std::mem::discriminant(&other),
                 "first IPC frame was not a handshake proof — rejecting unauthenticated peer"
             );
-            false
+            None
         }
         Err(e) => {
             tracing::warn!(error = %e, "failed to read handshake proof");
-            false
+            None
         }
     }
 }
@@ -356,6 +375,7 @@ pub(super) async fn run_reader(
     active_connections: Arc<AtomicI64>,
     connection_id: u64,
     response_router: ResponseRouter,
+    verified_identities: crate::ipc::VerifiedIdentityStore,
 ) {
     loop {
         tokio::select! {
@@ -386,8 +406,10 @@ pub(super) async fn run_reader(
             }
         }
     }
-    // Remove this connection from the response router before signalling shutdown.
+    // Remove this connection from the response router and the verified-identity
+    // store before signalling shutdown.
     response_router.write().await.remove(&connection_id);
+    verified_identities.write().await.remove(&connection_id);
     token.cancel(); // Signal the paired writer to stop.
     active_connections.fetch_sub(1, Ordering::Relaxed);
 }
@@ -533,7 +555,11 @@ mod tests {
         socket_path: std::path::PathBuf,
         token: CancellationToken,
         active_connections: Arc<AtomicI64>,
-    ) -> (mpsc::Receiver<(u64, IpcFrame)>, crate::ipc::ResponseRouter) {
+    ) -> (
+        mpsc::Receiver<(u64, IpcFrame)>,
+        crate::ipc::ResponseRouter,
+        crate::ipc::VerifiedIdentityStore,
+    ) {
         let config = IpcServerConfig {
             socket_path,
             agent_id: "test-agent".to_string(),
@@ -544,14 +570,23 @@ mod tests {
         let (tx, rx) = mpsc::channel(16);
         let router = crate::ipc::new_response_router();
         let router_clone = Arc::clone(&router);
+        let verified = crate::ipc::new_verified_identity_store();
+        let verified_clone = Arc::clone(&verified);
         let tracker = TaskTracker::new();
         let tracker_clone = tracker.clone();
         tracker.spawn(async move {
             server
-                .run(tracker_clone, token, tx, active_connections, router_clone)
+                .run(
+                    tracker_clone,
+                    token,
+                    tx,
+                    active_connections,
+                    router_clone,
+                    verified_clone,
+                )
                 .await;
         });
-        (rx, router)
+        (rx, router, verified)
     }
 
     /// Write a raw inbound frame (tag + varint len + payload) to the socket.
@@ -603,7 +638,7 @@ mod tests {
         let socket_path = temp_socket_path("heartbeat");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
         let (_, mut write_half) = client.into_split();
@@ -627,7 +662,7 @@ mod tests {
         let socket_path = temp_socket_path("policy-query");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
         let (_, mut write_half) = client.into_split();
@@ -656,7 +691,7 @@ mod tests {
         let socket_path = temp_socket_path("event-report");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
         let (_, mut write_half) = client.into_split();
@@ -685,7 +720,7 @@ mod tests {
         let socket_path = temp_socket_path("concurrent");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (_rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (_rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         const CONN_COUNT: usize = 5;
         let mut clients = Vec::new();
@@ -705,7 +740,7 @@ mod tests {
         let socket_path = temp_socket_path("latency");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
         let (_, mut write_half) = client.into_split();
@@ -737,7 +772,7 @@ mod tests {
         let socket_path = temp_socket_path("counter-increment");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (_rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (_rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         const CONN_COUNT: usize = 3;
         let mut clients = Vec::new();
@@ -769,7 +804,7 @@ mod tests {
         let socket_path = temp_socket_path("counter-decrement");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (_rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (_rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
 
@@ -809,7 +844,7 @@ mod tests {
         let socket_path = temp_socket_path("router-insert");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (_rx, router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (_rx, router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let _client = connect_client(&socket_path).await;
 
@@ -831,7 +866,7 @@ mod tests {
         let socket_path = temp_socket_path("router-remove");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (_rx, router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (_rx, router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
 
@@ -879,7 +914,8 @@ mod tests {
         let socket_path = temp_socket_path("violation-alert");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (inbound_rx, router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (inbound_rx, router, verified) =
+            start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         // Spin up the pipeline.
         let pipeline_config = PipelineConfig {
@@ -890,6 +926,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            min_sdk_version: None,
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
         let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(64);
@@ -907,6 +944,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            Arc::clone(&verified),
         ));
 
         // Connect a client.
@@ -974,7 +1012,8 @@ mod tests {
         let socket_path = temp_socket_path("no-alert");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (inbound_rx, router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (inbound_rx, router, verified) =
+            start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         // Spin up the pipeline.
         let pipeline_config = PipelineConfig {
@@ -985,6 +1024,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            min_sdk_version: None,
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
         let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(64);
@@ -1002,6 +1042,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            Arc::clone(&verified),
         ));
 
         // Connect a client.
@@ -1064,7 +1105,8 @@ mod tests {
         let socket_path = temp_socket_path("approval-roundtrip");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (inbound_rx, router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (inbound_rx, router, verified) =
+            start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         // Policy: TOOL_CALL requires approval.
         let policy = Arc::new(PolicyRules {
@@ -1087,6 +1129,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            min_sdk_version: None,
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
         let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(64);
@@ -1104,6 +1147,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            Arc::clone(&verified),
         ));
 
         // Connect a client.
@@ -1204,7 +1248,7 @@ mod tests {
         let socket_path = temp_socket_path("no-handshake-event");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         // Connect WITHOUT performing the handshake.
         let stream = {
@@ -1251,7 +1295,7 @@ mod tests {
         let socket_path = temp_socket_path("forged-handshake");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let mut stream = {
             let mut s = None;
@@ -1328,7 +1372,7 @@ mod tests {
         let socket_path = temp_socket_path("valid-handshake-event");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router, _verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         // connect_client performs the valid handshake as TEST_AGENT_ID.
         let client = connect_client(&socket_path).await;

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -899,6 +899,68 @@ mod tests {
         token.cancel();
     }
 
+    #[tokio::test]
+    async fn verified_identity_recorded_after_handshake() {
+        // AAASM-3640: a connection that completes the authenticated handshake
+        // has its verified identity recorded in the store, keyed by connection_id.
+        let socket_path = temp_socket_path("verified-insert");
+        let token = CancellationToken::new();
+        let counter = Arc::new(AtomicI64::new(0));
+        let (_rx, _router, verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+
+        let _client = connect_client(&socket_path).await;
+
+        for _ in 0..50 {
+            if counter.load(Ordering::Relaxed) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let map = verified.read().await;
+        assert_eq!(
+            map.len(),
+            1,
+            "verified-identity store should hold one entry after a handshake"
+        );
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn verified_identity_removed_after_disconnect() {
+        let socket_path = temp_socket_path("verified-remove");
+        let token = CancellationToken::new();
+        let counter = Arc::new(AtomicI64::new(0));
+        let (_rx, _router, verified) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+
+        let client = connect_client(&socket_path).await;
+
+        for _ in 0..50 {
+            if verified.read().await.len() == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(verified.read().await.len(), 1);
+
+        drop(client);
+
+        let mut observed_len = 1usize;
+        for _ in 0..100 {
+            observed_len = verified.read().await.len();
+            if observed_len == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            observed_len, 0,
+            "verified-identity entry should be removed after client disconnects"
+        );
+
+        token.cancel();
+    }
+
     /// Spin up an IPC server + pipeline and verify that a violation EventReport
     /// results in a ViolationAlert (tag 4) arriving on the same connection
     /// within 100 ms.

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -573,4 +573,120 @@ mod tests {
             "oversized policy stays fail-closed"
         );
     }
+
+    /// Build a label-bearing event with no secret-bearing detail.
+    fn event_with_labels(labels: &[(&str, &str)]) -> EnrichedEvent {
+        let mut event = EnrichedEvent {
+            inner: AuditEvent::default(),
+            received_at_ms: 0,
+            source: EventSource::Sdk,
+            agent_id: "test-agent".to_string(),
+            connection_id: 0,
+            sequence_number: 0,
+            observed_sdk_identity: Default::default(),
+        };
+        for (k, v) in labels {
+            event.inner.labels.insert((*k).to_string(), (*v).to_string());
+        }
+        event
+    }
+
+    #[test]
+    fn forged_trust_marker_is_stripped_and_counted() {
+        let scanner = RuntimeScanner::new();
+        let mut event = event_with_labels(&[("aa.trusted", "true")]);
+
+        let outcome = scanner.enforce(&mut event);
+
+        assert!(
+            !event.inner.labels.contains_key("aa.trusted"),
+            "forged trust marker must be stripped"
+        );
+        assert_eq!(outcome.forged_trust_markers, 1);
+        assert!(outcome.has_forged_trust_markers());
+    }
+
+    #[test]
+    fn every_reserved_trust_marker_is_stripped() {
+        let scanner = RuntimeScanner::new();
+        let labels: Vec<(&str, &str)> = TRUST_MARKER_LABELS.iter().map(|k| (*k, "1")).collect();
+        let mut event = event_with_labels(&labels);
+
+        let outcome = scanner.enforce(&mut event);
+
+        for key in TRUST_MARKER_LABELS {
+            assert!(!event.inner.labels.contains_key(*key), "{key} must be stripped");
+        }
+        assert_eq!(outcome.forged_trust_markers, TRUST_MARKER_LABELS.len());
+    }
+
+    #[test]
+    fn sdk_version_label_is_preserved_not_a_trust_marker() {
+        let scanner = RuntimeScanner::new();
+        let mut event = event_with_labels(&[("aa.sdk_version", "1.2.3"), ("aa.bypass", "1")]);
+
+        let outcome = scanner.enforce(&mut event);
+
+        assert_eq!(
+            event.inner.labels.get("aa.sdk_version").map(String::as_str),
+            Some("1.2.3"),
+            "the version claim is preserved for the classifier, not stripped"
+        );
+        assert!(!event.inner.labels.contains_key("aa.bypass"));
+        assert_eq!(outcome.forged_trust_markers, 1);
+    }
+
+    #[test]
+    fn stripping_a_marker_does_not_make_a_clean_event_dirty() {
+        // Forged markers are a distinct signal; they don't count as a redaction.
+        let scanner = RuntimeScanner::new();
+        let mut event = event_with_labels(&[("aa.trusted", "true")]);
+
+        let outcome = scanner.enforce(&mut event);
+
+        assert!(outcome.is_clean(), "no findings / oversized → still clean");
+        assert!(outcome.has_forged_trust_markers());
+    }
+
+    #[test]
+    fn forged_clean_marker_does_not_suppress_scanning() {
+        // The AAASM-2569 threat: an agent forges aa.scanned hoping the runtime
+        // skips the scan. The secret must still be redacted.
+        let scanner = RuntimeScanner::new();
+        let mut event = event_with(Detail::ToolCall(ToolCallDetail {
+            args_json: format!(r#"{{"key": "{AWS_KEY}"}}"#).into_bytes(),
+            ..Default::default()
+        }));
+        event.inner.labels.insert("aa.scanned".to_string(), "true".to_string());
+
+        let outcome = scanner.enforce(&mut event);
+
+        let Some(Detail::ToolCall(tc)) = event.inner.detail else {
+            unreachable!("detail was a ToolCall");
+        };
+        let body = String::from_utf8(tc.args_json).expect("utf-8");
+        assert!(
+            !body.contains(AWS_KEY),
+            "raw secret must not survive a forged scanned marker"
+        );
+        assert!(!event.inner.labels.contains_key("aa.scanned"), "forged marker stripped");
+        assert_eq!(outcome.forged_trust_markers, 1);
+        assert!(!outcome.is_clean(), "the secret was still found and redacted");
+    }
+
+    #[test]
+    fn no_trust_markers_leaves_outcome_unflagged() {
+        let scanner = RuntimeScanner::new();
+        let mut event = event_with_labels(&[("team", "payments")]);
+
+        let outcome = scanner.enforce(&mut event);
+
+        assert_eq!(
+            event.inner.labels.get("team").map(String::as_str),
+            Some("payments"),
+            "ordinary labels are untouched"
+        );
+        assert_eq!(outcome.forged_trust_markers, 0);
+        assert!(!outcome.has_forged_trust_markers());
+    }
 }

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -282,6 +282,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             connection_id: 0,
             sequence_number: 0,
+            observed_sdk_identity: Default::default(),
         }
     }
 
@@ -442,6 +443,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             connection_id: 0,
             sequence_number: 0,
+            observed_sdk_identity: Default::default(),
         };
 
         let outcome = scanner.enforce(&mut event);

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -328,6 +328,7 @@ mod tests {
             connection_id: 0,
             sequence_number: 0,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         }
     }
 
@@ -489,6 +490,7 @@ mod tests {
             connection_id: 0,
             sequence_number: 0,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         };
 
         let outcome = scanner.enforce(&mut event);
@@ -584,6 +586,7 @@ mod tests {
             connection_id: 0,
             sequence_number: 0,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         };
         for (k, v) in labels {
             event.inner.labels.insert((*k).to_string(), (*v).to_string());

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -20,6 +20,19 @@ use aa_security::{CredentialFinding, CredentialScanner};
 use super::event::EnrichedEvent;
 use crate::config::RuntimeConfig;
 
+/// Reserved `labels` keys that assert a *trust grant* — values the runtime must
+/// compute itself, never the SDK (AAASM-3630).
+///
+/// The SDK controls the `labels` map, so any of these keys arriving on the wire
+/// is a forgery attempt: an agent trying to shorten enforcement by claiming the
+/// event was already trusted / scanned / allowed. The runtime strips them
+/// unconditionally and counts the attempt — it never honours them. This is the
+/// concrete realization of the AAASM-2569 "no SDK-supplied trust marker" threat.
+///
+/// `aa.sdk_version` is deliberately **not** in this set: it is a *claim to be
+/// verified* (read in AAASM-3625), not a trust grant, so it is preserved.
+pub const TRUST_MARKER_LABELS: &[&str] = &["aa.trusted", "aa.scanned", "aa.allow", "aa.bypass"];
+
 /// Default upper bound, in bytes, on a single secret-bearing field handed to
 /// the scanner. Fields larger than this are handled per [`OversizedPolicy`].
 ///
@@ -90,10 +103,19 @@ pub struct EnforcementOutcome {
     pub oversized_fields: usize,
     /// Total bytes actually handed to the scanner across all fields.
     pub scanned_bytes: usize,
+    /// Number of SDK-supplied trust-marker labels (see [`TRUST_MARKER_LABELS`])
+    /// that were stripped from the event — i.e. forgery attempts the runtime
+    /// refused to honour (AAASM-3630). Read by the tamper audit / metric layer.
+    pub forged_trust_markers: usize,
 }
 
 impl EnforcementOutcome {
     /// `true` when nothing was redacted: no findings and no oversized fields.
+    ///
+    /// Forged trust markers do **not** affect this: they are a distinct tamper
+    /// signal (see [`has_forged_trust_markers`](Self::has_forged_trust_markers)),
+    /// not a payload redaction. Stripping a forged `aa.trusted` label from an
+    /// otherwise-clean event still leaves it clean.
     pub fn is_clean(&self) -> bool {
         self.findings.is_empty() && self.oversized_fields == 0
     }
@@ -101,6 +123,11 @@ impl EnforcementOutcome {
     /// Total number of redactions applied (findings + oversized fields).
     pub fn redaction_count(&self) -> usize {
         self.findings.len() + self.oversized_fields
+    }
+
+    /// `true` when at least one forged SDK trust-marker label was stripped.
+    pub fn has_forged_trust_markers(&self) -> bool {
+        self.forged_trust_markers > 0
     }
 }
 
@@ -145,10 +172,13 @@ impl RuntimeScanner {
     /// Runs **unconditionally** — no field of the event can request that
     /// scanning be skipped, and there is no SDK trust marker on the wire. Only
     /// the allowlisted secret-bearing fields are scanned; opaque numeric and
-    /// enumeration fields are left untouched.
+    /// enumeration fields are left untouched. Any SDK-supplied trust-marker
+    /// labels are stripped and counted (AAASM-3630) before the scan so a forged
+    /// marker can never shorten the work below.
     pub fn enforce(&self, event: &mut EnrichedEvent) -> EnforcementOutcome {
         let started = Instant::now();
         let mut outcome = EnforcementOutcome::default();
+        strip_trust_markers(&mut event.inner.labels, &mut outcome);
         if let Some(detail) = event.inner.detail.as_mut() {
             self.scan_detail(detail, &mut outcome);
         }
@@ -236,6 +266,21 @@ impl RuntimeScanner {
                 *field = OVERSIZED_MARKER.as_bytes().to_vec();
                 outcome.oversized_fields += 1;
             }
+        }
+    }
+}
+
+/// Strip every reserved SDK trust-marker label (see [`TRUST_MARKER_LABELS`])
+/// from `labels` in place, counting each removal into
+/// [`EnforcementOutcome::forged_trust_markers`].
+///
+/// The runtime computes trust itself; an SDK-supplied trust grant is a forgery
+/// attempt that is dropped and flagged, never honoured. `aa.sdk_version` (a
+/// claim, not a grant) is intentionally not in the marker set and is preserved.
+fn strip_trust_markers(labels: &mut std::collections::HashMap<String, String>, outcome: &mut EnforcementOutcome) {
+    for key in TRUST_MARKER_LABELS {
+        if labels.remove(*key).is_some() {
+            outcome.forged_trust_markers += 1;
         }
     }
 }

--- a/aa-runtime/src/pipeline/event.rs
+++ b/aa-runtime/src/pipeline/event.rs
@@ -1,6 +1,16 @@
 //! Enriched event type produced by the pipeline ingestion stage.
 
 use aa_proto::assembly::audit::v1::AuditEvent;
+use aa_security::sdk_identity::ObservedSdkIdentity;
+
+/// Reserved `AuditEvent.labels` key carrying the SDK version an agent *claims*.
+///
+/// The SDK controls the `labels` map, so this is an **untrusted claim**: it is
+/// transported to the server-side classifier (AAASM-3621) to be recomputed
+/// against the verified identity, never honoured at face value. Unlike the
+/// trust-marker keys stripped in enforcement (AAASM-3630), this key is
+/// preserved — it is a claim to be verified, not a trust grant.
+pub const SDK_VERSION_LABEL: &str = "aa.sdk_version";
 
 /// The input source that delivered the raw event to the pipeline.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,6 +48,13 @@ pub struct EnrichedEvent {
     /// buffer overflow (`RecvError::Lagged(n)` tells how many were dropped but not
     /// which ones — sequence numbers identify the missing range).
     pub sequence_number: u64,
+    /// The SDK identity the agent *claimed* on the wire, read from the
+    /// (attacker-controlled) `inner.labels` map at ingest (AAASM-3625).
+    ///
+    /// This is the **observed** signal only: it is recomputed server-side
+    /// against the verified handshake identity (AAASM-3640) by the classifier
+    /// before any tamper verdict is drawn. Never granted trust at face value.
+    pub observed_sdk_identity: ObservedSdkIdentity,
 }
 
 /// Top-level event type carried by the pipeline broadcast channel.
@@ -88,6 +105,7 @@ mod tests {
             agent_id: agent_id.clone(),
             connection_id,
             sequence_number: 0,
+            observed_sdk_identity: ObservedSdkIdentity::present("1.2.3"),
         };
 
         assert_eq!(enriched_event.inner, audit_event);
@@ -96,6 +114,8 @@ mod tests {
         assert_eq!(enriched_event.agent_id, agent_id);
         assert_eq!(enriched_event.connection_id, connection_id);
         assert_eq!(enriched_event.sequence_number, 0);
+        assert!(enriched_event.observed_sdk_identity.present);
+        assert_eq!(enriched_event.observed_sdk_identity.version.as_deref(), Some("1.2.3"));
     }
 
     #[test]
@@ -115,6 +135,7 @@ mod tests {
             agent_id: "original-agent".to_string(),
             connection_id: 7,
             sequence_number: 3,
+            observed_sdk_identity: ObservedSdkIdentity::missing(),
         };
 
         let cloned = original.clone();
@@ -143,6 +164,7 @@ mod tests {
             agent_id: "a".to_string(),
             connection_id: 0,
             sequence_number: 0,
+            observed_sdk_identity: ObservedSdkIdentity::default(),
         }));
         assert!(matches!(event, PipelineEvent::Audit(_)));
     }
@@ -166,6 +188,7 @@ mod tests {
             agent_id: "a".to_string(),
             connection_id: 0,
             sequence_number: 0,
+            observed_sdk_identity: ObservedSdkIdentity::default(),
         }));
         let cloned = event.clone();
         assert!(matches!(cloned, PipelineEvent::Audit(_)));

--- a/aa-runtime/src/pipeline/event.rs
+++ b/aa-runtime/src/pipeline/event.rs
@@ -1,7 +1,7 @@
 //! Enriched event type produced by the pipeline ingestion stage.
 
 use aa_proto::assembly::audit::v1::AuditEvent;
-use aa_security::sdk_identity::ObservedSdkIdentity;
+use aa_security::sdk_identity::{ObservedSdkIdentity, SdkIdentityVerdict};
 
 /// Reserved `AuditEvent.labels` key carrying the SDK version an agent *claims*.
 ///
@@ -11,6 +11,21 @@ use aa_security::sdk_identity::ObservedSdkIdentity;
 /// trust-marker keys stripped in enforcement (AAASM-3630), this key is
 /// preserved — it is a claim to be verified, not a trust grant.
 pub const SDK_VERSION_LABEL: &str = "aa.sdk_version";
+
+/// Server-recomputed SDK bypass/tamper signal attached to an event (AAASM-3637).
+///
+/// Set on an [`EnrichedEvent`] when the runtime suspects the SDK was stripped,
+/// forged, or downgraded — or forged trust markers were stripped. Carries only
+/// the recomputed verdict and the count of stripped markers (no agent free
+/// text), so it can ride into the audit payload as a queryable record without a
+/// proto change. `None` on an event means no tamper signal was computed for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TamperSignal {
+    /// The server-recomputed SDK-identity verdict.
+    pub verdict: SdkIdentityVerdict,
+    /// How many SDK-supplied trust-marker labels were stripped (AAASM-3630).
+    pub forged_trust_markers: usize,
+}
 
 /// The input source that delivered the raw event to the pipeline.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,6 +70,12 @@ pub struct EnrichedEvent {
     /// against the verified handshake identity (AAASM-3640) by the classifier
     /// before any tamper verdict is drawn. Never granted trust at face value.
     pub observed_sdk_identity: ObservedSdkIdentity,
+    /// Server-recomputed SDK bypass/tamper signal (AAASM-3637).
+    ///
+    /// `Some` on the distinct tamper governance event the pipeline emits when a
+    /// flagged verdict / forged trust markers are detected; carried into the
+    /// audit payload's `sdk_identity` section. `None` on ordinary events.
+    pub tamper: Option<TamperSignal>,
 }
 
 /// Top-level event type carried by the pipeline broadcast channel.
@@ -106,6 +127,7 @@ mod tests {
             connection_id,
             sequence_number: 0,
             observed_sdk_identity: ObservedSdkIdentity::present("1.2.3"),
+            tamper: None,
         };
 
         assert_eq!(enriched_event.inner, audit_event);
@@ -136,6 +158,7 @@ mod tests {
             connection_id: 7,
             sequence_number: 3,
             observed_sdk_identity: ObservedSdkIdentity::missing(),
+            tamper: None,
         };
 
         let cloned = original.clone();
@@ -165,6 +188,7 @@ mod tests {
             connection_id: 0,
             sequence_number: 0,
             observed_sdk_identity: ObservedSdkIdentity::default(),
+            tamper: None,
         }));
         assert!(matches!(event, PipelineEvent::Audit(_)));
     }
@@ -189,6 +213,7 @@ mod tests {
             connection_id: 0,
             sequence_number: 0,
             observed_sdk_identity: ObservedSdkIdentity::default(),
+            tamper: None,
         }));
         let cloned = event.clone();
         assert!(matches!(cloned, PipelineEvent::Audit(_)));

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -128,9 +128,12 @@ pub async fn run(
                             &verified,
                             config.min_sdk_version.as_deref(),
                         );
-                        // The audit event + metric for a flagged verdict / forged
-                        // markers is emitted in AAASM-3637.
-                        let _ = (&outcome, verdict);
+                        // AAASM-3637: a flagged verdict (Missing/Forged/Downgraded)
+                        // OR a forged trust marker is a distinct bypass/tamper
+                        // signal — emit its own audit record + metric, purely
+                        // observational (the enforcement decision below is
+                        // unchanged, runtime stays authoritative).
+                        emit_tamper_signal(verdict, &outcome, &enriched, &broadcast_tx, &seq);
                         tracing::debug!(sequence_number = enriched.sequence_number, connection_id, "event enriched");
                         metrics.record_processed(1);
                         ::metrics::counter!("aa_events_received_total").increment(1);
@@ -194,6 +197,8 @@ fn enrich(event: AuditEvent, agent_id: &str, connection_id: u64, seq: &AtomicU64
         connection_id,
         sequence_number,
         observed_sdk_identity,
+        // No tamper signal at ingest; set on the dedicated tamper event in run().
+        tamper: None,
     }
 }
 
@@ -234,6 +239,66 @@ async fn resolve_verified_identity(
         .get(&connection_id)
         .cloned()
         .unwrap_or_else(aa_security::sdk_identity::VerifiedSdkIdentity::none)
+}
+
+/// Emit a distinct "bypass/tamper suspected" audit event + metric (AAASM-3637).
+///
+/// Fires when the server-recomputed `verdict` is a tamper signal
+/// (Missing / Forged / VersionDowngraded) **or** the enforcement stage stripped
+/// forged trust markers. The emission is purely observational: it does not alter
+/// the allow/deny outcome for `source` (the runtime stays authoritative).
+///
+/// The record is a dedicated [`EnrichedEvent`] that preserves `source`'s agent
+/// identity and lineage (so the audit subject is keyed correctly) but carries no
+/// action `detail` — it is a tamper observation, not an intercepted action — and
+/// a `tamper` annotation the audit payload serialises into an `sdk_identity`
+/// section (AAASM-3637). The metric `aa_runtime_sdk_tamper_suspected_total` is
+/// labelled by the verdict kind for alerting.
+fn emit_tamper_signal(
+    verdict: aa_security::sdk_identity::SdkIdentityVerdict,
+    outcome: &enforcement::EnforcementOutcome,
+    source: &EnrichedEvent,
+    broadcast_tx: &broadcast::Sender<PipelineEvent>,
+    seq: &AtomicU64,
+) {
+    let forged = outcome.forged_trust_markers;
+    if !verdict.is_suspected_tamper() && forged == 0 {
+        return;
+    }
+
+    ::metrics::counter!("aa_runtime_sdk_tamper_suspected_total", "kind" => verdict.as_str()).increment(1);
+
+    // A tamper observation carries the originating agent's identity/lineage but
+    // no action detail — it records the bypass, not the action.
+    let mut tamper_inner = AuditEvent {
+        event_id: Uuid::new_v4().to_string(),
+        agent_id: source.inner.agent_id.clone(),
+        ..Default::default()
+    };
+    tamper_inner.session_id = source.inner.session_id.clone();
+    tamper_inner.team_id = source.inner.team_id.clone();
+
+    let tamper_event = EnrichedEvent {
+        inner: tamper_inner,
+        received_at_ms: source.received_at_ms,
+        source: source.source.clone(),
+        agent_id: source.agent_id.clone(),
+        connection_id: source.connection_id,
+        sequence_number: seq.fetch_add(1, Ordering::Relaxed),
+        observed_sdk_identity: source.observed_sdk_identity.clone(),
+        tamper: Some(event::TamperSignal {
+            verdict,
+            forged_trust_markers: forged,
+        }),
+    };
+
+    tracing::warn!(
+        verdict = verdict.as_str(),
+        forged_trust_markers = forged,
+        connection_id = source.connection_id,
+        "SDK bypass/tamper suspected"
+    );
+    let _ = broadcast_tx.send(PipelineEvent::Audit(Box::new(tamper_event)));
 }
 
 /// Returns `true` if this event should bypass batching and be emitted immediately.

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -1139,6 +1139,76 @@ mod tests {
         token.cancel();
     }
 
+    #[test]
+    fn emit_tamper_signal_broadcasts_distinct_event_and_metric_for_missing() {
+        use aa_security::sdk_identity::SdkIdentityVerdict;
+        use metrics_exporter_prometheus::PrometheusBuilder;
+
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<PipelineEvent>(8);
+        let seq = AtomicU64::new(0);
+        let source = enrich(normal_event(), "agent", 0, &seq);
+        let outcome = enforcement::EnforcementOutcome::default();
+
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        ::metrics::with_local_recorder(&recorder, || {
+            emit_tamper_signal(SdkIdentityVerdict::Missing, &outcome, &source, &broadcast_tx, &seq);
+        });
+
+        // A distinct tamper audit event is broadcast.
+        let event = unwrap_audit(broadcast_rx.try_recv().expect("tamper event broadcast"));
+        let tamper = event.tamper.expect("tamper annotation present");
+        assert_eq!(tamper.verdict, SdkIdentityVerdict::Missing);
+        assert_eq!(tamper.forged_trust_markers, 0);
+        // It is a tamper observation, not an action.
+        assert!(event.inner.detail.is_none());
+
+        // The dedicated metric is incremented, labelled by kind.
+        let rendered = handle.render();
+        assert!(rendered.contains("aa_runtime_sdk_tamper_suspected_total"));
+        assert!(rendered.contains("kind=\"missing\""));
+    }
+
+    #[test]
+    fn emit_tamper_signal_fires_for_forged_markers_even_when_verdict_ok() {
+        use aa_security::sdk_identity::SdkIdentityVerdict;
+
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<PipelineEvent>(8);
+        let seq = AtomicU64::new(0);
+        let source = enrich(normal_event(), "agent", 0, &seq);
+        let outcome = enforcement::EnforcementOutcome {
+            forged_trust_markers: 1,
+            ..Default::default()
+        };
+
+        emit_tamper_signal(SdkIdentityVerdict::Ok, &outcome, &source, &broadcast_tx, &seq);
+
+        let event = unwrap_audit(broadcast_rx.try_recv().expect("tamper event broadcast"));
+        let tamper = event.tamper.expect("tamper annotation present");
+        assert_eq!(tamper.verdict, SdkIdentityVerdict::Ok);
+        assert_eq!(tamper.forged_trust_markers, 1);
+    }
+
+    #[test]
+    fn emit_tamper_signal_is_silent_when_clean() {
+        use aa_security::sdk_identity::SdkIdentityVerdict;
+
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<PipelineEvent>(8);
+        let seq = AtomicU64::new(0);
+        let source = enrich(normal_event(), "agent", 0, &seq);
+        let outcome = enforcement::EnforcementOutcome::default();
+
+        // Ok verdict + no forged markers → no emission.
+        emit_tamper_signal(SdkIdentityVerdict::Ok, &outcome, &source, &broadcast_tx, &seq);
+        // Unverifiable is also not a tamper signal.
+        emit_tamper_signal(SdkIdentityVerdict::Unverifiable, &outcome, &source, &broadcast_tx, &seq);
+
+        assert!(
+            broadcast_rx.try_recv().is_err(),
+            "no tamper event for a clean/unverifiable event"
+        );
+    }
+
     #[tokio::test]
     async fn batch_flushes_on_interval() {
         let config = test_config(100, 50); // batch_size=100 (won't reach), interval=50ms

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -10,7 +10,7 @@ pub use metrics::PipelineMetrics;
 use crate::approval::{ApprovalDecision as RuntimeApprovalDecision, ApprovalQueue, ApprovalRequest};
 use crate::config::RuntimeConfig;
 use crate::gateway_client::GatewayClient;
-use crate::ipc::{IpcFrame, IpcResponse, ResponseRouter};
+use crate::ipc::{IpcFrame, IpcResponse, ResponseRouter, VerifiedIdentityStore};
 use crate::policy::PolicyRules;
 use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, PolicyViolation};
 use aa_proto::assembly::common::v1::{ActionType, Decision};
@@ -44,6 +44,9 @@ pub struct PipelineConfig {
     /// instead of falling back to permissive local evaluation (AAASM-3110).
     /// Copied from [`RuntimeConfig::gateway_fail_closed`]; defaults to `true`.
     pub gateway_fail_closed: bool,
+    /// Minimum supported SDK version. When set, an observed SDK version below it
+    /// is classified as a downgrade (AAASM-3640). `None` imposes no floor.
+    pub min_sdk_version: Option<String>,
 }
 
 impl PipelineConfig {
@@ -57,6 +60,9 @@ impl PipelineConfig {
             agent_id: c.agent_id.clone(),
             enforcement: enforcement::EnforcementConfig::from_runtime_config(c),
             gateway_fail_closed: c.gateway_fail_closed,
+            // No operator-configurable SDK version floor yet; downgrade
+            // detection activates once a minimum is wired into RuntimeConfig.
+            min_sdk_version: None,
         }
     }
 }
@@ -80,6 +86,7 @@ pub async fn run(
     gateway_client: Option<Arc<Mutex<GatewayClient>>>,
     op_control: crate::op_control::OpControlStore,
     seq: Arc<AtomicU64>,
+    verified_identities: VerifiedIdentityStore,
 ) {
     let mut batch: Vec<EnrichedEvent> = Vec::with_capacity(config.batch_size);
     let mut ticker = tokio::time::interval(config.flush_interval);
@@ -109,8 +116,21 @@ pub async fn run(
                         let mut enriched = enrich(event, &config.agent_id, connection_id, &seq);
                         // GATE: scan + redact + normalize before any forward or
                         // audit, on every path. Unconditional — no SDK signal can
-                        // skip this.
-                        scanner.enforce(&mut enriched);
+                        // skip this. The outcome also reports any forged trust
+                        // markers stripped (AAASM-3630).
+                        let outcome = scanner.enforce(&mut enriched);
+                        // AAASM-3640: recompute the SDK-identity verdict against
+                        // the handshake-verified identity for this connection
+                        // (Unverifiable when the connection never authenticated).
+                        let verified = resolve_verified_identity(&verified_identities, connection_id).await;
+                        let verdict = aa_security::sdk_identity::classify(
+                            &enriched.observed_sdk_identity,
+                            &verified,
+                            config.min_sdk_version.as_deref(),
+                        );
+                        // The audit event + metric for a flagged verdict / forged
+                        // markers is emitted in AAASM-3637.
+                        let _ = (&outcome, verdict);
                         tracing::debug!(sequence_number = enriched.sequence_number, connection_id, "event enriched");
                         metrics.record_processed(1);
                         ::metrics::counter!("aa_events_received_total").increment(1);
@@ -193,6 +213,27 @@ fn observe_sdk_identity(event: &AuditEvent) -> aa_security::sdk_identity::Observ
         },
         None => aa_security::sdk_identity::ObservedSdkIdentity::missing(),
     }
+}
+
+/// Resolve the AAASM-3569 handshake-verified SDK identity for `connection_id`
+/// (AAASM-3640).
+///
+/// Returns the identity the authenticated handshake established for the
+/// connection, or [`VerifiedSdkIdentity::none`] when the connection has no
+/// entry — i.e. it never completed a handshake, or its source has no IPC
+/// handshake (eBPF / proxy events use `connection_id` 0). Falling back to
+/// `none` keeps the verdict at `Unverifiable` rather than guessing, so there is
+/// no regression for non-handshake paths.
+async fn resolve_verified_identity(
+    store: &VerifiedIdentityStore,
+    connection_id: u64,
+) -> aa_security::sdk_identity::VerifiedSdkIdentity {
+    store
+        .read()
+        .await
+        .get(&connection_id)
+        .cloned()
+        .unwrap_or_else(aa_security::sdk_identity::VerifiedSdkIdentity::none)
 }
 
 /// Returns `true` if this event should bypass batching and be emitted immediately.
@@ -928,6 +969,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            min_sdk_version: None,
         };
 
         let cloned = pipeline_config.clone();
@@ -948,6 +990,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            min_sdk_version: None,
         }
     }
 
@@ -991,6 +1034,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // Send 3 events — batch threshold reached, should flush before interval
@@ -1029,6 +1073,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // Send 5 events (less than batch_size=100) — should arrive after interval flush
@@ -1067,6 +1112,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // Send a violation — should arrive immediately, bypassing batch
@@ -1104,6 +1150,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // Send 5 events (batch won't flush yet)
@@ -1160,6 +1207,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // Send non-event frames
@@ -1206,6 +1254,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // Build an AuditEvent with action_type = FILE_OPERATION
@@ -1261,6 +1310,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // `tokio::time::interval` fires an immediate first tick on creation. With the
@@ -1312,6 +1362,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         for _ in 0..3 {
@@ -1359,6 +1410,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // First batch of 2
@@ -1430,6 +1482,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // Spawn a receiver that drains the broadcast channel
@@ -1512,6 +1565,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
@@ -1562,6 +1616,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
@@ -1629,6 +1684,7 @@ mod tests {
             None,
             op_control,
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         tx.send((0, policy_query_frame_for_op(ActionType::ToolCall, "trace-1", "span-1")))
@@ -1684,6 +1740,7 @@ mod tests {
             None,
             op_control,
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         tx.send((0, policy_query_frame_for_op(ActionType::ToolCall, "trace-2", "span-2")))
@@ -1746,6 +1803,7 @@ mod tests {
             Some(gateway),
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
@@ -1799,6 +1857,7 @@ mod tests {
             Some(gateway),
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
@@ -1855,6 +1914,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
@@ -1914,6 +1974,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         // Send the query — get back PENDING with approval_id.
@@ -2008,6 +2069,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         tx.send((0, IpcFrame::EventReport(tool_call_with_secret())))
@@ -2056,6 +2118,7 @@ mod tests {
             None,
             crate::op_control::OpControlStore::new(),
             Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
         ));
 
         tx.send((0, IpcFrame::EventReport(tool_call_with_secret())))

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -165,6 +165,7 @@ fn enrich(event: AuditEvent, agent_id: &str, connection_id: u64, seq: &AtomicU64
         .unwrap_or(Duration::ZERO)
         .as_millis() as i64;
     let sequence_number = seq.fetch_add(1, Ordering::Relaxed);
+    let observed_sdk_identity = observe_sdk_identity(&event);
     EnrichedEvent {
         inner: event,
         received_at_ms,
@@ -172,6 +173,25 @@ fn enrich(event: AuditEvent, agent_id: &str, connection_id: u64, seq: &AtomicU64
         agent_id: agent_id.to_string(),
         connection_id,
         sequence_number,
+        observed_sdk_identity,
+    }
+}
+
+/// Read the SDK identity an agent *claimed* out of the (attacker-controlled)
+/// `labels` map (AAASM-3625).
+///
+/// `present` is set when the reserved [`event::SDK_VERSION_LABEL`] key exists;
+/// the label value is carried as the claimed version. This is an untrusted
+/// claim transported for server-side recomputation — the label is **not**
+/// removed here (that is sanitization's job) and is **never** honoured as a
+/// trust grant.
+fn observe_sdk_identity(event: &AuditEvent) -> aa_security::sdk_identity::ObservedSdkIdentity {
+    match event.labels.get(event::SDK_VERSION_LABEL) {
+        Some(version) => aa_security::sdk_identity::ObservedSdkIdentity {
+            present: true,
+            version: Some(version.clone()),
+        },
+        None => aa_security::sdk_identity::ObservedSdkIdentity::missing(),
     }
 }
 
@@ -777,6 +797,43 @@ mod tests {
         let seq = AtomicU64::new(0);
         let enriched = enrich(event, "agent", 0, &seq);
         assert_eq!(enriched.source, EventSource::Sdk);
+    }
+
+    #[test]
+    fn enrich_reads_claimed_sdk_version_from_label() {
+        let mut event = make_audit_event();
+        event
+            .labels
+            .insert(event::SDK_VERSION_LABEL.to_string(), "1.4.0".to_string());
+        let seq = AtomicU64::new(0);
+        let enriched = enrich(event, "agent", 0, &seq);
+        assert!(enriched.observed_sdk_identity.present);
+        assert_eq!(enriched.observed_sdk_identity.version.as_deref(), Some("1.4.0"));
+    }
+
+    #[test]
+    fn enrich_marks_missing_sdk_identity_when_label_absent() {
+        let event = make_audit_event();
+        let seq = AtomicU64::new(0);
+        let enriched = enrich(event, "agent", 0, &seq);
+        assert!(!enriched.observed_sdk_identity.present);
+        assert!(enriched.observed_sdk_identity.version.is_none());
+    }
+
+    #[test]
+    fn enrich_preserves_the_claimed_sdk_version_label_on_the_event() {
+        // The claim is transported to the classifier, not consumed here —
+        // sanitization is a separate step (AAASM-3630).
+        let mut event = make_audit_event();
+        event
+            .labels
+            .insert(event::SDK_VERSION_LABEL.to_string(), "2.0.0".to_string());
+        let seq = AtomicU64::new(0);
+        let enriched = enrich(event, "agent", 0, &seq);
+        assert_eq!(
+            enriched.inner.labels.get(event::SDK_VERSION_LABEL).map(String::as_str),
+            Some("2.0.0")
+        );
     }
 
     #[test]

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -861,6 +861,27 @@ mod tests {
         assert!(enriched.observed_sdk_identity.version.is_none());
     }
 
+    #[tokio::test]
+    async fn resolve_verified_identity_returns_stored_entry() {
+        let store = crate::ipc::new_verified_identity_store();
+        store
+            .write()
+            .await
+            .insert(7, aa_security::sdk_identity::VerifiedSdkIdentity::with_version("1.2.3"));
+
+        let resolved = resolve_verified_identity(&store, 7).await;
+        assert_eq!(resolved.version.as_deref(), Some("1.2.3"));
+    }
+
+    #[tokio::test]
+    async fn resolve_verified_identity_falls_back_to_none_when_absent() {
+        let store = crate::ipc::new_verified_identity_store();
+        // No handshake recorded for connection 99 → Unverifiable downstream.
+        let resolved = resolve_verified_identity(&store, 99).await;
+        assert!(resolved.version.is_none());
+        assert!(!resolved.is_available());
+    }
+
     #[test]
     fn enrich_preserves_the_claimed_sdk_version_label_on_the_event() {
         // The claim is transported to the classifier, not consumed here —

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -1081,11 +1081,19 @@ mod tests {
     }
 
     fn normal_event() -> AuditEvent {
-        AuditEvent::default()
+        // A well-behaved SDK presents its version, so the run loop draws no
+        // tamper signal (Unverifiable, not flagged) and forwards only the
+        // action event. Tamper-path behaviour is covered by the dedicated
+        // emit_tamper_signal tests and aaasm_3571_tamper_observability.
+        let mut event = AuditEvent::default();
+        event
+            .labels
+            .insert(event::SDK_VERSION_LABEL.to_string(), "1.0.0".to_string());
+        event
     }
 
     fn violation_event() -> AuditEvent {
-        AuditEvent {
+        let mut event = AuditEvent {
             detail: Some(Detail::Violation(PolicyViolation {
                 policy_rule: "rule".to_string(),
                 blocked_action: "action".to_string(),
@@ -1093,7 +1101,13 @@ mod tests {
                 latency_ms: 0,
             })),
             ..Default::default()
-        }
+        };
+        // Present SDK version → no tamper signal, so the violation path forwards
+        // only the violation event.
+        event
+            .labels
+            .insert(event::SDK_VERSION_LABEL.to_string(), "1.0.0".to_string());
+        event
     }
 
     // -----------------------------------------------------------------------
@@ -1474,11 +1488,16 @@ mod tests {
         // send the event, so the first tick cannot race ahead and flush our event.
         tokio::task::yield_now().await;
 
-        // Build a TOOL_CALL event — not blocked by the policy
-        let event = AuditEvent {
+        // Build a TOOL_CALL event — not blocked by the policy. Carries the SDK
+        // version label so it draws no tamper signal (which would bypass the
+        // batch and break this batching assertion).
+        let mut event = AuditEvent {
             action_type: ActionType::ToolCall as i32,
             ..Default::default()
         };
+        event
+            .labels
+            .insert(event::SDK_VERSION_LABEL.to_string(), "1.0.0".to_string());
         tx.send((0, IpcFrame::EventReport(event))).await.unwrap();
 
         // Wait until the run loop has enqueued the event into the batch.
@@ -2184,14 +2203,20 @@ mod tests {
     /// A ToolCall `AuditEvent` whose `args_json` embeds [`GATE_SECRET`].
     fn tool_call_with_secret() -> AuditEvent {
         use aa_proto::assembly::audit::v1::ToolCallDetail;
-        AuditEvent {
+        let mut event = AuditEvent {
             action_type: ActionType::ToolCall as i32,
             detail: Some(Detail::ToolCall(ToolCallDetail {
                 args_json: format!(r#"{{"api_key": "{GATE_SECRET}"}}"#).into_bytes(),
                 ..Default::default()
             })),
             ..Default::default()
-        }
+        };
+        // Present SDK version → no tamper event, so this redaction test sees only
+        // the single forwarded action event.
+        event
+            .labels
+            .insert(event::SDK_VERSION_LABEL.to_string(), "1.0.0".to_string());
+        event
     }
 
     /// Assert an audited pipeline event's `args_json` was redacted, not raw.

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -988,6 +988,7 @@ mod tests {
             agent_id: "test".to_string(),
             connection_id: 1,
             sequence_number: 0,
+            observed_sdk_identity: Default::default(),
         };
 
         // Build an eBPF/FILE_OPERATION action event.
@@ -1002,6 +1003,7 @@ mod tests {
             agent_id: "test".to_string(),
             connection_id: 1,
             sequence_number: 1,
+            observed_sdk_identity: Default::default(),
         };
 
         // Simulate the subscriber loop: convert and ingest.
@@ -1138,6 +1140,7 @@ mod tests {
             agent_id: "test".to_string(),
             connection_id: 1,
             sequence_number: 0,
+            observed_sdk_identity: Default::default(),
         };
 
         tx.send(PipelineEvent::Audit(Box::new(enriched))).unwrap();
@@ -1368,6 +1371,7 @@ mod tests {
             agent_id: "pipe-agent".to_string(),
             connection_id: 1,
             sequence_number: seq,
+            observed_sdk_identity: Default::default(),
         }))
     }
 

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -578,6 +578,9 @@ pub async fn run(config: RuntimeConfig) {
 
     // Shared response router — maps connection_id → per-connection IpcResponse sender.
     let response_router = crate::ipc::new_response_router();
+    // Shared verified-identity store (AAASM-3640) — maps connection_id → the SDK
+    // identity the AAASM-3569 handshake authenticated for that connection.
+    let verified_identities = crate::ipc::new_verified_identity_store();
 
     // Audit publisher (AAASM-2547): when [gateway.nats] is configured, the
     // approval queue's governance AuditEntry stream is drained to NATS; when
@@ -624,9 +627,17 @@ pub async fn run(config: RuntimeConfig) {
             let ipc_token = token.clone();
             let ipc_active_connections = std::sync::Arc::clone(&active_connections);
             let ipc_router = std::sync::Arc::clone(&response_router);
+            let ipc_verified = std::sync::Arc::clone(&verified_identities);
             tracker.spawn(async move {
                 ipc_server
-                    .run(ipc_tracker, ipc_token, inbound_tx, ipc_active_connections, ipc_router)
+                    .run(
+                        ipc_tracker,
+                        ipc_token,
+                        inbound_tx,
+                        ipc_active_connections,
+                        ipc_router,
+                        ipc_verified,
+                    )
                     .await;
             });
             tracing::info!("IPC server task spawned");
@@ -709,6 +720,7 @@ pub async fn run(config: RuntimeConfig) {
         let pipeline_approval_queue = std::sync::Arc::clone(&approval_queue);
         let pipeline_seq = std::sync::Arc::clone(&seq);
         let pipeline_op_control = op_control.clone();
+        let pipeline_verified = std::sync::Arc::clone(&verified_identities);
         tracker.spawn(async move {
             crate::pipeline::run(
                 inbound_rx,
@@ -722,6 +734,7 @@ pub async fn run(config: RuntimeConfig) {
                 gateway_client,
                 pipeline_op_control,
                 pipeline_seq,
+                pipeline_verified,
             )
             .await;
         });

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1002,6 +1002,7 @@ mod tests {
             connection_id: 1,
             sequence_number: 0,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         };
 
         // Build an eBPF/FILE_OPERATION action event.
@@ -1017,6 +1018,7 @@ mod tests {
             connection_id: 1,
             sequence_number: 1,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         };
 
         // Simulate the subscriber loop: convert and ingest.
@@ -1154,6 +1156,7 @@ mod tests {
             connection_id: 1,
             sequence_number: 0,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         };
 
         tx.send(PipelineEvent::Audit(Box::new(enriched))).unwrap();
@@ -1385,6 +1388,7 @@ mod tests {
             connection_id: 1,
             sequence_number: seq,
             observed_sdk_identity: Default::default(),
+            tamper: None,
         }))
     }
 

--- a/aa-runtime/tests/aaasm_2568_gate_verification.rs
+++ b/aa-runtime/tests/aaasm_2568_gate_verification.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, ToolCallDetail};
 use aa_proto::assembly::common::v1::ActionType;
 use aa_runtime::approval::ApprovalQueue;
-use aa_runtime::ipc::{new_response_router, IpcFrame};
+use aa_runtime::ipc::{new_response_router, new_verified_identity_store, IpcFrame};
 use aa_runtime::pipeline::enforcement::{EnforcementConfig, OVERSIZED_MARKER};
 use aa_runtime::pipeline::{run, PipelineConfig, PipelineEvent, PipelineMetrics};
 use aa_runtime::policy::{PolicyRule, PolicyRules};
@@ -33,6 +33,7 @@ fn verify_config(batch_size: usize) -> PipelineConfig {
         agent_id: "verify-agent".to_string(),
         enforcement: aa_runtime::pipeline::enforcement::EnforcementConfig::default(),
         gateway_fail_closed: true,
+        min_sdk_version: None,
     }
 }
 
@@ -81,6 +82,7 @@ async fn drive_one(policy: PolicyRules) -> PipelineEvent {
         None,
         aa_runtime::op_control::OpControlStore::new(),
         Arc::new(AtomicU64::new(0)),
+        new_verified_identity_store(),
     ));
 
     tx.send((0, IpcFrame::EventReport(tool_call_with_secret())))
@@ -149,6 +151,7 @@ async fn configured_size_cap_redacts_oversized_field_through_run() {
         None,
         aa_runtime::op_control::OpControlStore::new(),
         Arc::new(AtomicU64::new(0)),
+        new_verified_identity_store(),
     ));
 
     // tool_call_with_secret()'s args_json is ~37 bytes, exceeding the 16-byte cap.

--- a/aa-runtime/tests/aaasm_2568_gate_verification.rs
+++ b/aa-runtime/tests/aaasm_2568_gate_verification.rs
@@ -38,15 +38,24 @@ fn verify_config(batch_size: usize) -> PipelineConfig {
 }
 
 /// A ToolCall `AuditEvent` whose `args_json` embeds [`SECRET`].
+///
+/// Carries the reserved `aa.sdk_version` label so the run loop draws no
+/// AAASM-3571 tamper signal — this gate test asserts on the single forwarded
+/// (redacted) action event, not the tamper-observability path.
 fn tool_call_with_secret() -> AuditEvent {
-    AuditEvent {
+    let mut event = AuditEvent {
         action_type: ActionType::ToolCall as i32,
         detail: Some(Detail::ToolCall(ToolCallDetail {
             args_json: format!(r#"{{"api_key": "{SECRET}"}}"#).into_bytes(),
             ..Default::default()
         })),
         ..Default::default()
-    }
+    };
+    event.labels.insert(
+        aa_runtime::pipeline::event::SDK_VERSION_LABEL.to_string(),
+        "1.0.0".to_string(),
+    );
+    event
 }
 
 /// Assert that a forwarded pipeline event's `args_json` is redacted, not raw.

--- a/aa-runtime/tests/aaasm_3571_tamper_observability.rs
+++ b/aa-runtime/tests/aaasm_3571_tamper_observability.rs
@@ -1,0 +1,215 @@
+//! AAASM-3571 verification — SDK bypass/tamper observability in audit.
+//!
+//! Drives the public [`aa_runtime::pipeline::run`] loop end-to-end and proves the
+//! Story acceptance criteria:
+//!
+//! 1. A missing/forged/downgraded SDK identity produces a **distinct** tamper
+//!    audit event + the `aa_runtime_sdk_tamper_suspected_total` metric.
+//! 2. Forged SDK trust markers are **ignored AND flagged**: the raw marker never
+//!    survives onto the forwarded event, and a tamper signal is recorded.
+//! 3. Bypass observability does **not** change the enforcement decision — a
+//!    clean and a tampered event with the same action yield the same forwarded
+//!    outcome (the runtime stays authoritative).
+//!
+//! The run loop is driven on a current-thread Tokio runtime nested inside
+//! `metrics::with_local_recorder`, mirroring `audit_publisher::publisher`'s
+//! metric test, so the metric assertions never race a global recorder.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, ToolCallDetail};
+use aa_proto::assembly::common::v1::ActionType;
+use aa_runtime::approval::ApprovalQueue;
+use aa_runtime::ipc::{new_response_router, new_verified_identity_store, IpcFrame};
+use aa_runtime::pipeline::event::SDK_VERSION_LABEL;
+use aa_runtime::pipeline::{run, PipelineConfig, PipelineEvent, PipelineMetrics};
+use aa_runtime::policy::PolicyRules;
+use metrics_util::debugging::DebuggingRecorder;
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
+
+/// One of the reserved forged trust-marker labels stripped by the runtime.
+const FORGED_MARKER: &str = "aa.trusted";
+
+fn verify_config() -> PipelineConfig {
+    PipelineConfig {
+        input_buffer: 1_024,
+        // batch_size 1 so ordinary events flush immediately and the test does
+        // not depend on the flush interval.
+        batch_size: 1,
+        flush_interval: Duration::from_millis(10_000),
+        broadcast_capacity: 1_024,
+        agent_id: "verify-agent".to_string(),
+        enforcement: aa_runtime::pipeline::enforcement::EnforcementConfig::default(),
+        gateway_fail_closed: true,
+        min_sdk_version: None,
+    }
+}
+
+/// A clean ToolCall event with a present SDK-version label (no tamper).
+fn clean_tool_call() -> AuditEvent {
+    let mut event = AuditEvent {
+        action_type: ActionType::ToolCall as i32,
+        detail: Some(Detail::ToolCall(ToolCallDetail {
+            tool_name: "web_search".to_string(),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    event.labels.insert(SDK_VERSION_LABEL.to_string(), "1.0.0".to_string());
+    event
+}
+
+/// A ToolCall event with NO SDK-version label — a stripped / bypassed SDK.
+fn tool_call_without_sdk_identity() -> AuditEvent {
+    AuditEvent {
+        action_type: ActionType::ToolCall as i32,
+        detail: Some(Detail::ToolCall(ToolCallDetail {
+            tool_name: "web_search".to_string(),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
+/// A ToolCall event that forges a trust marker hoping to shorten enforcement.
+fn tool_call_with_forged_marker() -> AuditEvent {
+    let mut event = clean_tool_call();
+    event.labels.insert(FORGED_MARKER.to_string(), "true".to_string());
+    event
+}
+
+/// Spawn the pipeline, send `events`, and collect the events forwarded onto the
+/// broadcast channel within a short window. Returns the forwarded events.
+async fn drive(events: Vec<AuditEvent>) -> Vec<aa_runtime::pipeline::EnrichedEvent> {
+    let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+    let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<PipelineEvent>(64);
+    let token = CancellationToken::new();
+
+    let handle = tokio::spawn(run(
+        rx,
+        broadcast_tx,
+        verify_config(),
+        Arc::new(PipelineMetrics::default()),
+        token.clone(),
+        Arc::new(PolicyRules::default()),
+        new_response_router(),
+        ApprovalQueue::new(),
+        None,
+        aa_runtime::op_control::OpControlStore::new(),
+        Arc::new(AtomicU64::new(0)),
+        new_verified_identity_store(),
+    ));
+
+    let expected = events.len();
+    for event in events {
+        tx.send((0, IpcFrame::EventReport(event))).await.expect("send event");
+    }
+
+    // Each ordinary event forwards once; a tampered event additionally forwards a
+    // distinct tamper event. Collect until the channel goes quiet.
+    let mut forwarded = Vec::new();
+    while forwarded.len() < expected {
+        match tokio::time::timeout(Duration::from_millis(500), broadcast_rx.recv()).await {
+            Ok(Ok(PipelineEvent::Audit(e))) => forwarded.push(*e),
+            Ok(Ok(PipelineEvent::LayerDegradation(_))) => {}
+            _ => break,
+        }
+    }
+    // Drain any extra (tamper) events already queued.
+    while let Ok(PipelineEvent::Audit(e)) = broadcast_rx.try_recv() {
+        forwarded.push(*e);
+    }
+
+    token.cancel();
+    let _ = tokio::time::timeout(Duration::from_millis(500), handle).await;
+    forwarded
+}
+
+/// AC1: a missing SDK identity yields a distinct tamper audit event whose
+/// verdict is `missing`, plus the dedicated metric.
+#[test]
+fn missing_sdk_identity_emits_distinct_tamper_event_and_metric() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    let forwarded = metrics::with_local_recorder(&recorder, || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(drive(vec![tool_call_without_sdk_identity()]))
+    });
+
+    // A distinct tamper event (carrying the verdict, with no action detail) is
+    // present in addition to the forwarded action event.
+    let tamper: Vec<_> = forwarded.iter().filter_map(|e| e.tamper).collect();
+    assert_eq!(tamper.len(), 1, "exactly one distinct tamper event");
+    assert_eq!(
+        tamper[0].verdict,
+        aa_security::sdk_identity::SdkIdentityVerdict::Missing
+    );
+
+    let metric_present = snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .any(|(key, _, _, _)| key.key().name() == "aa_runtime_sdk_tamper_suspected_total");
+    assert!(metric_present, "aa_runtime_sdk_tamper_suspected_total recorded");
+}
+
+/// AC2: a forged trust marker is stripped from the forwarded event AND flagged.
+#[tokio::test]
+async fn forged_trust_marker_is_stripped_and_flagged() {
+    let forwarded = drive(vec![tool_call_with_forged_marker()]).await;
+
+    // The raw forged marker never survives onto any forwarded event.
+    for e in &forwarded {
+        assert!(
+            !e.inner.labels.contains_key(FORGED_MARKER),
+            "forged trust marker must never survive downstream"
+        );
+    }
+    // The forgery is flagged via a distinct tamper event.
+    assert!(
+        forwarded
+            .iter()
+            .any(|e| e.tamper.is_some_and(|t| t.forged_trust_markers > 0)),
+        "forged trust marker must be flagged in a tamper event"
+    );
+}
+
+/// AC3: bypass observability does not change the enforcement decision — a clean
+/// and a tampered event with the same action are both forwarded identically
+/// (the runtime stays authoritative; nothing is dropped or allowed differently).
+#[tokio::test]
+async fn observability_does_not_change_enforcement_decision() {
+    let clean = drive(vec![clean_tool_call()]).await;
+    let tampered = drive(vec![tool_call_without_sdk_identity()]).await;
+
+    // The clean event yields exactly its one forwarded action event (no tamper).
+    let clean_actions: Vec<_> = clean.iter().filter(|e| e.tamper.is_none()).collect();
+    assert_eq!(clean_actions.len(), 1, "clean event forwarded once");
+    assert!(
+        clean.iter().all(|e| e.tamper.is_none()),
+        "clean event has no tamper signal"
+    );
+
+    // The tampered event still forwards its action event with the same ToolCall
+    // detail preserved — observability added a record, it did not suppress or
+    // alter the action.
+    let tampered_actions: Vec<_> = tampered.iter().filter(|e| e.tamper.is_none()).collect();
+    assert_eq!(
+        tampered_actions.len(),
+        1,
+        "tampered event's action is still forwarded (decision unchanged)"
+    );
+    let action_detail_kind =
+        |e: &aa_runtime::pipeline::EnrichedEvent| matches!(e.inner.detail, Some(Detail::ToolCall(_)));
+    assert!(
+        action_detail_kind(clean_actions[0]) && action_detail_kind(tampered_actions[0]),
+        "both action events carry the same ToolCall detail — same decision"
+    );
+}

--- a/aa-runtime/tests/scan_latency_test.rs
+++ b/aa-runtime/tests/scan_latency_test.rs
@@ -144,6 +144,7 @@ fn tool_call_event(args_json: Vec<u8>) -> EnrichedEvent {
         agent_id: "bench-agent".to_string(),
         connection_id: 0,
         sequence_number: 0,
+        observed_sdk_identity: Default::default(),
     }
 }
 

--- a/aa-runtime/tests/scan_latency_test.rs
+++ b/aa-runtime/tests/scan_latency_test.rs
@@ -145,6 +145,7 @@ fn tool_call_event(args_json: Vec<u8>) -> EnrichedEvent {
         connection_id: 0,
         sequence_number: 0,
         observed_sdk_identity: Default::default(),
+        tamper: None,
     }
 }
 

--- a/aa-security/src/lib.rs
+++ b/aa-security/src/lib.rs
@@ -20,6 +20,8 @@
 pub mod policy;
 pub mod redaction;
 pub mod scanner;
+pub mod sdk_identity;
 
 pub use redaction::Redaction;
 pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};
+pub use sdk_identity::{ObservedSdkIdentity, SdkIdentityVerdict, VerifiedSdkIdentity};

--- a/aa-security/src/sdk_identity.rs
+++ b/aa-security/src/sdk_identity.rs
@@ -232,3 +232,123 @@ fn parse_components(v: &str) -> Option<Vec<u64>> {
     }
     v.split('.').map(|c| c.parse::<u64>().ok()).collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_when_not_present() {
+        let observed = ObservedSdkIdentity::missing();
+        let verdict = classify(&observed, &VerifiedSdkIdentity::none(), Some("1.0.0"));
+        assert_eq!(verdict, SdkIdentityVerdict::Missing);
+    }
+
+    #[test]
+    fn missing_takes_precedence_over_a_verified_reference() {
+        // No identity presented at all, even if a verified version exists.
+        let observed = ObservedSdkIdentity::missing();
+        let verified = VerifiedSdkIdentity::with_version("2.0.0");
+        assert_eq!(classify(&observed, &verified, None), SdkIdentityVerdict::Missing);
+    }
+
+    #[test]
+    fn forged_when_observed_version_mismatches_verified() {
+        let observed = ObservedSdkIdentity::present("9.9.9");
+        let verified = VerifiedSdkIdentity::with_version("1.2.3");
+        assert_eq!(classify(&observed, &verified, None), SdkIdentityVerdict::Forged);
+    }
+
+    #[test]
+    fn forged_beats_downgrade_when_both_apply() {
+        // Observed contradicts the verified reference AND is below the floor:
+        // the impersonation signal (Forged) is the more severe verdict.
+        let observed = ObservedSdkIdentity::present("0.1.0");
+        let verified = VerifiedSdkIdentity::with_version("2.0.0");
+        assert_eq!(
+            classify(&observed, &verified, Some("1.0.0")),
+            SdkIdentityVerdict::Forged
+        );
+    }
+
+    #[test]
+    fn ok_when_observed_matches_verified() {
+        let observed = ObservedSdkIdentity::present("1.2.3");
+        let verified = VerifiedSdkIdentity::with_version("1.2.3");
+        assert_eq!(classify(&observed, &verified, None), SdkIdentityVerdict::Ok);
+    }
+
+    #[test]
+    fn ok_when_observed_matches_verified_with_zero_padding() {
+        // "1.2" and "1.2.0" are equal under implicit-zero padding, so a match
+        // is not flagged as forged.
+        let observed = ObservedSdkIdentity::present("1.2");
+        let verified = VerifiedSdkIdentity::with_version("1.2.0");
+        assert_eq!(classify(&observed, &verified, None), SdkIdentityVerdict::Ok);
+    }
+
+    #[test]
+    fn version_downgraded_below_minimum() {
+        let observed = ObservedSdkIdentity::present("0.9.0");
+        let verdict = classify(&observed, &VerifiedSdkIdentity::none(), Some("1.0.0"));
+        assert_eq!(verdict, SdkIdentityVerdict::VersionDowngraded);
+    }
+
+    #[test]
+    fn ok_at_exactly_the_minimum() {
+        let observed = ObservedSdkIdentity::present("1.0.0");
+        let verdict = classify(&observed, &VerifiedSdkIdentity::none(), Some("1.0.0"));
+        assert_eq!(verdict, SdkIdentityVerdict::Ok);
+    }
+
+    #[test]
+    fn ok_above_the_minimum() {
+        let observed = ObservedSdkIdentity::present("1.5.2");
+        let verdict = classify(&observed, &VerifiedSdkIdentity::none(), Some("1.0.0"));
+        assert_eq!(verdict, SdkIdentityVerdict::Ok);
+    }
+
+    #[test]
+    fn unparseable_version_against_a_floor_fails_closed_as_downgrade() {
+        // A non-numeric claimed version must never silently pass a floor.
+        let observed = ObservedSdkIdentity::present("not-a-version");
+        let verdict = classify(&observed, &VerifiedSdkIdentity::none(), Some("1.0.0"));
+        assert_eq!(verdict, SdkIdentityVerdict::VersionDowngraded);
+    }
+
+    #[test]
+    fn unverifiable_when_present_but_no_verified_reference_and_no_floor() {
+        let observed = ObservedSdkIdentity::present("1.2.3");
+        let verdict = classify(&observed, &VerifiedSdkIdentity::none(), None);
+        assert_eq!(verdict, SdkIdentityVerdict::Unverifiable);
+    }
+
+    #[test]
+    fn present_without_a_claimed_version_and_no_floor_is_unverifiable() {
+        // present == true but no version string and nothing to compare against.
+        let observed = ObservedSdkIdentity {
+            present: true,
+            version: None,
+        };
+        let verdict = classify(&observed, &VerifiedSdkIdentity::none(), None);
+        assert_eq!(verdict, SdkIdentityVerdict::Unverifiable);
+    }
+
+    #[test]
+    fn as_str_labels_are_stable() {
+        assert_eq!(SdkIdentityVerdict::Ok.as_str(), "ok");
+        assert_eq!(SdkIdentityVerdict::Missing.as_str(), "missing");
+        assert_eq!(SdkIdentityVerdict::VersionDowngraded.as_str(), "downgraded");
+        assert_eq!(SdkIdentityVerdict::Forged.as_str(), "forged");
+        assert_eq!(SdkIdentityVerdict::Unverifiable.as_str(), "unverifiable");
+    }
+
+    #[test]
+    fn only_missing_downgraded_forged_are_suspected_tamper() {
+        assert!(SdkIdentityVerdict::Missing.is_suspected_tamper());
+        assert!(SdkIdentityVerdict::VersionDowngraded.is_suspected_tamper());
+        assert!(SdkIdentityVerdict::Forged.is_suspected_tamper());
+        assert!(!SdkIdentityVerdict::Ok.is_suspected_tamper());
+        assert!(!SdkIdentityVerdict::Unverifiable.is_suspected_tamper());
+    }
+}

--- a/aa-security/src/sdk_identity.rs
+++ b/aa-security/src/sdk_identity.rs
@@ -1,0 +1,234 @@
+//! SDK identity classification (AAASM-3621).
+//!
+//! A pure, no-I/O classifier that compares the SDK identity an agent *claimed*
+//! on the wire (the **observed** signal, attacker-controlled) against the
+//! identity an authenticated channel *established* (the **verified** signal,
+//! from the AAASM-3569 IPC handshake) and produces an [`SdkIdentityVerdict`].
+//!
+//! ## Why this is its own pure module
+//!
+//! The trusted enforcement layers must **never trust an SDK-supplied identity**
+//! at face value — they recompute the verdict from inputs they control
+//! (extends the AAASM-2569 no-trust-marker principle). Centralising that
+//! decision here, with zero I/O and no `tokio` / `aa-proto` dependency, keeps
+//! the forged / downgraded logic exhaustively unit-testable without a running
+//! runtime. The module mirrors the leaf placement of [`scanner`](crate::scanner)
+//! and [`redaction`](crate::redaction).
+//!
+//! ## What a "version" is here
+//!
+//! Versions are compared as dot-separated numeric components (a simple
+//! `semver`-ish ordering) without pulling in a `semver` crate — the leaf crate
+//! stays dependency-light. Non-numeric / malformed components fail closed:
+//! an unparseable observed version that has a minimum to clear is treated as a
+//! downgrade rather than silently passing.
+
+/// The SDK identity an agent **claimed** on the wire.
+///
+/// This is the *observed* (untrusted) channel: it is read out of the
+/// attacker-controlled `AuditEvent.labels` map by the runtime ingest stage
+/// (AAASM-3625). Nothing downstream may grant trust based on these values
+/// alone — they exist only to be recomputed against a [`VerifiedSdkIdentity`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ObservedSdkIdentity {
+    /// Whether the SDK presented an identity signal at all (the reserved
+    /// `aa.sdk_version` label was present). `false` means the agent connected
+    /// without claiming any SDK identity — a stripped / bypassed SDK.
+    pub present: bool,
+    /// The SDK version string the agent claimed, when present.
+    pub version: Option<String>,
+}
+
+impl ObservedSdkIdentity {
+    /// An observed identity that presented a version claim.
+    pub fn present(version: impl Into<String>) -> Self {
+        Self {
+            present: true,
+            version: Some(version.into()),
+        }
+    }
+
+    /// An observed identity with no SDK signal at all (stripped / bypassed SDK).
+    pub fn missing() -> Self {
+        Self {
+            present: false,
+            version: None,
+        }
+    }
+}
+
+/// The SDK identity an authenticated channel **established**.
+///
+/// This is the *verified* counterpart, populated from the AAASM-3569 IPC
+/// handshake (which authenticates the agent's Ed25519 identity bound to its
+/// configured agent id). When no authenticated version reference is available
+/// — no handshake completed, or the handshake carries no version — the fields
+/// are `None` and the classifier returns [`SdkIdentityVerdict::Unverifiable`]
+/// rather than guessing.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct VerifiedSdkIdentity {
+    /// The SDK version established over the authenticated channel, when the
+    /// channel carries one. `None` when only presence (not a version) was
+    /// authenticated, or when no handshake completed.
+    pub version: Option<String>,
+}
+
+impl VerifiedSdkIdentity {
+    /// No verified signal is available (no handshake / unsupported). Classifies
+    /// version comparisons as [`SdkIdentityVerdict::Unverifiable`].
+    pub fn none() -> Self {
+        Self { version: None }
+    }
+
+    /// A verified identity carrying an authenticated version reference.
+    pub fn with_version(version: impl Into<String>) -> Self {
+        Self {
+            version: Some(version.into()),
+        }
+    }
+
+    /// Whether any verified reference is available to compare against.
+    pub fn is_available(&self) -> bool {
+        self.version.is_some()
+    }
+}
+
+/// The server-recomputed verdict on an agent's presented SDK identity.
+///
+/// Ordered so the most security-relevant tampering signals are distinct enum
+/// variants the audit / metric layer (AAASM-3637) can label by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SdkIdentityVerdict {
+    /// Identity present, matches the verified reference (or no minimum to
+    /// clear), and is at or above the minimum supported version.
+    Ok,
+    /// No SDK identity was presented — a stripped / bypassed SDK.
+    Missing,
+    /// A version below the minimum supported version was presented (an old /
+    /// downgraded SDK build).
+    VersionDowngraded,
+    /// The observed version contradicts the version established over the
+    /// authenticated channel — an impersonation / forgery attempt.
+    Forged,
+    /// An identity was presented but there is no verified reference to compare
+    /// it against (handshake absent / unsupported). Not itself a tamper signal.
+    Unverifiable,
+}
+
+impl SdkIdentityVerdict {
+    /// A stable lowercase label for metric / audit dimensions. Never carries
+    /// any agent-supplied free text.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SdkIdentityVerdict::Ok => "ok",
+            SdkIdentityVerdict::Missing => "missing",
+            SdkIdentityVerdict::VersionDowngraded => "downgraded",
+            SdkIdentityVerdict::Forged => "forged",
+            SdkIdentityVerdict::Unverifiable => "unverifiable",
+        }
+    }
+
+    /// Whether this verdict is a tamper signal worth a distinct audit record
+    /// and metric. `Ok` and `Unverifiable` are not — they are the steady-state
+    /// outcomes for a well-behaved or not-yet-attested SDK.
+    pub fn is_suspected_tamper(&self) -> bool {
+        matches!(
+            self,
+            SdkIdentityVerdict::Missing | SdkIdentityVerdict::VersionDowngraded | SdkIdentityVerdict::Forged
+        )
+    }
+}
+
+/// Recompute the SDK-identity verdict from inputs the server controls.
+///
+/// Precedence (most severe first):
+/// 1. **`Missing`** — the agent presented no SDK identity at all.
+/// 2. **`Forged`** — a verified version reference exists and the observed
+///    version contradicts it.
+/// 3. **`VersionDowngraded`** — the observed version is below
+///    `min_supported_version` (or is unparseable while a minimum is required).
+/// 4. **`Unverifiable`** — an identity was presented but there is no verified
+///    reference and no minimum to clear.
+/// 5. **`Ok`** — otherwise.
+///
+/// `min_supported_version` is `None` when the operator imposes no floor.
+pub fn classify(
+    observed: &ObservedSdkIdentity,
+    verified: &VerifiedSdkIdentity,
+    min_supported_version: Option<&str>,
+) -> SdkIdentityVerdict {
+    if !observed.present {
+        return SdkIdentityVerdict::Missing;
+    }
+
+    // Forgery: the claim contradicts what the authenticated channel established.
+    if let (Some(claimed), Some(attested)) = (observed.version.as_deref(), verified.version.as_deref()) {
+        if !versions_equal(claimed, attested) {
+            return SdkIdentityVerdict::Forged;
+        }
+    }
+
+    // Downgrade: below the operator-configured minimum.
+    if let Some(min) = min_supported_version {
+        match observed.version.as_deref() {
+            Some(claimed) if version_at_least(claimed, min) => {}
+            // A claimed-but-unparseable or below-minimum version is a downgrade
+            // (fail closed — never pass an unparseable version against a floor).
+            _ => return SdkIdentityVerdict::VersionDowngraded,
+        }
+    }
+
+    // Present, consistent with any verified reference, but no verified reference
+    // and no floor cleared by comparison: nothing left to attest against.
+    if !verified.is_available() && min_supported_version.is_none() {
+        return SdkIdentityVerdict::Unverifiable;
+    }
+
+    SdkIdentityVerdict::Ok
+}
+
+/// Compare two dot-separated numeric version strings for equality, padding the
+/// shorter with implicit zero components (`"1.2" == "1.2.0"`).
+fn versions_equal(a: &str, b: &str) -> bool {
+    matches!(compare_versions(a, b), Some(std::cmp::Ordering::Equal))
+}
+
+/// `true` when `version >= min`. An unparseable `version` or `min` yields
+/// `false` (fail closed against the floor).
+fn version_at_least(version: &str, min: &str) -> bool {
+    matches!(
+        compare_versions(version, min),
+        Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal)
+    )
+}
+
+/// Compare two dot-separated numeric versions component-by-component.
+///
+/// Returns `None` when either side has a non-numeric component, so callers can
+/// fail closed on malformed input rather than treating it as comparable.
+fn compare_versions(a: &str, b: &str) -> Option<std::cmp::Ordering> {
+    let pa = parse_components(a)?;
+    let pb = parse_components(b)?;
+    let len = pa.len().max(pb.len());
+    for i in 0..len {
+        let ca = pa.get(i).copied().unwrap_or(0);
+        let cb = pb.get(i).copied().unwrap_or(0);
+        match ca.cmp(&cb) {
+            std::cmp::Ordering::Equal => continue,
+            other => return Some(other),
+        }
+    }
+    Some(std::cmp::Ordering::Equal)
+}
+
+/// Parse `"1.2.3"` into `[1, 2, 3]`. Returns `None` on any non-numeric or empty
+/// component so malformed versions are not silently treated as comparable.
+fn parse_components(v: &str) -> Option<Vec<u64>> {
+    if v.is_empty() {
+        return None;
+    }
+    v.split('.').map(|c| c.parse::<u64>().ok()).collect()
+}


### PR DESCRIPTION
## Description

Implements the SDK bypass/tamper observability Story (AAASM-3571, Epic AAASM-3567) end-to-end across `aa-security` and `aa-runtime`. The runtime now records, in audit, when an agent presents a missing / forged / downgraded SDK identity (independent of per-action enforcement), never trusts SDK-supplied trust markers/labels (recompute server-side + flag mismatch), and emits a distinct "bypass/tamper suspected" audit event + metric.

Subtasks delivered:
- **AAASM-3621** (aa-security): pure no-I/O `sdk_identity` classifier — `ObservedSdkIdentity` / `VerifiedSdkIdentity` / `SdkIdentityVerdict` + `classify()`.
- **AAASM-3625** (aa-runtime): carry the observed SDK identity on `EnrichedEvent`, read from the reserved `aa.sdk_version` label at ingest (untrusted claim, preserved for server-side recompute).
- **AAASM-3630** (aa-runtime): strip & flag forged trust-marker labels (`aa.trusted`/`aa.scanned`/`aa.allow`/`aa.bypass`) in `RuntimeScanner::enforce`; `aa.sdk_version` preserved.
- **AAASM-3640** (aa-runtime): consume the AAASM-3569 authenticated-handshake identity per `connection_id` (new `VerifiedIdentityStore`), feed it to the classifier; no handshake → `Unverifiable` (no regression). Consumes 3569's verified signal — no parallel identity channel.
- **AAASM-3637** (aa-runtime): emit a distinct tamper audit event + `aa_runtime_sdk_tamper_suspected_total{kind}` metric for a flagged verdict / forged markers; verdict + forged-marker count serialised into the audit payload's `sdk_identity` section. Observational only — enforcement decision unchanged.
- **AAASM-3644**: end-to-end verification test locking the three acceptance criteria.

### Design note on AAASM-3569
The merged 3569 handshake (`HandshakeProof`) authenticates the agent's Ed25519 identity (bound to `AA_AGENT_ID`) but carries no SDK *version* on the wire. The verified identity is captured per-connection on a successful handshake (present-without-version); version-mismatch (`Forged`/`Downgraded`) is computed when a verified version is available, else `Unverifiable`. No proto change.

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

(`EnrichedEvent` gains `observed_sdk_identity` + `tamper` fields and `PipelineConfig` gains `min_sdk_version`; all construction sites updated. `IpcServer::run` / `pipeline::run` gain a `VerifiedIdentityStore` parameter — internal APIs.)

## Related Issues

- Related Jira ticket: AAASM-3571 (subtasks AAASM-3621/3625/3630/3640/3637/3644)
- Epic: AAASM-3567

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Local validation: `cargo build --workspace` clean; `cargo nextest run -p aa-runtime -p aa-security` → all pass (435); new `aaasm_3571_tamper_observability` integration test passes (3 ACs); `cargo clippy --all-targets -- -D warnings` clean on aa-runtime/aa-security/aa-proxy/aa-api/aa-integration-tests; `cargo fmt` clean (enforced by pre-commit on every commit).

Note: `aa-integration-tests` shows 7 pre-existing `cli_dashboard` E2E timeouts (~90s each) — environmental (they spawn the `aasm dashboard` HTTP server); not in this PR's code path. Everything else in the crate passes.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
