### PR TITLE
[AAASM-3806] ✅ (aa-gateway,aa-proxy): Raise test coverage to ≥95%

### DIFF
--- a/aa-gateway/src/policy/rbac.rs
+++ b/aa-gateway/src/policy/rbac.rs
@@ -252,4 +252,34 @@ mod tests {
             PolicyScopeKind::Tool
         );
     }
+
+    // ── Display impls (audit/log rendering) ─────────────────────────────────
+    //
+    // These string forms land in audit records and tracing lines, so the
+    // snake_case spelling is a contract, not an implementation detail.
+
+    #[test]
+    fn policy_scope_kind_display_uses_snake_case_labels() {
+        assert_eq!(PolicyScopeKind::Global.to_string(), "global");
+        assert_eq!(PolicyScopeKind::Org.to_string(), "org");
+        assert_eq!(PolicyScopeKind::Team.to_string(), "team");
+        assert_eq!(PolicyScopeKind::Agent.to_string(), "agent");
+        assert_eq!(PolicyScopeKind::Tool.to_string(), "tool");
+    }
+
+    #[test]
+    fn mutation_kind_display_uses_lowercase_verbs() {
+        assert_eq!(MutationKind::Create.to_string(), "create");
+        assert_eq!(MutationKind::Update.to_string(), "update");
+        assert_eq!(MutationKind::Delete.to_string(), "delete");
+    }
+
+    #[test]
+    fn caller_role_display_uses_snake_case_labels() {
+        assert_eq!(CallerRole::OrgAdmin.to_string(), "org_admin");
+        assert_eq!(CallerRole::TeamAdmin.to_string(), "team_admin");
+        assert_eq!(CallerRole::Developer.to_string(), "developer");
+        assert_eq!(CallerRole::Viewer.to_string(), "viewer");
+        assert_eq!(CallerRole::Auditor.to_string(), "auditor");
+    }
 }

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -1273,4 +1273,114 @@ spec:
             out.warnings,
         );
     }
+
+    // ── Schedule active_hours missing/unknown fields ────────────────────────
+
+    #[test]
+    fn schedule_unknown_key_produces_warning() {
+        let yaml = "schedule:\n  surprise: 1\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(
+            out.warnings.iter().any(|w| w.field == "schedule.surprise"),
+            "expected warning for unknown schedule key, got: {:?}",
+            out.warnings,
+        );
+    }
+
+    #[test]
+    fn schedule_active_hours_unknown_key_produces_warning() {
+        let yaml = "schedule:\n  active_hours:\n    start: \"09:00\"\n    end: \"18:00\"\n    timezone: \"UTC\"\n    surprise: 1\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(
+            out.warnings.iter().any(|w| w.field == "schedule.active_hours.surprise"),
+            "expected warning for unknown active_hours key, got: {:?}",
+            out.warnings,
+        );
+    }
+
+    #[test]
+    fn schedule_missing_start_is_an_error() {
+        let yaml = "schedule:\n  active_hours:\n    end: \"18:00\"\n    timezone: \"UTC\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "schedule.active_hours.start"));
+    }
+
+    #[test]
+    fn schedule_invalid_end_format_is_an_error() {
+        let yaml = "schedule:\n  active_hours:\n    start: \"09:00\"\n    end: \"6pm\"\n    timezone: \"UTC\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "schedule.active_hours.end"));
+    }
+
+    #[test]
+    fn schedule_missing_end_is_an_error() {
+        let yaml = "schedule:\n  active_hours:\n    start: \"09:00\"\n    timezone: \"UTC\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "schedule.active_hours.end"));
+    }
+
+    #[test]
+    fn schedule_missing_timezone_is_an_error() {
+        let yaml = "schedule:\n  active_hours:\n    start: \"09:00\"\n    end: \"18:00\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "schedule.active_hours.timezone"));
+    }
+
+    #[test]
+    fn schedule_start_without_colon_is_rejected() {
+        // is_hhmm must reject a value with no ':' separator (e.g. "0900").
+        let yaml = "schedule:\n  active_hours:\n    start: \"0900\"\n    end: \"18:00\"\n    timezone: \"UTC\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "schedule.active_hours.start"));
+    }
+
+    #[test]
+    fn schedule_start_with_non_numeric_components_is_rejected() {
+        // is_hhmm must reject non-numeric HH/MM components (e.g. "ab:cd").
+        let yaml = "schedule:\n  active_hours:\n    start: \"ab:cd\"\n    end: \"18:00\"\n    timezone: \"UTC\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "schedule.active_hours.start"));
+    }
+
+    // ── Budget sub-day window (AAASM-1600) ──────────────────────────────────
+
+    #[test]
+    fn budget_window_valid_humantime_round_trips() {
+        let yaml = "budget:\n  daily_limit_usd: 10.0\n  window: \"30m\"\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let bp = out.document.budget.unwrap();
+        assert_eq!(bp.window, Some(std::time::Duration::from_secs(30 * 60)));
+    }
+
+    #[test]
+    fn budget_window_zero_duration_is_an_error() {
+        let yaml = "budget:\n  daily_limit_usd: 10.0\n  window: \"0s\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "budget.window"),
+            "zero window must be rejected, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn budget_window_unparseable_is_an_error() {
+        let yaml = "budget:\n  daily_limit_usd: 10.0\n  window: \"not-a-duration\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "budget.window"),
+            "unparseable window must be rejected, got: {errs:?}"
+        );
+    }
+
+    // ── Capabilities deny-list validation ───────────────────────────────────
+
+    #[test]
+    fn capabilities_invalid_deny_entry_is_an_error() {
+        let yaml = "capabilities:\n  deny:\n    - \"not::a::capability\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "capabilities.deny[0]"),
+            "invalid deny capability must be rejected, got: {errs:?}"
+        );
+    }
 }

--- a/aa-gateway/src/sanitizer/event.rs
+++ b/aa-gateway/src/sanitizer/event.rs
@@ -59,6 +59,28 @@ impl SanitizedAuditEvent {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn raw_audit_event_from_value_wraps_without_mutation() {
+        // The `From<Value>` ergonomic constructor must wrap the value verbatim:
+        // wrapping is a trust-boundary marker only — it performs no sanitization,
+        // so the inner value is byte-for-byte the untrusted input.
+        let value = json!({ "event": "tool_call", "secret_field": "leak-me" });
+        let raw: RawAuditEvent = value.clone().into();
+        assert_eq!(raw.into_value(), value);
+    }
+
+    #[test]
+    fn raw_audit_event_new_and_from_are_equivalent() {
+        let value = json!({ "k": 1 });
+        assert_eq!(RawAuditEvent::from(value.clone()), RawAuditEvent::new(value));
+    }
+}
+
 /// A collapsed heartbeat. Per-beat records are never stored; instead a
 /// heartbeat event becomes a single "last seen at" update on the agent row.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -425,4 +425,65 @@ mod tests {
         assert_eq!(resp.decision, Decision::Allow as i32);
         assert!(resp.redact.is_none());
     }
+
+    #[test]
+    fn request_to_core_maps_tool_result_action() {
+        // A ToolResult CheckAction (the second-pass evaluation the proxy issues
+        // on a tool's response) must map to GovernanceAction::ToolResult with
+        // the response body decoded from result_json bytes.
+        use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
+        use aa_proto::assembly::policy::v1::{action_context::Action, ActionContext, ToolResultContext};
+
+        let req = CheckActionRequest {
+            agent_id: Some(ProtoAgentId {
+                org_id: String::new(),
+                team_id: String::new(),
+                agent_id: "agent-1".into(),
+            }),
+            context: Some(ActionContext {
+                action: Some(Action::ToolResult(ToolResultContext {
+                    tool_name: "web_search".into(),
+                    tool_source: "mcp".into(),
+                    result_json: br#"{"hits":3}"#.to_vec(),
+                    ..Default::default()
+                })),
+            }),
+            ..Default::default()
+        };
+
+        let (_ctx, action) = request_to_core(&req).expect("conversion must succeed");
+        match action {
+            GovernanceAction::ToolResult { tool_name, result } => {
+                assert_eq!(tool_name, "web_search");
+                assert_eq!(result, r#"{"hits":3}"#);
+            }
+            other => panic!("expected ToolResult action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn approval_timed_out_with_requires_approval_fallback_denies() {
+        // A TimedOut decision whose fallback is itself RequiresApproval cannot
+        // re-enter the approval queue, so it must collapse to a hard Deny with
+        // an explanatory reason rather than loop.
+        let id: ApprovalRequestId = Uuid::new_v4().to_string().parse().unwrap();
+        let decision = ApprovalDecision::TimedOut {
+            fallback: PolicyResult::RequiresApproval { timeout_secs: 30 },
+        };
+        let resp = approval_decision_to_response(&decision, &id, 0, "rule-x");
+        assert_eq!(resp.decision, Decision::Deny as i32);
+        assert_eq!(resp.reason, "approval timed out");
+    }
+
+    #[test]
+    fn decide_request_unspecified_decision_is_an_error() {
+        let req = DecideRequest {
+            request_id: Uuid::new_v4().to_string(),
+            decision: ApprovalDecisionType::DecisionUnspecified as i32,
+            decided_by: "alice".into(),
+            reason: String::new(),
+        };
+        let err = decide_request_to_core(&req).unwrap_err();
+        assert!(matches!(err, ApprovalConvertError::UnspecifiedDecision));
+    }
 }

--- a/aa-gateway/src/simulation/error.rs
+++ b/aa-gateway/src/simulation/error.rs
@@ -33,3 +33,35 @@ impl From<std::io::Error> for SimulationError {
         Self::IoError(err)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_renders_each_variant_with_its_prefix() {
+        assert_eq!(
+            SimulationError::PolicyLoad("bad yaml".into()).to_string(),
+            "policy load error: bad yaml"
+        );
+        assert_eq!(
+            SimulationError::AuditParse("line 3".into()).to_string(),
+            "audit log parse error: line 3"
+        );
+        assert_eq!(
+            SimulationError::InvalidDuration("60x".into()).to_string(),
+            "invalid duration: 60x"
+        );
+    }
+
+    #[test]
+    fn io_error_converts_and_displays_through_io_variant() {
+        // The `?` conversion path and the IoError Display arm must surface the
+        // underlying os-error message so a failed file read is actionable.
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "missing.log");
+        let err: SimulationError = io.into();
+        assert!(matches!(err, SimulationError::IoError(_)));
+        assert!(err.to_string().starts_with("I/O error: "));
+        assert!(err.to_string().contains("missing.log"));
+    }
+}

--- a/aa-proxy/src/credentials.rs
+++ b/aa-proxy/src/credentials.rs
@@ -449,4 +449,79 @@ mod tests {
         let store = CredentialStore::from_pairs([("api.openai.com".to_string(), b"sk-forever".to_vec())]);
         assert!(store.authorization_for("api.openai.com").is_some());
     }
+
+    #[test]
+    fn empty_secret_constructs_and_does_not_pin() {
+        // A zero-length credential must not attempt to mlock an empty range
+        // (`lock_memory` returns false for an empty buffer) and must still
+        // construct, expose, and drop cleanly.
+        let secret = Secret::new(Vec::new());
+        assert!(secret.expose().is_empty());
+        drop(secret);
+    }
+
+    // ── from_env operator-configuration parsing ─────────────────────────────
+    //
+    // `from_env` is the only path that turns operator config into a live store,
+    // so its host=key parsing, lowercasing, and malformed-entry skipping are
+    // load-bearing for egress injection.
+
+    /// Serialise env-var tests so they don't race each other.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn from_env_unset_yields_empty_store() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("AA_PROXY_PROVIDER_KEYS");
+        let store = CredentialStore::from_env();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn from_env_empty_string_yields_empty_store() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_PROXY_PROVIDER_KEYS", "");
+        let store = CredentialStore::from_env();
+        assert!(store.is_empty());
+        std::env::remove_var("AA_PROXY_PROVIDER_KEYS");
+    }
+
+    #[test]
+    fn from_env_parses_multiple_host_key_pairs_lowercased() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var(
+            "AA_PROXY_PROVIDER_KEYS",
+            " API.OpenAI.com=sk-openai , api.anthropic.com=sk-ant ",
+        );
+        let store = CredentialStore::from_env();
+        assert_eq!(store.len(), 2);
+        // Hosts are stored lowercased and trimmed; keys keep their exact bytes.
+        assert_eq!(
+            store.authorization_for("api.openai.com").as_deref(),
+            Some(&b"Bearer sk-openai"[..])
+        );
+        assert_eq!(
+            store.authorization_for("api.anthropic.com").as_deref(),
+            Some(&b"Bearer sk-ant"[..])
+        );
+        std::env::remove_var("AA_PROXY_PROVIDER_KEYS");
+    }
+
+    #[test]
+    fn from_env_skips_malformed_entries_but_keeps_valid_ones() {
+        // Entries without '=', with an empty host, or an empty key are skipped
+        // (and never echoed); the surrounding valid entry must still load.
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var(
+            "AA_PROXY_PROVIDER_KEYS",
+            "no-equals-sign,=orphan-key,emptyval=,api.openai.com=sk-ok",
+        );
+        let store = CredentialStore::from_env();
+        assert_eq!(store.len(), 1, "only the well-formed entry should load");
+        assert_eq!(
+            store.authorization_for("api.openai.com").as_deref(),
+            Some(&b"Bearer sk-ok"[..])
+        );
+        std::env::remove_var("AA_PROXY_PROVIDER_KEYS");
+    }
 }


### PR DESCRIPTION
## Description

Raises **meaningful** unit-test coverage for `aa-gateway` and `aa-proxy` toward the ≥95% target (Subtask AAASM-3806 of Story AAASM-3798). Tests assert designed governance behaviour, not implementation internals — no padding, no snapshot churn. Six granular commits, one file each:

- `aa-gateway/policy/rbac.rs` — `Display` for `PolicyScopeKind` / `MutationKind` / `CallerRole` (audit/log labels are a contract): **78.9% → 100%**
- `aa-gateway/simulation/error.rs` — every `Display` arm + the `From<io::Error>` `?`-path (module had no tests): **50% → 97.8%**
- `aa-gateway/sanitizer/event.rs` — `RawAuditEvent::from(Value)` trust-boundary wrapper stores the untrusted value verbatim: **78.9% → 100%**
- `aa-gateway/policy/validator.rs` — schedule `active_hours` missing/bad-format fields, `is_hhmm` no-colon & non-numeric rejection, budget `window` zero/unparseable, invalid `capabilities.deny`: **96.0% → 99.5%**
- `aa-gateway/service/convert.rs` — `request_to_core` ToolResult mapping, `TimedOut`-with-`RequiresApproval` fallback collapsing to Deny, unspecified `DecideRequest` rejection: **~97.5%** (remaining gaps are `unreachable!`/`panic!` guard arms)
- `aa-proxy/credentials.rs` — `CredentialStore::from_env` host=key parsing (lowercase+trim), malformed-entry skipping, unset/empty env, zero-length `Secret`: **86.7% → 97.5%**

## Type of Change

- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3806 (Story AAASM-3798)

## Testing

- [x] Unit tests added / updated
- Local: `cargo nextest run -p aa-gateway -p aa-proxy` → 1330 passed (only the known macOS `policy_latency_test` p99 flake, which passed on retry). `cargo clippy -p aa-gateway -p aa-proxy --all-targets -- -D warnings` clean. `cargo fmt --all` clean.

> Note: the 91.4%/91.7% baseline is the CI Codecov/SonarCloud metric produced by `cargo llvm-cov nextest --all-features --workspace`, which exercises integration tests (testcontainers Postgres, live gRPC server) that cannot run in this local environment. These additions close the genuinely-unit-testable pure-logic gaps the integration suite also misses; CI coverage will confirm the final per-crate numbers.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmVbZVBF5jcJ81614hD2bU
