### PR TITLE
[AAASM-3691] 📝 (docs): Update releases.md series + latest tag to beta.3

### DIFF
--- a/docs/src/releases.md
+++ b/docs/src/releases.md
@@ -3,19 +3,19 @@
 This page tells you where to find a published build, which channels it ships to,
 and how the release is cut.
 
-`agent-assembly` is in the **`v0.0.1` alpha pre-release series**. The public API
+`agent-assembly` is in the **`v0.0.1` pre-release series**. The public API
 and wire protocol are not yet stable.
 
-> **Warning:** every published tag is a pre-release. Do not run `v0.0.1-alpha.*`
-> in production — the wire protocol can change between alphas.
+> **Warning:** every published tag is a pre-release. Do not run `v0.0.1-*`
+> in production — the wire protocol can change between pre-releases.
 
 ## Where releases live
 
 - **GitHub Releases:** <https://github.com/ai-agent-assembly/agent-assembly/releases>
   — the source of truth for published tags and changelogs. The latest tag is a
-  pre-release (`v0.0.1-beta.2`, 2026-06-15).
+  pre-release (`v0.0.1-beta.3`, 2026-06-20).
 - **Per-tag notes:** the source-controlled release notes live under
-  `docs/release/` (one file per tag, e.g. `docs/release/v0.0.1-beta.2.md`).
+  `docs/release/` (one file per tag, e.g. `docs/release/v0.0.1-beta.3.md`).
 - **Top-level changelog:** [`CHANGELOG.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/CHANGELOG.md).
 
 ## Distribution channels


### PR DESCRIPTION
## Description

`docs/src/releases.md` was stale on two points:

1. The intro called the project the "`v0.0.1` **alpha** pre-release series" and warned "Do not run `v0.0.1-alpha.*` in production". The project is now in the beta line. Promoted the wording to the channel-agnostic "`v0.0.1` pre-release series" (matching `quick-start/installation.md`) and broadened the warning to cover `v0.0.1-*`.
2. The "latest tag" reference said `v0.0.1-beta.2` (2026-06-15). The actual latest published tag is `v0.0.1-beta.3` (2026-06-20). Updated both the latest-tag line and the per-tag-notes example path to `docs/release/v0.0.1-beta.3.md` (which exists).

`compatibility.md` and `installation.md` were already on beta.3 — only `releases.md` lagged.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3691

## Testing

- [x] No tests required (explain why)

Docs-only. Confirmed the latest release via `gh release list -R ai-agent-assembly/agent-assembly` (top entry `v0.0.1-beta.3`, 2026-06-20) and that `docs/release/v0.0.1-beta.3.md` exists on master.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
