### PR TITLE
[AAASM-3713] 🔧 (ci): Add pull_request dry-run to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,17 @@ on:
   push:
     tags:
       - "v[0-9]*.[0-9]*.[0-9]*"
+  # Dry-run on PRs that can affect the release build (AAASM-3713). Every publish
+  # job is gated `if: github.event_name == 'push'`, so a pull_request only runs the
+  # build matrix + eBPF-integrity step and never publishes — surfacing release-build
+  # regressions (e.g. AAASM-3712) before tag time instead of at release.
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "scripts/build-ebpf-probes.sh"
+      - "aa-ebpf*/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Description

Closes the residual gap behind the release-only failures (AAASM-3711/3712): `release.yml` only ran on `push: tags` / `workflow_dispatch`, so its `build` job — including the eBPF integrity step (AAASM-3601) that failed in run [28138012079](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/28138012079) — was never exercised on a PR.

**Change:** add a path-scoped `pull_request` dry-run trigger. Every publish-side job is already gated `if: github.event_name == 'push'`, so on a PR the workflow **builds + runs the eBPF integrity step and publishes nothing**. To keep cost down, on `pull_request` only the `x86_64-unknown-linux-gnu` target runs (the one that performs the eBPF build); push/dispatch still builds the full matrix.

**Self-demonstrating:** this PR touches `release.yml`, so it should itself trigger the Release `Build (x86_64-unknown-linux-gnu)` job here — i.e. a run-28138012079-class failure would now turn this PR red.

## Type of Change
- [x] 🔧 CI / config

## Related Issues
- Closes AAASM-3713 · refs AAASM-3712 / AAASM-3711 / AAASM-3601

🤖 Generated with [Claude Code](https://claude.com/claude-code)
