### PR TITLE
[AAASM-3702] 🐛 (docs): Null-guard mermaid-init theme-toggle listeners

### DIFF
--- a/docs/mermaid-init.js
+++ b/docs/mermaid-init.js
@@ -22,7 +22,7 @@
     // Simplest way to make mermaid re-render the diagrams in the new theme is via refreshing the page
 
     for (const darkTheme of darkThemes) {
-        document.getElementById(darkTheme).addEventListener('click', () => {
+        document.getElementById(darkTheme)?.addEventListener('click', () => {
             if (lastThemeWasLight) {
                 window.location.reload();
             }
@@ -30,7 +30,7 @@
     }
 
     for (const lightTheme of lightThemes) {
-        document.getElementById(lightTheme).addEventListener('click', () => {
+        document.getElementById(lightTheme)?.addEventListener('click', () => {
             if (!lastThemeWasLight) {
                 window.location.reload();
             }


### PR DESCRIPTION
## Description

The published mdBook site threw `TypeError: Cannot read properties of null (reading 'addEventListener')` on every page. The cause is the vendored `docs/mermaid-init.js` (referenced from `book.toml` `additional-js`), which iterates the theme ids (`ayu`/`navy`/`coal`/`light`/`rust`) and calls `document.getElementById(id).addEventListener('click', …)`. When the rendered theme picker does not contain every one of those ids, `getElementById` returns `null` and the chained `addEventListener` throws, aborting the rest of the inline script.

Fix: add optional chaining (`?.`) before `addEventListener` on both loop bodies so a missing theme-toggle element is skipped instead of throwing. Minimal, behaviour-preserving change.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3702

## Testing

- [x] Manual testing performed

Validated `docs/mermaid-init.js` parses cleanly with `node --check`. The guard is a standard optional-chaining null check; when the element exists the listener is attached exactly as before.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
