### PR TITLE
[AAASM-3821] ✅ (dashboard): Raise vitest coverage toward ≥95%

### DIFF
--- a/dashboard/src/api/client.test.ts
+++ b/dashboard/src/api/client.test.ts
@@ -9,7 +9,8 @@ const fetchMock = vi.fn(
 )
 
 function lastRequest(): Request {
-  return fetchMock.mock.calls[0][0] as Request
+  // openapi-fetch invokes `fetch(request)` with a single Request argument.
+  return (fetchMock.mock.calls[0] as unknown as [Request])[0]
 }
 
 describe('api client auth middleware', () => {

--- a/dashboard/src/api/client.test.ts
+++ b/dashboard/src/api/client.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from './client'
+
+// openapi-fetch resolves `globalThis.fetch` at request time, so stubbing it
+// here lets us inspect the Request the auth middleware actually produced.
+const fetchMock = vi.fn(
+  async () =>
+    new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }),
+)
+
+function lastRequest(): Request {
+  return fetchMock.mock.calls[0][0] as Request
+}
+
+describe('api client auth middleware', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    fetchMock.mockClear()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('injects the stored JWT as a Bearer token', async () => {
+    localStorage.setItem('aa_token', 'jwt-abc')
+    // Cast: the concrete path is irrelevant — we only assert on the headers
+    // the middleware attaches before the request leaves the client.
+    await api.GET('http://localhost/api/v1/health' as never, { fetch: fetchMock } as never)
+    expect(lastRequest().headers.get('Authorization')).toBe('Bearer jwt-abc')
+  })
+
+  it('omits the Authorization header when no token is stored', async () => {
+    await api.GET('http://localhost/api/v1/health' as never, { fetch: fetchMock } as never)
+    expect(lastRequest().headers.get('Authorization')).toBeNull()
+  })
+})

--- a/dashboard/src/components/AppShell.test.tsx
+++ b/dashboard/src/components/AppShell.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AuthProvider } from '../auth/AuthProvider'
+import { AppShell } from './AppShell'
+
+function Boom(): never {
+  throw new Error('child exploded')
+}
+
+function renderShell({ child }: { child?: React.ReactNode } = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/']}>
+        <AuthProvider>
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/" element={child ?? <div data-testid="page">page body</div>} />
+            </Route>
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('AppShell', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders the shell chrome and the routed outlet content', () => {
+    renderShell()
+    expect(screen.getByTestId('appshell')).toBeInTheDocument()
+    expect(screen.getByTestId('appshell-nav')).toBeInTheDocument()
+    expect(screen.getByTestId('page')).toHaveTextContent('page body')
+  })
+
+  it('shows the logged-in token in the topbar and logs out on click', async () => {
+    localStorage.setItem('aa_token', 'jwt-123')
+    const user = userEvent.setup()
+    renderShell()
+    expect(screen.getByTestId('appshell-user')).toHaveTextContent('jwt-123')
+
+    await user.click(screen.getByTestId('logout-btn'))
+    expect(screen.getByTestId('appshell-user')).toHaveTextContent('')
+    expect(localStorage.getItem('aa_token')).toBeNull()
+  })
+
+  it('toggles the mobile nav open via the hamburger and closes it on nav click', async () => {
+    const user = userEvent.setup()
+    renderShell()
+    const nav = screen.getByTestId('appshell-nav')
+    expect(nav.className).not.toContain('appshell__nav--open')
+
+    await user.click(screen.getByTestId('nav-hamburger'))
+    expect(nav.className).toContain('appshell__nav--open')
+
+    await user.click(nav)
+    expect(nav.className).not.toContain('appshell__nav--open')
+  })
+
+  it('catches a render error in the outlet and offers recovery', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const user = userEvent.setup()
+    renderShell({ child: <Boom /> })
+
+    expect(screen.getByTestId('error-boundary')).toBeInTheDocument()
+    expect(screen.getByText('child exploded')).toBeInTheDocument()
+
+    // "Try again" clears the boundary; the child re-throws, so the boundary
+    // simply renders the error UI again rather than crashing the app.
+    await user.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(screen.getByTestId('error-boundary')).toBeInTheDocument()
+    errSpy.mockRestore()
+  })
+})

--- a/dashboard/src/components/LoadingState.test.tsx
+++ b/dashboard/src/components/LoadingState.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { LoadingState } from './LoadingState'
+
+describe('LoadingState', () => {
+  it('renders the generic skeleton by default', () => {
+    render(<LoadingState />)
+    const region = screen.getByTestId('loading-state-generic')
+    expect(region).toBeInTheDocument()
+    expect(region).toHaveAttribute('aria-busy')
+  })
+
+  it('renders the capability matrix skeleton with one cell per grid slot', () => {
+    const { container } = render(<LoadingState page="capability" />)
+    expect(screen.getByTestId('loading-state-capability')).toBeInTheDocument()
+    expect(container.querySelectorAll('.sk-matrix-cell')).toHaveLength(9 * 7)
+  })
+
+  it('renders the fleet table skeleton with one row per placeholder', () => {
+    const { container } = render(<LoadingState page="fleet" />)
+    expect(screen.getByTestId('loading-state-fleet')).toBeInTheDocument()
+    expect(container.querySelectorAll('.sk-table-row')).toHaveLength(8)
+  })
+
+  it('renders the overview skeleton variant', () => {
+    const { container } = render(<LoadingState page="overview" />)
+    expect(screen.getByTestId('loading-state-overview')).toBeInTheDocument()
+    // Overview shows a single large block, not matrix/table skeletons.
+    expect(container.querySelectorAll('.sk-matrix-cell')).toHaveLength(0)
+    expect(container.querySelectorAll('.sk-table-row')).toHaveLength(0)
+  })
+})

--- a/dashboard/src/components/Toast.test.tsx
+++ b/dashboard/src/components/Toast.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useToast } from './Toast'
+import { ToastProvider } from './ToastProvider'
+
+function Trigger() {
+  const { toast } = useToast()
+  return (
+    <div>
+      <button type="button" onClick={() => toast('saved', 'success')}>
+        success
+      </button>
+      <button type="button" onClick={() => toast('boom', 'error')}>
+        error
+      </button>
+      <button type="button" onClick={() => toast('default-variant')}>
+        default
+      </button>
+    </div>
+  )
+}
+
+describe('useToast', () => {
+  it('throws when used outside a ToastProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    function Orphan() {
+      useToast()
+      return null
+    }
+    expect(() => render(<Orphan />)).toThrow('useToast must be used within a ToastProvider')
+    spy.mockRestore()
+  })
+
+  it('renders a toast with its variant when toast() is called', async () => {
+    const user = userEvent.setup()
+    render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    )
+    await user.click(screen.getByRole('button', { name: 'success' }))
+    const toast = screen.getByTestId('toast')
+    expect(toast).toHaveTextContent('saved')
+    expect(toast).toHaveAttribute('data-variant', 'success')
+  })
+
+  it('defaults to the info variant when none is given', async () => {
+    const user = userEvent.setup()
+    render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    )
+    await user.click(screen.getByRole('button', { name: 'default' }))
+    expect(screen.getByTestId('toast')).toHaveAttribute('data-variant', 'info')
+  })
+
+  it('stacks multiple toasts', async () => {
+    const user = userEvent.setup()
+    render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    )
+    await user.click(screen.getByRole('button', { name: 'success' }))
+    await user.click(screen.getByRole('button', { name: 'error' }))
+    expect(screen.getAllByTestId('toast')).toHaveLength(2)
+  })
+
+  it('auto-dismisses a toast after its TTL elapses', () => {
+    vi.useFakeTimers()
+    try {
+      render(
+        <ToastProvider>
+          <Trigger />
+        </ToastProvider>,
+      )
+      act(() => {
+        screen.getByRole('button', { name: 'success' }).click()
+      })
+      expect(screen.getByTestId('toast')).toBeInTheDocument()
+      act(() => {
+        vi.advanceTimersByTime(4000)
+      })
+      expect(screen.queryByTestId('toast')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/dashboard/src/components/Tooltip.test.tsx
+++ b/dashboard/src/components/Tooltip.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Tooltip } from './Tooltip'
+
+describe('Tooltip', () => {
+  it('hides the popup by default', () => {
+    render(
+      <Tooltip content="more info">
+        <button type="button">target</button>
+      </Tooltip>,
+    )
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'target' })).toBeInTheDocument()
+  })
+
+  it('forces the popup visible when open is true', () => {
+    render(
+      <Tooltip content="forced" open>
+        <span>anchor</span>
+      </Tooltip>,
+    )
+    expect(screen.getByRole('tooltip')).toHaveTextContent('forced')
+  })
+
+  it('reveals the popup on hover and hides it on mouse leave', async () => {
+    const user = userEvent.setup()
+    render(
+      <Tooltip content="hover text">
+        <span>anchor</span>
+      </Tooltip>,
+    )
+    const wrapper = screen.getByText('anchor').parentElement as HTMLElement
+    await user.hover(wrapper)
+    expect(screen.getByRole('tooltip')).toHaveTextContent('hover text')
+    await user.unhover(wrapper)
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
+  it('reveals the popup on focus and hides it on blur', async () => {
+    const user = userEvent.setup()
+    render(
+      <Tooltip content="focus text">
+        <button type="button">anchor</button>
+      </Tooltip>,
+    )
+    await user.tab()
+    expect(screen.getByRole('tooltip')).toHaveTextContent('focus text')
+    await user.tab()
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/alerts/AlertDetailDrawer.test.tsx
+++ b/dashboard/src/features/alerts/AlertDetailDrawer.test.tsx
@@ -53,4 +53,26 @@ describe('AlertDetailDrawer', () => {
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  it('closes when Enter/Space is pressed on the scrim but ignores other keys and child events', () => {
+    const onClose = vi.fn()
+    render(
+      <AlertDetailDrawer open onClose={onClose}>
+        <div data-testid="child">body</div>
+      </AlertDetailDrawer>,
+    )
+    const scrim = screen.getByTestId('alert-detail-drawer')
+
+    fireEvent.keyDown(scrim, { key: 'Tab' })
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(screen.getByTestId('child'), { key: 'Enter' })
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(scrim, { key: 'Enter' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(scrim, { key: ' ' })
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
 })

--- a/dashboard/src/features/alerts/AlertFilterBar.test.tsx
+++ b/dashboard/src/features/alerts/AlertFilterBar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AlertFilterBar } from './AlertFilterBar'
 import { applyClientFilters } from './alertFilters'
@@ -66,5 +66,56 @@ describe('AlertFilterBar', () => {
     render(<AlertFilterBar value={value} onChange={vi.fn()} />)
     expect(screen.getByTestId('alerts-filter-custom-from')).toBeInTheDocument()
     expect(screen.getByTestId('alerts-filter-custom-to')).toBeInTheDocument()
+  })
+
+  it('removes an already-selected severity when its chip is clicked again', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const value: AlertFilters = { ...DEFAULT_ALERT_FILTERS, severities: ['CRITICAL', 'HIGH'] }
+    render(<AlertFilterBar value={value} onChange={onChange} />)
+    const chip = screen.getByTestId('alerts-filter-severity-CRITICAL')
+    expect(chip).toHaveAttribute('aria-pressed', 'true')
+    await user.click(chip)
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ severities: ['HIGH'] }))
+  })
+
+  it('toggles a status chip', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<AlertFilterBar value={DEFAULT_ALERT_FILTERS} onChange={onChange} />)
+    await user.click(screen.getByTestId('alerts-filter-status-FIRING'))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ statuses: ['FIRING'] }))
+  })
+
+  it('emits agent query changes', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<AlertFilterBar value={DEFAULT_ALERT_FILTERS} onChange={onChange} />)
+    await user.type(screen.getByTestId('alerts-filter-agent'), 'x')
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ agentQuery: 'x' }))
+  })
+
+  it('emits a new time range when the select changes', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<AlertFilterBar value={DEFAULT_ALERT_FILTERS} onChange={onChange} />)
+    await user.selectOptions(screen.getByTestId('alerts-filter-range'), '7d')
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ timeRange: '7d' }))
+  })
+
+  it('emits custom from/to bounds and nulls them when cleared', () => {
+    const onChange = vi.fn()
+    const value: AlertFilters = { ...DEFAULT_ALERT_FILTERS, timeRange: 'custom' }
+    render(<AlertFilterBar value={value} onChange={onChange} />)
+
+    fireEvent.change(screen.getByTestId('alerts-filter-custom-from'), {
+      target: { value: '2026-05-13T09:00' },
+    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ customFrom: '2026-05-13T09:00' }),
+    )
+
+    fireEvent.change(screen.getByTestId('alerts-filter-custom-to'), { target: { value: '' } })
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ customTo: null }))
   })
 })

--- a/dashboard/src/features/alerts/DedupAndSuppressionFields.test.tsx
+++ b/dashboard/src/features/alerts/DedupAndSuppressionFields.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormProvider, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import type { ReactNode } from 'react'
+import { DedupAndSuppressionFields } from './DedupAndSuppressionFields'
+import { ruleFormSchema, type RuleFormValues } from './ruleFormSchema'
+
+const BASE_VALUES: RuleFormValues = {
+  name: 'rule',
+  description: '',
+  metric: 'budget_spent_pct',
+  operator: '>',
+  threshold: 50,
+  evaluationWindowSeconds: 300,
+  severity: 'HIGH',
+  destinationIds: ['d1'],
+  dedupWindowSeconds: 60,
+  suppressionLabels: [],
+  enabled: true,
+}
+
+function Harness({
+  defaults = {},
+  children,
+}: {
+  defaults?: Partial<RuleFormValues>
+  children?: ReactNode
+}) {
+  const methods = useForm<RuleFormValues>({
+    resolver: zodResolver(ruleFormSchema),
+    defaultValues: { ...BASE_VALUES, ...defaults },
+    mode: 'onChange',
+  })
+  return (
+    <FormProvider {...methods}>
+      <form>
+        <DedupAndSuppressionFields />
+        {children}
+        <button type="button" data-testid="validate" onClick={() => methods.trigger()}>
+          validate
+        </button>
+      </form>
+    </FormProvider>
+  )
+}
+
+describe('DedupAndSuppressionFields', () => {
+  it('shows the empty-state hint when there are no suppression labels', () => {
+    render(<Harness />)
+    expect(screen.getByTestId('rule-dedup-suppression')).toBeInTheDocument()
+    expect(
+      screen.getByText(/No suppression labels — the rule will fire regardless/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('rule-suppression-row-0')).not.toBeInTheDocument()
+  })
+
+  it('appends a new suppression label row on Add', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    await user.click(screen.getByTestId('rule-suppression-add'))
+    expect(screen.getByTestId('rule-suppression-row-0')).toBeInTheDocument()
+    expect(screen.getByTestId('rule-suppression-key-0')).toBeInTheDocument()
+    expect(screen.getByTestId('rule-suppression-value-0')).toBeInTheDocument()
+  })
+
+  it('renders pre-seeded rows and removes a row on the remove button', async () => {
+    const user = userEvent.setup()
+    render(<Harness defaults={{ suppressionLabels: [{ key: 'env', value: 'prod' }] }} />)
+    expect(screen.getByTestId('rule-suppression-key-0')).toHaveValue('env')
+    expect(screen.getByTestId('rule-suppression-value-0')).toHaveValue('prod')
+
+    await user.click(screen.getByTestId('rule-suppression-remove-0'))
+    expect(screen.queryByTestId('rule-suppression-row-0')).not.toBeInTheDocument()
+  })
+
+  it('surfaces validation errors for an invalid suppression key and empty value', async () => {
+    const user = userEvent.setup()
+    render(<Harness defaults={{ suppressionLabels: [{ key: '1bad', value: '' }] }} />)
+
+    await act(async () => {
+      await user.click(screen.getByTestId('validate'))
+    })
+
+    expect(await screen.findByText(/key must match/i)).toBeInTheDocument()
+    expect(screen.getByText(/value cannot be empty/i)).toBeInTheDocument()
+  })
+
+  it('surfaces a dedup-window validation error for a negative value', async () => {
+    const user = userEvent.setup()
+    render(<Harness defaults={{ dedupWindowSeconds: -5 }} />)
+
+    await act(async () => {
+      await user.click(screen.getByTestId('validate'))
+    })
+
+    expect(await screen.findByText(/dedup window cannot be negative/i)).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/alerts/DestinationManager.test.tsx
+++ b/dashboard/src/features/alerts/DestinationManager.test.tsx
@@ -198,4 +198,70 @@ describe('DestinationManager', () => {
     fireEvent.click(screen.getByTestId('destination-delete-dest-1'))
     await waitFor(() => expect(toastSpy).toHaveBeenCalledWith('gateway down', 'error'))
   })
+
+  it('updates an existing destination when submitting in edit mode', async () => {
+    const updateMut = { mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }
+    vi.spyOn(api, 'useUpdateDestinationMutation').mockReturnValue(updateMut as unknown as never)
+    vi.spyOn(api, 'useDestinationsQuery').mockReturnValue(
+      mockQuery({ data: DESTINATIONS, isLoading: false, isError: false }),
+    )
+    renderManager()
+    fireEvent.click(screen.getByTestId('destination-edit-dest-1'))
+    fireEvent.click(screen.getByTestId('destination-form-submit'))
+    await waitFor(() =>
+      expect(updateMut.mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'dest-1' }),
+      ),
+    )
+    expect(toastSpy).toHaveBeenCalledWith('Updated destination "Ops webhook"', 'success')
+  })
+
+  it('surfaces a create failure as an error toast', async () => {
+    createMut.mutateAsync.mockRejectedValueOnce(new Error('create boom'))
+    vi.spyOn(api, 'useDestinationsQuery').mockReturnValue(
+      mockQuery({ data: [], isLoading: false, isError: false }),
+    )
+    renderManager()
+    fireEvent.change(screen.getByTestId('destination-form-name'), {
+      target: { value: 'New hook' },
+    })
+    fireEvent.click(screen.getByTestId('destination-form-submit'))
+    await waitFor(() => expect(toastSpy).toHaveBeenCalledWith('create boom', 'error'))
+  })
+
+  it('reports a non-2xx test fire as an error toast', async () => {
+    testMut.mutateAsync.mockResolvedValueOnce({ connectorResponseStatus: 500 })
+    vi.spyOn(api, 'useDestinationsQuery').mockReturnValue(
+      mockQuery({ data: DESTINATIONS, isLoading: false, isError: false }),
+    )
+    renderManager()
+    fireEvent.click(screen.getByTestId('destination-test-dest-1'))
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith('Test fired → 500 (Ops webhook)', 'error'),
+    )
+  })
+
+  it('surfaces a test fire failure as an error toast', async () => {
+    testMut.mutateAsync.mockRejectedValueOnce(new Error('connector unreachable'))
+    vi.spyOn(api, 'useDestinationsQuery').mockReturnValue(
+      mockQuery({ data: DESTINATIONS, isLoading: false, isError: false }),
+    )
+    renderManager()
+    fireEvent.click(screen.getByTestId('destination-test-dest-1'))
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith('connector unreachable', 'error'),
+    )
+  })
+
+  it('updates the draft kind when the kind select changes', () => {
+    vi.spyOn(api, 'useDestinationsQuery').mockReturnValue(
+      mockQuery({ data: [], isLoading: false, isError: false }),
+    )
+    renderManager()
+    const select = screen.getByTestId('destination-form-kind') as HTMLSelectElement
+    const other = Array.from(select.options).find((o) => o.value !== select.value)
+    expect(other).toBeDefined()
+    fireEvent.change(select, { target: { value: other!.value } })
+    expect(select.value).toBe(other!.value)
+  })
 })

--- a/dashboard/src/features/analytics/FilterBar.test.tsx
+++ b/dashboard/src/features/analytics/FilterBar.test.tsx
@@ -127,6 +127,16 @@ describe('FilterBar — agents multi-select', () => {
     const select = screen.getByTestId<HTMLSelectElement>('filter-agents')
     expect(Array.from(select.selectedOptions).map(o => o.value)).toEqual(['a1'])
   })
+
+  it('emits the chosen agent ids on selection', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <FilterBar filters={DEFAULT_FILTERS} onFiltersChange={onChange} agents={MOCK_AGENTS} />,
+    )
+    await user.selectOptions(screen.getByTestId('filter-agents'), 'a2')
+    expect(onChange).toHaveBeenLastCalledWith({ agents: ['a2'] })
+  })
 })
 
 describe('FilterBar — teams multi-select', () => {
@@ -148,6 +158,16 @@ describe('FilterBar — teams multi-select', () => {
     )
     const select = screen.getByTestId<HTMLSelectElement>('filter-teams')
     expect(Array.from(select.selectedOptions).map(o => o.value)).toEqual(['team-alpha'])
+  })
+
+  it('emits the chosen team ids on selection', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <FilterBar filters={DEFAULT_FILTERS} onFiltersChange={onChange} teams={MOCK_TEAMS} />,
+    )
+    await user.selectOptions(screen.getByTestId('filter-teams'), ['team-beta'])
+    expect(onChange).toHaveBeenLastCalledWith({ teams: ['team-beta'] })
   })
 })
 

--- a/dashboard/src/features/iam/AccessLogPanel.test.tsx
+++ b/dashboard/src/features/iam/AccessLogPanel.test.tsx
@@ -143,6 +143,48 @@ describe('AccessLogPanel (AAASM-1398)', () => {
     })
   })
 
+  it('renders the error state and retries the query on Retry', async () => {
+    let attempts = 0
+    _accessLogInternal.setFetchOverride(() => {
+      attempts += 1
+      return attempts === 1
+        ? Promise.reject(new Error('boom'))
+        : Promise.resolve([makeEvent({ id: 'evt-after-retry' }, 1)])
+    })
+    render(<Harness />)
+    const retry = await screen.findByRole('button', { name: /Retry/ })
+    expect(screen.getByTestId('access-log-error')).toBeInTheDocument()
+
+    await userEvent.click(retry)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-log-row-evt-after-retry')).toBeInTheDocument(),
+    )
+  })
+
+  it('clicking the row View link still resolves to the audit event path', async () => {
+    render(<Harness />)
+    const row = await screen.findByTestId('access-log-row-evt-1')
+    const link = within(row).getByTestId('access-log-row-link-evt-1')
+    await userEvent.click(link)
+    await waitFor(() =>
+      expect(screen.getByTestId('location-display')).toHaveTextContent('/audit/event/evt-1'),
+    )
+  })
+
+  it('pagination prev returns to the previous window', async () => {
+    const many = Array.from({ length: 15 }, (_, i) => makeEvent({ id: `pg-${i + 1}` }, i))
+    _accessLogInternal.setFetchOverride(() => Promise.resolve(many))
+    render(<Harness />)
+    await screen.findByTestId('access-log-row-pg-1')
+
+    await userEvent.click(screen.getByTestId('access-log-pagination-next'))
+    expect(screen.getByTestId('access-log-page-indicator')).toHaveTextContent('Page 2 of 2')
+
+    await userEvent.click(screen.getByTestId('access-log-pagination-prev'))
+    expect(screen.getByTestId('access-log-page-indicator')).toHaveTextContent('Page 1 of 2')
+    expect(screen.getByTestId('access-log-row-pg-1')).toBeInTheDocument()
+  })
+
   it('pagination prev/next moves the visible window when rows exceed page size', async () => {
     // Override the fetcher with 15 fake rows so we get exactly two pages.
     const many = Array.from({ length: 15 }, (_, i) =>

--- a/dashboard/src/features/iam/CustomRolePanel.test.tsx
+++ b/dashboard/src/features/iam/CustomRolePanel.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CustomRolePanel } from './CustomRolePanel'
+import {
+  BUILTIN_ROLE_CATALOGUE,
+  IAM_CUSTOM_ROLES_COPY,
+  IAM_UPSELL_EVENT,
+} from './copy'
+
+describe('CustomRolePanel', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the title and description copy', () => {
+    render(<CustomRolePanel />)
+    expect(screen.getByText(IAM_CUSTOM_ROLES_COPY.title)).toBeInTheDocument()
+    expect(screen.getByText(IAM_CUSTOM_ROLES_COPY.description)).toBeInTheDocument()
+  })
+
+  it('points the upgrade CTA at the docs URL in a safe new tab', () => {
+    render(<CustomRolePanel />)
+    const cta = screen.getByTestId('upgrade-cta')
+    expect(cta).toHaveAttribute('href', IAM_CUSTOM_ROLES_COPY.upgradeUrl)
+    expect(cta).toHaveAttribute('target', '_blank')
+    expect(cta).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('lists every built-in role from the catalogue', () => {
+    render(<CustomRolePanel />)
+    for (const role of BUILTIN_ROLE_CATALOGUE) {
+      expect(screen.getByTestId(`builtin-role-${role.id}`)).toHaveTextContent(role.description)
+    }
+  })
+
+  it('fires the upsell analytics event when the CTA is clicked', async () => {
+    const user = userEvent.setup()
+    render(<CustomRolePanel />)
+    await user.click(screen.getByTestId('upgrade-cta'))
+    expect(console.info).toHaveBeenCalledWith(
+      `[analytics] ${IAM_UPSELL_EVENT}`,
+      { source: 'custom-roles-panel' },
+    )
+  })
+})

--- a/dashboard/src/features/iam/RevealOnceModal.test.tsx
+++ b/dashboard/src/features/iam/RevealOnceModal.test.tsx
@@ -1,0 +1,126 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { RevealOnceModal, REVEAL_AUTOCLOSE_MS } from './RevealOnceModal'
+import { ToastProvider } from '../../components/ToastProvider'
+import type { GeneratedApiKey } from './types'
+
+const GENERATED: GeneratedApiKey = {
+  id: 'key-1',
+  secret: 'aa-secret-xyz',
+} as GeneratedApiKey
+
+function renderModal(props: Partial<React.ComponentProps<typeof RevealOnceModal>> = {}) {
+  const handlers = {
+    onCopied: vi.fn(),
+    onClose: vi.fn(),
+    onAttemptCloseBeforeCopy: vi.fn(),
+  }
+  const Wrapper = ({ children }: { children: ReactNode }) => <ToastProvider>{children}</ToastProvider>
+  render(
+    <RevealOnceModal generated={GENERATED} copied={false} {...handlers} {...props} />,
+    { wrapper: Wrapper },
+  )
+  return handlers
+}
+
+describe('RevealOnceModal', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows the secret and the pre-copy button labels', () => {
+    renderModal()
+    expect(screen.getByTestId('reveal-once-secret')).toHaveValue('aa-secret-xyz')
+    expect(screen.getByTestId('copy-secret-button')).toHaveTextContent('Copy to clipboard')
+    expect(screen.getByTestId('reveal-once-close')).toHaveTextContent('Close without copying')
+    expect(screen.queryByTestId('reveal-once-copied')).not.toBeInTheDocument()
+  })
+
+  it('copies the secret and reports success', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    const { onCopied } = renderModal()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-secret-button'))
+    })
+
+    expect(writeText).toHaveBeenCalledWith('aa-secret-xyz')
+    expect(onCopied).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('toast')).toHaveAttribute('data-variant', 'success')
+  })
+
+  it('surfaces a clipboard failure as an error toast', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    Object.assign(navigator, { clipboard: { writeText } })
+    const { onCopied } = renderModal()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-secret-button'))
+    })
+
+    expect(onCopied).not.toHaveBeenCalled()
+    const toast = screen.getByTestId('toast')
+    expect(toast).toHaveAttribute('data-variant', 'error')
+    expect(toast).toHaveTextContent('denied')
+  })
+
+  it('treats a backdrop click before copy as an attempted early close', () => {
+    const { onAttemptCloseBeforeCopy, onClose } = renderModal()
+    fireEvent.click(screen.getByTestId('reveal-once-modal'))
+    expect(onAttemptCloseBeforeCopy).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes immediately on backdrop click once copied', () => {
+    const { onClose, onAttemptCloseBeforeCopy } = renderModal({ copied: true })
+    fireEvent.click(screen.getByTestId('reveal-once-modal'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onAttemptCloseBeforeCopy).not.toHaveBeenCalled()
+  })
+
+  it('does not close when the inner dialog body is clicked', () => {
+    const { onClose, onAttemptCloseBeforeCopy } = renderModal()
+    fireEvent.click(screen.getByTestId('reveal-once-secret'))
+    expect(onClose).not.toHaveBeenCalled()
+    expect(onAttemptCloseBeforeCopy).not.toHaveBeenCalled()
+  })
+
+  it('activates the backdrop via the Enter key', () => {
+    const { onAttemptCloseBeforeCopy } = renderModal()
+    fireEvent.keyDown(screen.getByTestId('reveal-once-modal'), { key: 'Enter' })
+    expect(onAttemptCloseBeforeCopy).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores backdrop key events that bubble from inner content', () => {
+    const { onAttemptCloseBeforeCopy } = renderModal()
+    fireEvent.keyDown(screen.getByTestId('reveal-once-secret'), { key: 'Enter' })
+    expect(onAttemptCloseBeforeCopy).not.toHaveBeenCalled()
+  })
+
+  it('shows the copied affordances and auto-closes after the delay', () => {
+    vi.useFakeTimers()
+    try {
+      const handlers = {
+        onCopied: vi.fn(),
+        onClose: vi.fn(),
+        onAttemptCloseBeforeCopy: vi.fn(),
+      }
+      render(
+        <ToastProvider>
+          <RevealOnceModal generated={GENERATED} copied {...handlers} />
+        </ToastProvider>,
+      )
+      expect(screen.getByTestId('reveal-once-copied')).toBeInTheDocument()
+      expect(screen.getByTestId('copy-secret-button')).toBeDisabled()
+      expect(screen.getByTestId('reveal-once-close')).toHaveTextContent('Close')
+
+      act(() => {
+        vi.advanceTimersByTime(REVEAL_AUTOCLOSE_MS)
+      })
+      expect(handlers.onClose).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
+++ b/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
@@ -55,6 +55,20 @@ describe('ServiceIdentitiesPanel — listing', () => {
     expect(screen.queryByTestId('api-key-revoke-key-3')).not.toBeInTheDocument()
     expect(screen.getByTestId('api-key-revoke-key-1')).toBeInTheDocument()
   })
+
+  it('shows the empty hint until a key is selected, then the detail card', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+    await screen.findByTestId('api-key-row-key-1')
+    expect(screen.getByTestId('iam-services-detail-empty')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('api-key-row-key-1'))
+    expect(await screen.findByTestId('identity-detail-card')).toBeInTheDocument()
+    expect(screen.queryByTestId('iam-services-detail-empty')).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('identity-detail-card-close'))
+    expect(screen.getByTestId('iam-services-detail-empty')).toBeInTheDocument()
+  })
 })
 
 describe('ServiceIdentitiesPanel — generate-and-reveal flow', () => {
@@ -158,6 +172,25 @@ describe('ServiceIdentitiesPanel — generate-and-reveal flow', () => {
       expect(screen.queryByTestId('confirm-destroy-unseen-key')).not.toBeInTheDocument(),
     )
     expect(screen.getByTestId('reveal-once-modal')).toBeInTheDocument()
+  })
+
+  it('surfaces a generate failure via toast without revealing a secret', async () => {
+    _apiKeysInternal.setGenerateOverride(() =>
+      Promise.reject(new Error('quota exceeded')),
+    )
+    const user = userEvent.setup()
+    renderPanel()
+    await screen.findByTestId('api-key-row-key-1')
+
+    await user.click(screen.getByTestId('generate-key-button'))
+    await user.type(screen.getByTestId('generate-key-label-input'), 'doomed')
+    await user.click(screen.getByTestId('generate-key-scope-admin'))
+    await user.click(screen.getByTestId('generate-key-submit'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('toast-container').textContent).toContain('quota exceeded'),
+    )
+    expect(screen.queryByTestId('reveal-once-modal')).not.toBeInTheDocument()
   })
 
   it('blocks generate submit until label + scope are present', async () => {

--- a/dashboard/src/features/iam/accessLog.test.tsx
+++ b/dashboard/src/features/iam/accessLog.test.tsx
@@ -92,6 +92,36 @@ describe('accessLog seed + filter (AAASM-1398)', () => {
     expect(data.length).toBeLessThan(10)
   })
 
+  it.each(['7d', '30d'] as const)('timeRange %s drops events older than the cutoff', async (kind) => {
+    const { result } = renderHook(() => useAccessLogQuery({ timeRange: { kind } }), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    const ms = kind === '7d' ? 7 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000
+    const cutoff = Date.now() - ms
+    for (const e of result.current.data as AccessLogEvent[]) {
+      expect(new Date(e.timestamp).getTime()).toBeGreaterThanOrEqual(cutoff)
+    }
+  })
+
+  it('custom time range filters to the inclusive from/to window', async () => {
+    const sorted = [..._accessLogInternal.snapshot()].sort((a, b) =>
+      a.timestamp < b.timestamp ? -1 : 1,
+    )
+    const from = sorted[2].timestamp
+    const to = sorted[6].timestamp
+    const { result } = renderHook(
+      () => useAccessLogQuery({ timeRange: { kind: 'custom', from, to } }),
+      { wrapper: makeWrapper() },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    const data = result.current.data as AccessLogEvent[]
+    expect(data.length).toBeGreaterThan(0)
+    for (const e of data) {
+      expect(e.timestamp >= from && e.timestamp <= to).toBe(true)
+    }
+  })
+
   it('setFetchOverride swaps the source (proves the eventual fetch swap is one-function)', async () => {
     _accessLogInternal.setFetchOverride(() =>
       Promise.resolve([

--- a/dashboard/src/features/iam/upsellAnalytics.test.ts
+++ b/dashboard/src/features/iam/upsellAnalytics.test.ts
@@ -1,0 +1,33 @@
+import { fireUpsellClicked } from './upsellAnalytics'
+import { IAM_UPSELL_EVENT } from './copy'
+
+describe('fireUpsellClicked', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the upsell event name', () => {
+    expect(fireUpsellClicked()).toBe(IAM_UPSELL_EVENT)
+  })
+
+  it('logs the event with the default source', () => {
+    fireUpsellClicked()
+    expect(console.info).toHaveBeenCalledWith(
+      `[analytics] ${IAM_UPSELL_EVENT}`,
+      { source: 'custom-roles-panel' },
+    )
+  })
+
+  it('forwards a custom source in the analytics payload', () => {
+    const result = fireUpsellClicked('settings-banner')
+    expect(result).toBe(IAM_UPSELL_EVENT)
+    expect(console.info).toHaveBeenCalledWith(
+      `[analytics] ${IAM_UPSELL_EVENT}`,
+      { source: 'settings-banner' },
+    )
+  })
+})

--- a/dashboard/src/pages/OverviewPage.test.tsx
+++ b/dashboard/src/pages/OverviewPage.test.tsx
@@ -344,4 +344,42 @@ describe('OverviewPage', () => {
     expect(overviewTsx).not.toMatch(/stroke="(?!var\()/)
     expect(overviewTsx).not.toMatch(/fill="(?!var\(|none)/)
   })
+
+  it('routes each drill-down action to its destination page', () => {
+    setup({
+      agents: [makeAgent()],
+      approvals: [{ id: 'ap-1' }] as unknown as Approval[],
+      policies: [{ name: 'p-1' }] as unknown as Policy[],
+      alerts: [makeAlert()],
+    })
+    renderPage()
+    const probe = screen.getByTestId('location-probe')
+
+    fireEvent.click(within(screen.getByTestId('overview-hero')).getByRole('button', { name: /open Capability/ }))
+    expect(probe).toHaveTextContent('/capability')
+
+    const issue = within(screen.getByTestId('overview-top-issue'))
+    fireEvent.click(issue.getByRole('button', { name: /review alerts/ }))
+    expect(probe).toHaveTextContent('/alerts')
+    fireEvent.click(issue.getByRole('button', { name: /review policy/ }))
+    expect(probe).toHaveTextContent('/policies')
+
+    const approvals = within(screen.getByTestId('overview-approvals'))
+    fireEvent.click(approvals.getByRole('button', { name: /review queue/ }))
+    expect(probe).toHaveTextContent('/approvals')
+    fireEvent.click(approvals.getByRole('button', { name: /open Live Ops/ }))
+    expect(probe).toHaveTextContent('/live')
+
+    fireEvent.click(screen.getByTestId('overview-layer-Identity'))
+    expect(probe).toHaveTextContent('/agents')
+    fireEvent.click(screen.getByTestId('overview-layer-Capability'))
+    expect(probe).toHaveTextContent('/capability')
+    fireEvent.click(screen.getByTestId('overview-layer-Scrub'))
+    expect(probe).toHaveTextContent('/scrub')
+
+    fireEvent.click(within(screen.getByTestId('overview-recent')).getByRole('button', { name: /tail/ }))
+    expect(probe).toHaveTextContent('/live')
+    fireEvent.click(within(screen.getByTestId('overview-snapshot')).getByRole('button', { name: /open Fleet/ }))
+    expect(probe).toHaveTextContent('/agents')
+  })
 })


### PR DESCRIPTION
## Description

Raises the dashboard (React/TS) vitest coverage toward >=95% with meaningful
React Testing Library tests — exercising real render states, user interactions,
error/empty/loading paths, formatters and hooks — to lift the agent-assembly
SonarCloud aggregate. Tests + test-setup only; no app/runtime behaviour changed
and no `sonar-project.properties` edits.

Coverage (dashboard, `pnpm test:coverage`), before -> after:

| Metric | Before | After |
|---|---|---|
| Lines | 94.24% | **95.61%** |
| Statements | 92.21% | 93.69% |
| Functions | 91.60% | 94.19% |
| Branches | 85.16% | 86.27% |

Test count: 1364 -> 1426 (+62 across 14 files).

New/extended suites (lowest-covered components/hooks/utils first):
- New: `upsellAnalytics`, `CustomRolePanel`, `Tooltip`, `LoadingState`, `Toast`
  (useToast + provider), `RevealOnceModal` (copy/error/autoclose),
  `DedupAndSuppressionFields` (add/remove/zod validation), `AppShell`
  (nav toggle, logout, error boundary), `api/client` (JWT auth middleware).
- Extended: `AlertFilterBar` (chip/status/agent/range/custom interactions),
  `AlertDetailDrawer` (scrim keyboard close), `ServiceIdentitiesPanel`
  (select detail + generate-error toast), `OverviewPage` (drill-down nav),
  `accessLog` (7d/30d/custom ranges), `DestinationManager`
  (edit/create-error/test-fire status+failure/kind change), analytics
  `FilterBar` (agent/team multiselect), `AccessLogPanel` (error+retry, View
  link, prev paging).

Known dashboard test gotchas respected: user-event clipboard clobber
(`Object.assign(navigator, { clipboard })` + `fireEvent`), openapi-fetch
captures `globalThis.fetch` (per-request `fetch` override) + absolute URLs,
typecheck run before push.

## Type of Change

- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3821 (Story AAASM-3798)

## Testing

- [x] Unit tests added / updated
- [x] `pnpm test:coverage` green (1426 passed), `pnpm type-check` clean, `pnpm lint` clean

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmVbZVBF5jcJ81614hD2bU
