### PR TITLE
[AAASM-3690] 📝 (docs): Drop stripped run/tools from usage-guide overview

### DIFF
--- a/docs/src/usage-guide/overview.md
+++ b/docs/src/usage-guide/overview.md
@@ -53,9 +53,7 @@ Commands:
   cost        Query cost summary and forecast spending
   dashboard   Open an interactive TUI dashboard for real-time governance monitoring
   gateway     Manage the aa-gateway governance daemon
-  run         Launch an AI dev tool (claude, codex, copilot, windsurf) with governance wiring
   sandbox     Run a WebAssembly tool inside the Agent Assembly sandbox
-  tools       List and manage AI dev tools on this system
   topology    Visualize agent topology, trees, lineage, and statistics
   proxy       Manage the aa-proxy sidecar — lifecycle, CA trust, and log tailing
   start       Start the locally-managed Agent Assembly gateway process


### PR DESCRIPTION
## Description

The usage-guide overview embeds a copy of the `aasm --help` command list under "The shape of every scenario". That block advertised two top-level commands — `run` ("Launch an AI dev tool…") and `tools` ("List and manage AI dev tools…") — that are gated behind the `devtool` region in `aa-cli/src/commands/mod.rs` (wrapped in `// strip-for-publish:begin/end devtool`) and removed from the published binary by `.ci/strip-for-publish.sh`. The published `aasm --help` does not list them, so the docs were misleading. This removes both lines, matching the published surface and `docs/src/cli/overview.md` (which already documents them as stripped).

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3690

## Testing

- [x] No tests required (explain why)

Docs-only change. Verified the `strip-for-publish:begin/end devtool` markers around `pub mod run;`, `pub mod tools;`, the `Run`/`Tools` enum variants, and their dispatch arms still exist in `aa-cli/src/commands/mod.rs`, confirming these commands are stripped from the published binary.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
