### PR TITLE
[AAASM-3777] 📝 (docs): Add READMEs for internal crates

### DIFF
--- a/aa-cache/README.md
+++ b/aa-cache/README.md
@@ -1,0 +1,16 @@
+# aa-cache
+
+In-process L1 cache wrapper (DashMap + TTL + stampede protection) for the Agent
+Assembly storage traits.
+
+[![crates.io](https://img.shields.io/crates/v/aa-cache?logo=rust&label=crates.io)](https://crates.io/crates/aa-cache)
+[![docs.rs](https://img.shields.io/docsrs/aa-cache?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-cache)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+Wraps any storage backend behind an in-process `DashMap` with a configurable TTL
+and per-key stampede protection, so policy lookups on the tool-call critical path
+hit memory instead of crossing the network to Postgres or the gateway. The wrapped
+store is abstracted by the `CacheSource` trait, so the cache is agnostic to what it
+fronts.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-cache/README.md
+++ b/aa-cache/README.md
@@ -13,4 +13,4 @@ hit memory instead of crossing the network to Postgres or the gateway. The wrapp
 store is abstracted by the `CacheSource` trait, so the cache is agnostic to what it
 fronts.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-ebpf-common/README.md
+++ b/aa-ebpf-common/README.md
@@ -11,4 +11,4 @@ crate is compiled twice — for the host target by `aa-ebpf` (userspace consumer
 and for the bpf target by `aa-ebpf-programs` (kernel producer). All types are
 `#[repr(C)]` and `Copy` so they cross the BPF ring buffer with no serialization.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-ebpf-common/README.md
+++ b/aa-ebpf-common/README.md
@@ -1,0 +1,14 @@
+# aa-ebpf-common
+
+Shared `no_std` types between eBPF kernel probes and userspace loader.
+
+[![crates.io](https://img.shields.io/crates/v/aa-ebpf-common?logo=rust&label=crates.io)](https://crates.io/crates/aa-ebpf-common)
+[![docs.rs](https://img.shields.io/docsrs/aa-ebpf-common?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-ebpf-common)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+The shared event types for Layer 3 (eBPF) of the interception model. This `no_std`
+crate is compiled twice — for the host target by `aa-ebpf` (userspace consumer)
+and for the bpf target by `aa-ebpf-programs` (kernel producer). All types are
+`#[repr(C)]` and `Copy` so they cross the BPF ring buffer with no serialization.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-proto/README.md
+++ b/aa-proto/README.md
@@ -1,0 +1,14 @@
+# aa-proto
+
+Generated protobuf/gRPC types for Agent Assembly (prost + tonic).
+
+[![crates.io](https://img.shields.io/crates/v/aa-proto?logo=rust&label=crates.io)](https://crates.io/crates/aa-proto)
+[![docs.rs](https://img.shields.io/docsrs/aa-proto?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-proto)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+The single code-generation entrypoint for every proto definition under `proto/`,
+and the single source of truth for the wire format. Other crates (`aa-runtime`,
+`aa-gateway`, …) depend on this crate rather than running their own prost/tonic
+codegen; the generated modules mirror the proto package hierarchy.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-proto/README.md
+++ b/aa-proto/README.md
@@ -11,4 +11,4 @@ and the single source of truth for the wire format. Other crates (`aa-runtime`,
 `aa-gateway`, …) depend on this crate rather than running their own prost/tonic
 codegen; the generated modules mirror the proto package hierarchy.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-proxy/README.md
+++ b/aa-proxy/README.md
@@ -1,0 +1,14 @@
+# aa-proxy
+
+Sidecar traffic interception proxy for Agent Assembly.
+
+[![crates.io](https://img.shields.io/crates/v/aa-proxy?logo=rust&label=crates.io)](https://crates.io/crates/aa-proxy)
+[![docs.rs](https://img.shields.io/docsrs/aa-proxy?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-proxy)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+Implements Layer 2 of the three-layer interception model: a sidecar proxy that
+sits alongside each AI agent process, intercepting outbound HTTPS traffic and
+enforcing governance policy before forwarding requests — with no code changes to
+the agent. Runs as a standalone binary or embedded in-process via `aa_proxy::run()`.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-proxy/README.md
+++ b/aa-proxy/README.md
@@ -11,4 +11,4 @@ sits alongside each AI agent process, intercepting outbound HTTPS traffic and
 enforcing governance policy before forwarding requests — with no code changes to
 the agent. Runs as a standalone binary or embedded in-process via `aa_proxy::run()`.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-runtime/README.md
+++ b/aa-runtime/README.md
@@ -11,4 +11,4 @@ environment — runtime initialization, shutdown coordination, and agent lifecyc
 hooks. The runtime is the authoritative enforcement point in the three-layer
 interception model.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-runtime/README.md
+++ b/aa-runtime/README.md
@@ -1,0 +1,14 @@
+# aa-runtime
+
+Tokio async runtime wrapper and lifecycle management for Agent Assembly.
+
+[![crates.io](https://img.shields.io/crates/v/aa-runtime?logo=rust&label=crates.io)](https://crates.io/crates/aa-runtime)
+[![docs.rs](https://img.shields.io/docsrs/aa-runtime?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-runtime)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+Wraps `tokio` to give Agent Assembly components a consistent async execution
+environment — runtime initialization, shutdown coordination, and agent lifecycle
+hooks. The runtime is the authoritative enforcement point in the three-layer
+interception model.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-sandbox/README.md
+++ b/aa-sandbox/README.md
@@ -11,4 +11,4 @@ the gateway, enforcing three independent isolation surfaces — filesystem allow
 (WASI preopened directories), CPU budget (instruction fuel), and memory ceiling —
 each surfaced as a deterministic `SandboxError`.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-sandbox/README.md
+++ b/aa-sandbox/README.md
@@ -1,0 +1,14 @@
+# aa-sandbox
+
+WebAssembly/WASI sandbox runtime for Agent Assembly tool execution.
+
+[![crates.io](https://img.shields.io/crates/v/aa-sandbox?logo=rust&label=crates.io)](https://crates.io/crates/aa-sandbox)
+[![docs.rs](https://img.shields.io/docsrs/aa-sandbox?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-sandbox)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+Hosts a `wasmtime`-based runtime that executes WASM-marked tools registered with
+the gateway, enforcing three independent isolation surfaces — filesystem allowlist
+(WASI preopened directories), CPU budget (instruction fuel), and memory ceiling —
+each surfaced as a deterministic `SandboxError`.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-security/README.md
+++ b/aa-security/README.md
@@ -13,4 +13,4 @@ types, and the canonical policy AST relied on by the trusted enforcement layers
 **leaf** crate with no `aa-core` dependency, so the shared policy AST is hosted
 here without a dependency cycle.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-security/README.md
+++ b/aa-security/README.md
@@ -1,0 +1,16 @@
+# aa-security
+
+Security primitives for Agent Assembly — credential scanning, redaction, and
+audit-normalization.
+
+[![crates.io](https://img.shields.io/crates/v/aa-security?logo=rust&label=crates.io)](https://crates.io/crates/aa-security)
+[![docs.rs](https://img.shields.io/docsrs/aa-security?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-security)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+Owns the credential-detection scanner, redaction primitives, audit-normalization
+types, and the canonical policy AST relied on by the trusted enforcement layers
+(`aa-runtime`, `aa-gateway`, `aa-proxy`, and the eBPF loader). Deliberately a
+**leaf** crate with no `aa-core` dependency, so the shared policy AST is hosted
+here without a dependency cycle.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-storage-memory/README.md
+++ b/aa-storage-memory/README.md
@@ -11,4 +11,4 @@ for unit/integration tests and local development without a real database. State 
 ephemeral — it lives only for the life of the process — and the driver registers
 under the name `memory` for selection via `agent-assembly.toml`.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-storage-memory/README.md
+++ b/aa-storage-memory/README.md
@@ -1,0 +1,14 @@
+# aa-storage-memory
+
+In-memory `aa-storage` driver (DashMap-backed) for tests and local development.
+
+[![crates.io](https://img.shields.io/crates/v/aa-storage-memory?logo=rust&label=crates.io)](https://crates.io/crates/aa-storage-memory)
+[![docs.rs](https://img.shields.io/docsrs/aa-storage-memory?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-storage-memory)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+`DashMap`- and `parking_lot`-backed implementations of the six `aa-storage` traits
+for unit/integration tests and local development without a real database. State is
+ephemeral — it lives only for the life of the process — and the driver registers
+under the name `memory` for selection via `agent-assembly.toml`.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-storage-redis/README.md
+++ b/aa-storage-redis/README.md
@@ -11,4 +11,4 @@ Implements the high-frequency `aa-storage` traits (`SessionStore`,
 instance, so multiple Assembly processes coordinate through one shared L2 cache
 instead of each hitting the L3 store. All keys are namespaced under `aa:`.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-storage-redis/README.md
+++ b/aa-storage-redis/README.md
@@ -1,0 +1,14 @@
+# aa-storage-redis
+
+Redis L2 shared-cache storage driver for Agent Assembly.
+
+[![crates.io](https://img.shields.io/crates/v/aa-storage-redis?logo=rust&label=crates.io)](https://crates.io/crates/aa-storage-redis)
+[![docs.rs](https://img.shields.io/docsrs/aa-storage-redis?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-storage-redis)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+Implements the high-frequency `aa-storage` traits (`SessionStore`,
+`RateLimitCounter`, and a read-through `PolicyStore`) against a Redis or Valkey
+instance, so multiple Assembly processes coordinate through one shared L2 cache
+instead of each hitting the L3 store. All keys are namespaced under `aa:`.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-storage-sqlite-buffer/README.md
+++ b/aa-storage-sqlite-buffer/README.md
@@ -1,0 +1,15 @@
+# aa-storage-sqlite-buffer
+
+Local in-process SQLite event buffer that survives brief gateway/queue outages and
+flushes audit events on reconnect.
+
+[![crates.io](https://img.shields.io/crates/v/aa-storage-sqlite-buffer?logo=rust&label=crates.io)](https://crates.io/crates/aa-storage-sqlite-buffer)
+[![docs.rs](https://img.shields.io/docsrs/aa-storage-sqlite-buffer?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-storage-sqlite-buffer)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+A single WAL-mode SQLite file that buffers governance `AuditEntry` records when the
+upstream NATS/gateway is briefly unreachable, then flushes the backlog in insertion
+order on reconnect. Buffered events survive a process restart, giving Assembly
+partial autonomy so a transient outage never silently loses audit-trail data.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-storage-sqlite-buffer/README.md
+++ b/aa-storage-sqlite-buffer/README.md
@@ -12,4 +12,4 @@ upstream NATS/gateway is briefly unreachable, then flushes the backlog in insert
 order on reconnect. Buffered events survive a process restart, giving Assembly
 partial autonomy so a transient outage never silently loses audit-trail data.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-storage/README.md
+++ b/aa-storage/README.md
@@ -12,4 +12,4 @@ A thin facade over `aa_core::storage` that re-exports the storage trait contract
 driver crates can express "I implement the storage contract" without coupling to
 the rest of `aa-core`.
 
-Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-storage/README.md
+++ b/aa-storage/README.md
@@ -1,0 +1,15 @@
+# aa-storage
+
+Storage trait abstraction (pure interface) for the Agent Assembly persistence layer.
+
+[![crates.io](https://img.shields.io/crates/v/aa-storage?logo=rust&label=crates.io)](https://crates.io/crates/aa-storage)
+[![docs.rs](https://img.shields.io/docsrs/aa-storage?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-storage)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+A thin facade over `aa_core::storage` that re-exports the storage trait contract
+(`PolicyStore`, `AuditSink`, `SessionStore`, `CredentialStore`, `RateLimitCounter`,
+`LifecycleStore`). It is a pure interface with no concrete backend dependency, so
+driver crates can express "I implement the storage contract" without coupling to
+the rest of `aa-core`.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://ai-agent-assembly.github.io/agent-assembly-docs/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -6,7 +6,7 @@ This book is the contributor and operator reference for the core. If you build *
 
 New here? Start with the **[Introduction](introduction/README.md)** — it explains what Agent Assembly is, the problem it solves, the core concepts, and the three-layer interception model. Then move on to the [Quick Start](quick-start/requirements.md).
 
-> **Other docs:** [Docs Hub](https://ai-agent-assembly.github.io/agent-assembly-docs/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
+> **Other docs:** [Docs Hub](https://docs.agent-assembly.com/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
 
 ## Run it locally
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -6,7 +6,7 @@ This book is the contributor and operator reference for the core. If you build *
 
 New here? Start with the **[Introduction](introduction/README.md)** — it explains what Agent Assembly is, the problem it solves, the core concepts, and the three-layer interception model. Then move on to the [Quick Start](quick-start/requirements.md).
 
-> **Other docs:** [Docs Hub](https://docs.agent-assembly.com/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
+> **Other docs:** [Docs Hub](https://ai-agent-assembly.github.io/agent-assembly-docs/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
 
 ## Run it locally
 


### PR DESCRIPTION
## Description

Adds a concise `README.md` to each of the 11 internal/infra crates that are
published from the monorepo but previously had no crate-level README (so their
crates.io / docs.rs pages had no landing text). Each README carries the crate
title + `Cargo.toml` description, the dynamic badge strip (crates.io version,
docs.rs, Apache-2.0 license), 1–2 sentences on the crate's role in the
three-layer Agent Assembly architecture (sourced from each crate's `Cargo.toml`
description and `src/lib.rs` module docs), and a "Part of Agent Assembly" links
line. `cargo` auto-detects `README.md`, so each is now packaged with its crate.

READMEs added:

- `aa-runtime/README.md`
- `aa-proxy/README.md`
- `aa-sandbox/README.md`
- `aa-security/README.md`
- `aa-proto/README.md`
- `aa-ebpf-common/README.md`
- `aa-storage/README.md`
- `aa-storage-memory/README.md`
- `aa-storage-redis/README.md`
- `aa-storage-sqlite-buffer/README.md`
- `aa-cache/README.md`

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3777

Closes AAASM-3777

## Testing

- [x] No tests required (docs-only; verified each crate packages its README via `cargo package --list -p <crate> --allow-dirty | grep README.md`)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
