### PR TITLE
[AAASM-3711] 🐛 (aa-ebpf-probes): Set panic=abort for no_std BPF target

### DIFF
--- a/aa-ebpf-probes/Cargo.toml
+++ b/aa-ebpf-probes/Cargo.toml
@@ -29,3 +29,9 @@ path = "src/syscall_guard.rs"
 # Declare this crate as its own standalone workspace so Cargo does not
 # attempt to include it in the parent agent-assembly workspace.
 [workspace]
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"


### PR DESCRIPTION
## Description

Fixes the `release.yml` `Build (x86_64-unknown-linux-gnu)` failure on the `v0.0.1-beta.4` tag (run [28111966057](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/28111966057), job 83241443988), which **skipped crates.io publish + GH Release + FFI-pin PRs + Homebrew** — so the release published nothing.

**Root cause:** the AAASM-3601 integrity step builds `aa-ebpf-probes` standalone (`cargo build --release --manifest-path aa-ebpf-probes/Cargo.toml`, nightly + `build-std=["core"]`) for the no_std `bpfel-unknown-none` target. With the default `panic = "unwind"`, rustc errors `unwinding panics are not supported without std`. The crate's `Cargo.toml` had no `panic` profile setting. This step is new this cycle (security wave), so the gap only surfaced on a real tag.

**Fix:** add `[profile.dev]` / `[profile.release]` `panic = "abort"` (the aya-template standard for eBPF crates).

**Verified locally:** `rustup run nightly cargo build --release --manifest-path aa-ebpf-probes/Cargo.toml` no longer emits the unwinding error (it then fails only on `invalid Mach-O section specifier` because the host is macOS; the Linux/ELF CI target is unaffected).

## Type of Change
- [x] 🐛 Bug fix

## Related Issues
- Closes AAASM-3711 · blocks AAASM-3705 (beta.4 release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
