### PR TITLE
[AAASM-3754] 🐛 (installer): Resolve newest pre-release for the one-liner installer

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # One-line installer for the aasm CLI.
-# Usage: curl -fsSL https://tool.agent-assembly.dev | sh
+# Usage: curl -sSf https://agent-assembly.com/install.sh | sh
 #
 # Detects the host OS and CPU architecture, downloads the matching
 # pre-built tarball plus its SHA256SUMS file from the ai-agent-assembly

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -135,8 +135,17 @@ verify_signature() {
 
 latest_release() {
   need curl
-  tag=$(curl -sSf "https://api.github.com/repos/${REPO}/releases/latest" \
+  # Prefer the latest stable (non-prerelease) release. Stderr is silenced because a
+  # 404 here is expected (and benign) when no stable release exists yet — see fallback.
+  tag=$(curl -sSf "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
     | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+  # Fall back to the newest release overall when no stable release exists yet:
+  # the 0.0.1 series ships entirely as pre-releases, which /releases/latest skips
+  # (it 404s when every release is a pre-release), so resolve the newest from the list.
+  if [ -z "$tag" ]; then
+    tag=$(curl -sSf "https://api.github.com/repos/${REPO}/releases?per_page=1" \
+      | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+  fi
   [ -n "$tag" ] || err "could not determine latest release — does ${REPO} have a published release?"
   echo "$tag"
 }


### PR DESCRIPTION
## What

`latest_release()` in `scripts/install-cli.sh` now falls back to the newest release from `/releases` when GitHub's `/releases/latest` returns nothing, and the script's usage comment points at the canonical `https://agent-assembly.com/install.sh`.

## Why

GitHub's `/releases/latest` only returns **non-prerelease** releases. The entire `v0.0.1-*` series is (correctly) pre-release except `v0.0.1-alpha.1`, which alone is flagged stable — so the one-liner installs the stale **alpha.1** instead of the newest **beta.4**. Once we mark alpha.1 pre-release too (the accurate metadata, AAASM-3754), `/releases/latest` would 404 and the installer could not resolve any version. This fallback fixes both: it picks the newest pre-release today, and will still prefer a real stable once one is cut.

## How it works

1. Try `/releases/latest` (stable) — stderr silenced because a 404 here is expected/benign when no stable exists.
2. If empty, resolve the newest entry from `/releases?per_page=1` (includes pre-releases, newest first).
3. If still empty (no releases at all), the existing guard errors with a clear message.

## How to verify

- `sh -n scripts/install-cli.sh` — parses clean.
- Exercised under `set -eu` against a no-stable repo (node-sdk, whose `/releases/latest` 404s): the fallback resolves `v0.0.1-beta.5`, exit 0, no error noise.
- Against the current agent-assembly state (stable=alpha.1): resolves alpha.1 — unchanged until the release flag is flipped.
- Existing `tests/install_cli_sh.bats` only covers `verify_signature` — untouched.

## Coordinated rollout (order matters)

This PR + the served-copy sync (`official-website`) must be **merged and live before** `v0.0.1-alpha.1` is flagged pre-release — flipping it first would 404 `/releases/latest` and break the live installer. Sequence: this PR → official-website served-copy PR (deploys) → flip the flag → re-verify.

Closes AAASM-3754 (installer portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)