### PR TITLE
[AAASM-3712] 🐛 (ci): Unify eBPF probe build via shared script (release.yml + ci.yml)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
             ebpf:
               - 'aa-ebpf*/**'
               - '.github/workflows/ci.yml'
+              - 'scripts/build-ebpf-probes.sh'
+              - '.github/workflows/release.yml'
   # AAASM-2582: build the dashboard assets (embedded by aa-cli's build.rs)
   # exactly once and share them via an artifact, instead of running
   # `pnpm install && pnpm build` in each of build/clippy/test/coverage.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,7 +753,13 @@ jobs:
         if: steps.cache-bpf-linker.outputs.cache-hit != 'true'
         run: cargo install bpf-linker
       - name: Build eBPF probes
-        run: cargo build --release
+        # AAASM-3712: build via the shared script — the SINGLE SOURCE OF TRUTH
+        # also used by release.yml's AAASM-3601 step, so the two recipes can
+        # never diverge again. Run from the repo root (overriding this job's
+        # working-directory: aa-ebpf-probes default) so the scripts/ path
+        # resolves; the script then cd's into aa-ebpf-probes/ itself.
+        working-directory: .
+        run: bash scripts/build-ebpf-probes.sh
       - name: Clippy on eBPF probes
         # --all-targets would try to build test harness binaries, which require the
         # `test` crate — unavailable on the no_std bpfel-unknown-none target.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,16 +150,11 @@ jobs:
           rustup component add rust-src --toolchain nightly
           OUT="$GITHUB_WORKSPACE/ebpf-objects"
           mkdir -p "$OUT"
-          rustup run nightly cargo build --release \
-            --manifest-path aa-ebpf-probes/Cargo.toml \
-            --target-dir "$OUT/target" || {
-              echo "::error::eBPF probe compilation failed — cannot produce integrity manifest"
-              exit 1
-            }
-          REL="$OUT/target/bpfel-unknown-none/release"
-          for obj in aa-file-io aa-exec-probes aa-tls-probes; do
-            cp "$REL/$obj" "$OUT/$obj"
-          done
+          # AAASM-3712: build + stage via the shared script (single source of
+          # truth with ci.yml's ebpf-build job). The script builds from inside
+          # aa-ebpf-probes/ so .cargo/config.toml (bpfel-unknown-none target +
+          # build-std=core) applies, and installs bpf-linker if missing.
+          bash scripts/build-ebpf-probes.sh "$OUT"
           ls -l "$OUT"
 
       - name: Upload eBPF probe objects (Linux x86_64 — AAASM-3601)

--- a/scripts/build-ebpf-probes.sh
+++ b/scripts/build-ebpf-probes.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build the standalone eBPF probe objects for bpfel-unknown-none.
+# SINGLE SOURCE OF TRUTH shared by ci.yml (ebpf-build PR job) and release.yml
+# (AAASM-3601 integrity manifest) so the two recipes can never diverge again
+# (AAASM-3712). MUST build from INSIDE aa-ebpf-probes/ so its .cargo/config.toml
+# (target=bpfel-unknown-none, build-std=core) applies — a root `cargo build
+# --manifest-path` ignores it and builds for the host (undefined main/libc).
+# Requires: a nightly toolchain with rust-src already installed by the caller.
+# Usage: scripts/build-ebpf-probes.sh [STAGE_DIR]
+#   STAGE_DIR (optional): copy the 4 built .o objects there.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STAGE_DIR="${1:-}"
+# bpf-linker is required to link aya BPF programs.
+if ! command -v bpf-linker >/dev/null 2>&1; then
+  echo "Installing bpf-linker..."
+  cargo install bpf-linker --locked
+fi
+cd "$REPO_ROOT/aa-ebpf-probes"
+cargo +nightly build --release
+REL="target/bpfel-unknown-none/release"
+OBJS=(aa-file-io aa-exec-probes aa-tls-probes aa-syscall-guard)
+for o in "${OBJS[@]}"; do
+  test -f "$REL/$o" || { echo "::error::expected eBPF object missing: $REL/$o"; exit 1; }
+done
+if [ -n "$STAGE_DIR" ]; then
+  mkdir -p "$STAGE_DIR"
+  for o in "${OBJS[@]}"; do cp "$REL/$o" "$STAGE_DIR/$o"; done
+  echo "Staged ${#OBJS[@]} eBPF objects to $STAGE_DIR"
+fi


### PR DESCRIPTION
## Description

The release.yml eBPF-integrity build (AAASM-3601) had diverged from the proven `ebpf-build` recipe in ci.yml and was broken: it ran from the repo root as

```
rustup run nightly cargo build --release --manifest-path aa-ebpf-probes/Cargo.toml --target-dir "$OUT/target"
```

Cargo only applies `aa-ebpf-probes/.cargo/config.toml` (which sets `target = "bpfel-unknown-none"` and `[unstable] build-std = ["core"]`) when invoked from **inside** that directory — a root `--manifest-path` build ignores it and links for the **host**, producing the link error `undefined main / __libc_start_main / rust_eh_personality`. The step also never installed `bpf-linker`, the linker required for the BPF target.

This PR unifies both workflows behind a single shared script, `scripts/build-ebpf-probes.sh`, so the two recipes can never diverge again:

- The script `cd`s into `aa-ebpf-probes/` before building (so `.cargo/config.toml` applies), installs `bpf-linker` if missing, verifies all 4 probe objects (`aa-file-io`, `aa-exec-probes`, `aa-tls-probes`, `aa-syscall-guard`), and optionally stages them into a caller-supplied dir.
- `release.yml`'s AAASM-3601 step now calls `bash scripts/build-ebpf-probes.sh "$OUT"`; the existing upload/sign/manifest steps are unchanged.
- `ci.yml`'s `ebpf-build` job ("eBPF probes build (Linux nightly)") now calls the same script for its build step (run from the repo root via a `working-directory: .` override). Its bpf-linker cache/install, toolchain setup, Clippy, and load/attach integration-test steps are unchanged.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3712

## Testing

The green `eBPF probes build (Linux nightly)` PR job in this very workflow now runs the exact shared script the release uses, so it validates the release recipe on Linux. Locally, `bash -n scripts/build-ebpf-probes.sh` passes and the 4 bin names match `aa-ebpf-probes/Cargo.toml`; a full BPF link build is not possible on macOS (no `bpf-linker`).

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (explain why) — CI-only change; the existing `ebpf-build` job is the regression gate and now exercises the shared recipe.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3712

🤖 Generated with [Claude Code](https://claude.com/claude-code)
