### PR TITLE
[AAASM-3847] 🔒 (aa-gateway): Fail-closed on invalid schedule timezone (single-policy path)

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -829,7 +829,19 @@ impl PolicyEngine {
     fn eval_schedule_stage(policy: &PolicyDocument) -> Option<EvaluationResult> {
         let ah = policy.schedule.as_ref()?.active_hours.as_ref()?;
         use chrono::Timelike;
-        let tz: chrono_tz::Tz = ah.timezone.parse().unwrap_or(chrono_tz::UTC);
+        // AAASM-3847: an unparseable timezone must fail closed. Silently
+        // falling back to UTC let an operator's active-hours window be
+        // evaluated in the wrong zone — e.g. a window meant for business hours
+        // in `America/New_York` evaluated in UTC could be wide open when it
+        // should be shut, bypassing the schedule control. Deny when the
+        // configured tz does not parse, matching the cascade twin
+        // `decision.rs::stage_schedule` (AAASM-3133).
+        let Ok(tz) = ah.timezone.parse::<chrono_tz::Tz>() else {
+            return Some(EvaluationResult::deny(format!(
+                "invalid schedule timezone: {}",
+                ah.timezone
+            )));
+        };
         let now = chrono::Utc::now().with_timezone(&tz);
         let current_hhmm = format!("{:02}:{:02}", now.hour(), now.minute());
         if current_hhmm < ah.start || current_hhmm >= ah.end {

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1833,6 +1833,34 @@ mod tests {
     }
 
     #[test]
+    fn schedule_invalid_timezone_fails_closed() {
+        // AAASM-3847: an unparseable tz on the single-policy `evaluate_primary`
+        // path must DENY, not silently fall back to UTC. The window is the full
+        // day, so the only reason to deny is the invalid timezone — proving the
+        // fail-closed behaviour rather than a coincidental out-of-window deny.
+        let mut doc = empty_doc();
+        doc.schedule = Some(SchedulePolicy {
+            active_hours: Some(ActiveHours {
+                start: "00:00".to_string(),
+                end: "23:59".to_string(),
+                timezone: "Not/AZone".to_string(),
+            }),
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        let action = tool_call("any", "");
+        match engine.evaluate(&ctx, &action).decision {
+            PolicyResult::Deny { reason } => {
+                assert!(
+                    reason.contains("invalid schedule timezone"),
+                    "expected invalid-timezone deny, got: {reason}"
+                );
+            }
+            other => panic!("expected fail-closed Deny, got: {other:?}"),
+        }
+    }
+
+    #[test]
     fn network_denies_unlisted_host() {
         let mut doc = empty_doc();
         doc.network = Some(NetworkPolicy {


### PR DESCRIPTION
## Description

`eval_schedule_stage` in `aa-gateway/src/engine/mod.rs` — the schedule stage of
the single-policy `evaluate_primary` path (the common/default single global-policy
deployment) — parsed the configured `active_hours.timezone` with
`parse().unwrap_or(chrono_tz::UTC)`. On an invalid/misconfigured timezone it
**failed open**: it silently fell back to UTC and evaluated the active-hours
window in the wrong zone, so a window meant for, e.g., business hours in
`America/New_York` could be wide open when it should be shut — bypassing the
schedule control.

This makes the stage **fail closed**: an unparseable timezone now returns
`Deny { reason: "invalid schedule timezone: <tz>" }`, matching the cascade twin
`decision.rs::stage_schedule`, which was fixed for this exact divergence class by
AAASM-3133. (Same primary-vs-cascade divergence pattern as the AAASM-3728 network
allowlist fix.)

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

A policy with an unparseable `active_hours.timezone` was previously evaluated
(incorrectly) against UTC; it now denies. This is the intended fail-closed
security posture. Valid timezones are unaffected.

## Related Issues

- Related Jira ticket: AAASM-3847

## Testing

- [x] Unit tests added / updated

Added `schedule_invalid_timezone_fails_closed` in `aa-gateway/src/engine/mod.rs`:
an invalid timezone with a full-day (`00:00`–`23:59`) window on the
`evaluate_primary` path must `Deny` with reason `invalid schedule timezone` —
proving the fail-closed behaviour rather than a coincidental out-of-window deny.

Validation (own `CARGO_TARGET_DIR`): `cargo build -p aa-gateway`,
`cargo nextest run -p aa-gateway`, `cargo fmt --all -- --check`,
`cargo clippy -p aa-gateway --all-targets -- -D warnings`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3847

🤖 Generated with [Claude Code](https://claude.com/claude-code)
