### PR TITLE
[AAASM-3829] 🔧 (ci): Stabilize Rust LCOV ingestion for SonarCloud + pure-entrypoint coverage exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,7 +487,11 @@ jobs:
         with:
           name: rust-coverage-lcov
           path: lcov.info
-          retention-days: 1
+          # AAASM-3829: 14d (not 1d) so the AAASM-3197 cross-run backfill in the
+          # `sonar` job reliably finds this artifact when a Rust-less master push
+          # (dashboard-only / dep bump) path-skips the `coverage` job — otherwise
+          # the scan silently runs without Rust LCOV (dashboard-only, ~5k lines).
+          retention-days: 14
 
   # AAASM-1858: dedicated TimescaleDB job for env-gated tests in
   # aa-gateway. Sibling tests (in storage::timescale::tests and
@@ -1118,7 +1122,10 @@ jobs:
         with:
           name: dashboard-coverage-lcov
           path: dashboard/coverage/lcov.info
-          retention-days: 1
+          # AAASM-3829: 14d for parity with rust-coverage-lcov (Codecov + any
+          # backfill consumer); the sonar job regenerates dashboard LCOV in-job
+          # (AAASM-3803 Option C), so this is a non-critical safety margin.
+          retention-days: 14
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -113,7 +113,18 @@ sonar.coverage.exclusions=\
   aa-cli/src/commands/proxy/ca.rs,\
   aa-cli/src/commands/dashboard/start.rs,\
   aa-cli/src/commands/dashboard/mod.rs,\
-  aa-cli/src/commands/dashboard/feed.rs
+  aa-cli/src/commands/dashboard/feed.rs,\
+  aa-proxy/src/main.rs,\
+  aa-gateway/src/remote_mode/server.rs,\
+  aa-proxy/src/tls/keychain.rs
 
+# AAASM-3829: only the three PURE e2e-only files above are added for aa-gateway/
+# aa-proxy — a binary entrypoint (aa-proxy/main.rs), a socket-bind server
+# (remote_mode/server.rs), and an OS-keychain shim (tls/keychain.rs, macOS-only).
+# Mixed files (local_mode.rs, server.rs, proxy/mod.rs, etc.) that contain real
+# unit-tested logic are deliberately NOT excluded — file-level exclusion there
+# would hide genuinely-covered code. Postgres/Timescale/SQLite storage drivers
+# are NOT excluded either: they ARE exercised by the `coverage` job's `postgres`
+# service. The residual gap to a literal 95% is honest, not hidden.
 sonar.sourceEncoding=UTF-8
 sonar.scm.provider=git


### PR DESCRIPTION
## What
1. **Reliability:** bump `rust-coverage-lcov` (and `dashboard-coverage-lcov`) artifact `retention-days` 1 → 14.
2. **Exclusions:** add three *pure* e2e-only files to `sonar.coverage.exclusions`.

## Why
agent-assembly's SonarCloud coverage flickered between full (~57k lines, ~92%) and **dashboard-only (~5k lines)** depending on whether the Rust LCOV reached the scan. Root cause: a Rust-less master push (dashboard-only / dependency bump) path-skips the `coverage` job, so `sonar` falls to the AAASM-3197 cross-run backfill — which used `retention-days: 1`, so any artifact >1 day old was expired → soft `::warning:: scanning without it` → Rust-less scan. The 14-day retention makes the backfill reliable, so every master scan ingests the full codebase and the coverage % is stable and truthful.

### Exclusions (the only 3 — pure, no unit-testable logic)
- `aa-proxy/src/main.rs` — binary entrypoint
- `aa-gateway/src/remote_mode/server.rs` — socket-bind server (0 tests)
- `aa-proxy/src/tls/keychain.rs` — macOS keychain shim (0 tests, not compiled on the Linux coverage runner)

**Deliberately NOT excluded:** mixed files that contain real tested logic (`local_mode.rs`, `server.rs`, `proxy/mod.rs`, `tls.rs`, `main.rs` gateway) — excluding them would hide covered code; and the Postgres/Timescale/SQLite storage drivers, which ARE exercised by the `coverage` job's `postgres` service.

## Verify
Config/CI only — no production or test code changed. `actionlint` clean. Effect visible on the next master scan: `lines_to_cover` returns to ~57k and the coverage % is stable.

Refs AAASM-3798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)