### PR TITLE
[AAASM-3803] 🔧 (ci): Restore dashboard LCOV ingestion for SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1243,30 +1243,44 @@ jobs:
           echo "Backfilling rust-coverage-lcov from master run ${run_id}."
           gh run download "$run_id" --name rust-coverage-lcov --dir . \
             || echo "::warning::rust-coverage-lcov artifact unavailable on run ${run_id} (expired/absent); scanning without it."
-      # ---- TypeScript coverage (generated fresh in-job) ---------------------
-      # AAASM-3803: the dashboard LCOV used to be pulled from the `dashboard-test`
-      # artifact (with an AAASM-3197 cross-run backfill). When that artifact was
-      # expired/absent — common on the billing-throttled scan — the step degraded
-      # to a soft `::warning:: ... scanning without it`, so Sonar scanned with NO
-      # dashboard coverage and dashboard/src reported 0.0%. Generating the LCOV
-      # here makes it unconditionally present, which also preserves the AAASM-3197
-      # full-snapshot invariant (a Rust-only push no longer wipes dashboard
-      # coverage to 0) without depending on any cross-run artifact.
+      # ---- TypeScript coverage ---------------------------------------------
+      # AAASM-3803 (Option C): prefer the SAME-RUN `dashboard-test` artifact and
+      # only regenerate in-job when that job did not run this build. Same-run
+      # artifacts never expire, so the download is reliable — unlike the previous
+      # cross-run backfill, which degraded to a soft `::warning:: ... scanning
+      # without it` when the artifact was expired/absent (common on the
+      # billing-throttled scan), letting Sonar scan with 0.0% dashboard coverage.
+      # This avoids re-running the dashboard tests on the common path (a dashboard
+      # PR, where `dashboard-test` already ran) while still guaranteeing coverage
+      # on a Rust-only master push (where `dashboard-test` is path-skipped but the
+      # AAASM-3197 full-snapshot invariant still requires dashboard coverage).
+      - name: Download TypeScript coverage (LCOV) from the Dashboard test job
+        if: needs.dashboard-test.result == 'success'
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: dashboard-coverage-lcov
+          path: dashboard/coverage
+      # Fallback — regenerate only when `dashboard-test` was skipped/failed.
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        if: needs.dashboard-test.result != 'success'
         with:
           version: 10.9.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: needs.dashboard-test.result != 'success'
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: dashboard/pnpm-lock.yaml
-      - name: Install dashboard dependencies
+      - name: Install dashboard dependencies (fallback)
+        if: needs.dashboard-test.result != 'success'
         working-directory: dashboard
         run: pnpm install --frozen-lockfile
-      - name: Generate API types from OpenAPI spec
+      - name: Generate API types from OpenAPI spec (fallback)
+        if: needs.dashboard-test.result != 'success'
         working-directory: dashboard
         run: pnpm generate:api
-      - name: Generate TypeScript coverage (LCOV) for SonarCloud
+      - name: Generate TypeScript coverage (LCOV) for SonarCloud (fallback)
+        if: needs.dashboard-test.result != 'success'
         working-directory: dashboard
         run: pnpm test:coverage
       # ---- Scan -------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1243,33 +1243,32 @@ jobs:
           echo "Backfilling rust-coverage-lcov from master run ${run_id}."
           gh run download "$run_id" --name rust-coverage-lcov --dir . \
             || echo "::warning::rust-coverage-lcov artifact unavailable on run ${run_id} (expired/absent); scanning without it."
-      # ---- TypeScript coverage (only when the dashboard side ran) ------------
-      - name: Download TypeScript coverage (LCOV) from the Dashboard test job
-        if: needs.dashboard-test.result == 'success'
-        uses: actions/download-artifact@v8.0.1
+      # ---- TypeScript coverage (generated fresh in-job) ---------------------
+      # AAASM-3803: the dashboard LCOV used to be pulled from the `dashboard-test`
+      # artifact (with an AAASM-3197 cross-run backfill). When that artifact was
+      # expired/absent — common on the billing-throttled scan — the step degraded
+      # to a soft `::warning:: ... scanning without it`, so Sonar scanned with NO
+      # dashboard coverage and dashboard/src reported 0.0%. Generating the LCOV
+      # here makes it unconditionally present, which also preserves the AAASM-3197
+      # full-snapshot invariant (a Rust-only push no longer wipes dashboard
+      # coverage to 0) without depending on any cross-run artifact.
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          name: dashboard-coverage-lcov
-          path: dashboard/coverage
-      # AAASM-3197: symmetric backfill for the TypeScript side. When
-      # `dashboard-test` was skipped or failed on a push (Rust-only change),
-      # pull `dashboard/coverage/lcov.info` from the last successful master run
-      # so the full-snapshot scan does not wipe dashboard coverage to 0.
-      - name: Backfill TypeScript coverage (LCOV) from last successful master run
-        if: ${{ github.event_name == 'push' && needs.dashboard-test.result != 'success' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          run_id="$(gh run list --workflow ci.yml --branch master \
-            --status success --limit 1 --json databaseId \
-            --jq '.[0].databaseId')"
-          if [ -z "$run_id" ]; then
-            echo "::warning::No prior successful master CI run found; scanning without backfilled TypeScript LCOV."
-            exit 0
-          fi
-          echo "Backfilling dashboard-coverage-lcov from master run ${run_id}."
-          gh run download "$run_id" --name dashboard-coverage-lcov --dir dashboard/coverage \
-            || echo "::warning::dashboard-coverage-lcov artifact unavailable on run ${run_id} (expired/absent); scanning without it."
+          version: 10.9.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Install dashboard dependencies
+        working-directory: dashboard
+        run: pnpm install --frozen-lockfile
+      - name: Generate API types from OpenAPI spec
+        working-directory: dashboard
+        run: pnpm generate:api
+      - name: Generate TypeScript coverage (LCOV) for SonarCloud
+        working-directory: dashboard
+        run: pnpm test:coverage
       # ---- Scan -------------------------------------------------------------
       - name: Cache SonarCloud analysis state
         uses: actions/cache@v6


### PR DESCRIPTION
## Description

Fixes the agent-assembly CI so the dashboard coverage LCOV reliably reaches SonarCloud. SonarCloud reported `dashboard/src` at **0.0%** (3,915 lines all counted uncovered) despite merged vitest tests.

**Root cause:** the SonarCloud (`sonar`) job in `.github/workflows/ci.yml` obtained `dashboard/coverage/lcov.info` by downloading the `dashboard-coverage-lcov` artifact from the `dashboard-test` job and backfilling from the last successful master run (AAASM-3197). When that artifact was expired/absent — common on the billing-throttled scan — the backfill step degraded to a soft `::warning:: ... scanning without it`, so Sonar scanned with **no** dashboard coverage and reported 0.0%. (`sonar-project.properties` correctly points `sonar.javascript.lcov.reportPaths` at `dashboard/coverage/lcov.info`.)

**Fix:** generate the dashboard LCOV **fresh in the Sonar job** (`pnpm install --frozen-lockfile` + `pnpm generate:api` + `pnpm test:coverage`) instead of relying on a cross-run artifact download. The LCOV is now unconditionally present at scan time. This also preserves the AAASM-3197 full-snapshot invariant — a Rust-only push no longer wipes dashboard coverage to 0 — without any artifact dependency. The Rust LCOV path (cargo-llvm-cov via the `coverage` job + its backfill) is untouched.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3803 (Story AAASM-3798, Epic AAASM-3797)

## Testing

- [x] Manual testing performed
- [x] No tests required (CI workflow change)

Verified locally in `dashboard/`: `pnpm install --frozen-lockfile` + `pnpm generate:api` + `pnpm test:coverage` all exit 0 and produce a non-empty `dashboard/coverage/lcov.info` (199 KB, 14,357 lines with real `DA:` hit data). `actionlint .github/workflows/ci.yml` passes clean (exit 0).

> Note: SonarCloud's dashboard coverage % only updates after this merges and the next master scan runs.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
