### PR TITLE
[AAASM-3747] ✅ (aa-gateway): Fix flaky cascade test isolation (#1249 follow-up)

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -3413,7 +3413,16 @@ mod tests {
 
     /// Build a cascade engine: a Global allow-all baseline plus an
     /// `org:owner-org`-scoped deny of `bash`.
-    fn cascade_engine_owner_org_denies_bash() -> PolicyEngine {
+    ///
+    /// Returns the owning [`tempfile::TempDir`] alongside the engine: the
+    /// directory MUST outlive the engine. `load_cascade_from_dir_with_budget`
+    /// starts a live filesystem watcher on the directory, and dropping the
+    /// `TempDir` deletes those `*.yaml` files. If the guard were dropped at the
+    /// helper boundary, the watcher would race to re-read the now-empty
+    /// directory and atomically swap in an empty (allow-all) cascade — making
+    /// `evaluate` nondeterministically see Allow instead of the org-scoped Deny
+    /// under CI parallelism (AAASM-3729 follow-up).
+    fn cascade_engine_owner_org_denies_bash() -> (PolicyEngine, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(
             tmp.path().join("000-global-allow-all.yaml"),
@@ -3437,7 +3446,8 @@ mod tests {
             None,
             chrono_tz::UTC,
         ));
-        PolicyEngine::load_cascade_from_dir_with_budget(tmp.path(), budget).expect("cascade loads")
+        let engine = PolicyEngine::load_cascade_from_dir_with_budget(tmp.path(), budget).expect("cascade loads");
+        (engine, tmp)
     }
 
     #[test]
@@ -3450,7 +3460,10 @@ mod tests {
         registry
             .register(registry_record([0xaa; 16], "owner-team", Some("owner-org")))
             .expect("register");
-        let engine = cascade_engine_owner_org_denies_bash().with_registry(registry);
+        // `_tmp` keeps the cascade directory alive for the whole test so the
+        // live watcher never re-reads a deleted dir mid-evaluate (AAASM-3729).
+        let (engine, _tmp) = cascade_engine_owner_org_denies_bash();
+        let engine = engine.with_registry(registry);
 
         // ctx carries a forged org_id pointing at an org with no deny rules.
         let mut ctx = make_ctx();
@@ -3471,7 +3484,9 @@ mod tests {
         // With no registry record for the agent, the ctx-supplied lineage is
         // used (untenanted / convert.rs path). An agent claiming owner-org sees
         // that org's deny; this preserves the pre-registry behaviour.
-        let engine = cascade_engine_owner_org_denies_bash();
+        // `_tmp` keeps the cascade directory alive for the whole test so the
+        // live watcher never re-reads a deleted dir mid-evaluate (AAASM-3729).
+        let (engine, _tmp) = cascade_engine_owner_org_denies_bash();
         let mut ctx = make_ctx();
         ctx.agent_id = AgentId::from_bytes([0xcc; 16]);
         ctx.metadata.insert("org_id".to_string(), "owner-org".to_string());


### PR DESCRIPTION
## Description

Fixes an order/parallelism-dependent flake in `aa-gateway::engine::tests::cascade_uses_registered_org_not_client_forged_org` (and its sibling `cascade_falls_back_to_ctx_org_when_agent_unregistered`), both added by PR #1249 / AAASM-3729. The tests pass locally and in the serial full suite but fail nondeterministically under CI parallelism — they failed all 3 retries on PR #1247's merge-CI while master passed the identical test.

**Root cause (deterministically proven):** the helper `cascade_engine_owner_org_denies_bash()` built the policy cascade in a `tempfile::tempdir()` and returned **only** the `PolicyEngine`. `load_cascade_from_dir_with_budget` starts a **live `notify` filesystem watcher** on that directory (AAASM-3497 hot-reload). When the helper returns, the `TempDir` guard drops and **recursively deletes the directory's `*.yaml` files**. The live watcher observes the removal, re-reads the now-empty directory, and atomically swaps in an empty (allow-all) cascade. When that swap lands before the test's `evaluate(...)` — far more likely under CPU contention / high `-j`, and under Linux inotify which fires promptly (macOS FSEvents coalesced it, hiding the bug locally) — the org-scoped Deny is gone and `evaluate` returns Allow, failing the assertion.

I reproduced the mechanism deterministically with a scratch test: removing the watched dir's YAML files then calling `evaluate` flips the decision Deny → Allow within ~1s.

**Fix:** return the owning `TempDir` from the helper as `(PolicyEngine, TempDir)` and bind it for each test's full lifetime (`let (engine, _tmp) = ...`), so the watched directory never vanishes mid-evaluate. This is real isolation — each test owns a stable directory; no retries (retries=2 already exist and can't fix a deterministic-per-ordering failure) and no serialization needed. Mirrors how the non-flaky sibling tests (e.g. `binary_loader_cascades_org_scoped_deny_over_global_allow`) already hold the `TempDir` in the test body.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3747
- Follow-up to PR #1249 (AAASM-3729)

Closes AAASM-3747

## Testing

- [x] Unit tests added / updated (test-isolation fix — no behaviour change to product code)

`cargo nextest run -p aa-gateway 'engine::tests::cascade'` run repeatedly at high concurrency (`-j 24`/`-j 32`) — all green. `cargo clippy -p aa-gateway --all-targets -- -D warnings` clean. `cargo fmt --all --check` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)