### PR TITLE
[AAASM-3808] 📝 (docs): Cross-link the core base-images guide to per-SDK guides

### DIFF
--- a/docs/src/usage-guide/container-base-images.md
+++ b/docs/src/usage-guide/container-base-images.md
@@ -67,6 +67,15 @@ To actually **enforce** policy, run your agent alongside the `aa-runtime` sideca
 authoritative chokepoint). The `docker compose` example in the repo
 (`examples/docker-compose/`) wires this up; see [Self-hosting](self-hosting.md).
 
+## Language-specific guides
+
+Each SDK's documentation has a container guide with the `FROM` example, install
+command, and `SDK_VERSION` usage tailored to that language:
+
+- **Python** — [Container base image (Python SDK)](https://docs.agent-assembly.com/python-sdk/latest/guides/container-base-image/)
+- **Node.js** — [Container base image (Node SDK)](https://docs.agent-assembly.com/node-sdk/guides/container-base-image)
+- **Go** — [Container base image (Go SDK)](https://docs.agent-assembly.com/go-sdk/guides/container-base-image/)
+
 ## Choosing the SDK version — the `SDK_VERSION` build-arg
 
 The SDK that ships in the image is controlled by an **optional** `SDK_VERSION`

--- a/docs/src/usage-guide/container-base-images.md
+++ b/docs/src/usage-guide/container-base-images.md
@@ -12,13 +12,15 @@ first run with no extra install step — you just build your agent `FROM` one of
 ## The images
 
 Three languages × three runtime versions = **9 images**, under
-`ghcr.io/ai-agent-assembly/`:
+`ghcr.io/ai-agent-assembly/`. Each language also has its own container guide — with
+the `FROM` example, install command, and `SDK_VERSION` usage tailored to that
+language:
 
-| Language | Image | Runtime variants |
-|---|---|---|
-| Python | `ghcr.io/ai-agent-assembly/python` | `3.14-slim`, `3.13-slim`, `3.12-slim` |
-| Node.js | `ghcr.io/ai-agent-assembly/node` | `24-slim`, `22-slim`, `20-slim` |
-| Go | `ghcr.io/ai-agent-assembly/go` | `1.26-alpine`, `1.25-alpine`, `1.24-alpine` |
+| Language | Image | Runtime variants | Language-specific guide |
+|---|---|---|---|
+| Python | `ghcr.io/ai-agent-assembly/python` | `3.14-slim`, `3.13-slim`, `3.12-slim` | [Python SDK container guide](https://docs.agent-assembly.com/python-sdk/latest/guides/container-base-image/) |
+| Node.js | `ghcr.io/ai-agent-assembly/node` | `24-slim`, `22-slim`, `20-slim` | [Node SDK container guide](https://docs.agent-assembly.com/node-sdk/guides/container-base-image) |
+| Go | `ghcr.io/ai-agent-assembly/go` | `1.26-alpine`, `1.25-alpine`, `1.24-alpine` | [Go SDK container guide](https://docs.agent-assembly.com/go-sdk/guides/container-base-image/) |
 
 Each is a small two-stage build (the `aasm` CLI is compiled and copied into an
 official `python` / `node` / `golang` slim base) and is published for
@@ -66,15 +68,6 @@ What you get inside the image:
 To actually **enforce** policy, run your agent alongside the `aa-runtime` sidecar (the
 authoritative chokepoint). The `docker compose` example in the repo
 (`examples/docker-compose/`) wires this up; see [Self-hosting](self-hosting.md).
-
-## Language-specific guides
-
-Each SDK's documentation has a container guide with the `FROM` example, install
-command, and `SDK_VERSION` usage tailored to that language:
-
-- **Python** — [Container base image (Python SDK)](https://docs.agent-assembly.com/python-sdk/latest/guides/container-base-image/)
-- **Node.js** — [Container base image (Node SDK)](https://docs.agent-assembly.com/node-sdk/guides/container-base-image)
-- **Go** — [Container base image (Go SDK)](https://docs.agent-assembly.com/go-sdk/guides/container-base-image/)
 
 ## Choosing the SDK version — the `SDK_VERSION` build-arg
 


### PR DESCRIPTION
## What

Adds a **"Language-specific guide" column to the supported-language table** in the core "Governed container base images" page (`docs/src/usage-guide/container-base-images.md`), so each language row links straight to its SDK's container guide on the canonical docs domain:

- Python → `https://docs.agent-assembly.com/python-sdk/latest/guides/container-base-image/`
- Node → `https://docs.agent-assembly.com/node-sdk/guides/container-base-image`
- Go → `https://docs.agent-assembly.com/go-sdk/guides/container-base-image/`

## Why

Linking was one-directional (each SDK page → core guide). The core guide is the canonical landing page, so it should point **out** to the per-language guides — and the most discoverable place is right in the language table, next to each image, so a reader can drill into their language's `FROM` example / install / `SDK_VERSION` details. Completes the bidirectional cross-reference.

## How to verify

- mdBook `Build mdBook` renders the table with the new column. (No `linkcheck` backend, so the build is green even before the targets resolve.)

## Notes

- The links target **docs.agent-assembly.com** (the canonical docs domain). They go live once the docs hub (`agent-assembly-docs`) re-aggregates (`aggregate.yml`, push-to-hub / `workflow_dispatch`) — that same run publishes the updated core page + the new SDK pages together.
- Single-file, additive doc change; no side effects.

Closes AAASM-3808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)