### PR TITLE
[AAASM-3820] ✅ (aa-gateway,aa-proxy): Raise coverage toward ≥95%

### DIFF
--- a/aa-gateway/src/engine/cache.rs
+++ b/aa-gateway/src/engine/cache.rs
@@ -243,4 +243,109 @@ mod tests {
         let key_err = CacheKey::new(&[1u8; 16], 1, &err);
         assert_ne!(key_ok, key_err);
     }
+
+    #[test]
+    fn distinct_action_kinds_hash_to_distinct_keys() {
+        // Each GovernanceAction variant tags its discriminant before hashing the
+        // payload, so the five non-tool kinds must never collapse onto one key.
+        let actions = [
+            aa_core::GovernanceAction::NetworkRequest {
+                url: "https://api.openai.com".to_string(),
+                method: "POST".to_string(),
+            },
+            aa_core::GovernanceAction::FileAccess {
+                path: "/etc/passwd".to_string(),
+                mode: aa_core::FileMode::Read,
+            },
+            aa_core::GovernanceAction::ProcessExec {
+                command: "rm -rf /".to_string(),
+            },
+            aa_core::GovernanceAction::SendMessage {
+                source_team_id: Some("eng".to_string()),
+                target_team_id: Some("ops".to_string()),
+                channel_id: Some("c1".to_string()),
+            },
+            tool_action("bash"),
+        ];
+        let keys: Vec<_> = actions.iter().map(|a| CacheKey::new(&[1u8; 16], 1, a)).collect();
+        for i in 0..keys.len() {
+            for j in (i + 1)..keys.len() {
+                assert_ne!(keys[i], keys[j], "action kinds {i} and {j} collided");
+            }
+        }
+    }
+
+    #[test]
+    fn network_request_payload_fields_are_part_of_the_key() {
+        let base = aa_core::GovernanceAction::NetworkRequest {
+            url: "https://a.example.com".to_string(),
+            method: "GET".to_string(),
+        };
+        let other_url = aa_core::GovernanceAction::NetworkRequest {
+            url: "https://b.example.com".to_string(),
+            method: "GET".to_string(),
+        };
+        let other_method = aa_core::GovernanceAction::NetworkRequest {
+            url: "https://a.example.com".to_string(),
+            method: "POST".to_string(),
+        };
+        let k = |a| CacheKey::new(&[1u8; 16], 1, a);
+        assert_ne!(k(&base), k(&other_url), "url must affect the key");
+        assert_ne!(k(&base), k(&other_method), "method must affect the key");
+    }
+
+    #[test]
+    fn file_access_mode_is_part_of_the_key() {
+        // The mode is hashed via its Debug form, so read vs write on the same
+        // path must produce distinct keys.
+        let read = aa_core::GovernanceAction::FileAccess {
+            path: "/data/x".to_string(),
+            mode: aa_core::FileMode::Read,
+        };
+        let write = aa_core::GovernanceAction::FileAccess {
+            path: "/data/x".to_string(),
+            mode: aa_core::FileMode::Write,
+        };
+        assert_ne!(
+            CacheKey::new(&[1u8; 16], 1, &read),
+            CacheKey::new(&[1u8; 16], 1, &write)
+        );
+    }
+
+    #[test]
+    fn send_message_channel_is_part_of_the_key() {
+        let c1 = aa_core::GovernanceAction::SendMessage {
+            source_team_id: Some("eng".to_string()),
+            target_team_id: Some("ops".to_string()),
+            channel_id: Some("alpha".to_string()),
+        };
+        let c2 = aa_core::GovernanceAction::SendMessage {
+            source_team_id: Some("eng".to_string()),
+            target_team_id: Some("ops".to_string()),
+            channel_id: Some("beta".to_string()),
+        };
+        assert_ne!(CacheKey::new(&[1u8; 16], 1, &c1), CacheKey::new(&[1u8; 16], 1, &c2));
+    }
+
+    #[test]
+    fn invalidate_all_evicts_every_entry() {
+        let cache = DecisionCache::new(128);
+        let key = CacheKey::new(&[1u8; 16], 1, &tool_action("bash"));
+        cache.insert(key.clone(), PolicyDecision::Allow);
+        assert!(cache.get(&key).is_some());
+        cache.invalidate_all();
+        cache.inner.run_pending_tasks();
+        assert_eq!(cache.get(&key), None, "invalidate_all must drop the entry");
+    }
+
+    #[test]
+    fn invalidate_for_agent_evicts_the_agents_entry() {
+        let cache = DecisionCache::new(128);
+        let key = CacheKey::new(&[7u8; 16], 1, &tool_action("deploy"));
+        cache.insert(key.clone(), PolicyDecision::Allow);
+        assert!(cache.get(&key).is_some());
+        cache.invalidate_for_agent(&[7u8; 16]);
+        cache.inner.run_pending_tasks();
+        assert_eq!(cache.get(&key), None, "invalidate_for_agent must drop the entry");
+    }
 }

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -110,6 +110,199 @@ impl<'a> PolicyContext for ProductionPolicyContext<'a> {
     }
 }
 
+#[cfg(test)]
+mod production_context_tests {
+    //! Direct tests for the registry/budget-backed [`ProductionPolicyContext`].
+    //!
+    //! The graph-variable getters are normally exercised only through a full
+    //! `PolicyEngine::evaluate` call, which left this impl's individual
+    //! resolution paths thinly covered. These tests build a real
+    //! [`AgentRegistry`] + [`BudgetTracker`] and assert each getter resolves
+    //! the topology fact it claims to — both the present and the absent
+    //! (`None`) branch that drives the null-as-no-match policy semantics.
+
+    use super::*;
+    use crate::budget::{BudgetTracker, PricingTable};
+    use crate::registry::{AgentRecord, AgentRegistry, AgentStatus};
+    use rust_decimal::Decimal;
+
+    fn dec(s: &str) -> Decimal {
+        s.parse().unwrap()
+    }
+
+    /// Build an [`AgentRecord`] with the fields the graph-variable getters read;
+    /// the rest are inert defaults. Children are linked automatically by
+    /// `AgentRegistry::register`, so callers never set them here.
+    #[allow(clippy::too_many_arguments)]
+    fn rec(
+        id: [u8; 16],
+        parent_key: Option<[u8; 16]>,
+        team_id: Option<&str>,
+        depth: u32,
+        risk_tier: i32,
+        tool_names: Vec<String>,
+        registered_at_unix: i64,
+        parent_agent_id: Option<&str>,
+    ) -> AgentRecord {
+        AgentRecord {
+            agent_id: id,
+            name: "test".into(),
+            framework: "test".into(),
+            version: "0.0.1".into(),
+            risk_tier,
+            tool_names,
+            public_key: "deadbeef".into(),
+            // Empty so repeated registrations don't share a credential index key.
+            credential_token: String::new(),
+            metadata: Default::default(),
+            registered_at: chrono::DateTime::from_timestamp(registered_at_unix, 0).unwrap(),
+            last_heartbeat: chrono::Utc::now(),
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: vec![],
+            recent_events: Default::default(),
+            recent_traces: vec![],
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: parent_agent_id.map(|s| s.to_string()),
+            team_id: team_id.map(|s| s.to_string()),
+            depth,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: None,
+            children: vec![],
+            parent_key,
+            enforcement_mode: None,
+            org_id: None,
+        }
+    }
+
+    const T0: i64 = 1_000_000;
+    const PARENT: [u8; 16] = [1u8; 16];
+    const CHILD: [u8; 16] = [2u8; 16];
+
+    /// Registry with a root parent (High tier) and one child (Medium tier) on
+    /// team `eng`. `register` links the child into the parent's `children` and
+    /// the team index automatically.
+    fn registry_with_family() -> AgentRegistry {
+        let reg = AgentRegistry::new();
+        reg.register(rec(PARENT, None, Some("eng"), 0, 3, vec!["search".into()], T0, None))
+            .unwrap();
+        reg.register(rec(
+            CHILD,
+            Some(PARENT),
+            Some("eng"),
+            1,
+            2,
+            vec!["write".into(), "exec".into()],
+            T0,
+            Some("parent-str"),
+        ))
+        .unwrap();
+        reg
+    }
+
+    #[test]
+    fn parent_context_resolves_topology_facts() {
+        let reg = registry_with_family();
+        let budget = BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC);
+        let ctx = ProductionPolicyContext::new(&reg, &budget, PARENT, Some("eng".into()), (T0 + 500) as u64);
+
+        assert_eq!(ctx.agent_depth(), Some(0));
+        // Both agents share team "eng".
+        assert_eq!(ctx.team_active_agents(), Some(2));
+        // Parent's sole child contributes its declared tools.
+        let mut tools = ctx.child_tools();
+        tools.sort();
+        assert_eq!(tools, vec!["exec".to_string(), "write".to_string()]);
+        assert_eq!(ctx.agent_risk_tier(), Some(aa_core::RiskTier::High));
+        // A root has no parent, so parent_risk_tier is absent.
+        assert_eq!(ctx.parent_risk_tier(), None);
+        // child_risk_tier is the proposed-spawn tier, unset on a plain context.
+        assert_eq!(ctx.child_risk_tier(), None);
+        // now_secs - registered_at = 500.
+        assert_eq!(ctx.agent_age_secs(), Some(500));
+        assert_eq!(ctx.agent_parent_id(), None);
+        assert_eq!(ctx.agent_team_id(), Some("eng".to_string()));
+        assert_eq!(ctx.agent_children_count(), Some(1));
+    }
+
+    #[test]
+    fn child_context_resolves_parent_facts() {
+        let reg = registry_with_family();
+        let budget = BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC);
+        let ctx = ProductionPolicyContext::new(&reg, &budget, CHILD, Some("eng".into()), (T0 + 10) as u64);
+
+        assert_eq!(ctx.agent_depth(), Some(1));
+        assert_eq!(ctx.agent_risk_tier(), Some(aa_core::RiskTier::Medium));
+        // The child's parent is the High-tier root.
+        assert_eq!(ctx.parent_risk_tier(), Some(aa_core::RiskTier::High));
+        assert_eq!(ctx.agent_parent_id(), Some("parent-str".to_string()));
+        assert_eq!(ctx.agent_children_count(), Some(0));
+        assert_eq!(ctx.agent_age_secs(), Some(10));
+    }
+
+    #[test]
+    fn team_budget_remaining_subtracts_recorded_spend_from_limit() {
+        let reg = registry_with_family();
+        // Global monthly limit 100; team "eng" has spent 30.
+        let budget = BudgetTracker::new(PricingTable::default_table(), None, Some(dec("100")), chrono_tz::UTC);
+        budget.record_raw_spend(aa_core::AgentId::from_bytes(PARENT), Some("eng"), None, dec("30"));
+
+        let ctx = ProductionPolicyContext::new(&reg, &budget, PARENT, Some("eng".into()), T0 as u64);
+        assert_eq!(ctx.team_budget_remaining(), Some(70.0));
+    }
+
+    #[test]
+    fn team_budget_remaining_is_none_without_a_monthly_limit() {
+        let reg = registry_with_family();
+        // No global monthly limit configured, but the team has recorded spend.
+        let budget = BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC);
+        budget.record_raw_spend(aa_core::AgentId::from_bytes(PARENT), Some("eng"), None, dec("5"));
+
+        let ctx = ProductionPolicyContext::new(&reg, &budget, PARENT, Some("eng".into()), T0 as u64);
+        // `monthly_limit_usd()` is None → the whole getter short-circuits.
+        assert_eq!(ctx.team_budget_remaining(), None);
+    }
+
+    #[test]
+    fn missing_agent_resolves_every_registry_getter_to_none() {
+        // An agent_key that was never registered must make every
+        // registry-backed getter return None (null-as-no-match), and the
+        // child-tools union must be empty rather than panic.
+        let reg = AgentRegistry::new();
+        let budget = BudgetTracker::new(PricingTable::default_table(), None, Some(dec("100")), chrono_tz::UTC);
+        let ctx = ProductionPolicyContext::new(&reg, &budget, [9u8; 16], None, T0 as u64);
+
+        assert_eq!(ctx.agent_depth(), None);
+        assert_eq!(ctx.agent_risk_tier(), None);
+        assert_eq!(ctx.parent_risk_tier(), None);
+        assert_eq!(ctx.agent_age_secs(), None);
+        assert_eq!(ctx.agent_parent_id(), None);
+        assert_eq!(ctx.agent_children_count(), None);
+        assert!(ctx.child_tools().is_empty());
+        // No team on the context → the team-scoped getters are all None.
+        assert_eq!(ctx.team_active_agents(), None);
+        assert_eq!(ctx.team_budget_remaining(), None);
+        assert_eq!(ctx.agent_team_id(), None);
+    }
+
+    #[test]
+    fn agent_risk_tier_is_none_for_unspecified_tier() {
+        // risk_tier 0 is the proto UNSPECIFIED sentinel; from_proto_i32 maps it
+        // to None so an undeclared tier never silently reads as Low.
+        let reg = AgentRegistry::new();
+        reg.register(rec([7u8; 16], None, None, 0, 0, vec![], T0, None))
+            .unwrap();
+        let budget = BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC);
+        let ctx = ProductionPolicyContext::new(&reg, &budget, [7u8; 16], None, T0 as u64);
+        assert_eq!(ctx.agent_risk_tier(), None);
+    }
+}
+
 /// Minimal test double for [`PolicyContext`] that returns canned values.
 #[cfg(test)]
 #[derive(Default)]

--- a/aa-proxy/src/error.rs
+++ b/aa-proxy/src/error.rs
@@ -25,3 +25,37 @@ pub enum ProxyError {
     #[error("Keychain error: {0}")]
     Keychain(String),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn io_variant_wraps_and_displays_source() {
+        // The `#[from]` conversion must produce an Io variant whose Display
+        // carries the underlying error text.
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "missing ca");
+        let err: ProxyError = io.into();
+        assert!(matches!(err, ProxyError::Io(_)));
+        assert!(err.to_string().contains("missing ca"));
+    }
+
+    #[test]
+    fn string_variants_render_their_label_and_message() {
+        // Each string-carrying variant must prefix its category and include the
+        // supplied detail so log lines are self-describing.
+        assert_eq!(ProxyError::Tls("handshake".into()).to_string(), "TLS error: handshake");
+        assert_eq!(
+            ProxyError::CertGen("rcgen failed".into()).to_string(),
+            "Certificate generation error: rcgen failed"
+        );
+        assert_eq!(
+            ProxyError::Config("bad port".into()).to_string(),
+            "Configuration error: bad port"
+        );
+        assert_eq!(
+            ProxyError::Keychain("denied".into()).to_string(),
+            "Keychain error: denied"
+        );
+    }
+}

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -685,4 +685,213 @@ mod tests {
         assert_eq!(fields.model, "gpt-4");
         assert_eq!(fields.prompt_tokens, Some(5));
     }
+
+    // ── intercept_request verdict matrix ────────────────────────────────────
+    //
+    // The request-side credential gate maps (findings × CredentialAction) onto
+    // the data-path VerdictDecision. These tests pin every arm.
+
+    /// A synthetic OpenAI key that the default scanner detects. Not a real key.
+    const CRED_BODY: &[u8] = b"leaking sk-TESTONLY-NOT-REAL-1234567890abcdef1234567890ab here";
+
+    #[test]
+    fn intercept_request_disabled_scanner_forwards_even_with_credential() {
+        let (tx, _rx) = broadcast::channel(16);
+        let interceptor = Interceptor::with_scanner(tx, None);
+        let verdict = interceptor.intercept_request(CRED_BODY, CredentialAction::Block);
+        assert_eq!(verdict.decision, VerdictDecision::Forward);
+        assert!(verdict.findings.is_empty());
+        assert!(verdict.redacted_body.is_none());
+    }
+
+    #[test]
+    fn intercept_request_clean_body_forwards() {
+        let interceptor = make_interceptor();
+        let verdict = interceptor.intercept_request(b"nothing secret here", CredentialAction::Block);
+        assert_eq!(verdict.decision, VerdictDecision::Forward);
+        assert!(verdict.findings.is_empty());
+        assert!(verdict.redacted_body.is_none());
+    }
+
+    #[test]
+    fn intercept_request_block_action_blocks_on_finding() {
+        let interceptor = make_interceptor();
+        let verdict = interceptor.intercept_request(CRED_BODY, CredentialAction::Block);
+        assert_eq!(verdict.decision, VerdictDecision::Block);
+        assert!(!verdict.findings.is_empty(), "a finding must be reported");
+        // Block never forwards bytes, so no redacted body is produced.
+        assert!(verdict.redacted_body.is_none());
+    }
+
+    #[test]
+    fn intercept_request_redact_only_returns_redacted_bytes() {
+        let interceptor = make_interceptor();
+        let verdict = interceptor.intercept_request(CRED_BODY, CredentialAction::RedactOnly);
+        assert_eq!(verdict.decision, VerdictDecision::ForwardRedacted);
+        assert!(!verdict.findings.is_empty());
+        let redacted = verdict.redacted_body.expect("redact_only must populate the body");
+        assert!(
+            !redacted
+                .windows(b"TESTONLY-NOT-REAL".len())
+                .any(|w| w == b"TESTONLY-NOT-REAL"),
+            "redacted body must not contain the raw secret"
+        );
+    }
+
+    #[test]
+    fn intercept_request_alert_only_forwards_original_with_findings() {
+        let interceptor = make_interceptor();
+        let verdict = interceptor.intercept_request(CRED_BODY, CredentialAction::AlertOnly);
+        assert_eq!(verdict.decision, VerdictDecision::AlertAndForward);
+        assert!(!verdict.findings.is_empty());
+        // alert_only forwards the original body unmodified, so no redaction.
+        assert!(verdict.redacted_body.is_none());
+    }
+
+    // ── redact_response_body ────────────────────────────────────────────────
+
+    #[test]
+    fn redact_response_body_disabled_scanner_returns_none() {
+        let (tx, _rx) = broadcast::channel(16);
+        let interceptor = Interceptor::with_scanner(tx, None);
+        assert!(interceptor.redact_response_body(CRED_BODY).is_none());
+    }
+
+    #[test]
+    fn redact_response_body_clean_payload_returns_none() {
+        let interceptor = make_interceptor();
+        assert!(interceptor.redact_response_body(b"clean upstream response").is_none());
+    }
+
+    #[test]
+    fn redact_response_body_with_credential_returns_redacted() {
+        let interceptor = make_interceptor();
+        let redacted = interceptor
+            .redact_response_body(CRED_BODY)
+            .expect("a credential payload must yield redacted bytes");
+        assert!(
+            !redacted
+                .windows(b"TESTONLY-NOT-REAL".len())
+                .any(|w| w == b"TESTONLY-NOT-REAL"),
+            "redacted response must not contain the raw secret"
+        );
+    }
+
+    // ── emit_policy_decision (CONNECT tunnel audit) ─────────────────────────
+
+    #[tokio::test]
+    async fn emit_policy_decision_denied_emits_violation() {
+        let (tx, mut rx) = broadcast::channel(16);
+        let interceptor = Interceptor::new(tx);
+        interceptor.emit_policy_decision("evil.example.com", true).await;
+
+        let event = rx.try_recv().expect("a pipeline event must be emitted");
+        let PipelineEvent::Audit(enriched) = event else {
+            panic!("expected Audit event");
+        };
+        assert_eq!(enriched.source, EventSource::Proxy);
+        match enriched.inner.detail.expect("detail") {
+            audit_event::Detail::Violation(v) => {
+                assert_eq!(v.blocked_action, "CONNECT evil.example.com");
+            }
+            other => panic!("expected Violation detail, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_policy_decision_allowed_emits_network_detail() {
+        let (tx, mut rx) = broadcast::channel(16);
+        let interceptor = Interceptor::new(tx);
+        interceptor.emit_policy_decision("api.openai.com", false).await;
+
+        let PipelineEvent::Audit(enriched) = rx.try_recv().expect("event") else {
+            panic!("expected Audit event");
+        };
+        match enriched.inner.detail.expect("detail") {
+            audit_event::Detail::Network(n) => {
+                assert_eq!(n.host, "api.openai.com");
+                assert_eq!(n.protocol, "https");
+                assert!(n.succeeded);
+            }
+            other => panic!("expected Network detail, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_policy_decision_with_no_receiver_does_not_panic() {
+        // Standalone proxy mode: the broadcast send returns Err with no
+        // receivers, which the method must swallow.
+        let (tx, rx) = broadcast::channel(16);
+        drop(rx);
+        let interceptor = Interceptor::new(tx);
+        interceptor.emit_policy_decision("api.openai.com", true).await;
+    }
+
+    // ── emit_mcp_decision (tools/call audit) ────────────────────────────────
+
+    #[tokio::test]
+    async fn emit_mcp_decision_denied_emits_violation_with_blocked_action() {
+        let (tx, mut rx) = broadcast::channel(16);
+        let interceptor = Interceptor::new(tx);
+        interceptor
+            .emit_mcp_decision("read_file", b"{}", true, "blocked on /etc paths")
+            .await;
+
+        let PipelineEvent::Audit(enriched) = rx.try_recv().expect("event") else {
+            panic!("expected Audit event");
+        };
+        match enriched.inner.detail.expect("detail") {
+            audit_event::Detail::Violation(v) => {
+                assert_eq!(v.blocked_action, "tools/call read_file");
+                assert_eq!(v.reason, "blocked on /etc paths");
+            }
+            other => panic!("expected Violation detail, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_mcp_decision_allowed_redacts_credentials_in_args() {
+        let (tx, mut rx) = broadcast::channel(16);
+        let interceptor = Interceptor::new(tx);
+        let args = br#"{"token":"sk-TESTONLY-NOT-REAL-1234567890abcdef1234567890ab"}"#;
+        interceptor.emit_mcp_decision("call_api", args, false, "").await;
+
+        let PipelineEvent::Audit(enriched) = rx.try_recv().expect("event") else {
+            panic!("expected Audit event");
+        };
+        match enriched.inner.detail.expect("detail") {
+            audit_event::Detail::ToolCall(tc) => {
+                assert_eq!(tc.tool_name, "call_api");
+                assert_eq!(tc.tool_source, "mcp");
+                assert!(tc.succeeded);
+                // Producer-side scrub: the raw secret never enters the audit chain.
+                assert!(
+                    !tc.args_json
+                        .windows(b"TESTONLY-NOT-REAL".len())
+                        .any(|w| w == b"TESTONLY-NOT-REAL"),
+                    "args_json must be redacted in the audit record"
+                );
+            }
+            other => panic!("expected ToolCall detail, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_mcp_decision_allowed_clean_args_pass_through() {
+        let (tx, mut rx) = broadcast::channel(16);
+        let interceptor = Interceptor::new(tx);
+        let args = br#"{"path":"/tmp/readme.txt"}"#;
+        interceptor.emit_mcp_decision("read_file", args, false, "").await;
+
+        let PipelineEvent::Audit(enriched) = rx.try_recv().expect("event") else {
+            panic!("expected Audit event");
+        };
+        match enriched.inner.detail.expect("detail") {
+            audit_event::Detail::ToolCall(tc) => {
+                // No findings → the original args bytes are preserved verbatim.
+                assert_eq!(tc.args_json, args);
+            }
+            other => panic!("expected ToolCall detail, got {other:?}"),
+        }
+    }
 }

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -435,4 +435,156 @@ mod tests {
             "agent header forwarded: {text}"
         );
     }
+
+    // ── request-side error branches ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn malformed_request_line_is_config_error() {
+        // A request line that does not split into method/target/version must be
+        // rejected rather than silently mis-parsed.
+        let mut reader = make_reader(b"GET-ONLY\r\n\r\n");
+        let err = read_http_request(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(err, ProxyError::Config(_)),
+            "expected Config error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_header_line_is_config_error() {
+        // A header line with no colon separator is malformed.
+        let mut reader = make_reader(b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n");
+        let err = read_http_request(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(err, ProxyError::Config(_)),
+            "expected Config error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unexpected_eof_reading_request_headers_is_error() {
+        // Stream ends after the request line, before the header-terminating
+        // blank line — this is a truncated request, not a clean inter-request
+        // EOF, so it must surface as an error.
+        let mut reader = make_reader(b"GET / HTTP/1.1\r\n");
+        let err = read_http_request(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(err, ProxyError::Config(_)),
+            "expected Config error, got {err:?}"
+        );
+    }
+
+    // ── response-side parsing ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn parses_response_with_content_length_body() {
+        let raw = b"HTTP/1.1 200 OK\r\n\
+                    Content-Type: application/json\r\n\
+                    Content-Length: 11\r\n\
+                    \r\n\
+                    {\"ok\":true}";
+        let mut reader = make_reader(raw);
+        let resp = read_http_response(&mut reader)
+            .await
+            .unwrap()
+            .expect("response present");
+        assert_eq!(resp.version, "HTTP/1.1");
+        assert_eq!(resp.status_code, "200");
+        assert_eq!(resp.reason, "OK");
+        assert_eq!(&resp.body, b"{\"ok\":true}");
+    }
+
+    #[tokio::test]
+    async fn response_returns_none_on_clean_eof() {
+        let mut reader = make_reader(b"");
+        assert!(read_http_response(&mut reader).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn response_with_no_reason_phrase_parses() {
+        // A status line with only version + code (no reason phrase) is valid;
+        // the reason is captured as an empty string.
+        let raw = b"HTTP/1.1 204\r\nContent-Length: 0\r\n\r\n";
+        let mut reader = make_reader(raw);
+        let resp = read_http_response(&mut reader).await.unwrap().unwrap();
+        assert_eq!(resp.status_code, "204");
+        assert_eq!(resp.reason, "");
+        assert!(resp.body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn malformed_status_line_is_config_error() {
+        // Fewer than two whitespace-separated parts is not a status line.
+        let mut reader = make_reader(b"GARBAGE\r\n\r\n");
+        let err = read_http_response(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(err, ProxyError::Config(_)),
+            "expected Config error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_response_header_line_is_config_error() {
+        let mut reader = make_reader(b"HTTP/1.1 200 OK\r\nNoColonHeader\r\n\r\n");
+        let err = read_http_response(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(err, ProxyError::Config(_)),
+            "expected Config error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unexpected_eof_reading_response_headers_is_error() {
+        let mut reader = make_reader(b"HTTP/1.1 200 OK\r\n");
+        let err = read_http_response(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(err, ProxyError::Config(_)),
+            "expected Config error, got {err:?}"
+        );
+    }
+
+    // ── response-side re-serialisation ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn serialize_response_rewrites_content_length_and_drops_transfer_encoding() {
+        let raw = b"HTTP/1.1 200 OK\r\n\
+                    Content-Type: application/json\r\n\
+                    Transfer-Encoding: chunked\r\n\
+                    Content-Length: 3\r\n\
+                    \r\n\
+                    old";
+        let mut reader = make_reader(raw);
+        let resp = read_http_response(&mut reader).await.unwrap().unwrap();
+
+        let new_body = b"redacted";
+        let wire = serialize_http_response(&resp, new_body);
+        let text = std::str::from_utf8(&wire).unwrap();
+
+        assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(text.contains("Content-Type: application/json\r\n"));
+        // Stale framing headers are dropped and replaced by one accurate length.
+        assert!(
+            !text.to_ascii_lowercase().contains("transfer-encoding"),
+            "Transfer-Encoding must be stripped: {text}"
+        );
+        // The original Content-Length: 3 is dropped; only the new value remains.
+        assert_eq!(text.matches("Content-Length:").count(), 1);
+        assert_eq!(text.matches("Content-Length: 8\r\n").count(), 1);
+        assert!(text.ends_with("\r\n\r\nredacted"));
+    }
+
+    #[tokio::test]
+    async fn serialize_response_omits_empty_reason_phrase() {
+        // When the parsed response carried no reason phrase, the re-serialised
+        // status line must not emit a trailing space after the code.
+        let raw = b"HTTP/1.1 204\r\nContent-Length: 0\r\n\r\n";
+        let mut reader = make_reader(raw);
+        let resp = read_http_response(&mut reader).await.unwrap().unwrap();
+        let wire = serialize_http_response(&resp, b"");
+        let text = std::str::from_utf8(&wire).unwrap();
+        assert!(
+            text.starts_with("HTTP/1.1 204\r\n"),
+            "no trailing reason space: {text:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Description

Tests-only PR raising the unit-testable coverage of `aa-gateway/src` and
`aa-proxy/src` toward the ≥95% target (Story AAASM-3798). No production code
was changed. Each commit targets a previously thinly-covered, pure/deterministic
unit and lifts it to ~96–100% line coverage:

- **`aa-gateway/src/policy/context.rs`** 46% → **100%** — direct tests for the
  registry/budget-backed `ProductionPolicyContext` graph-variable getters
  (`agent.depth`, `team.active_agents`, `team.budget_remaining`, `child_tools`,
  risk-tier resolution, `agent.age`, parent/children) in both the present and
  the absent (`None`) branch that drives null-as-no-match policy semantics.
- **`aa-gateway/src/engine/cache.rs`** 84% → **100%** — the
  NetworkRequest/FileAccess/ProcessExec/SendMessage `action_discriminant` arms,
  per-kind payload sensitivity, and `invalidate_all` / `invalidate_for_agent`.
- **`aa-proxy/src/proxy/http.rs`** 73% → **100%** — the upstream
  `read_http_response` / `serialize_http_response` path and the request-side
  malformed-line / truncated-stream error branches.
- **`aa-proxy/src/intercept/mod.rs`** 79% → **97%** — `intercept_request`
  (the findings × `CredentialAction` verdict matrix), `redact_response_body`,
  and the `emit_policy_decision` / `emit_mcp_decision` audit shapes incl.
  producer-side credential scrub of `args_json`.
- **`aa-proxy/src/error.rs`** → **100%** — `ProxyError` `Display` + `Io` `From`.

`service/approval_service.rs` and `iam/grpc_auth.rs` were intentionally left
untouched to avoid conflicting with the parallel refactor in AAASM-3823.

### Honest ceiling note

The remaining sub-95% gap in both crates is dominated by files that are
genuinely **e2e-only / not unit-testable** — Postgres/Timescale/SQLite storage
integration, the gateway/remote-mode/proxy accept-loop network servers, the
macOS keychain trust-store mutation, and the `main.rs` / `lib.rs` process
entrypoints — the same category already carved out of the coverage denominator
for `aa-api`/`aa-cli` under AAASM-3813. The pure-logic surface that *can* be
unit-tested is now at or near 100% for the files in this PR.

## Type of Change

- [x] ♻️ Refactoring (tests-only; no behaviour change)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3820 (Story AAASM-3798)

## Testing

- [x] Unit tests added / updated
- [x] No production code changed — `cargo nextest run -p aa-gateway -p aa-proxy` green; `cargo clippy -p aa-gateway -p aa-proxy --all-targets -- -D warnings` clean; `cargo fmt --all` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmVbZVBF5jcJ81614hD2bU