### PR TITLE
[AAASM-3650] 🐛 (aa-gateway): De-flake healthz timing test + nextest retry safety net

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,16 @@
+# cargo-nextest configuration.
+#
+# AAASM-3650: a modest global retry absorbs residual runner-starvation
+# flakes (e.g. a healthz round-trip that is slow on a noisy-neighbour
+# GitHub-hosted runner) without masking real regressions:
+#
+#   * Retries only rescue NON-deterministic failures. A deterministic
+#     regression fails all 3 attempts and is still reported as failed.
+#   * nextest reports any test that passed only after a retry as FLAKY,
+#     so the noise stays visible instead of being silently swallowed.
+#
+# CI invokes nextest with the default profile (`cargo nextest run
+# --workspace ...`, `-p aa-gateway`, etc. — no `--profile ci`), so the
+# retry policy belongs under `[profile.default]`.
+[profile.default]
+retries = 2

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -980,35 +980,52 @@ mod tests {
         let _ = second.shutdown_tx.send(());
     }
 
-    /// AAASM-1576 AC #5: wall-clock from `start_local()` call to a
-    /// successful `/healthz` round-trip must be **under 500 ms** on a
-    /// standard developer laptop. The ceiling is generous against the
-    /// real expected latency (single-digit ms locally) so we catch
-    /// genuine regressions — e.g. someone adding a blocking migration
-    /// step to `open_storage` — without flaking on slow CI runners.
+    /// AAASM-1576 AC #5 (de-flaked per AAASM-3650): `start_local()`
+    /// brings the gateway up and a `/healthz` round-trip succeeds with a
+    /// ready response. The required assertion is **functional** — the
+    /// round-trip completes and reports `mode == "local"` — not a
+    /// wall-clock latency bound.
+    ///
+    /// The original test asserted the round-trip finished in under
+    /// **500 ms** to catch a regression such as a blocking migration
+    /// added to `open_storage`. On loaded/shared CI runners that hard
+    /// bound was exceeded even when the code was correct (observed p99
+    /// 1.2–2.7 s under concurrent test load), so a busy runner could
+    /// fail this *correctness* gate purely on latency. We removed the
+    /// performance assertion from the required gate and keep only a
+    /// generous deadline that bounds a true hang (start-up wedged /
+    /// server never binds), never normal slow-runner jitter. The
+    /// latency-regression signal lives in the non-gating `Benchmark`
+    /// job and the `policy_*` benches, not here.
     #[tokio::test]
-    async fn start_local_healthz_round_trip_completes_within_500ms() {
+    async fn start_local_healthz_round_trip_succeeds() {
         let (config, _tmp, port) = test_config_with_ephemeral_port().await;
         let pid_path = _tmp.path().join("gateway.pid");
 
-        let started = std::time::Instant::now();
-        let handle = start_local_with_pid_path(&config, &pid_path)
-            .await
-            .expect("start_local");
-        let _ = reqwest::get(format!("http://127.0.0.1:{port}/healthz"))
-            .await
-            .expect("GET /healthz")
-            .json::<serde_json::Value>()
-            .await
-            .expect("parse json");
-        let elapsed = started.elapsed();
+        // Generous ceiling — large enough that a healthy gateway on the
+        // slowest CI runner clears it comfortably; small enough to fail
+        // fast on a genuine hang instead of waiting on the test harness
+        // timeout.
+        let body = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let handle = start_local_with_pid_path(&config, &pid_path)
+                .await
+                .expect("start_local");
+            let body = reqwest::get(format!("http://127.0.0.1:{port}/healthz"))
+                .await
+                .expect("GET /healthz")
+                .json::<serde_json::Value>()
+                .await
+                .expect("parse json");
+            (handle, body)
+        })
+        .await
+        .map(|(handle, body)| {
+            let _ = handle.shutdown_tx.send(());
+            body
+        })
+        .expect("start_local → /healthz round-trip must complete (a timeout here means a true hang)");
 
-        assert!(
-            elapsed < std::time::Duration::from_millis(500),
-            "AAASM-1576 AC #5: start_local → /healthz round-trip must be < 500 ms, took {elapsed:?}"
-        );
-
-        let _ = handle.shutdown_tx.send(());
+        assert_eq!(body["mode"], "local", "healthz must report a ready local-mode gateway");
     }
 
     /// AAASM-1576 AC #8 (server stops accepting connections): after


### PR DESCRIPTION
## Description

De-flakes the `aa-gateway` local-mode healthz timing test and adds a suite-wide nextest retry safety net.

**Part A — De-gate wall-clock latency from the required test (primary fix).**
`local_mode::tests::start_local_healthz_round_trip_completes_within_500ms` asserted a hard **500 ms wall-clock** bound on a `start_local` → `/healthz` round-trip. On loaded/shared GitHub-hosted runners that bound was exceeded even when the code was correct (the Test job already documents observed p99 of 1.2–2.7 s under concurrent load), so a busy runner could fail a **correctness** gate purely on latency — a non-deterministic false failure (seen on CI run 28009351377 vs. a pass on 28008961352 for the same code).

The required assertion is now **functional**: the round-trip completes and `/healthz` reports a ready local-mode gateway (`mode == "local"`), wrapped in a generous 10 s deadline that only bounds a true hang (start-up wedged / server never binds), never normal slow-runner jitter. The test is renamed `start_local_healthz_round_trip_succeeds` to match the new contract. The latency-regression signal already lives in the non-gating `Benchmark` job and the `policy_*` benches, so no perf coverage is lost.

**Part B — nextest retry safety net (residual runner-starvation flakes).**
The repo had **no** nextest config. Added `.config/nextest.toml`:

```toml
[profile.default]
retries = 2
```

Why this is safe, not masking:
- Retries only rescue **non-deterministic** failures. A deterministic regression fails all 3 attempts and is still reported **failed**.
- nextest flags any test that only passes after a retry as **FLAKY**, so the noise stays visible instead of being silently swallowed (this PR's own full-suite run already surfaced an unrelated flaky `edge_repo_test` this way).

Profile choice: CI invokes nextest with the **default** profile (`cargo nextest run --workspace …`, `-p aa-gateway`, etc. — no `--profile ci` anywhere in `.github/workflows/`), so the retry policy belongs under `[profile.default]`.

**Part C — self-inflicted starvation (investigative, no change).**
The Test job runs `cargo nextest run --workspace` at the default test-thread count (= nCPU) and does spawn Postgres/Timescale testcontainers concurrently. However, the existing mitigation for the known noisy-neighbor variance is **relaxing `AA_BENCH_SLA_P99_MS` to 5000** (see `ci.yml` "Run tests" step comment), not a thread cap. A global `test-threads` cap would slow the whole suite materially across 14+ crates to address jitter that Parts A+B already neutralize for the gate. **No tuning applied** — flagging the finding rather than over-engineering.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3650

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

Local validation (macOS, `RUSTUP_TOOLCHAIN=stable`):
- `cargo build -p aa-gateway` — clean
- Target test looped **10×**: `pass=10 fail=0` (deterministic)
- `cargo nextest run -p aa-gateway` — **1162 passed, 0 failed** (profile: default, so the new retry config is exercised)
- `.config/nextest.toml` parses with no config error (`cargo nextest list` / scoped run)
- `cargo clippy -p aa-gateway --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- pre-commit (fmt/clippy/deny) + pre-push (`cargo doc`) hooks passed without bypass

> CI run conclusions to be verified by the reviewer.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (test docstring + config comments)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
