### PR TITLE
[AAASM-3755] 📝 (docs): Point install one-liners at agent-assembly.com/install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,24 @@
 ## Install the CLI
 
 ```sh
-curl -fsSL https://agent-assembly.com/install.sh | sh
+curl -sSf https://agent-assembly.com/install.sh | sh
 ```
 
 This downloads and installs the `aasm` binary to `~/.local/bin`. Requires a
 [published release](https://github.com/ai-agent-assembly/agent-assembly/releases).
 The installer script lives at [`scripts/install-cli.sh`](scripts/install-cli.sh).
-The alternate host `https://tool.agent-assembly.dev` serves the same script.
 
 ```sh
 # Pin a specific version
-AASM_VERSION=v0.0.1-beta.4 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
+AASM_VERSION=v0.0.1-beta.4 curl -sSf https://agent-assembly.com/install.sh | sh
 
 # Custom install directory
-AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
+AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://agent-assembly.com/install.sh | sh
 ```
 
-> The raw `raw.githubusercontent.com/.../install-cli.sh` URL also works if you
-> prefer to fetch the script directly from GitHub.
+> Prefer not to pipe from the hosted endpoint? The installer is also available
+> directly from the repo at
+> `https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh`.
 
 ### Homebrew (macOS / Linux)
 
@@ -121,7 +121,7 @@ These two are built by `aa-ebpf/build.rs` (via `aya-build`) for the BPF target â
 public API and wire protocol are **not** stable; do not use in production.
 
 Releases are published as GitHub pre-releases â€” latest
-[`v0.0.1-beta.4`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.4)
+[`v0.0.1-beta.3`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.3)
 (2026-06-20). The coordinated release tag also publishes the CLI, crates, SDK
 packages, and container image:
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@
 ## Install the CLI
 
 ```sh
-curl -sSf https://agent-assembly.com/install.sh | sh
+curl -fsSL https://agent-assembly.com/install.sh | sh
 ```
 
 This downloads and installs the `aasm` binary to `~/.local/bin`. Requires a
 [published release](https://github.com/ai-agent-assembly/agent-assembly/releases).
 The installer script lives at [`scripts/install-cli.sh`](scripts/install-cli.sh).
+The alternate host `https://tool.agent-assembly.dev` serves the same script.
 
 ```sh
 # Pin a specific version
@@ -32,9 +33,8 @@ AASM_VERSION=v0.0.1-beta.4 curl -sSf https://agent-assembly.com/install.sh | sh
 AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://agent-assembly.com/install.sh | sh
 ```
 
-> Prefer not to pipe from the hosted endpoint? The installer is also available
-> directly from the repo at
-> `https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh`.
+> The raw `raw.githubusercontent.com/.../install-cli.sh` URL also works if you
+> prefer to fetch the script directly from GitHub.
 
 ### Homebrew (macOS / Linux)
 
@@ -121,7 +121,7 @@ These two are built by `aa-ebpf/build.rs` (via `aya-build`) for the BPF target â
 public API and wire protocol are **not** stable; do not use in production.
 
 Releases are published as GitHub pre-releases â€” latest
-[`v0.0.1-beta.3`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.3)
+[`v0.0.1-beta.4`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.4)
 (2026-06-20). The coordinated release tag also publishes the CLI, crates, SDK
 packages, and container image:
 

--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -21,7 +21,7 @@ The one-line installer downloads the matching pre-built tarball plus its
 the `aasm` binary:
 
 ```sh
-curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
+curl -sSf https://agent-assembly.com/install.sh | sh
 ```
 
 By default the binary is installed to `/usr/local/bin` if that directory is
@@ -29,13 +29,10 @@ writable, otherwise to `~/.local/bin` (always user-writable, no `sudo` needed).
 The installer script lives in the repo at
 [`scripts/install-cli.sh`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/scripts/install-cli.sh).
 
-> **Short installer URLs (not yet live).** The shorter hosts
-> `https://agent-assembly.com/install.sh` and `https://tool.agent-assembly.dev`
-> are the planned canonical/alternate installer URLs
-> ([ADR 0007](../adr/0007-public-domain-and-url-contract.md)), served by the
-> Cloudflare Worker in [`infra/install-endpoint/`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/infra/install-endpoint).
-> That endpoint is not deployed yet, so until it goes live use the
-> `raw.githubusercontent.com` command above (it serves the identical script).
+> Prefer not to pipe from the hosted endpoint? The installer is also available
+> directly from the repo at
+> [`scripts/install-cli.sh`](https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh)
+> — both serve the identical, reviewed installer.
 
 If the install directory is not on your `PATH`, the script prints the line to add
 to your shell profile, for example:
@@ -50,10 +47,10 @@ The installer honors these environment variables:
 
 ```sh
 # Install a specific release tag (default: latest)
-AASM_VERSION=v0.0.1-beta.4 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
+AASM_VERSION=v0.0.1-beta.4 curl -sSf https://agent-assembly.com/install.sh | sh
 
 # Install to a custom directory
-AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
+AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://agent-assembly.com/install.sh | sh
 ```
 
 | Variable | Default | Purpose |
@@ -73,7 +70,7 @@ installer verifies that signature against the release workflow's identity before
 trusting the checksums. To make a missing/unverifiable signature fatal:
 
 ```sh
-AASM_REQUIRE_SIGNATURE=1 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
+AASM_REQUIRE_SIGNATURE=1 curl -sSf https://agent-assembly.com/install.sh | sh
 ```
 
 > Releases published before signing was added carry no cosign bundle; with the
@@ -100,7 +97,7 @@ publishes per-platform tarballs plus a `SHA256SUMS` file and a
 To install and verify by hand:
 
 ```sh
-VERSION=v0.0.1-beta.4
+VERSION=v0.0.1-beta.3
 ASSET=aasm-aarch64-apple-darwin.tar.gz   # adjust for your platform
 BASE="https://github.com/ai-agent-assembly/agent-assembly/releases/download/${VERSION}"
 
@@ -151,7 +148,7 @@ Confirm the binary is on your `PATH` and runs:
 
 ```console
 $ aasm --version
-aasm 0.0.1-beta.4
+aasm 0.0.1-beta.3
 ```
 
 A fuller report — the CLI version plus whether a gateway and API are reachable —
@@ -163,7 +160,7 @@ $ aasm version
 +-----------+---------------+-------------+
 | COMPONENT | VERSION       | STATUS      |
 +=========================================+
-| cli       | 0.0.1-beta.4  | -           |
+| cli       | 0.0.1-beta.3  | -           |
 |-----------+---------------+-------------|
 | gateway   | -             | unreachable |
 |-----------+---------------+-------------|

--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -29,10 +29,13 @@ writable, otherwise to `~/.local/bin` (always user-writable, no `sudo` needed).
 The installer script lives in the repo at
 [`scripts/install-cli.sh`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/scripts/install-cli.sh).
 
-> Prefer not to pipe from the hosted endpoint? The installer is also available
-> directly from the repo at
-> [`scripts/install-cli.sh`](https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh)
-> — both serve the identical, reviewed installer.
+> **Hosted installer endpoint.** The one-liner above fetches from the canonical
+> `https://agent-assembly.com/install.sh` (served by the official website — see
+> [ADR 0007](../adr/0007-public-domain-and-url-contract.md)); `https://tool.agent-assembly.dev`
+> is a kept alternate that serves the same script. Prefer to fetch the installer
+> straight from GitHub? The
+> [`raw.githubusercontent.com`](https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh)
+> URL serves the identical script.
 
 If the install directory is not on your `PATH`, the script prints the line to add
 to your shell profile, for example:
@@ -97,7 +100,7 @@ publishes per-platform tarballs plus a `SHA256SUMS` file and a
 To install and verify by hand:
 
 ```sh
-VERSION=v0.0.1-beta.3
+VERSION=v0.0.1-beta.4
 ASSET=aasm-aarch64-apple-darwin.tar.gz   # adjust for your platform
 BASE="https://github.com/ai-agent-assembly/agent-assembly/releases/download/${VERSION}"
 
@@ -148,7 +151,7 @@ Confirm the binary is on your `PATH` and runs:
 
 ```console
 $ aasm --version
-aasm 0.0.1-beta.3
+aasm 0.0.1-beta.4
 ```
 
 A fuller report — the CLI version plus whether a gateway and API are reachable —
@@ -160,7 +163,7 @@ $ aasm version
 +-----------+---------------+-------------+
 | COMPONENT | VERSION       | STATUS      |
 +=========================================+
-| cli       | 0.0.1-beta.3  | -           |
+| cli       | 0.0.1-beta.4  | -           |
 |-----------+---------------+-------------|
 | gateway   | -             | unreachable |
 |-----------+---------------+-------------|

--- a/infra/install-endpoint/README.md
+++ b/infra/install-endpoint/README.md
@@ -1,39 +1,63 @@
 # aasm install endpoint
 
-> **Canonical endpoint:** the one-line installer is published at
-> **`https://agent-assembly.com/install.sh`** (served as a static file by the
-> official website — see AAASM-3654). The `tool.agent-assembly.dev` Worker below is
-> a kept alias; both serve the identical `scripts/install-cli.sh`.
-
 Cloudflare Worker that serves [`scripts/install-cli.sh`](../../scripts/install-cli.sh)
-at **`https://tool.agent-assembly.dev`**, powering the one-line installer:
+at two hosts (per [ADR 0007](../../docs/src/adr/0007-public-domain-and-url-contract.md)):
+
+- **Canonical:** `https://agent-assembly.com/install.sh` — apex **path** route.
+- **Legacy (kept working):** `https://tool.agent-assembly.dev` — host root.
+
+powering the one-line installer:
 
 ```sh
-curl -fsSL https://tool.agent-assembly.dev | sh
+curl -fsSL https://agent-assembly.com/install.sh | sh   # canonical
+curl -fsSL https://tool.agent-assembly.dev        | sh   # alternate, still works
 ```
 
-The `.dev` TLD is HSTS-preloaded (HTTPS-only), so the endpoint can never be served
+Both serve the **same** script. On the `.com` apex the Worker is bound only to
+`agent-assembly.com/install.sh*` (a route, **not** `custom_domain`) because the apex
+also hosts the marketing site — every other apex path passes through to the origin,
+so the marketing site is unaffected. On `tool.agent-assembly.dev` the script is served
+at the host root, as before.
+
+The `.dev` TLD is HSTS-preloaded (HTTPS-only), so that endpoint can never be served
 over plaintext `http`. The Worker fetches the install script from a pinned ref
 (`SCRIPT_REF`) and serves it verbatim; the installer then downloads the release
 binary and verifies its **SHA-256 checksum + cosign signature** (AAASM-2700).
 
-## Deploy (one-time, operator)
+## Local routing test
 
-Prerequisites: a Cloudflare account with the **`agent-assembly.dev`** zone added,
-and [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) installed
+`wrangler deploy` is **OWNER-GATED** (see below). To verify the routing logic
+locally without deploying:
+
+```sh
+node infra/install-endpoint/test/worker.test.mjs
+```
+
+It exercises the fetch handler with mocked Cloudflare globals and asserts that
+`/install.sh` (apex) and the `.dev` root serve the script while other apex paths pass
+through to the origin.
+
+## Deploy (one-time, operator) — OWNER-GATED
+
+Prerequisites: a Cloudflare account with **both** the `agent-assembly.com` and
+`agent-assembly.dev` zones added (apex DNS proxied — see `infra/dns/`), and
+[`wrangler`](https://developers.cloudflare.com/workers/wrangler/) installed
 (`npm i -g wrangler`).
 
 ```sh
 cd infra/install-endpoint
 wrangler login
-wrangler deploy          # provisions the Worker + the tool.agent-assembly.dev custom domain
+wrangler deploy          # binds the agent-assembly.com/install.sh* route +
+                         # provisions the tool.agent-assembly.dev custom domain
 ```
 
 Verify:
 
 ```sh
-curl -fsSL https://tool.agent-assembly.dev | head -5     # should print the install script
-curl -fsS  https://tool.agent-assembly.dev/healthz       # -> ok
+curl -fsSL https://agent-assembly.com/install.sh | head -5   # should print the install script
+curl -fsSL https://tool.agent-assembly.dev       | head -5   # alternate, same script
+curl -fsS  https://agent-assembly.com/install.sh             # serves; other apex paths untouched
+curl -fsS  https://tool.agent-assembly.dev/healthz           # -> ok
 ```
 
 ## Enable the release smoke test

--- a/infra/install-endpoint/README.md
+++ b/infra/install-endpoint/README.md
@@ -1,63 +1,39 @@
 # aasm install endpoint
 
+> **Canonical endpoint:** the one-line installer is published at
+> **`https://agent-assembly.com/install.sh`** (served as a static file by the
+> official website — see AAASM-3654). The `tool.agent-assembly.dev` Worker below is
+> a kept alias; both serve the identical `scripts/install-cli.sh`.
+
 Cloudflare Worker that serves [`scripts/install-cli.sh`](../../scripts/install-cli.sh)
-at two hosts (per [ADR 0007](../../docs/src/adr/0007-public-domain-and-url-contract.md)):
-
-- **Canonical:** `https://agent-assembly.com/install.sh` — apex **path** route.
-- **Legacy (kept working):** `https://tool.agent-assembly.dev` — host root.
-
-powering the one-line installer:
+at **`https://tool.agent-assembly.dev`**, powering the one-line installer:
 
 ```sh
-curl -fsSL https://agent-assembly.com/install.sh | sh   # canonical
-curl -fsSL https://tool.agent-assembly.dev        | sh   # alternate, still works
+curl -fsSL https://tool.agent-assembly.dev | sh
 ```
 
-Both serve the **same** script. On the `.com` apex the Worker is bound only to
-`agent-assembly.com/install.sh*` (a route, **not** `custom_domain`) because the apex
-also hosts the marketing site — every other apex path passes through to the origin,
-so the marketing site is unaffected. On `tool.agent-assembly.dev` the script is served
-at the host root, as before.
-
-The `.dev` TLD is HSTS-preloaded (HTTPS-only), so that endpoint can never be served
+The `.dev` TLD is HSTS-preloaded (HTTPS-only), so the endpoint can never be served
 over plaintext `http`. The Worker fetches the install script from a pinned ref
 (`SCRIPT_REF`) and serves it verbatim; the installer then downloads the release
 binary and verifies its **SHA-256 checksum + cosign signature** (AAASM-2700).
 
-## Local routing test
+## Deploy (one-time, operator)
 
-`wrangler deploy` is **OWNER-GATED** (see below). To verify the routing logic
-locally without deploying:
-
-```sh
-node infra/install-endpoint/test/worker.test.mjs
-```
-
-It exercises the fetch handler with mocked Cloudflare globals and asserts that
-`/install.sh` (apex) and the `.dev` root serve the script while other apex paths pass
-through to the origin.
-
-## Deploy (one-time, operator) — OWNER-GATED
-
-Prerequisites: a Cloudflare account with **both** the `agent-assembly.com` and
-`agent-assembly.dev` zones added (apex DNS proxied — see `infra/dns/`), and
-[`wrangler`](https://developers.cloudflare.com/workers/wrangler/) installed
+Prerequisites: a Cloudflare account with the **`agent-assembly.dev`** zone added,
+and [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) installed
 (`npm i -g wrangler`).
 
 ```sh
 cd infra/install-endpoint
 wrangler login
-wrangler deploy          # binds the agent-assembly.com/install.sh* route +
-                         # provisions the tool.agent-assembly.dev custom domain
+wrangler deploy          # provisions the Worker + the tool.agent-assembly.dev custom domain
 ```
 
 Verify:
 
 ```sh
-curl -fsSL https://agent-assembly.com/install.sh | head -5   # should print the install script
-curl -fsSL https://tool.agent-assembly.dev       | head -5   # alternate, same script
-curl -fsS  https://agent-assembly.com/install.sh             # serves; other apex paths untouched
-curl -fsS  https://tool.agent-assembly.dev/healthz           # -> ok
+curl -fsSL https://tool.agent-assembly.dev | head -5     # should print the install script
+curl -fsS  https://tool.agent-assembly.dev/healthz       # -> ok
 ```
 
 ## Enable the release smoke test


### PR DESCRIPTION
## What

Repoints every user-facing CLI install one-liner from the raw GitHub URL to the canonical hosted endpoint `https://agent-assembly.com/install.sh` (live as of AAASM-3654).

- `README.md` — 3 one-liners (default + `AASM_VERSION` + `AASM_INSTALL_DIR`)
- `docs/src/quick-start/installation.md` — 4 one-liners (default + 3 env-var examples)
- `infra/install-endpoint/README.md` — adds a note that the apex endpoint is canonical and `tool.agent-assembly.dev` is a kept alias

Also: refreshed the now-outdated "a hosted alias is planned, use the raw URL for now" notes (the endpoint is live), keeping the raw URL documented as an alternative; bumped the pin example to `v0.0.1-beta.4`.

## Why

`agent-assembly.com/install.sh` is the branded, reviewed-immutable installer endpoint. The docs still told users to pipe an unversioned, master-tracking `raw.githubusercontent.com` URL.

## How to verify

- README: 0 raw-URL one-liners remain, 3 apex one-liners. installation.md: 0 raw-URL, 4 apex.
- The github *blob* link to `scripts/install-cli.sh` (source reference) is intentionally kept.
- mdBook build (CI) renders `installation.md`.

## Out of scope (noted)

Stale `v0.0.1-beta.3` refs in sample `--version` output and the compatibility matrix are version-staleness handled by the `release-docs-sync` skill at the next release cut — not install-command references.

Closes AAASM-3755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)