### PR TITLE
[AAASM-3677] ♻️ (sonar): clear code smells to customized criteria

### DIFF
--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -140,58 +140,18 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
 
     // Main event dispatch loop.
     loop {
-        let event = tokio::select! {
-            Ok(pipeline_ev) = pipeline_rx.recv() => {
-                Some(build_governance_event(
-                    &next_id,
-                    EventType::Violation,
-                    extract_pipeline_agent_id(&pipeline_ev),
-                    EventPayload::Violation(build_violation_payload(&pipeline_ev)),
-                ))
-            }
-            Ok(approval_ev) = approval_rx.recv() => {
-                Some(build_governance_event(
-                    &next_id,
-                    EventType::Approval,
-                    approval_ev.agent_id.clone(),
-                    EventPayload::Approval(build_approval_payload(&approval_ev)),
-                ))
-            }
-            Ok(expired_ev) = approval_expiry_rx.recv() => {
-                // AAASM-1453: a pending request's per-request timeout
-                // elapsed without a human decision. Propagate as an
-                // `approval` event with `status: "expired"` so the
-                // dashboard can move the row to the Expired section.
-                Some(build_governance_event(
-                    &next_id,
-                    EventType::Approval,
-                    expired_ev.agent_id.clone(),
-                    EventPayload::Approval(build_expired_approval_payload(&expired_ev)),
-                ))
-            }
-            Ok(budget_ev) = budget_rx.recv() => {
-                Some(build_governance_event(
-                    &next_id,
-                    EventType::Budget,
-                    format!("{:02x?}", budget_ev.agent_id.as_bytes()),
-                    EventPayload::Budget(build_budget_alert_payload(&budget_ev)),
-                ))
-            }
-            Ok(ops_ev) = ops_change_rx.recv() => {
-                // AAASM-1657 PR-H: forward operator-driven ops registry
-                // transitions to the dashboard so it can clear optimistic
-                // overrides and update the row in place by op_id.
-                Some(build_governance_event(
-                    &next_id,
-                    EventType::OpsChange,
-                    ops_ev.agent_id,
-                    EventPayload::OpsChange(ops_ev.payload),
-                ))
-            }
-            else => None,
+        let Some(event) = next_governance_event(
+            &next_id,
+            &mut pipeline_rx,
+            &mut approval_rx,
+            &mut approval_expiry_rx,
+            &mut budget_rx,
+            &mut ops_change_rx,
+        )
+        .await
+        else {
+            break;
         };
-
-        let Some(event) = event else { break };
 
         // Store in replay buffer before filtering.
         state.replay_buffer.push(event.clone());
@@ -207,6 +167,70 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
 
     ping_handle.abort();
     reader_handle.abort();
+}
+
+/// Await the next event from any of the five live broadcast channels and map it
+/// onto a [`GovernanceEvent`]. Returns `None` only when every channel has closed
+/// (the `else` arm), which signals the dispatch loop to terminate.
+#[allow(clippy::too_many_arguments)]
+async fn next_governance_event(
+    next_id: &std::sync::atomic::AtomicU64,
+    pipeline_rx: &mut tokio::sync::broadcast::Receiver<aa_runtime::pipeline::event::PipelineEvent>,
+    approval_rx: &mut tokio::sync::broadcast::Receiver<aa_runtime::approval::ApprovalRequest>,
+    approval_expiry_rx: &mut tokio::sync::broadcast::Receiver<aa_runtime::approval::ApprovalRequest>,
+    budget_rx: &mut tokio::sync::broadcast::Receiver<aa_gateway::budget::types::BudgetAlert>,
+    ops_change_rx: &mut tokio::sync::broadcast::Receiver<crate::events::OpsChangeBroadcast>,
+) -> Option<GovernanceEvent> {
+    tokio::select! {
+        Ok(pipeline_ev) = pipeline_rx.recv() => {
+            Some(build_governance_event(
+                next_id,
+                EventType::Violation,
+                extract_pipeline_agent_id(&pipeline_ev),
+                EventPayload::Violation(build_violation_payload(&pipeline_ev)),
+            ))
+        }
+        Ok(approval_ev) = approval_rx.recv() => {
+            Some(build_governance_event(
+                next_id,
+                EventType::Approval,
+                approval_ev.agent_id.clone(),
+                EventPayload::Approval(build_approval_payload(&approval_ev)),
+            ))
+        }
+        Ok(expired_ev) = approval_expiry_rx.recv() => {
+            // AAASM-1453: a pending request's per-request timeout
+            // elapsed without a human decision. Propagate as an
+            // `approval` event with `status: "expired"` so the
+            // dashboard can move the row to the Expired section.
+            Some(build_governance_event(
+                next_id,
+                EventType::Approval,
+                expired_ev.agent_id.clone(),
+                EventPayload::Approval(build_expired_approval_payload(&expired_ev)),
+            ))
+        }
+        Ok(budget_ev) = budget_rx.recv() => {
+            Some(build_governance_event(
+                next_id,
+                EventType::Budget,
+                format!("{:02x?}", budget_ev.agent_id.as_bytes()),
+                EventPayload::Budget(build_budget_alert_payload(&budget_ev)),
+            ))
+        }
+        Ok(ops_ev) = ops_change_rx.recv() => {
+            // AAASM-1657 PR-H: forward operator-driven ops registry
+            // transitions to the dashboard so it can clear optimistic
+            // overrides and update the row in place by op_id.
+            Some(build_governance_event(
+                next_id,
+                EventType::OpsChange,
+                ops_ev.agent_id,
+                EventPayload::OpsChange(ops_ev.payload),
+            ))
+        }
+        else => None,
+    }
 }
 
 /// Assemble a [`GovernanceEvent`] with the next monotonic id and current

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -696,91 +696,48 @@ fn eval_string_field(field: &FieldRef, op: &OpKind, literal: &LiteralVal, action
     let lhs = field_value(field, action);
 
     match op {
-        OpKind::Contains => {
-            if let LiteralVal::Str(rhs) = literal {
-                lhs.contains(rhs.as_str())
-            } else {
-                false
-            }
-        }
-        OpKind::StartsWith => {
-            if let LiteralVal::Str(rhs) = literal {
-                lhs.starts_with(rhs.as_str())
-            } else {
-                false
-            }
-        }
-        OpKind::In => {
-            if let LiteralVal::StrList(list) = literal {
-                list.iter().any(|s| s.as_str() == lhs)
-            } else {
-                false
-            }
-        }
-        OpKind::NotIn => {
-            if let LiteralVal::StrList(list) = literal {
-                !list.iter().any(|s| s.as_str() == lhs)
-            } else {
-                false
-            }
-        }
-        OpKind::Eq => match literal {
-            LiteralVal::Num(rhs) => {
-                if let Ok(lhs_num) = lhs.parse::<f64>() {
-                    lhs_num == *rhs
-                } else {
-                    false
-                }
-            }
-            LiteralVal::Str(rhs) => lhs == rhs.as_str(),
-            // A level/tier/list/duration literal against a generic string field cannot match.
-            LiteralVal::Level(_) | LiteralVal::Tier(_) | LiteralVal::StrList(_) | LiteralVal::Duration(_) => false,
-        },
-        OpKind::Ne => match literal {
-            LiteralVal::Num(rhs) => {
-                if let Ok(lhs_num) = lhs.parse::<f64>() {
-                    lhs_num != *rhs
-                } else {
-                    true // can't parse as number, so not equal numerically
-                }
-            }
-            LiteralVal::Str(rhs) => lhs != rhs.as_str(),
-            // A level/tier/list/duration literal against a generic string field is unconditionally
-            // not-equal — matches the symmetric `Eq` handling above.
-            LiteralVal::Level(_) | LiteralVal::Tier(_) | LiteralVal::StrList(_) | LiteralVal::Duration(_) => true,
-        },
-        OpKind::Gt => {
-            let rhs = numeric_literal(literal);
-            let lhs_n = lhs.parse::<f64>().ok();
-            match (lhs_n, rhs) {
-                (Some(l), Some(r)) => l > r,
-                _ => false,
-            }
-        }
-        OpKind::Gte => {
-            let rhs = numeric_literal(literal);
-            let lhs_n = lhs.parse::<f64>().ok();
-            match (lhs_n, rhs) {
-                (Some(l), Some(r)) => l >= r,
-                _ => false,
-            }
-        }
-        OpKind::Lt => {
-            let rhs = numeric_literal(literal);
-            let lhs_n = lhs.parse::<f64>().ok();
-            match (lhs_n, rhs) {
-                (Some(l), Some(r)) => l < r,
-                _ => false,
-            }
-        }
-        OpKind::Lte => {
-            let rhs = numeric_literal(literal);
-            let lhs_n = lhs.parse::<f64>().ok();
-            match (lhs_n, rhs) {
-                (Some(l), Some(r)) => l <= r,
-                _ => false,
-            }
-        }
+        OpKind::Contains | OpKind::StartsWith | OpKind::In | OpKind::NotIn => eval_string_membership(lhs, op, literal),
+        OpKind::Eq | OpKind::Ne => eval_string_equality(lhs, op, literal),
+        OpKind::Gt | OpKind::Gte | OpKind::Lt | OpKind::Lte => eval_string_numeric(lhs, op, literal),
+    }
+}
+
+/// Substring / prefix / list-membership operators on a generic string field.
+/// A literal of the wrong shape (e.g. `contains` against a non-string) is a
+/// null-safe no-match (`false`).
+fn eval_string_membership(lhs: &str, op: &OpKind, literal: &LiteralVal) -> bool {
+    match (op, literal) {
+        (OpKind::Contains, LiteralVal::Str(rhs)) => lhs.contains(rhs.as_str()),
+        (OpKind::StartsWith, LiteralVal::Str(rhs)) => lhs.starts_with(rhs.as_str()),
+        (OpKind::In, LiteralVal::StrList(list)) => list.iter().any(|s| s.as_str() == lhs),
+        (OpKind::NotIn, LiteralVal::StrList(list)) => !list.iter().any(|s| s.as_str() == lhs),
+        _ => false,
+    }
+}
+
+/// Equality / inequality on a generic string field. A numeric literal compares
+/// numerically (after parsing `lhs`); a string literal compares textually. A
+/// level/tier/list/duration literal can never equal a generic string field, so
+/// `Eq` is `false` and `Ne` is the symmetric `true`.
+fn eval_string_equality(lhs: &str, op: &OpKind, literal: &LiteralVal) -> bool {
+    let eq = match literal {
+        LiteralVal::Num(rhs) => lhs.parse::<f64>().map(|n| n == *rhs).unwrap_or(false),
+        LiteralVal::Str(rhs) => lhs == rhs.as_str(),
+        LiteralVal::Level(_) | LiteralVal::Tier(_) | LiteralVal::StrList(_) | LiteralVal::Duration(_) => false,
+    };
+    match op {
+        OpKind::Ne => !eq,
+        _ => eq,
+    }
+}
+
+/// Ordered numeric operators on a generic string field. Both sides must resolve
+/// to a number (`lhs` parsed from the string, `rhs` via [`numeric_literal`]);
+/// otherwise the comparison is a null-safe no-match (`false`).
+fn eval_string_numeric(lhs: &str, op: &OpKind, literal: &LiteralVal) -> bool {
+    match (lhs.parse::<f64>().ok(), numeric_literal(literal)) {
+        (Some(l), Some(r)) => compare_ord(l, r, op),
+        _ => false,
     }
 }
 

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -169,28 +169,11 @@ impl ProxyConfig {
             Err(_) => true,
         };
 
-        let denied_hosts = match std::env::var("AA_PROXY_DENIED_HOSTS") {
-            Ok(val) if !val.is_empty() => val
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect(),
-            _ => Vec::new(),
-        };
+        let denied_hosts = env_csv("AA_PROXY_DENIED_HOSTS");
 
-        let network_allowlist = match std::env::var("AA_PROXY_NETWORK_ALLOWLIST") {
-            Ok(val) if !val.is_empty() => val
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect(),
-            _ => Vec::new(),
-        };
+        let network_allowlist = env_csv("AA_PROXY_NETWORK_ALLOWLIST");
 
-        let skip_upstream_tls_verify_requested = match std::env::var("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY") {
-            Ok(val) => val == "1" || val.to_lowercase() == "true",
-            Err(_) => false,
-        };
+        let skip_upstream_tls_verify_requested = env_truthy("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY");
         // AAASM-3131: this flag disables upstream certificate verification and
         // is for integration tests only. In a release (production) build it must
         // be unreachable — silently ignore the request and shout, so a stray env
@@ -220,10 +203,7 @@ impl ProxyConfig {
 
         // AAASM-3357: default fail-closed. Only an explicit truthy value
         // opts into the historical fail-open soft-degradation behaviour.
-        let mcp_fail_open = match std::env::var("AA_PROXY_MCP_FAIL_OPEN") {
-            Ok(val) => val == "1" || val.to_lowercase() == "true",
-            Err(_) => false,
-        };
+        let mcp_fail_open = env_truthy("AA_PROXY_MCP_FAIL_OPEN");
 
         Ok(Self {
             bind_addr,
@@ -240,6 +220,29 @@ impl ProxyConfig {
             // No env var: production binaries can never relax the SSRF guard.
             allow_private_connect_targets: false,
         })
+    }
+}
+
+/// Read an env var as an opt-in boolean: `true` only for an explicit `1`/`true`
+/// (case-insensitive). Unset or any other value is `false` — these flags relax
+/// a security default, so they must fail closed unless deliberately enabled.
+fn env_truthy(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(val) => val == "1" || val.to_lowercase() == "true",
+        Err(_) => false,
+    }
+}
+
+/// Read an env var as a comma-separated list, trimming each entry and dropping
+/// empties. An unset or empty var yields an empty `Vec`.
+fn env_csv(name: &str) -> Vec<String> {
+    match std::env::var(name) {
+        Ok(val) if !val.is_empty() => val
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => Vec::new(),
     }
 }
 

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -504,6 +504,59 @@ fn spawn_pipeline_audit_publisher(
     });
 }
 
+/// AAASM-3430: build the gateway client used to forward per-tool policy checks
+/// to the authoritative governance gateway.
+///
+/// Returns `None` only when no endpoint is configured (the pipeline then
+/// evaluates policy locally). A configured-but-unreachable endpoint yields a
+/// lazy client so the pipeline's fail-closed path (AAASM-3110) governs the
+/// unreachable case at check time — a connect failure must never silently
+/// degrade to a permissive local allow.
+async fn build_gateway_client(
+    config: &RuntimeConfig,
+) -> Option<std::sync::Arc<tokio::sync::Mutex<crate::gateway_client::GatewayClient>>> {
+    let Some(endpoint) = &config.gateway_endpoint else {
+        tracing::info!("no gateway endpoint configured — policy checks evaluated locally");
+        return None;
+    };
+    match crate::gateway_client::GatewayClient::connect(endpoint).await {
+        Ok(client) => {
+            tracing::info!(endpoint, "gateway client connected — forwarding policy checks");
+            Some(std::sync::Arc::new(tokio::sync::Mutex::new(client)))
+        }
+        Err(e) => {
+            tracing::warn!(
+                endpoint,
+                error = %e,
+                "gateway client initial connect failed — using lazy channel (checks fail-closed when unreachable)"
+            );
+            crate::gateway_client::GatewayClient::connect_lazy_owned(endpoint)
+                .map(|client| std::sync::Arc::new(tokio::sync::Mutex::new(client)))
+        }
+    }
+}
+
+/// AAASM-3491: start the op-control subscriber when a gateway endpoint is
+/// configured, so the gateway's pause/resume/terminate signals reach the shared
+/// [`OpControlStore`]. Without an endpoint there is no kill-switch channel, so
+/// the store stays empty and this is a no-op.
+fn spawn_op_control(tracker: &TaskTracker, config: &RuntimeConfig, op_control: &crate::op_control::OpControlStore) {
+    let Some(endpoint) = &config.gateway_endpoint else {
+        tracing::info!("no gateway endpoint configured — op-control kill switch inactive");
+        return;
+    };
+    let subscriber_agent = aa_proto::assembly::common::v1::AgentId {
+        org_id: config.agent_org_id.clone(),
+        team_id: config.agent_team_id.clone(),
+        agent_id: config.agent_id.clone(),
+    };
+    let handle = crate::op_control::OpControlClient::start(endpoint.clone(), subscriber_agent, op_control.clone());
+    tracker.spawn(async move {
+        let _ = handle.await;
+    });
+    tracing::info!(endpoint, "op-control subscriber spawned — live kill switch active");
+}
+
 /// Start the runtime and block until graceful shutdown completes.
 ///
 /// This is the main async entry point called from `main()`. It creates the
@@ -662,33 +715,8 @@ pub async fn run(config: RuntimeConfig) {
 
     // AAASM-3430: build the gateway client when an endpoint is configured so
     // policy checks are forwarded to the authoritative governance gateway. When
-    // no endpoint is set the pipeline falls back to local evaluation. Without
-    // this, the pipeline always received `None` and every per-tool deny held by
-    // the gateway was silently dropped to a permissive local allow.
-    let gateway_client = match &config.gateway_endpoint {
-        Some(endpoint) => match crate::gateway_client::GatewayClient::connect(endpoint).await {
-            Ok(client) => {
-                tracing::info!(endpoint, "gateway client connected — forwarding policy checks");
-                Some(std::sync::Arc::new(tokio::sync::Mutex::new(client)))
-            }
-            Err(e) => {
-                // Construction failure must not silently degrade to local allow.
-                // Build a lazy client so the pipeline's fail-closed path
-                // (AAASM-3110) governs the unreachable case at check time.
-                tracing::warn!(
-                    endpoint,
-                    error = %e,
-                    "gateway client initial connect failed — using lazy channel (checks fail-closed when unreachable)"
-                );
-                crate::gateway_client::GatewayClient::connect_lazy_owned(endpoint)
-                    .map(|client| std::sync::Arc::new(tokio::sync::Mutex::new(client)))
-            }
-        },
-        None => {
-            tracing::info!("no gateway endpoint configured — policy checks evaluated locally");
-            None
-        }
-    };
+    // no endpoint is set the pipeline falls back to local evaluation.
+    let gateway_client = build_gateway_client(&config).await;
 
     // AAASM-3491: shared op-control store + subscriber. The store records the
     // gateway's pause/resume/terminate signals; the pipeline consults it on
@@ -696,20 +724,7 @@ pub async fn run(config: RuntimeConfig) {
     // running agent. Without a configured gateway there is no kill-switch
     // channel to subscribe to, so the store simply stays empty (no op control).
     let op_control = crate::op_control::OpControlStore::new();
-    if let Some(endpoint) = &config.gateway_endpoint {
-        let subscriber_agent = aa_proto::assembly::common::v1::AgentId {
-            org_id: config.agent_org_id.clone(),
-            team_id: config.agent_team_id.clone(),
-            agent_id: config.agent_id.clone(),
-        };
-        let handle = crate::op_control::OpControlClient::start(endpoint.clone(), subscriber_agent, op_control.clone());
-        tracker.spawn(async move {
-            let _ = handle.await;
-        });
-        tracing::info!(endpoint, "op-control subscriber spawned — live kill switch active");
-    } else {
-        tracing::info!("no gateway endpoint configured — op-control kill switch inactive");
-    }
+    spawn_op_control(&tracker, &config, &op_control);
 
     // Spawn the event aggregation pipeline task.
     {

--- a/dashboard/src/components/SubtreeBurnChart.test.tsx
+++ b/dashboard/src/components/SubtreeBurnChart.test.tsx
@@ -151,7 +151,7 @@ describe('SubtreeBurnChart — tooltip content', () => {
     const tooltip = screen.getByTestId('subtree-burn-tooltip')
     // Only one per-child row — the `total` entry must be filtered out.
     const rows = tooltip.querySelectorAll('.sbc__tooltip-row')
-    expect(rows.length).toBe(1)
+    expect(rows).toHaveLength(1)
     expect(tooltip).toHaveTextContent('Total:')
   })
 

--- a/dashboard/src/components/topology/NodeDetailPanel.css
+++ b/dashboard/src/components/topology/NodeDetailPanel.css
@@ -45,7 +45,7 @@
   margin: 0.125rem 0 0;
   font-size: 1rem;
   font-weight: 700;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .node-detail-panel__head-right {

--- a/dashboard/src/components/topology/TopologyGraph.test.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.test.tsx
@@ -92,9 +92,12 @@ describe('TopologyGraph', () => {
 
   it('does not fire onNodeClick when callback is omitted', async () => {
     render(<TopologyGraph nodes={[NODES[0]]} edges={[]} />)
-    // The handler should not even attach — clicks just no-op.
-    await userEvent.click(screen.getByTestId('topology-node'))
-    // No assertion target — absence of errors is the contract.
+    const node = screen.getByTestId('topology-node')
+    // With no callback the node must stay non-interactive: the click handler
+    // is never attached, so it carries neither role=button nor a tab stop.
+    await userEvent.click(node)
+    expect(node).not.toHaveAttribute('role')
+    expect(node).not.toHaveAttribute('tabindex')
   })
 
   // ── Team grouping (AAASM-1339) ─────────────────────────────────────────────

--- a/dashboard/src/features/iam/IdentityDetailCard.css
+++ b/dashboard/src/features/iam/IdentityDetailCard.css
@@ -33,7 +33,7 @@
 .iam-identity-detail-card__title {
   margin: 0.125rem 0 0;
   font-size: 1rem;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .iam-identity-detail-card__close {
@@ -67,7 +67,7 @@
 .iam-identity-detail-card__section-value {
   font-size: 0.875rem;
   color: var(--shell-text);
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .iam-identity-detail-card__empty {

--- a/dashboard/src/features/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/dashboard/src/features/onboarding/__tests__/OnboardingPage.test.tsx
@@ -67,10 +67,10 @@ describe('OnboardingPage', () => {
     renderAt('/onboarding')
     // The wizard mounts and immediately persists its initial snapshot,
     // so the session key is present.
-    expect(globalThis.localStorage.getItem(ONBOARDING_SESSION_KEY)).not.toBe(null)
+    expect(globalThis.localStorage.getItem(ONBOARDING_SESSION_KEY)).not.toBeNull()
     fireEvent.click(screen.getByTestId('onboarding-skip-all'))
     expect(globalThis.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
-    expect(globalThis.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBe(null)
+    expect(globalThis.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBeNull()
     expect(screen.getByTestId('root-page')).toBeInTheDocument()
     expect(screen.getByTestId('toast-container')).toHaveTextContent(/Onboarding skipped/i)
   })
@@ -94,7 +94,7 @@ describe('OnboardingPage', () => {
     renderAt('/onboarding')
     fireEvent.click(screen.getByTestId('onboarding-continue'))
     expect(globalThis.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
-    expect(globalThis.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBe(null)
+    expect(globalThis.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBeNull()
     expect(screen.getByTestId('toast-container')).toHaveTextContent(/Setup complete/i)
   })
 })

--- a/dashboard/src/features/onboarding/__tests__/useWizardSession.test.ts
+++ b/dashboard/src/features/onboarding/__tests__/useWizardSession.test.ts
@@ -29,7 +29,7 @@ const FILLED_STATE: WizardState = {
 describe('useWizardSession storage helpers', () => {
   it('returns null when no session is persisted', () => {
     const s = new MemoryStorage()
-    expect(loadWizardSession(s)).toBe(null)
+    expect(loadWizardSession(s)).toBeNull()
   })
 
   it('round-trips step + state through save / load', () => {
@@ -43,13 +43,13 @@ describe('useWizardSession storage helpers', () => {
     const s = new MemoryStorage()
     saveWizardSession({ step: 'install', state: EMPTY_STATE }, s)
     clearWizardSession(s)
-    expect(loadWizardSession(s)).toBe(null)
+    expect(loadWizardSession(s)).toBeNull()
   })
 
   it('returns null for malformed JSON', () => {
     const s = new MemoryStorage()
     s.setItem(ONBOARDING_SESSION_KEY, '{not json')
-    expect(loadWizardSession(s)).toBe(null)
+    expect(loadWizardSession(s)).toBeNull()
   })
 
   it('returns null when the persisted step id is unknown', () => {
@@ -58,7 +58,7 @@ describe('useWizardSession storage helpers', () => {
       ONBOARDING_SESSION_KEY,
       JSON.stringify({ step: 'unknown-step', state: EMPTY_STATE }),
     )
-    expect(loadWizardSession(s)).toBe(null)
+    expect(loadWizardSession(s)).toBeNull()
   })
 
   it('returns null when state is missing required slice keys', () => {
@@ -67,7 +67,7 @@ describe('useWizardSession storage helpers', () => {
       ONBOARDING_SESSION_KEY,
       JSON.stringify({ step: 'framework', state: { framework: 'langchain' } }),
     )
-    expect(loadWizardSession(s)).toBe(null)
+    expect(loadWizardSession(s)).toBeNull()
   })
 
   it('resolveInitialSession falls back to step framework + EMPTY_STATE when nothing persisted', () => {

--- a/dashboard/src/features/onboarding/__tests__/wizardState.test.ts
+++ b/dashboard/src/features/onboarding/__tests__/wizardState.test.ts
@@ -44,7 +44,7 @@ describe('wizardState helpers', () => {
     })
 
     it('returns null past the final step', () => {
-      expect(nextStep('enroll')).toBe(null)
+      expect(nextStep('enroll')).toBeNull()
     })
 
     it('walks backward through the 5 steps', () => {
@@ -55,7 +55,7 @@ describe('wizardState helpers', () => {
     })
 
     it('returns null before the first step', () => {
-      expect(prevStep('framework')).toBe(null)
+      expect(prevStep('framework')).toBeNull()
     })
   })
 

--- a/dashboard/src/features/onboarding/steps/Steps.css
+++ b/dashboard/src/features/onboarding/steps/Steps.css
@@ -204,7 +204,7 @@
 
 .onb-term-line {
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .onb-term-prompt { color: var(--term-prompt); user-select: none; }

--- a/dashboard/src/features/policies/api.ts
+++ b/dashboard/src/features/policies/api.ts
@@ -38,7 +38,7 @@ interface OptimisticContext {
  * the YAML is empty or doesn't have a metadata.name line.
  */
 function nameFromYaml(yaml: string): string {
-  const match = /^\s*name:\s*"?([^"\n]+)"?/m.exec(yaml)
+  const match = /^[^\S\n]*name:[^\S\n]*"?([^"\n]+)"?/m.exec(yaml)
   return match ? match[1].trim() : '(new policy)'
 }
 

--- a/dashboard/src/features/scrub/PayloadDiff.css
+++ b/dashboard/src/features/scrub/PayloadDiff.css
@@ -112,7 +112,7 @@
 .scrub-diff-pre {
   margin: 0;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
   font-size: 11px;
   line-height: 1.55;
   font-family: 'JetBrains Mono', monospace;

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -351,7 +351,7 @@ describe('AgentDetailPage — sandbox events toggle + amber badge', () => {
   it('filters the events table down to dry-run rows when the toggle is on', async () => {
     mockWithMixedEvents()
     renderApp('/agents/abc123')
-    expect((await screen.findAllByTestId('event-row')).length).toBe(2)
+    expect(await screen.findAllByTestId('event-row')).toHaveLength(2)
     fireEvent.click(screen.getByTestId('agent-events-sandbox-toggle'))
     const filtered = screen.getAllByTestId('event-row')
     expect(filtered).toHaveLength(1)

--- a/dashboard/src/pages/Settings/RetentionPolicy.test.tsx
+++ b/dashboard/src/pages/Settings/RetentionPolicy.test.tsx
@@ -175,7 +175,7 @@ describe('RetentionPolicyPage', () => {
     await user.click(saveBtn)
 
     await waitFor(() => {
-      expect(client.calls.update.length).toBe(1)
+      expect(client.calls.update).toHaveLength(1)
     })
     expect(client.calls.update[0]?.hot_days).toBe(15)
     expect(client.calls.update[0]?.warm_days).toBe(90)


### PR DESCRIPTION
## Description

Clears all 24 open SonarCloud `CODE_SMELL` issues on `ai-agent-assembly_agent-assembly` to the customized quality criteria (0 security / <10 bugs / 0 smells), behaviour-preserving. Every issue was verified against current `remote/master` and fixed at the source — no false-positive marking was needed.

Breakdown by rule:

- **`rust:S3776` (4× CRITICAL, cognitive complexity)** — extracted helpers to drop each function ≤15, no behaviour change:
  - `aa-gateway/src/policy/expr.rs` `eval_string_field` 33→ split into `eval_string_membership` / `eval_string_equality` / `eval_string_numeric`.
  - `aa-runtime/src/runtime.rs` `run` 20→ extracted `build_gateway_client` + `spawn_op_control` (fail-closed semantics preserved).
  - `aa-proxy/src/config.rs` `from_env` 17→ extracted `env_truthy` / `env_csv` env-parse helpers.
  - `aa-api/src/ws/handler.rs` `handle_socket` 16→ extracted the 5-arm broadcast `tokio::select!` into `next_governance_event`.
- **`typescript:S8786` (1× MAJOR, super-linear regex)** — `nameFromYaml` in `dashboard/src/features/policies/api.ts`: restricted whitespace classes to horizontal whitespace (`[^\S\n]`) so the multiline `^` anchor can no longer let `\s*` span newlines. Same matches for real YAML.
- **`typescript:S2699` (1× BLOCKER, no assertion)** — `TopologyGraph.test.tsx` omitted-callback test now asserts the node stays non-interactive (no `role`/`tabindex`) after a click — the actual contract.
- **`typescript:S5906` (13× MINOR, generic assertion)** — replaced `.toBe(null)`→`.toBeNull()` and `.length).toBe(n)`→`.toHaveLength(n)` across onboarding / agent-detail / retention / burn-chart tests.
- **`css:S1874` (5× MINOR, deprecated keyword)** — replaced `word-break: break-word` with the standards-track `overflow-wrap: break-word` (same wrapping).

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3677

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

Local validation (all green):

- `cargo nextest run -p aa-gateway` — 1162 passed
- `cargo nextest run -p aa-proxy` — 135 passed
- `cargo nextest run -p aa-api` — 607 passed
- `cargo nextest run -p aa-runtime` — 341 passed
- `cargo clippy -p aa-gateway -p aa-proxy -p aa-api -p aa-runtime --all-targets --all-features -- -D warnings` — clean
- `cd dashboard && pnpm lint && pnpm type-check && pnpm test` — lint clean, type-check clean, 1360 tests passed (149 files)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Expected SonarCloud result after analysis: open code smells → 0; 0 security maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
