### PR TITLE
[AAASM-3830] 🚨 (agent-assembly): Clear 20 SonarCloud code smells

### DIFF
--- a/aa-api/src/routes/edges.rs
+++ b/aa-api/src/routes/edges.rs
@@ -386,6 +386,60 @@ pub struct GraphResponse {
     pub edges: Vec<EdgeResponse>,
 }
 
+/// `edge_repo.list_outgoing` with the route's uniform 500 mapping.
+///
+/// Factored out so the BFS traversal and the edge-collection pass share one
+/// error-mapping site instead of duplicating it.
+async fn list_outgoing_or_500(state: &AppState, node: AgentId) -> Result<Vec<Edge>, ProblemDetail> {
+    state.edge_repo.list_outgoing(node, None, 1000).await.map_err(|e| {
+        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
+    })
+}
+
+/// BFS outward from `root` up to `depth` hops, returning the set of reachable
+/// nodes. A neighbour is admitted only when `node_authorized` returns true, so
+/// the walk never crosses a tenant boundary (AAASM-3825). `root` is always
+/// included.
+async fn collect_reachable_nodes(
+    state: &AppState,
+    root: AgentId,
+    depth: u32,
+    node_authorized: impl Fn(AgentId) -> bool,
+) -> Result<HashSet<AgentId>, ProblemDetail> {
+    let mut visited: HashSet<AgentId> = HashSet::new();
+    let mut queue: VecDeque<(AgentId, u32)> = VecDeque::new();
+    queue.push_back((root, 0));
+    visited.insert(root);
+
+    while let Some((node, d)) = queue.pop_front() {
+        if d >= depth {
+            continue;
+        }
+        for edge in list_outgoing_or_500(state, node).await? {
+            // Never traverse into another tenant's agent; short-circuit keeps
+            // an unauthorized target out of `visited`.
+            if node_authorized(edge.target) && visited.insert(edge.target) {
+                queue.push_back((edge.target, d + 1));
+            }
+        }
+    }
+    Ok(visited)
+}
+
+/// Collect every edge whose source and target both lie within `nodes`, i.e.
+/// the edges internal to the already-authorized subgraph.
+async fn collect_internal_edges(state: &AppState, nodes: &HashSet<AgentId>) -> Result<Vec<Edge>, ProblemDetail> {
+    let mut all_edges: Vec<Edge> = Vec::new();
+    for &node in nodes {
+        for edge in list_outgoing_or_500(state, node).await? {
+            if nodes.contains(&edge.target) {
+                all_edges.push(edge);
+            }
+        }
+    }
+    Ok(all_edges)
+}
+
 /// Return the topology subgraph reachable from an agent.
 ///
 /// Performs BFS outward from `id` up to `depth` hops (default 2, max 5).
@@ -433,43 +487,9 @@ pub async fn get_agent_graph(
         }
     };
 
-    // BFS: collect unique node IDs within `depth` hops
-    let mut visited: HashSet<AgentId> = HashSet::new();
-    let mut queue: VecDeque<(AgentId, u32)> = VecDeque::new();
-    queue.push_back((root_id, 0));
-    visited.insert(root_id);
-
-    while let Some((node, d)) = queue.pop_front() {
-        if d >= depth {
-            continue;
-        }
-        let outgoing = state.edge_repo.list_outgoing(node, None, 1000).await.map_err(|e| {
-            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
-        })?;
-        for edge in outgoing {
-            // Never traverse into another tenant's agent.
-            if !node_authorized(edge.target) {
-                continue;
-            }
-            if visited.insert(edge.target) {
-                queue.push_back((edge.target, d + 1));
-            }
-        }
-    }
-
-    // Batch-fetch all edges where source is in the visited set
-    let mut all_edges: Vec<Edge> = Vec::new();
-    for &node in &visited {
-        let outgoing = state.edge_repo.list_outgoing(node, None, 1000).await.map_err(|e| {
-            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
-        })?;
-        // Keep only edges whose target is also in the subgraph
-        for edge in outgoing {
-            if visited.contains(&edge.target) {
-                all_edges.push(edge);
-            }
-        }
-    }
+    // BFS the tenant-bounded subgraph, then collect the edges internal to it.
+    let visited = collect_reachable_nodes(&state, root_id, depth, node_authorized).await?;
+    let all_edges = collect_internal_edges(&state, &visited).await?;
 
     let cross_team_flags = compute_cross_team(&all_edges, &state);
     let edge_responses: Vec<EdgeResponse> = all_edges

--- a/dashboard/src/components/SuspendReasonDialog.tsx
+++ b/dashboard/src/components/SuspendReasonDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ChangeEvent, type FormEvent, type MouseEvent } from 'react'
+import { useEffect, useState, type ChangeEvent, type SyntheticEvent, type MouseEvent } from 'react'
 import './SuspendReasonDialog.css'
 
 interface SuspendReasonDialogProps {
@@ -42,7 +42,7 @@ export function SuspendReasonDialog({
     if (e.target === e.currentTarget) onCancel()
   }
 
-  function handleSubmit(e: FormEvent) {
+  function handleSubmit(e: SyntheticEvent) {
     e.preventDefault()
     setTouched(true)
     if (invalid) return

--- a/dashboard/src/features/alerts/ruleFormSchema.ts
+++ b/dashboard/src/features/alerts/ruleFormSchema.ts
@@ -22,9 +22,9 @@ export const ruleFormSchema = z
     description: z.string().trim().max(500, 'description must be ≤ 500 chars'),
     metric: z.enum(METRICS, { message: 'select a metric' }),
     operator: z.enum(OPERATORS, { message: 'select an operator' }),
-    threshold: z
-      .number({ message: 'threshold must be a number' })
-      .finite('threshold must be a finite number'),
+    // z.number() already rejects non-finite values in zod v4, so the former
+    // .finite() check is a no-op and was dropped (its message never fired).
+    threshold: z.number({ message: 'threshold must be a number' }),
     evaluationWindowSeconds: z.union([z.literal(300), z.literal(900), z.literal(3600)]),
     severity: z.enum(SEVERITIES),
     destinationIds: z
@@ -49,14 +49,14 @@ export const ruleFormSchema = z
     const max = isPercentage ? 100 : Number.MAX_SAFE_INTEGER
     if (data.threshold < 0) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: 'custom',
         path: ['threshold'],
         message: 'threshold must be ≥ 0',
       })
     }
     if (data.threshold > max) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: 'custom',
         path: ['threshold'],
         message: `threshold must be ≤ ${max} for metric ${data.metric}`,
       })

--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts'
+import { PieChart, Pie, Tooltip, ResponsiveContainer } from 'recharts'
 import { useAnalyticsFilters } from './useAnalyticsFilters'
 import { useApprovalAnalyticsQuery } from './useApprovalAnalyticsQuery'
 import { CHART_COLORBLIND_PALETTE } from './chartPalette'
@@ -37,7 +37,18 @@ export function ApprovalAnalyticsPanel() {
   const { filters } = useAnalyticsFilters()
   const { data, isPending, isError } = useApprovalAnalyticsQuery(filters)
 
-  const donutData = useMemo(() => (data ? buildDonutData(data) : []), [data])
+  // Per-slice colour is carried on each datum's `fill` (recharts reads it when
+  // computing sector colours), replacing the deprecated <Cell> child elements.
+  const donutData = useMemo(
+    () =>
+      data
+        ? buildDonutData(data).map((entry, i) => ({
+            ...entry,
+            fill: DONUT_COLORS[i % DONUT_COLORS.length],
+          }))
+        : [],
+    [data],
+  )
 
   function renderBody() {
     if (isPending) {
@@ -83,11 +94,7 @@ export function ApprovalAnalyticsPanel() {
                   outerRadius={72}
                   dataKey="value"
                   isAnimationActive={false}
-                >
-                  {donutData.map((entry, i) => (
-                    <Cell key={entry.name} fill={DONUT_COLORS[i % DONUT_COLORS.length]} />
-                  ))}
-                </Pie>
+                />
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                 <Tooltip formatter={(value: any) => [value.toLocaleString(), '']} />
               </PieChart>

--- a/dashboard/src/features/analytics/ToolUsagePanel.tsx
+++ b/dashboard/src/features/analytics/ToolUsagePanel.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   XAxis,
   YAxis,
-  Cell,
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
@@ -18,7 +17,16 @@ export function ToolUsagePanel() {
 
   const rawTools = data?.tools
   const tools = useMemo(() => rawTools ?? [], [rawTools])
-  const sortedTools = useMemo(() => sortToolsByCallsDesc(tools), [tools])
+  // Per-bar colour is carried on each datum's `fill` (recharts reads it when
+  // rendering each bar rectangle), replacing the deprecated <Cell> child elements.
+  const sortedTools = useMemo(
+    () =>
+      sortToolsByCallsDesc(tools).map((tool) => ({
+        ...tool,
+        fill: errorRateColor(tool.errorRate),
+      })),
+    [tools],
+  )
 
   function renderBody() {
     if (isPending) {
@@ -73,11 +81,7 @@ export function ToolUsagePanel() {
                 return [value, name]
               }}
             />
-            <Bar dataKey="calls" radius={[0, 3, 3, 0]}>
-              {sortedTools.map(tool => (
-                <Cell key={tool.name} fill={errorRateColor(tool.errorRate)} />
-              ))}
-            </Bar>
+            <Bar dataKey="calls" radius={[0, 3, 3, 0]} />
           </BarChart>
         </ResponsiveContainer>
         </>

--- a/dashboard/src/features/iam/GenerateKeyDialog.tsx
+++ b/dashboard/src/features/iam/GenerateKeyDialog.tsx
@@ -29,7 +29,7 @@ function GenerateKeyDialogBody({ onClose, onSubmit, isSubmitting }: Readonly<Gen
     setScopes((prev) => (prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope]))
   }
 
-  function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault()
     setTouched(true)
     if (!labelValid || !scopesValid) return

--- a/dashboard/src/features/iam/InviteMemberDialog.tsx
+++ b/dashboard/src/features/iam/InviteMemberDialog.tsx
@@ -32,7 +32,7 @@ function InviteMemberDialogBody({ onClose, onSubmit, isSubmitting }: Readonly<Om
   const emailValid = isValidEmail(trimmed)
   const showError = touched && !emailValid
 
-  function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault()
     setTouched(true)
     if (!emailValid) return

--- a/dashboard/src/features/policies/editor/SubClauses.tsx
+++ b/dashboard/src/features/policies/editor/SubClauses.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import { useState, type SyntheticEvent } from 'react'
 import {
   APPROVER_QUORUM_OPTS,
   APPROVER_SLA_OPTS,
@@ -39,7 +39,7 @@ function ChipList({
 }>) {
   const [draft, setDraft] = useState('')
 
-  const handleAdd = (e: FormEvent<HTMLFormElement>) => {
+  const handleAdd = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
     const trimmed = draft.trim()
     if (trimmed.length === 0) return

--- a/dashboard/src/features/trace/exportSchema.ts
+++ b/dashboard/src/features/trace/exportSchema.ts
@@ -28,7 +28,7 @@ const traceEventSchema = z.object({
 
 export const traceExportSchema = z.object({
   version: z.literal('1'),
-  exportedAt: z.string().datetime(),
+  exportedAt: z.iso.datetime(),
   agentId: z.string(),
   sessionId: z.string(),
   events: z.array(traceEventSchema),

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -103,7 +103,7 @@ function IdentityStrip({ agent }: Readonly<{ agent: Agent }>) {
           className={`ad-identity__metric${fleetAgent.blocked24h !== null && fleetAgent.blocked24h > 50 ? ' ad-identity__metric--danger' : ''}`}
           data-testid="agent-detail-blocked"
         >
-          {fleetAgent.blocked24h === null ? '—' : fleetAgent.blocked24h}
+          {fleetAgent.blocked24h ?? '—'}
         </p>
         <p className="ad-identity__metric-sub">capability denials</p>
       </div>
@@ -114,7 +114,7 @@ function IdentityStrip({ agent }: Readonly<{ agent: Agent }>) {
           className="ad-identity__metric ad-identity__metric--scrub"
           data-testid="agent-detail-scrubbed"
         >
-          {fleetAgent.scrubbed24h === null ? '—' : fleetAgent.scrubbed24h}
+          {fleetAgent.scrubbed24h ?? '—'}
         </p>
         <p className="ad-identity__metric-sub">secrets stripped at L3</p>
       </div>

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -9,7 +9,7 @@ export function LoginPage() {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault()
     setError(null)
     setLoading(true)

--- a/dashboard/src/pages/PoliciesPage.tsx
+++ b/dashboard/src/pages/PoliciesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type MutableRefObject } from 'react'
+import { useCallback, useMemo, useRef, useState, type RefObject } from 'react'
 import { ignorePromise } from '../lib/ignorePromise'
 import { usePoliciesQuery, useCreatePolicy, type Policy } from '../features/policies/api'
 import { useSandboxSummaryQuery } from '../features/audit/api'
@@ -28,7 +28,7 @@ const FILTER_TABS: ReadonlyArray<{ id: FilterTab; label: string }> = [
 ]
 
 interface PolicyEditorOverlayContainerProps {
-  dirtyRef: MutableRefObject<boolean>
+  dirtyRef: RefObject<boolean>
   onRequestClose: () => void
 }
 


### PR DESCRIPTION
## Description

Clears all 20 open SonarCloud code smells on `agent-assembly`. Behaviour-preserving only — no business-logic changes; the dashboard renders identically and the `/agents/{id}/graph` route returns identical responses.

Breakdown of the 20 smells:

- **17× `typescript:S1874` (deprecated API)** — replaced each with its current equivalent (no suppressions):
  - `react` `FormEvent` → `SyntheticEvent` (7 sites across SuspendReasonDialog, GenerateKeyDialog, InviteMemberDialog, SubClauses, LoginPage). `FormEvent` is a no-member alias of `SyntheticEvent` and is contravariantly assignable to a `<form>` `onSubmit` handler, so behaviour is unchanged.
  - `react` `MutableRefObject` → `RefObject` (2 sites in PoliciesPage). In `@types/react` 19, `RefObject<T>.current` is mutable and is the documented replacement; `useRef(false)` already yields `RefObject<boolean>`.
  - `recharts` `<Cell>` → per-datum `fill` (4 sites in ApprovalAnalyticsPanel + ToolUsagePanel). Recharts reads `fill` from each Pie sector / Bar rectangle datum, giving identical colours without the deprecated component.
  - `zod` v4 (4 sites): `.finite()` dropped (no-op in v4 — `z.number()` already rejects non-finite), `z.string().datetime()` → `z.iso.datetime()`, `z.ZodIssueCode.custom` → `'custom'` literal.
- **2× `typescript:S6606` (prefer `??`)** — `AgentDetailPage` blocked/scrubbed metrics. The ternaries were explicit `=== null` fallbacks (and `0` must still render as `0`), so `?? '—'` is semantically equivalent and safe.
- **1× `rust:S3776` (cognitive complexity 19 → ≤15)** — `aa-api` `get_agent_graph`. Extracted three cohesive helpers (`list_outgoing_or_500`, `collect_reachable_nodes`, `collect_internal_edges`) and merged the `!node_authorized` continue + `visited.insert` into one short-circuiting condition. Same response and error mapping; tenant-boundary BFS (AAASM-3790/3825) unchanged.

## Type of Change

- [x] ♻️ Refactoring
- [x] 🚨 Lint / deprecation cleanup

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3830

## Testing

- [x] Existing unit/integration tests cover the changes (no new tests required)
- `dashboard`: `pnpm lint` clean, `pnpm type-check` clean, full vitest suite **1426/1426 passed** (incl. ApprovalAnalyticsPanel / ToolUsagePanel / AgentDetailPage / alerts / trace schema tests).
- `aa-api`: `cargo fmt --all` clean, `cargo clippy -p aa-api --all-targets -- -D warnings` clean, `cargo nextest run -p aa-api` **793/793 passed** — including the `get_agent_graph` behaviour-lock tests (`get_agent_graph_four_agent_chain`, `_depth_limits_reachability`, `_root_only_when_no_edges`, `_cross_tenant_is_403`, `_excludes_cross_tenant_nodes`), which already fully exercise the refactored helpers.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — no behaviour change)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmVbZVBF5jcJ81614hD2bU
