### PR TITLE
[AAASM-3726] 🔒 (aa-api): Uniform write-scope + tenant authz on agent/destination endpoints

### DIFF
--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -10,10 +10,51 @@ use utoipa::ToSchema;
 
 use aa_gateway::registry::{AgentStatus, OrphanMode};
 
-use crate::auth::scope::{RequireRead, Scope};
+use crate::auth::scope::{RequireRead, RequireWrite, Scope};
+use crate::auth::AuthenticatedCaller;
 use crate::error::ProblemDetail;
 use crate::pagination::{PaginatedResponse, PaginationParams};
 use crate::state::AppState;
+
+/// Enforce tenant ownership of an agent for a caller that already cleared the
+/// scope gate (AAASM-3726 / AAASM-3687).
+///
+/// Mirrors the per-tenant authz of [`get_agent_budget`]: an admin may act on any
+/// agent; a tenant-scoped caller may act only on agents in its own team; a
+/// caller with neither admin scope nor any team scope is denied up front so it
+/// cannot enumerate agents via a 403-vs-404 oracle. Returns `Ok(())` when the
+/// caller is authorized and the agent exists, otherwise the appropriate
+/// `ProblemDetail` (403 for an unauthorized caller, 404 when the agent is
+/// unknown to an authorized caller).
+fn authorize_agent_access(
+    caller: &AuthenticatedCaller,
+    state: &AppState,
+    agent_id_bytes: &[u8; 16],
+    id: &str,
+) -> Result<(), ProblemDetail> {
+    let is_admin = caller.scopes.contains(&Scope::Admin);
+    if !is_admin && caller.tenant.team_id.is_none() {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("This operation requires admin scope or a team scope"));
+    }
+
+    if state.agent_registry.get(agent_id_bytes).is_none() {
+        return Err(ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {id}")));
+    }
+
+    let lineage = state.agent_registry.lineage(agent_id_bytes);
+    let team_id = lineage.as_ref().and_then(|l| l.team_id.as_deref());
+    let authorized = match team_id {
+        Some(team) => caller.can_access_team(team),
+        // The agent has no team — only an admin may act on it.
+        None => is_admin,
+    };
+    if !authorized {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("This operation requires admin scope or membership in the agent's team"));
+    }
+    Ok(())
+}
 
 /// Parse a hex-encoded agent ID string into a 16-byte array.
 fn parse_agent_id(id: &str) -> Result<[u8; 16], ProblemDetail> {
@@ -262,10 +303,14 @@ pub async fn get_agent(
     tag = "agents"
 )]
 pub async fn delete_agent(
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<StatusCode, ProblemDetail> {
     let agent_id = parse_agent_id(&id)?;
+
+    // AAASM-3726: write-scope + tenant ownership before any state change.
+    authorize_agent_access(&caller, &state, &agent_id, &id)?;
 
     state
         .agent_registry

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -696,6 +696,7 @@ fn parse_subtree_burn_period(s: Option<&str>) -> (&'static str, u32) {
     tag = "agents"
 )]
 pub async fn get_agent_subtree_burn(
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
     axum::extract::Query(params): axum::extract::Query<SubtreeBurnParams>,
@@ -703,9 +704,10 @@ pub async fn get_agent_subtree_burn(
     let agent_id_bytes = parse_agent_id(&id)?;
     let agent_id = aa_core::identity::AgentId::from_bytes(agent_id_bytes);
 
-    if state.agent_registry.get(&agent_id_bytes).is_none() {
-        return Err(ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {id}")));
-    }
+    // AAASM-3687: read-scope + tenant ownership — the subtree-burn series
+    // exposes per-child spend / topology, so a cross-tenant caller must not
+    // read another team's agent. Mirrors get_agent_budget.
+    authorize_agent_access(&caller, &state, &agent_id_bytes, &id)?;
 
     let (period_label, period_days) = parse_subtree_burn_period(params.period.as_deref());
 

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -385,10 +385,14 @@ pub async fn suspend_agent(
     tag = "agents"
 )]
 pub async fn resume_agent(
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<(StatusCode, Json<ResumeResponse>), ProblemDetail> {
     let agent_id = parse_agent_id(&id)?;
+
+    // AAASM-3726: write-scope + tenant ownership before resuming.
+    authorize_agent_access(&caller, &state, &agent_id, &id)?;
 
     let current_status = state
         .agent_registry

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -337,11 +337,15 @@ pub async fn delete_agent(
     tag = "agents"
 )]
 pub async fn suspend_agent(
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
     Json(body): Json<SuspendRequest>,
 ) -> Result<(StatusCode, Json<SuspendResponse>), ProblemDetail> {
     let agent_id = parse_agent_id(&id)?;
+
+    // AAASM-3726: write-scope + tenant ownership before suspending.
+    authorize_agent_access(&caller, &state, &agent_id, &id)?;
 
     let previous_status = state
         .agent_registry

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -12,6 +12,7 @@ use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
+use crate::auth::scope::{RequireRead, RequireWrite};
 use crate::destinations::connectors::slack::SlackConnector;
 use crate::destinations::connectors::webhook::WebhookConnector;
 use crate::destinations::connectors::{ConnectorError, DispatchRequest, NotificationConnector};
@@ -274,6 +275,7 @@ impl IntoResponse for TestDestinationFailure {
     tag = "alert-destinations"
 )]
 pub async fn list_destinations(
+    _auth: RequireRead,
     Extension(state): Extension<AppState>,
     Query(filter): Query<DestinationListFilter>,
 ) -> Json<Vec<DestinationResponse>> {
@@ -302,6 +304,7 @@ pub async fn list_destinations(
     tag = "alert-destinations"
 )]
 pub async fn create_destination(
+    _auth: RequireWrite,
     Extension(state): Extension<AppState>,
     body: Bytes,
 ) -> Result<(StatusCode, Json<DestinationResponse>), ProblemDetail> {
@@ -332,6 +335,7 @@ pub async fn create_destination(
     tag = "alert-destinations"
 )]
 pub async fn get_destination(
+    _auth: RequireRead,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<DestinationResponse>, ProblemDetail> {
@@ -357,6 +361,7 @@ pub async fn get_destination(
     tag = "alert-destinations"
 )]
 pub async fn update_destination(
+    _auth: RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
     body: Bytes,
@@ -400,6 +405,7 @@ pub async fn update_destination(
     tag = "alert-destinations"
 )]
 pub async fn delete_destination(
+    _auth: RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ProblemDetail> {
@@ -429,6 +435,7 @@ pub async fn delete_destination(
     tag = "alert-destinations"
 )]
 pub async fn test_destination(
+    _auth: RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
     body: Option<Json<TestDestinationRequest>>,

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -49,12 +49,29 @@ pub struct DestinationResponse {
     pub updated_at: String,
 }
 
+/// Sentinel returned in place of a configured webhook secret. The real value is
+/// write-only (accepted on create/update, never returned).
+const SECRET_MASK: &str = "********";
+
 impl From<Destination> for DestinationResponse {
     fn from(d: Destination) -> Self {
+        // AAASM-3688: never return the webhook `secret_header` in cleartext.
+        // Mask it to a fixed sentinel when set so the response still signals
+        // that a secret is configured, without leaking the value.
+        let config = match d.config {
+            DestinationConfig::Webhook {
+                url,
+                secret_header: Some(_),
+            } => DestinationConfig::Webhook {
+                url,
+                secret_header: Some(SECRET_MASK.to_string()),
+            },
+            other => other,
+        };
         Self {
             id: d.id,
             name: d.name,
-            config: d.config,
+            config,
             enabled: d.enabled,
             created_at: d.created_at,
             updated_at: d.updated_at,

--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -375,3 +375,141 @@ async fn test_webhook_returns_502_connector_failed() {
     assert_eq!(body["connector_body"], "Invalid token");
     mock.assert();
 }
+
+// ---------------------------------------------------------------------------
+// AAASM-3688 — destination handlers require read/write scope, and the webhook
+// secret_header is never returned in cleartext.
+// ---------------------------------------------------------------------------
+
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
+
+fn bearer_json(method: &str, uri: &str, token: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+fn bearer_empty(method: &str, uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+#[tokio::test]
+async fn create_destination_read_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[Scope::Read]);
+    let resp = app
+        .oneshot(bearer_json(
+            "POST",
+            "/api/v1/alerts/destinations",
+            &token,
+            webhook_payload("hook", "https://example.com/hook"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a read-only caller must not create a destination"
+    );
+}
+
+#[tokio::test]
+async fn delete_destination_read_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[Scope::Read]);
+    let resp = app
+        .oneshot(bearer_empty("DELETE", "/api/v1/alerts/destinations/dst_x", &token))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a read-only caller must not delete a destination"
+    );
+}
+
+#[tokio::test]
+async fn update_destination_read_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[Scope::Read]);
+    let resp = app
+        .oneshot(bearer_json(
+            "PUT",
+            "/api/v1/alerts/destinations/dst_x",
+            &token,
+            json!({ "enabled": false }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a read-only caller must not update a destination"
+    );
+}
+
+#[tokio::test]
+async fn webhook_secret_header_is_not_returned_in_cleartext() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    // A write caller creates a webhook destination with a secret.
+    let write_token = common::generate_test_jwt("w", &[Scope::Write]);
+    let payload = json!({
+        "name": "hook",
+        "kind": "webhook",
+        "config": { "url": "https://example.com/hook", "secret_header": "shh" },
+        "enabled": true,
+    });
+    let resp = app
+        .clone()
+        .oneshot(bearer_json(
+            "POST",
+            "/api/v1/alerts/destinations",
+            &write_token,
+            payload,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let created = body_json(resp).await;
+    // The create response must not echo the raw secret.
+    assert_ne!(
+        created["config"]["secret_header"], "shh",
+        "create response leaked the raw webhook secret"
+    );
+    let id = created["id"].as_str().unwrap().to_string();
+
+    // A read caller fetching the destination must not receive the raw secret.
+    let read_token = common::generate_test_jwt("r", &[Scope::Read]);
+    let resp = app
+        .oneshot(bearer_empty(
+            "GET",
+            &format!("/api/v1/alerts/destinations/{id}"),
+            &read_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let fetched = body_json(resp).await;
+    assert_ne!(
+        fetched["config"]["secret_header"], "shh",
+        "GET response leaked the raw webhook secret in cleartext"
+    );
+}

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -28,6 +28,17 @@ fn agent_with_team(id_byte: u8, team: &str) -> AgentRecord {
     agent_with_tenant(id_byte, Some(team), None)
 }
 
+/// Build a request with an explicit method, URI, bearer token, and JSON body.
+fn json_bearer(method: &str, uri: &str, token: &str, body: &str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
 /// Build a root `AgentRecord` tagged with an optional team and org (AAASM-3483).
 fn agent_with_tenant(id_byte: u8, team: Option<&str>, org: Option<&str>) -> AgentRecord {
     AgentRecord {
@@ -373,4 +384,132 @@ async fn logs_cross_org_explicit_filter_is_empty() {
         "an acme-scoped caller must not read globex's audit via ?org_id=globex"
     );
     assert!(json["items"].as_array().unwrap().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// AAASM-3726 — agent lifecycle (delete/suspend/resume) require write-scope +
+// tenant ownership. AAASM-3687 — subtree-burn requires read-scope + tenant
+// ownership. A read-only token and a cross-tenant token must each be denied.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn delete_agent_read_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xA1, "alpha")).unwrap();
+    let app = aa_api::build_app(state);
+
+    // Read-only token scoped to the agent's own team — still denied (no write).
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}", hex_id(0xA1));
+    let response = app.oneshot(json_bearer("DELETE", &uri, &token, "")).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "a read-only caller must not delete an agent"
+    );
+}
+
+#[tokio::test]
+async fn delete_agent_cross_tenant_write_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xB1, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    // Write token scoped to "alpha" must not delete a "beta" agent.
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Write], "alpha");
+    let uri = format!("/api/v1/agents/{}", hex_id(0xB1));
+    let response = app.oneshot(json_bearer("DELETE", &uri, &token, "")).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "cross-tenant agent delete is denied"
+    );
+}
+
+#[tokio::test]
+async fn suspend_agent_read_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xA2, "alpha")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}/suspend", hex_id(0xA2));
+    let response = app
+        .oneshot(json_bearer("POST", &uri, &token, r#"{"reason":"x"}"#))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn suspend_agent_cross_tenant_write_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xB2, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Write], "alpha");
+    let uri = format!("/api/v1/agents/{}/suspend", hex_id(0xB2));
+    let response = app
+        .oneshot(json_bearer("POST", &uri, &token, r#"{"reason":"x"}"#))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn resume_agent_read_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xA3, "alpha")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}/resume", hex_id(0xA3));
+    let response = app.oneshot(json_bearer("POST", &uri, &token, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn resume_agent_cross_tenant_write_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xB3, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Write], "alpha");
+    let uri = format!("/api/v1/agents/{}/resume", hex_id(0xB3));
+    let response = app.oneshot(json_bearer("POST", &uri, &token, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn delete_agent_own_team_write_token_is_allowed() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xA4, "alpha")).unwrap();
+    let app = aa_api::build_app(state);
+
+    // A write token scoped to the agent's own team may delete it.
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Write], "alpha");
+    let uri = format!("/api/v1/agents/{}", hex_id(0xA4));
+    let response = app.oneshot(json_bearer("DELETE", &uri, &token, "")).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "an own-team write caller may delete its agent"
+    );
+}
+
+#[tokio::test]
+async fn subtree_burn_cross_tenant_read_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xC1, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    // An alpha-scoped read caller must not read a beta agent's subtree burn.
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}/subtree-burn", hex_id(0xC1));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "cross-tenant subtree-burn read is denied"
+    );
 }


### PR DESCRIPTION
## Description

Closes three authorization gaps in `aa-api` where handlers relied only on the global `require_authentication` gate (authentication, not authorization), so any authenticated caller — including a read-only or cross-tenant token — could perform writes or read another tenant's data.

A reusable `authorize_agent_access` helper (mirroring the existing `get_agent_budget` per-tenant authz) resolves the target agent's team via registry lineage and enforces admin-or-own-team access, with a fail-closed deny for callers that have neither admin scope nor any team scope.

- **AAASM-3726** — `delete_agent`, `suspend_agent`, `resume_agent` now require `RequireWrite` + agent-team ownership. Previously a read-only token could destructively write, and a cross-tenant token could deregister/suspend/resume any tenant's agents (privilege escalation + cross-tenant IDOR).
- **AAASM-3687** — `get_agent_subtree_burn` now requires `RequireRead` + agent-team ownership, closing the cross-tenant IDOR that exposed another team's per-child spend / topology.
- **AAASM-3688** — alert-destination handlers are gated: reads require `RequireRead`, mutating handlers (create/update/delete/test) require `RequireWrite`. The webhook `secret_header` is masked in `DestinationResponse` (write-only on create/update), so GET/list no longer return the outbound webhook secret in cleartext.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] Yes — the webhook `secret_header` is no longer returned in API responses (masked sentinel). Callers must not round-trip the masked value back as the real secret. Write-scope is now required for destination/agent-lifecycle mutations.

## Related Issues

- Related Jira ticket: AAASM-3726, AAASM-3687, AAASM-3688

Closes AAASM-3726
Closes AAASM-3687
Closes AAASM-3688

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Added integration regression tests (`tests/tenant_scope.rs`, `tests/destinations.rs`): read-only and cross-tenant write tokens each receive 403 from delete/suspend/resume; own-team write token succeeds; cross-tenant subtree-burn read is 403; read-only token is 403 on destination create/update/delete; webhook secret is not returned in cleartext on create or GET. Full suite `cargo nextest run -p aa-api` → 619 passed. `cargo clippy -p aa-api --all-targets -- -D warnings` clean. `cargo fmt` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention