### PR TITLE
[AAASM-3732] 🐛 (docs): Use the working raw URL as the primary install command

### DIFF
--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -21,7 +21,7 @@ The one-line installer downloads the matching pre-built tarball plus its
 the `aasm` binary:
 
 ```sh
-curl -fsSL https://agent-assembly.com/install.sh | sh
+curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 ```
 
 By default the binary is installed to `/usr/local/bin` if that directory is
@@ -29,19 +29,13 @@ writable, otherwise to `~/.local/bin` (always user-writable, no `sudo` needed).
 The installer script lives in the repo at
 [`scripts/install-cli.sh`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/scripts/install-cli.sh).
 
-> The canonical installer URL is `https://agent-assembly.com/install.sh`. The
-> alternate host `https://tool.agent-assembly.dev` serves the **same** script and
-> stays working:
->
-> ```sh
-> curl -fsSL https://tool.agent-assembly.dev | sh
-> ```
->
-> You can also fetch the raw script directly from GitHub:
->
-> ```sh
-> curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
-> ```
+> **Short installer URLs (not yet live).** The shorter hosts
+> `https://agent-assembly.com/install.sh` and `https://tool.agent-assembly.dev`
+> are the planned canonical/alternate installer URLs
+> ([ADR 0007](../adr/0007-public-domain-and-url-contract.md)), served by the
+> Cloudflare Worker in [`infra/install-endpoint/`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/infra/install-endpoint).
+> That endpoint is not deployed yet, so until it goes live use the
+> `raw.githubusercontent.com` command above (it serves the identical script).
 
 If the install directory is not on your `PATH`, the script prints the line to add
 to your shell profile, for example:


### PR DESCRIPTION
## Description

The Quick Start › Installation "Quick-install script" section presented two installer hosts that do not work:

1. `curl -fsSL https://agent-assembly.com/install.sh | sh` — apex root 200s but `/install.sh` 404s.
2. `curl -fsSL https://tool.agent-assembly.dev | sh` — host is NXDOMAIN.

Both are served by the Cloudflare Worker in `infra/install-endpoint/`, which is **not deployed yet** (no deploy workflow; `wrangler deploy` is owner-gated). The Worker code and routing are correct — the gap is purely owner infra (DNS + `wrangler deploy`).

This promotes the always-working `raw.githubusercontent.com/.../scripts/install-cli.sh` command (already used in the version-pin examples below) to the primary command, and flags the two short hosts as planned-but-not-yet-live (per ADR 0007). A new user's first copy-pasted command now succeeds.

## Type of Change

- [x] 🐛 Bug fix
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3732

## Testing

- [x] Manual testing performed — `mdbook build docs` is clean (link check passes; ADR 0007 relative link resolves); verified the raw URL renders as the primary command.

## Checklist

- [x] Self-review of the diff completed

### Owner action still required (infra, not code) — to make the short URLs live

Per `infra/install-endpoint/README.md` and `infra/dns/README.md`:
1. Add the `agent-assembly.com` and `agent-assembly.dev` zones to Cloudflare; create the apex DNS record **proxied** (orange-cloud) and, in the `.dev` zone, allow the custom-domain provisioning.
2. `cd infra/install-endpoint && wrangler login && wrangler deploy` — binds the `agent-assembly.com/install.sh*` route and provisions `tool.agent-assembly.dev`.
3. `gh variable set INSTALL_ENDPOINT_LIVE --body true --repo ai-agent-assembly/agent-assembly` to enable the release smoke test.

**Exact DNS records needed:** `agent-assembly.com` apex CNAME/A → marketing origin, 🟠 proxied (required so the `/install.sh` Worker route runs); `tool.agent-assembly.dev` is auto-provisioned by `wrangler deploy` (`custom_domain = true`). Once live, the short-URL commands can be restored as primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)