### PR TITLE
[AAASM-3832] 🐛 (aa-api): Fix Coverage job — gate pagerduty test to feature-off build

### DIFF
--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -738,6 +738,13 @@ async fn delete_destination_returns_404_for_unknown_id() {
 /// build, so `connector_for` returns `UnsupportedConnector`, whose `dispatch`
 /// always fails with a transport error. Firing a test against a pagerduty
 /// destination must surface as 502 `connector_failed` with status 0.
+///
+/// AAASM-3832: gated to the default (feature-off) build. Under `--all-features`
+/// — which the CI Coverage job uses — `connector-pagerduty` compiles the real
+/// connector, so `connector_for` no longer returns `UnsupportedConnector` and
+/// this stub-failure assertion would instead attempt a live PagerDuty call.
+/// Skipping it there keeps the Coverage job deterministic and offline.
+#[cfg(not(feature = "connector-pagerduty"))]
 #[tokio::test]
 async fn test_pagerduty_destination_returns_502_transport_error() {
     let app = common::test_app();


### PR DESCRIPTION
## Bug
The master **Coverage** job (cargo-llvm-cov, `--all-features`) has been **failing** on one test — `aa-api::destinations::test_pagerduty_destination_returns_502_transport_error` — which aborts `nextest` (fail-fast) so **no Rust `lcov.info`/`clippy-report.json` is produced**. SonarCloud then degrades every scan to **dashboard-only** (`lines_to_cover` 5,087 vs ~57k full) and the `edges.rs` rust:S3776 (fixed in #1282) persists on a stale clippy report.

## Root cause (regression from #1274 / AAASM-3811)
`connector-pagerduty` is an **off-by-default** feature. The test asserts the feature-OFF behaviour (`UnsupportedConnector` → synthetic 502 `connector_failed`, status 0, "not enabled") — its own doc-comment says so. The Coverage job runs `--all-features`, compiling the **real** connector, so the assertion would attempt a **live PagerDuty call** → fails/hangs. The default-feature Test job passes, so PR CI was green and missed it.

## Fix
`#[cfg(not(feature = "connector-pagerduty"))]` on the test — skipped under `--all-features`, still run under default.

## Verify (local)
- default: `cargo nextest run -p aa-api -E 'test(test_pagerduty…)'` → **1 passed**
- `--all-features`: same filter → **0 run (skipped/not compiled)** ✅

Test-only; no production code touched. After merge, the Coverage job goes green and the next master scan ingests the full Rust LCOV. Refs AAASM-3798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)