### PR TITLE
[AAASM-3787] 🐛 (aa-gateway): Include action args in decision cache key

### DIFF
--- a/aa-gateway/src/engine/cache.rs
+++ b/aa-gateway/src/engine/cache.rs
@@ -22,7 +22,11 @@ pub struct CacheKey {
     /// Policy epoch at the time of evaluation. Stale entries are invalidated
     /// when the epoch advances (via `load_policy` or `apply_yaml`).
     pub policy_epoch: u64,
-    /// FNV-1a hash of a canonical `"{action_kind}:{action_discriminant}"` string.
+    /// Hash of the action's kind tag **and** its full evaluated payload (tool
+    /// name + args, network URL + method, file path + mode, …). The payload is
+    /// part of the key because stage-5 `requires_approval_if` predicates evaluate
+    /// over it — a key that ignored args would serve a benign payload's cached
+    /// `Allow` for a dangerous one (AAASM-3787). See [`action_discriminant`].
     pub action_hash: u64,
 }
 
@@ -44,9 +48,14 @@ fn action_discriminant(action: &aa_core::GovernanceAction) -> u64 {
 
     let mut h = AHasher::default();
     match action {
-        aa_core::GovernanceAction::ToolCall { name, .. } => {
+        aa_core::GovernanceAction::ToolCall { name, args } => {
             "tool".hash(&mut h);
             name.hash(&mut h);
+            // Hash the full args payload: stage-5 `requires_approval_if`
+            // predicates (e.g. `args.amount > 1000`) are evaluated against the
+            // args, so two calls to the same tool with different args must not
+            // collide on the cache key (AAASM-3787).
+            args.hash(&mut h);
         }
         aa_core::GovernanceAction::ToolResult { tool_name, .. } => {
             "tool_result".hash(&mut h);

--- a/aa-gateway/src/engine/cache.rs
+++ b/aa-gateway/src/engine/cache.rs
@@ -209,4 +209,21 @@ mod tests {
         let key_e2 = CacheKey::new(&[1u8; 16], 2, &action);
         assert_ne!(key_e1, key_e2);
     }
+
+    #[test]
+    fn different_tool_args_produce_different_keys() {
+        // AAASM-3787: same tool name, different args must not collide — a
+        // benign payload's cached verdict must not be served for a dangerous one.
+        let benign = aa_core::GovernanceAction::ToolCall {
+            name: "transfer".to_string(),
+            args: r#"{"amount":1}"#.to_string(),
+        };
+        let dangerous = aa_core::GovernanceAction::ToolCall {
+            name: "transfer".to_string(),
+            args: r#"{"amount":1000000}"#.to_string(),
+        };
+        let key_benign = CacheKey::new(&[1u8; 16], 1, &benign);
+        let key_dangerous = CacheKey::new(&[1u8; 16], 1, &dangerous);
+        assert_ne!(key_benign, key_dangerous);
+    }
 }

--- a/aa-gateway/src/engine/cache.rs
+++ b/aa-gateway/src/engine/cache.rs
@@ -57,9 +57,14 @@ fn action_discriminant(action: &aa_core::GovernanceAction) -> u64 {
             // collide on the cache key (AAASM-3787).
             args.hash(&mut h);
         }
-        aa_core::GovernanceAction::ToolResult { tool_name, .. } => {
+        aa_core::GovernanceAction::ToolResult { tool_name, result } => {
             "tool_result".hash(&mut h);
             tool_name.hash(&mut h);
+            // Hash the full result payload: response-side `tool_result.<key>`
+            // predicates evaluate over it (the mirror of `args.<key>`), so two
+            // results for the same tool with different bodies must not collide
+            // on the cache key (AAASM-3787).
+            result.hash(&mut h);
         }
         aa_core::GovernanceAction::NetworkRequest { url, method } => {
             "net".hash(&mut h);

--- a/aa-gateway/src/engine/cache.rs
+++ b/aa-gateway/src/engine/cache.rs
@@ -226,4 +226,21 @@ mod tests {
         let key_dangerous = CacheKey::new(&[1u8; 16], 1, &dangerous);
         assert_ne!(key_benign, key_dangerous);
     }
+
+    #[test]
+    fn different_tool_results_produce_different_keys() {
+        // AAASM-3787: response-side mirror — same tool, different result bodies
+        // must not collide, since `tool_result.<key>` predicates read the body.
+        let ok = aa_core::GovernanceAction::ToolResult {
+            tool_name: "lookup".to_string(),
+            result: r#"{"ok":true}"#.to_string(),
+        };
+        let err = aa_core::GovernanceAction::ToolResult {
+            tool_name: "lookup".to_string(),
+            result: r#"{"ok":false}"#.to_string(),
+        };
+        let key_ok = CacheKey::new(&[1u8; 16], 1, &ok);
+        let key_err = CacheKey::new(&[1u8; 16], 1, &err);
+        assert_ne!(key_ok, key_err);
+    }
 }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2037,6 +2037,40 @@ mod tests {
     }
 
     #[test]
+    fn cached_allow_not_served_for_dangerous_args_through_cascade() {
+        // AAASM-3787 regression: the cascade decision cache must key on the
+        // action args. A benign `transfer {amount:1}` evaluates to Allow and is
+        // cached; a subsequent `transfer {amount:1000000}` within the TTL — same
+        // agent, epoch, and tool name but different args — must NOT be served
+        // the cached Allow. It must re-evaluate and trip the stage-5
+        // `requires_approval_if` predicate (`args.amount > 100`).
+        let mut doc = empty_doc();
+        doc.tools.insert(
+            "transfer".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: None,
+                requires_approval_if: Some("args.amount > 100".to_string()),
+            },
+        );
+        let engine = make_engine(empty_doc());
+        let ctx = make_ctx();
+        let cascade = vec![Arc::new(doc)];
+
+        let benign = tool_call("transfer", r#"{"amount":1}"#);
+        assert_eq!(
+            engine.evaluate_with_cascade(cascade.clone(), &ctx, &benign).decision,
+            PolicyResult::Allow,
+        );
+
+        let dangerous = tool_call("transfer", r#"{"amount":1000000}"#);
+        assert_eq!(
+            engine.evaluate_with_cascade(cascade, &ctx, &dangerous).decision,
+            PolicyResult::RequiresApproval { timeout_secs: 300 },
+        );
+    }
+
+    #[test]
     fn data_pattern_redacts_on_custom_match() {
         // Stage 6 no longer denies — it redacts in-memory and sets credential_findings.
         let mut doc = empty_doc();


### PR DESCRIPTION
## Description

The cascade decision cache (`aa-gateway/src/engine/cache.rs`) built its key for a
`ToolCall` from the agent id, policy epoch, and only the tool **name** — the action
**args** were discarded (`ToolCall { name, .. }`). The same gap applied to
`ToolResult` (keyed on `tool_name` only, dropping the response body).

Because stage-5 `requires_approval_if` predicates are evaluated over the payload
(e.g. `args.amount > 1000`, or response-side `tool_result.<key>`), a benign call's
cached `Allow` could be served — within the 60-second TTL — for a *different* call
that used the same tool name but a dangerous payload. That is an **approval bypass**:
a high-value action that should return `RequiresApproval` is silently allowed.

The fix hashes the full payload into `action_hash`:
- `ToolCall` now hashes `args`.
- `ToolResult` now hashes `result`.

So distinct payloads produce distinct cache keys and are re-evaluated through the
full stage-5 path instead of colliding on a cached verdict.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Cache keys change shape, but the cache is an internal, derive-on-the-fly structure
with no persisted form and no public API surface — there is no compatibility concern.

## Related Issues

- Related Jira ticket: AAASM-3787
- Related GitHub issues: #N/A

Closes AAASM-3787

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Added regression tests:
- `cache.rs::different_tool_args_produce_different_keys` — same tool, different args → distinct keys.
- `cache.rs::different_tool_results_produce_different_keys` — same tool, different result bodies → distinct keys.
- `engine::tests::cached_allow_not_served_for_dangerous_args_through_cascade` — the end-to-end
  regression: a benign `transfer {amount:1}` (Allow, cached) followed within the TTL by
  `transfer {amount:1000000}` re-evaluates and yields `RequiresApproval` rather than the cached Allow.

Local validation (per-crate; the full-workspace `--all-features` pre-commit hook includes
the Linux-only `aa-ebpf` crate and cannot run on this macOS host — CI runs the full gate):

```
cargo build -p aa-gateway          # ok
cargo nextest run -p aa-gateway    # ok
cargo fmt --all -- --check         # ok
cargo clippy -p aa-gateway --all-targets -- -D warnings   # ok
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
