### PR TITLE
[release] 🔧 (release): Prepare v0.0.1-rc.2 — bump + security sign-off + notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to **AI Agent Assembly** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-rc.2] — 2026-06-27 (pre-release)
+
+> **Not for production use.** Second **release candidate** in the v0.0.1 series
+> (patch on the `rc` channel). Security-hardening + test-coverage + docs; no API,
+> ABI, or wire-protocol stability commitment at `0.x.y`.
+
+### Security
+
+- **AAASM-3788** — gRPC per-RPC auth + mTLS scaffold on the agent plane
+  (fail-closed interceptor; approval decisions bound to the authenticated caller);
+  closes the unauthenticated-gateway gap (AAASM-3416).
+- **AAASM-3790 / 3824 / 3825** — REST cross-tenant IDOR hardening: tenant
+  ownership + write-scope across agent/alert/op handlers; `get_agent_capabilities`
+  gated; `get_agent_graph` traversal tenant-filtered.
+- **AAASM-3789** webhook SSRF guard + masked-secret round-trip; **AAASM-3787**
+  eval cache key includes action args (prevents wrong-decision cache reuse).
+
+### Documentation
+
+- **AAASM-3774** — every published crate ships a `README.md` (renders on
+  crates.io/docs.rs); release-readiness enforces it. Docs use `docs.agent-assembly.com`.
+
+### Build / quality
+
+- **AAASM-3765** versioned container base images; large test-coverage expansion
+  (aa-api/aa-cli/aa-gateway/aa-proxy/aa-runtime/dashboard); Rust + dashboard
+  coverage stabilisation; SonarCloud smell/deprecation cleanups.
+
+### Changed
+
+- Workspace + inter-crate path-dependency versions bumped `0.0.1-rc.1` → `0.0.1-rc.2`.
+
 ## [0.0.1-rc.1] — 2026-06-26 (pre-release)
 
 > **Not for production use.** First **release candidate** in the v0.0.1 series,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aa-api"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "aa-cache"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-cache",
  "aa-core",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aa-cli"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aa-core"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-security",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-claude-code"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-codex"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -179,14 +179,14 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-contract"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
 ]
 
 [[package]]
 name = "aa-devtool-copilot"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-saas"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-sample-myeditor"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-windsurf"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-devtool-contract",
  "async-trait",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-ebpf-common",
@@ -260,11 +260,11 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf-common"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 
 [[package]]
 name = "aa-gateway"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "aa-integration-tests"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-api",
  "aa-core",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "prost",
  "tonic",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proxy"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "aa-runtime"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-ebpf",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "aa-sandbox"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "tempfile",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "aa-sdk-client"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "aa-security"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-memory"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-storage",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-postgres"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-storage",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-redis"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-storage",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "aa-storage-sqlite-buffer"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "aa-wasm"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "wasm-bindgen",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 dependencies = [
  "aa-core",
  "aa-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ exclude = ["node-sdk", "aa-sandbox/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ai-agent-assembly/agent-assembly"

--- a/aa-cache/Cargo.toml
+++ b/aa-cache/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "In-process L1 cache wrapper (DashMap + TTL + stampede protection) for the Agent Assembly storage traits"
 
 [dependencies]
-aa-core = { path = "../aa-core", version = "0.0.1-rc.1" }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.2" }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -11,8 +11,8 @@ name = "aasm"
 path = "src/main.rs"
 
 [dependencies]
-aa-core              = { path = "../aa-core", version = "0.0.1-rc.1" }
-aa-security          = { path = "../aa-security", version = "0.0.1-rc.1", features = ["serde"] }
+aa-core              = { path = "../aa-core", version = "0.0.1-rc.2" }
+aa-security          = { path = "../aa-security", version = "0.0.1-rc.2", features = ["serde"] }
 # strip-for-publish:begin devtool
 # AAASM-2340: these three deps wire `aasm run` + `aasm tools` to the
 # `aa-devtool*` adapter crates. The dev-tool subsystem isn't ready to
@@ -20,16 +20,16 @@ aa-security          = { path = "../aa-security", version = "0.0.1-rc.1", featur
 # (and the source files that consume it) before `cargo workspaces publish`
 # runs. Source builds keep the full surface — no edits required to
 # develop on `aasm run` / `aasm tools` locally.
-aa-devtool           = { path = "../aa-devtool", version = "0.0.1-rc.1" }
-aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-rc.1" }
-aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-rc.1" }
+aa-devtool           = { path = "../aa-devtool", version = "0.0.1-rc.2" }
+aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-rc.2" }
+aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-rc.2" }
 # strip-for-publish:end devtool
-aa-gateway           = { path = "../aa-gateway", version = "0.0.1-rc.1" }
-aa-proxy             = { path = "../aa-proxy", version = "0.0.1-rc.1" }
-aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-rc.1" }
-aa-storage           = { path = "../aa-storage", version = "0.0.1-rc.1" }
-aa-storage-memory    = { path = "../aa-storage-memory", version = "0.0.1-rc.1" }
-aa-storage-redis     = { path = "../aa-storage-redis", version = "0.0.1-rc.1" }
+aa-gateway           = { path = "../aa-gateway", version = "0.0.1-rc.2" }
+aa-proxy             = { path = "../aa-proxy", version = "0.0.1-rc.2" }
+aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-rc.2" }
+aa-storage           = { path = "../aa-storage", version = "0.0.1-rc.2" }
+aa-storage-memory    = { path = "../aa-storage-memory", version = "0.0.1-rc.2" }
+aa-storage-redis     = { path = "../aa-storage-redis", version = "0.0.1-rc.2" }
 anyhow         = { workspace = true }
 async-trait    = { workspace = true }
 axum           = { workspace = true }

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Pure domain logic for Agent Assembly — no_std compatible"
 
 [dependencies]
-aa-security  = { path = "../aa-security", version = "0.0.1-rc.1", optional = true }
+aa-security  = { path = "../aa-security", version = "0.0.1-rc.2", optional = true }
 async-trait  = { workspace = true, optional = true }
 cfg-if       = "1"
 chrono       = { workspace = true, default-features = false, features = ["clock"], optional = true }

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -30,8 +30,8 @@ default = []
 integration-test = []
 
 [dependencies]
-aa-core        = { path = "../aa-core", version = "0.0.1-rc.1" }
-aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.1", features = ["std"] }
+aa-core        = { path = "../aa-core", version = "0.0.1-rc.2" }
+aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.2", features = ["std"] }
 anyhow         = { workspace = true }
 bytes          = { workspace = true }
 hex            = { workspace = true }

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -7,10 +7,10 @@ repository.workspace = true
 description = "Control plane — policy enforcement engine and agent registry for Agent Assembly"
 
 [dependencies]
-aa-core      = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
-aa-security  = { path = "../aa-security", version = "0.0.1-rc.1", features = ["serde"] }
-aa-proto     = { path = "../aa-proto", version = "0.0.1-rc.1" }
-aa-runtime   = { path = "../aa-runtime", version = "0.0.1-rc.1" }
+aa-core      = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
+aa-security  = { path = "../aa-security", version = "0.0.1-rc.2", features = ["serde"] }
+aa-proto     = { path = "../aa-proto", version = "0.0.1-rc.2" }
+aa-runtime   = { path = "../aa-runtime", version = "0.0.1-rc.2" }
 tokio        = { workspace = true, features = ["full"] }
 regex        = "1"
 serde        = { workspace = true }

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -14,10 +14,10 @@ name = "aa-proxy"
 path = "src/main.rs"
 
 [dependencies]
-aa-core    = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
-aa-security = { path = "../aa-security", version = "0.0.1-rc.1", features = ["serde"] }
-aa-proto   = { path = "../aa-proto", version = "0.0.1-rc.1" }
-aa-runtime = { path = "../aa-runtime", version = "0.0.1-rc.1" }
+aa-core    = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
+aa-security = { path = "../aa-security", version = "0.0.1-rc.2", features = ["serde"] }
+aa-proto   = { path = "../aa-proto", version = "0.0.1-rc.2" }
+aa-runtime = { path = "../aa-runtime", version = "0.0.1-rc.2" }
 clap       = { workspace = true, features = ["derive"] }
 tokio      = { workspace = true, features = ["full"] }
 hyper      = { workspace = true, features = ["server", "http1"] }

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -14,10 +14,10 @@ default = []
 integration-test = []
 
 [dependencies]
-aa-core                     = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
-aa-security                 = { path = "../aa-security", version = "0.0.1-rc.1", features = ["serde"] }
-aa-proto                    = { path = "../aa-proto", version = "0.0.1-rc.1" }
-aa-storage-sqlite-buffer    = { path = "../aa-storage-sqlite-buffer", version = "0.0.1-rc.1" }
+aa-core                     = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
+aa-security                 = { path = "../aa-security", version = "0.0.1-rc.2", features = ["serde"] }
+aa-proto                    = { path = "../aa-proto", version = "0.0.1-rc.2" }
+aa-storage-sqlite-buffer    = { path = "../aa-storage-sqlite-buffer", version = "0.0.1-rc.2" }
 async-nats                  = { workspace = true }
 async-trait                 = { workspace = true }
 axum                        = { workspace = true }
@@ -48,7 +48,7 @@ tracing-subscriber          = { workspace = true, features = ["json", "env-filte
 which                       = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-aa-ebpf = { path = "../aa-ebpf", version = "0.0.1-rc.1" }
+aa-ebpf = { path = "../aa-ebpf", version = "0.0.1-rc.2" }
 
 # Peer-credential (geteuid) check on the IPC socket — all Unix targets
 # (AAASM-3579). Backed by getpeereid/SO_PEERCRED via tokio's peer_cred.
@@ -58,7 +58,7 @@ libc = { workspace = true }
 # Linux-only dev dep: the AAASM-3128 regression test constructs a
 # `TlsCaptureEvent` to prove the DEBUG log never emits its plaintext payload.
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.1", features = ["std"] }
+aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.2", features = ["std"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/aa-sandbox/Cargo.toml
+++ b/aa-sandbox/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "WebAssembly/WASI sandbox runtime for Agent Assembly tool execution"
 
 [dependencies]
-aa-core       = { path = "../aa-core", version = "0.0.1-rc.1" }
+aa-core       = { path = "../aa-core", version = "0.0.1-rc.2" }
 thiserror     = { workspace = true }
 wasmtime      = "46"
 wasmtime-wasi = "46"

--- a/aa-storage-memory/Cargo.toml
+++ b/aa-storage-memory/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 description = "In-memory aa-storage driver (DashMap-backed) for tests and local development"
 
 [dependencies]
-aa-core = { path = "../aa-core", version = "0.0.1-rc.1" }
-aa-storage = { path = "../aa-storage", version = "0.0.1-rc.1" }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.2" }
+aa-storage = { path = "../aa-storage", version = "0.0.1-rc.2" }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }

--- a/aa-storage-postgres/Cargo.toml
+++ b/aa-storage-postgres/Cargo.toml
@@ -10,8 +10,8 @@ description = "PostgreSQL storage driver (L3 primary) for the Agent Assembly per
 publish = false
 
 [dependencies]
-aa-core    = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
-aa-storage = { path = "../aa-storage", version = "0.0.1-rc.1" }
+aa-core    = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
+aa-storage = { path = "../aa-storage", version = "0.0.1-rc.2" }
 async-trait = { workspace = true }
 sqlx       = { workspace = true, default-features = false, features = ["runtime-tokio-rustls", "postgres", "macros", "migrate", "uuid", "chrono", "json"] }
 serde      = { workspace = true }

--- a/aa-storage-redis/Cargo.toml
+++ b/aa-storage-redis/Cargo.toml
@@ -9,11 +9,11 @@ description = "Redis L2 shared-cache storage driver (SessionStore, RateLimitCoun
 [dependencies]
 # Trait contract — the storage traits live in `aa-core::storage` and are
 # re-exported verbatim by the `aa-storage` facade.
-aa-storage = { path = "../aa-storage", version = "0.0.1-rc.1" }
+aa-storage = { path = "../aa-storage", version = "0.0.1-rc.2" }
 # Pulled in only to enable `aa-core`'s `serde` feature so `PolicyDocument`
 # (re-exported through `aa-storage`) gains `Serialize`/`Deserialize`, which the
 # JSON-backed `RedisPolicyStore` needs. No `aa-core` items are named directly.
-aa-core = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
 
 async-trait = { workspace = true }
 # `redis = 1.2` matches the workspace pin. `tokio-rustls-comp` backs the
@@ -33,7 +33,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 testcontainers-modules = { workspace = true, features = ["redis"] }
 # Second driver for the mixed-config registry-integration test (redis backs the
 # L2 kinds; memory backs the durable kinds).
-aa-storage-memory = { path = "../aa-storage-memory", version = "0.0.1-rc.1" }
+aa-storage-memory = { path = "../aa-storage-memory", version = "0.0.1-rc.2" }
 
 [lints]
 workspace = true

--- a/aa-storage-sqlite-buffer/Cargo.toml
+++ b/aa-storage-sqlite-buffer/Cargo.toml
@@ -10,7 +10,7 @@ description = "Local in-process SQLite event buffer that survives brief gateway/
 # The buffer serializes and replays the storage contract's `AuditEntry` through
 # the `AuditSink` trait, both reached from `aa-core`. `serde` is enabled so
 # `AuditEntry` can be encoded into the on-disk BLOB.
-aa-core = { path = "../aa-core", version = "0.0.1-rc.1", features = ["serde"] }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
 # Pinned to the rusqlite line that depends on `libsqlite3-sys 0.30`, matching
 # the `sqlx-sqlite 0.8.6` already resolved for `aa-gateway`. Only one crate in
 # the workspace may link the native `sqlite3` library, so both must resolve to

--- a/aa-storage/Cargo.toml
+++ b/aa-storage/Cargo.toml
@@ -11,7 +11,7 @@ description = "Storage trait abstraction (pure interface) for the Agent Assembly
 # here. `serde`/`toml` back the `[storage]` config schema + driver registry; the
 # crate stays a pure interface (no `sqlx`/`redis`/`tonic` backend dependency).
 # `async-trait` is a dev-dep used by the conformance test's example implementation.
-aa-core   = { path = "../aa-core", version = "0.0.1-rc.1" }
+aa-core   = { path = "../aa-core", version = "0.0.1-rc.2" }
 serde     = { workspace = true }
 thiserror = { workspace = true }
 toml      = { workspace = true }

--- a/docs/release/security-signoff/v0.0.1-rc.2.md
+++ b/docs/release/security-signoff/v0.0.1-rc.2.md
@@ -1,0 +1,40 @@
+# Security sign-off — v0.0.1-rc.2
+
+- **Version:** v0.0.1-rc.2
+- **Release type:** patch (same `rc` pre-release channel; counter rc.1 → rc.2)
+- **Previous tag:** v0.0.1-rc.1
+- **Reviewer:** Claude Code (`/release-security-gate`)
+- **Date:** 2026-06-27
+
+## Inputs reviewed
+
+- `cargo deny check advisories` — **advisories ok** (exit 0)
+- Open CodeQL alerts — **0**
+- Open Dependabot alerts — **0**
+- Release diff — `git log v0.0.1-rc.1..HEAD` (~178 commits; dominated by security hardening, test coverage, and docs)
+- Native `/security-review` (Anthropic diff scanner) on the release delta — run; findings folded below. An initial review BLOCKED on one High (AAASM-3824); that fix merged (#1279) and the gate was re-run on the fixed master.
+
+## Findings
+
+| Severity | Finding | Status |
+|---|---|---|
+| ~~High~~ | **AAASM-3824** — `aa-api` `get_agent_capabilities` ungated cross-tenant IDOR (read any agent's capability matrix by ID). Pre-existing; missed by the AAASM-3790 IDOR sweep. | **Fixed** — PR #1279 (gate with `RequireRead` + `authorize_agent_access`, mirroring siblings; cross-tenant 403 test) |
+| Medium | **AAASM-3825** — `get_agent_graph` returned a cross-tenant subgraph (gated only the root) | **Fixed** — PR #1279 (BFS tenant-filter via `node_authorized`; refactor #1282 preserves it; exclusion test) |
+| Medium | **AAASM-3826** — webhook SSRF guard is DNS-rebinding TOCTOU (resolved IP not pinned) | Accepted — non-blocking follow-up (authenticated-operator-only; tracked) |
+| Medium | **AAASM-3827** — Slack connector SSRF + upstream body reflection (guard webhook-only; bypassable host check) | Accepted — non-blocking follow-up (tracked) |
+| Medium | **AAASM-3828** — `InvalidationService::Subscribe` is the one agent-plane gRPC RPC without the auth interceptor (read-only events) | Accepted — non-blocking follow-up (tracked) |
+| Info | **AAASM-3788** gRPC per-RPC auth + mTLS scaffold | Verified correct & fail-closed — closes the parked unauthenticated-gateway gap (AAASM-3416) for the audit/approval/topology/secrets services; policy/lifecycle self-validate the body token; `decided_by` bound to the authenticated caller; TLS fails closed |
+| Info | **AAASM-3787** eval cache-key includes action args | Verified correct & complete (no cross-args/cross-kind collision; fixes a wrong-decision cache-reuse) |
+| Info | **AAASM-3789** webhook SSRF guard + masked-secret update | Correct for the webhook connector (residual gaps tracked as 3826/3827) |
+
+> No unaddressed Critical or High remains. The accepted Mediums are authenticated-only / read-only residuals tracked for a follow-up pass; consistent with the patch-tier gate (BLOCK only on unaddressed Critical/High).
+
+## Threat-model refresh / trust-boundary checklist
+
+n/a — patch tier (same pre-release channel). Note: the delta's gRPC-auth work (3788) *tightens* the agent-plane (adds a fail-closed enforcement point); it adds no new unauthenticated surface and loosens no default. The one residual unauthenticated RPC (`InvalidationService::Subscribe`) is tracked as AAASM-3828.
+
+## Verdict
+
+<!-- The token `Verdict: PASS` is what release-readiness.sh greps for. -->
+
+Verdict: PASS

--- a/docs/release/v0.0.1-rc.2.md
+++ b/docs/release/v0.0.1-rc.2.md
@@ -1,0 +1,54 @@
+# v0.0.1-rc.2 — second release candidate
+
+> **Operator note** — source-controlled draft of the GitHub Release description for
+> the `v0.0.1-rc.2` tag. `prerelease: true` is applied automatically by `release.yml`.
+
+---
+
+## v0.0.1-rc.2 — release-candidate hardening
+
+Second release candidate in the v0.0.1 series (patch on the `rc` channel,
+`rc.1 → rc.2`). A **security-hardening + test-coverage + docs** cut.
+
+> **Not for production use.** At `0.x.y` SemVer, rc carries no API/ABI/wire-protocol
+> stability commitment.
+
+### Security
+
+- **AAASM-3788** — **gRPC per-RPC auth + mTLS scaffold** on the agent plane: a
+  fail-closed auth interceptor on the audit/approval/topology/secrets services;
+  policy/lifecycle independently validate the body credential token; approval
+  decisions bound to the authenticated caller; TLS fails closed. Closes the
+  long-standing unauthenticated-gateway gap (AAASM-3416).
+- **AAASM-3790 / 3824 / 3825** — REST cross-tenant IDOR hardening: tenant
+  ownership + write-scope across the agent/alert/op handlers; `get_agent_capabilities`
+  gated; `get_agent_graph` traversal tenant-filtered; cross-tenant reads/writes 403.
+- **AAASM-3789** — webhook destination SSRF guard + masked-secret round-trip.
+- **AAASM-3787** — eval cache key now includes action args (prevents wrong-decision
+  cache reuse).
+
+### Documentation
+
+- **AAASM-3774** — every published crate now ships a `README.md` (renders on
+  crates.io/docs.rs); a release-readiness check enforces it. Docs links use the
+  canonical `docs.agent-assembly.com` domain.
+
+### Build / quality
+
+- Versioned container base images (AAASM-3765); Rust + dashboard coverage
+  stabilisation and a large test-coverage expansion across aa-api/aa-cli/aa-gateway/
+  aa-proxy/aa-runtime/dashboard; SonarCloud smell + deprecation cleanups.
+
+### Release security sign-off
+
+Stage-0 `/release-security-gate` (patch tier) **PASS** — see
+[`docs/release/security-signoff/v0.0.1-rc.2.md`](security-signoff/v0.0.1-rc.2.md).
+`cargo deny check advisories` ok; 0 open CodeQL / Dependabot; no unaddressed
+Critical/High (the rc.2-gate High AAASM-3824 was fixed in #1279 before tagging).
+Residual Mediums (AAASM-3826/3827/3828) are tracked non-blocking follow-ups.
+
+### Coordinated SDK releases
+
+The matching SDK release candidates (`python-sdk 0.0.1rc2`, `node-sdk 0.0.1-rc.2`,
+`go-sdk v0.0.1-rc.2`) are cut after this tag's `release.yml` fan-out opens the
+`aa-ffi-pin` bump PRs on each SDK repo (per AAASM-3007).

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -79,6 +79,7 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 | v0.0.1-beta.3 | v0.0.1-beta.3 (PyPI `0.0.1b3`) ✓ | v0.0.1-beta.3 ✓ | v0.0.1-beta.3 ✓ | protocol/v1 |
 | v0.0.1-beta.4 | v0.0.1-beta.5 (PyPI `0.0.1b5`) ✓ | v0.0.1-beta.5 ✓ | v0.0.1-beta.3 ✓ | protocol/v1 |
 | v0.0.1-rc.1 | v0.0.1-rc.1 (PyPI `0.0.1rc1`) ✓ | v0.0.1-rc.1 ✓ | v0.0.1-rc.1 ✓ | protocol/v1 |
+| v0.0.1-rc.2 | v0.0.1-rc.2 (PyPI `0.0.1rc2`) ✓ | v0.0.1-rc.2 ✓ | v0.0.1-rc.2 ✓ | protocol/v1 |
 
 **Legend:**
 - ✓ Compatible — fully supported
@@ -88,6 +89,8 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 > **Note (v0.0.1-beta.4):** components version independently — each repo advances its own pre-release iterator — so one `aa-runtime` release pairs with differently-numbered SDK releases while staying `protocol/v1`-compatible. `aa-runtime` v0.0.1-beta.4 ships alongside python-sdk `0.0.1b5` (git `v0.0.1-beta.5`) and node-sdk `v0.0.1-beta.5`; go-sdk remains at `v0.0.1-beta.3` (no new cut this wave).
 
 > **Note (v0.0.1-rc.1):** first release-candidate cut — a coordinated promotion to the `rc` channel across all components. `aa-runtime` v0.0.1-rc.1 pairs with python-sdk `0.0.1rc1`, node-sdk `v0.0.1-rc.1`, and go-sdk `v0.0.1-rc.1`, all `protocol/v1`-compatible. The SDK `rc.1` cuts follow this tag's `release.yml` fan-out (per the `aa-ffi-pin` SDK-coordination SOP).
+
+> **Note (v0.0.1-rc.2):** second release candidate (patch on the `rc` channel) — security-hardening + coverage cut. `aa-runtime` v0.0.1-rc.2 pairs with python-sdk `0.0.1rc2`, node-sdk `v0.0.1-rc.2`, and go-sdk `v0.0.1-rc.2`, all `protocol/v1`-compatible. SDK `rc.2` cuts follow this tag's `release.yml` fan-out.
 
 ---
 
@@ -124,6 +127,7 @@ A runtime version may support multiple protocol versions to allow SDK upgrades w
 | v0.0.1-beta.3 | protocol/v1 |
 | v0.0.1-beta.4 | protocol/v1 |
 | v0.0.1-rc.1 | protocol/v1 |
+| v0.0.1-rc.2 | protocol/v1 |
 
 ---
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectName=agent-assembly
 # (AAASM-3819). ci.yml also overrides this with
 # -Dsonar.projectVersion=<Cargo version> at scan time, so it never silently
 # goes stale; this static value is the source of truth / local-scan fallback.
-sonar.projectVersion=0.0.1-rc.1
+sonar.projectVersion=0.0.1-rc.2
 
 sonar.projectBaseDir=./
 


### PR DESCRIPTION
## Release prep for **v0.0.1-rc.2** (second release candidate; patch on the rc channel)

Reversible prep PR for the rc.2 cut. Merging it lands the bump + sign-off on `master`; the **irreversible** `v0.0.1-rc.2` tag is cut from merged master (paused for operator go).

### What changed
- **Workspace + inter-crate pins** `0.0.1-rc.1` → `0.0.1-rc.2`; `Cargo.lock` regenerated.
- **Stage-0 security sign-off: `Verdict: PASS`** (`docs/release/security-signoff/v0.0.1-rc.2.md`, patch tier). The rc.2-gate High **AAASM-3824** (cross-tenant IDOR) + sibling **3825** were fixed in #1279 before this cut; advisories ok, 0 CodeQL/Dependabot. Residual Mediums (AAASM-3826/3827/3828) tracked non-blocking.
- Release notes `docs/release/v0.0.1-rc.2.md` + `CHANGELOG.md` entry + `docs/src/compatibility.md` matrix row.

### Readiness
`scripts/release-readiness.sh 0.0.1-rc.2` → version ✓, 40 literals ✓, CHANGELOG ✓, sign-off PASS ✓, **all published crates have a README ✓**. Remaining 3 (uncommitted/not-on-master/diverges) are PR-context, satisfied at tag time.

### Next (after merge, on operator go)
Cut `v0.0.1-rc.2` from master → `release.yml` fan-out (crates.io · GH Release · GHCR · Homebrew tap PR · SDK `aa-ffi-pin` bump PRs) → SDK rc.2 releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)