### PR TITLE
[AAASM-3736] 🐛 (dashboard): Guard Analytics panel against partial API responses

### DIFF
--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.test.tsx
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.test.tsx
@@ -126,6 +126,20 @@ describe('ApprovalAnalyticsPanel', () => {
     expect(screen.getByText('33')).toBeInTheDocument()
   })
 
+  it('degrades to a zero-state when scalar fields are missing on a partial response', async () => {
+    // A 200 with an empty body (no volume/medianTta/approvalRate/byOutcome) must
+    // render a zero-state instead of crashing the route into the error boundary.
+    mockFetch({} as ApprovalAnalyticsResponse)
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    // Panel body renders (donut present) rather than the error boundary taking over.
+    expect(await screen.findByTestId('approval-donut')).toBeInTheDocument()
+    // Each unguarded scalar falls back to its zero formatting.
+    expect(screen.getAllByText('0').length).toBeGreaterThan(0) // volume → 0
+    expect(screen.getByText('0s')).toBeInTheDocument() // medianTta → 0s
+    expect(screen.getByText('0.0%')).toBeInTheDocument() // approvalRate → 0.0%
+    expect(screen.getByText('Total volume')).toBeInTheDocument()
+  })
+
   it('renders without crashing when byOutcome is missing on a partial response', async () => {
     // A 200 with a partial object (no `byOutcome`) must not crash the panel.
     mockFetch({ volume: 0, medianTta: 0, approvalRate: 0 } as ApprovalAnalyticsResponse)

--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
@@ -54,19 +54,19 @@ export function ApprovalAnalyticsPanel() {
           <div className="approval-analytics-panel__stats">
             <div className="approval-analytics-panel__stat">
               <span className="approval-analytics-panel__stat-value">
-                {data.volume.toLocaleString()}
+                {(data.volume ?? 0).toLocaleString()}
               </span>
               <span className="approval-analytics-panel__stat-label">Total volume</span>
             </div>
             <div className="approval-analytics-panel__stat">
               <span className="approval-analytics-panel__stat-value">
-                {formatTta(data.medianTta)}
+                {formatTta(data.medianTta ?? 0)}
               </span>
               <span className="approval-analytics-panel__stat-label">Median TTA</span>
             </div>
             <div className="approval-analytics-panel__stat">
               <span className="approval-analytics-panel__stat-value">
-                {formatRate(data.approvalRate)}
+                {formatRate(data.approvalRate ?? 0)}
               </span>
               <span className="approval-analytics-panel__stat-label">Approval rate</span>
             </div>


### PR DESCRIPTION
## Description

A partial `200` from `GET /api/v1/analytics/approvals` (a body missing the scalar fields `volume` / `medianTta` / `approvalRate`, e.g. `{}`) crashed the entire `/analytics` route into the AppShell error boundary ("Something went wrong" / `Cannot read properties of undefined (reading 'toLocaleString')`).

`ApprovalAnalyticsPanel.renderBody()` only checked `if (!data) return null` but then accessed three scalars unguarded:
- `data.volume.toLocaleString()`
- `formatTta(data.medianTta)`
- `formatRate(data.approvalRate)`

This is a residual gap of the **same class** fixed in AAASM-3703 (the sibling `byOutcome` donut path was already guarded with `?? 0`). This PR defaults each scalar to `0` so every panel degrades to a zero-state (`0` / `0s` / `0.0%`) instead of taking the route down.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3736
- Closes AAASM-3736

## Testing

- [x] Unit tests added / updated — new regression test asserts the panel renders `0` / `0s` / `0.0%` (zero-state) instead of crashing when the response omits its scalar fields. Verified the test fails on unpatched source and passes with the fix.
- [x] Manual testing performed — ran the dashboard (`vite`) against a mock backend returning a partial `{}` for `/analytics/approvals`. Before: route crashes into the error boundary. After: Analytics page renders fully with the Approval Analytics panel in a clean zero-state. Before/after screenshots captured (`16-analytics-partial-CRASH.png`, `13-analytics-partial-FIXED.png`).
- Full dashboard suite green (1364 tests), `type-check` and `lint` clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
