### PR TITLE
[AAASM-3824] 🔒 (aa-api): Gate get_agent_capabilities + tenant-filter get_agent_graph (cross-tenant IDOR)

### DIFF
--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -473,11 +473,18 @@ fn cap_set_to_strings(set: &aa_core::CapabilitySet) -> (Vec<String>, Vec<String>
     tag = "agents"
 )]
 pub async fn get_agent_capabilities(
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<(StatusCode, Json<EffectivePermissionsResponse>), ProblemDetail> {
     let agent_id_bytes = parse_agent_id(&id)?;
     let agent_id = aa_core::identity::AgentId::from_bytes(agent_id_bytes);
+
+    // AAASM-3824: read-scope + tenant ownership before exposing the cascade.
+    // Siblings `get_agent` / `get_agent_budget` already gate here; the
+    // capabilities path was missed, letting any caller read any team's
+    // effective permissions.
+    authorize_agent_access(&caller, &state, &agent_id_bytes, &id)?;
 
     if state.agent_registry.get(&agent_id_bytes).is_none() {
         return Err(ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {id}")));

--- a/aa-api/src/routes/edges.rs
+++ b/aa-api/src/routes/edges.rs
@@ -419,6 +419,20 @@ pub async fn get_agent_graph(
 
     let depth = params.depth.unwrap_or(2).min(5);
 
+    // AAASM-3825: the BFS must not cross a tenant boundary. The root is already
+    // authorized; every other node is admitted to the subgraph only if the
+    // caller is authorized for its owning team (admins see all; a team-scoped
+    // caller sees only its own team; team-less nodes are admin-only). This keeps
+    // both the returned node set and the inter-node edges within the caller's
+    // tenant, mirroring `authorize_agent_team_access`.
+    let is_admin = caller.scopes.contains(&Scope::Admin);
+    let node_authorized = |node: AgentId| -> bool {
+        match agent_team_id(&state, node) {
+            Some(team) => caller.can_access_team(&team),
+            None => is_admin,
+        }
+    };
+
     // BFS: collect unique node IDs within `depth` hops
     let mut visited: HashSet<AgentId> = HashSet::new();
     let mut queue: VecDeque<(AgentId, u32)> = VecDeque::new();
@@ -433,6 +447,10 @@ pub async fn get_agent_graph(
             ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
         })?;
         for edge in outgoing {
+            // Never traverse into another tenant's agent.
+            if !node_authorized(edge.target) {
+                continue;
+            }
             if visited.insert(edge.target) {
                 queue.push_back((edge.target, d + 1));
             }

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -979,3 +979,50 @@ async fn get_agent_capabilities_cross_tenant_read_is_403() {
         "cross-tenant capabilities read is denied"
     );
 }
+
+// AAASM-3825 — get_agent_graph authorized only the root agent and then BFS-walked
+// across teams, leaking cross-tenant node IDs and inter-team edges. An
+// alpha-scoped caller walking its own root must see only alpha nodes/edges, even
+// when an alpha agent has an edge into a beta agent.
+#[tokio::test]
+async fn get_agent_graph_excludes_cross_tenant_nodes() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    // Root + neighbour in team alpha; a beta agent reachable via an alpha edge.
+    state.agent_registry.register(agent_with_team(0x01, "alpha")).unwrap();
+    state.agent_registry.register(agent_with_team(0x02, "alpha")).unwrap();
+    state.agent_registry.register(agent_with_team(0x03, "beta")).unwrap();
+
+    let edge = |src: u8, tgt: u8| aa_core::topology::NewEdge {
+        source: aa_core::identity::AgentId::from_bytes([src; 16]),
+        target: aa_core::identity::AgentId::from_bytes([tgt; 16]),
+        edge_type: aa_core::topology::EdgeType::Messages,
+        metadata: None,
+    };
+    // alpha -> alpha (in-tenant) and alpha -> beta (cross-tenant boundary).
+    state.edge_repo.insert(edge(0x01, 0x02)).await.unwrap();
+    state.edge_repo.insert(edge(0x02, 0x03)).await.unwrap();
+
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}/graph?depth=3", hex_id(0x01));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+
+    let nodes: Vec<&str> = json["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|n| n["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(nodes.len(), 2, "only the two alpha nodes are in the subgraph");
+    assert!(
+        !nodes.contains(&hex_id(0x03).as_str()),
+        "the beta agent must not appear in an alpha caller's subgraph"
+    );
+
+    // The only edge returned is the in-tenant one; the alpha->beta edge is gone.
+    let edges = json["edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 1, "only the in-tenant edge survives");
+    assert_eq!(edges[0]["target_agent_id"], hex_id(0x02));
+}

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -959,3 +959,23 @@ async fn silence_alert_cross_tenant_is_403() {
         "cross-tenant alert silence is denied"
     );
 }
+
+// AAASM-3824 — get_agent_capabilities exposed any team's effective-permission
+// cascade with no auth. An alpha-scoped caller must not read a beta agent's
+// capabilities; the gate fires before any existence check, so there is no
+// 403-vs-404 enumeration oracle.
+#[tokio::test]
+async fn get_agent_capabilities_cross_tenant_read_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xC2, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}/capabilities", hex_id(0xC2));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "cross-tenant capabilities read is denied"
+    );
+}


### PR DESCRIPTION
## Description

Fixes two cross-tenant IDOR vulnerabilities in `aa-api`'s agent read surface, both rooted in handlers that walked tenant-owned data after an insufficient (or missing) authorization check. Each fix mirrors the existing sibling read handlers' fail-closed authz pattern; no response shapes change.

**Bug 1 — AAASM-3824 (High): `get_agent_capabilities` ungated.**
`GET /api/v1/agents/{id}/capabilities` took only `(Extension(state), Path(id))` — no caller, no scope gate, no tenant check — so any authenticated key could read any team's effective permission cascade. Its read siblings (`get_agent`, `get_agent_budget`) already gate with `RequireRead(caller)` + `authorize_agent_access(...)`. The fix adds the `RequireRead` extractor and calls `authorize_agent_access(&caller, &state, &agent_id_bytes, &id)` before serving — fail-closed, and before any existence check so there is no 403-vs-404 enumeration oracle.

**Bug 2 — AAASM-3825 (Medium): `get_agent_graph` returned a cross-tenant subgraph.**
`GET /api/v1/agents/{id}/graph` authorized only the *root* agent, then BFS-walked `list_outgoing` across team boundaries (depth ≤ 5), returning cross-tenant node IDs and inter-team edges. The fix tenant-filters the traversal: a node is admitted to the subgraph only when the caller is authorized for its owning team (admins see all; a team-scoped caller sees only its own team; team-less nodes are admin-only — consistent with `authorize_agent_team_access`). Cross-tenant nodes are never visited, and since emitted edges are already confined to the visited set, inter-team edges drop out automatically. Legitimate intra-tenant graphs are unaffected, and admin callers still get the full graph.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

A previously-unauthenticated read endpoint now requires read scope + tenant ownership, and the graph endpoint no longer leaks cross-tenant topology. These are security corrections, not API-shape changes.

## Related Issues

- Related Jira ticket: AAASM-3824, AAASM-3825

## Testing

- [x] Integration tests added / updated

Added two cross-tenant tests in `aa-api/tests/tenant_scope.rs`, mirroring the existing `…_cross_tenant_…_is_403` convention:

- `get_agent_capabilities_cross_tenant_read_is_403` — alpha-scoped caller reading a beta agent's capabilities → 403.
- `get_agent_graph_excludes_cross_tenant_nodes` — alpha caller walking an alpha root that edges into a beta agent: subgraph contains only the two alpha nodes and the single in-tenant edge; the beta node and the alpha→beta edge are excluded.

Fail-without / pass-with confirmed by temporarily reverting the source fixes:
- Without the fix: capabilities test gets `200` (expected `403`); graph test fails (beta node/edge leak).
- With the fix: both pass.

Full suite: `cargo nextest run -p aa-api` → **793 passed, 0 failed**. `cargo fmt --all` (no diff) and `cargo clippy -p aa-api --all-targets -- -D warnings` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3824
Closes AAASM-3825

🤖 Generated with [Claude Code](https://claude.com/claude-code)
