### PR TITLE
[AAASM-3703] 🐛 (dashboard): Guard pages against partial API objects

### DIFF
--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.test.tsx
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.test.tsx
@@ -125,4 +125,13 @@ describe('ApprovalAnalyticsPanel', () => {
     expect(screen.getByText('124')).toBeInTheDocument()
     expect(screen.getByText('33')).toBeInTheDocument()
   })
+
+  it('renders without crashing when byOutcome is missing on a partial response', async () => {
+    // A 200 with a partial object (no `byOutcome`) must not crash the panel.
+    mockFetch({ volume: 0, medianTta: 0, approvalRate: 0 } as ApprovalAnalyticsResponse)
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    expect(await screen.findByTestId('approval-donut')).toBeInTheDocument()
+    // The legend falls back to zeroed outcome counts rather than throwing.
+    expect(screen.getByText('Approved')).toBeInTheDocument()
+  })
 })

--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
@@ -21,9 +21,9 @@ function formatRate(rate: number): string {
 
 function buildDonutData(data: ApprovalAnalyticsResponse) {
   return [
-    { name: 'Approved', value: data.byOutcome.approved },
-    { name: 'Rejected', value: data.byOutcome.rejected },
-    { name: 'Expired',  value: data.byOutcome.expired  },
+    { name: 'Approved', value: data?.byOutcome?.approved ?? 0 },
+    { name: 'Rejected', value: data?.byOutcome?.rejected ?? 0 },
+    { name: 'Expired',  value: data?.byOutcome?.expired  ?? 0 },
   ]
 }
 

--- a/dashboard/src/features/teams/api.test.tsx
+++ b/dashboard/src/features/teams/api.test.tsx
@@ -163,6 +163,11 @@ describe('joinTeamRows', () => {
     expect(joinTeamRows(undefined, MOCK_COSTS)).toEqual([])
   })
 
+  it('returns an empty list when overview is missing the teams field', () => {
+    // A 200 response with a partial object (no `teams` array) must not throw.
+    expect(joinTeamRows({} as TopologyOverview, MOCK_COSTS)).toEqual([])
+  })
+
   it('joins overview rows with parsed cost data and computes burn percentage', () => {
     const rows = joinTeamRows(MOCK_OVERVIEW, MOCK_COSTS)
     expect(rows).toHaveLength(2)

--- a/dashboard/src/features/teams/api.ts
+++ b/dashboard/src/features/teams/api.ts
@@ -102,7 +102,7 @@ export function joinTeamRows(overview: TopologyOverview | undefined, costs: Cost
   const dailyLimit = parseUsd(costs?.daily_limit_usd)
   const costByTeam = new Map<string, TeamCostEntry>()
   for (const entry of costs?.per_team ?? []) costByTeam.set(entry.team_id, entry)
-  return overview.teams.map((team): TeamListRow => {
+  return (overview?.teams ?? []).map((team): TeamListRow => {
     const cost = costByTeam.get(team.team_id)
     const dailySpend = parseUsd(cost?.daily_spend_usd)
     const burnPct = dailySpend != null && dailyLimit != null && dailyLimit > 0

--- a/dashboard/src/pages/TopologyPage.test.tsx
+++ b/dashboard/src/pages/TopologyPage.test.tsx
@@ -58,6 +58,15 @@ describe('TopologyPage', () => {
     expect(screen.getByTestId('topology-meta')).toHaveTextContent('0 agents · 0 teams')
   })
 
+  it('falls back to "0 agents · 0 teams" on a partial object missing the nodes field', () => {
+    // A 200 with a partial object (no `nodes` array) must not crash the page.
+    vi.spyOn(topologyApi, 'useTopologyQuery').mockReturnValue(
+      mockQuery({ data: {} as TopologyGraph, isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderPage()
+    expect(screen.getByTestId('topology-meta')).toHaveTextContent('0 agents · 0 teams')
+  })
+
   it('renders skeleton rows while loading and hides the body', () => {
     vi.spyOn(topologyApi, 'useTopologyQuery').mockReturnValue(
       mockQuery({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() }),

--- a/dashboard/src/pages/TopologyPage.tsx
+++ b/dashboard/src/pages/TopologyPage.tsx
@@ -24,9 +24,9 @@ export function TopologyPage() {
   const { open: openTraceDrawer } = useTraceDrawer()
   const teamCount = useMemo(() => {
     if (!data) return 0
-    return new Set(data.nodes.map(n => n.team)).size
+    return new Set((data?.nodes ?? []).map(n => n.team)).size
   }, [data])
-  const agentCount = data?.nodes.length ?? 0
+  const agentCount = data?.nodes?.length ?? 0
 
   const handleViewTrace = (agentId: string, sessionId: string) => {
     openTraceDrawer(agentId, sessionId)


### PR DESCRIPTION
## Description

Three dashboard call sites crashed the route into the ErrorBoundary (white screen) when the gateway returned a 200 with a partial object missing an expected array/field. Each guarded only the top-level value, then dereferenced a nested field:

- `dashboard/src/pages/TopologyPage.tsx` — `data.nodes.map(...)` / `data?.nodes.length` guarded only by `if (!data)`. Now `data?.nodes ?? []` and `data?.nodes?.length ?? 0`.
- `dashboard/src/features/teams/api.ts` (`joinTeamRows`, used by `CostsPage`) — `overview.teams.map(...)` guarded only by `if (!overview)`. Now `(overview?.teams ?? []).map(...)`.
- `dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx` (`buildDonutData`) — `data.byOutcome.approved/rejected/expired`. Now `data?.byOutcome?.<k> ?? 0`.

These are robustness fixes (LOW): under a correct gateway these pages already render fine. Added a partial-API-object regression test for each of the three guards.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3703

## Testing

- [x] Unit tests added / updated

Ran in `dashboard/`:
- `pnpm test` — 149 files / 1363 tests pass (includes the 3 new partial-object tests).
- `pnpm type-check` (`tsc --noEmit`) — clean.
- `pnpm lint` (eslint, `--max-warnings 0`) — clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Unit tests added
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
