### PR TITLE
[release] 🔧 (release): Prepare v0.0.1-rc.1 — bump + security sign-off + notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to **AI Agent Assembly** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-rc.1] — 2026-06-26 (pre-release)
+
+> **Not for production use.** First **release candidate** in the v0.0.1 series,
+> promoting the channel from `0.0.1-beta.4`. A security-hardening + release-QA
+> cut; no API, ABI, or wire-protocol stability commitment at `0.x.y`.
+
+### Security
+
+- **AAASM-3726** — REST agent-lifecycle handlers (delete/suspend/resume +
+  subtree-burn) gated with write-scope + tenant ownership (IDOR closed).
+- **AAASM-3728** — network egress fails closed on an empty allowlist (cascade
+  and single-file paths share one fail-closed helper).
+- **AAASM-3689** — credential scanner / redaction hardening (case/whitespace
+  variant detection, overlapping-finding coalescing, no fragment leaks).
+- **AAASM-3751** — policy cascade + budget lineage anchored to the credential
+  token's registered owner (defense-in-depth); webhook `secret_header` masked
+  in destination responses and preserved on masked round-trip.
+
+### Fixed
+
+- **AAASM-3732** install script, **AAASM-3733** `latest/` channel alias,
+  **AAASM-3736** dashboard partial-data guards, **AAASM-3719** SonarCloud
+  residuals.
+
+### Changed
+
+- Workspace + inter-crate path-dependency versions bumped `0.0.1-beta.4` →
+  `0.0.1-rc.1` (path-dep pins realigned to the release version).
+
 ## [0.0.1-beta.4] — 2026-06-24 (pre-release)
 
 > **Not for production use.** Fourth pre-release in the v0.0.1 beta

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aa-api"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "aa-cache"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-cache",
  "aa-core",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aa-cli"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aa-core"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-security",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-claude-code"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-codex"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -179,14 +179,14 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-contract"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
 ]
 
 [[package]]
 name = "aa-devtool-copilot"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-saas"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-sample-myeditor"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-windsurf"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-ebpf-common",
@@ -260,11 +260,11 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf-common"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 
 [[package]]
 name = "aa-gateway"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "aa-integration-tests"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-api",
  "aa-core",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "prost",
  "tonic",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proxy"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "aa-runtime"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-ebpf",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "aa-sandbox"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "tempfile",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "aa-sdk-client"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "aa-security"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-memory"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-storage",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-postgres"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-storage",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-redis"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-storage",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-sqlite-buffer"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "aa-wasm"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "wasm-bindgen",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 dependencies = [
  "aa-core",
  "aa-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ exclude = ["node-sdk", "aa-sandbox/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1-beta.4"
+version = "0.0.1-rc.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ai-agent-assembly/agent-assembly"

--- a/aa-cache/Cargo.toml
+++ b/aa-cache/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "In-process L1 cache wrapper (DashMap + TTL + stampede protection) for the Agent Assembly storage traits"
 
 [dependencies]
-aa-core = { path = "../aa-core", version = "0.0.1-beta.2" }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.1" }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -11,8 +11,8 @@ name = "aasm"
 path = "src/main.rs"
 
 [dependencies]
-aa-core              = { path = "../aa-core", version = "0.0.1-beta.2" }
-aa-security          = { path = "../aa-security", version = "0.0.1-beta.2", features = ["serde"] }
+aa-core              = { path = "../aa-core", version = "0.0.1-rc.1" }
+aa-security          = { path = "../aa-security", version = "0.0.1-rc.1", features = ["serde"] }
 # strip-for-publish:begin devtool
 # AAASM-2340: these three deps wire `aasm run` + `aasm tools` to the
 # `aa-devtool*` adapter crates. The dev-tool subsystem isn't ready to
@@ -20,16 +20,16 @@ aa-security          = { path = "../aa-security", version = "0.0.1-beta.2", feat
 # (and the source files that consume it) before `cargo workspaces publish`
 # runs. Source builds keep the full surface — no edits required to
 # develop on `aasm run` / `aasm tools` locally.
-aa-devtool           = { path = "../aa-devtool", version = "0.0.1-beta.2" }
-aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-beta.2" }
-aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-beta.2" }
+aa-devtool           = { path = "../aa-devtool", version = "0.0.1-rc.1" }
+aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-rc.1" }
+aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-rc.1" }
 # strip-for-publish:end devtool
-aa-gateway           = { path = "../aa-gateway", version = "0.0.1-beta.2" }
-aa-proxy             = { path = "../aa-proxy", version = "0.0.1-beta.2" }
-aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-beta.2" }
-aa-storage           = { path = "../aa-storage", version = "0.0.1-beta.2" }
-aa-storage-memory    = { path = "../aa-storage-memory", version = "0.0.1-beta.2" }
-aa-storage-redis     = { path = "../aa-storage-redis", version = "0.0.1-beta.2" }
+aa-gateway           = { path = "../aa-gateway", version = "0.0.1-rc.1" }
+aa-proxy             = { path = "../aa-proxy", version = "0.0.1-rc.1" }
+aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-rc.1" }
+aa-storage           = { path = "../aa-storage", version = "0.0.1-rc.1" }
+aa-storage-memory    = { path = "../aa-storage-memory", version = "0.0.1-rc.1" }
+aa-storage-redis     = { path = "../aa-storage-redis", version = "0.0.1-rc.1" }
 anyhow         = { workspace = true }
 async-trait    = { workspace = true }
 axum           = { workspace = true }

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Pure domain logic for Agent Assembly — no_std compatible"
 
 [dependencies]
-aa-security  = { path = "../aa-security", version = "0.0.1-beta.2", optional = true }
+aa-security  = { path = "../aa-security", version = "0.0.1-rc.1", optional = true }
 async-trait  = { workspace = true, optional = true }
 cfg-if       = "1"
 chrono       = { workspace = true, default-features = false, features = ["clock"], optional = true }

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -30,8 +30,8 @@ default = []
 integration-test = []
 
 [dependencies]
-aa-core        = { path = "../aa-core", version = "0.0.1-beta.2" }
-aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-beta.2", features = ["std"] }
+aa-core        = { path = "../aa-core", version = "0.0.1-rc.1" }
+aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.1", features = ["std"] }
 anyhow         = { workspace = true }
 bytes          = { workspace = true }
 hex            = { workspace = true }

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -7,10 +7,10 @@ repository.workspace = true
 description = "Control plane — policy enforcement engine and agent registry for Agent Assembly"
 
 [dependencies]
-aa-core      = { path = "../aa-core", version = "0.0.1-beta.2", features = ["serde"] }
-aa-security  = { path = "../aa-security", version = "0.0.1-beta.2", features = ["serde"] }
-aa-proto     = { path = "../aa-proto", version = "0.0.1-beta.2" }
-aa-runtime   = { path = "../aa-runtime", version = "0.0.1-beta.2" }
+aa-core      = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
+aa-security  = { path = "../aa-security", version = "0.0.1-rc.1", features = ["serde"] }
+aa-proto     = { path = "../aa-proto", version = "0.0.1-rc.1" }
+aa-runtime   = { path = "../aa-runtime", version = "0.0.1-rc.1" }
 tokio        = { workspace = true, features = ["full"] }
 regex        = "1"
 serde        = { workspace = true }

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -14,10 +14,10 @@ name = "aa-proxy"
 path = "src/main.rs"
 
 [dependencies]
-aa-core    = { path = "../aa-core", version = "0.0.1-beta.2", features = ["serde"] }
-aa-security = { path = "../aa-security", version = "0.0.1-beta.2", features = ["serde"] }
-aa-proto   = { path = "../aa-proto", version = "0.0.1-beta.2" }
-aa-runtime = { path = "../aa-runtime", version = "0.0.1-beta.2" }
+aa-core    = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
+aa-security = { path = "../aa-security", version = "0.0.1-rc.1", features = ["serde"] }
+aa-proto   = { path = "../aa-proto", version = "0.0.1-rc.1" }
+aa-runtime = { path = "../aa-runtime", version = "0.0.1-rc.1" }
 clap       = { workspace = true, features = ["derive"] }
 tokio      = { workspace = true, features = ["full"] }
 hyper      = { workspace = true, features = ["server", "http1"] }

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -14,10 +14,10 @@ default = []
 integration-test = []
 
 [dependencies]
-aa-core                     = { path = "../aa-core", version = "0.0.1-beta.2", features = ["serde"] }
-aa-security                 = { path = "../aa-security", version = "0.0.1-beta.2", features = ["serde"] }
-aa-proto                    = { path = "../aa-proto", version = "0.0.1-beta.2" }
-aa-storage-sqlite-buffer    = { path = "../aa-storage-sqlite-buffer", version = "0.0.1-beta.2" }
+aa-core                     = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
+aa-security                 = { path = "../aa-security", version = "0.0.1-rc.1", features = ["serde"] }
+aa-proto                    = { path = "../aa-proto", version = "0.0.1-rc.1" }
+aa-storage-sqlite-buffer    = { path = "../aa-storage-sqlite-buffer", version = "0.0.1-rc.1" }
 async-nats                  = { workspace = true }
 async-trait                 = { workspace = true }
 axum                        = { workspace = true }
@@ -48,7 +48,7 @@ tracing-subscriber          = { workspace = true, features = ["json", "env-filte
 which                       = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-aa-ebpf = { path = "../aa-ebpf", version = "0.0.1-beta.2" }
+aa-ebpf = { path = "../aa-ebpf", version = "0.0.1-rc.1" }
 
 # Peer-credential (geteuid) check on the IPC socket — all Unix targets
 # (AAASM-3579). Backed by getpeereid/SO_PEERCRED via tokio's peer_cred.
@@ -58,7 +58,7 @@ libc = { workspace = true }
 # Linux-only dev dep: the AAASM-3128 regression test constructs a
 # `TlsCaptureEvent` to prove the DEBUG log never emits its plaintext payload.
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-beta.2", features = ["std"] }
+aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.1", features = ["std"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/aa-sandbox/Cargo.toml
+++ b/aa-sandbox/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "WebAssembly/WASI sandbox runtime for Agent Assembly tool execution"
 
 [dependencies]
-aa-core       = { path = "../aa-core", version = "0.0.1-beta.2" }
+aa-core       = { path = "../aa-core", version = "0.0.1-rc.1" }
 thiserror     = { workspace = true }
 wasmtime      = "46"
 wasmtime-wasi = "46"

--- a/aa-storage-memory/Cargo.toml
+++ b/aa-storage-memory/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 description = "In-memory aa-storage driver (DashMap-backed) for tests and local development"
 
 [dependencies]
-aa-core = { path = "../aa-core", version = "0.0.1-beta.2" }
-aa-storage = { path = "../aa-storage", version = "0.0.1-beta.2" }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.1" }
+aa-storage = { path = "../aa-storage", version = "0.0.1-rc.1" }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }

--- a/aa-storage-postgres/Cargo.toml
+++ b/aa-storage-postgres/Cargo.toml
@@ -10,8 +10,8 @@ description = "PostgreSQL storage driver (L3 primary) for the Agent Assembly per
 publish = false
 
 [dependencies]
-aa-core    = { path = "../aa-core", version = "0.0.1-beta.2", features = ["serde"] }
-aa-storage = { path = "../aa-storage", version = "0.0.1-beta.2" }
+aa-core    = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
+aa-storage = { path = "../aa-storage", version = "0.0.1-rc.1" }
 async-trait = { workspace = true }
 sqlx       = { workspace = true, default-features = false, features = ["runtime-tokio-rustls", "postgres", "macros", "migrate", "uuid", "chrono", "json"] }
 serde      = { workspace = true }

--- a/aa-storage-redis/Cargo.toml
+++ b/aa-storage-redis/Cargo.toml
@@ -9,11 +9,11 @@ description = "Redis L2 shared-cache storage driver (SessionStore, RateLimitCoun
 [dependencies]
 # Trait contract — the storage traits live in `aa-core::storage` and are
 # re-exported verbatim by the `aa-storage` facade.
-aa-storage = { path = "../aa-storage", version = "0.0.1-beta.2" }
+aa-storage = { path = "../aa-storage", version = "0.0.1-rc.1" }
 # Pulled in only to enable `aa-core`'s `serde` feature so `PolicyDocument`
 # (re-exported through `aa-storage`) gains `Serialize`/`Deserialize`, which the
 # JSON-backed `RedisPolicyStore` needs. No `aa-core` items are named directly.
-aa-core = { path = "../aa-core", version = "0.0.1-beta.2", features = ["serde"] }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
 
 async-trait = { workspace = true }
 # `redis = 1.2` matches the workspace pin. `tokio-rustls-comp` backs the
@@ -33,7 +33,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 testcontainers-modules = { workspace = true, features = ["redis"] }
 # Second driver for the mixed-config registry-integration test (redis backs the
 # L2 kinds; memory backs the durable kinds).
-aa-storage-memory = { path = "../aa-storage-memory", version = "0.0.1-beta.2" }
+aa-storage-memory = { path = "../aa-storage-memory", version = "0.0.1-rc.1" }
 
 [lints]
 workspace = true

--- a/aa-storage-sqlite-buffer/Cargo.toml
+++ b/aa-storage-sqlite-buffer/Cargo.toml
@@ -10,7 +10,7 @@ description = "Local in-process SQLite event buffer that survives brief gateway/
 # The buffer serializes and replays the storage contract's `AuditEntry` through
 # the `AuditSink` trait, both reached from `aa-core`. `serde` is enabled so
 # `AuditEntry` can be encoded into the on-disk BLOB.
-aa-core = { path = "../aa-core", version = "0.0.1-beta.2", features = ["serde"] }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
 # Pinned to the rusqlite line that depends on `libsqlite3-sys 0.30`, matching
 # the `sqlx-sqlite 0.8.6` already resolved for `aa-gateway`. Only one crate in
 # the workspace may link the native `sqlite3` library, so both must resolve to

--- a/aa-storage/Cargo.toml
+++ b/aa-storage/Cargo.toml
@@ -11,7 +11,7 @@ description = "Storage trait abstraction (pure interface) for the Agent Assembly
 # here. `serde`/`toml` back the `[storage]` config schema + driver registry; the
 # crate stays a pure interface (no `sqlx`/`redis`/`tonic` backend dependency).
 # `async-trait` is a dev-dep used by the conformance test's example implementation.
-aa-core   = { path = "../aa-core", version = "0.0.1-beta.2" }
+aa-core   = { path = "../aa-core", version = "0.0.1-rc.1" }
 serde     = { workspace = true }
 thiserror = { workspace = true }
 toml      = { workspace = true }

--- a/docs/release/security-signoff/v0.0.1-rc.1.md
+++ b/docs/release/security-signoff/v0.0.1-rc.1.md
@@ -1,0 +1,58 @@
+# Security sign-off — v0.0.1-rc.1
+
+- **Version:** v0.0.1-rc.1
+- **Release type:** minor (pre-release channel promotion `beta.4` → `rc.1`)
+- **Previous tag:** v0.0.1-beta.4
+- **Reviewer:** Claude Code (`/release-security-gate`)
+- **Date:** 2026-06-26
+
+## Inputs reviewed
+
+- `cargo deny check advisories` — **advisories ok** (exit 0)
+- Open CodeQL alerts — **0**
+- Open Dependabot alerts — **0**
+- Release diff — `git log v0.0.1-beta.4..HEAD` (**50 commits**; HEAD `c068a550`)
+- Native `/security-review` (Anthropic diff scanner) on the release delta — run; findings folded below. The delta is predominantly security hardening (it closes the prior review's findings); the only High raised (AAASM-3751) was independently re-verified and reclassified — see Findings.
+- `anthropics/claude-code-security-review` Action (major only) — n/a (minor tier)
+
+> The release-diff review wraps the built-in `/security-review`; its findings are folded into the table below.
+
+## Findings
+
+| Severity | Finding | Status |
+|---|---|---|
+| ~~High~~ → **Low** | AAASM-3751 — "cross-tenant policy downgrade via forged `org_id`". Independently re-verified: **not exploitable for a credentialed caller** — `validate_credential_token` Denies a forged-org request as impersonation (`a2a_identity_verification`) before evaluation; a key-hit implies claimed org == registered org. Residual = unauthenticated/tokenless caller = parked **AAASM-3416**. | **Fixed (defense-in-depth)** — PR #1252 token-anchors lineage via `find_by_credential_token`; reclassified Low |
+| Medium | Destination `secret_header` write-back: a GET(masked)→PUT round-trip clobbered the stored secret with the mask literal | **Fixed** — PR #1252 preserves stored secret when incoming == mask |
+| Medium→Fixed | aa-api agent-lifecycle authz (AAASM-3726) + fail-closed egress (AAASM-3728) + cascade owner selection + webhook secret masking + scanner/redaction hardening (AAASM-3689) | **Fixed** in the delta (each with tests) |
+| Low | Destinations have no per-tenant ownership check (delta added read/write scope-gating only) | Accepted — global alert-config by design; follow-up to confirm/scope if needed |
+| Low | `aa-security` scanner skips redaction spans not on a UTF-8 char boundary (defensive; offsets are char-aligned in practice) | Accepted (defensive, non-triggering) |
+| Info | WS `ws_events_handler` requires `AuthenticatedCaller` but no tenant scoping (pre-existing; refactor preserved behavior) | Tracked under AAASM-3416 (gateway auth posture, parked) |
+
+> No unaddressed Critical or High remains.
+
+## Trust-boundary review checklist (minor)
+
+| # | Trust boundary | Changed? (Y/N) | Commit / PR | Reviewer note |
+|---|---|---|---|---|
+| 1 | Authoritative enforcement point moved? | N | — | Enforcement stays in `aa-runtime`/engine; the rc fix only re-sources lineage from the credential token (no relocation to SDK). |
+| 2 | Field gained a wire trust marker? (**must stay N**) | **N** | — | No `clean`/`already_scanned` marker emitted or honored. |
+| 3 | New network egress path added? | N | — | Egress path **tightened** (fail-closed on empty allowlist), not added. |
+| 4 | New endpoint or RPC method added? | N | — | Existing aa-api handlers gained authz scope checks (AAASM-3726); no new endpoint/RPC. |
+| 5 | New IPC / UDS surface? | N | — | No change to the SDK↔runtime↔gateway transport. |
+| 6 | Loosened policy default? | N | — | Defaults **tightened**: empty egress allowlist = Deny; empty cascade stays fail-closed Deny. |
+| 7 | Changed sanitizer / redaction scope? | Y | AAASM-3689 (#1247) | **Hardening only** — adds case/whitespace credential-variant detection + overlapping-finding coalescing (prevents fragment leaks); no field newly exempted from scanning. |
+| 8 | Changed audit subject / publish path? | N | — | Unchanged. |
+| 9 | Budget / spend-enforcement default changed? | N | — | Budget tenancy resolution token-anchored (defense-in-depth); no limit/default changed. |
+| 10 | eBPF probe coverage changed or removed? | N | — | Unchanged. |
+
+All rows N except row 7 (redaction **hardening**, justified). Row 2 stays N.
+
+## Threat-model refresh (major only)
+
+n/a — minor tier.
+
+## Verdict
+
+<!-- The token `Verdict: PASS` is what release-readiness.sh greps for. -->
+
+Verdict: PASS

--- a/docs/release/v0.0.1-rc.1.md
+++ b/docs/release/v0.0.1-rc.1.md
@@ -1,0 +1,54 @@
+# v0.0.1-rc.1 — first release-candidate cut (beta → rc)
+
+> **Operator note** — this file is the source-controlled draft of the GitHub
+> Release description for the `v0.0.1-rc.1` tag. The `prerelease: true` flag is
+> applied automatically by `release.yml`.
+
+---
+
+## v0.0.1-rc.1 — beta → rc channel promotion
+
+First **release candidate** in the v0.0.1 series, promoting the channel up from
+`v0.0.1-beta.4`. The beta series surfaced and stabilised the full product
+surface; this cut moves the pre-release channel to **rc** to signal the v0.0.1
+line is feature-complete and the focus is now release-candidate hardening.
+
+> **Not for production use.** At `0.x.y` SemVer, rc still carries no
+> API/ABI/wire-protocol stability commitment.
+
+### What rides this tag (since `v0.0.1-beta.4`)
+
+This cut is a **security-hardening + release-QA** wave (50 commits). Highlights:
+
+**Security hardening**
+- **AAASM-3726** — REST agent-lifecycle handlers (`delete`/`suspend`/`resume`,
+  subtree-burn) gated with write-scope + tenant ownership; IDOR closed.
+- **AAASM-3728** — network egress fails **closed** on an empty allowlist
+  (cascade and single-file paths routed through one shared fail-closed helper).
+- **AAASM-3689** — credential scanner / redaction hardening: case/whitespace
+  credential-variant detection + overlapping-finding coalescing (no fragment
+  leaks).
+- Webhook `secret_header` masked in destination responses.
+- **AAASM-3751** — policy cascade + budget lineage anchored to the credential
+  token's registered owner (defense-in-depth on top of the credential-token
+  impersonation check); destination secret-mask write-back preserved on
+  round-trip.
+
+**Release / docs QA**
+- **AAASM-3732** install script, **AAASM-3733** `latest/` channel alias,
+  **AAASM-3736** dashboard partial-data guards, **AAASM-3719** SonarCloud
+  residuals.
+
+### Release security sign-off
+
+Stage-0 `/release-security-gate` (minor tier) **PASS** — see
+[`docs/release/security-signoff/v0.0.1-rc.1.md`](security-signoff/v0.0.1-rc.1.md).
+`cargo deny check advisories` ok; 0 open CodeQL / Dependabot. No unaddressed
+Critical/High.
+
+### Coordinated SDK releases
+
+The matching SDK release candidates (`python-sdk 0.0.1rc1`,
+`node-sdk 0.0.1-rc.1`, `go-sdk v0.0.1-rc.1`) are cut after this tag's
+`release.yml` fan-out opens the `aa-ffi-pin` bump PRs on each SDK repo
+(per the SDK-coordination SOP, AAASM-3007).

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -78,6 +78,7 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 | v0.0.1-beta.2 | v0.0.1-beta.2 (PyPI `0.0.1b2`) ✓ | v0.0.1-beta.2 ✓ | v0.0.1-beta.2 ✓ | protocol/v1 |
 | v0.0.1-beta.3 | v0.0.1-beta.3 (PyPI `0.0.1b3`) ✓ | v0.0.1-beta.3 ✓ | v0.0.1-beta.3 ✓ | protocol/v1 |
 | v0.0.1-beta.4 | v0.0.1-beta.5 (PyPI `0.0.1b5`) ✓ | v0.0.1-beta.5 ✓ | v0.0.1-beta.3 ✓ | protocol/v1 |
+| v0.0.1-rc.1 | v0.0.1-rc.1 (PyPI `0.0.1rc1`) ✓ | v0.0.1-rc.1 ✓ | v0.0.1-rc.1 ✓ | protocol/v1 |
 
 **Legend:**
 - ✓ Compatible — fully supported
@@ -85,6 +86,8 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 - ✗ Incompatible — do not use together
 
 > **Note (v0.0.1-beta.4):** components version independently — each repo advances its own pre-release iterator — so one `aa-runtime` release pairs with differently-numbered SDK releases while staying `protocol/v1`-compatible. `aa-runtime` v0.0.1-beta.4 ships alongside python-sdk `0.0.1b5` (git `v0.0.1-beta.5`) and node-sdk `v0.0.1-beta.5`; go-sdk remains at `v0.0.1-beta.3` (no new cut this wave).
+
+> **Note (v0.0.1-rc.1):** first release-candidate cut — a coordinated promotion to the `rc` channel across all components. `aa-runtime` v0.0.1-rc.1 pairs with python-sdk `0.0.1rc1`, node-sdk `v0.0.1-rc.1`, and go-sdk `v0.0.1-rc.1`, all `protocol/v1`-compatible. The SDK `rc.1` cuts follow this tag's `release.yml` fan-out (per the `aa-ffi-pin` SDK-coordination SOP).
 
 ---
 
@@ -120,6 +123,7 @@ A runtime version may support multiple protocol versions to allow SDK upgrades w
 | v0.0.1-beta.2 | protocol/v1 |
 | v0.0.1-beta.3 | protocol/v1 |
 | v0.0.1-beta.4 | protocol/v1 |
+| v0.0.1-rc.1 | protocol/v1 |
 
 ---
 


### PR DESCRIPTION
## Release prep for **v0.0.1-rc.1** (first release candidate; beta → rc channel promotion)

This is the **reversible prep PR** for the rc.1 cut. Merging it lands the version bump + sign-off on `master`; the **irreversible** `v0.0.1-rc.1` tag is then cut from merged master (paused for operator go).

### What changed
- **Workspace version** `0.0.1-beta.4` → `0.0.1-rc.1` (via `release-tag-cut.sh`).
- **Inter-crate path-dep pins realigned** `0.0.1-beta.2` → `0.0.1-rc.1` (40 literals). These had drifted to `beta.2` and were never re-caught by the bump helper (it only rewrites the current workspace literal), so `release-readiness.sh` check 5 was failing. Realigning to the release version is the check's prescribed remediation and gives crates.io exact-match version requirements. *(Latent-drift correction — flagged for awareness; `cargo check` green, build unaffected since path deps resolve by path.)*
- `Cargo.lock` regenerated.
- **Stage-0 security sign-off: `Verdict: PASS`** — `docs/release/security-signoff/v0.0.1-rc.1.md` (minor tier: `cargo deny advisories` ok, 0 CodeQL/Dependabot, the AAASM-3751 finding reclassified credential-token-mitigated + token-anchored defense-in-depth merged in #1252; no unaddressed Critical/High).
- Release notes `docs/release/v0.0.1-rc.1.md` + `CHANGELOG.md` entry.

### Readiness
`bash scripts/release-readiness.sh 0.0.1-rc.1` → CHANGELOG ✓, all 40 version literals ✓, sign-off PASS ✓. The remaining 3 (uncommitted / not-on-master / diverges) are PR-branch context and are satisfied when the tag is cut from merged master.

### Next (after merge, on operator go)
Cut `v0.0.1-rc.1` from master → `release.yml` fan-out (crates.io · GH Release · GHCR · Homebrew tap PR · SDK `aa-ffi-pin` bump PRs) → SDK rc.1 releases (dry-run first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)