### PR TITLE
[AAASM-3728] 🔒 (aa-gateway): Fail closed on empty egress allowlist + consolidate policy paths

### DIFF
--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -622,4 +622,28 @@ mod egress_tests {
         assert!(is_host_allowed_by_egress_allowlist("api.anthropic.com", &list));
         assert!(!is_host_allowed_by_egress_allowlist("api.cohere.com", &list));
     }
+
+    // AAASM-3730: fail-closed matcher — empty allowlist DENIES all hosts.
+    use super::is_host_allowed_by_egress_allowlist_fail_closed as fail_closed;
+
+    #[test]
+    fn fail_closed_empty_allowlist_denies_every_host() {
+        assert!(!fail_closed("api.openai.com", &[]));
+        assert!(!fail_closed("evil.attacker.net", &[]));
+    }
+
+    #[test]
+    fn fail_closed_non_empty_matches_like_default_matcher() {
+        let list = vec!["api.openai.com".to_string(), "*.anthropic.com".to_string()];
+        assert!(fail_closed("api.openai.com", &list));
+        assert!(fail_closed("chat.anthropic.com", &list));
+        assert!(!fail_closed("evil.attacker.net", &list));
+    }
+
+    #[test]
+    fn fail_closed_universal_wildcard_still_allows_any_host() {
+        let list = vec!["*".to_string()];
+        assert!(fail_closed("api.openai.com", &list));
+        assert!(fail_closed("evil.attacker.net", &list));
+    }
 }

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -512,6 +512,31 @@ pub fn is_host_allowed_by_egress_allowlist(host: &str, allowlist: &[alloc::strin
     false
 }
 
+/// Fail-closed egress decision: like [`is_host_allowed_by_egress_allowlist`],
+/// but an **empty** allowlist denies all hosts instead of allowing them.
+///
+/// AAASM-3730: the policy layer (`aa-gateway` cascade + single-file engine, and
+/// the `aa-proxy` L2 egress gate) treats the presence of a `network:` clause as
+/// "egress is governed". A governed-but-empty allowlist is the most restrictive
+/// posture — "permit nothing" — not "permit everything". Defaulting an empty
+/// allowlist to allow-all silently disabled the entire egress control whenever
+/// an operator wrote an empty list, the canonical fail-open footgun.
+///
+/// Callers that genuinely mean "no allowlist configured ⇒ no restriction" must
+/// gate on the *absence* of the network policy before reaching this matcher, not
+/// on the allowlist being empty.
+///
+/// Non-empty allowlists match identically to
+/// [`is_host_allowed_by_egress_allowlist`] (exact, leftmost-label wildcard,
+/// universal `*`, case-insensitive).
+#[cfg(feature = "alloc")]
+pub fn is_host_allowed_by_egress_allowlist_fail_closed(host: &str, allowlist: &[alloc::string::String]) -> bool {
+    if allowlist.is_empty() {
+        return false;
+    }
+    is_host_allowed_by_egress_allowlist(host, allowlist)
+}
+
 #[cfg(feature = "alloc")]
 fn egress_pattern_matches(pattern: &str, host_lower: &str) -> bool {
     let pattern_lower = pattern.to_ascii_lowercase();

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -119,6 +119,31 @@ fn stage_network(doc: &PolicyDocument, action: &aa_core::GovernanceAction) -> Op
         return None;
     };
     let np = doc.network.as_ref()?;
+    if !network_request_url_allowed(url, np) {
+        return Some(PolicyDecision::Deny {
+            reason: "host not in network allowlist".into(),
+            source_scope: doc.scope.clone(),
+        });
+    }
+    None
+}
+
+/// Shared egress decision for a `NetworkRequest` URL against a [`NetworkPolicy`].
+///
+/// This is the single source of truth for the gateway's network-stage check:
+/// both the cascade path ([`stage_network`]) and the single-file engine path
+/// (`PolicyEngine::eval_network_stage`) route through it so they cannot diverge
+/// (AAASM-3728).
+///
+/// * Extracts the authority from `proto://host:port/...` and strips a trailing
+///   numeric `:port` (AAASM-3350) — allowlist entries are bare hosts.
+/// * Delegates matching to the **fail-closed** matcher
+///   ([`aa_core::policy::is_host_allowed_by_egress_allowlist_fail_closed`]):
+///   a configured-but-empty allowlist denies all egress, and wildcard patterns
+///   (`*.host`, `*`) are honoured (AAASM-3127/AAASM-3730). The previous
+///   single-file path used an empty-is-allow-all default and an exact-only
+///   compare — a fail-open egress control.
+pub(crate) fn network_request_url_allowed(url: &str, np: &crate::policy::NetworkPolicy) -> bool {
     let host_port = url
         .split_once("://")
         .map(|x| x.1)
@@ -126,25 +151,11 @@ fn stage_network(doc: &PolicyDocument, action: &aa_core::GovernanceAction) -> Op
         .split('/')
         .next()
         .unwrap_or("");
-    // AAASM-3350: `convert.rs` builds the URL as `proto://host:port`, so the
-    // authority extracted above still carries the `:port` suffix. Allowlist
-    // entries are bare hosts (`api.openai.com`, `*.openai.com`), so comparing
-    // `host:port` against them always failed and every allowlisted host was
-    // denied. Strip a trailing numeric `:port` before the allowlist compare.
     let host = match host_port.rsplit_once(':') {
         Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => h,
         _ => host_port,
     };
-    // An empty allowlist denies all egress (fail-closed); `is_host_allowed_*`
-    // treats an empty list as allow-all, so guard it explicitly here.
-    let allowed = !np.allowlist.is_empty() && aa_core::policy::is_host_allowed_by_egress_allowlist(host, &np.allowlist);
-    if !allowed {
-        return Some(PolicyDecision::Deny {
-            reason: "host not in network allowlist".into(),
-            source_scope: doc.scope.clone(),
-        });
-    }
-    None
+    aa_core::policy::is_host_allowed_by_egress_allowlist_fail_closed(host, &np.allowlist)
 }
 
 /// Stage 3 — Tool allow/deny: deny a `ToolCall` whose tool policy is not allowed.

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1867,6 +1867,55 @@ mod tests {
     }
 
     #[test]
+    fn network_empty_allowlist_denies_all_egress() {
+        // AAASM-3728: the single-file path failed OPEN on an empty allowlist
+        // (returned None ⇒ allow-all). A configured `network:` clause with an
+        // empty allowlist must deny ALL egress (fail-closed).
+        let mut doc = empty_doc();
+        doc.network = Some(NetworkPolicy { allowlist: vec![] });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        let action = network_req("https://api.openai.com/v1");
+        assert_eq!(
+            engine.evaluate(&ctx, &action).decision,
+            PolicyResult::Deny {
+                reason: "host not in network allowlist".into()
+            },
+            "empty allowlist must deny all egress, not allow it"
+        );
+    }
+
+    #[test]
+    fn network_wildcard_allows_subdomain_on_single_file_path() {
+        // AAASM-3728: the single-file path used exact-match only (`entry ==
+        // host`), so a `*.openai.com` allowlist entry never matched and denied
+        // traffic the operator believed allowed. It must now honour the
+        // wildcard-aware shared matcher, like the cascade path.
+        let mut doc = empty_doc();
+        doc.network = Some(NetworkPolicy {
+            allowlist: vec!["*.openai.com".to_string()],
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        assert_eq!(
+            engine
+                .evaluate(&ctx, &network_req("https://chat.openai.com/v1"))
+                .decision,
+            PolicyResult::Allow,
+            "wildcard *.openai.com must match chat.openai.com"
+        );
+        assert_eq!(
+            engine
+                .evaluate(&ctx, &network_req("https://evil.attacker.net/x"))
+                .decision,
+            PolicyResult::Deny {
+                reason: "host not in network allowlist".into()
+            },
+            "a non-matching host must still be denied"
+        );
+    }
+
+    #[test]
     fn tool_deny_blocks_call() {
         let mut doc = empty_doc();
         doc.tools.insert(

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -3408,4 +3408,80 @@ mod tests {
 
         assert!(engine.budget.team_state("ctx-team").is_some());
     }
+
+    // ── AAASM-3729: cascade selected by registered owner, not client claim ───
+
+    /// Build a cascade engine: a Global allow-all baseline plus an
+    /// `org:owner-org`-scoped deny of `bash`.
+    fn cascade_engine_owner_org_denies_bash() -> PolicyEngine {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("000-global-allow-all.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: t-global-allow\n  version: \"0.1.0\"\n\
+             spec:\n  tools: {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("100-org-owner-deny-bash.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: t-owner-deny-bash\n  version: \"0.1.0\"\n\
+             spec:\n  scope: org:owner-org\n  tools:\n    bash:\n      allow: false\n",
+        )
+        .unwrap();
+        let budget = Arc::new(BudgetTracker::new(
+            crate::budget::PricingTable::default_table(),
+            None,
+            None,
+            chrono_tz::UTC,
+        ));
+        PolicyEngine::load_cascade_from_dir_with_budget(tmp.path(), budget).expect("cascade loads")
+    }
+
+    #[test]
+    fn cascade_uses_registered_org_not_client_forged_org() {
+        // AAASM-3729: an agent registered in `owner-org` (which denies `bash`)
+        // must not escape that policy by forging a different, more permissive
+        // org_id in the request context. The cascade must select the registered
+        // owner's org-scoped deny.
+        let registry = Arc::new(crate::registry::AgentRegistry::new());
+        registry
+            .register(registry_record([0xaa; 16], "owner-team", Some("owner-org")))
+            .expect("register");
+        let engine = cascade_engine_owner_org_denies_bash().with_registry(registry);
+
+        // ctx carries a forged org_id pointing at an org with no deny rules.
+        let mut ctx = make_ctx();
+        ctx.agent_id = AgentId::from_bytes([0xaa; 16]);
+        ctx.metadata.insert("org_id".to_string(), "permissive-org".to_string());
+
+        assert_eq!(
+            engine.evaluate(&ctx, &tool_call("bash", "")).decision,
+            PolicyResult::Deny {
+                reason: "tool denied by policy".into()
+            },
+            "registered owner-org deny must apply despite the client-forged org_id"
+        );
+    }
+
+    #[test]
+    fn cascade_falls_back_to_ctx_org_when_agent_unregistered() {
+        // With no registry record for the agent, the ctx-supplied lineage is
+        // used (untenanted / convert.rs path). An agent claiming owner-org sees
+        // that org's deny; this preserves the pre-registry behaviour.
+        let engine = cascade_engine_owner_org_denies_bash();
+        let mut ctx = make_ctx();
+        ctx.agent_id = AgentId::from_bytes([0xcc; 16]);
+        ctx.metadata.insert("org_id".to_string(), "owner-org".to_string());
+
+        assert_eq!(
+            engine.evaluate(&ctx, &tool_call("bash", "")).decision,
+            PolicyResult::Deny {
+                reason: "tool denied by policy".into()
+            },
+            "unregistered agent falls back to ctx-supplied org lineage"
+        );
+    }
 }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -853,27 +853,13 @@ impl PolicyEngine {
             return None;
         };
         let np = policy.network.as_ref()?;
-        if np.allowlist.is_empty() {
-            return None;
-        }
-        let host_port = url
-            .split_once("://")
-            .map(|x| x.1)
-            .unwrap_or("")
-            .split('/')
-            .next()
-            .unwrap_or("");
-        // AAASM-3350: `convert.rs` builds the URL as `proto://host:port`, so the
-        // authority extracted above still carries the `:port` suffix. Allowlist
-        // entries are bare hosts (`api.openai.com`), so comparing `host:port`
-        // against them always failed and every allowlisted host was denied on
-        // the live `evaluate`/`eval_network_stage` path. Strip a trailing
-        // numeric `:port` before the allowlist compare (mirrors `decision.rs`).
-        let host = match host_port.rsplit_once(':') {
-            Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => h,
-            _ => host_port,
-        };
-        if !np.allowlist.iter().any(|entry| entry == host) {
+        // AAASM-3728: this single-file path previously failed OPEN — an empty
+        // allowlist returned `None` (allow-all) and matching was exact-only
+        // (`entry == host`), so wildcard entries never matched and a blank
+        // allowlist disabled egress control entirely, while the hardened
+        // cascade path (`decision::stage_network`) already denied. Route both
+        // through the one shared helper so they cannot diverge again.
+        if !crate::engine::decision::network_request_url_allowed(url, np) {
             return Some(EvaluationResult::deny("host not in network allowlist"));
         }
         None

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -802,25 +802,17 @@ impl PolicyEngine {
     /// single-policy pipeline (`evaluate_primary`) when no scoped policies are
     /// present, preserving full backward compatibility.
     pub fn evaluate(&self, ctx: &aa_core::AgentContext, action: &aa_core::GovernanceAction) -> EvaluationResult {
-        // AAASM-2023 — resolve lineage from ctx FIRST (convert.rs already
-        // deposits proto.org_id / proto.team_id into ctx.metadata) before
-        // falling back to a registry lookup. The registry-keyed-by-composite
-        // path doesn't match `ctx.agent_id` (which is hashed from just the
-        // agent_id string), so without this preference org-scoped cascades
-        // would never see the agent's org_id.
-        let ctx_lineage = crate::registry::Lineage {
-            org_id: ctx.metadata.get("org_id").cloned(),
-            team_id: ctx.team_id.clone().or_else(|| ctx.metadata.get("team_id").cloned()),
-            ..Default::default()
-        };
-        let lineage = if ctx_lineage.org_id.is_some() || ctx_lineage.team_id.is_some() {
-            ctx_lineage
-        } else {
-            self.registry
-                .as_ref()
-                .and_then(|r| r.lineage(ctx.agent_id.as_bytes()))
-                .unwrap_or_default()
-        };
+        // AAASM-3729: the policy cascade is selected by the agent's (org, team)
+        // lineage, so that lineage MUST be authoritative tenancy — the agent's
+        // *registered* owner — not values the client asserted in the request.
+        // Trusting client-supplied `org_id` / `team_id` lets a caller name a
+        // tenant whose scoped policy is more permissive (e.g. an org with no
+        // deny rules) and thereby DOWNGRADE the policy that applies to it.
+        // Resolve from the registry by agent_id first; fall back to the
+        // ctx-supplied lineage only when no registry is attached or the agent
+        // is unregistered (untenanted / pre-registry deployments, and the
+        // convert.rs path where the agent isn't keyed in the registry).
+        let lineage = self.authoritative_lineage(ctx);
         let cascade = self.collect_cascade_with_lineage(&ctx.agent_id, &lineage);
 
         // Backward-compat: no scoped policies loaded → use primary policy only.
@@ -1377,6 +1369,29 @@ impl PolicyEngine {
         let team_id = ctx.team_id.clone();
         let org_id = ctx.metadata.get("org_id").cloned();
         (team_id, org_id)
+    }
+
+    /// Resolve the policy-cascade lineage (`org_id` / `team_id` + delegation
+    /// chain) for `ctx` from the authoritative agent registry, falling back to
+    /// the client-supplied `ctx` lineage only when no registry is attached or
+    /// the agent is not registered.
+    ///
+    /// AAASM-3729: the registered owner is the trust anchor for cascade
+    /// *selection* — a client must not be able to point evaluation at a more
+    /// permissive tenant's policy by forging `org_id` / `team_id` in the
+    /// request context. Mirrors [`Self::authoritative_tenancy`] (AAASM-3138),
+    /// which already keys budget spend on the registered owner.
+    fn authoritative_lineage(&self, ctx: &aa_core::AgentContext) -> crate::registry::Lineage {
+        if let Some(registry) = self.registry.as_ref() {
+            if let Some(lineage) = registry.lineage(ctx.agent_id.as_bytes()) {
+                return lineage;
+            }
+        }
+        crate::registry::Lineage {
+            org_id: ctx.metadata.get("org_id").cloned(),
+            team_id: ctx.team_id.clone().or_else(|| ctx.metadata.get("team_id").cloned()),
+            ..Default::default()
+        }
     }
 
     /// Check whether an agent is within both daily and monthly budget limits.

--- a/aa-gateway/src/policy/network.rs
+++ b/aa-gateway/src/policy/network.rs
@@ -23,9 +23,15 @@ pub struct EgressDecision {
 /// Evaluate `host` against the network policy's allowlist.
 ///
 /// When `policy` is `None` (no `network:` clause in the YAML), the host is
-/// allowed — the caller's default-open posture wins. When the policy is set
-/// but the allowlist is empty, the host is also allowed (an empty list means
-/// "no restriction").
+/// allowed — the caller's default-open posture wins.
+///
+/// AAASM-3728/AAASM-3730: when the policy IS set but the allowlist is empty,
+/// the host is **denied**. A configured `network:` clause means egress is
+/// governed; an empty allowlist is the most restrictive posture ("permit
+/// nothing"), not "no restriction". This wrapper must agree with the live
+/// enforcement paths (`engine::decision::stage_network` /
+/// `PolicyEngine::eval_network_stage`) so the dashboard/REST/CLI "would this
+/// host be allowed?" answer never disagrees with what the engine actually does.
 ///
 /// Glob semantics match `aa_core::policy::is_host_allowed_by_egress_allowlist`:
 /// exact case-insensitive match, leftmost-label wildcard (`*.example.com`),
@@ -37,11 +43,11 @@ pub fn check_network_egress(host: &str, policy: Option<&NetworkPolicy>) -> Egres
             reason: "no network policy configured".into(),
         },
         Some(np) if np.allowlist.is_empty() => EgressDecision {
-            allowed: true,
-            reason: "network allowlist empty (no restriction)".into(),
+            allowed: false,
+            reason: "network allowlist empty (deny all egress)".into(),
         },
         Some(np) => {
-            if aa_core::policy::is_host_allowed_by_egress_allowlist(host, &np.allowlist) {
+            if aa_core::policy::is_host_allowed_by_egress_allowlist_fail_closed(host, &np.allowlist) {
                 EgressDecision {
                     allowed: true,
                     reason: format!("host matches network allowlist ({} pattern(s))", np.allowlist.len()),

--- a/aa-gateway/src/policy/network.rs
+++ b/aa-gateway/src/policy/network.rs
@@ -80,11 +80,12 @@ mod tests {
     }
 
     #[test]
-    fn empty_allowlist_allows_any_host() {
+    fn empty_allowlist_denies_any_host() {
+        // AAASM-3728/AAASM-3730: a configured-but-empty allowlist is deny-all.
         let np = list(&[]);
         let d = check_network_egress("evil.attacker.net", Some(&np));
-        assert!(d.allowed);
-        assert!(d.reason.contains("empty"));
+        assert!(!d.allowed);
+        assert!(d.reason.contains("deny all egress"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Closes a set of fail-open security bugs in the policy/egress path. The single-file policy engine permitted all egress on an empty allowlist (and exact-match only), the `aa-core` shared matcher defaulted empty to allow, the dashboard/CLI dry-run wrapper disagreed with live enforcement, and the policy cascade was selected from client-asserted tenancy. All paths now fail closed and route through one shared, wildcard-aware matcher so they cannot diverge.

- **AAASM-3728** — `PolicyEngine::eval_network_stage` (single-file path) failed OPEN: empty allowlist = allow-all and exact-match only (wildcards never matched). Now routes through a new shared `engine::decision::network_request_url_allowed` helper (the cascade path uses the same helper), so the two policy code paths cannot diverge. The dry-run wrapper `check_network_egress` is aligned too.
- **AAASM-3730** — `aa-core` egress matcher default-opened on empty allowlist (aa-proxy L2 inherits). Added `is_host_allowed_by_egress_allowlist_fail_closed` (empty = deny); the gateway policy layer now uses it. The original allow-on-empty matcher is left for callers that genuinely mean "no restriction" (e.g. aa-proxy's documented default-open config); the proxy is out of this unit's scope and unchanged.
- **AAASM-3729** — `evaluate()` selected the policy cascade from client-supplied `ctx` org/team first, letting a caller forge a more permissive tenant to downgrade the policy applied to it. Lineage is now resolved registry-first (authoritative tenancy), falling back to `ctx` only when no registry is attached or the agent is unregistered. Mirrors the AAASM-3138 budget-tenancy trust anchor.

## Type of Change

- [x] 🐛 Bug fix
- [x] ♻️ Refactoring

## Breaking Changes

- [x] Yes (describe below)

A `GovernancePolicy` that declares a `network:` clause with an **empty** allowlist now **denies all egress** instead of allowing it (fail-closed). Operators who relied on an empty allowlist meaning "no restriction" must remove the `network:` clause entirely to keep default-open behaviour. This is the intended security fix.

## Related Issues

- Related Jira tickets: AAASM-3728, AAASM-3729, AAASM-3730

Closes AAASM-3728
Closes AAASM-3729
Closes AAASM-3730

## Testing

- [x] Unit tests added / updated

Regression tests: empty allowlist denies (aa-core matcher, single-file engine path, dry-run wrapper); wildcard `*.host` matches on the single-file path; client-spoofed org cannot downgrade the cascade (registry-first) with an unregistered-fallback test.

Validation (`aa-gateway` + `aa-core`): `cargo build`, `cargo nextest run` (1391 passed), `cargo clippy --all-targets -D warnings` (clean), `cargo fmt --check` (clean).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc comments)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
