### PR TITLE
[AAASM-3714] 🐛 (ci): Docs cut only on tag-push Release runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,14 @@ jobs:
     name: Build mdBook
     runs-on: ubuntu-latest
     # PR + master-push always build. A workflow_run only proceeds when the
-    # upstream Release succeeded AND it was a release tag (vX.Y.Z[-pre]).
+    # upstream Release succeeded, was a TAG PUSH (not a pull_request / dispatch
+    # dry-run — AAASM-3714; our branch names also start with 'v', so the
+    # head_branch check alone is insufficient), and the tag looks like a release
+    # version (vX.Y.Z[-pre]).
     if: >-
       github.event_name != 'workflow_run' ||
       (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
        startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
       - uses: actions/checkout@v7.0.0


### PR DESCRIPTION
## Description

Fixes the Docs workflow failure (run [28142062286](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/28142062286)) now live on master after #1242 added release.yml's `pull_request` dry-run.

`docs.yml` triggers on `workflow_run` of **Release**. Its gate `startsWith(github.event.workflow_run.head_branch, 'v')` was meant to match release **tags**, but the repo's **branch names start with `v` too** (`v0.0.1/AAASM-…`). So a PR-triggered Release run passes the gate, then "Resolve target version subpath" tries to classify the branch name as a tag and `exit 1`s.

**Fix:** require `github.event.workflow_run.event == 'push'` — only real tag-push Releases cut docs; pull_request / workflow_dispatch Release runs skip the job (no error).

## Type of Change
- [x] 🐛 Bug fix (CI)

## Related Issues
- Closes AAASM-3714 · refs AAASM-3713 (#1242 introduced the trigger)

## Testing
- A `workflow_dispatch` Release run on master already reproduced the failing condition; this gate makes such runs skip the Docs job. A real `v*` tag still cuts docs (`event == 'push'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
