### PR TITLE
[AAASM-3683] 🔒 (agent-assembly): Pass language-SDK package version through the FFI into the handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,6 @@ dependencies = [
  "aa-security",
  "bs58",
  "ed25519-dalek",
- "getrandom 0.2.17",
  "hex",
  "prost",
  "rand 0.8.6",

--- a/aa-sdk-client/Cargo.toml
+++ b/aa-sdk-client/Cargo.toml
@@ -44,10 +44,9 @@ tokio = { workspace = true, features = ["test-util", "rt", "rt-multi-thread", "s
 # Mock gateway gRPC server for the with-core register+check test (AAASM-3398).
 tokio-stream = { workspace = true }
 # CSPRNG for fresh per-test handshake challenge nonces. `rand` returns the
-# value directly (no `[0u8; 32]` buffer literal in the data-flow → CodeQL-clean);
-# getrandom kept for the lifecycle_e2e fixture.
+# value directly (no `[0u8; 32]` buffer literal in the data-flow → CodeQL-clean),
+# used by every test that generates a nonce (unit + lifecycle_e2e fixture).
 rand = "0.8"
-getrandom = "0.2"
 
 [lints]
 workspace = true

--- a/aa-sdk-client/src/config.rs
+++ b/aa-sdk-client/src/config.rs
@@ -30,6 +30,13 @@ pub struct AssemblyConfig {
     /// registration so the gateway can build the topology / delegation graph.
     /// `None` marks the agent as a root agent.
     pub parent_agent_id: Option<String>,
+    /// User-facing language-package version of the SDK that opened this session
+    /// (the PyPI / npm / go-module version), passed down through the FFI at init.
+    /// Signed into the IPC handshake (AAASM-3666) so AAASM-3571 downgrade
+    /// detection reflects the *installed SDK release* the customer runs, not the
+    /// shared `aa-sdk-client` crate version. `None` falls back to the crate's
+    /// `CARGO_PKG_VERSION` (AAASM-3683), preserving the pre-passthrough behaviour.
+    pub sdk_version: Option<String>,
 }
 
 impl AssemblyConfig {
@@ -79,6 +86,29 @@ impl AssemblyConfig {
         DEFAULT_GATEWAY_ENDPOINT.to_string()
     }
 
+    /// Resolve the SDK version string to sign into the IPC handshake.
+    ///
+    /// Resolution order (mirrors the explicit-overrides-ambient precedence used
+    /// for `gateway_endpoint`):
+    /// 1. Explicit non-empty `sdk_version` — the language-package version the FFI
+    ///    forwards at init (PyPI / npm / go-module version, AAASM-3683).
+    /// 2. Fallback: this crate's `CARGO_PKG_VERSION` (the pre-AAASM-3683
+    ///    behaviour from AAASM-3666, so there is no regression when the FFI does
+    ///    not supply a version).
+    ///
+    /// The result authenticates the version under the handshake signature
+    /// (`nonce || sdk_version`, AAASM-3666); an empty explicit value is treated
+    /// as absent rather than signing an empty version.
+    pub fn resolved_sdk_version(&self) -> String {
+        if let Some(ref version) = self.sdk_version {
+            if !version.is_empty() {
+                return version.clone();
+            }
+        }
+
+        env!("CARGO_PKG_VERSION").to_string()
+    }
+
     /// Return the agent identity to send on gateway registration.
     ///
     /// The gateway's `AgentLifecycleService.Register` rejects a plain
@@ -102,6 +132,7 @@ mod tests {
             gateway_endpoint: None,
             team_id: None,
             parent_agent_id: None,
+            sdk_version: None,
         }
     }
 
@@ -130,6 +161,7 @@ mod tests {
             gateway_endpoint: Some("http://gw.example:50051".into()),
             team_id: None,
             parent_agent_id: None,
+            sdk_version: None,
         };
         assert_eq!(config.resolve_gateway_endpoint(), "http://gw.example:50051");
     }
@@ -139,6 +171,30 @@ mod tests {
         env::remove_var("AA_GATEWAY_ENDPOINT");
         let config = make_config("a", None);
         assert_eq!(config.resolve_gateway_endpoint(), DEFAULT_GATEWAY_ENDPOINT);
+    }
+
+    #[test]
+    fn resolved_sdk_version_prefers_explicit_language_version() {
+        let mut config = make_config("a", None);
+        config.sdk_version = Some("9.9.9".into());
+        // The FFI-forwarded language-package version wins over the crate version.
+        assert_eq!(config.resolved_sdk_version(), "9.9.9");
+    }
+
+    #[test]
+    fn resolved_sdk_version_falls_back_to_crate_version_when_none() {
+        // AAASM-3683: no FFI-supplied version → fall back to CARGO_PKG_VERSION
+        // (the AAASM-3666 behaviour), so there is no regression.
+        let config = make_config("a", None);
+        assert_eq!(config.resolved_sdk_version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn resolved_sdk_version_treats_empty_explicit_as_absent() {
+        let mut config = make_config("a", None);
+        config.sdk_version = Some(String::new());
+        // An empty explicit value must not sign an empty version — fall back.
+        assert_eq!(config.resolved_sdk_version(), env!("CARGO_PKG_VERSION"));
     }
 
     #[test]

--- a/aa-sdk-client/src/gateway.rs
+++ b/aa-sdk-client/src/gateway.rs
@@ -87,6 +87,7 @@ mod tests {
             gateway_endpoint: None,
             team_id: None,
             parent_agent_id: None,
+            sdk_version: None,
         }
     }
 

--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -78,7 +78,18 @@ pub struct IpcHandle {
 /// `agent_id` is the agent identity (AA_AGENT_ID); the loop derives the
 /// deterministic Ed25519 keypair from it to complete the runtime's session
 /// handshake before sending any traffic (AAASM-3587).
-pub fn spawn_ipc_thread(socket_path: PathBuf, agent_id: String) -> Result<IpcHandle, std::io::Error> {
+///
+/// `sdk_version` is the SDK version signed into the handshake (AAASM-3666). The
+/// FFI shims forward the user-facing language-package version here via
+/// [`AssemblyConfig::resolved_sdk_version`](crate::config::AssemblyConfig::resolved_sdk_version),
+/// which falls back to this crate's `CARGO_PKG_VERSION` when none is supplied
+/// (AAASM-3683). An empty string reduces the signed payload to the bare nonce
+/// (pre-AAASM-3666 behaviour).
+pub fn spawn_ipc_thread(
+    socket_path: PathBuf,
+    agent_id: String,
+    sdk_version: String,
+) -> Result<IpcHandle, std::io::Error> {
     let (cmd_tx, cmd_rx) = mpsc::channel::<IpcCommand>(256);
 
     let thread = std::thread::Builder::new().name("aa-ipc".to_string()).spawn(move || {
@@ -86,7 +97,7 @@ pub fn spawn_ipc_thread(socket_path: PathBuf, agent_id: String) -> Result<IpcHan
             .enable_all()
             .build()
             .expect("failed to build Tokio runtime for IPC thread");
-        rt.block_on(ipc_loop(socket_path, agent_id, cmd_rx));
+        rt.block_on(ipc_loop(socket_path, agent_id, sdk_version, cmd_rx));
     })?;
 
     Ok(IpcHandle {
@@ -104,7 +115,7 @@ pub fn spawn_ipc_thread(socket_path: PathBuf, agent_id: String) -> Result<IpcHan
 /// decisions), which a dedicated reader task drains so the socket never backs
 /// up. Blocking on an ack the runtime never sends would deadlock this loop and
 /// hang `shutdown()` (AAASM-3000).
-async fn ipc_loop(socket_path: PathBuf, agent_id: String, mut cmd_rx: mpsc::Receiver<IpcCommand>) {
+async fn ipc_loop(socket_path: PathBuf, agent_id: String, sdk_version: String, mut cmd_rx: mpsc::Receiver<IpcCommand>) {
     use tokio::net::UnixStream;
 
     let stream = match UnixStream::connect(&socket_path).await {
@@ -126,7 +137,7 @@ async fn ipc_loop(socket_path: PathBuf, agent_id: String, mut cmd_rx: mpsc::Rece
     // the runtime's nonce challenge, sign it with the agent's key, and send the
     // proof. Fail-closed — if the handshake fails, abort the loop rather than
     // leak heartbeats/events onto an unauthenticated channel.
-    if let Err(e) = perform_handshake(&mut reader, &mut writer, &agent_id).await {
+    if let Err(e) = perform_handshake(&mut reader, &mut writer, &agent_id, &sdk_version).await {
         tracing::error!(error = %e, "IPC handshake failed — aborting (fail-closed)");
         return;
     }
@@ -185,27 +196,21 @@ async fn ipc_loop(socket_path: PathBuf, agent_id: String, mut cmd_rx: mpsc::Rece
 /// Ed25519 key, and writes back a `HandshakeProof`. Returns an error if the
 /// challenge cannot be read or the proof cannot be sent — the caller treats this
 /// as fail-closed and aborts the loop.
+///
+/// `sdk_version` is the already-resolved version to sign (the FFI-forwarded
+/// language-package version, or this crate's `CARGO_PKG_VERSION` fallback;
+/// AAASM-3683). It is bound into the signature, not merely carried (AAASM-3666).
 async fn perform_handshake(
     reader: &mut tokio::net::unix::OwnedReadHalf,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     agent_id: &str,
+    sdk_version: &str,
 ) -> Result<(), codec::CodecError> {
     let nonce = codec::read_handshake_challenge(reader).await?;
-    let proof = build_handshake_proof(agent_id, &nonce, sdk_version());
+    let proof = build_handshake_proof(agent_id, &nonce, sdk_version);
     codec::write_handshake_proof(writer, &proof).await?;
     tracing::debug!("IPC session handshake completed");
     Ok(())
-}
-
-/// The SDK build version this client reports in the handshake (AAASM-3666).
-///
-/// Sourced from `aa-sdk-client`'s own `CARGO_PKG_VERSION` — the single shared
-/// runtime-client crate every language FFI shim wraps, so it is the meaningful
-/// "SDK version" the runtime can apply a downgrade floor against. Propagating a
-/// language-specific SDK version (e.g. the python/node/go package version)
-/// through the FFI boundary is a future follow-up.
-fn sdk_version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
 }
 
 /// Build a `HandshakeProof` for `agent_id` over the runtime-issued `nonce`,
@@ -327,11 +332,6 @@ mod tests {
     }
 
     #[test]
-    fn reported_sdk_version_is_the_crate_version() {
-        assert_eq!(sdk_version(), env!("CARGO_PKG_VERSION"));
-    }
-
-    #[test]
     fn query_policy_debug_does_not_leak_credential_token() {
         // Redaction guard (AAASM-3634): the QueryPolicy variant carries the
         // gateway credential_token, but its Debug must never print it — only
@@ -361,6 +361,11 @@ mod tests {
     /// The agent id the mock-server tests handshake as.
     const TEST_AGENT_ID: &str = "test-agent";
 
+    /// A distinctive language-package version the mock-server tests forward into
+    /// `spawn_ipc_thread`, so they can assert the *FFI-passed* version (not the
+    /// crate version) is what reaches the signed handshake (AAASM-3683).
+    const TEST_SDK_VERSION: &str = "py-99.88.77";
+
     /// A fresh 32-byte test nonce from a value-returning CSPRNG. `rand::random`
     /// returns the bytes directly, so no constant literal (e.g. `[0u8; 32]`) ever
     /// flows into the signing payload — CodeQL's hard-coded-crypto rule does not
@@ -372,7 +377,10 @@ mod tests {
     /// Server-side handshake (AAASM-3587): send a nonce challenge, read the
     /// client's proof, and verify it signs the nonce under the agent key. Mock
     /// servers call this first so the now-handshaking client can proceed.
-    async fn server_handshake<S>(stream: &mut S, agent_id: &str)
+    ///
+    /// Returns the `sdk_version` the client signed into the proof so callers can
+    /// assert the FFI-forwarded version reached the handshake (AAASM-3683).
+    async fn server_handshake<S>(stream: &mut S, agent_id: &str) -> String
     where
         S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
     {
@@ -421,6 +429,8 @@ mod tests {
         let vk2 = VerifyingKey::from_bytes(&vk.to_bytes()).unwrap();
         vk2.verify(&signed_payload, &Signature::from_bytes(&sig_bytes))
             .expect("client proof must verify");
+
+        proof.sdk_version
     }
 
     #[tokio::test]
@@ -430,6 +440,7 @@ mod tests {
         let handle = spawn_ipc_thread(
             PathBuf::from("/tmp/nonexistent-aa-test.sock"),
             TEST_AGENT_ID.to_string(),
+            TEST_SDK_VERSION.to_string(),
         );
         assert!(handle.is_ok());
         let mut handle = handle.unwrap();
@@ -450,14 +461,26 @@ mod tests {
 
         let listener = UnixListener::bind(&socket_path).unwrap();
 
-        // Spawn the IPC client thread.
-        let handle = spawn_ipc_thread(PathBuf::from(&socket_path), TEST_AGENT_ID.to_string()).unwrap();
+        // Spawn the IPC client thread, forwarding a distinctive language-package
+        // version (AAASM-3683).
+        let handle = spawn_ipc_thread(
+            PathBuf::from(&socket_path),
+            TEST_AGENT_ID.to_string(),
+            TEST_SDK_VERSION.to_string(),
+        )
+        .unwrap();
 
         // Accept the connection on the mock server side.
         let (mut stream, _) = listener.accept().await.unwrap();
 
         // AAASM-3587: the client completes the handshake before any heartbeat.
-        server_handshake(&mut stream, TEST_AGENT_ID).await;
+        // AAASM-3683: the FFI-forwarded version (not the crate version) is what
+        // the client signs into the proof.
+        let signed_version = server_handshake(&mut stream, TEST_AGENT_ID).await;
+        assert_eq!(
+            signed_version, TEST_SDK_VERSION,
+            "the FFI-passed sdk_version must reach the signed handshake"
+        );
 
         let (mut reader, mut writer) = tokio::io::split(stream);
 
@@ -506,7 +529,12 @@ mod tests {
             }
         });
 
-        let mut handle = spawn_ipc_thread(PathBuf::from(&socket_path), TEST_AGENT_ID.to_string()).unwrap();
+        let mut handle = spawn_ipc_thread(
+            PathBuf::from(&socket_path),
+            TEST_AGENT_ID.to_string(),
+            TEST_SDK_VERSION.to_string(),
+        )
+        .unwrap();
 
         // Ship several events — fire-and-forget, must not block.
         for i in 0..5 {
@@ -588,7 +616,12 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(200)).await;
         });
 
-        let handle = spawn_ipc_thread(PathBuf::from(&socket_path), TEST_AGENT_ID.to_string()).unwrap();
+        let handle = spawn_ipc_thread(
+            PathBuf::from(&socket_path),
+            TEST_AGENT_ID.to_string(),
+            TEST_SDK_VERSION.to_string(),
+        )
+        .unwrap();
         let client = AssemblyClient::new(handle, Vec::new());
 
         // query_policy blocks the calling thread, so run it off the async runtime.

--- a/aa-sdk-client/tests/gateway_register_with_core.rs
+++ b/aa-sdk-client/tests/gateway_register_with_core.rs
@@ -154,6 +154,7 @@ async fn register_then_check_carries_token_and_surfaces_deny() {
         gateway_endpoint: Some(endpoint.clone()),
         team_id: None,
         parent_agent_id: None,
+        sdk_version: None,
     };
 
     // 1) Register directly against the mock gateway — issues + stores the token.

--- a/aa-sdk-client/tests/lifecycle_e2e.rs
+++ b/aa-sdk-client/tests/lifecycle_e2e.rs
@@ -14,6 +14,11 @@ use tokio::net::UnixListener;
 /// The agent id the e2e client handshakes as.
 const TEST_AGENT_ID: &str = "e2e-agent";
 
+/// A distinctive language-package version forwarded into `spawn_ipc_thread`, so
+/// the e2e asserts the FFI-passed version (not the crate version) reaches the
+/// signed handshake (AAASM-3683).
+const TEST_SDK_VERSION: &str = "node-1.2.3-rc.4";
+
 /// Read a prost varint length prefix from `reader`.
 async fn read_varint<R: AsyncReadExt + Unpin>(reader: &mut R) -> usize {
     let mut result: u64 = 0;
@@ -31,15 +36,20 @@ async fn read_varint<R: AsyncReadExt + Unpin>(reader: &mut R) -> usize {
 
 /// Server side of the AAASM-3587 session handshake: send a nonce challenge, read
 /// the client's signed proof, and verify it under the agent's deterministic key.
-async fn server_handshake<S>(stream: &mut S, agent_id: &str)
+///
+/// Returns the `sdk_version` the client signed into the proof so the caller can
+/// assert the FFI-forwarded version reached the handshake (AAASM-3683).
+async fn server_handshake<S>(stream: &mut S, agent_id: &str) -> String
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     use ed25519_dalek::{Signature, Verifier};
     use sha2::{Digest, Sha256};
 
-    let mut nonce = vec![0u8; 32];
-    getrandom::getrandom(&mut nonce).expect("OS RNG must be available for the handshake nonce");
+    // Value-returning CSPRNG so no constant literal (e.g. `[0u8; 32]`) flows
+    // into the signed nonce — CodeQL's hard-coded-crypto rule does not model
+    // getrandom's in-place `&mut` fill as sanitizing the zero-init buffer.
+    let nonce = rand::random::<[u8; 32]>().to_vec();
     let challenge = aa_proto::assembly::ipc::v1::HandshakeChallenge { nonce: nonce.clone() };
     let payload = challenge.encode_to_vec();
     stream.write_u8(TAG_HANDSHAKE_CHALLENGE).await.unwrap();
@@ -63,6 +73,8 @@ where
     let sig: [u8; 64] = proof.signature.as_slice().try_into().unwrap();
     vk.verify(&signed_payload, &Signature::from_bytes(&sig))
         .expect("client handshake proof must verify");
+
+    proof.sdk_version
 }
 
 #[tokio::test]
@@ -71,14 +83,24 @@ async fn client_ships_event_to_mock_runtime_and_shuts_down() {
     let _ = std::fs::remove_file(&socket_path);
     let listener = UnixListener::bind(&socket_path).unwrap();
 
-    let ipc = spawn_ipc_thread(PathBuf::from(&socket_path), TEST_AGENT_ID.to_string()).unwrap();
+    let ipc = spawn_ipc_thread(
+        PathBuf::from(&socket_path),
+        TEST_AGENT_ID.to_string(),
+        TEST_SDK_VERSION.to_string(),
+    )
+    .unwrap();
     let client = Arc::new(AssemblyClient::new(ipc, vec!["openai".to_string()]));
     assert_eq!(client.detected_frameworks(), vec!["openai".to_string()]);
 
     let (mut stream, _) = listener.accept().await.unwrap();
 
     // 0. AAASM-3587: complete the session handshake before any application frame.
-    server_handshake(&mut stream, TEST_AGENT_ID).await;
+    //    AAASM-3683: the FFI-forwarded version reaches the signed proof.
+    let signed_version = server_handshake(&mut stream, TEST_AGENT_ID).await;
+    assert_eq!(
+        signed_version, TEST_SDK_VERSION,
+        "the FFI-passed sdk_version must reach the signed handshake"
+    );
 
     let (mut reader, mut writer) = tokio::io::split(stream);
 


### PR DESCRIPTION
## Description

AAASM-3666 added a **signed** `sdk_version` to the IPC handshake, but sourced it from `aa-sdk-client`'s own `CARGO_PKG_VERSION` (the shared shim crate), so AAASM-3571 downgrade detection reflected the crate, not the user-facing language-package version.

This PR makes the language-package version flow through:
- Adds `sdk_version: Option<String>` to `AssemblyConfig` plus `resolved_sdk_version()`, which returns the explicit (FFI-forwarded) version and falls back to `CARGO_PKG_VERSION` when absent or empty. Mirrors the explicit-overrides-ambient precedence AAASM-3415 used for `gateway_endpoint`/`team_id`.
- Threads the version through `spawn_ipc_thread` → `ipc_loop` → `perform_handshake`, so the handshake proof signs the caller-supplied version instead of a hardcoded `CARGO_PKG_VERSION`. Drops the now-redundant `sdk_version()` helper.

The per-language FFI shims (`aa-ffi-{python,node,go}`, which live in the SDK repos) will pass `AssemblyConfig::resolved_sdk_version()` into `spawn_ipc_thread`; those changes ship as separate PRs (python-sdk / node-sdk / go-sdk) that bump their `aa-sdk-client` pin to this branch.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] Yes (describe below)

`spawn_ipc_thread` gains a third `sdk_version: String` parameter, and `AssemblyConfig` gains a `sdk_version` field. Both are internal crate APIs consumed only by the FFI shims; the **wire format is unchanged** (the `HandshakeProof.sdk_version` field already exists from AAASM-3666). No regression vs 3666: an unset version still signs the crate version.

## Related Issues

- Related Jira ticket: AAASM-3683
- Relates AAASM-3666, AAASM-3571, AAASM-3415

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated

- `cargo nextest run -p aa-sdk-client` (58 pass) — new config tests for explicit/empty/none precedence; mock-server + lifecycle e2e assert the FFI-passed version reaches the signed handshake proof.
- `cargo nextest run -p aa-runtime -p aa-security` (441 pass) — handshake verifier + AAASM-3571 `classify()` unaffected (wire format unchanged).
- `cargo nextest run -p aa-integration-tests` — handshake e2e.
- `cargo clippy -p aa-sdk-client --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean. Workspace clippy/fmt also run green via lefthook pre-commit on every commit.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
