### PR TITLE
[AAASM-3823] ♻️ (aa-gateway): Reduce cognitive complexity of approval_service + grpc_auth (S3776)

### DIFF
--- a/aa-gateway/src/iam/grpc_auth.rs
+++ b/aa-gateway/src/iam/grpc_auth.rs
@@ -76,29 +76,26 @@ impl VerifiedCaller {
 /// `None` when neither is present or the value is empty / non-ASCII.
 fn extract_token(req: &Request<()>) -> Option<String> {
     let md = req.metadata();
+    token_from_credential_header(md).or_else(|| token_from_authorization_header(md))
+}
 
-    if let Some(value) = md.get(CREDENTIAL_METADATA_KEY) {
-        if let Ok(s) = value.to_str() {
-            let token = s.trim();
-            if !token.is_empty() {
-                return Some(token.to_owned());
-            }
-        }
-    }
+/// Read a non-empty, trimmed token from the dedicated [`CREDENTIAL_METADATA_KEY`]
+/// header. Returns `None` for an absent, non-ASCII, or empty value.
+fn token_from_credential_header(md: &tonic::metadata::MetadataMap) -> Option<String> {
+    let token = md.get(CREDENTIAL_METADATA_KEY)?.to_str().ok()?.trim();
+    (!token.is_empty()).then(|| token.to_owned())
+}
 
-    if let Some(value) = md.get("authorization") {
-        if let Ok(s) = value.to_str() {
-            let s = s.trim();
-            if let Some(rest) = s.strip_prefix("Bearer ").or_else(|| s.strip_prefix("bearer ")) {
-                let token = rest.trim();
-                if !token.is_empty() {
-                    return Some(token.to_owned());
-                }
-            }
-        }
-    }
-
-    None
+/// Read a non-empty, trimmed token from a standard `authorization: Bearer <token>`
+/// header (case-insensitive scheme). Returns `None` for an absent, non-ASCII,
+/// non-bearer, or empty value.
+fn token_from_authorization_header(md: &tonic::metadata::MetadataMap) -> Option<String> {
+    let value = md.get("authorization")?.to_str().ok()?.trim();
+    let token = value
+        .strip_prefix("Bearer ")
+        .or_else(|| value.strip_prefix("bearer "))?
+        .trim();
+    (!token.is_empty()).then(|| token.to_owned())
 }
 
 /// Resolve a credential token to a [`VerifiedCaller`] against the registry's
@@ -294,5 +291,49 @@ mod tests {
             org_id: None,
         };
         assert_eq!(caller.agent_id_str(), "00000000-0000-0000-0000-000000000000");
+    }
+
+    // Behavior locks for the `extract_token` precedence/trim/fall-through logic
+    // split into helpers by the AAASM-3823 S3776 refactor (must not change).
+    #[test]
+    fn extract_token_prefers_credential_header_over_authorization() {
+        let mut req = Request::new(());
+        req.metadata_mut()
+            .insert(CREDENTIAL_METADATA_KEY, "cred-tok".parse().unwrap());
+        req.metadata_mut()
+            .insert("authorization", "Bearer bearer-tok".parse().unwrap());
+        assert_eq!(extract_token(&req).as_deref(), Some("cred-tok"));
+    }
+
+    #[test]
+    fn extract_token_falls_back_to_authorization_when_credential_empty() {
+        let mut req = Request::new(());
+        req.metadata_mut()
+            .insert(CREDENTIAL_METADATA_KEY, "   ".parse().unwrap());
+        req.metadata_mut()
+            .insert("authorization", "Bearer bearer-tok".parse().unwrap());
+        assert_eq!(extract_token(&req).as_deref(), Some("bearer-tok"));
+    }
+
+    #[test]
+    fn extract_token_trims_credential_value() {
+        let mut req = Request::new(());
+        req.metadata_mut()
+            .insert(CREDENTIAL_METADATA_KEY, "  spaced  ".parse().unwrap());
+        assert_eq!(extract_token(&req).as_deref(), Some("spaced"));
+    }
+
+    #[test]
+    fn extract_token_accepts_lowercase_bearer_scheme() {
+        let mut req = Request::new(());
+        req.metadata_mut()
+            .insert("authorization", "bearer low-tok".parse().unwrap());
+        assert_eq!(extract_token(&req).as_deref(), Some("low-tok"));
+    }
+
+    #[test]
+    fn extract_token_none_when_no_headers() {
+        let req = Request::new(());
+        assert_eq!(extract_token(&req), None);
     }
 }

--- a/aa-gateway/src/service/approval_service.rs
+++ b/aa-gateway/src/service/approval_service.rs
@@ -70,6 +70,47 @@ impl ApprovalServiceImpl {
         self.db_escalation_scheduler = scheduler;
         self
     }
+
+    /// Reject a cross-tenant `decide`: when the caller is tenanted and the target
+    /// approval belongs to a *different* tenant, deny with `permission_denied`
+    /// (the governance-bypass primary impact of AAASM-3788). An unparseable id or
+    /// an absent pending row is intentionally a no-op — the later
+    /// `convert`/`queue.decide` path surfaces those — preserving the original
+    /// inline fall-through behavior exactly.
+    fn enforce_decide_tenancy(&self, caller: &VerifiedCaller, request_id: &str) -> Result<(), Status> {
+        if let Ok(id) = request_id.parse::<ApprovalRequestId>() {
+            if let Some(ApprovalLookup::Pending(pending)) = self.queue.get_by_id(id) {
+                if !caller_may_act_on(caller, pending.team_id.as_deref()) {
+                    return Err(Status::permission_denied("approval belongs to a different tenant"));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Cancel any pending in-memory escalation timer for a decided request.
+    /// Best-effort: logs on failure, never errors the RPC.
+    fn cancel_escalation_timer(&self, id: ApprovalRequestId) {
+        if let Some(scheduler) = &self.escalation_scheduler {
+            match scheduler.cancel(id) {
+                Ok(true) => tracing::debug!(approval_id = %id, "escalation timer cancelled"),
+                Ok(false) => {} // already fired or never registered
+                Err(e) => tracing::warn!(error = %e, approval_id = %id, "failed to cancel escalation timer"),
+            }
+        }
+    }
+
+    /// Cancel any DB-backed escalation row for a decided request.
+    /// Best-effort: logs on failure, never errors the RPC.
+    async fn cancel_db_escalation_row(&self, id: ApprovalRequestId) {
+        if let Some(db_scheduler) = &self.db_escalation_scheduler {
+            match db_scheduler.cancel(id).await {
+                Ok(true) => tracing::debug!(approval_id = %id, "DB escalation row cancelled"),
+                Ok(false) => {}
+                Err(e) => tracing::warn!(error = %e, approval_id = %id, "failed to cancel DB escalation row"),
+            }
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -105,13 +146,7 @@ impl ApprovalService for ApprovalServiceImpl {
         if let Some(caller) = &caller {
             // Bind the decision to the authenticated approver's tenant: reject a
             // cross-tenant decide (the governance-bypass primary impact).
-            if let Ok(id) = req.request_id.parse::<ApprovalRequestId>() {
-                if let Some(ApprovalLookup::Pending(pending)) = self.queue.get_by_id(id) {
-                    if !caller_may_act_on(caller, pending.team_id.as_deref()) {
-                        return Err(Status::permission_denied("approval belongs to a different tenant"));
-                    }
-                }
-            }
+            self.enforce_decide_tenancy(caller, &req.request_id)?;
             // `decided_by` is derived from the authenticated caller, never
             // trusted from the request body (which an attacker could forge to
             // attribute the decision to a spoofed operator in the audit trail).
@@ -123,22 +158,9 @@ impl ApprovalService for ApprovalServiceImpl {
 
         match self.queue.decide(id, decision) {
             Ok(()) => {
-                // Cancel any pending escalation timer for this request now that a
-                // decision has been made — best-effort, log on failure.
-                if let Some(scheduler) = &self.escalation_scheduler {
-                    match scheduler.cancel(id) {
-                        Ok(true) => tracing::debug!(approval_id = %id, "escalation timer cancelled"),
-                        Ok(false) => {} // already fired or never registered
-                        Err(e) => tracing::warn!(error = %e, approval_id = %id, "failed to cancel escalation timer"),
-                    }
-                }
-                if let Some(db_scheduler) = &self.db_escalation_scheduler {
-                    match db_scheduler.cancel(id).await {
-                        Ok(true) => tracing::debug!(approval_id = %id, "DB escalation row cancelled"),
-                        Ok(false) => {}
-                        Err(e) => tracing::warn!(error = %e, approval_id = %id, "failed to cancel DB escalation row"),
-                    }
-                }
+                // Cancel any pending escalation now that a decision has been made.
+                self.cancel_escalation_timer(id);
+                self.cancel_db_escalation_row(id).await;
                 Ok(Response::new(DecideResponse {
                     success: true,
                     error_message: String::new(),
@@ -261,6 +283,80 @@ mod tests {
             !scheduler.cancel(id).unwrap(),
             "entry should have been removed by decide()"
         );
+    }
+
+    fn make_approval_request_with_team(id: Uuid, team: Option<&str>) -> ApprovalRequest {
+        let mut r = make_approval_request(id);
+        r.team_id = team.map(|s| s.to_owned());
+        r
+    }
+
+    fn verified_caller(team: Option<&str>) -> VerifiedCaller {
+        VerifiedCaller {
+            agent_key: [1u8; 16],
+            team_id: team.map(|s| s.to_owned()),
+            org_id: None,
+        }
+    }
+
+    // Behavior lock for the cross-tenant authorization extracted into
+    // `enforce_decide_tenancy` (AAASM-3823 S3776 refactor must not change it).
+    #[tokio::test]
+    async fn decide_cross_tenant_is_permission_denied() {
+        let queue = Arc::new(ApprovalQueue::new());
+        let service = ApprovalServiceImpl::new(Arc::clone(&queue));
+        let id = Uuid::new_v4();
+        queue.submit(make_approval_request_with_team(id, Some("team-b")));
+
+        let mut req = tonic::Request::new(DecideRequest {
+            request_id: id.to_string(),
+            decision: ApprovalDecisionType::Approved.into(),
+            decided_by: "attacker".to_string(),
+            reason: String::new(),
+        });
+        req.extensions_mut().insert(verified_caller(Some("team-a")));
+
+        let err = service.decide(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn decide_same_tenant_is_allowed() {
+        let queue = Arc::new(ApprovalQueue::new());
+        let service = ApprovalServiceImpl::new(Arc::clone(&queue));
+        let id = Uuid::new_v4();
+        queue.submit(make_approval_request_with_team(id, Some("team-a")));
+
+        let mut req = tonic::Request::new(DecideRequest {
+            request_id: id.to_string(),
+            decision: ApprovalDecisionType::Approved.into(),
+            decided_by: "ignored".to_string(),
+            reason: String::new(),
+        });
+        req.extensions_mut().insert(verified_caller(Some("team-a")));
+
+        let resp = service.decide(req).await.unwrap().into_inner();
+        assert!(resp.success);
+    }
+
+    #[tokio::test]
+    async fn decide_untenanted_caller_allowed_cross_team() {
+        // Untenanted caller falls back to allow (single-tenant deployment).
+        let queue = Arc::new(ApprovalQueue::new());
+        let service = ApprovalServiceImpl::new(Arc::clone(&queue));
+        let id = Uuid::new_v4();
+        queue.submit(make_approval_request_with_team(id, Some("team-b")));
+
+        let mut req = tonic::Request::new(DecideRequest {
+            request_id: id.to_string(),
+            decision: ApprovalDecisionType::Approved.into(),
+            decided_by: "ops".to_string(),
+            reason: String::new(),
+        });
+        req.extensions_mut().insert(verified_caller(None));
+
+        let resp = service.decide(req).await.unwrap().into_inner();
+        assert!(resp.success);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Behaviour-preserving structural refactor clearing the two CRITICAL `rust:S3776`
cognitive-complexity smells introduced by the gRPC per-RPC auth work (AAASM-3788):

1. **`aa-gateway/src/service/approval_service.rs` — `ApprovalService::decide` (21 → ≤15).**
   Extracted three private helpers off the deeply-nested body:
   - `enforce_decide_tenancy(caller, request_id)` — the cross-tenant authorization
     check (parse id → look up pending → `caller_may_act_on`), returning the same
     `Status::permission_denied`; an unparseable id / absent pending row stays a
     no-op exactly as before (`?` propagates identically to the old early `return`).
   - `cancel_escalation_timer(id)` — the best-effort in-memory escalation cancel.
   - `cancel_db_escalation_row(id).await` — the best-effort DB escalation-row cancel.
   `decide` now reads as a flat sequence of helper calls.

2. **`aa-gateway/src/iam/grpc_auth.rs` — `extract_token` (16 → ≤15).**
   Split the two parallel 3-deep `if let` ladders into `token_from_credential_header`
   and `token_from_authorization_header` using `?`-based early returns, composed with
   `or_else`. Same credential-key-over-`authorization` precedence, same trim/empty
   fall-through, same case-insensitive `Bearer`/`bearer` scheme handling.

No allow/deny decision, approval outcome, error mapping, or fail-closed semantic
changes — same inputs produce identical outputs and side-effects.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3823 (Story AAASM-3822)
- Related GitHub issues: n/a

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Added behaviour-lock tests pinning the unchanged outcomes:
- `approval_service`: `decide_cross_tenant_is_permission_denied`,
  `decide_same_tenant_is_allowed`, `decide_untenanted_caller_allowed_cross_team`.
- `grpc_auth`: `extract_token_prefers_credential_header_over_authorization`,
  `extract_token_falls_back_to_authorization_when_credential_empty`,
  `extract_token_trims_credential_value`,
  `extract_token_accepts_lowercase_bearer_scheme`,
  `extract_token_none_when_no_headers`.

`cargo nextest run -p aa-gateway` → 1219 passed, 0 failed.
`cargo clippy -p aa-gateway --all-targets -- -D warnings` → clean. `cargo fmt --all` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmVbZVBF5jcJ81614hD2bU
