### PR TITLE
[AAASM-3776] 📝 (docs): Add READMEs for developer-facing crates

### DIFF
--- a/aa-cli/README.md
+++ b/aa-cli/README.md
@@ -1,0 +1,73 @@
+# aa-cli
+
+`aasm` — the command-line tool for Agent Assembly.
+
+[![crates.io](https://img.shields.io/crates/v/aa-cli?logo=rust&label=crates.io)](https://crates.io/crates/aa-cli)
+[![docs.rs](https://img.shields.io/docsrs/aa-cli?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-cli)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](../LICENSE)
+[![Rust](https://img.shields.io/badge/rust-%E2%89%A51.75-orange?logo=rust)](https://www.rust-lang.org)
+
+## What is this
+
+`aa-cli` is the operator front-end for [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly),
+the governance-native runtime for AI agents. It ships the **`aasm`** binary — the
+terminal entry point for inspecting agent topology, managing policies, watching
+the audit trail, and driving the governance gateway.
+
+Agent Assembly enforces governance across three independently-deployable
+interception layers (in-process SDK shim, sidecar proxy, and eBPF). `aasm` is how
+an operator observes and controls that system from the command line, talking to
+the gateway over its HTTP/OpenAPI surface.
+
+## Install
+
+The recommended way to get the `aasm` binary is the one-line installer, which
+downloads the matching pre-built release tarball, verifies its checksum, and
+installs to `~/.local/bin`:
+
+```sh
+curl -fsSL https://agent-assembly.com/install.sh | sh
+```
+
+Pin a specific version with `AASM_VERSION`:
+
+```sh
+AASM_VERSION=v0.0.1-beta.4 curl -sSf https://agent-assembly.com/install.sh | sh
+```
+
+Or build/install from source via cargo:
+
+```sh
+cargo install aa-cli
+```
+
+Then confirm the install:
+
+```sh
+aasm --help
+```
+
+## Usage
+
+```sh
+# Show the agent topology
+aasm topology
+
+# Manage governance policies
+aasm policy --help
+
+# Launch the operator dashboard (TUI)
+aasm dashboard
+
+# Tail the audit log
+aasm audit
+```
+
+Run `aasm <command> --help` for the full set of subcommands (`agent`, `policy`,
+`audit`, `budget`, `cost`, `gateway`, `proxy`, `sandbox`, `topology`, and more).
+
+## Links
+
+- Documentation: <https://ai-agent-assembly.github.io/agent-assembly-docs/>
+- Source: <https://github.com/ai-agent-assembly/agent-assembly>
+- License: [Apache-2.0](../LICENSE)

--- a/aa-cli/README.md
+++ b/aa-cli/README.md
@@ -68,6 +68,6 @@ Run `aasm <command> --help` for the full set of subcommands (`agent`, `policy`,
 
 ## Links
 
-- Documentation: <https://ai-agent-assembly.github.io/agent-assembly-docs/>
+- Documentation: <https://docs.agent-assembly.com/>
 - Source: <https://github.com/ai-agent-assembly/agent-assembly>
 - License: [Apache-2.0](../LICENSE)

--- a/aa-core/README.md
+++ b/aa-core/README.md
@@ -1,0 +1,61 @@
+# aa-core
+
+Pure domain logic for Agent Assembly — `no_std` compatible.
+
+[![crates.io](https://img.shields.io/crates/v/aa-core?logo=rust&label=crates.io)](https://crates.io/crates/aa-core)
+[![docs.rs](https://img.shields.io/docsrs/aa-core?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-core)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](../LICENSE)
+[![Rust](https://img.shields.io/badge/rust-%E2%89%A51.75-orange?logo=rust)](https://www.rust-lang.org)
+
+## What is this
+
+`aa-core` is the foundational crate of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly),
+the governance-native runtime for AI agents. It holds the shared domain types,
+traits, and pure logic that every other layer of the system depends on — agent
+identity, policy decisions, risk tiers, capabilities, and the audit model.
+
+It has **no runtime or I/O dependencies** and is `no_std` compatible, so the same
+types flow unchanged through the gateway, the runtime, the FFI shims the language
+SDKs bind to, and the operator CLI. Anything used across layers lives here.
+
+## Install
+
+```sh
+cargo add aa-core
+```
+
+### Feature flags
+
+| Feature | Default | Purpose |
+|---|---|---|
+| `std` | yes | `std`-dependent convenience impls and types (config, storage, scanner) |
+| `alloc` | via `std` | heap types (`String`, `Vec`, `BTreeMap`) for `no_std` builds |
+| `serde` | no | `Serialize`/`Deserialize` derives on the core types |
+| `schemars` | no | `JsonSchema` derives |
+| `test-utils` | no | exposes `PermitAllEvaluator` / `DenyAllEvaluator` for downstream tests |
+
+For a `no_std` build, disable default features and opt back into `alloc`:
+
+```sh
+cargo add aa-core --no-default-features --features alloc
+```
+
+## Usage
+
+```rust
+use aa_core::{AgentId, PolicyDecision, RiskTier};
+
+// AgentId is an opaque 16-byte (UUID v4) identifier.
+let agent = AgentId::from_bytes([0u8; 16]);
+let tier = RiskTier::default();
+let decision = PolicyDecision::Allow;
+```
+
+See the [API documentation](https://docs.rs/aa-core) for the full set of domain
+types (`agent`, `policy`, `capability`, `audit`, `identity`, `risk_tier`, …).
+
+## Links
+
+- Documentation: <https://ai-agent-assembly.github.io/agent-assembly-docs/>
+- Source: <https://github.com/ai-agent-assembly/agent-assembly>
+- License: [Apache-2.0](../LICENSE)

--- a/aa-core/README.md
+++ b/aa-core/README.md
@@ -56,6 +56,6 @@ types (`agent`, `policy`, `capability`, `audit`, `identity`, `risk_tier`, …).
 
 ## Links
 
-- Documentation: <https://ai-agent-assembly.github.io/agent-assembly-docs/>
+- Documentation: <https://docs.agent-assembly.com/>
 - Source: <https://github.com/ai-agent-assembly/agent-assembly>
 - License: [Apache-2.0](../LICENSE)

--- a/aa-gateway/README.md
+++ b/aa-gateway/README.md
@@ -47,6 +47,6 @@ as a service.
 
 ## Links
 
-- Documentation: <https://ai-agent-assembly.github.io/agent-assembly-docs/>
+- Documentation: <https://docs.agent-assembly.com/>
 - Source: <https://github.com/ai-agent-assembly/agent-assembly>
 - License: [Apache-2.0](../LICENSE)

--- a/aa-gateway/README.md
+++ b/aa-gateway/README.md
@@ -1,0 +1,52 @@
+# aa-gateway
+
+Control plane — policy enforcement engine and agent registry for Agent Assembly.
+
+[![crates.io](https://img.shields.io/crates/v/aa-gateway?logo=rust&label=crates.io)](https://crates.io/crates/aa-gateway)
+[![docs.rs](https://img.shields.io/docsrs/aa-gateway?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-gateway)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](../LICENSE)
+[![Rust](https://img.shields.io/badge/rust-%E2%89%A51.75-orange?logo=rust)](https://www.rust-lang.org)
+
+## What is this
+
+`aa-gateway` is the brain of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly),
+the governance-native runtime for AI agents. It is the central coordination point:
+it maintains the **agent registry**, evaluates **governance policies**, tracks
+**per-team budgets**, routes enforcement decisions back to the proxy and SDK
+shims, and writes the audit trail.
+
+Agent Assembly enforces governance through three independently-deployable
+interception layers (in-process SDK shim, sidecar proxy, eBPF). The gateway sits
+behind all of them — exposing **gRPC** for the SDK shims and an **HTTP/OpenAPI**
+surface (via `aa-api`) for the dashboard and operator tooling.
+
+The crate ships both a library and the `aa-gateway` binary.
+
+## Install
+
+```sh
+cargo add aa-gateway
+```
+
+The Redis-backed policy cache is behind an off-by-default feature:
+
+```sh
+cargo add aa-gateway --features redis-cache
+```
+
+## Usage
+
+```rust
+use aa_gateway::{AgentRegistry, PolicyEngine};
+```
+
+`PolicyEngine` loads and evaluates governance policies; `AgentRegistry` tracks
+registered agents and their status. See the [API documentation](https://docs.rs/aa-gateway)
+for how to construct and wire them, and the project docs for running the gateway
+as a service.
+
+## Links
+
+- Documentation: <https://ai-agent-assembly.github.io/agent-assembly-docs/>
+- Source: <https://github.com/ai-agent-assembly/agent-assembly>
+- License: [Apache-2.0](../LICENSE)

--- a/aa-sdk-client/README.md
+++ b/aa-sdk-client/README.md
@@ -55,6 +55,6 @@ the crate's API docs and the language SDKs for end-to-end usage.
 
 ## Links
 
-- Documentation: <https://ai-agent-assembly.github.io/agent-assembly-docs/>
+- Documentation: <https://docs.agent-assembly.com/>
 - Source: <https://github.com/ai-agent-assembly/agent-assembly>
 - License: [Apache-2.0](../LICENSE)

--- a/aa-sdk-client/README.md
+++ b/aa-sdk-client/README.md
@@ -1,0 +1,60 @@
+# aa-sdk-client
+
+Shared SDK runtime-client for Agent Assembly — UDS transport, IPC wire codec,
+`AssemblyClient` lifecycle, and advisory credential preflight.
+
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](../LICENSE)
+[![Rust](https://img.shields.io/badge/rust-%E2%89%A51.75-orange?logo=rust)](https://www.rust-lang.org)
+
+> **Not published to crates.io.** This crate is distributed to the external SDK
+> shims as a **git-SHA pin** (ADR 0002), so it is `publish = false`. Add it as a
+> git dependency rather than via `cargo add`.
+
+## What is this
+
+`aa-sdk-client` is the single, FFI-agnostic implementation of the agent-side SDK
+runtime client for [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly),
+the governance-native runtime for AI agents. It provides the Unix-domain-socket
+transport, the IPC wire codec, the `AssemblyClient` lifecycle, and event
+capture/shipping to the runtime.
+
+It is Layer 1 (the in-process SDK layer) of the three-layer interception model.
+The thin per-language FFI shims (`aa-ffi-python`, `aa-ffi-node`, `aa-ffi-go`) are
+wrappers over this crate, so the transport/codec/lifecycle logic lives in exactly
+one place and cannot drift between languages.
+
+### Trust model
+
+The SDK is **untrusted** and is **not** a security boundary. Authoritative
+credential scanning, redaction, and normalization happen at the mandatory runtime
+chokepoint (`aa-runtime`), which re-scans every event unconditionally. Any
+credential preflight this crate performs (behind the default `preflight` feature)
+is **advisory, best-effort only**.
+
+## Install
+
+Because the crate is git-pinned, depend on it from a Git revision:
+
+```toml
+[dependencies]
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly", rev = "<commit-sha>" }
+```
+
+Disable the advisory preflight (drops the `aa-security` dependency) with
+`default-features = false`.
+
+## Usage
+
+```rust
+use aa_sdk_client::{AssemblyClient, AssemblyConfig};
+```
+
+`AssemblyConfig` resolves the socket/transport configuration and `AssemblyClient`
+drives the connection lifecycle and ships governance events to the runtime. See
+the crate's API docs and the language SDKs for end-to-end usage.
+
+## Links
+
+- Documentation: <https://ai-agent-assembly.github.io/agent-assembly-docs/>
+- Source: <https://github.com/ai-agent-assembly/agent-assembly>
+- License: [Apache-2.0](../LICENSE)

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -6,7 +6,7 @@ This book is the contributor and operator reference for the core. If you build *
 
 New here? Start with the **[Introduction](introduction/README.md)** — it explains what Agent Assembly is, the problem it solves, the core concepts, and the three-layer interception model. Then move on to the [Quick Start](quick-start/requirements.md).
 
-> **Other docs:** [Docs Hub](https://ai-agent-assembly.github.io/agent-assembly-docs/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
+> **Other docs:** [Docs Hub](https://docs.agent-assembly.com/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
 
 ## Run it locally
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -6,7 +6,7 @@ This book is the contributor and operator reference for the core. If you build *
 
 New here? Start with the **[Introduction](introduction/README.md)** — it explains what Agent Assembly is, the problem it solves, the core concepts, and the three-layer interception model. Then move on to the [Quick Start](quick-start/requirements.md).
 
-> **Other docs:** [Docs Hub](https://docs.agent-assembly.com/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
+> **Other docs:** [Docs Hub](https://ai-agent-assembly.github.io/agent-assembly-docs/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
 
 ## Run it locally
 


### PR DESCRIPTION
## Description

Adds hand-written `README.md` files for the four developer-facing crates in the
monorepo — `aa-cli`, `aa-core`, `aa-sdk-client`, and `aa-gateway`. Each README
follows the house style established by `aa-ebpf/README.md` (H1 + one-line summary
from the crate's `Cargo.toml` `description`, a dynamic/live badge strip, a "What
is this" paragraph placing the crate in the three-layer architecture, an
**Install** section, a minimal accurate **Usage** snippet, and **Links**).

- **aa-cli** — `aasm` operator binary; install via the `install.sh` one-liner /
  `cargo install aa-cli`, plus `aasm --help` and common subcommands.
- **aa-core** — pure `no_std` domain logic; `cargo add aa-core`, feature-flag
  table, and an accurate `AgentId::from_bytes` / `PolicyDecision` snippet.
- **aa-sdk-client** — shared SDK runtime-client; documented as **`publish = false`**
  (git-SHA pinned per ADR 0002), so Install shows the git-dependency form, and the
  untrusted/advisory trust model is called out.
- **aa-gateway** — control-plane brain; `cargo add aa-gateway`, the `redis-cache`
  feature, and `PolicyEngine` / `AgentRegistry` imports.

cargo auto-detects `README.md` in each crate directory, so these will render on
crates.io / docs.rs on the next release — no `Cargo.toml` change required.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3776

## Testing

Verified with `cargo package --list -p <crate>` for each crate — `README.md`
appears in the packaged file list for `aa-cli`, `aa-core`, `aa-sdk-client`, and
`aa-gateway`. Documentation-only change; no code touched.

- [x] No tests required (explain why) — documentation-only; verified packaging picks up each README.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3776

🤖 Generated with [Claude Code](https://claude.com/claude-code)
