### PR TITLE
[AAASM-3789] 🐛 (aa-api): Guard webhook /test against SSRF

### DIFF
--- a/aa-api/src/destinations/connectors/mod.rs
+++ b/aa-api/src/destinations/connectors/mod.rs
@@ -100,6 +100,12 @@ pub(crate) fn shared_client() -> &'static Client {
         Client::builder()
             .connect_timeout(Duration::from_secs(8))
             .timeout(Duration::from_secs(15))
+            // AAASM-3789: never follow redirects. A redirect can bounce an
+            // otherwise-allowlisted destination to an internal address (cloud
+            // metadata, loopback, RFC1918), re-opening the SSRF the egress
+            // guard closes. A 3xx is surfaced to the caller as a non-2xx
+            // outcome instead of being chased inward.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("reqwest client construction failed")
     })

--- a/aa-api/src/destinations/connectors/webhook.rs
+++ b/aa-api/src/destinations/connectors/webhook.rs
@@ -8,7 +8,7 @@
 use chrono::Utc;
 
 use crate::destinations::connectors::{
-    shared_client, truncate_body, ConnectorError, DispatchOutcome, DispatchRequest, NotificationConnector,
+    shared_client, ConnectorError, DispatchOutcome, DispatchRequest, NotificationConnector,
 };
 use crate::destinations::types::{Destination, DestinationConfig};
 
@@ -45,17 +45,23 @@ impl NotificationConnector for WebhookConnector {
             .await
             .map_err(|e| ConnectorError::Transport(e.to_string()))?;
         let status = resp.status().as_u16();
-        let body = resp.text().await.unwrap_or_default();
-        let body = truncate_body(body);
+        // AAASM-3789: do NOT capture or return the upstream response body. A
+        // webhook test-fire must not reflect origin/internal response content
+        // back to the caller (SSRF data-exfiltration vector). Drain and discard
+        // the body so only the observed status is surfaced.
+        drop(resp.bytes().await);
 
         if (200..300).contains(&status) {
             Ok(DispatchOutcome {
                 delivered_at: Utc::now().to_rfc3339(),
                 connector_response_status: status,
-                connector_response_body: body,
+                connector_response_body: String::new(),
             })
         } else {
-            Err(ConnectorError::Http { status, body })
+            Err(ConnectorError::Http {
+                status,
+                body: String::new(),
+            })
         }
     }
 }

--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -4,6 +4,8 @@
 //! connector relies on at dispatch time (URL parse, https-only for Slack,
 //! non-empty PagerDuty routing key, OpsGenie key + team).
 
+use std::net::{IpAddr, ToSocketAddrs};
+
 use crate::destinations::types::{Destination, DestinationConfig};
 
 /// Reason a destination payload failed validation. The `'static str`
@@ -74,6 +76,99 @@ pub fn validate_config(c: &DestinationConfig) -> Result<(), ValidationError> {
             }
             if team_id.trim().is_empty() {
                 return Err(ValidationError::InvalidConfig("opsgenie.team_id must be non-empty"));
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Environment variable that, when set to a truthy value (`1`/`true`/`yes`/`on`),
+/// disables the webhook egress guard.
+///
+/// Unset — the default and the SaaS posture — keeps the guard active so an
+/// outbound webhook test-fire can never reach an internal address (cloud
+/// metadata, loopback, RFC1918, link-local). A *limited-function self-hosted*
+/// deployment that legitimately needs to reach a webhook on its own private
+/// network can opt out via this flag — the configurable egress allowlist the
+/// remediation calls for (AAASM-3789).
+const ALLOW_PRIVATE_EGRESS_ENV: &str = "AA_ALLOW_PRIVATE_WEBHOOK_EGRESS";
+
+/// Whether the operator has explicitly opted in to private-network webhook
+/// egress via [`ALLOW_PRIVATE_EGRESS_ENV`].
+fn private_egress_allowed() -> bool {
+    std::env::var(ALLOW_PRIVATE_EGRESS_ENV)
+        .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+/// True when `ip` is an address an SSRF guard must refuse: loopback, RFC1918
+/// private, link-local (incl. the `169.254.169.254` cloud-metadata endpoint),
+/// IPv4 broadcast, the unspecified address, or — for IPv6 — loopback,
+/// unspecified, unique-local (`fc00::/7`), or link-local (`fe80::/10`).
+/// IPv4-mapped IPv6 addresses are unwrapped and re-checked against the v4 rules.
+fn ip_is_internal(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified() || v4.is_broadcast()
+        }
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return ip_is_internal(IpAddr::V4(mapped));
+            }
+            let octets = v6.octets();
+            v6.is_loopback()
+                || v6.is_unspecified()
+                // fc00::/7 unique-local
+                || (octets[0] & 0xfe) == 0xfc
+                // fe80::/10 link-local
+                || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80)
+        }
+    }
+}
+
+/// Reject an address that resolves into a disallowed internal range.
+fn check_egress_addr(ip: IpAddr) -> Result<(), ValidationError> {
+    if ip_is_internal(ip) {
+        Err(ValidationError::InvalidConfig(
+            "webhook.url resolves to a disallowed internal address",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Guard a webhook URL against SSRF before it is dispatched (AAASM-3789).
+///
+/// Rejects a URL whose host — or any address it resolves to — falls in a
+/// loopback / private / link-local / ULA / metadata range. Literal-IP hosts are
+/// checked directly; hostnames are resolved and *every* returned address must be
+/// allowed, so a single internal answer rejects the whole host (defeating
+/// DNS-rebinding to an internal target). Honors [`ALLOW_PRIVATE_EGRESS_ENV`].
+///
+/// Performs a **blocking** DNS lookup for hostname targets, so call it from a
+/// blocking context (e.g. `tokio::task::spawn_blocking`) rather than directly
+/// on an async task.
+pub fn validate_webhook_egress(url: &url::Url) -> Result<(), ValidationError> {
+    if private_egress_allowed() {
+        return Ok(());
+    }
+    let host = url
+        .host()
+        .ok_or(ValidationError::InvalidConfig("webhook.url has no host"))?;
+    match host {
+        url::Host::Ipv4(ip) => check_egress_addr(IpAddr::V4(ip)),
+        url::Host::Ipv6(ip) => check_egress_addr(IpAddr::V6(ip)),
+        url::Host::Domain(domain) => {
+            let port = url.port_or_known_default().unwrap_or(443);
+            let mut resolved = (domain, port)
+                .to_socket_addrs()
+                .map_err(|_| ValidationError::InvalidConfig("webhook.url host could not be resolved"))?
+                .peekable();
+            if resolved.peek().is_none() {
+                return Err(ValidationError::InvalidConfig("webhook.url host did not resolve"));
+            }
+            for sa in resolved {
+                check_egress_addr(sa.ip())?;
             }
             Ok(())
         }

--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -285,4 +285,48 @@ mod tests {
             Err(ValidationError::InvalidConfig("name must be non-empty"))
         );
     }
+
+    // ── Egress guard (AAASM-3789) ────────────────────────────────────────────
+
+    fn egress(url: &str) -> Result<(), ValidationError> {
+        validate_webhook_egress(&url::Url::parse(url).expect("test url parses"))
+    }
+
+    #[test]
+    fn egress_rejects_loopback_metadata_and_private() {
+        // Loopback, the cloud-metadata link-local address, and an RFC1918 host
+        // must all be refused before any request is dispatched.
+        for url in [
+            "http://127.0.0.1/hook",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1/hook",
+            "http://192.168.1.1/hook",
+            "http://172.16.0.1/hook",
+            "http://[::1]/hook",
+        ] {
+            assert_eq!(
+                egress(url),
+                Err(ValidationError::InvalidConfig(
+                    "webhook.url resolves to a disallowed internal address"
+                )),
+                "{url} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn egress_allows_public_ip() {
+        // A public literal IP carries no DNS dependency and must be allowed.
+        assert!(egress("http://8.8.8.8/hook").is_ok());
+        assert!(egress("https://1.1.1.1/hook").is_ok());
+    }
+
+    #[test]
+    fn egress_env_escape_allows_private() {
+        // The documented self-host opt-out disables the guard.
+        std::env::set_var(ALLOW_PRIVATE_EGRESS_ENV, "1");
+        let allowed = egress("http://127.0.0.1/hook");
+        std::env::remove_var(ALLOW_PRIVATE_EGRESS_ENV);
+        assert!(allowed.is_ok(), "private egress must be allowed when opted in");
+    }
 }

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -18,7 +18,7 @@ use crate::destinations::connectors::webhook::WebhookConnector;
 use crate::destinations::connectors::{ConnectorError, DispatchRequest, NotificationConnector};
 use crate::destinations::store::StoreError;
 use crate::destinations::types::{Destination, DestinationConfig, DestinationKind};
-use crate::destinations::validate::{validate_config, ValidationError};
+use crate::destinations::validate::{validate_config, validate_webhook_egress, ValidationError};
 use crate::error::ProblemDetail;
 use crate::state::AppState;
 
@@ -246,6 +246,10 @@ impl NotificationConnector for UnsupportedConnector {
 pub enum TestDestinationFailure {
     /// Destination does not exist — surfaced as 404.
     NotFound(ProblemDetail),
+    /// Request rejected before dispatch (e.g. the SSRF egress guard refused the
+    /// webhook target) — surfaced as the status carried by the `ProblemDetail`
+    /// (400). (AAASM-3789.)
+    Rejected(ProblemDetail),
     /// Connector failed — surfaced as 502 with `ConnectorFailedBody`.
     Connector(ConnectorFailedBody),
 }
@@ -254,6 +258,7 @@ impl IntoResponse for TestDestinationFailure {
     fn into_response(self) -> Response {
         match self {
             TestDestinationFailure::NotFound(p) => p.into_response(),
+            TestDestinationFailure::Rejected(p) => p.into_response(),
             TestDestinationFailure::Connector(body) => (StatusCode::BAD_GATEWAY, Json(body)).into_response(),
         }
     }
@@ -465,6 +470,26 @@ pub async fn test_destination(
         .destination_store
         .get(&id)
         .ok_or_else(|| TestDestinationFailure::NotFound(not_found_problem()))?;
+
+    // AAASM-3789: SSRF egress guard. Before dispatching a webhook test-fire,
+    // reject targets that resolve to an internal address (loopback / RFC1918 /
+    // link-local incl. the cloud-metadata endpoint / ULA). The resolution does
+    // a blocking DNS lookup, so it runs on the blocking pool.
+    if let DestinationConfig::Webhook { url, .. } = &destination.config {
+        let parsed = url::Url::parse(url).map_err(|_| {
+            TestDestinationFailure::Rejected(validation_error_to_problem(ValidationError::InvalidConfig(
+                "webhook.url is not a valid URL",
+            )))
+        })?;
+        let egress = tokio::task::spawn_blocking(move || validate_webhook_egress(&parsed))
+            .await
+            .map_err(|_| {
+                TestDestinationFailure::Rejected(
+                    ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail("egress_check_failed"),
+                )
+            })?;
+        egress.map_err(|e| TestDestinationFailure::Rejected(validation_error_to_problem(e)))?;
+    }
 
     let req_in = body.map(|Json(b)| b).unwrap_or_default();
     let dispatch = DispatchRequest {

--- a/aa-api/tests/connectors.rs
+++ b/aa-api/tests/connectors.rs
@@ -187,6 +187,36 @@ async fn webhook_connector_rejects_non_webhook_destination() {
     }
 }
 
+#[tokio::test]
+async fn webhook_dispatch_does_not_follow_redirects() {
+    // AAASM-3789: a redirect must NOT be chased — otherwise an allowlisted
+    // target could 3xx-bounce the request to an internal address. With
+    // `redirect(Policy::none())` the 3xx is surfaced as a non-2xx outcome and
+    // the `Location` (here an internal metadata host) is never fetched.
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(MOCK_POST).path("/hook");
+        then.status(308)
+            .header("location", "http://169.254.169.254/latest/meta-data/");
+    });
+
+    let dst = destination(DestinationConfig::Webhook {
+        url: server.url("/hook"),
+        secret_header: None,
+    });
+
+    let err = WebhookConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .expect_err("a redirect must surface as a non-2xx error, not be followed");
+
+    match err {
+        ConnectorError::Http { status, .. } => assert_eq!(status, 308, "the redirect itself must be returned"),
+        other => panic!("expected Http error carrying the 3xx, got {other:?}"),
+    }
+    mock.assert();
+}
+
 // ── Slack connector ────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/aa-api/tests/connectors.rs
+++ b/aa-api/tests/connectors.rs
@@ -67,7 +67,11 @@ async fn webhook_dispatch_posts_payload_and_returns_outcome_on_2xx() {
 
     mock.assert();
     assert_eq!(outcome.connector_response_status, 202);
-    assert_eq!(outcome.connector_response_body, "queued");
+    // AAASM-3789: the upstream body is no longer reflected to the caller.
+    assert!(
+        outcome.connector_response_body.is_empty(),
+        "upstream webhook body must not be reflected"
+    );
     assert!(!outcome.delivered_at.is_empty());
 }
 
@@ -114,16 +118,19 @@ async fn webhook_dispatch_maps_non_2xx_to_http_error() {
     match err {
         ConnectorError::Http { status, body } => {
             assert_eq!(status, 500);
-            assert_eq!(body, "upstream boom");
+            // AAASM-3789: the upstream error body must not be reflected either.
+            assert!(body.is_empty(), "upstream webhook error body must not be reflected");
         }
         other => panic!("expected Http error, got {other:?}"),
     }
 }
 
 #[tokio::test]
-async fn webhook_dispatch_truncates_oversized_response_body() {
+async fn webhook_dispatch_never_reflects_response_body() {
+    // AAASM-3789: regardless of how much the upstream returns, none of it may
+    // leak back to the caller via the outcome — the webhook test-fire is an
+    // SSRF data-exfiltration sink otherwise.
     let server = MockServer::start();
-    // A 3000-byte body must be capped at the 2048-byte ceiling.
     let big = "x".repeat(3000);
     server.mock(|when, then| {
         when.method(MOCK_POST).path("/hook");
@@ -140,7 +147,10 @@ async fn webhook_dispatch_truncates_oversized_response_body() {
         .await
         .unwrap();
 
-    assert_eq!(outcome.connector_response_body.len(), 2048);
+    assert!(
+        outcome.connector_response_body.is_empty(),
+        "no part of the upstream body may be reflected"
+    );
 }
 
 #[tokio::test]

--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -372,7 +372,8 @@ async fn test_webhook_returns_502_connector_failed() {
     let body = body_json(resp).await;
     assert_eq!(body["error"], "connector_failed");
     assert_eq!(body["connector_status"], 401);
-    assert_eq!(body["connector_body"], "Invalid token");
+    // AAASM-3789: the upstream error body is no longer reflected to the caller.
+    assert_eq!(body["connector_body"], "");
     mock.assert();
 }
 

--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -383,6 +383,54 @@ async fn test_webhook_returns_502_connector_failed() {
     mock.assert();
 }
 
+#[tokio::test]
+async fn test_webhook_to_internal_host_is_rejected() {
+    // AAASM-3789: a webhook test-fire aimed at an internal address (cloud
+    // metadata, loopback, RFC1918) must be refused with 400 before any request
+    // is dispatched — the SSRF the egress guard closes. The guard is on by
+    // default, so this test must NOT opt in to private egress.
+    std::env::remove_var("AA_ALLOW_PRIVATE_WEBHOOK_EGRESS");
+
+    for internal in [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://127.0.0.1/hook",
+        "http://10.0.0.1/hook",
+    ] {
+        let app = common::test_app();
+        let resp = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/alerts/destinations",
+                webhook_payload("hook", internal),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "create should still succeed for {internal}"
+        );
+        let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+        let resp = app
+            .oneshot(json_request(
+                "POST",
+                &format!("/api/v1/alerts/destinations/{id}/test"),
+                json!({ "severity": "LOW" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "test-fire to internal host {internal} must be rejected"
+        );
+        let body = body_json(resp).await;
+        assert_eq!(body["detail"], "webhook.url resolves to a disallowed internal address");
+    }
+}
+
 // ---------------------------------------------------------------------------
 // AAASM-3688 — destination handlers require read/write scope, and the webhook
 // secret_header is never returned in cleartext.

--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -308,6 +308,10 @@ async fn get_unknown_returns_404_destination_not_found() {
 
 #[tokio::test]
 async fn test_webhook_returns_200_and_hits_connector() {
+    // AAASM-3789: the test-fire egress guard blocks loopback/private targets by
+    // default; opt in so this happy-path can drive a loopback httpmock server.
+    // (nextest runs each test in its own process, so this env is test-local.)
+    std::env::set_var("AA_ALLOW_PRIVATE_WEBHOOK_EGRESS", "1");
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
         when.method(MOCK_POST).path("/hook");
@@ -342,6 +346,8 @@ async fn test_webhook_returns_200_and_hits_connector() {
 
 #[tokio::test]
 async fn test_webhook_returns_502_connector_failed() {
+    // AAASM-3789: opt in to private egress so the loopback mock is reachable.
+    std::env::set_var("AA_ALLOW_PRIVATE_WEBHOOK_EGRESS", "1");
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
         when.method(MOCK_POST).path("/hook");
@@ -522,6 +528,8 @@ async fn update_with_masked_secret_preserves_stored_secret() {
     // PRESERVE the real stored secret rather than clobber it with the mask.
     // Verified end-to-end: after the masked round-trip, a test-fire must still
     // ship the ORIGINAL secret in the `X-AAASM-Token` header.
+    // AAASM-3789: opt in to private egress so the loopback mock is reachable.
+    std::env::set_var("AA_ALLOW_PRIVATE_WEBHOOK_EGRESS", "1");
     let server = MockServer::start();
     let mock = server.mock(|when, then| {
         when.method(MOCK_POST).path("/hook").header("X-AAASM-Token", "shh");


### PR DESCRIPTION
## Description

Closes the authenticated SSRF in the alert-webhook destination test-fire
(`POST /api/v1/alerts/destinations/{id}/test`). Previously a caller with Write
scope could point a webhook destination at `http://169.254.169.254/…` (cloud
metadata), loopback, or any RFC1918 host, fire the connector, and read the
upstream response — the validation was scheme-only, the HTTP client followed
redirects, and the upstream body was reflected back to the caller.

Three layers of defense are added:

1. **Egress guard** (`destinations/validate.rs`) — new `validate_webhook_egress`
   resolves the URL host and rejects loopback / RFC1918 private / link-local
   (`169.254.0.0/16`, incl. the IMDS address) / IPv6 ULA (`fc00::/7`) /
   link-local (`fe80::/10`) / unspecified addresses. Literal-IP hosts are checked
   directly; hostnames are resolved and **every** returned address must be
   allowed (defeats DNS-rebinding to an internal target). It is enforced in the
   `test_destination` handler **before dispatch** (run on the blocking pool since
   it does a DNS lookup) and returns `400` with detail
   `webhook.url resolves to a disallowed internal address`.
2. **No redirects** (`connectors/mod.rs`) — the shared `reqwest::Client` now uses
   `redirect(Policy::none())`, so an allowlisted target cannot 3xx-bounce inward;
   a redirect is surfaced as a non-2xx outcome instead of being chased.
3. **No body reflection** (`connectors/webhook.rs`) — the webhook connector no
   longer captures or returns the upstream response body on either the success
   or HTTP-error path, so internal/origin content can never leak to the caller.

A documented, **secure-by-default** opt-out (`AA_ALLOW_PRIVATE_WEBHOOK_EGRESS`)
lets a *limited-function self-hosted* deployment legitimately reach a webhook on
its own private network — the configurable egress allowlist the ticket suggests.
Unset (the SaaS default) keeps the guard active.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

Behavioural change (no schema change): a webhook test-fire to an internal
address now returns `400` instead of dispatching, and the
`connector_response_body` / `connector_body` fields are now always empty for the
webhook kind (the upstream body is no longer reflected). The response DTO shapes
(`TestDestinationResponse`, `ConnectorFailedBody`) are unchanged, so the OpenAPI
contract and dashboard generated types are unaffected.

## Related Issues

- Related Jira ticket: AAASM-3789
- Related GitHub issues: #XX

Closes AAASM-3789

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

New / updated coverage (all green via `cargo nextest run -p aa-api`):
- `validate::tests::egress_rejects_loopback_metadata_and_private` — `127.0.0.1`,
  `169.254.169.254`, `10.0.0.1`, `192.168.1.1`, `172.16.0.1`, `[::1]` rejected.
- `validate::tests::egress_allows_public_ip` — `8.8.8.8` / `1.1.1.1` allowed.
- `validate::tests::egress_env_escape_allows_private` — opt-out works.
- `connectors::webhook_dispatch_never_reflects_response_body` — body withheld.
- `connectors::webhook_dispatch_does_not_follow_redirects` — 308 not chased.
- `destinations::test_webhook_to_internal_host_is_rejected` — route returns 400
  for metadata/loopback/RFC1918 targets.
- Existing webhook route tests updated to opt into private egress (loopback
  httpmock) and to assert the upstream body is no longer reflected.

How to verify manually:
```
# default (guard on): rejected
curl -XPOST .../alerts/destinations/{id}/test   # id is a 169.254.169.254 webhook -> 400
# self-host opt-out:
AA_ALLOW_PRIVATE_WEBHOOK_EGRESS=1 <serve>        # private target allowed
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
