### PR TITLE
[AAASM-3708] 📝 (skill): Add version forward-ref + sweep logic to release-docs-sync

### DIFF
--- a/.claude/skills/release-docs-sync/SKILL.md
+++ b/.claude/skills/release-docs-sync/SKILL.md
@@ -24,7 +24,30 @@ not on `X`.
 > (latest / pre-release / stable labels, version dropdowns) is already fully
 > **release-workflow-driven** (AAASM-2741 / AAASM-2744). **Do NOT hand-edit
 > channel labels or the channel dropdown** — only update the in-content version
-> references listed below.
+> references listed below. (For **node-sdk**, `website/versions.json` and
+> `website/versionChannels.json` are that channel config — auto-managed by the
+> release docs-snapshot step; **do not hand-edit them**.)
+
+> **Principle — three kinds of version reference; only one gets bumped.** Before
+> changing any version string, classify it:
+> - **Current / canonical** — install snippets, sample CLI output, "captured
+>   against `vX`" provenance, the latest-release link, the *new* compat-matrix
+>   row → **bump to `X`**.
+> - **Historical** — CHANGELOG, `docs/release/*`, older compat-matrix rows,
+>   `versioned_docs/` snapshots, a security "last full refresh" marker → **leave**.
+>   They record the past; bumping a refresh marker without an actual re-review is
+>   a lie.
+> - **Forward-reference** — a dependency pin to the release that *ships a feature*
+>   (an example for an adapter/feature added after the last published tag, pinned
+>   `>=X`) → **correct, not stale; leave it / set to `X`**. Do NOT downgrade it to
+>   the last *published* version. This is the AAASM-3695 trap — see Step 3.5.
+
+> **Timing — consumer repos lag; the release repos lead.** Repos that **install
+> from registries** (`agent-assembly-examples`, the docs-hub live badges) must
+> reference the **currently-published** version. Do **not** bump them to `X`
+> *before* `X` is published — `pip install` / `npm i` / `go get` of an unpublished
+> `X` breaks. Bump those **after** the publish step. The release repos' own docs
+> (this skill) *describe* the upcoming release and may lead.
 
 ## When to use
 
@@ -123,6 +146,36 @@ uses **static** shields.io badges that do NOT self-update:
 edits (badges are live). Only a **channel change** requires the dist-tag /
 prose edits in node-sdk above.
 
+### Step 3.5 — example dependency pins for newly-added features (forward-refs)
+
+**Easy to miss, and NOT covered by `check-docs-versions.sh`.** When a release adds
+new SDK features/adapters, their example docs must pin the release that **ships**
+them — not the last published version. Pinning the older version means a reader
+installs a build that lacks the feature (`ImportError` / missing export). This is
+the AAASM-3695 class: the LlamaIndex example correctly pins `>=0.0.1b5` while only
+`b4` was published, because the adapter is **absent** from `b4`.
+
+1. Grep every example/doc dependency pin:
+   - python: `git grep -nE 'agent-assembly\s*[<>=]' docs/`
+   - node:   `git grep -nE '@agent-assembly/sdk@' docs/`
+2. For each pinned feature, check whether it exists in the **last published tag**:
+
+   ```sh
+   git cat-file -e <last-published-tag>:agent_assembly/adapters/<name>/__init__.py
+   ```
+
+   - **errors (absent)** → the feature is new in `X`; the pin **must** be the `X`
+     registry form (`>=0.0.1b5`, etc.).
+   - **succeeds (present)** → the existing lower pin is valid; **leave it**.
+3. Fix any pin naming a version that does not actually contain its feature. (The
+   beta.4 wave found four the QA pass missed: `agno` at `>=b4`, and `haystack` /
+   `microsoft-agent-framework` / `smolagents` at `>=b2` — all adapters that only
+   ship in `b5`.)
+
+> Do this for **every** new feature's example, not just the canonical version
+> files. A green `check-docs-versions.sh` does **not** catch these — it only
+> checks the core install examples + the compat-matrix row.
+
 ### Step 4 — verify
 
 From the agent-assembly worktree:
@@ -157,4 +210,9 @@ you touched the script.
 - A new compat-matrix row for `X` exists in **both** the core and hub
   compatibility files.
 - The hub's **static** core/Go badges read `X`.
-- Channel labels were **not** hand-edited (they're workflow-driven).
+- Every new-feature example pin points at the release that ships it (Step 3.5),
+  verified absent from the prior published tag — not downgraded to the last
+  published version.
+- Consumer / registry-install repos were **not** bumped ahead of publish.
+- Channel labels (incl. node-sdk `versions.json` / `versionChannels.json`) were
+  **not** hand-edited (they're workflow-driven).

--- a/.claude/skills/release-docs-sync/SKILL.md
+++ b/.claude/skills/release-docs-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-docs-sync
-description: Sync every version-dependent doc/content reference to a new agent-assembly release version (alpha / beta / rc / official). Use right before or as part of cutting a release — after release-tag-cut bumps the Cargo version literals but before/while the docs are published — to update the compatibility matrix, install examples, sample CLI output, and SDK README version refs so docs never go stale. Version-type-agnostic: the same checklist applies to any pre-release or official version.
+description: Sync every version-dependent doc/content reference to a new agent-assembly release version (alpha / beta / rc / official). Use right before or as part of cutting a release — after release-tag-cut bumps the Cargo version literals but before/while the docs are published — to update the compatibility matrix, install examples, sample CLI output, and the SDK version files + docs-site/README version refs (incl. new-feature example pins) so docs never go stale. Version-type-agnostic: the same checklist applies to any pre-release or official version.
 ---
 
 # release-docs-sync
@@ -125,26 +125,56 @@ uses **static** shields.io badges that do NOT self-update:
 > The hub lives in the sibling `agent-assembly-docs` repo. Make these edits in
 > that repo's own PR — do not edit it from the agent-assembly worktree.
 
-### Step 3 — SDK READMEs (read-only siblings; mostly self-updating)
+### Step 3 — SDK repos: version files, READMEs, AND docs sites
 
-- **python-sdk** — all version badges are **live** (`pypi/v`, GitHub release,
-  pyversions). Install snippets use `pip install agent-assembly` with **no
-  pinned version**. **Nothing to bump** on a normal release. Only touch if a
-  snippet ever hard-codes `==0.0.1bN`.
-- **node-sdk** — the npm badge is **live** (`npm/v/.../beta`). Install snippets
-  use the `@beta` dist-tag, not a pinned version. On a **channel promotion**
-  (e.g. beta→rc→latest), repoint the dist-tag in the badge URL, the
-  `pnpm add @agent-assembly/sdk@<tag>` snippet, and the "current release line is
-  `0.0.1-beta.x`" prose. Otherwise nothing to bump.
-- **go-sdk** — badges are static `docs-live` only; the install snippet is
-  `go get github.com/<org>/go-sdk` with no version. **Nothing version-bump to
-  do.** (Note: the canonical org id is lowercase `ai-agent-assembly`; if a
-  README's `go get` path ever uses mixed case, that is a casing fix tracked
-  separately, not part of version-sync.)
+> ⚠️ **SDKs are NOT "nothing to bump."** The README *badges* are mostly live, but
+> every SDK in the release cycle also has (a) a checked-in **version file** and
+> (b) a **docs site** with **pinned** install commands and per-example version
+> lines. The beta.4 wave bumped all three across python and node. **No SDK file
+> is covered by `check-docs-versions.sh`** — these are all manual. "Badges are
+> live" ≠ "the SDK needs no edits."
 
-**Net for SDKs:** on a same-channel forward-roll, the SDK READMEs need **no**
-edits (badges are live). Only a **channel change** requires the dist-tag /
-prose edits in node-sdk above.
+For each SDK being released this cycle, do all three of:
+
+**3a — canonical version file** (the SDK release PR carries this; the *published*
+version also comes from the release `workflow_dispatch` input — `pypi_version` /
+`npm_version` — but keep the checked-in file in sync for repo honesty + badges):
+
+- **python-sdk** — `pyproject.toml` `version` + `agent_assembly/__init__.py`
+  `__version__` → PyPI form (e.g. `0.0.1b5`); regenerate `uv.lock`.
+- **node-sdk** — root `package.json` `version` → e.g. `0.0.1-beta.5`. (The 4
+  runtime sub-package `package.json` files stay at their tree value;
+  `release-node.yml` rewrites all 5 at publish from `npm_version`. `pnpm-lock.yaml`
+  usually does not pin the root version — only touch if it does.)
+- **go-sdk** — `assembly/version.go` `Version` const, *if* go-sdk is part of the
+  cycle. go-sdk is tag-driven — **skip it entirely when it has no new commits**.
+
+**3b — README badges** — `pypi/v`, `npm/v/.../<tag>`, GitHub-release and
+`docs-live` badges are **live**; do **not** hand-edit them. Only on a **channel
+change** (alpha→beta→rc→latest) repoint the npm dist-tag in node-sdk's badge URL +
+the `pnpm add @agent-assembly/sdk@<tag>` snippet + the "current release line is
+`…`" prose.
+
+**3c — SDK docs site (the easily-missed part)** — these carry **pinned** version
+strings that are NOT live and NOT covered by the verifier:
+
+- **node-sdk `website/docs/`** — the quick-start **`npm install @agent-assembly/sdk@<X>`**
+  command IS pinned to an explicit version (not a bare `@beta`), and each
+  `09-examples/*.md` page states "depends only on `@agent-assembly/sdk` (version
+  `<X>`)". Bump **every** one to `X`. Leave `website/versions.json` /
+  `versionChannels.json` (auto-managed) and `website/versioned_docs/**` snapshots.
+- **python-sdk `docs/`** — example dependency tables pin `agent-assembly>=<…>`.
+  Bump current-version pins to `X`, and run **Step 3.5** for new-feature adapter
+  examples (forward-ref pins — this is where the agno/haystack/smolagents/
+  ms-agent-framework misses happened).
+- **go-sdk** — library install is `go get …@vX` with no in-repo pinned version;
+  nothing in-repo to bump. (Its examples live in `agent-assembly-examples` and
+  track the *published* go-sdk tag — bump them **post-publish** per the timing
+  rule, not here. The org id is lowercase `ai-agent-assembly`; a mixed-case
+  `go get` path is a separate casing fix.)
+
+> **Net for SDKs:** a release that ships SDK changes touches the **version file +
+> docs-site pins** in every SDK in the cycle. Only the *badges* are no-ops.
 
 ### Step 3.5 — example dependency pins for newly-added features (forward-refs)
 
@@ -210,6 +240,10 @@ you touched the script.
 - A new compat-matrix row for `X` exists in **both** the core and hub
   compatibility files.
 - The hub's **static** core/Go badges read `X`.
+- **Every SDK in the cycle** has its **version file** (pyproject + `__init__` /
+  root `package.json` / `version.go`) AND its **docs-site pinned versions**
+  (node quick-start `@X` install + `09-examples` "version" lines; python example
+  dependency tables) bumped to `X` — none of which the verifier checks.
 - Every new-feature example pin points at the release that ships it (Step 3.5),
   verified absent from the prior published tag — not downgraded to the last
   published version.


### PR DESCRIPTION
## Description

Encodes three release-process lessons from the v0.0.1-beta.4 coordinated wave into the `release-docs-sync` skill — they're important but easy to forget at release time. Doc-only (no mechanics change).

### What's added to `.claude/skills/release-docs-sync/SKILL.md`
1. **Forward-reference vs stale principle** — a version pin to the release that *ships a feature* is correct, not stale. Verify with `git cat-file -e <last-published-tag>:<path>` before changing a pin. (AAASM-3695: LlamaIndex `>=0.0.1b5` was right because the adapter is absent from published `b4`; downgrading would `ImportError`.)
2. **New Step 3.5 — example dependency pins for newly-added features** — the case `check-docs-versions.sh` does NOT catch. The beta.4 wave found 4 broken pins the QA pass missed: `agno` (`>=b4`), `haystack`/`microsoft-agent-framework`/`smolagents` (`>=b2`) — all adapters that only ship in `b5`.
3. **Consumer-repo timing rule** — repos that install from registries (`agent-assembly-examples`, hub live badges) must track the *currently-published* version; bumping pre-publish breaks installs. Bump them after publish.
4. Plus: node-sdk `website/versions.json` / `versionChannels.json` flagged as auto-managed (reinforces the existing channel-labels warning), and matching "Done when" criteria.

## Type of Change
- [x] 📝 Documentation

## Related Issues
- Closes AAASM-3708 · refs AAASM-3695

## Testing
- [x] Skill-doc only; markdownlint runs in CI (not available locally — noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
