### PR TITLE
[AAASM-3819] 📝 (skill): Cover sonar.projectVersion bump in release-tag-cut

### DIFF
--- a/.claude/skills/release-tag-cut/REFERENCE.md
+++ b/.claude/skills/release-tag-cut/REFERENCE.md
@@ -57,7 +57,8 @@ if `$CURRENT` equals `<X>` (no-op release) or if the value cannot be parsed.
 ### 2. Bump every Cargo.toml version literal + regenerate Cargo.lock
 
 Run the helper script — it enumerates `**/Cargo.toml` declaring `$CURRENT`,
-sed-replaces each, regenerates `Cargo.lock`, and refuses no-op invocations:
+sed-replaces each, bumps `sonar.projectVersion`, regenerates `Cargo.lock`, and
+refuses no-op invocations:
 
 ```bash
 ./scripts/release-tag-cut.sh "$CURRENT" "<X>"
@@ -67,10 +68,18 @@ The script prints the file list before mutating (sanity check it), then
 runs `cargo update --workspace`. For reference, the AAASM-2849 alpha-9 cut
 touched **~16 crates with ~43 literal occurrences**.
 
-### 3. Commit the version bump — Cargo.toml diff only
+It also bumps `sonar.projectVersion` in `sonar-project.properties` from
+`$CURRENT` to `<X>` so SonarCloud's reported project version tracks the release
+instead of going stale (AAASM-3819). The static value is the source of truth /
+local-scan fallback; `ci.yml` additionally overrides it dynamically from the
+Cargo version at scan time, so the line only needs to match `$CURRENT` for the
+helper to rewrite it — if it has drifted, the helper warns and leaves it
+untouched rather than failing the release.
+
+### 3. Commit the version bump — manifests + sonar
 
 ```bash
-git add '**/Cargo.toml' Cargo.toml
+git add '**/Cargo.toml' Cargo.toml sonar-project.properties
 git commit -m "🔧 (release): Bump workspace to v<X>"
 ```
 

--- a/.claude/skills/release-tag-cut/SKILL.md
+++ b/.claude/skills/release-tag-cut/SKILL.md
@@ -145,12 +145,15 @@ no-op guard rationale are in
 
 1. **Resolve the current literal** — read the workspace version from
    `Cargo.toml` into `$CURRENT`; refuse the run if `$CURRENT == <X>` (no-op).
-2. **Bump + regenerate lockfile** — run
+2. **Bump version literals + regenerate lockfile** — run
    `./scripts/release-tag-cut.sh "$CURRENT" "<X>"`. The bundled helper
    enumerates every `**/Cargo.toml` declaring `$CURRENT`, sed-replaces each,
+   bumps `sonar.projectVersion` in `sonar-project.properties` from `$CURRENT`
+   to `<X>` (so SonarCloud's reported version tracks the release — AAASM-3819),
    regenerates `Cargo.lock`, and refuses no-op invocations.
-3. **Commit the bump (Cargo.toml only)** —
-   `🔧 (release): Bump workspace to v<X>`; verify the old literal is gone.
+3. **Commit the bump (manifests + sonar)** —
+   `🔧 (release): Bump workspace to v<X>` — stage the `Cargo.toml` files and
+   `sonar-project.properties`; verify the old literal is gone.
 4. **Commit `Cargo.lock` separately** —
    `🔧 (release): Regenerate Cargo.lock for v<X>` (reviewable in isolation).
 5. **Create the annotated tag** — ensure `docs/release/v<X>.md` exists (copy

--- a/.claude/skills/release-tag-cut/scripts/release-tag-cut.sh
+++ b/.claude/skills/release-tag-cut/scripts/release-tag-cut.sh
@@ -79,6 +79,27 @@ if [ -n "$REMAINING" ]; then
     exit 7
 fi
 
+# Bump sonar.projectVersion so SonarCloud's reported project version tracks the
+# release (AAASM-3819). The static value is the source of truth / local-scan
+# fallback; ci.yml additionally overrides it dynamically from the Cargo version
+# at scan time, so a drift here never breaks CI. Only rewrite the line when it
+# currently equals $CURRENT — if it has drifted, warn and leave it untouched
+# rather than failing the release.
+SONAR_PROPS="sonar-project.properties"
+if [ -f "$SONAR_PROPS" ]; then
+    if grep -qE "^sonar\.projectVersion=$CURRENT$" "$SONAR_PROPS"; then
+        if ! sed -i.bak -E "s/^sonar\.projectVersion=$CURRENT$/sonar.projectVersion=$TARGET/" "$SONAR_PROPS"; then
+            echo "error: sed failed on $SONAR_PROPS" >&2
+            exit 9
+        fi
+        rm -f "$SONAR_PROPS.bak"
+        echo "==> Bumped sonar.projectVersion: $CURRENT -> $TARGET"
+    else
+        echo "==> note: sonar.projectVersion != $CURRENT in $SONAR_PROPS" \
+             "(ci.yml overrides it dynamically); leaving it untouched"
+    fi
+fi
+
 echo "==> Regenerating Cargo.lock via cargo update --workspace"
 if ! cargo update --workspace; then
     echo "error: cargo update --workspace failed" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1284,6 +1284,17 @@ jobs:
         working-directory: dashboard
         run: pnpm test:coverage
       # ---- Scan -------------------------------------------------------------
+      # AAASM-3819: derive sonar.projectVersion from the workspace Cargo version
+      # so SonarCloud's reported project version tracks the release automatically
+      # and the static value in sonar-project.properties can never silently go
+      # stale. Passed to every scan attempt below via the scanner `args` input,
+      # which overrides the file value.
+      - name: Resolve sonar.projectVersion from Cargo version
+        id: sonar-version
+        run: |
+          version="$(grep -E '^version = ' Cargo.toml | head -1 | sed -E 's/version = "([^"]+)"/\1/')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Resolved sonar.projectVersion=${version}"
       - name: Cache SonarCloud analysis state
         uses: actions/cache@v6
         with:
@@ -1295,6 +1306,8 @@ jobs:
         id: sonar-scan-attempt-1
         continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        with:
+          args: -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -1308,6 +1321,8 @@ jobs:
         if: steps.sonar-scan-attempt-1.outcome == 'failure'
         continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        with:
+          args: -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -1319,6 +1334,8 @@ jobs:
       - name: SonarCloud scan (attempt 3 — final)
         if: steps.sonar-scan-attempt-1.outcome == 'failure' && steps.sonar-scan-attempt-2.outcome == 'failure'
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        with:
+          args: -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.projectKey=ai-agent-assembly_agent-assembly
 sonar.organization=ai-agent-assembly
 
 sonar.projectName=agent-assembly
-sonar.projectVersion=0.0.1
+sonar.projectVersion=0.0.1-rc.1
 
 sonar.projectBaseDir=./
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,10 @@ sonar.projectKey=ai-agent-assembly_agent-assembly
 sonar.organization=ai-agent-assembly
 
 sonar.projectName=agent-assembly
+# Kept in sync with the workspace Cargo version by the release-tag-cut skill
+# (AAASM-3819). ci.yml also overrides this with
+# -Dsonar.projectVersion=<Cargo version> at scan time, so it never silently
+# goes stale; this static value is the source of truth / local-scan fallback.
 sonar.projectVersion=0.0.1-rc.1
 
 sonar.projectBaseDir=./


### PR DESCRIPTION
## Description

Release-skill + config hygiene only — **no functional code change**.

`sonar-project.properties` already carried `sonar.projectVersion=0.0.1`, so the SonarCloud gate is not blocked here. But the release process never bumped that value, so it would silently go stale as the workspace version advanced (it had already drifted: the manifest is `0.0.1-rc.1`). This PR closes that gap from three directions:

1. **Align the static value** — `sonar.projectVersion` `0.0.1` → `0.0.1-rc.1` to match the workspace Cargo manifest version.
2. **release-tag-cut helper** — `scripts/release-tag-cut.sh` now also sed-bumps `sonar.projectVersion` (from `$CURRENT` to the target) alongside the Cargo version literals. It only rewrites the line when it equals `$CURRENT`; on drift it warns and leaves it untouched so a release never fails on this.
3. **release-tag-cut skill docs** — `SKILL.md` step 2/3 and `REFERENCE.md` now document that the version bump covers `sonar.projectVersion` and is committed with the manifests.
4. **CI dynamic override (optional)** — the Sonar scan job resolves the live Cargo version and passes `-Dsonar.projectVersion=<version>` to all three scan attempts, so the reported version tracks the release automatically and can never drift. The `sonar` job is non-gating (excluded from the `CI Success` aggregate), so this carries no merge-gate risk.

## Type of Change

- [x] 🔧 Configuration / CI change
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3819 (parent Epic AAASM-3814)

Closes AAASM-3819

## Testing

- [x] No tests required (explain why)

Markdown / shell-config / workflow-YAML only. Validated locally:
- `bash -n scripts/release-tag-cut.sh` → syntax OK.
- `python3 -c "yaml.safe_load(...)` on `ci.yml` → parses OK.
- The static value now matches the manifest (`0.0.1-rc.1`), so the helper's `$CURRENT`-keyed sed will match on the next cut.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — N/A, no Rust changed
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
