### PR TITLE
[AAASM-3710] 🐛 (docker): Fix node image cargo cache-mount race on multi-arch tag build

### DIFF
--- a/docker/Dockerfile.node-20-slim
+++ b/docker/Dockerfile.node-20-slim
@@ -30,9 +30,9 @@ RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
 WORKDIR /build
 
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/build/target \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=aasm-builder-cargo-registry-node-20,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,id=aasm-builder-cargo-git-node-20,sharing=locked \
+    --mount=type=cache,target=/build/target,id=aasm-builder-target-node-20,sharing=locked \
     cargo build --release -p aa-cli --bin aasm \
  && cp /build/target/release/aasm /usr/local/bin/aasm
 

--- a/docker/Dockerfile.node-22-slim
+++ b/docker/Dockerfile.node-22-slim
@@ -30,9 +30,9 @@ RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
 WORKDIR /build
 
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/build/target \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=aasm-builder-cargo-registry-node-22,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,id=aasm-builder-cargo-git-node-22,sharing=locked \
+    --mount=type=cache,target=/build/target,id=aasm-builder-target-node-22,sharing=locked \
     cargo build --release -p aa-cli --bin aasm \
  && cp /build/target/release/aasm /usr/local/bin/aasm
 

--- a/docker/Dockerfile.node-24-slim
+++ b/docker/Dockerfile.node-24-slim
@@ -30,9 +30,9 @@ RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
 WORKDIR /build
 
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/build/target \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=aasm-builder-cargo-registry-node-24,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,id=aasm-builder-cargo-git-node-24,sharing=locked \
+    --mount=type=cache,target=/build/target,id=aasm-builder-target-node-24,sharing=locked \
     cargo build --release -p aa-cli --bin aasm \
  && cp /build/target/release/aasm /usr/local/bin/aasm
 


### PR DESCRIPTION
## Description

Fixes the node language-image build failure on the `v0.0.1-beta.4` tag (run [28111966012](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/28111966012)): all node jobs died at `cargo build -p aa-cli` with `download of ar/bi/arbitrary failed`.

**Root cause:** on a tag push `docker.yml` builds multi-arch (`linux/amd64,linux/arm64`); BuildKit runs both per-arch `cargo build` stages in parallel. The 3 node Dockerfiles declared their cargo cache mounts with **no `id` / no `sharing`** (default `sharing=shared`), so the two arch builds shared one cargo registry cache concurrently and corrupted the index download. PR builds are amd64-only, so it never reproduced in PR CI.

**Fix:** add per-variant `id=aasm-builder-{cargo-registry,cargo-git,target}-node-<ver>` + `sharing=locked` to each cache mount in `Dockerfile.node-{20,22,24}-slim` — identical to what `Dockerfile.go-*` and `Dockerfile.python-*` already do (node was the only one missed).

## Type of Change
- [x] 🐛 Bug fix

## Related Issues
- Closes AAASM-3710

## Testing
- [x] Mirrors the proven go/python cache-mount config (those images build multi-arch on tags without the race).
- Validation: re-run the Docker workflow node jobs against the tag (or workflow_dispatch) → node-20/22/24 multi-arch images build + push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
