### PR TITLE
[AAASM-3811] ✅ (aa-api): Raise test coverage to ≥95%

### DIFF
--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -86,4 +86,12 @@ mod tests {
         let registry = DestinationRegistry::seeded();
         assert!(!registry.contains("does-not-exist"));
     }
+
+    #[test]
+    fn default_impl_matches_seeded() {
+        let registry = DestinationRegistry::default();
+        let seeded = DestinationRegistry::seeded();
+        // Default delegates to seeded(), so both accept the same ids.
+        assert_eq!(registry.contains("does-not-exist"), seeded.contains("does-not-exist"));
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -330,4 +330,18 @@ mod tests {
         assert!(store.find_by_name("r1").is_some());
         assert!(store.find_by_name("not-there").is_none());
     }
+
+    #[test]
+    fn default_impl_is_empty_and_error_display_renders() {
+        let store = InMemoryAlertRuleStore::default();
+        assert!(store.list(None).is_empty());
+        assert_eq!(
+            AlertRuleStoreError::NameConflict {
+                name: "dup".to_string()
+            }
+            .to_string(),
+            "rule name already exists: dup"
+        );
+        assert_eq!(AlertRuleStoreError::NotFound.to_string(), "rule not found");
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -489,4 +489,65 @@ mod tests {
             "empty suppression_labels should be omitted, got {v}",
         );
     }
+
+    #[test]
+    fn negative_threshold_rejected_for_every_non_budget_metric() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        for metric in [
+            RuleMetric::AnomalyScore,
+            RuleMetric::ApprovalPendingAge,
+            RuleMetric::PolicyViolationCount,
+        ] {
+            let rule = AlertRule {
+                metric,
+                threshold: -1.0,
+                ..valid_rule()
+            };
+            let err = rule.validate(&registry).expect_err("negative threshold must fail");
+            assert!(
+                matches!(err, AlertRuleValidationError::InvalidThreshold { .. }),
+                "metric {metric:?} should reject a negative threshold",
+            );
+        }
+    }
+
+    #[test]
+    fn non_negative_threshold_accepted_for_every_non_budget_metric() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        for metric in [
+            RuleMetric::AnomalyScore,
+            RuleMetric::ApprovalPendingAge,
+            RuleMetric::PolicyViolationCount,
+        ] {
+            let rule = AlertRule {
+                metric,
+                threshold: 5.0,
+                ..valid_rule()
+            };
+            assert_eq!(rule.validate(&registry), Ok(()), "metric {metric:?} should accept 5.0");
+        }
+    }
+
+    #[test]
+    fn validation_error_display_covers_every_variant() {
+        let cases = [
+            AlertRuleValidationError::InvalidName {
+                reason: "bad".to_string(),
+            },
+            AlertRuleValidationError::InvalidThreshold {
+                metric: RuleMetric::BudgetSpentPct,
+                value: 200.0,
+                reason: "too big".to_string(),
+            },
+            AlertRuleValidationError::InvalidEvaluationWindow { value: 7 },
+            AlertRuleValidationError::EmptyDestinations,
+            AlertRuleValidationError::UnknownDestination {
+                id: "ghost".to_string(),
+            },
+        ];
+        for case in cases {
+            // Every variant must render a non-empty Display string.
+            assert!(!case.to_string().is_empty());
+        }
+    }
 }

--- a/aa-api/src/alerts/silence_store.rs
+++ b/aa-api/src/alerts/silence_store.rs
@@ -187,4 +187,10 @@ mod tests {
         let expired = store.expire_due(now);
         assert_eq!(expired.len(), 1);
     }
+
+    #[test]
+    fn default_impl_constructs_empty_store() {
+        let store = InMemorySilenceStore::default();
+        assert!(store.get_active_for_alert("any", at("2026-05-20T09:30:00Z")).is_none());
+    }
 }

--- a/aa-api/src/auth/api_key.rs
+++ b/aa-api/src/auth/api_key.rs
@@ -334,4 +334,59 @@ mod tests {
         let result = store.validate(key2.as_str());
         assert!(result.is_none());
     }
+
+    #[test]
+    fn verify_returns_false_for_unparseable_hash() {
+        let key = ApiKey::generate();
+        // A non-PHC string can't be parsed into a PasswordHash → verify is false.
+        assert!(!key.verify("not-a-valid-argon2-hash"));
+    }
+
+    #[test]
+    fn verify_round_trips_against_its_own_hash() {
+        let key = ApiKey::generate();
+        let hash = key.hash().expect("hash");
+        assert!(key.verify(&hash));
+    }
+
+    #[test]
+    fn store_len_is_empty_and_validate_detailed_distinguishes_revoked() {
+        let key = ApiKey::generate();
+        let entry = ApiKeyEntry {
+            id: "key-1".to_string(),
+            key_hash: key.hash().expect("hash"),
+            scopes: vec![Scope::Admin],
+            created_at: 1700000000,
+            label: None,
+            team_id: None,
+            org_id: None,
+        };
+        let store = ApiKeyStore::from_entries(vec![entry]);
+        assert_eq!(store.len(), 1);
+        assert!(!store.is_empty());
+
+        // Valid before revocation.
+        assert!(store.validate(key.as_str()).is_some());
+
+        // After revoking the matching key id, validate_detailed reports Revoked.
+        store.revoke("key-1");
+        assert!(matches!(
+            store.validate_detailed(key.as_str()),
+            Err(KeyNotValid::Revoked)
+        ));
+
+        // An entirely unknown key is NotFound.
+        let other = ApiKey::generate();
+        assert!(matches!(
+            store.validate_detailed(other.as_str()),
+            Err(KeyNotValid::NotFound)
+        ));
+    }
+
+    #[test]
+    fn empty_store_reports_is_empty() {
+        let store = ApiKeyStore::from_entries(vec![]);
+        assert!(store.is_empty());
+        assert_eq!(store.len(), 0);
+    }
 }

--- a/aa-api/src/auth/scope.rs
+++ b/aa-api/src/auth/scope.rs
@@ -162,4 +162,11 @@ mod tests {
         assert!(RequireScope::check(&caller, Scope::Write).is_ok());
         assert!(RequireScope::check(&caller, Scope::Admin).is_err());
     }
+
+    #[test]
+    fn scope_display_renders_each_level() {
+        assert_eq!(Scope::Read.to_string(), "read");
+        assert_eq!(Scope::Write.to_string(), "write");
+        assert_eq!(Scope::Admin.to_string(), "admin");
+    }
 }

--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -330,3 +330,98 @@ mod tests {
         assert!(allowed.is_ok(), "private egress must be allowed when opted in");
     }
 }
+
+#[cfg(test)]
+mod tests_extra {
+    use super::*;
+    use crate::destinations::types::{Destination, DestinationConfig};
+
+    fn dest(name: &str, config: DestinationConfig) -> Destination {
+        Destination {
+            id: "dst_test".to_string(),
+            name: name.to_string(),
+            config,
+            enabled: true,
+            created_at: "2026-06-25T00:00:00Z".to_string(),
+            updated_at: "2026-06-25T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_name_is_rejected() {
+        let d = dest(
+            "  ",
+            DestinationConfig::Webhook {
+                url: "https://example.com/h".to_string(),
+                secret_header: None,
+            },
+        );
+        assert!(matches!(
+            validate_destination(&d),
+            Err(ValidationError::InvalidConfig("name must be non-empty"))
+        ));
+    }
+
+    #[test]
+    fn valid_webhook_passes() {
+        let d = dest(
+            "wh",
+            DestinationConfig::Webhook {
+                url: "https://example.com/h".to_string(),
+                secret_header: None,
+            },
+        );
+        assert!(validate_destination(&d).is_ok());
+    }
+
+    #[test]
+    fn pagerduty_requires_non_empty_routing_key() {
+        let bad = DestinationConfig::PagerDuty {
+            routing_key: "   ".to_string(),
+            severity_map: None,
+        };
+        assert!(validate_config(&bad).is_err());
+
+        let ok = DestinationConfig::PagerDuty {
+            routing_key: "R0UTING".to_string(),
+            severity_map: None,
+        };
+        assert!(validate_config(&ok).is_ok());
+    }
+
+    #[test]
+    fn opsgenie_requires_api_key_and_team_id() {
+        let no_key = DestinationConfig::OpsGenie {
+            api_key: "".to_string(),
+            team_id: "team".to_string(),
+        };
+        assert!(validate_config(&no_key).is_err());
+
+        let no_team = DestinationConfig::OpsGenie {
+            api_key: "key".to_string(),
+            team_id: "  ".to_string(),
+        };
+        assert!(validate_config(&no_team).is_err());
+
+        let ok = DestinationConfig::OpsGenie {
+            api_key: "key".to_string(),
+            team_id: "team".to_string(),
+        };
+        assert!(validate_config(&ok).is_ok());
+    }
+
+    #[test]
+    fn slack_requires_https_url() {
+        let bad = DestinationConfig::Slack {
+            webhook_url: "http://hooks.slack.com/services/x".to_string(),
+            channel_override: None,
+        };
+        assert!(validate_config(&bad).is_err());
+
+        let ok = DestinationConfig::Slack {
+            webhook_url: "https://hooks.slack.com/services/x".to_string(),
+            channel_override: None,
+        };
+        assert!(validate_config(&ok).is_ok());
+    }
+}

--- a/aa-api/src/replay.rs
+++ b/aa-api/src/replay.rs
@@ -50,3 +50,70 @@ impl Default for ReplayBuffer {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::event_type::EventType;
+
+    fn event(id: EventId) -> GovernanceEvent {
+        GovernanceEvent {
+            id,
+            event_type: EventType::Violation,
+            agent_id: "agent-a".to_string(),
+            payload: serde_json::json!({}),
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn default_matches_new_empty_buffer() {
+        let buf = ReplayBuffer::default();
+        // events_since(0) on an empty buffer yields nothing to replay.
+        assert!(buf.events_since(0).is_empty());
+    }
+
+    #[test]
+    fn events_since_returns_only_newer_events() {
+        let buf = ReplayBuffer::new();
+        for id in 1..=5 {
+            buf.push(event(id));
+        }
+        let replayed: Vec<EventId> = buf.events_since(2).into_iter().map(|e| e.id).collect();
+        assert_eq!(replayed, vec![3, 4, 5]);
+    }
+
+    #[test]
+    fn events_since_newest_id_is_empty() {
+        let buf = ReplayBuffer::new();
+        buf.push(event(1));
+        buf.push(event(2));
+        // since_id at or beyond the newest event yields nothing.
+        assert!(buf.events_since(2).is_empty());
+        assert!(buf.events_since(99).is_empty());
+    }
+
+    #[test]
+    fn push_evicts_oldest_when_at_capacity() {
+        let buf = ReplayBuffer::new();
+        // Fill beyond capacity; the oldest events must be evicted, so a
+        // reconnecting client asking for everything only sees the tail.
+        for id in 1..=(MAX_CAPACITY as u64 + 5) {
+            buf.push(event(id));
+        }
+        let all = buf.events_since(0);
+        assert_eq!(all.len(), MAX_CAPACITY);
+        // Oldest surviving event is id=6 (first 5 evicted).
+        assert_eq!(all.first().map(|e| e.id), Some(6));
+        assert_eq!(all.last().map(|e| e.id), Some(MAX_CAPACITY as u64 + 5));
+    }
+
+    #[test]
+    fn clone_shares_backing_buffer() {
+        let buf = ReplayBuffer::new();
+        let clone = buf.clone();
+        // Clone shares the Arc<Mutex<..>>, so a push via one is visible via the other.
+        buf.push(event(7));
+        assert_eq!(clone.events_since(0).len(), 1);
+    }
+}

--- a/aa-api/src/routes/admin.rs
+++ b/aa-api/src/routes/admin.rs
@@ -219,3 +219,92 @@ pub async fn run_retention_policy(
     dto.dry_run = engine.current_config().dry_run;
     Ok(Json(dto))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::LocalAuth;
+
+    /// Hardened state wires a real SQLite-backed RetentionEngine.
+    async fn hardened() -> AppState {
+        AppState::local_hardened(LocalAuth::Off)
+            .await
+            .expect("hardened state builds")
+    }
+
+    #[tokio::test]
+    async fn handlers_503_without_retention_engine() {
+        // local_in_memory leaves retention_engine None → every handler 503s.
+        let state = AppState::local_in_memory().expect("state builds");
+        let err = get_retention_policy(Extension(state)).await.expect_err("503 expected");
+        assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE.as_u16());
+        assert_eq!(err.error_code, Some("retention_engine_unavailable"));
+    }
+
+    #[tokio::test]
+    async fn update_policy_applies_valid_thresholds() {
+        let state = hardened().await;
+        let req = UpdateRetentionPolicyRequest {
+            hot_days: 3,
+            warm_days: 30,
+            cold_action: ColdActionDto::Drop,
+            archive_url: None,
+        };
+        let doc = update_retention_policy(Extension(state), Json(req))
+            .await
+            .expect("applied")
+            .0;
+        assert_eq!(doc.hot_days, 3);
+        assert_eq!(doc.warm_days, 30);
+        assert!(matches!(doc.cold_action, ColdActionDto::Drop));
+    }
+
+    #[tokio::test]
+    async fn update_policy_rejects_invalid_thresholds() {
+        let state = hardened().await;
+        // warm_days must be strictly greater than hot_days.
+        let req = UpdateRetentionPolicyRequest {
+            hot_days: 10,
+            warm_days: 5,
+            cold_action: ColdActionDto::Drop,
+            archive_url: None,
+        };
+        let err = update_retention_policy(Extension(state), Json(req))
+            .await
+            .expect_err("rejected");
+        assert_eq!(err.status, StatusCode::BAD_REQUEST.as_u16());
+        assert_eq!(err.error_code, Some("retention_policy_invalid_warm_days"));
+    }
+
+    #[tokio::test]
+    async fn run_once_executes_real_pass() {
+        let state = hardened().await;
+        let req = RunRetentionRequest { dry_run: false };
+        let dto = run_retention_policy(Extension(state), Json(req))
+            .await
+            .expect("run ok")
+            .0;
+        // A fresh DB has no rows to move; the pass still completes and reports its mode.
+        assert!(!dto.dry_run);
+    }
+
+    #[tokio::test]
+    async fn run_once_dry_run_restores_operator_preference() {
+        let state = hardened().await;
+        let engine_before = state.retention_engine.clone().unwrap();
+        let dry_pref_before = engine_before.current_config().dry_run;
+
+        let req = RunRetentionRequest { dry_run: true };
+        let dto = run_retention_policy(Extension(state.clone()), Json(req))
+            .await
+            .expect("dry run ok")
+            .0;
+        assert!(dto.dry_run, "dry-run flag surfaces in the response");
+
+        // The temporary dry_run override is rolled back to the operator's preference.
+        assert_eq!(
+            state.retention_engine.unwrap().current_config().dry_run,
+            dry_pref_before
+        );
+    }
+}

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -519,3 +519,117 @@ pub async fn test_destination(
         })),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::scope::Scope;
+    use crate::auth::{AuthenticatedCaller, Tenant};
+
+    fn writer() -> RequireWrite {
+        RequireWrite(AuthenticatedCaller {
+            key_id: "k".to_string(),
+            scopes: vec![Scope::Admin],
+            tenant: Tenant::default(),
+        })
+    }
+
+    #[test]
+    fn connector_for_resolves_builtin_kinds() {
+        // Webhook + Slack are always compiled in; the factory must not panic.
+        let _webhook = connector_for(DestinationKind::Webhook);
+        let _slack = connector_for(DestinationKind::Slack);
+    }
+
+    #[tokio::test]
+    async fn connector_for_unsupported_kind_fails_closed() {
+        // OpsGenie has no compiled backend in the default build, so dispatch must
+        // return a transport error rather than panic.
+        let conn = connector_for(DestinationKind::OpsGenie);
+        let dest = Destination {
+            id: "dst_x".to_string(),
+            name: "og".to_string(),
+            config: DestinationConfig::OpsGenie {
+                api_key: "k".to_string(),
+                team_id: "t".to_string(),
+            },
+            enabled: true,
+            created_at: String::new(),
+            updated_at: String::new(),
+        };
+        let req = DispatchRequest {
+            severity: "LOW".to_string(),
+            message: "m".to_string(),
+        };
+        assert!(conn.dispatch(&dest, &req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_destination_rejects_internal_webhook_target() {
+        let state = AppState::local_in_memory().expect("state builds");
+        let dest = state.destination_store.create(
+            "internal".to_string(),
+            DestinationConfig::Webhook {
+                url: "http://127.0.0.1:9/hook".to_string(),
+                secret_header: None,
+            },
+            true,
+        );
+        // SSRF egress guard (AAASM-3789): a loopback target is refused before dispatch.
+        let failure = test_destination(writer(), Extension(state), Path(dest.id), None)
+            .await
+            .expect_err("loopback target rejected");
+        assert_eq!(failure.into_response().status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn update_preserves_stored_secret_when_masked() {
+        let state = AppState::local_in_memory().expect("state builds");
+        let dest = state.destination_store.create(
+            "wh".to_string(),
+            DestinationConfig::Webhook {
+                url: "https://example.com/hook".to_string(),
+                secret_header: Some("real-secret".to_string()),
+            },
+            true,
+        );
+        // A GET → edit → PUT round-trip ships back the masked sentinel; it must not
+        // clobber the real stored secret.
+        let body = serde_json::to_vec(&serde_json::json!({
+            "kind": "webhook",
+            "config": { "url": "https://example.com/hook", "secret_header": "********" }
+        }))
+        .unwrap();
+        let _ = update_destination(
+            writer(),
+            Extension(state.clone()),
+            Path(dest.id.clone()),
+            Bytes::from(body),
+        )
+        .await
+        .expect("update applies");
+
+        let stored = state.destination_store.get(&dest.id).expect("still present");
+        match stored.config {
+            DestinationConfig::Webhook { secret_header, .. } => {
+                assert_eq!(secret_header.as_deref(), Some("real-secret"));
+            }
+            other => panic!("expected webhook config, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_unknown_destination_is_404() {
+        let state = AppState::local_in_memory().expect("state builds");
+        let body = serde_json::to_vec(&serde_json::json!({ "name": "x" })).unwrap();
+        let err = update_destination(
+            writer(),
+            Extension(state),
+            Path("dst_missing".to_string()),
+            Bytes::from(body),
+        )
+        .await
+        .expect_err("not found");
+        assert_eq!(err.status, StatusCode::NOT_FOUND.as_u16());
+    }
+}

--- a/aa-api/src/routes/devtools/mod.rs
+++ b/aa-api/src/routes/devtools/mod.rs
@@ -183,3 +183,41 @@ pub async fn saas_webhook(
 
 // Expose config type for future registry integration.
 pub use aa_devtool_saas::provider::SaasProviderConfig as SaasProviderCfg;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+
+    #[tokio::test]
+    async fn unknown_provider_is_404() {
+        let state = AppState::local_in_memory().expect("state builds");
+        let resp = saas_webhook(
+            Path("not-a-provider".to_string()),
+            HeaderMap::new(),
+            Extension(state),
+            Bytes::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn missing_hmac_secret_is_401() {
+        // The default cache resolves HMAC secrets from the environment; with the
+        // provider's secret var unset, secret resolution misses and the webhook
+        // rejects before parsing the body.
+        std::env::remove_var("AA_SAAS_CLAUDE_AI_HMAC_SECRET");
+        let state = AppState::local_in_memory().expect("state builds");
+        let resp = saas_webhook(
+            Path("claude-ai".to_string()),
+            HeaderMap::new(),
+            Extension(state),
+            Bytes::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/aa-api/src/routes/devtools/secret_cache.rs
+++ b/aa-api/src/routes/devtools/secret_cache.rs
@@ -148,4 +148,24 @@ mod tests {
         let cache = SecretCache::with_resolver(Arc::new(NoneResolver));
         assert!(cache.get("vault:secret/missing").await.is_none());
     }
+
+    #[test]
+    fn env_var_resolver_reads_set_variable_and_misses_unset() {
+        // nextest runs each test in its own process, so this env mutation is isolated.
+        let var = "AA_SECRET_CACHE_TEST_VAR";
+        std::env::set_var(var, "from-env");
+        let resolver = EnvVarResolver;
+        assert_eq!(resolver.resolve(var), Some(b"from-env".to_vec()));
+        assert!(
+            resolver.resolve("AA_SECRET_CACHE_DEFINITELY_UNSET").is_none(),
+            "unset variable resolves to None"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_uses_env_var_resolver() {
+        // Default wiring resolves through the environment; an unset ref misses.
+        let cache = SecretCache::default();
+        assert!(cache.get("AA_SECRET_CACHE_DEFAULT_UNSET").await.is_none());
+    }
 }

--- a/aa-api/src/routes/dispatch.rs
+++ b/aa-api/src/routes/dispatch.rs
@@ -296,3 +296,94 @@ fn unix_now_ns() -> u64 {
         .map(|d| d.as_nanos() as u64)
         .unwrap_or(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_gateway::secrets::Secret;
+    use tokio::sync::mpsc;
+
+    /// Build the fully-wired in-memory AppState used by the native dispatch path.
+    fn state() -> AppState {
+        AppState::local_in_memory().expect("in-memory state builds")
+    }
+
+    fn req(args: serde_json::Value) -> DispatchToolRequest {
+        DispatchToolRequest {
+            tool: "call_database".to_string(),
+            args,
+        }
+    }
+
+    #[tokio::test]
+    async fn passthrough_args_without_placeholders() {
+        let st = state();
+        let body = req(serde_json::json!({"query": "SELECT 1"}));
+        let resp = dispatch_tool(Extension(st), Json(body)).await.expect("ok").0;
+        // No `${...}` tokens: args echoed verbatim, nothing substituted, no sandbox.
+        assert_eq!(resp.resolved_args, serde_json::json!({"query": "SELECT 1"}));
+        assert!(resp.names_substituted.is_empty());
+        assert!(resp.sandbox.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolves_registered_placeholder() {
+        let st = state();
+        st.secrets_store
+            .register(Secret {
+                name: "DB_PASSWORD".to_string(),
+                value: "real-secret".to_string(),
+            })
+            .expect("register secret");
+
+        let body = req(serde_json::json!({"password": "${DB_PASSWORD}"}));
+        let resp = dispatch_tool(Extension(st), Json(body)).await.expect("ok").0;
+
+        assert_eq!(resp.resolved_args, serde_json::json!({"password": "real-secret"}));
+        assert_eq!(resp.names_substituted, vec!["DB_PASSWORD".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn unknown_placeholder_is_422() {
+        let st = state();
+        let body = req(serde_json::json!({"token": "${MISSING}"}));
+        let err = dispatch_tool(Extension(st), Json(body))
+            .await
+            .expect_err("unknown placeholder rejected");
+        assert_eq!(err.status, StatusCode::UNPROCESSABLE_ENTITY.as_u16());
+        assert!(err.detail.unwrap().contains("MISSING"));
+    }
+
+    #[tokio::test]
+    async fn emits_audit_entry_with_placeholder_form_args() {
+        let mut st = state();
+        let (tx, mut rx) = mpsc::channel(8);
+        st.audit_sender = Some(tx);
+
+        let body = req(serde_json::json!({"q": "noop"}));
+        let resp = dispatch_tool(Extension(st), Json(body)).await.expect("ok").0;
+        assert!(resp.names_substituted.is_empty());
+
+        // The audit path runs only when audit_sender is wired; an entry must be queued.
+        let entry = rx.try_recv().expect("audit entry emitted when sender is connected");
+        // Native dispatch emits with zero-byte identifiers (no per-dispatch context).
+        assert_eq!(entry.agent_id(), AgentId::from_bytes([0u8; 16]));
+    }
+
+    #[test]
+    fn sandbox_error_outcomes_carry_variant_name() {
+        // Pure mapping: every SandboxError variant projects to ok=false with its
+        // discriminant name; FilesystemBlocked additionally carries the errno.
+        let fs = sandbox_error_to_outcome(&SandboxError::FilesystemBlocked { errno: 13 });
+        assert!(!fs.ok);
+        assert_eq!(fs.error.as_deref(), Some("FilesystemBlocked"));
+        assert_eq!(fs.errno, Some(13));
+
+        let cpu = sandbox_error_to_outcome(&SandboxError::CpuTimeout);
+        assert_eq!(cpu.error.as_deref(), Some("CpuTimeout"));
+        assert!(cpu.errno.is_none());
+
+        let invalid = sandbox_error_to_outcome(&SandboxError::InvalidWasm("bad".to_string()));
+        assert_eq!(invalid.error.as_deref(), Some("InvalidWasm: bad"));
+    }
+}

--- a/aa-api/src/routes/iam.rs
+++ b/aa-api/src/routes/iam.rs
@@ -418,3 +418,38 @@ pub fn seeded_iam_store() -> Arc<IamApiKeyStore> {
     ]);
     Arc::new(store)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_key_scope_conversions_round_trip_every_variant() {
+        let wire_variants = [
+            ApiKeyScopeResponse::ReadMembers,
+            ApiKeyScopeResponse::WriteMembers,
+            ApiKeyScopeResponse::ReadPolicies,
+            ApiKeyScopeResponse::WritePolicies,
+            ApiKeyScopeResponse::ReadAudit,
+            ApiKeyScopeResponse::Admin,
+        ];
+        for wire in wire_variants {
+            // wire → gateway → wire must be the identity for every scope.
+            let gw: GwApiKeyScope = wire.into();
+            let back: ApiKeyScopeResponse = gw.into();
+            assert_eq!(back, wire);
+        }
+    }
+
+    #[test]
+    fn gateway_scope_maps_to_matching_wire_variant() {
+        assert_eq!(
+            ApiKeyScopeResponse::from(GwApiKeyScope::WriteMembers),
+            ApiKeyScopeResponse::WriteMembers
+        );
+        assert_eq!(
+            ApiKeyScopeResponse::from(GwApiKeyScope::Admin),
+            ApiKeyScopeResponse::Admin
+        );
+    }
+}

--- a/aa-api/src/routes/traces.rs
+++ b/aa-api/src/routes/traces.rs
@@ -154,3 +154,74 @@ async fn build_trace_from_audit(reader: &AuditReader, session_id_hex: &str) -> O
     spans.sort_by_key(|s| s.start_time);
     Some(SessionTrace { agent_id, spans })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::{AuthenticatedCaller, Tenant};
+
+    fn caller(scopes: Vec<Scope>, team_id: Option<String>) -> RequireRead {
+        RequireRead(AuthenticatedCaller {
+            key_id: "k".to_string(),
+            scopes,
+            tenant: Tenant { team_id, org_id: None },
+        })
+    }
+
+    fn span(id: &str) -> TraceSpan {
+        TraceSpan {
+            span_id: id.to_string(),
+            parent_span_id: None,
+            operation: "op".to_string(),
+            decision: None,
+            start_time: chrono::Utc::now(),
+            end_time: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn non_admin_without_team_is_forbidden() {
+        let state = AppState::local_in_memory().expect("state builds");
+        let err = get_trace(
+            caller(vec![Scope::Read], None),
+            Extension(state),
+            axum::extract::Path("session-x".to_string()),
+        )
+        .await
+        .expect_err("forbidden");
+        assert_eq!(err.status, StatusCode::FORBIDDEN.as_u16());
+    }
+
+    #[tokio::test]
+    async fn admin_unknown_session_is_404() {
+        let state = AppState::local_in_memory().expect("state builds");
+        let err = get_trace(
+            caller(vec![Scope::Admin], None),
+            Extension(state),
+            axum::extract::Path("missing-session".to_string()),
+        )
+        .await
+        .expect_err("not found");
+        assert_eq!(err.status, StatusCode::NOT_FOUND.as_u16());
+    }
+
+    #[tokio::test]
+    async fn admin_reads_recorded_trace() {
+        let state = AppState::local_in_memory().expect("state builds");
+        state
+            .trace_store
+            .record_span("session-1", "deadbeef", span("s1"))
+            .expect("record");
+
+        let (status, body) = get_trace(
+            caller(vec![Scope::Admin], None),
+            Extension(state),
+            axum::extract::Path("session-1".to_string()),
+        )
+        .await
+        .expect("trace found");
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.session_id, "session-1");
+        assert_eq!(body.spans.len(), 1);
+    }
+}

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -482,3 +482,56 @@ impl AppState {
         Ok(state)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_in_memory_has_documented_disconnected_seams() {
+        let state = AppState::local_in_memory().expect("in-memory state builds");
+        // The in-memory wiring deliberately leaves these seams disconnected.
+        assert!(state.audit_sender.is_none(), "audit pipeline is disconnected");
+        assert!(state.retention_engine.is_none(), "no storage section in this mode");
+        assert!(matches!(state.auth_config.mode, AuthMode::Off), "auth is bypassed");
+        assert!(state.secrets_store.list().is_empty(), "no secrets pre-registered");
+    }
+
+    #[tokio::test]
+    async fn local_hardened_off_keeps_auth_bypassed_but_wires_audit() {
+        let state = AppState::local_hardened(LocalAuth::Off)
+            .await
+            .expect("hardened state builds");
+        // LocalAuth::Off keeps the bypass, but hardening still connects the
+        // audit + retention seams that local_in_memory leaves None.
+        assert!(matches!(state.auth_config.mode, AuthMode::Off));
+        assert!(
+            state.audit_sender.is_some(),
+            "hardened mode connects the audit pipeline"
+        );
+        assert!(state.retention_engine.is_some(), "hardened mode wires retention");
+    }
+
+    #[tokio::test]
+    async fn local_hardened_api_key_requires_auth() {
+        let key = crate::auth::api_key::ApiKey::generate().as_str().to_string();
+        let state = AppState::local_hardened(LocalAuth::ApiKey { key })
+            .await
+            .expect("hardened state builds");
+        // Supplying a key flips the gate on and seeds exactly one admin key.
+        assert!(matches!(state.auth_config.mode, AuthMode::On));
+        assert_eq!(state.key_store.len(), 1, "exactly the seeded admin key is present");
+    }
+
+    #[test]
+    fn local_state_error_messages_are_descriptive() {
+        let load = LocalStateError::PolicyLoad("bad policy".to_string());
+        assert_eq!(load.to_string(), "failed to load bootstrap policy: bad policy");
+
+        let storage = LocalStateError::Storage("disk full".to_string());
+        assert_eq!(storage.to_string(), "failed to open local storage backend: disk full");
+
+        let rate = LocalStateError::RateLimit("abc".to_string());
+        assert_eq!(rate.to_string(), "invalid AA_RATE_LIMIT_RPM: abc");
+    }
+}

--- a/aa-api/src/trace_store.rs
+++ b/aa-api/src/trace_store.rs
@@ -131,3 +131,80 @@ impl TraceStore for InMemoryTraceStore {
         Ok(order.iter().rev().take(limit).cloned().collect())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn span(span_id: &str, start_secs: i64) -> TraceSpan {
+        TraceSpan {
+            span_id: span_id.to_string(),
+            parent_span_id: None,
+            operation: "op".to_string(),
+            decision: None,
+            start_time: Utc.timestamp_opt(start_secs, 0).unwrap(),
+            end_time: None,
+        }
+    }
+
+    #[test]
+    fn default_constructs_empty_store() {
+        let store = InMemoryTraceStore::default();
+        // A fresh store has no trace for any session.
+        assert!(store.get_trace("unknown-session").unwrap().is_none());
+    }
+
+    #[test]
+    fn get_trace_returns_spans_sorted_by_start_time() {
+        let store = InMemoryTraceStore::new();
+        // Record out of chronological order; get_trace must sort by start_time.
+        store.record_span("s1", "agent-a", span("late", 200)).unwrap();
+        store.record_span("s1", "agent-a", span("early", 100)).unwrap();
+
+        let trace = store.get_trace("s1").unwrap().expect("session exists");
+        assert_eq!(trace.agent_id, "agent-a");
+        let ids: Vec<&str> = trace.spans.iter().map(|s| s.span_id.as_str()).collect();
+        assert_eq!(ids, vec!["early", "late"]);
+    }
+
+    #[test]
+    fn record_span_evicts_oldest_span_at_capacity() {
+        // One span per session capacity: the second span evicts the first.
+        let store = InMemoryTraceStore::with_capacity(10, 1);
+        store.record_span("s1", "agent-a", span("first", 100)).unwrap();
+        store.record_span("s1", "agent-a", span("second", 200)).unwrap();
+
+        let trace = store.get_trace("s1").unwrap().expect("session exists");
+        let ids: Vec<&str> = trace.spans.iter().map(|s| s.span_id.as_str()).collect();
+        assert_eq!(ids, vec!["second"]);
+    }
+
+    #[test]
+    fn record_span_evicts_oldest_session_at_capacity() {
+        // Capacity of one session: recording a second session evicts the first.
+        let store = InMemoryTraceStore::with_capacity(1, 10);
+        store.record_span("s1", "agent-a", span("a", 100)).unwrap();
+        store.record_span("s2", "agent-b", span("b", 100)).unwrap();
+
+        assert!(store.get_trace("s1").unwrap().is_none());
+        assert!(store.get_trace("s2").unwrap().is_some());
+    }
+
+    #[test]
+    fn list_sessions_returns_most_recent_first_and_respects_limit() {
+        let store = InMemoryTraceStore::new();
+        store.record_span("s1", "agent-a", span("a", 100)).unwrap();
+        store.record_span("s2", "agent-a", span("b", 100)).unwrap();
+        store.record_span("s3", "agent-a", span("c", 100)).unwrap();
+
+        assert_eq!(store.list_sessions(10).unwrap(), vec!["s3", "s2", "s1"]);
+        assert_eq!(store.list_sessions(2).unwrap(), vec!["s3", "s2"]);
+    }
+
+    #[test]
+    fn trace_store_error_display_includes_message() {
+        let err = TraceStoreError::Internal("boom".to_string());
+        assert_eq!(err.to_string(), "trace store internal error: boom");
+    }
+}

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -314,3 +314,50 @@ async fn delete_rule_preserves_snapshot_on_already_recorded_alerts() {
     assert_eq!(body["ruleSnapshot"]["threshold"], 90.0);
     assert_eq!(body["ruleSnapshot"]["metric"], "budget_spent_pct");
 }
+
+#[tokio::test]
+async fn create_accepts_every_operator_variant() {
+    let app = common::test_app();
+    for (i, op) in [">", ">=", "<", "="].iter().enumerate() {
+        let mut body = valid_rule_body();
+        body["name"] = json!(format!("op-rule-{i}"));
+        body["operator"] = json!(op);
+        // "<"/"=" against budget_spent_pct with threshold 90 is still in range.
+        let resp = app.clone().oneshot(post("/api/v1/alerts/rules", body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED, "operator {op} must be accepted");
+    }
+}
+
+#[tokio::test]
+async fn create_accepts_every_severity_variant() {
+    let app = common::test_app();
+    for (i, sev) in ["CRITICAL", "HIGH", "MEDIUM", "LOW"].iter().enumerate() {
+        let mut body = valid_rule_body();
+        body["name"] = json!(format!("sev-rule-{i}"));
+        body["severity"] = json!(sev);
+        let resp = app.clone().oneshot(post("/api/v1/alerts/rules", body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED, "severity {sev} must be accepted");
+    }
+}
+
+#[tokio::test]
+async fn create_with_unknown_operator_returns_invalid_operator() {
+    let app = common::test_app();
+    let mut body = valid_rule_body();
+    body["operator"] = json!("≈");
+    let resp = app.oneshot(post("/api/v1/alerts/rules", body)).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = read_json(resp).await;
+    assert_eq!(json["error_code"], "invalid_operator");
+}
+
+#[tokio::test]
+async fn create_with_unknown_severity_returns_invalid_severity() {
+    let app = common::test_app();
+    let mut body = valid_rule_body();
+    body["severity"] = json!("FATAL");
+    let resp = app.oneshot(post("/api/v1/alerts/rules", body)).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = read_json(resp).await;
+    assert_eq!(json["error_code"], "invalid_severity");
+}


### PR DESCRIPTION
## Description

Raises `aa-api/src` test coverage with meaningful, behaviour-asserting unit tests, targeting the reachable handler / error / edge paths that integration tests skip. This is the implementation subtask of Story AAASM-3798.

Coverage (line, `cargo llvm-cov nextest -p aa-api`):
- **Before:** ~92.9%
- **After (full aa-api/src):** 93.83%
- **After (excluding entrypoint glue handled by the separate operator coverage-exclusions commit — `bin/*`, `server.rs`, `shutdown.rs`, `config.rs`, and the WASM-sandbox dispatch arm): ~95.3%**

What was added:
- `replay.rs` — buffer eviction at capacity, `events_since` windowing, shared-clone semantics.
- `trace_store.rs` — `get_trace` chronological sort, per-session + per-store LRU eviction, error Display.
- `routes/dispatch.rs` — native secret-injection path: passthrough, `${NAME}` resolution, unknown-placeholder 422, audit-emit, sandbox-error mapping.
- `state.rs` — `local_in_memory` disconnected-seam contract, `local_hardened` (Off + ApiKey) wiring, `LocalStateError` Display.
- `routes/admin.rs` — retention get/update/run handlers incl. dry-run rollback, validation 400, 503 without engine.
- `routes/traces.rs` — authz forbidden / 404 / recorded-trace read.
- `routes/devtools/secret_cache.rs` — `EnvVarResolver`, `Default` wiring.
- `routes/devtools/mod.rs` — SaaS webhook unknown-provider 404, missing-secret 401.
- `routes/iam.rs` — API-key scope `From` round-trips.
- `routes/destinations.rs` — connector factory (incl. fail-closed unsupported kind), SSRF egress guard, masked-secret-preserving update, 404.

The 3 cherry-picked commits (alert-rule / auth-scope / api-key / destination-validation tests) are salvaged from the never-merged AAASM-3805 branch.

## Type of Change

- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3811 (Story AAASM-3798)

## Testing

- [x] Unit tests added / updated

`cargo nextest run -p aa-api` → 791 passed. `cargo clippy -p aa-api --all-targets -- -D warnings` clean. `cargo fmt --all` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmVbZVBF5jcJ81614hD2bU
