### PR TITLE
[AAASM-3812] ✅ (aa-cli): Additional coverage tests

### DIFF
--- a/aa-cli/tests/agent_suspend_resume.rs
+++ b/aa-cli/tests/agent_suspend_resume.rs
@@ -139,3 +139,77 @@ async fn resume_returns_failure_on_404() {
 
     assert_eq!(result, ExitCode::FAILURE);
 }
+
+// ── render-format coverage (AAASM-3812) ───────────────────────────────
+//
+// The success tests above only render in `Json`; the `Table` and `Yaml`
+// success-render arms of `suspend`/`resume` were never exercised.
+
+async fn suspend_ok(uri: String, fmt: aa_cli::output::OutputFormat) -> ExitCode {
+    std::thread::spawn(move || {
+        let args = aa_cli::commands::agent::suspend::SuspendArgs {
+            agent_id: "aabbccdd00112233".to_string(),
+            reason: "drift".to_string(),
+            force: true,
+        };
+        aa_cli::commands::agent::suspend::run(args, &make_context(&uri), fmt)
+    })
+    .join()
+    .unwrap()
+}
+
+async fn mount_suspend_ok(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/api/v1/agents/aabbccdd00112233/suspend"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "agent_id": "aabbccdd00112233",
+            "previous_status": "Active",
+            "new_status": "Suspended(Manual)"
+        })))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn suspend_table_success_renders() {
+    let server = MockServer::start().await;
+    mount_suspend_ok(&server).await;
+    assert_eq!(
+        suspend_ok(server.uri(), aa_cli::output::OutputFormat::Table).await,
+        ExitCode::SUCCESS
+    );
+}
+
+#[tokio::test]
+async fn suspend_yaml_success_renders() {
+    let server = MockServer::start().await;
+    mount_suspend_ok(&server).await;
+    assert_eq!(
+        suspend_ok(server.uri(), aa_cli::output::OutputFormat::Yaml).await,
+        ExitCode::SUCCESS
+    );
+}
+
+#[tokio::test]
+async fn resume_yaml_success_renders() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/agents/aabbccdd00112233/resume"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "agent_id": "aabbccdd00112233",
+            "previous_status": "Suspended(Manual)",
+            "new_status": "Active"
+        })))
+        .mount(&server)
+        .await;
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::agent::resume::ResumeArgs {
+            agent_id: "aabbccdd00112233".to_string(),
+        };
+        aa_cli::commands::agent::resume::run(args, &make_context(&uri), aa_cli::output::OutputFormat::Yaml)
+    })
+    .join()
+    .unwrap();
+    assert_eq!(result, ExitCode::SUCCESS);
+}

--- a/aa-cli/tests/dispatch_router_cov.rs
+++ b/aa-cli/tests/dispatch_router_cov.rs
@@ -1,0 +1,164 @@
+//! Top-level `commands::dispatch` routing coverage (AAASM-3812).
+//!
+//! `dispatch_cov.rs` proves a handful of router arms (agent / policy /
+//! approvals / audit / proxy-status). The remaining arms — and the small
+//! group-`dispatch` shims they delegate to (`alerts::dispatch`,
+//! `cost::dispatch`) plus the daemon-free `completion`/`version` handlers —
+//! were never driven through the top-level router. Each test parses no CLI;
+//! it constructs the `Commands` variant and asserts the router reaches the
+//! correct handler (success against a mocked gateway, or the documented
+//! graceful-degradation exit for `version`). The per-command tokio runtime
+//! is built inside `run()`, so HTTP-backed arms run on a dedicated thread.
+
+use std::process::ExitCode;
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use aa_cli::commands::{self, Commands};
+use aa_cli::output::OutputFormat;
+
+fn make_context(api_url: &str) -> aa_cli::config::ResolvedContext {
+    aa_cli::config::ResolvedContext {
+        name: None,
+        api_url: api_url.to_string(),
+        api_key: None,
+    }
+}
+
+/// Mount a GET endpoint returning `body`, then route `cmd` through the
+/// top-level dispatcher on a dedicated thread and return its exit code.
+async fn dispatch_with_get(endpoint: &str, body: serde_json::Value, cmd: Commands) -> ExitCode {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(endpoint.to_string()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+    let uri = server.uri();
+    std::thread::spawn(move || commands::dispatch(cmd, &make_context(&uri), OutputFormat::Table))
+        .join()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn dispatch_routes_alerts_list() {
+    let cmd = Commands::Alerts(aa_cli::commands::alerts::AlertsArgs {
+        command: aa_cli::commands::alerts::AlertsCommands::List(aa_cli::commands::alerts::list::ListArgs {
+            agent: None,
+            severity: None,
+            status: Some("unresolved".to_string()),
+        }),
+    });
+    let body = serde_json::json!({"items": [], "page": 1, "per_page": 20, "total": 0});
+    assert_eq!(dispatch_with_get("/api/v1/alerts", body, cmd).await, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn dispatch_routes_cost_summary() {
+    let cmd = Commands::Cost(aa_cli::commands::cost::CostArgs {
+        command: aa_cli::commands::cost::CostCommands::Summary(aa_cli::commands::cost::summary::SummaryArgs {
+            period: aa_cli::commands::cost::summary::Period::Today,
+            group_by: None,
+        }),
+    });
+    let body = serde_json::json!({
+        "daily_spend_usd": "1.00",
+        "monthly_spend_usd": "10.00",
+        "date": "2026-04-15",
+        "daily_limit_usd": "50.00",
+        "monthly_limit_usd": "500.00",
+        "per_agent": []
+    });
+    assert_eq!(dispatch_with_get("/api/v1/costs", body, cmd).await, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn dispatch_routes_logs_fetch() {
+    let cmd = Commands::Logs(aa_cli::commands::logs::LogsArgs {
+        follow: false,
+        agent: None,
+        r#type: None,
+        since: None,
+        until: None,
+        limit: 50,
+        no_color: true,
+        output: None,
+    });
+    let body = serde_json::json!({"items": [], "page": 1, "per_page": 50, "total": 0});
+    assert_eq!(dispatch_with_get("/api/v1/logs", body, cmd).await, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn dispatch_routes_trace() {
+    let sid = "sess-router";
+    let cmd = Commands::Trace(aa_cli::commands::trace::TraceArgs {
+        session_id: sid.to_string(),
+        format: aa_cli::commands::trace::TraceFormat::Tree,
+    });
+    let body = serde_json::json!({
+        "session_id": sid,
+        "agent_id": "aabbccdd00112233aabbccdd00112233",
+        "spans": [
+            {"span_id": "root", "parent_span_id": null, "operation": "llm_call",
+             "decision": "allow", "start_time": "2026-01-01T00:00:00Z",
+             "end_time": "2026-01-01T00:00:00.800Z"}
+        ]
+    });
+    assert_eq!(
+        dispatch_with_get(&format!("/api/v1/traces/{sid}"), body, cmd).await,
+        ExitCode::SUCCESS
+    );
+}
+
+#[tokio::test]
+async fn dispatch_routes_topology_overview() {
+    let cmd = Commands::Topology(aa_cli::commands::topology::TopologyArgs {
+        command: aa_cli::commands::topology::TopologyCommands::Overview(
+            aa_cli::commands::topology::overview::OverviewArgs {
+                status: None,
+                show_budget: false,
+            },
+        ),
+    });
+    let body = serde_json::json!({
+        "team_count": 0,
+        "root_agent_count": 0,
+        "total_agent_count": 0,
+        "teams": [],
+        "standalone_root_agents": []
+    });
+    assert_eq!(
+        dispatch_with_get("/api/v1/topology/overview", body, cmd).await,
+        ExitCode::SUCCESS
+    );
+}
+
+/// `completion` needs no gateway — it writes a shell script to stdout and is
+/// routed through the top-level dispatcher here for both a POSIX and a
+/// non-POSIX shell.
+#[test]
+fn dispatch_routes_completion_for_multiple_shells() {
+    for shell in [clap_complete::Shell::Bash, clap_complete::Shell::Fish] {
+        let cmd = Commands::Completion(aa_cli::commands::completion::CompletionArgs { shell });
+        let code = commands::dispatch(cmd, &make_context("http://127.0.0.1:1"), OutputFormat::Table);
+        assert_eq!(code, ExitCode::SUCCESS);
+    }
+}
+
+/// `version` degrades gracefully: against an unreachable gateway it still
+/// exits 0 with "unreachable" rows. Routing it through the dispatcher with a
+/// dead URL covers the `Commands::Version` arm without a mock server.
+#[test]
+fn dispatch_routes_version_against_dead_gateway() {
+    let code = std::thread::spawn(|| {
+        commands::dispatch(
+            Commands::Version,
+            &make_context("http://127.0.0.1:1"),
+            OutputFormat::Table,
+        )
+    })
+    .join()
+    .unwrap();
+    assert_eq!(code, ExitCode::SUCCESS);
+}

--- a/aa-cli/tests/policy_history_simulate_cov.rs
+++ b/aa-cli/tests/policy_history_simulate_cov.rs
@@ -1,0 +1,170 @@
+//! Coverage for `aasm policy simulate` and the filesystem-backed
+//! `policy history` / `rollback` / `diff` handlers (AAASM-3812).
+//!
+//! The existing simulate tests only exercise the early-return failure arms
+//! (bad policy, missing `--against`, `--live`). Here we drive the full
+//! replay path: parse an audit-log JSONL, evaluate it against a real
+//! `PolicyEngine`, write the JSON report, and assert both the report
+//! contents and the exit-code contract (denials → FAILURE). The history
+//! handlers use `FsHistoryStore` rooted at `$AA_DATA_DIR`, so an isolated
+//! empty data dir lets us cover the empty-listing and not-found error arms
+//! deterministically.
+
+use std::io::Write;
+use std::process::ExitCode;
+use std::sync::{Mutex, MutexGuard};
+
+use aa_cli::commands::policy::history::{self, DiffArgs, HistoryArgs, RollbackArgs};
+use aa_cli::commands::policy::simulate::{self, SimulateArgs};
+
+/// Minimal allow-everything policy (section-based schema, AAASM-3351).
+const ALLOW_ALL_POLICY: &str = "version: \"1.0\"\n";
+/// Policy that denies the `bash` tool, forcing a simulated denial.
+const DENY_BASH_POLICY: &str = "version: \"1.0\"\ntools:\n  bash:\n    allow: false\n";
+
+/// Serialize one audit-log line wrapping a `ToolCall` governance action.
+fn tool_call_jsonl(tool: &str) -> String {
+    let payload = serde_json::to_string(&aa_core::GovernanceAction::ToolCall {
+        name: tool.to_string(),
+        args: "{}".to_string(),
+    })
+    .unwrap();
+    serde_json::to_string(&serde_json::json!({
+        "event_type": "ToolCallIntercepted",
+        "agent_id": "test-agent",
+        "payload": payload,
+    }))
+    .unwrap()
+}
+
+fn write_temp(contents: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(contents.as_bytes()).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+// ── policy simulate: full replay path ─────────────────────────────────
+
+#[test]
+fn simulate_allow_all_succeeds_and_writes_report() {
+    let policy = write_temp(ALLOW_ALL_POLICY);
+    let log = write_temp(&format!(
+        "{}\n{}\n",
+        tool_call_jsonl("read_file"),
+        tool_call_jsonl("write_file")
+    ));
+    let report_path = tempfile::NamedTempFile::new().unwrap();
+
+    let args = SimulateArgs {
+        policy: policy.path().to_path_buf(),
+        against: Some(log.path().to_path_buf()),
+        live: false,
+        duration: None,
+        output_file: Some(report_path.path().to_path_buf()),
+    };
+    assert_eq!(simulate::run(args), ExitCode::SUCCESS);
+
+    // The report file was written and reflects the two allowed events.
+    let written = std::fs::read_to_string(report_path.path()).unwrap();
+    let report: serde_json::Value = serde_json::from_str(&written).unwrap();
+    assert_eq!(report["total_events"], 2);
+    assert_eq!(report["allowed"], 2);
+    assert_eq!(report["denied"], 0);
+}
+
+#[test]
+fn simulate_with_denials_returns_failure() {
+    let policy = write_temp(DENY_BASH_POLICY);
+    let log = write_temp(&format!("{}\n", tool_call_jsonl("bash")));
+
+    let args = SimulateArgs {
+        policy: policy.path().to_path_buf(),
+        against: Some(log.path().to_path_buf()),
+        live: false,
+        duration: None,
+        output_file: None,
+    };
+    // A denied event drives the `denied > 0` exit-code branch (and the
+    // flagged-outcomes print loop).
+    assert_eq!(simulate::run(args), ExitCode::FAILURE);
+}
+
+#[test]
+fn simulate_unreadable_against_file_returns_failure() {
+    let policy = write_temp(ALLOW_ALL_POLICY);
+    let args = SimulateArgs {
+        policy: policy.path().to_path_buf(),
+        against: Some(std::path::PathBuf::from("/nonexistent/aaasm-3812/audit-log.jsonl")),
+        live: false,
+        duration: None,
+        output_file: None,
+    };
+    assert_eq!(simulate::run(args), ExitCode::FAILURE);
+}
+
+// ── policy history / rollback / diff against an isolated store ─────────
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Point `AA_DATA_DIR` at a fresh empty temp dir for the guard's lifetime so
+/// `FsHistoryStore::default_config()` resolves to an isolated, empty store.
+struct DataDir {
+    _lock: MutexGuard<'static, ()>,
+    _tmp: tempfile::TempDir,
+    prior: Option<String>,
+}
+
+impl DataDir {
+    fn new() -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let prior = std::env::var("AA_DATA_DIR").ok();
+        std::env::set_var("AA_DATA_DIR", tmp.path());
+        Self {
+            _lock: lock,
+            _tmp: tmp,
+            prior,
+        }
+    }
+}
+
+impl Drop for DataDir {
+    fn drop(&mut self) {
+        match self.prior.take() {
+            Some(v) => std::env::set_var("AA_DATA_DIR", v),
+            None => std::env::remove_var("AA_DATA_DIR"),
+        }
+    }
+}
+
+#[test]
+fn history_empty_store_succeeds() {
+    let _dd = DataDir::new();
+    // No versions have been applied in the isolated data dir → the empty
+    // listing arm is taken and the command still exits 0.
+    assert_eq!(history::run_history(HistoryArgs { limit: 10 }), ExitCode::SUCCESS);
+}
+
+#[test]
+fn rollback_nonexistent_version_returns_failure() {
+    let _dd = DataDir::new();
+    assert_eq!(
+        history::run_rollback(RollbackArgs {
+            version: "deadbeefdeadbeef".to_string(),
+        }),
+        ExitCode::FAILURE
+    );
+}
+
+#[test]
+fn diff_nonexistent_versions_returns_failure() {
+    let _dd = DataDir::new();
+    assert_eq!(
+        history::run_diff(DiffArgs {
+            version_a: "aaaaaaaaaaaa".to_string(),
+            version_b: "bbbbbbbbbbbb".to_string(),
+        }),
+        ExitCode::FAILURE
+    );
+}

--- a/aa-cli/tests/topology_render_cov.rs
+++ b/aa-cli/tests/topology_render_cov.rs
@@ -1,0 +1,379 @@
+//! Coverage for the topology render layer (AAASM-3812).
+//!
+//! The existing `topology.rs` suite drives each subcommand's `run()` in
+//! `Table` format only, so the JSON/YAML serialisation arms in
+//! `render::json` and several data-dependent table branches were never
+//! exercised. Here we:
+//!
+//! 1. drive every topology shape through `run()` in `Json` *and* `Yaml`
+//!    format (the house pattern — wiremock + a dedicated thread for the
+//!    per-command tokio runtime), covering `render_json` / `render_yaml`
+//!    for all five `TopologyPayload` variants; and
+//! 2. call the pure table/tree render helpers directly with branch-covering
+//!    data (standalone roots, root lineage, an over-60-char delegation
+//!    reason that guards the `&r[..60]` slice, populated histograms, nested
+//!    children, and the otherwise-unwired `render_lineage_chain`).
+
+use std::process::ExitCode;
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use aa_cli::commands::topology::render::{
+    self, AgentLineage, AgentNode, AgentTree, LineageStep, TeamSummary, TopologyOverview, TopologyStats,
+};
+use aa_cli::output::OutputFormat;
+
+fn make_context(api_url: &str) -> aa_cli::config::ResolvedContext {
+    aa_cli::config::ResolvedContext {
+        name: None,
+        api_url: api_url.to_string(),
+        api_key: None,
+    }
+}
+
+// ── run() in Json + Yaml for every topology shape ─────────────────────
+
+#[tokio::test]
+async fn overview_json_and_yaml_succeed() {
+    let body = serde_json::json!({
+        "team_count": 1,
+        "root_agent_count": 1,
+        "total_agent_count": 2,
+        "teams": [{"team_id": "team-alpha", "agent_count": 2, "root_agent_count": 1}],
+        "standalone_root_agents": []
+    });
+    for fmt in [OutputFormat::Json, OutputFormat::Yaml] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/topology/overview"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let uri = server.uri();
+        let code = std::thread::spawn(move || {
+            let args = aa_cli::commands::topology::overview::OverviewArgs {
+                status: None,
+                show_budget: false,
+            };
+            aa_cli::commands::topology::overview::run(args, &make_context(&uri), fmt)
+        })
+        .join()
+        .unwrap();
+        assert_eq!(code, ExitCode::SUCCESS);
+    }
+}
+
+#[tokio::test]
+async fn tree_json_and_yaml_succeed() {
+    let root_id = "0102030405060708090a0b0c0d0e0f10";
+    let body = serde_json::json!({
+        "id": root_id,
+        "name": "root-agent",
+        "depth": 0,
+        "status": "active",
+        "team_id": "team-alpha",
+        "delegation_reason": null,
+        "spawned_by_tool": null,
+        "children": []
+    });
+    for fmt in [OutputFormat::Json, OutputFormat::Yaml] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/api/v1/topology/tree/{root_id}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let uri = server.uri();
+        let code = std::thread::spawn(move || {
+            let args = aa_cli::commands::topology::tree::TreeArgs {
+                agent_id: root_id.to_string(),
+                depth: None,
+                status: None,
+                show_budget: false,
+            };
+            aa_cli::commands::topology::tree::run(args, &make_context(&uri), fmt)
+        })
+        .join()
+        .unwrap();
+        assert_eq!(code, ExitCode::SUCCESS);
+    }
+}
+
+#[tokio::test]
+async fn team_json_and_yaml_succeed() {
+    let body = serde_json::json!({
+        "team_id": "team-alpha",
+        "agent_count": 1,
+        "members": [
+            {"id": "aabb", "name": "agent-1", "depth": 0, "status": "active", "team_id": "team-alpha"}
+        ]
+    });
+    for fmt in [OutputFormat::Json, OutputFormat::Yaml] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/topology/team/team-alpha"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let uri = server.uri();
+        let code = std::thread::spawn(move || {
+            let args = aa_cli::commands::topology::team::TeamArgs {
+                team_id: "team-alpha".to_string(),
+                status: None,
+                show_budget: false,
+            };
+            aa_cli::commands::topology::team::run(args, &make_context(&uri), fmt)
+        })
+        .join()
+        .unwrap();
+        assert_eq!(code, ExitCode::SUCCESS);
+    }
+}
+
+#[tokio::test]
+async fn lineage_json_and_yaml_succeed() {
+    let agent_id = "aabbccdd00112233aabbccdd00112233";
+    let body = serde_json::json!({
+        "agent_id": agent_id,
+        "ancestor_count": 1,
+        "ancestors": [
+            {"id": agent_id, "name": "root", "depth": 0, "delegation_reason": null, "team_id": null}
+        ]
+    });
+    for fmt in [OutputFormat::Json, OutputFormat::Yaml] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/api/v1/topology/lineage/{agent_id}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let uri = server.uri();
+        let code = std::thread::spawn(move || {
+            let args = aa_cli::commands::topology::lineage::LineageArgs {
+                agent_id: agent_id.to_string(),
+                show_permissions: false,
+            };
+            aa_cli::commands::topology::lineage::run(args, &make_context(&uri), fmt)
+        })
+        .join()
+        .unwrap();
+        assert_eq!(code, ExitCode::SUCCESS);
+    }
+}
+
+#[tokio::test]
+async fn stats_json_and_yaml_succeed() {
+    let body = serde_json::json!({
+        "total_agents": 3,
+        "root_agent_count": 1,
+        "max_depth": 2,
+        "active_count": 3,
+        "suspended_count": 0,
+        "deregistered_count": 0,
+        "team_count": 1,
+        "team_sizes": {"team-alpha": 3},
+        "depth_histogram": {"0": 1, "1": 2},
+        "team_size_histogram": {"3": 1},
+        "spawn_count_histogram": {"0": 1},
+        "orphan_count": 0,
+        "avg_children_per_parent": 1.0
+    });
+    for fmt in [OutputFormat::Json, OutputFormat::Yaml] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/topology/stats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let uri = server.uri();
+        let code = std::thread::spawn(move || {
+            let args = aa_cli::commands::topology::stats::StatsArgs {};
+            aa_cli::commands::topology::stats::run(args, &make_context(&uri), fmt)
+        })
+        .join()
+        .unwrap();
+        assert_eq!(code, ExitCode::SUCCESS);
+    }
+}
+
+// ── pure render helpers: branch coverage via direct calls ─────────────
+
+fn node(id: &str, name: &str, status: &str, team: Option<&str>) -> AgentNode {
+    AgentNode {
+        id: id.to_string(),
+        name: name.to_string(),
+        depth: 0,
+        status: status.to_string(),
+        team_id: team.map(str::to_string),
+        governance_level: None,
+    }
+}
+
+/// The overview table's "standalone root agents" block is only reached when
+/// `standalone_root_agents` is non-empty — the wiremock suite always sends an
+/// empty list, so cover it here.
+#[test]
+fn overview_table_renders_standalone_root_agents() {
+    let overview = TopologyOverview {
+        team_count: 1,
+        root_agent_count: 2,
+        total_agent_count: 3,
+        teams: vec![TeamSummary {
+            team_id: "team-alpha".to_string(),
+            agent_count: 2,
+            root_agent_count: 1,
+        }],
+        standalone_root_agents: vec![
+            node("dead", "loner-1", "active", None),
+            node("beef", "loner-2", "deregistered", Some("team-x")),
+        ],
+    };
+    // Renders both the team table and the standalone-agents table without panic.
+    render::table::render_overview_table(&overview);
+}
+
+/// A single depth-0 ancestor triggers the "(this is a root agent)" footer; an
+/// over-60-char delegation reason exercises the `&r[..60]` truncation slice (a
+/// panic risk if the boundary logic were wrong).
+#[test]
+fn lineage_table_handles_root_and_long_reason() {
+    let root = AgentLineage {
+        agent_id: "root0000000000000000000000000000".to_string(),
+        ancestor_count: 1,
+        ancestors: vec![LineageStep {
+            id: "root0000000000000000000000000000".to_string(),
+            name: "root".to_string(),
+            depth: 0,
+            delegation_reason: None,
+            team_id: None,
+        }],
+    };
+    render::table::render_lineage_table(&root);
+
+    let long_reason = "x".repeat(120);
+    let chain = AgentLineage {
+        agent_id: "child".to_string(),
+        ancestor_count: 2,
+        ancestors: vec![
+            LineageStep {
+                id: "root".to_string(),
+                name: "root".to_string(),
+                depth: 0,
+                delegation_reason: None,
+                team_id: Some("team-alpha".to_string()),
+            },
+            LineageStep {
+                id: "child".to_string(),
+                name: "child".to_string(),
+                depth: 1,
+                delegation_reason: Some(long_reason),
+                team_id: None,
+            },
+        ],
+    };
+    render::table::render_lineage_table(&chain);
+}
+
+/// An empty-ancestry lineage takes the "No ancestry data." early return.
+#[test]
+fn lineage_table_handles_empty_ancestry() {
+    let empty = AgentLineage {
+        agent_id: "ghost".to_string(),
+        ancestor_count: 0,
+        ancestors: vec![],
+    };
+    render::table::render_lineage_table(&empty);
+}
+
+/// Populated depth and team-size histograms exercise the two optional
+/// histogram blocks in the stats table.
+#[test]
+fn stats_table_renders_histograms() {
+    use std::collections::{BTreeMap, HashMap};
+    let mut team_sizes = HashMap::new();
+    team_sizes.insert("team-alpha".to_string(), 5usize);
+    let mut depth_histogram = BTreeMap::new();
+    depth_histogram.insert("0".to_string(), 1u32);
+    depth_histogram.insert("1".to_string(), 4u32);
+    let mut team_size_histogram = BTreeMap::new();
+    team_size_histogram.insert("5".to_string(), 1u32);
+    let stats = TopologyStats {
+        total_agents: 5,
+        root_agent_count: 1,
+        max_depth: 1,
+        active_count: 4,
+        suspended_count: 1,
+        deregistered_count: 0,
+        team_count: 1,
+        team_sizes,
+        depth_histogram,
+        team_size_histogram,
+        spawn_count_histogram: BTreeMap::new(),
+        orphan_count: 0,
+        avg_children_per_parent: 4.0,
+    };
+    render::table::render_stats_table(&stats);
+}
+
+fn tree_node(name: &str, team: Option<&str>, children: Vec<AgentTree>) -> AgentTree {
+    AgentTree {
+        id: format!("id-{name}"),
+        name: name.to_string(),
+        depth: 0,
+        status: "active".to_string(),
+        team_id: team.map(str::to_string),
+        delegation_reason: None,
+        spawned_by_tool: None,
+        governance_level: None,
+        children,
+    }
+}
+
+/// Nested children and a `None` team_id cover the recursion and the empty
+/// `team_tag` branch of `render_agent_tree`.
+#[test]
+fn agent_tree_renders_nested_children() {
+    let tree = tree_node(
+        "root",
+        Some("team-alpha"),
+        vec![
+            tree_node("child-a", None, vec![tree_node("grandchild", None, vec![])]),
+            tree_node("child-b", Some("team-beta"), vec![]),
+        ],
+    );
+    render::tree::render_agent_tree(&tree, "", true);
+}
+
+/// `render_lineage_chain` is a public helper that the `render()` dispatcher
+/// does not wire up (lineage Table uses the flat table form), so it has no
+/// other caller. Exercise both the `Some`/`None` delegation-reason arms.
+#[test]
+fn lineage_chain_renders_with_and_without_reason() {
+    let lineage = AgentLineage {
+        agent_id: "child".to_string(),
+        ancestor_count: 2,
+        ancestors: vec![
+            LineageStep {
+                id: "root".to_string(),
+                name: "root".to_string(),
+                depth: 0,
+                delegation_reason: None,
+                team_id: None,
+            },
+            LineageStep {
+                id: "child".to_string(),
+                name: "child".to_string(),
+                depth: 1,
+                delegation_reason: Some("orchestrate".to_string()),
+                team_id: Some("team-alpha".to_string()),
+            },
+        ],
+    };
+    render::tree::render_lineage_chain(&lineage);
+}


### PR DESCRIPTION
## Description

Round-2 coverage work for `aa-cli/src` (AAASM-3812, Story AAASM-3798). Adds
meaningful, behaviour-asserting tests for reachable-but-uncovered logic and
identifies the genuinely e2e-only code that no unit test can reach.

Line coverage (`cargo llvm-cov nextest -p aa-cli`): **85.78% → 87.02%**
(741 → 768 tests). Notable per-file gains:

| File | Before → After |
|---|---|
| `commands/completion.rs` | 0% → 100% |
| `commands/topology/render/tree.rs` | 37% → 100% |
| `commands/topology/render/json.rs` | 27% → 91% |
| `commands/topology/render/table.rs` | 88% → 99% |
| `commands/policy/simulate.rs` | 62% → 91% |
| `commands/policy/history.rs` | 53% → 76% |
| `commands/mod.rs` (top-level router) | 35% → 58% |
| `commands/cost/mod.rs` | 0% → 80% |
| `commands/agent/suspend.rs` / `resume.rs` | 64%/75% → 81%/85% |

New test files:
- `tests/topology_render_cov.rs` — every topology shape through `run()` in
  Json/Yaml + direct branch coverage of the pure table/tree render helpers
  (standalone roots, root lineage, over-60-char delegation reason that
  guards the `&r[..60]` slice, histograms, nested children, and the
  otherwise-unwired `render_lineage_chain`).
- `tests/dispatch_router_cov.rs` — routes the alerts/cost/logs/trace/
  topology/completion/version arms through the top-level `commands::dispatch`.
- `tests/policy_history_simulate_cov.rs` — full `policy simulate` replay path
  (parse JSONL → evaluate against a real `PolicyEngine` → write JSON report →
  assert the denials→FAILURE exit contract) plus the `FsHistoryStore`-backed
  history/rollback/diff handlers against an isolated empty `$AA_DATA_DIR`.
- `tests/agent_suspend_resume.rs` — Table/Yaml success-render arms.

### Genuinely non-unit-testable (e2e-only) files/functions

These are NOT faked-covered. They require a live daemon, a kernel/OS trust
store, a WebSocket peer, a TTY raw-mode loop, or a `tail -f` loop, and should
be added to `sonar.coverage.exclusions` in a separate operator-owned commit:

- `commands/approvals/watch.rs` — WebSocket approval follow-loop (0%)
- `commands/logs/follow.rs` — WebSocket `logs --follow` tail loop
- `commands/gateway/start.rs` / `commands/proxy/start.rs` / `commands/dashboard/start.rs` — daemon fork/exec + spawn
- `commands/status/watch.rs` — live polling watch loop (0%)
- `commands/run.rs` — dev-tool process exec/spawn (`aasm run`)
- `commands/proxy/logs.rs` / `commands/gateway/logs.rs` — `tail -f` log-follow loops
- `commands/dashboard/mod.rs` (+ `feed.rs`) — crossterm raw-mode TUI event loop
- `commands/proxy/ca.rs` — OS keychain / `update-ca-certificates` trust-store mutation + interactive confirm

The residual uncovered lines in otherwise-tested files are almost entirely the
interactive `confirm_*` stdin prompts (kill/suspend/resolve/ca), which are
interactive-only by nature.

## Type of Change

- [x] ♻️ Refactoring (tests only — no production code changed)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3812 (Story AAASM-3798)

## Testing

- [x] Integration tests added / updated
- [x] `cargo nextest run -p aa-cli` — 768 passed, 0 failed
- [x] `cargo clippy -p aa-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmVbZVBF5jcJ81614hD2bU