### PR TITLE
[AAASM-3805] ✅ (aa-runtime,aa-api): Raise test coverage (aa-runtime ≥95%)

### DIFF
--- a/aa-api/src/alerts/capture.rs
+++ b/aa-api/src/alerts/capture.rs
@@ -102,3 +102,85 @@ pub fn spawn_anomaly_alert_capture(
         }
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alerts::store::InMemoryAlertStore;
+    use aa_core::identity::AgentId;
+    use aa_gateway::anomaly::types::{AnomalyResponse, AnomalyType};
+    use aa_security::scanner::CredentialKind;
+
+    /// Wait until `store` reports at least `n` alerts, or the deadline passes.
+    async fn await_count(store: &Arc<InMemoryAlertStore>, n: u64) -> u64 {
+        for _ in 0..100 {
+            let (_, total) = store.list(100, 0);
+            if total >= n {
+                return total;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        store.list(100, 0).1
+    }
+
+    #[tokio::test]
+    async fn budget_capture_records_then_stops_on_close() {
+        let (tx, rx) = broadcast::channel(8);
+        let store = Arc::new(InMemoryAlertStore::new());
+        let handle = spawn_alert_capture(rx, store.clone());
+
+        tx.send(BudgetAlert {
+            agent_id: AgentId::from_bytes([1u8; 16]),
+            team_id: None,
+            threshold_pct: 95,
+            spent_usd: 95.0,
+            limit_usd: 100.0,
+        })
+        .unwrap();
+
+        assert_eq!(await_count(&store, 1).await, 1);
+
+        // Dropping the only sender closes the channel → the task exits.
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn secret_capture_records_then_stops_on_close() {
+        let (tx, rx) = broadcast::channel(8);
+        let store = Arc::new(InMemoryAlertStore::new());
+        let handle = spawn_secret_alert_capture(rx, store.clone());
+
+        tx.send(SecretAlert {
+            agent_id: AgentId::from_bytes([2u8; 16]),
+            team_id: Some("team-x".to_string()),
+            kinds: vec![CredentialKind::AwsAccessKey],
+            finding_count: 1,
+        })
+        .unwrap();
+
+        assert_eq!(await_count(&store, 1).await, 1);
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn anomaly_capture_records_then_stops_on_close() {
+        let (tx, rx) = broadcast::channel(8);
+        let store = Arc::new(InMemoryAlertStore::new());
+        let handle = spawn_anomaly_alert_capture(rx, store.clone());
+
+        tx.send(AnomalyEvent {
+            anomaly_type: AnomalyType::BehaviorSpike,
+            response: AnomalyResponse::Pause,
+            agent_id: AgentId::from_bytes([3u8; 16]),
+            description: "spike".to_string(),
+            detected_at: chrono::Utc::now(),
+        })
+        .unwrap();
+
+        assert_eq!(await_count(&store, 1).await, 1);
+        drop(tx);
+        handle.await.unwrap();
+    }
+}

--- a/aa-api/src/alerts/rules/evaluator.rs
+++ b/aa-api/src/alerts/rules/evaluator.rs
@@ -362,4 +362,76 @@ mod tests {
         assert_eq!(snapshot.operator, RuleOperator::Gt);
         assert_eq!(snapshot.metric, RuleMetric::BudgetSpentPct);
     }
+
+    #[test]
+    fn metric_as_str_covers_every_variant() {
+        assert_eq!(metric_as_str(RuleMetric::BudgetSpentPct), "budget_spent_pct");
+        assert_eq!(metric_as_str(RuleMetric::AnomalyScore), "anomaly_score");
+        assert_eq!(metric_as_str(RuleMetric::ApprovalPendingAge), "approval_pending_age");
+        assert_eq!(
+            metric_as_str(RuleMetric::PolicyViolationCount),
+            "policy_violation_count"
+        );
+    }
+
+    #[test]
+    fn operator_as_str_covers_every_variant() {
+        assert_eq!(operator_as_str(RuleOperator::Gt), ">");
+        assert_eq!(operator_as_str(RuleOperator::Gte), ">=");
+        assert_eq!(operator_as_str(RuleOperator::Lt), "<");
+        assert_eq!(operator_as_str(RuleOperator::Eq), "=");
+    }
+
+    #[test]
+    fn severity_as_str_covers_every_variant() {
+        assert_eq!(severity_as_str(RuleSeverity::Critical), "CRITICAL");
+        assert_eq!(severity_as_str(RuleSeverity::High), "HIGH");
+        assert_eq!(severity_as_str(RuleSeverity::Medium), "MEDIUM");
+        assert_eq!(severity_as_str(RuleSeverity::Low), "LOW");
+    }
+
+    #[test]
+    fn build_rule_alert_seed_renders_non_default_metric_op_severity() {
+        let mut r = rule(RuleOperator::Lt, 5.0);
+        r.metric = RuleMetric::AnomalyScore;
+        r.severity = RuleSeverity::Medium;
+        let seed = build_rule_alert_seed(&r, 3.0);
+        assert_eq!(seed.rule_snapshot.metric, "anomaly_score");
+        assert_eq!(seed.rule_snapshot.operator, "<");
+        assert_eq!(seed.rule_snapshot.severity, "MEDIUM");
+    }
+
+    #[test]
+    fn budget_metric_source_none_when_limit_zero() {
+        use aa_gateway::budget::tracker::BudgetTracker;
+        use aa_gateway::budget::PricingTable;
+        use rust_decimal::Decimal;
+
+        let tracker = std::sync::Arc::new(BudgetTracker::new(
+            PricingTable::default_table(),
+            Some(Decimal::ZERO),
+            None,
+            chrono_tz::UTC,
+        ));
+        let source = BudgetMetricSource::new(tracker);
+        // A zero daily limit must short-circuit to None (avoids divide-by-zero).
+        assert_eq!(source.current_value(RuleMetric::BudgetSpentPct), None);
+    }
+
+    #[tokio::test]
+    async fn spawn_rule_evaluator_fires_on_tick() {
+        let rules = std::sync::Arc::new(InMemoryAlertRuleStore::new());
+        rules.create(rule(RuleOperator::Gt, 90.0)).expect("create");
+        let alerts = std::sync::Arc::new(InMemoryAlertStore::new());
+        let metrics = std::sync::Arc::new(FixedMetric(95.0));
+
+        let handle = spawn_rule_evaluator(rules.clone(), metrics, alerts.clone(), Duration::from_millis(10));
+
+        // Give the loop a few ticks to record at least one alert.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        handle.abort();
+
+        let (items, _) = alerts.list(10, 0);
+        assert!(!items.is_empty(), "the spawned evaluator loop must record alerts");
+    }
 }

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -797,4 +797,62 @@ mod tests {
         assert_ne!(id_a, id_b, "different rule_ids must not dedup against each other");
         assert_eq!(outcome_b, DedupOutcome::Created);
     }
+
+    #[test]
+    fn default_impl_matches_new() {
+        let store = InMemoryAlertStore::default();
+        let (items, total) = store.list(10, 0);
+        assert!(items.is_empty());
+        assert_eq!(total, 0);
+    }
+
+    #[test]
+    fn record_secret_evicts_oldest_at_capacity() {
+        let store = InMemoryAlertStore::with_capacity(2);
+        store.record_secret(&test_secret_alert(CredentialKind::AwsAccessKey));
+        store.record_secret(&test_secret_alert(CredentialKind::OpenAiKey));
+        store.record_secret(&test_secret_alert(CredentialKind::AwsAccessKey)); // evicts oldest
+        assert_eq!(store.list(10, 0).1, 2);
+    }
+
+    #[test]
+    fn record_rule_alert_evicts_oldest_at_capacity() {
+        let store = InMemoryAlertStore::with_capacity(2);
+        let mut seed = test_rule_seed();
+        seed.rule_snapshot.dedup_window_seconds = 0; // force a fresh record each call
+        store.record_rule_alert(&seed);
+        store.record_rule_alert(&seed);
+        store.record_rule_alert(&seed); // evicts oldest
+        assert_eq!(store.list(10, 0).1, 2);
+    }
+
+    #[test]
+    fn dedup_create_evicts_oldest_at_capacity() {
+        let store = InMemoryAlertStore::with_capacity(2);
+        let mut seed = test_rule_seed();
+        seed.rule_snapshot.dedup_window_seconds = 0; // every call creates
+        let now = fixed_now();
+        store.dedup_or_record_rule_alert(&seed, now);
+        store.dedup_or_record_rule_alert(&seed, now);
+        store.dedup_or_record_rule_alert(&seed, now); // evicts oldest on create
+        assert_eq!(store.list(10, 0).1, 2);
+    }
+
+    #[test]
+    fn dedup_skips_non_rule_and_foreign_rule_entries_then_creates() {
+        let store = InMemoryAlertStore::with_capacity(100);
+        // A budget alert has no rule_context → the dedup scan `continue`s past it.
+        store.record(&test_alert(80));
+        // A rule alert recorded via record_rule_alert carries a rule_context but
+        // no dedup_window_expires_at → the dedup scan also `continue`s past it.
+        let mut other = test_rule_seed();
+        other.rule_id = "some-other-rule".to_string();
+        store.record_rule_alert(&other);
+
+        // Now dedup a fresh seed: it must skip both existing entries and create.
+        let seed = test_rule_seed();
+        let now = fixed_now();
+        let (_id, outcome) = store.dedup_or_record_rule_alert(&seed, now);
+        assert_eq!(outcome, DedupOutcome::Created);
+    }
 }

--- a/aa-api/tests/admin.rs
+++ b/aa-api/tests/admin.rs
@@ -252,3 +252,76 @@ async fn post_run_returns_503_when_retention_engine_is_unconfigured() {
 
     assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
 }
+
+#[tokio::test]
+async fn put_with_hot_days_zero_returns_400() {
+    let app = common::test_app();
+    let req_body = serde_json::json!({
+        "hot_days": 0,
+        "warm_days": 90,
+        "cold_action": "drop",
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/admin/retention-policy")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = json_body(resp).await;
+    assert_eq!(body["error_code"].as_str(), Some("retention_policy_invalid_hot_days"));
+}
+
+#[tokio::test]
+async fn put_with_archive_action_and_valid_s3_url_returns_200() {
+    let (engine, _tmp) = build_engine().await;
+    let app = build_app(common::test_state_with_retention_engine(engine));
+    let req_body = serde_json::json!({
+        "hot_days": 5,
+        "warm_days": 30,
+        "cold_action": "archive",
+        "archive_url": "s3://my-bucket/retention/",
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/admin/retention-policy")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = json_body(resp).await;
+    assert_eq!(body["cold_action"].as_str(), Some("archive"));
+    assert_eq!(body["archive_url"].as_str(), Some("s3://my-bucket/retention/"));
+}
+
+#[tokio::test]
+async fn post_run_non_dry_run_returns_stats() {
+    let (engine, _tmp) = build_engine().await;
+    let app = build_app(common::test_state_with_retention_engine(Arc::clone(&engine)));
+    let req_body = serde_json::json!({ "dry_run": false });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/admin/retention-policy/run")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = json_body(resp).await;
+    assert!(body["ran_at"].is_string());
+    assert_eq!(body["dry_run"].as_bool(), Some(false));
+}

--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -463,3 +463,63 @@ async fn resume_agent_returns_404_for_unknown_id() {
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
+
+// ── Additional coverage tests (AAASM-3805) ────────────────────────────────────
+
+/// A valid hex string whose byte length ≠ 16 triggers the "wrong length" error
+/// branch in `parse_agent_id` (lines 69–72 of agents.rs).
+#[tokio::test]
+async fn get_agent_with_short_hex_id_returns_400() {
+    let app = common::test_app();
+    // "aabb" is valid hex but decodes to 2 bytes, not 16.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/agents/aabb")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(
+        json["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("32 hex characters"),
+        "detail should mention 32-char requirement"
+    );
+}
+
+/// An agent registered with non-empty `recent_traces` must include those traces
+/// in the GET /agents/{id} response (tests lines 99–106 of agents.rs).
+#[tokio::test]
+async fn get_agent_includes_recent_traces_in_response() {
+    let state = common::test_state();
+    let mut rec = test_agent(0x77);
+    rec.recent_traces = vec![aa_gateway::registry::store::RecentTrace {
+        session_id: "test-session-abc".to_string(),
+        timestamp: chrono::Utc::now(),
+    }];
+    state.agent_registry.register(rec).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}", hex_id(0x77)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let traces = json["recent_traces"].as_array().unwrap();
+    assert_eq!(traces.len(), 1);
+    assert_eq!(traces[0]["session_id"], "test-session-abc");
+    assert!(traces[0]["timestamp"].is_string());
+}

--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -523,3 +523,97 @@ async fn get_agent_includes_recent_traces_in_response() {
     assert_eq!(traces[0]["session_id"], "test-session-abc");
     assert!(traces[0]["timestamp"].is_string());
 }
+
+/// A registered agent's effective-permissions endpoint returns the merged
+/// allow/deny sets plus per-scope provenance (covers the happy path of
+/// get_agent_capabilities).
+#[tokio::test]
+async fn get_agent_capabilities_returns_200_for_registered_agent() {
+    let state = common::test_state();
+    state.agent_registry.register(test_agent(0x42)).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/capabilities", hex_id(0x42)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json["allow"].is_array());
+    assert!(json["deny"].is_array());
+    assert!(json["sources"].is_array());
+}
+
+#[tokio::test]
+async fn get_agent_capabilities_returns_404_for_unknown_agent() {
+    let app = common::test_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/capabilities", hex_id(0x99)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// Subtree-burn over an agent with recorded spend (self) and a child with
+/// recorded spend emits a dense per-day point series with per-child rows.
+#[tokio::test]
+async fn get_agent_subtree_burn_includes_self_and_child_spend() {
+    use rust_decimal::Decimal;
+
+    let state = common::test_state();
+
+    // Parent agent declares one child; both are registered.
+    let mut parent = test_agent(0x10);
+    let child_bytes = [0x20u8; 16];
+    parent.children = vec![child_bytes];
+    state.agent_registry.register(parent).unwrap();
+
+    let mut child = test_agent(0x20);
+    child.parent_agent_id = Some(hex_id(0x10));
+    state.agent_registry.register(child).unwrap();
+
+    // Record spend so both the "(self)" and child rows are emitted.
+    let parent_id = aa_core::identity::AgentId::from_bytes([0x10u8; 16]);
+    let child_id = aa_core::identity::AgentId::from_bytes(child_bytes);
+    state
+        .budget_tracker
+        .record_raw_spend(parent_id, None, None, Decimal::new(150, 2));
+    state
+        .budget_tracker
+        .record_raw_spend(child_id, None, None, Decimal::new(75, 2));
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/subtree-burn?period=7d", hex_id(0x10)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let points = json["points"].as_array().unwrap();
+    assert!(!points.is_empty());
+    // The most recent day should carry per-child rows including the "(self)" row.
+    let last = points.last().unwrap();
+    let per_child = last["per_child"].as_array().unwrap();
+    let names: Vec<&str> = per_child
+        .iter()
+        .map(|c| c["child_name"].as_str().unwrap_or_default())
+        .collect();
+    assert!(names.contains(&"(self)"), "self row must be present; got {names:?}");
+}

--- a/aa-api/tests/agents_detail.rs
+++ b/aa-api/tests/agents_detail.rs
@@ -1,0 +1,216 @@
+//! Integration tests for the agent detail endpoints — capabilities, budget
+//! rollup, and subtree-burn — plus the resume-conflict guard (AAASM-3805).
+//!
+//! These handlers carry tenant-authz, existence (404), and id-validation (400)
+//! branches that the core agents test suite did not exercise. Auth is left off
+//! (the bypass caller is admin) so these focus on the handler bodies and their
+//! 400/404/409 error paths; tenant-403 paths are covered by tenant_scope.rs.
+
+mod common;
+
+use std::collections::BTreeMap;
+
+use aa_gateway::registry::{AgentRecord, AgentStatus};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+/// Build a test `AgentRecord` with a known 16-byte id and the given status.
+fn test_agent(id_byte: u8, status: AgentStatus) -> AgentRecord {
+    AgentRecord {
+        agent_id: [id_byte; 16],
+        name: format!("test-agent-{id_byte}"),
+        framework: "langgraph".to_string(),
+        version: "0.1.0".to_string(),
+        risk_tier: 1,
+        tool_names: vec!["read_file".to_string()],
+        public_key: "test-pubkey".to_string(),
+        credential_token: "test-token".to_string(),
+        metadata: BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: std::collections::VecDeque::new(),
+        recent_traces: Vec::new(),
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+        children: Vec::new(),
+        parent_key: None,
+        enforcement_mode: None,
+        org_id: None,
+    }
+}
+
+fn hex_id(id_byte: u8) -> String {
+    format!("{id_byte:02x}").repeat(16)
+}
+
+async fn get(app: axum::Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let response = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, value)
+}
+
+// ── capabilities ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_capabilities_returns_200_for_registered_agent() {
+    let state = common::test_state();
+    state
+        .agent_registry
+        .register(test_agent(0x11, AgentStatus::Active))
+        .unwrap();
+    let app = aa_api::server::build_app(state);
+
+    let (status, body) = get(app, &format!("/api/v1/agents/{}/capabilities", hex_id(0x11))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["allow"].is_array());
+    assert!(body["deny"].is_array());
+    assert!(body["sources"].is_array());
+}
+
+#[tokio::test]
+async fn get_capabilities_returns_404_for_unknown_agent() {
+    let app = common::test_app();
+    let (status, _) = get(app, &format!("/api/v1/agents/{}/capabilities", hex_id(0x99))).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_capabilities_returns_400_for_invalid_id() {
+    let app = common::test_app();
+    let (status, _) = get(app, "/api/v1/agents/not-hex/capabilities").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ── budget rollup ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_budget_returns_200_for_registered_agent() {
+    let state = common::test_state();
+    state
+        .agent_registry
+        .register(test_agent(0x22, AgentStatus::Active))
+        .unwrap();
+    let app = aa_api::server::build_app(state);
+
+    let (status, body) = get(app, &format!("/api/v1/agents/{}/budget", hex_id(0x22))).await;
+    assert_eq!(status, StatusCode::OK);
+    // The rollup always carries at least the agent + global rows.
+    assert!(!body["rows"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn get_budget_returns_404_for_unknown_agent() {
+    let app = common::test_app();
+    let (status, _) = get(app, &format!("/api/v1/agents/{}/budget", hex_id(0x98))).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_budget_returns_400_for_invalid_id() {
+    let app = common::test_app();
+    let (status, _) = get(app, "/api/v1/agents/zz/budget").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ── subtree-burn ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_subtree_burn_returns_200_with_default_and_30d_period() {
+    let state = common::test_state();
+    state
+        .agent_registry
+        .register(test_agent(0x33, AgentStatus::Active))
+        .unwrap();
+    let app = aa_api::server::build_app(state);
+
+    // Default period (7d) — one dense point per day, even with no recorded spend.
+    let (status, body) = get(app, &format!("/api/v1/agents/{}/subtree-burn", hex_id(0x33))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["period"], "7d");
+    assert_eq!(body["points"].as_array().unwrap().len(), 7);
+
+    // Opt-in 30d period.
+    let state = common::test_state();
+    state
+        .agent_registry
+        .register(test_agent(0x33, AgentStatus::Active))
+        .unwrap();
+    let app = aa_api::server::build_app(state);
+    let (status, body) = get(app, &format!("/api/v1/agents/{}/subtree-burn?period=30d", hex_id(0x33))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["period"], "30d");
+    assert_eq!(body["points"].as_array().unwrap().len(), 30);
+}
+
+#[tokio::test]
+async fn get_subtree_burn_returns_404_for_unknown_agent() {
+    let app = common::test_app();
+    let (status, _) = get(app, &format!("/api/v1/agents/{}/subtree-burn", hex_id(0x97))).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_subtree_burn_returns_400_for_invalid_id() {
+    let app = common::test_app();
+    let (status, _) = get(app, "/api/v1/agents/xyz/subtree-burn").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ── resume conflict + id validation ──────────────────────────────────────────
+
+#[tokio::test]
+async fn resume_active_agent_returns_409() {
+    let state = common::test_state();
+    state
+        .agent_registry
+        .register(test_agent(0x44, AgentStatus::Active))
+        .unwrap();
+    let app = aa_api::server::build_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/agents/{}/resume", hex_id(0x44)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Only suspended agents can be resumed; an already-active one is a conflict.
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn resume_invalid_id_returns_400() {
+    let app = common::test_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/agents/nothex/resume")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/aa-api/tests/approvals.rs
+++ b/aa-api/tests/approvals.rs
@@ -410,3 +410,116 @@ async fn get_approval_returns_400_for_invalid_uuid() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
+
+// =============================================================================
+// AlreadyDecided + empty-reason edge cases (AAASM-3805)
+// =============================================================================
+
+#[tokio::test]
+async fn approve_action_returns_409_when_already_decided() {
+    let state = common::test_state();
+    let req = make_approval_request(600);
+    let id = req.request_id;
+    let (_rid, _fut) = state.approval_queue.submit(req);
+    let app = aa_api::server::build_app(state);
+
+    // First approval succeeds.
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/approvals/{id}/approve"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"by": "alice"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Second approval on the same id → 409 AlreadyDecided.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/approvals/{id}/approve"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"by": "bob"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("already been decided"));
+}
+
+#[tokio::test]
+async fn reject_action_returns_400_for_whitespace_reason() {
+    let state = common::test_state();
+    let req = make_approval_request(600);
+    let id = req.request_id;
+    let (_rid, _fut) = state.approval_queue.submit(req);
+    let app = aa_api::server::build_app(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/approvals/{id}/reject"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"by": "alice", "reason": "   "}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json["detail"].as_str().unwrap_or_default().contains("non-empty reason"));
+}
+
+#[tokio::test]
+async fn reject_action_returns_409_when_already_decided() {
+    let state = common::test_state();
+    let req = make_approval_request(600);
+    let id = req.request_id;
+    let (_rid, _fut) = state.approval_queue.submit(req);
+    let app = aa_api::server::build_app(state);
+
+    // Approve first.
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/approvals/{id}/approve"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"by": "alice"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Now try to reject the already-approved request → 409.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/approvals/{id}/reject"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"by": "bob", "reason": "changed mind"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("already been decided"));
+}

--- a/aa-api/tests/approvals.rs
+++ b/aa-api/tests/approvals.rs
@@ -6,7 +6,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
 
-use aa_runtime::approval::ApprovalRequest;
+use aa_runtime::approval::{ApprovalRequest, RoutingHistoryEntry};
 
 fn make_approval_request(timeout_secs: u64) -> ApprovalRequest {
     ApprovalRequest {
@@ -522,4 +522,88 @@ async fn reject_action_returns_409_when_already_decided() {
         .as_str()
         .unwrap_or_default()
         .contains("already been decided"));
+}
+
+#[tokio::test]
+async fn list_approvals_includes_routing_status_when_recorded() {
+    let state = common::test_state();
+    let req = make_approval_request(600);
+    let id = req.request_id;
+    let (_rid, _fut) = state.approval_queue.submit(req);
+
+    // Record routing metadata so pending_to_response surfaces routing_status.
+    let recorded = state.approval_queue.record_routing(
+        id,
+        "routed".to_string(),
+        Some("oncall".to_string()),
+        Some(1_700_000_100),
+        Some(1_700_000_900),
+        Some(RoutingHistoryEntry {
+            at: 1_700_000_100,
+            action: "routed".to_string(),
+            from_role: None,
+            to_role: "oncall".to_string(),
+        }),
+    );
+    assert!(recorded);
+
+    let app = aa_api::server::build_app(state);
+    let resp = app
+        .oneshot(Request::builder().uri("/api/v1/approvals").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let item = &json["items"][0];
+    assert_eq!(item["routing_status"]["status"], "routed");
+    assert_eq!(item["routing_status"]["target_role"], "oncall");
+    assert_eq!(item["routing_status"]["routed_at"], 1_700_000_100);
+    assert_eq!(item["routing_status"]["escalate_at"], 1_700_000_900);
+    let history = item["routing_status"]["history"].as_array().unwrap();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0]["action"], "routed");
+    assert_eq!(history[0]["to_role"], "oncall");
+}
+
+#[tokio::test]
+async fn get_approval_includes_routing_status_when_recorded() {
+    let state = common::test_state();
+    let req = make_approval_request(600);
+    let id = req.request_id;
+    let (_rid, _fut) = state.approval_queue.submit(req);
+
+    state.approval_queue.record_routing(
+        id,
+        "escalated".to_string(),
+        Some("manager".to_string()),
+        None,
+        None,
+        Some(RoutingHistoryEntry {
+            at: 1_700_000_200,
+            action: "escalated".to_string(),
+            from_role: Some("oncall".to_string()),
+            to_role: "manager".to_string(),
+        }),
+    );
+
+    let app = aa_api::server::build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/approvals/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["routing_status"]["status"], "escalated");
+    assert_eq!(json["routing_status"]["target_role"], "manager");
+    let history = json["routing_status"]["history"].as_array().unwrap();
+    assert_eq!(history[0]["from_role"], "oncall");
 }

--- a/aa-api/tests/audit_violations.rs
+++ b/aa-api/tests/audit_violations.rs
@@ -1,0 +1,45 @@
+//! Integration tests for `GET /api/v1/audit/violations-by-lineage` (AAASM-3805).
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn violations_by_lineage_returns_200_with_empty_set() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/audit/violations-by-lineage")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json["nodes"].is_array());
+    assert!(json["window_secs"].is_number());
+    assert!(json["generated_at"].is_string());
+}
+
+#[tokio::test]
+async fn violations_by_lineage_accepts_window_param() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/audit/violations-by-lineage?window=1h")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["window_secs"], 3600);
+}

--- a/aa-api/tests/capability.rs
+++ b/aa-api/tests/capability.rs
@@ -399,3 +399,56 @@ async fn get_matrix_with_effective_only_excludes_all_na_cells() {
         }
     }
 }
+
+// ── TTL auto-revert (covers the spawned revert task) ──────────────────────────
+
+#[tokio::test]
+async fn apply_override_with_short_ttl_auto_reverts_cell() {
+    use aa_api::models::capability::{Decision, Verb};
+    use aa_api::routes::capability::CapabilityStore;
+    use std::sync::Arc;
+
+    let store = CapabilityStore::new_seeded();
+
+    // Capture the original decision for support-triage / pg / write.
+    let before = store.snapshot().await;
+    let original = before
+        .agents
+        .iter()
+        .find(|a| a.id == "support-triage")
+        .and_then(|a| a.caps.get("pg"))
+        .map(|c| c.write)
+        .expect("seed must include support-triage/pg");
+
+    let req = aa_api::models::capability::CapabilityOverrideRequest {
+        agent_ids: vec!["support-triage".to_string()],
+        resource_id: "pg".to_string(),
+        verb: Verb::Write,
+        decision: Decision::Deny,
+        ttl_seconds: Some(1),
+    };
+    let (_id, _updated) = Arc::clone(&store).apply_override(&req).await.unwrap();
+
+    // Immediately after applying, the cell reflects the override.
+    let during = store.snapshot().await;
+    let during_write = during
+        .agents
+        .iter()
+        .find(|a| a.id == "support-triage")
+        .and_then(|a| a.caps.get("pg"))
+        .map(|c| c.write)
+        .unwrap();
+    assert_eq!(during_write, Decision::Deny);
+
+    // After the TTL elapses the spawned task reverts the cell to its original value.
+    tokio::time::sleep(std::time::Duration::from_millis(1300)).await;
+    let after = store.snapshot().await;
+    let after_write = after
+        .agents
+        .iter()
+        .find(|a| a.id == "support-triage")
+        .and_then(|a| a.caps.get("pg"))
+        .map(|c| c.write)
+        .unwrap();
+    assert_eq!(after_write, original, "TTL expiry must restore the original decision");
+}

--- a/aa-api/tests/capability.rs
+++ b/aa-api/tests/capability.rs
@@ -180,3 +180,222 @@ async fn apply_override_rejects_unknown_agent_with_400() {
         "ProblemDetail should name the offending agent id; got: {detail}"
     );
 }
+
+// ── Additional coverage tests (AAASM-3805) ────────────────────────────────────
+
+async fn oneshot_get(app: axum::Router, uri: &str) -> (axum::http::StatusCode, serde_json::Value) {
+    let resp = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri(uri)
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let body = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, body)
+}
+
+async fn oneshot_delete(app: axum::Router, uri: &str) -> axum::http::StatusCode {
+    app.oneshot(
+        axum::http::Request::builder()
+            .method("DELETE")
+            .uri(uri)
+            .body(axum::body::Body::empty())
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+    .status()
+}
+
+// ── list_overrides ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_overrides_returns_200_with_empty_list_initially() {
+    let app = common::test_app();
+    let (status, body) = oneshot_get(app, "/api/v1/capability/override").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn list_overrides_reflects_applied_override() {
+    let app = common::test_app();
+    // Apply one override first.
+    app.clone()
+        .oneshot(post_override_request(
+            json!({
+                "agentIds": ["support-triage"],
+                "resourceId": "pg",
+                "verb": "read",
+                "decision": "deny"
+            }),
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let (status, body) = oneshot_get(app, "/api/v1/capability/override").await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body.as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["resourceId"], "pg");
+    assert_eq!(items[0]["verb"], "read");
+}
+
+#[tokio::test]
+async fn list_overrides_with_agent_id_filter_returns_matching_entries() {
+    let app = common::test_app();
+    // Apply overrides for two different agents.
+    app.clone()
+        .oneshot(post_override_request(
+            json!({"agentIds": ["support-triage"], "resourceId": "gmail", "verb": "read", "decision": "deny"}),
+            None,
+        ))
+        .await
+        .unwrap();
+    app.clone()
+        .oneshot(post_override_request(
+            json!({"agentIds": ["research-bot-04"], "resourceId": "slack", "verb": "write", "decision": "deny"}),
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let (status, body) = oneshot_get(app, "/api/v1/capability/override?agent_id=support-triage").await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body.as_array().unwrap();
+    // Only the support-triage override should be visible.
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["agentIds"].as_array().unwrap()[0], "support-triage");
+}
+
+// ── revoke_override ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn revoke_override_returns_204_and_removes_entry() {
+    let app = common::test_app();
+
+    // Apply an override and grab its id.
+    let apply_resp = app
+        .clone()
+        .oneshot(post_override_request(
+            json!({"agentIds": ["support-triage"], "resourceId": "pg", "verb": "write", "decision": "deny"}),
+            None,
+        ))
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(apply_resp.into_body(), usize::MAX).await.unwrap();
+    let apply_json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let override_id = apply_json["overrideId"].as_str().unwrap().to_string();
+
+    // Delete it.
+    let status = oneshot_delete(app.clone(), &format!("/api/v1/capability/override/{override_id}")).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn revoke_override_returns_404_for_unknown_id() {
+    let app = common::test_app();
+    let status = oneshot_delete(app, "/api/v1/capability/override/does-not-exist").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+// ── apply_override with different verbs ─────────────────────────────────────
+
+#[tokio::test]
+async fn apply_override_with_verb_delete() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(post_override_request(
+            json!({"agentIds": ["support-triage"], "resourceId": "pg", "verb": "delete", "decision": "deny"}),
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["updated"][0]["caps"]["pg"]["delete"], "deny");
+}
+
+#[tokio::test]
+async fn apply_override_with_verb_exec() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(post_override_request(
+            json!({"agentIds": ["support-triage"], "resourceId": "pg", "verb": "exec", "decision": "deny"}),
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["updated"][0]["caps"]["pg"]["exec"], "deny");
+}
+
+#[tokio::test]
+async fn apply_override_with_ttl_returns_201() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(post_override_request(
+            json!({
+                "agentIds": ["support-triage"],
+                "resourceId": "pg",
+                "verb": "write",
+                "decision": "deny",
+                "ttlSeconds": 3600
+            }),
+            None,
+        ))
+        .await
+        .unwrap();
+    // TTL present → 201 Created (not 200 OK).
+    assert_eq!(resp.status(), StatusCode::CREATED);
+}
+
+// ── get_matrix filters ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_matrix_with_team_id_filter_returns_matching_agent_only() {
+    let (status, body) = oneshot_get(common::test_app(), "/api/v1/capability/matrix?team_id=support-triage").await;
+    assert_eq!(status, StatusCode::OK);
+    let agents = body["agents"].as_array().unwrap();
+    // All returned agents should have id == "support-triage".
+    for a in agents {
+        assert_eq!(a["id"], "support-triage");
+    }
+}
+
+#[tokio::test]
+async fn get_matrix_with_tool_filter_returns_single_resource_column() {
+    let (status, body) = oneshot_get(common::test_app(), "/api/v1/capability/matrix?tool=gmail").await;
+    assert_eq!(status, StatusCode::OK);
+    // The resources list should only contain "gmail".
+    let resources = body["resources"].as_array().unwrap();
+    assert!(resources.iter().all(|r| r["id"] == "gmail"));
+}
+
+#[tokio::test]
+async fn get_matrix_with_effective_only_excludes_all_na_cells() {
+    let (status, body) = oneshot_get(common::test_app(), "/api/v1/capability/matrix?effective_only=true").await;
+    assert_eq!(status, StatusCode::OK);
+    // Every remaining cell must have at least one non-"na" decision.
+    let agents = body["agents"].as_array().unwrap();
+    for agent in agents {
+        let caps = agent["caps"].as_object().unwrap();
+        for (_rid, cell) in caps {
+            let all_na = ["read", "write", "delete", "exec"].iter().all(|v| cell[v] == "na");
+            assert!(
+                !all_na,
+                "effective_only=true must remove all-na cells; found one in agent {}",
+                agent["id"]
+            );
+        }
+    }
+}

--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -674,3 +674,102 @@ async fn delete_destination_returns_404_for_unknown_id() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
+
+// ── PagerDuty connector not compiled in → 502 connector_failed (transport) ────
+
+/// PagerDuty/OpsGenie connectors are feature-gated and disabled in the default
+/// build, so `connector_for` returns `UnsupportedConnector`, whose `dispatch`
+/// always fails with a transport error. Firing a test against a pagerduty
+/// destination must surface as 502 `connector_failed` with status 0.
+#[tokio::test]
+async fn test_pagerduty_destination_returns_502_transport_error() {
+    let app = common::test_app();
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/api/v1/alerts/destinations",
+            json!({
+                "name": "pd",
+                "kind": "pagerduty",
+                "config": { "routing_key": "R0UTINGKEY123456" },
+                "enabled": true,
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let created = body_json(resp).await;
+    assert_eq!(created["kind"], "pagerduty");
+    let id = created["id"].as_str().unwrap().to_string();
+
+    let resp = app
+        .oneshot(json_request(
+            "POST",
+            &format!("/api/v1/alerts/destinations/{id}/test"),
+            json!({ "severity": "HIGH" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    let body = body_json(resp).await;
+    assert_eq!(body["error"], "connector_failed");
+    // Transport failures carry a synthetic status of 0.
+    assert_eq!(body["connector_status"], 0);
+    assert!(body["connector_body"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("not enabled"));
+}
+
+// ── malformed JSON (not an unknown-variant error) → generic 400 ───────────────
+
+#[tokio::test]
+async fn create_destination_with_malformed_json_returns_400() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/alerts/destinations")
+                .header("content-type", "application/json")
+                // Valid kind, but `config` has the wrong type → serde error that
+                // is NOT "unknown variant", exercising the generic 400 branch.
+                .body(Body::from(r#"{"name":"x","kind":"webhook","config":"not-an-object","enabled":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn update_destination_with_malformed_json_returns_400() {
+    let app = common::test_app();
+    // Create a webhook to target.
+    let resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/api/v1/alerts/destinations",
+            webhook_payload("upd", "https://example.com/hook"),
+        ))
+        .await
+        .unwrap();
+    let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/v1/alerts/destinations/{id}"))
+                .header("content-type", "application/json")
+                // `name` must be a string; a number is a non-variant serde
+                // error → generic 400 (not the invalid_kind branch).
+                .body(Body::from(r#"{"name": 12345}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -595,3 +595,82 @@ async fn update_with_masked_secret_preserves_stored_secret() {
     // was hit proves the real secret survived the masked update.
     mock.assert();
 }
+
+// ── Additional coverage tests (AAASM-3805) ────────────────────────────────────
+
+#[tokio::test]
+async fn create_destination_with_empty_name_returns_400() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(json_request(
+            "POST",
+            "/api/v1/alerts/destinations",
+            json!({"name": "  ", "kind": "webhook", "config": {"url": "https://example.com"}, "enabled": true}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_json(resp).await;
+    assert!(body["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("name must be non-empty"));
+}
+
+#[tokio::test]
+async fn update_destination_with_empty_name_returns_400() {
+    // Create a destination, then try to rename it to blank.
+    let app = common::test_app();
+    let create_resp = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/api/v1/alerts/destinations",
+            webhook_payload("keep-me", "https://example.com/keep"),
+        ))
+        .await
+        .unwrap();
+    let id = body_json(create_resp).await["id"].as_str().unwrap().to_string();
+
+    let resp = app
+        .oneshot(json_request(
+            "PUT",
+            &format!("/api/v1/alerts/destinations/{id}"),
+            json!({"name": "  "}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn update_destination_returns_404_for_unknown_id() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(json_request(
+            "PUT",
+            "/api/v1/alerts/destinations/nonexistent-id",
+            json!({"name": "new-name"}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = body_json(resp).await;
+    assert_eq!(body["detail"].as_str(), Some("destination_not_found"));
+}
+
+#[tokio::test]
+async fn delete_destination_returns_404_for_unknown_id() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/v1/alerts/destinations/nonexistent-id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/aa-api/tests/dispatch_tool.rs
+++ b/aa-api/tests/dispatch_tool.rs
@@ -1,0 +1,98 @@
+//! Integration tests for `POST /api/v1/dispatch_tool` (AAASM-3805).
+//!
+//! Covers the native secret-injection branch of the dispatch handler: passthrough
+//! of placeholder-free args, resolution of registered `${NAME}` placeholders, and
+//! the fail-closed 422 when an unknown placeholder is referenced. The WASM-sandbox
+//! branch is exercised by the sandbox crate's own tests (it needs a real wasm
+//! module registered as `ToolKind::Wasm`), so it is intentionally out of scope here.
+
+mod common;
+
+use aa_api::server::build_app;
+use aa_gateway::secrets::Secret;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tower::ServiceExt;
+
+/// POST a dispatch request and return (status, parsed-JSON-body).
+async fn post_dispatch(app: axum::Router, body: serde_json::Value) -> (StatusCode, serde_json::Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/dispatch_tool")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, value)
+}
+
+#[tokio::test]
+async fn dispatch_passes_through_args_without_placeholders() {
+    let app = common::test_app_no_auth();
+    let (status, body) = post_dispatch(
+        app,
+        json!({ "tool": "call_database", "args": { "query": "SELECT 1", "limit": 10 } }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    // No `${...}` tokens → args are returned unchanged and nothing was substituted.
+    assert_eq!(body["resolved_args"]["query"], "SELECT 1");
+    assert_eq!(body["resolved_args"]["limit"], 10);
+    assert!(body["names_substituted"].as_array().unwrap().is_empty());
+    // Native path leaves the sandbox verdict absent.
+    assert!(body.get("sandbox").is_none() || body["sandbox"].is_null());
+}
+
+#[tokio::test]
+async fn dispatch_resolves_registered_placeholder() {
+    // Seed a secret, then reference it via a `${DB_PASSWORD}` placeholder.
+    let state = common::test_state();
+    state
+        .secrets_store
+        .register(Secret {
+            name: "DB_PASSWORD".to_string(),
+            value: "s3cr3t-value".to_string(),
+        })
+        .expect("register secret");
+    let app = build_app(state);
+
+    let (status, body) = post_dispatch(
+        app,
+        json!({ "tool": "call_database", "args": { "password": "${DB_PASSWORD}" } }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["resolved_args"]["password"], "s3cr3t-value");
+    assert_eq!(
+        body["names_substituted"].as_array().unwrap(),
+        &vec![serde_json::Value::String("DB_PASSWORD".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn dispatch_unknown_placeholder_returns_422() {
+    let app = common::test_app_no_auth();
+    let (status, body) = post_dispatch(
+        app,
+        json!({ "tool": "call_database", "args": { "token": "${MISSING_SECRET}" } }),
+    )
+    .await;
+
+    // The resolver refuses to silently forward an unresolved `${...}` token.
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    let detail = body["detail"].as_str().unwrap_or_default();
+    assert!(
+        detail.contains("MISSING_SECRET"),
+        "422 detail should name the unknown placeholder, got: {detail}"
+    );
+}

--- a/aa-api/tests/edges.rs
+++ b/aa-api/tests/edges.rs
@@ -509,3 +509,143 @@ async fn list_agent_edges_with_before_filter_excludes_newer_edges() {
     // All seeded edges were created after epoch, so filter removes them all.
     assert_eq!(body["count"], 0);
 }
+
+// ── GET /agents/{id}/edges?before=<invalid> ──────────────────────────────────
+
+#[tokio::test]
+async fn list_agent_edges_with_invalid_before_returns_400() {
+    let app = common::test_app();
+    let (status, body) = get_json(
+        app,
+        &format!("/api/v1/agents/{}/edges?before=not-a-timestamp", hex(0x01)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("Invalid 'before' timestamp"));
+}
+
+// ── GET /agents/{id}/edges?direction=incoming ────────────────────────────────
+
+#[tokio::test]
+async fn list_agent_edges_incoming_direction_returns_inbound_edges() {
+    let state = common::test_state();
+    state
+        .edge_repo
+        .insert(aa_core::topology::NewEdge {
+            source: agent_id(0x02),
+            target: agent_id(0x01),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    let app = build_app(state);
+    let (status, body) = get_json(app, &format!("/api/v1/agents/{}/edges?direction=incoming", hex(0x01))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["count"], 1);
+    assert_eq!(body["edges"][0]["source_agent_id"], hex(0x02));
+}
+
+// ── cross-team detection + GET /topology/edges?team_id= ──────────────────────
+
+/// Build a minimal registered `AgentRecord` tagged with a team.
+fn team_agent(id_byte: u8, team: &str) -> aa_gateway::registry::AgentRecord {
+    aa_gateway::registry::AgentRecord {
+        agent_id: [id_byte; 16],
+        name: format!("agent-{id_byte}"),
+        framework: "langgraph".to_string(),
+        version: "0.1.0".to_string(),
+        risk_tier: 1,
+        tool_names: vec![],
+        public_key: "pk".to_string(),
+        credential_token: "tok".to_string(),
+        metadata: std::collections::BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: aa_gateway::registry::AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: std::collections::VecDeque::new(),
+        recent_traces: Vec::new(),
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: Some(team.to_string()),
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+        children: Vec::new(),
+        parent_key: None,
+        enforcement_mode: None,
+        org_id: None,
+    }
+}
+
+#[tokio::test]
+async fn list_agent_edges_marks_cross_team_edges() {
+    let state = common::test_state();
+    state.agent_registry.register(team_agent(0x01, "alpha")).unwrap();
+    state.agent_registry.register(team_agent(0x02, "beta")).unwrap();
+    state
+        .edge_repo
+        .insert(aa_core::topology::NewEdge {
+            source: agent_id(0x01),
+            target: agent_id(0x02),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let app = build_app(state);
+    let (status, body) = get_json(app, &format!("/api/v1/agents/{}/edges?direction=outgoing", hex(0x01))).await;
+    assert_eq!(status, StatusCode::OK);
+    // The edge spans two distinct teams → is_cross_team must be true.
+    assert_eq!(body["edges"][0]["is_cross_team"], true);
+}
+
+#[tokio::test]
+async fn list_topology_edges_with_team_filter_keeps_only_team_edges() {
+    let state = common::test_state();
+    state.agent_registry.register(team_agent(0x01, "alpha")).unwrap();
+    state.agent_registry.register(team_agent(0x02, "alpha")).unwrap();
+    state.agent_registry.register(team_agent(0x03, "beta")).unwrap();
+    state.agent_registry.register(team_agent(0x04, "beta")).unwrap();
+
+    // An alpha→alpha edge and a beta→beta edge.
+    state
+        .edge_repo
+        .insert(aa_core::topology::NewEdge {
+            source: agent_id(0x01),
+            target: agent_id(0x02),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    state
+        .edge_repo
+        .insert(aa_core::topology::NewEdge {
+            source: agent_id(0x03),
+            target: agent_id(0x04),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let app = build_app(state);
+    let (status, body) = get_json(app, "/api/v1/topology/edges?team_id=alpha").await;
+    assert_eq!(status, StatusCode::OK);
+    let edges = body["edges"].as_array().unwrap();
+    // Only the alpha→alpha edge survives the team filter.
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0]["source_agent_id"], hex(0x01));
+}

--- a/aa-api/tests/edges.rs
+++ b/aa-api/tests/edges.rs
@@ -372,3 +372,140 @@ async fn get_agent_graph_root_only_when_no_edges() {
     assert_eq!(nodes.len(), 1, "only the root node when no edges");
     assert!(json["edges"].as_array().unwrap().is_empty());
 }
+
+// ── Additional coverage tests (AAASM-3805) ────────────────────────────────────
+
+async fn get_json(app: axum::Router, uri: &str) -> (StatusCode, Value) {
+    let resp = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let body = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, body)
+}
+
+// ── GET /api/v1/topology/edges ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_topology_edges_returns_200_with_empty_list() {
+    let app = common::test_app();
+    let (status, body) = get_json(app, "/api/v1/topology/edges").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["edges"].is_array());
+    assert_eq!(body["count"], 0);
+}
+
+#[tokio::test]
+async fn list_topology_edges_returns_recorded_edges() {
+    let state = common::test_state();
+    // Seed two edges directly via the repo.
+    state
+        .edge_repo
+        .insert(aa_core::topology::NewEdge {
+            source: agent_id(0xaa),
+            target: agent_id(0xbb),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    state
+        .edge_repo
+        .insert(aa_core::topology::NewEdge {
+            source: agent_id(0xcc),
+            target: agent_id(0xdd),
+            edge_type: aa_core::topology::EdgeType::DelegatesTo,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let app = build_app(state);
+    let (status, body) = get_json(app, "/api/v1/topology/edges").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["count"], 2);
+}
+
+// ── report_edge: metadata edge cases ─────────────────────────────────────────
+
+#[tokio::test]
+async fn report_edge_empty_metadata_json_is_treated_as_none() {
+    let app = common::test_app();
+    let (status, body) = post_edge(
+        app,
+        json!({
+            "source_agent_id": hex(0x10),
+            "target_agent_id": hex(0x11),
+            "edge_type": "messages",
+            "metadata_json": ""
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert!(body["id"].is_number());
+}
+
+#[tokio::test]
+async fn report_edge_invalid_metadata_json_returns_400() {
+    let app = common::test_app();
+    let (status, _body) = post_edge(
+        app,
+        json!({
+            "source_agent_id": hex(0x12),
+            "target_agent_id": hex(0x13),
+            "edge_type": "messages",
+            "metadata_json": "{not valid json"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ── parse_agent_id: wrong-length hex string ──────────────────────────────────
+
+#[tokio::test]
+async fn report_edge_wrong_length_source_hex_returns_400() {
+    let app = common::test_app();
+    // Valid hex but only 4 chars (2 bytes), not 32 (16 bytes).
+    let (status, _body) = post_edge(
+        app,
+        json!({
+            "source_agent_id": "aabb",
+            "target_agent_id": hex(0x02),
+            "edge_type": "messages"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ── GET /agents/{id}/edges?before= ───────────────────────────────────────────
+
+#[tokio::test]
+async fn list_agent_edges_with_before_filter_excludes_newer_edges() {
+    let state = common::test_state();
+    // Seed an edge so there is something to query.
+    state
+        .edge_repo
+        .insert(aa_core::topology::NewEdge {
+            source: agent_id(0x30),
+            target: agent_id(0x31),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let app = build_app(state);
+    // A `before` timestamp in the past (Unix epoch) → no edges qualify.
+    let (status, body) = get_json(
+        app,
+        &format!("/api/v1/agents/{}/edges?before=1970-01-01T00:00:00Z", hex(0x30)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    // All seeded edges were created after epoch, so filter removes them all.
+    assert_eq!(body["count"], 0);
+}

--- a/aa-api/tests/local_auth_from_env.rs
+++ b/aa-api/tests/local_auth_from_env.rs
@@ -1,0 +1,52 @@
+//! Unit-level coverage for `LocalAuth::from_env` (AAASM-3805).
+//!
+//! Each test runs in its own nextest process, so mutating process-wide
+//! environment variables here does not race with other tests.
+
+use aa_api::LocalAuth;
+
+#[test]
+fn from_env_returns_off_when_auth_disabled() {
+    std::env::set_var("AASM_API_AUTH", "off");
+    std::env::remove_var("AASM_API_KEY");
+
+    let (auth, generated) = LocalAuth::from_env();
+    assert!(matches!(auth, LocalAuth::Off));
+    assert!(!generated, "explicit off must not report a generated key");
+}
+
+#[test]
+fn from_env_uses_supplied_api_key() {
+    std::env::remove_var("AASM_API_AUTH");
+    std::env::set_var("AASM_API_KEY", "aa_supplied_key_value");
+
+    let (auth, generated) = LocalAuth::from_env();
+    match auth {
+        LocalAuth::ApiKey { key } => assert_eq!(key, "aa_supplied_key_value"),
+        LocalAuth::Off => panic!("expected ApiKey, got Off"),
+    }
+    assert!(!generated, "a supplied key must not be reported as generated");
+}
+
+#[test]
+fn from_env_generates_key_when_unset() {
+    std::env::remove_var("AASM_API_AUTH");
+    std::env::remove_var("AASM_API_KEY");
+
+    let (auth, generated) = LocalAuth::from_env();
+    match auth {
+        LocalAuth::ApiKey { key } => assert!(!key.is_empty(), "generated key must be non-empty"),
+        LocalAuth::Off => panic!("expected a generated ApiKey, got Off"),
+    }
+    assert!(generated, "an unset key must be reported as generated");
+}
+
+#[test]
+fn from_env_generates_key_when_supplied_key_is_empty() {
+    std::env::remove_var("AASM_API_AUTH");
+    std::env::set_var("AASM_API_KEY", "");
+
+    let (auth, generated) = LocalAuth::from_env();
+    assert!(matches!(auth, LocalAuth::ApiKey { .. }));
+    assert!(generated, "an empty supplied key falls through to generation");
+}

--- a/aa-api/tests/ops_lifecycle.rs
+++ b/aa-api/tests/ops_lifecycle.rs
@@ -127,3 +127,50 @@ async fn unknown_action_falls_through_to_404() {
     let (status, _body) = post_empty(app, "/api/v1/ops/op-1/delete").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn list_ops_returns_200_with_all_registered_ops() {
+    let app = build_app(common::test_state());
+    // Register two ops then list them.
+    post_json(app.clone(), "/api/v1/ops", json!({"op_id": "op-list-a"})).await;
+    post_json(app.clone(), "/api/v1/ops", json!({"op_id": "op-list-b"})).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/ops")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    let ops = body.as_array().unwrap();
+    assert_eq!(ops.len(), 2);
+}
+
+#[tokio::test]
+async fn register_op_empty_op_id_returns_400() {
+    let app = build_app(common::test_state());
+    let (status, body) = post_json(app, "/api/v1/ops", json!({"op_id": "   "})).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("op_id must not be empty"));
+}
+
+#[tokio::test]
+async fn invalid_transition_returns_409() {
+    let app = build_app(common::test_state());
+    // Register then immediately try to resume — resume from running is invalid.
+    post_json(app.clone(), "/api/v1/ops", json!({"op_id": "op-conflict"})).await;
+    let (status, body) = post_empty(app, "/api/v1/ops/op-conflict/resume").await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(body["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("state does not permit"));
+}

--- a/aa-api/tests/policies.rs
+++ b/aa-api/tests/policies.rs
@@ -243,3 +243,31 @@ async fn list_policies_with_include_archived_true_returns_all_versions() {
     // Both versions should appear when include_archived=true.
     assert_eq!(json["total"].as_u64().unwrap(), 2);
 }
+
+// ── get_active_policy 404 (no named policy loaded) ────────────────────────────
+
+#[tokio::test]
+async fn get_active_policy_returns_404_when_no_named_policy_loaded() {
+    // `PolicyEngine::for_testing()` yields an engine whose
+    // `active_policy_info().name == None`, exercising the documented 404 path.
+    let mut state = common::test_state();
+    state.policy_engine = std::sync::Arc::new(aa_gateway::engine::PolicyEngine::for_testing());
+    let app = aa_api::server::build_app(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/policies/active")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("no active policy loaded"));
+}

--- a/aa-api/tests/policies.rs
+++ b/aa-api/tests/policies.rs
@@ -209,3 +209,37 @@ async fn get_active_policy_reflects_applied_policy() {
     // policy_yaml is fetched from history (most-recent entry == active).
     assert_eq!(json["policy_yaml"], ENVELOPE_POLICY_WITH_TOOLS);
 }
+
+// ── Additional coverage tests (AAASM-3805) ────────────────────────────────────
+
+#[tokio::test]
+async fn list_policies_with_include_archived_true_returns_all_versions() {
+    let state = common::test_state();
+    // Apply two policies so history has two entries.
+    state
+        .policy_engine
+        .apply_yaml(VALID_POLICY_YAML, Some("test"), state.policy_history.as_ref())
+        .await
+        .unwrap();
+    state
+        .policy_engine
+        .apply_yaml(ENVELOPE_POLICY_WITH_TOOLS, Some("test"), state.policy_history.as_ref())
+        .await
+        .unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/policies?include_archived=true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    // Both versions should appear when include_archived=true.
+    assert_eq!(json["total"].as_u64().unwrap(), 2);
+}

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -718,3 +718,77 @@ async fn topology_stats_large_fixture_histograms_are_correct() {
     // avg_children_per_parent > 0 (root-a has 4 children, a1 has 2, root-b has 3)
     assert!(json["avg_children_per_parent"].as_f64().unwrap() > 0.0);
 }
+
+#[tokio::test]
+async fn topology_stats_counts_suspended_and_orphan_agents() {
+    let state = common::test_state();
+    // Active root in a team.
+    state
+        .agent_registry
+        .register(make_agent(0x01, "root", 0, Some("team-a"), None))
+        .unwrap();
+    // Suspended child in the team → exercises the Suspended arm.
+    let mut suspended = make_agent(0x02, "child", 1, Some("team-a"), Some([0x01; 16]));
+    suspended.status = AgentStatus::Suspended(SuspendReason::Manual);
+    state.agent_registry.register(suspended).unwrap();
+    // Orphan: depth > 0 but no team_id → exercises the orphan branch.
+    let orphan = make_agent(0x03, "orphan", 1, None, Some([0x01; 16]));
+    state.agent_registry.register(orphan).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total_agents"], 3);
+    // root + orphan are Active; child is Suspended.
+    assert_eq!(json["active_count"], 2);
+    assert_eq!(json["suspended_count"], 1);
+    assert_eq!(json["orphan_count"], 1);
+}
+
+#[tokio::test]
+async fn topology_stats_second_call_is_served_from_cache() {
+    let state = common::test_state();
+    state
+        .agent_registry
+        .register(make_agent(0x01, "root", 0, Some("team-a"), None))
+        .unwrap();
+
+    let app = aa_api::server::build_app(state);
+    // First call populates the stats cache.
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+    let first_body = axum::body::to_bytes(first.into_body(), usize::MAX).await.unwrap();
+
+    // Second call hits the cache-return branch and must yield identical bytes.
+    let second = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::OK);
+    let second_body = axum::body::to_bytes(second.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(first_body, second_body);
+}

--- a/aa-api/tests/ws_alerts.rs
+++ b/aa-api/tests/ws_alerts.rs
@@ -181,3 +181,72 @@ async fn ws_alerts_missing_subprotocol_rejected_400() {
         "expected 400 in handshake error, got: {err_str}"
     );
 }
+
+/// An unexpected client data frame is a protocol violation → the server
+/// replies with a 1008 close frame and tears the socket down.
+#[tokio::test]
+async fn ws_alerts_unexpected_client_frame_triggers_1008_close() {
+    use futures::SinkExt;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let (url, _handle) = start_server().await;
+    let request = alerts_ws_request(&url, "");
+    let (mut ws, _response) = tokio_tungstenite::connect_async(request).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Send a Text frame — the alerts protocol only permits Close from clients.
+    ws.send(Message::Text("hello".into())).await.unwrap();
+
+    // The next frame from the server must be a Close with code 1008.
+    let mut saw_close = false;
+    for _ in 0..5 {
+        match tokio::time::timeout(std::time::Duration::from_millis(200), ws.next()).await {
+            Ok(Some(Ok(Message::Close(Some(frame))))) => {
+                assert_eq!(u16::from(frame.code), 1008);
+                saw_close = true;
+                break;
+            }
+            Ok(Some(Ok(_))) => continue, // skip any heartbeat/text already queued
+            _ => break,
+        }
+    }
+    assert!(saw_close, "server must answer an unexpected frame with a 1008 close");
+}
+
+/// Client Ping/Pong frames are ignored (the loop `continue`s) and a
+/// subsequent Close terminates the connection cleanly.
+#[tokio::test]
+async fn ws_alerts_ping_pong_ignored_then_close() {
+    use futures::SinkExt;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let (url, handle) = start_server().await;
+    let request = alerts_ws_request(&url, "");
+    let (mut ws, _response) = tokio_tungstenite::connect_async(request).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Pong is consumed and ignored — the connection stays open and can still
+    // deliver a subsequent fire frame.
+    ws.send(Message::Pong(vec![].into())).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    let _id = handle.state.alert_store.record(&budget_alert(95));
+
+    let mut saw_fire = false;
+    for _ in 0..5 {
+        match tokio::time::timeout(std::time::Duration::from_millis(200), ws.next()).await {
+            Ok(Some(Ok(Message::Text(t)))) => {
+                let frame: serde_json::Value = serde_json::from_str(&t).unwrap();
+                if frame["type"] == "alert.fire" {
+                    saw_fire = true;
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    assert!(saw_fire, "a fire frame must still arrive after a client Pong");
+
+    // A Close frame ends the loop.
+    ws.send(Message::Close(None)).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+}

--- a/aa-api/tests/ws_streaming.rs
+++ b/aa-api/tests/ws_streaming.rs
@@ -327,3 +327,144 @@ async fn ws_cli_logs_follow_integration() {
         "CLI follow stream should receive all three event types"
     );
 }
+
+// ── Non-pipeline dispatch arms: approval / budget / ops-change ───────────────
+
+fn make_approval_request() -> aa_runtime::approval::ApprovalRequest {
+    aa_runtime::approval::ApprovalRequest {
+        request_id: uuid::Uuid::new_v4(),
+        agent_id: "approver-agent".to_string(),
+        action: "read_file /etc/shadow".to_string(),
+        condition_triggered: "sensitive-file".to_string(),
+        submitted_at: 1_700_000_000,
+        timeout_secs: 600,
+        fallback: aa_core::PolicyResult::Deny {
+            reason: "timeout".to_string(),
+        },
+        team_id: None,
+        timeout_override_secs: None,
+        escalation_role_override: None,
+    }
+}
+
+async fn read_gov_event(
+    ws: &mut (impl futures::StreamExt<
+        Item = Result<tokio_tungstenite::tungstenite::Message, tokio_tungstenite::tungstenite::Error>,
+    > + Unpin),
+) -> GovernanceEvent {
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(2), ws.next())
+        .await
+        .expect("timeout waiting for WS message")
+        .expect("stream ended")
+        .expect("ws error");
+    serde_json::from_str(&msg.into_text().unwrap()).unwrap()
+}
+
+#[tokio::test]
+async fn ws_receives_approval_event() {
+    let (url, handle) = start_server().await;
+    let ws_url = format!("{url}/api/v1/ws/events?types=approval");
+    let (mut ws, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    handle
+        .state
+        .events
+        .approval_sender()
+        .send(make_approval_request())
+        .unwrap();
+
+    let ev = read_gov_event(&mut ws).await;
+    assert_eq!(ev.event_type, EventType::Approval);
+    assert_eq!(ev.agent_id, "approver-agent");
+}
+
+#[tokio::test]
+async fn ws_receives_approval_expiry_event() {
+    let (url, handle) = start_server().await;
+    let ws_url = format!("{url}/api/v1/ws/events?types=approval");
+    let (mut ws, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    handle
+        .state
+        .events
+        .approval_expiry_sender()
+        .send(make_approval_request())
+        .unwrap();
+
+    let ev = read_gov_event(&mut ws).await;
+    assert_eq!(ev.event_type, EventType::Approval);
+    // The expiry arm marks the payload status as "expired".
+    assert_eq!(ev.payload["status"], "expired");
+}
+
+#[tokio::test]
+async fn ws_receives_budget_event() {
+    let (url, handle) = start_server().await;
+    let ws_url = format!("{url}/api/v1/ws/events?types=budget");
+    let (mut ws, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    handle
+        .state
+        .events
+        .budget_sender()
+        .send(aa_gateway::budget::types::BudgetAlert {
+            agent_id: aa_core::identity::AgentId::from_bytes([7u8; 16]),
+            team_id: Some("team-a".to_string()),
+            threshold_pct: 95,
+            spent_usd: 95.0,
+            limit_usd: 100.0,
+        })
+        .unwrap();
+
+    let ev = read_gov_event(&mut ws).await;
+    assert_eq!(ev.event_type, EventType::Budget);
+}
+
+#[tokio::test]
+async fn ws_receives_ops_change_event() {
+    let (url, handle) = start_server().await;
+    let ws_url = format!("{url}/api/v1/ws/events?types=ops_change");
+    let (mut ws, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    handle
+        .state
+        .events
+        .ops_change_sender()
+        .send(aa_api::events::OpsChangeBroadcast {
+            agent_id: "ops-agent".to_string(),
+            payload: aa_api::models::ws_payloads::OpsChangePayload {
+                op_id: "trace-1:span-1".to_string(),
+                state: aa_api::ops::OpState::Running,
+                updated_at: "2026-06-25T00:00:00Z".to_string(),
+            },
+        })
+        .unwrap();
+
+    let ev = read_gov_event(&mut ws).await;
+    assert_eq!(ev.event_type, EventType::OpsChange);
+    assert_eq!(ev.agent_id, "ops-agent");
+    assert_eq!(ev.payload["op_id"], "trace-1:span-1");
+}
+
+#[tokio::test]
+async fn ws_handles_client_pong_then_close_frame() {
+    use futures::SinkExt;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let (url, _handle) = start_server().await;
+    let ws_url = format!("{url}/api/v1/ws/events");
+    let (mut ws, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // A client Pong is consumed by the reader loop (keep-alive bookkeeping).
+    ws.send(Message::Pong(vec![].into())).await.unwrap();
+    // A client Close frame terminates the reader loop cleanly.
+    ws.send(Message::Close(None)).await.unwrap();
+
+    // The server acknowledges the close; the stream then ends without error.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+}

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -63,6 +63,9 @@ aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.1", features 
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+# `net` (TcpListenerStream) lets the invalidation-dispatch test stand up an
+# in-process mock gateway InvalidationService over loopback (AAASM-3805).
+tokio-stream = { workspace = true, features = ["net"] }
 tower = { workspace = true }
 # Captures emitted metric values so the audit-publisher metric tests can assert
 # the exact counter values recorded by `metrics::counter!`.

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -961,6 +961,104 @@ mod tests {
         }
     }
 
+    // --- routing metadata (record_routing / update_routing_status) ---
+
+    #[tokio::test]
+    async fn record_routing_inserts_then_updates_pending_metadata() {
+        let q = ApprovalQueue::new();
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+
+        // First record: or_insert path — fresh RoutingMeta with one history entry.
+        assert!(q.record_routing(
+            id,
+            "routed".to_string(),
+            Some("oncall".to_string()),
+            Some(1_700_000_100),
+            Some(1_700_000_400),
+            Some(RoutingHistoryEntry {
+                at: 1_700_000_100,
+                action: "routed".to_string(),
+                from_role: None,
+                to_role: "oncall".to_string(),
+            }),
+        ));
+
+        let p = q
+            .list()
+            .into_iter()
+            .find(|p| p.request_id == id)
+            .expect("still pending");
+        assert_eq!(p.routing_status.as_deref(), Some("routed"));
+        assert_eq!(p.target_role.as_deref(), Some("oncall"));
+        assert_eq!(p.routed_at, Some(1_700_000_100));
+        assert_eq!(p.escalate_at, Some(1_700_000_400));
+        assert_eq!(p.routing_history.len(), 1);
+
+        // Second record: and_modify path — status changes, history appends, and
+        // the None target_role leaves the prior role intact.
+        assert!(q.record_routing(
+            id,
+            "escalated".to_string(),
+            None,
+            None,
+            None,
+            Some(RoutingHistoryEntry {
+                at: 1_700_000_500,
+                action: "escalated".to_string(),
+                from_role: Some("oncall".to_string()),
+                to_role: "manager".to_string(),
+            }),
+        ));
+        let p = q.list().into_iter().find(|p| p.request_id == id).unwrap();
+        assert_eq!(p.routing_status.as_deref(), Some("escalated"));
+        assert_eq!(p.target_role.as_deref(), Some("oncall"), "None must not clear the role");
+        assert_eq!(p.routing_history.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_routing_status_classifies_action_and_appends_history() {
+        let q = ApprovalQueue::new();
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+
+        // A non-"escalated" status is classified as a "routed" history action.
+        assert!(q.update_routing_status(id, "routed:oncall".to_string()));
+        let p = q.list().into_iter().find(|p| p.request_id == id).unwrap();
+        assert_eq!(p.routing_status.as_deref(), Some("routed:oncall"));
+        assert_eq!(p.routing_history.len(), 1);
+        assert_eq!(p.routing_history[0].action, "routed");
+
+        // An "escalated"-prefixed status is classified as an "escalated" action.
+        assert!(q.update_routing_status(id, "escalated:manager".to_string()));
+        let p = q.list().into_iter().find(|p| p.request_id == id).unwrap();
+        assert_eq!(p.routing_status.as_deref(), Some("escalated:manager"));
+        assert_eq!(p.routing_history.len(), 2);
+        assert_eq!(p.routing_history[1].action, "escalated");
+    }
+
+    #[tokio::test]
+    async fn routing_updates_are_noop_after_resolution() {
+        let q = ApprovalQueue::new();
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+        q.decide(
+            id,
+            ApprovalDecision::Rejected {
+                by: "alice".to_string(),
+                reason: "denied".to_string(),
+            },
+        )
+        .expect("decide");
+
+        // Both routing entry points must report false for a resolved request.
+        assert!(!q.update_routing_status(id, "routed:oncall".to_string()));
+        assert!(!q.record_routing(id, "routed".to_string(), None, None, None, None));
+    }
+
     // --- ApprovalQueue::submit ---
 
     #[tokio::test]

--- a/aa-runtime/src/ipc/codec.rs
+++ b/aa-runtime/src/ipc/codec.rs
@@ -257,6 +257,26 @@ mod tests {
         buf
     }
 
+    #[test]
+    fn codec_error_display_covers_all_variants() {
+        let io = CodecError::Io(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "eof"));
+        assert!(io.to_string().contains("IO error"), "got: {io}");
+
+        let unknown = CodecError::UnknownTag(0xAB);
+        assert!(unknown.to_string().contains("unknown frame tag"), "got: {unknown}");
+
+        // Build a genuine prost decode error from malformed wire bytes (a field
+        // header promising a varint with no body).
+        use prost::Message;
+        let decode_err = aa_proto::assembly::policy::v1::CheckActionRequest::decode([0x08u8].as_slice())
+            .expect_err("truncated varint must fail to decode");
+        let decode = CodecError::DecodeError(decode_err);
+        assert!(decode.to_string().contains("decode"), "got: {decode}");
+
+        let too_large = CodecError::FrameTooLarge { len: 10, max: 5 };
+        assert!(too_large.to_string().contains("exceeds maximum"), "got: {too_large}");
+    }
+
     #[tokio::test]
     async fn heartbeat_round_trip() {
         // Heartbeat frame: just the tag byte, no payload or length.

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -743,6 +743,70 @@ mod tests {
         token.cancel();
     }
 
+    /// The accept loop's semaphore bounds in-flight connections: a peer that
+    /// arrives while the only permit is held by a still-handshaking connection is
+    /// dropped without being served a challenge. This is the resource guard that
+    /// stops a flood of half-open connections from exhausting the runtime.
+    #[tokio::test]
+    async fn connection_over_limit_is_dropped() {
+        use tokio::io::AsyncReadExt;
+
+        let socket_path = temp_socket_path("conn-limit");
+        let _ = std::fs::remove_file(&socket_path);
+        let token = CancellationToken::new();
+        let active = Arc::new(AtomicI64::new(0));
+
+        let config = IpcServerConfig {
+            socket_path: socket_path.clone(),
+            agent_id: TEST_AGENT_ID.to_string(),
+            max_connections: 1,
+            inbound_channel_capacity: 16,
+        };
+        let server = IpcServer::bind(config).expect("bind failed");
+        let (tx, _rx) = mpsc::channel(16);
+        let router = crate::ipc::new_response_router();
+        let verified = crate::ipc::new_verified_identity_store();
+        let tracker = TaskTracker::new();
+        let tracker_clone = tracker.clone();
+        let run_token = token.clone();
+        let run_active = Arc::clone(&active);
+        tracker.spawn(async move {
+            server
+                .run(tracker_clone, run_token, tx, run_active, router, verified)
+                .await;
+        });
+
+        // First client connects but deliberately stalls — it reads the challenge
+        // and never replies, so its connection task keeps holding the single
+        // permit while it awaits the proof (well within the 5 s handshake bound).
+        let mut c1 = UnixStream::connect(&socket_path).await.expect("c1 connect");
+        let tag = tokio::time::timeout(Duration::from_secs(2), c1.read_u8())
+            .await
+            .expect("c1 read did not resolve within 2s")
+            .expect("c1 should receive a challenge");
+        assert_eq!(
+            tag,
+            crate::ipc::codec::TAG_HANDSHAKE_CHALLENGE,
+            "first connection should be served a handshake challenge"
+        );
+
+        // Second client arrives while the permit is held: the UDS connect
+        // succeeds but the server drops the stream without a challenge, so the
+        // peer reads EOF.
+        let mut c2 = UnixStream::connect(&socket_path).await.expect("c2 connect");
+        let mut byte = [0u8; 1];
+        let read = tokio::time::timeout(Duration::from_secs(2), c2.read(&mut byte))
+            .await
+            .expect("c2 read did not resolve within 2s");
+        assert!(
+            matches!(read, Ok(0) | Err(_)),
+            "over-limit connection must be dropped (EOF/err), got {read:?}"
+        );
+
+        token.cancel();
+        let _ = std::fs::remove_file(&socket_path);
+    }
+
     /// Round-trip latency test. Marked #[ignore] — run explicitly only.
     #[tokio::test]
     #[ignore]

--- a/aa-runtime/src/policy.rs
+++ b/aa-runtime/src/policy.rs
@@ -158,6 +158,26 @@ mod tests {
     }
 
     #[test]
+    fn load_policy_returns_io_error_for_non_notfound_failure() {
+        // Pointing at a directory makes read_to_string fail with a non-NotFound
+        // I/O error, which must surface as PolicyLoadError::Io (not be swallowed
+        // as "absent → no enforcement").
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = load_policy(dir.path());
+        assert!(matches!(result, Err(PolicyLoadError::Io(_))));
+    }
+
+    #[test]
+    fn policy_load_error_display_renders_both_variants() {
+        let io = PolicyLoadError::Io(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "nope"));
+        assert!(io.to_string().contains("I/O error"), "got: {io}");
+
+        let parse_err = toml::from_str::<PolicyRules>("rules = 5").expect_err("type mismatch is a parse error");
+        let parse = PolicyLoadError::Parse(parse_err);
+        assert!(parse.to_string().contains("parse error"), "got: {parse}");
+    }
+
+    #[test]
     fn load_policy_errors_on_malformed_toml() {
         use std::io::Write;
         let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1333,6 +1333,86 @@ mod tests {
             .is_none());
     }
 
+    /// A NATS config path that exists but holds malformed TOML must disable the
+    /// audit publisher (fail-soft), never abort startup (AAASM-2547).
+    #[tokio::test]
+    async fn build_audit_publisher_disabled_on_invalid_nats_config() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        writeln!(tmp, "this is = not valid [gateway.nats] toml = = =").unwrap();
+        tmp.flush().unwrap();
+        assert!(
+            super::build_audit_publisher(&audit_test_config(Some(tmp.path().to_path_buf())))
+                .await
+                .is_none(),
+            "malformed NATS config must disable audit publishing, not crash startup"
+        );
+    }
+
+    // ── build_gateway_client tests (AAASM-3430) ──────────────────────────────
+
+    #[tokio::test]
+    async fn build_gateway_client_none_when_unconfigured() {
+        // No endpoint ⇒ no client; the pipeline evaluates policy locally.
+        let config = audit_test_config(None);
+        assert!(config.gateway_endpoint.is_none());
+        assert!(super::build_gateway_client(&config).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn build_gateway_client_lazy_when_initial_connect_fails() {
+        // A configured-but-unreachable endpoint must NOT yield None (which the
+        // pipeline would treat as "evaluate locally / allow"). The eager connect
+        // fails, so build_gateway_client falls back to a lazy channel — a Some
+        // whose checks fail-closed at call time (AAASM-3110 + AAASM-3430).
+        let mut config = audit_test_config(None);
+        // Port chosen to be almost certainly closed so the eager connect fails fast.
+        config.gateway_endpoint = Some("http://127.0.0.1:1".to_string());
+        assert!(
+            super::build_gateway_client(&config).await.is_some(),
+            "unreachable gateway must yield a lazy client, never None (no permissive local fallback)"
+        );
+    }
+
+    // ── spawn_op_control tests (AAASM-3491) ──────────────────────────────────
+
+    #[tokio::test]
+    async fn spawn_op_control_noop_without_endpoint() {
+        // Without a gateway endpoint there is no kill-switch channel, so no
+        // subscriber task is spawned.
+        let tracker = TaskTracker::new();
+        let store = crate::op_control::OpControlStore::new();
+        let config = audit_test_config(None);
+        assert!(config.gateway_endpoint.is_none());
+
+        super::spawn_op_control(&tracker, &config, &store);
+
+        assert_eq!(
+            tracker.len(),
+            0,
+            "no op-control task should be spawned without an endpoint"
+        );
+        tracker.close();
+    }
+
+    #[tokio::test]
+    async fn spawn_op_control_spawns_subscriber_with_endpoint() {
+        // With an endpoint configured, the op-control subscriber is spawned onto
+        // the tracker (it reconnects in the background; we only assert it was
+        // registered, not that it connects).
+        let tracker = TaskTracker::new();
+        let store = crate::op_control::OpControlStore::new();
+        let mut config = audit_test_config(None);
+        config.gateway_endpoint = Some("http://127.0.0.1:1".to_string());
+
+        super::spawn_op_control(&tracker, &config, &store);
+
+        assert_eq!(tracker.len(), 1, "an op-control subscriber task should be spawned");
+        // Don't await — the subscriber reconnect-loops forever by design; the
+        // detached task is dropped when the test runtime shuts down.
+        tracker.close();
+    }
+
     // ── spawn_pipeline_audit_publisher tests (AAASM-2610) ────────────────────
 
     use aa_core::storage::{AuditEntry, AuditSink, Result as StorageResult};

--- a/aa-runtime/tests/invalidation_dispatch.rs
+++ b/aa-runtime/tests/invalidation_dispatch.rs
@@ -1,0 +1,138 @@
+//! Dispatch test for [`aa_runtime::invalidation_client`] (AAASM-3805).
+//!
+//! The reconnect/replay end-to-end path is covered by the `aa-integration-tests`
+//! crate against the real gateway service; that crate's tests do not run under
+//! `-p aa-runtime`, so the client's stream-dispatch logic (the `subscribe_once`
+//! match arms and per-subscriber sequence tracking) is otherwise unexercised
+//! when measuring this crate alone.
+//!
+//! This test stands up a minimal in-process `InvalidationService` over loopback
+//! that streams one `PolicyInvalidated`, one `ApprovalResolved`, and one
+//! empty-payload event, then asserts the client fans each out to its sinks with
+//! the correct arguments — proving the L1-cache / approval-wakeup consumer wiring
+//! actually applies pushed invalidations.
+
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tokio_stream::Stream;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status, Streaming};
+
+use aa_proto::assembly::gateway::v1::invalidation_event::Payload;
+use aa_proto::assembly::gateway::v1::invalidation_service_server::{InvalidationService, InvalidationServiceServer};
+use aa_proto::assembly::gateway::v1::{
+    ApprovalResolved, Decision, InvalidationEvent, PolicyInvalidated, SubscribeRequest,
+};
+use aa_runtime::invalidation_client::{InvalidationClient, InvalidationSink};
+
+/// A mock gateway that, on Subscribe, streams a fixed sequence of events then
+/// closes the stream cleanly.
+struct MockInvalidationService;
+
+#[tonic::async_trait]
+impl InvalidationService for MockInvalidationService {
+    type SubscribeStream = Pin<Box<dyn Stream<Item = Result<InvalidationEvent, Status>> + Send>>;
+
+    async fn subscribe(
+        &self,
+        _request: Request<Streaming<SubscribeRequest>>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        let events = vec![
+            Ok(InvalidationEvent {
+                seq: 1,
+                payload: Some(Payload::PolicyInvalidated(PolicyInvalidated {
+                    agent_id: "agent-a".to_string(),
+                    policy_version: 7,
+                })),
+            }),
+            Ok(InvalidationEvent {
+                seq: 2,
+                payload: Some(Payload::ApprovalResolved(ApprovalResolved {
+                    request_id: "req-1".to_string(),
+                    decision: Decision::Approved as i32,
+                })),
+            }),
+            // An event with no payload must be tolerated (forward-compat arm).
+            Ok(InvalidationEvent { seq: 3, payload: None }),
+        ];
+        let stream = tokio_stream::iter(events);
+        Ok(Response::new(Box::pin(stream)))
+    }
+}
+
+/// Records every fan-out call so the test can assert exact dispatch arguments.
+#[derive(Default)]
+struct RecordingSink {
+    policy: Mutex<Vec<String>>,
+    approvals: Mutex<Vec<(String, i32)>>,
+}
+
+impl InvalidationSink for RecordingSink {
+    fn on_policy_invalidated(&self, agent_id: &str) {
+        self.policy.lock().unwrap().push(agent_id.to_string());
+    }
+
+    fn on_approval_resolved(&self, request_id: &str, decision: Decision) {
+        self.approvals
+            .lock()
+            .unwrap()
+            .push((request_id.to_string(), decision as i32));
+    }
+}
+
+#[tokio::test]
+async fn client_fans_pushed_events_out_to_sinks() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind loopback");
+    let addr = listener.local_addr().expect("local_addr");
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(InvalidationServiceServer::new(MockInvalidationService))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("mock gateway serve");
+    });
+
+    let sink = Arc::new(RecordingSink::default());
+    let client = InvalidationClient::start(
+        format!("http://{addr}"),
+        "asm-test".to_string(),
+        vec![Arc::clone(&sink) as Arc<dyn InvalidationSink>],
+    );
+
+    // Wait until both meaningful events have been dispatched.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if !sink.policy.lock().unwrap().is_empty() && !sink.approvals.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("client did not dispatch the streamed events within 5s");
+
+    // Stop the client first; on a clean stream close it re-subscribes promptly,
+    // so the mock's fixed events may have been delivered more than once. The
+    // dispatch contract is about *what* is delivered, not how many times.
+    client.abort();
+    server.abort();
+
+    let policy = sink.policy.lock().unwrap();
+    let approvals = sink.approvals.lock().unwrap();
+    assert!(!policy.is_empty(), "expected at least one PolicyInvalidated dispatch");
+    assert!(!approvals.is_empty(), "expected at least one ApprovalResolved dispatch");
+    assert!(
+        policy.iter().all(|a| a == "agent-a"),
+        "every PolicyInvalidated must carry the streamed agent id, got {policy:?}"
+    );
+    assert!(
+        approvals
+            .iter()
+            .all(|(id, d)| id == "req-1" && *d == Decision::Approved as i32),
+        "every ApprovalResolved must carry the streamed request id and verdict, got {approvals:?}"
+    );
+}

--- a/aa-runtime/tests/op_control_dispatch.rs
+++ b/aa-runtime/tests/op_control_dispatch.rs
@@ -1,0 +1,110 @@
+//! Dispatch test for [`aa_runtime::op_control`] (AAASM-3805).
+//!
+//! The op-control kill switch's end-to-end path against the real gateway lives
+//! in `aa-integration-tests`, which does not run under `-p aa-runtime`, leaving
+//! the client's stream-consumption loop (`subscribe_once` + `run`) uncovered for
+//! this crate alone.
+//!
+//! This test stands up a minimal in-process `PolicyService` over loopback whose
+//! `OpControlStream` pushes a Pause then a Terminate for one op, and asserts the
+//! client applies them to the shared [`OpControlStore`] — proving the runtime
+//! actually observes the operator's kill switch (the bug AAASM-3491 fixed: a
+//! terminate that nothing on the execution path consumed).
+
+use std::pin::Pin;
+use std::time::Duration;
+
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tokio_stream::Stream;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+use aa_proto::assembly::common::v1::AgentId;
+use aa_proto::assembly::policy::v1::policy_service_server::{PolicyService, PolicyServiceServer};
+use aa_proto::assembly::policy::v1::{
+    BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse, OpControlMessage, OpControlSignal,
+    OpControlSubscribeRequest,
+};
+use aa_runtime::op_control::{OpControlClient, OpControlStore, OpState};
+
+/// A mock gateway whose only live method is `op_control_stream`; it pushes a
+/// Pause then a Terminate for one op, then closes the stream.
+struct MockPolicyService;
+
+#[tonic::async_trait]
+impl PolicyService for MockPolicyService {
+    async fn check_action(
+        &self,
+        _request: Request<CheckActionRequest>,
+    ) -> Result<Response<CheckActionResponse>, Status> {
+        Err(Status::unimplemented("not exercised by the op-control consumer test"))
+    }
+
+    async fn batch_check(&self, _request: Request<BatchCheckRequest>) -> Result<Response<BatchCheckResponse>, Status> {
+        Err(Status::unimplemented("not exercised by the op-control consumer test"))
+    }
+
+    type OpControlStreamStream = Pin<Box<dyn Stream<Item = Result<OpControlMessage, Status>> + Send>>;
+
+    async fn op_control_stream(
+        &self,
+        _request: Request<OpControlSubscribeRequest>,
+    ) -> Result<Response<Self::OpControlStreamStream>, Status> {
+        let messages = vec![
+            Ok(OpControlMessage {
+                op_id: "trace-1:span-1".to_string(),
+                signal: OpControlSignal::Pause as i32,
+                sequence: 1,
+            }),
+            Ok(OpControlMessage {
+                op_id: "trace-1:span-1".to_string(),
+                signal: OpControlSignal::Terminate as i32,
+                sequence: 2,
+            }),
+        ];
+        Ok(Response::new(Box::pin(tokio_stream::iter(messages))))
+    }
+}
+
+#[tokio::test]
+async fn client_applies_pushed_kill_switch_signals_to_store() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind loopback");
+    let addr = listener.local_addr().expect("local_addr");
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(PolicyServiceServer::new(MockPolicyService))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("mock gateway serve");
+    });
+
+    let store = OpControlStore::new();
+    let agent = AgentId {
+        org_id: String::new(),
+        team_id: String::new(),
+        agent_id: "agent-1".to_string(),
+    };
+    let handle = OpControlClient::start(format!("http://{addr}"), agent, store.clone());
+
+    // The terminate is sticky and terminal, so once the store reads Terminated
+    // for the op we know both pushed signals were consumed in order.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while store.state("trace-1:span-1") != Some(OpState::Terminated) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("client did not apply the pushed kill-switch signals within 5s");
+
+    assert_eq!(
+        store.state("trace-1:span-1"),
+        Some(OpState::Terminated),
+        "an operator terminate pushed over the stream must reach the runtime store"
+    );
+    // An op the gateway never mentioned stays runnable.
+    assert_eq!(store.state("trace-1:span-2"), None);
+
+    handle.abort();
+    server.abort();
+}

--- a/aa-runtime/tests/runtime_lifecycle.rs
+++ b/aa-runtime/tests/runtime_lifecycle.rs
@@ -1,0 +1,102 @@
+//! End-to-end lifecycle test for [`aa_runtime::run`] (AAASM-3805).
+//!
+//! `run()` is the runtime's top-level orchestrator: it installs the metrics
+//! recorder, loads policy, detects layers, binds the IPC socket, spawns the
+//! pipeline / correlation / health subsystems, and then blocks in
+//! [`aa_runtime::lifecycle::wait_for_shutdown_signal`] until SIGTERM/SIGINT.
+//! None of the existing unit tests drive this path because it depends on a real
+//! OS shutdown signal.
+//!
+//! This test exercises the whole startup→serve→graceful-shutdown cycle in a
+//! single process. It is isolated in its own integration-test binary so that the
+//! process-global Prometheus recorder `run()` installs is never installed twice,
+//! and so the self-directed SIGTERM only affects this test's process (nextest
+//! runs each test binary as a separate process).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use aa_runtime::config::RuntimeConfig;
+use aa_runtime::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES;
+
+/// A runtime config that stands the agent up with every optional subsystem
+/// (gateway forwarding, NATS audit, eBPF, policy file) disabled, an ephemeral
+/// health port, and a uniquely-named IPC socket so the test never collides with
+/// a real runtime or a concurrent test process.
+fn lifecycle_config(agent_id: &str) -> RuntimeConfig {
+    RuntimeConfig {
+        agent_id: agent_id.to_string(),
+        agent_team_id: String::new(),
+        agent_org_id: String::new(),
+        worker_threads: 0,
+        // Generous enough that a clean drain never trips the timeout branch.
+        shutdown_timeout_secs: 10,
+        ipc_max_connections: 8,
+        pipeline_input_buffer: 1_000,
+        pipeline_batch_size: 16,
+        pipeline_flush_interval_ms: 50,
+        pipeline_broadcast_capacity: 256,
+        // Port 0 → the OS assigns an ephemeral port, so the health server bind
+        // never races another test or a real process on a fixed port.
+        metrics_addr: "127.0.0.1:0".to_string(),
+        // No policy file → enforcement disabled (empty rules), agent still runs.
+        policy_path: None,
+        // No gateway → policy evaluated locally, op-control kill switch inactive.
+        gateway_endpoint: None,
+        correlation_window_ms: 500,
+        correlation_interval_ms: 50,
+        // No NATS config → audit publisher disabled.
+        nats_config_path: None,
+        audit_buffer_path: std::env::temp_dir().join(format!("aa-audit-buffer-{agent_id}.db")),
+        enforcement_max_field_bytes: DEFAULT_MAX_FIELD_BYTES,
+        gateway_fail_closed: true,
+    }
+}
+
+/// `run()` must start every subsystem, serve, and then drain to completion when
+/// it receives SIGTERM — proving the structured-concurrency shutdown path works
+/// end to end and that the IPC socket is cleaned up on exit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn run_starts_subsystems_and_shuts_down_on_sigterm() {
+    let agent_id = format!("lifecycle-test-{}", std::process::id());
+    let socket_path = PathBuf::from(format!("/tmp/aa-runtime-{agent_id}.sock"));
+    // Defensive: clear any leftover socket from a previously aborted run.
+    let _ = std::fs::remove_file(&socket_path);
+
+    let config = lifecycle_config(&agent_id);
+    let runtime = tokio::spawn(aa_runtime::run(config));
+
+    // The IPC socket is created synchronously by `IpcServer::bind` inside `run()`,
+    // shortly before it parks on the shutdown signal. Its appearance is the
+    // observable proof that startup reached the serve phase.
+    let mut bound = false;
+    for _ in 0..200 {
+        if socket_path.exists() {
+            bound = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(bound, "runtime never bound its IPC socket — startup did not complete");
+
+    // Small margin so `wait_for_shutdown_signal` has installed its SIGTERM
+    // handler before we raise the signal (otherwise the default disposition
+    // would terminate the process). Everything between the IPC bind and the
+    // signal wait is non-blocking spawns, so this is comfortably sufficient.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Deliver the shutdown signal the same way an orchestrator would.
+    let rc = unsafe { libc::raise(libc::SIGTERM) };
+    assert_eq!(rc, 0, "failed to raise SIGTERM");
+
+    // `run()` must return after a graceful drain — not hang and not be killed.
+    let result = tokio::time::timeout(Duration::from_secs(15), runtime).await;
+    let join = result.expect("run() did not return within 15s of SIGTERM — shutdown hung");
+    join.expect("run() task panicked during shutdown");
+
+    // Graceful shutdown removes the IPC socket file.
+    assert!(
+        !socket_path.exists(),
+        "IPC socket should be cleaned up after graceful shutdown"
+    );
+}


### PR DESCRIPTION
## Description

Raises **meaningful, behaviour-asserting** test coverage for `aa-runtime` and
`aa-api` (Subtask AAASM-3805 of Story AAASM-3798). All new tests assert real
behaviour (status codes, response/state, fail-closed/fail-soft semantics,
kill-switch enforcement) — no assertions on private internals, no padding.

### `aa-runtime` — 86.9% → **95.15%** line coverage (target ≥95% met)

- **`run()` full lifecycle** (`tests/runtime_lifecycle.rs`): startup → serve →
  graceful SIGTERM drain in an isolated test binary — the only test that drives
  the top-level orchestrator and the SIGTERM arm of `wait_for_shutdown_signal`,
  also covering `lifecycle.rs`.
- **gateway-client / op-control / audit-config branches**: the
  `build_gateway_client` lazy fail-closed fallback, `spawn_op_control`
  endpoint/no-endpoint branches, and the malformed-NATS-config fail-soft path.
- **IPC accept-loop connection-limit drop**: the semaphore-exhaustion guard
  bounding half-open-connection floods.
- **invalidation client fan-out** + **op-control kill-switch consumer**: in-process
  mock gateway gRPC services prove the L1-invalidation and pause/terminate
  consumers actually apply pushed signals (the e2e variants live in
  `aa-integration-tests`, which is not measured under `-p aa-runtime`).
- **approval routing metadata** (`record_routing` / `update_routing_status`
  insert/update/no-op-after-resolution) and **policy/codec error Display + IO**
  branches.

### `aa-api` — 87.4% → **88.4%** line coverage (improved; **did not reach 95%**)

- **`dispatch_tool` native secret-injection path**: placeholder-free passthrough,
  `${NAME}` resolution with `names_substituted`, and the fail-closed 422 on an
  unknown placeholder.
- **agent detail handlers**: capabilities / budget-rollup / subtree-burn (7d/30d)
  for 200/404/400, plus the resume already-active 409 and id-validation 400.

## Type of Change

- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Jira Story: AAASM-3798 · Subtask: AAASM-3805

## Testing

- [x] `cargo nextest run -p aa-runtime -p aa-api` — 979 passed, 0 failed
- [x] `cargo clippy -p aa-runtime -p aa-api --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- Coverage (`cargo llvm-cov nextest --summary-only`, line):
  - `aa-runtime`: 412/8495 uncovered → **95.15%**
  - `aa-api`: 1082/9357 uncovered → **88.44%**

## Honest shortfall — `aa-api` did not reach 95%

Per the "quality over the number, do not pad" guidance, `aa-api` is reported at
its true ceiling rather than inflated. Reaching ≥95% needs ~370 more covered
lines across handler error/authz paths that this change did not get to:

- `routes/capability.rs` (~103), `routes/edges.rs` (~78), `routes/destinations.rs`
  (~39), `routes/admin.rs` (~35), `routes/approvals.rs` / `routes/audit.rs` /
  `routes/topology.rs` (~27 each), `ws/handler.rs` (~45), `ws/alerts_handler.rs`
  (~30), `state.rs` (~31) — mostly tenant-403 paths needing team/org-scoped JWT
  fixtures, and pagination/validation edges.
- `routes/dispatch.rs` WASM-sandbox branch (~106) needs a real wasm module
  registered as `ToolKind::Wasm`; it is exercised by the `aa-sandbox` crate.
- `bin/*.rs`, `server.rs`, `shutdown.rs`, `config.rs` are entrypoint/glue
  (conventionally excluded) and remain at ~0%.

A follow-up subtask is recommended to finish `aa-api` to ≥95%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
