### PR TITLE
[AAASM-3778] 👷 (ci): Enforce per-crate README in release-readiness

### DIFF
--- a/scripts/release-readiness.sh
+++ b/scripts/release-readiness.sh
@@ -5,7 +5,7 @@
 # Usage: bash scripts/release-readiness.sh <version>
 #   e.g. bash scripts/release-readiness.sh 0.0.1-alpha.5
 #
-# Runs 11 local checks that must all pass before pushing a release tag.
+# Runs 12 local checks that must all pass before pushing a release tag.
 # Each check prints ✓ <description> or ✗ <description>: <remediation hint>.
 # Exits non-zero on any failure.
 
@@ -146,6 +146,29 @@ elif grep -qE '^Verdict:[[:space:]]*PASS[[:space:]]*$' "$SIGNOFF"; then
   pass "Security-review sign-off present and Verdict: PASS ($SIGNOFF)"
 else
   fail "Security-review sign-off verdict is not PASS ($SIGNOFF)" "resolve High/Critical findings and re-run /release-security-gate $VERSION"
+fi
+
+# 12. Every published workspace crate has a README.md (AAASM-3778, Epic AAASM-3774).
+# crates.io renders the crate page from its README; a missing one ships a blank
+# package page. Enumerate members from [workspace].members (same source as the
+# version-literal check above) and skip crates marked `publish = false` — those are
+# never uploaded, so their READMEs are not release-gated.
+MEMBERS="$(awk '/^\[workspace\]/{w=1} w && /members[[:space:]]*=[[:space:]]*\[/{m=1; next} m && /\]/{m=0} m{gsub(/[",]/,""); gsub(/[[:space:]]/,""); if ($0 != "") print}' Cargo.toml)"
+MISSING_READMES=""
+for CRATE in $MEMBERS; do
+  if grep -qE '^[[:space:]]*publish[[:space:]]*=[[:space:]]*false' "$CRATE/Cargo.toml" 2>/dev/null; then
+    continue
+  fi
+  if [ ! -f "$CRATE/README.md" ]; then
+    MISSING_READMES="$MISSING_READMES $CRATE"
+  fi
+done
+if [ -z "$MISSING_READMES" ]; then
+  pass "All published crates have a README"
+else
+  for CRATE in $MISSING_READMES; do
+    fail "$CRATE has no README.md" "add $CRATE/README.md"
+  done
 fi
 
 echo


### PR DESCRIPTION
## Description

Adds a new release-readiness check (#12) to `scripts/release-readiness.sh` that
enforces a `README.md` for every **published** workspace crate. It enumerates
members from the root `Cargo.toml` `[workspace].members` (the same source as the
existing version-literal check), skips any crate marked `publish = false` (those
are never uploaded to crates.io, so their READMEs are not release-gated), and
fails the readiness run for each published crate missing a `README.md`.

crates.io renders the crate page from its README, so a missing one ships a blank
package page. This gate prevents the **Epic AAASM-3774** regression (published
crates without READMEs) from recurring at release time.

The check follows the surrounding style: `pass`/`fail` helpers, one `✓`/`✗` line
per result, and a tallied non-zero exit on any failure.

### Check added

```sh
# 12. Every published workspace crate has a README.md (AAASM-3778, Epic AAASM-3774).
MEMBERS="$(awk '/^\[workspace\]/{w=1} w && /members[[:space:]]*=[[:space:]]*\[/{m=1; next} m && /\]/{m=0} m{gsub(/[",]/,""); gsub(/[[:space:]]/,""); if ($0 != "") print}' Cargo.toml)"
MISSING_READMES=""
for CRATE in $MEMBERS; do
  if grep -qE '^[[:space:]]*publish[[:space:]]*=[[:space:]]*false' "$CRATE/Cargo.toml" 2>/dev/null; then
    continue
  fi
  if [ ! -f "$CRATE/README.md" ]; then
    MISSING_READMES="$MISSING_READMES $CRATE"
  fi
done
if [ -z "$MISSING_READMES" ]; then
  pass "All published crates have a README"
else
  for CRATE in $MISSING_READMES; do
    fail "$CRATE has no README.md" "add $CRATE/README.md"
  done
fi
```

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3778 (Epic AAASM-3774)

## Testing

- [x] Manual testing performed
- [x] No tests required (explain why)

`bash -n scripts/release-readiness.sh` passes. Ran
`bash scripts/release-readiness.sh 0.0.1-rc.1` in the worktree — the new check
**correctly reports the currently-missing READMEs** (it will pass once the README
PRs AAASM-3776 / AAASM-3777 merge):

```
✗ aa-core has no README.md: add aa-core/README.md
✗ aa-security has no README.md: add aa-security/README.md
✗ aa-storage has no README.md: add aa-storage/README.md
✗ aa-storage-memory has no README.md: add aa-storage-memory/README.md
✗ aa-storage-redis has no README.md: add aa-storage-redis/README.md
✗ aa-cache has no README.md: add aa-cache/README.md
✗ aa-storage-sqlite-buffer has no README.md: add aa-storage-sqlite-buffer/README.md
✗ aa-proto has no README.md: add aa-proto/README.md
✗ aa-runtime has no README.md: add aa-runtime/README.md
✗ aa-ebpf-common has no README.md: add aa-ebpf-common/README.md
✗ aa-proxy has no README.md: add aa-proxy/README.md
✗ aa-sandbox has no README.md: add aa-sandbox/README.md
✗ aa-gateway has no README.md: add aa-gateway/README.md
✗ aa-cli has no README.md: add aa-cli/README.md
```

`publish = false` crates (`aa-api`, `aa-wasm`, `aa-sdk-client`, `conformance`,
`aa-storage-postgres`, the `aa-devtool-*` set, `aa-integration-tests`,
`examples/aa-devtool-sample-myeditor`) are correctly skipped, and `aa-ebpf`
(which already has a README) is correctly not flagged.

Pass path verified by temporarily `touch`-ing the missing READMEs and re-running —
the check flips to:

```
✓ All published crates have a README
```

(the temporary files were removed; only `scripts/release-readiness.sh` is committed).

> NOTE: this check reports failures until the README PRs (AAASM-3776 / AAASM-3777)
> merge — that's expected; the readiness gate runs at release time.

## Checklist

- [x] Code follows project style guidelines (`bash -n` clean; matches surrounding check style)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (header check-count comment bumped to 12)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
