### PR TITLE
[AAASM-3733] 🐛 (docs): Publish the latest/ channel alias on a release cut

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -244,6 +244,20 @@ jobs:
           mkdir -p "_site/$VERSION"
           cp -R docs/book/. "_site/$VERSION/"
 
+          # 1b. Always materialise the `latest/` channel directory (AAASM-3733).
+          #     `latest` is a guaranteed channel in versions.json and the root
+          #     redirect's final fallback target, but it was only written on a
+          #     master-push cut (VERSION=latest). A release-only deploy (the only
+          #     kind this site has had) left `latest/` as a dangling target, so
+          #     the documented entry point /latest/ 404'd. On a release cut the
+          #     freshly built book is the newest live docs, so it is the correct
+          #     content for `latest/` too; on a master cut this is a no-op copy.
+          if [ "$VERSION" != "latest" ]; then
+            rm -rf "_site/latest"
+            mkdir -p "_site/latest"
+            cp -R docs/book/. "_site/latest/"
+          fi
+
           # 2. Recompute versions.json via the testable channel module
           #    (docs/ci/channels.py), which applies the pre-release semver
           #    gate and unions extra-archived.txt (written by the rebuild


### PR DESCRIPTION
## Description

The product docs Pages root (`/agent-assembly/`) redirects to a channel target and uses `latest/` as its final fallback; `latest` is also a guaranteed channel in `versions.json`. But the assemble step in `docs.yml` only created `_site/latest/` on a **master-push** cut (`VERSION=latest`). A **release-only** deploy (a `workflow_run` from Release, the only kind of deploy this site has had) publishes into `_site/<tag>/` and never creates `latest/`, leaving the documented entry point `/agent-assembly/latest/` returning **HTTP 404**.

This copies the freshly built book into `_site/latest/` on a release cut too (the tagged build is the newest live docs, so it is the correct content for `latest/`); on a master cut the block is skipped (no-op).

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3733 (dup AAASM-3734)

## Testing

- [x] Manual testing performed
- [x] No tests required (CI/workflow change) — `docs/ci/test_channels.py` (channel logic, untouched) still passes; `mdbook build docs` produces `docs/book/index.html` (the copy source); YAML parses; the new shell only uses the trusted `$VERSION` env var.

## Checklist

- [x] Self-review of the diff completed

### Owner action still required (infra, not code)

`latest/` will be created on the **next** docs deploy (next master push or next successful Release). To resolve the live 404 immediately without waiting for a content change, re-run the `Docs` workflow (`workflow_dispatch`) on `master`, which publishes `_site/latest/` from master HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)