### PR TITLE
[AAASM-3844] 🔒 (aa-api): Require admin authz on retention-policy endpoints

### DIFF
--- a/aa-api/src/routes/admin.rs
+++ b/aa-api/src/routes/admin.rs
@@ -13,6 +13,7 @@ use axum::Json;
 
 use aa_gateway::storage::{ColdAction, RetentionConfig, RetentionEngine, RetentionStats};
 
+use crate::auth::scope::RequireAdmin;
 use crate::error::ProblemDetail;
 use crate::models::retention::{
     ColdActionDto, RetentionPolicyDocument, RetentionRunStatsDto, RunRetentionRequest, UpdateRetentionPolicyRequest,
@@ -78,6 +79,7 @@ fn stats_to_dto(stats: RetentionStats) -> RetentionRunStatsDto {
     tag = "admin"
 )]
 pub async fn get_retention_policy(
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
 ) -> Result<Json<RetentionPolicyDocument>, ProblemDetail> {
     let engine = require_engine(&state)?;
@@ -149,6 +151,7 @@ fn merge_request_into_config(base: &RetentionConfig, req: &UpdateRetentionPolicy
     tag = "admin"
 )]
 pub async fn update_retention_policy(
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     Json(req): Json<UpdateRetentionPolicyRequest>,
 ) -> Result<Json<RetentionPolicyDocument>, ProblemDetail> {
@@ -181,6 +184,7 @@ pub async fn update_retention_policy(
     tag = "admin"
 )]
 pub async fn run_retention_policy(
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     Json(req): Json<RunRetentionRequest>,
 ) -> Result<Json<RetentionRunStatsDto>, ProblemDetail> {
@@ -223,6 +227,8 @@ pub async fn run_retention_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::scope::Scope;
+    use crate::auth::{AuthenticatedCaller, Tenant};
     use crate::state::LocalAuth;
 
     /// Hardened state wires a real SQLite-backed RetentionEngine.
@@ -232,11 +238,25 @@ mod tests {
             .expect("hardened state builds")
     }
 
+    /// An admin-scoped `RequireAdmin` for invoking the handlers directly in
+    /// unit tests (these bypass the router, so the extractor is constructed
+    /// by hand). The 403 path for non-admin callers is covered end-to-end in
+    /// `tests/admin.rs`.
+    fn admin_auth() -> RequireAdmin {
+        RequireAdmin(AuthenticatedCaller {
+            key_id: "test-admin".to_string(),
+            scopes: vec![Scope::Admin],
+            tenant: Tenant::default(),
+        })
+    }
+
     #[tokio::test]
     async fn handlers_503_without_retention_engine() {
         // local_in_memory leaves retention_engine None → every handler 503s.
         let state = AppState::local_in_memory().expect("state builds");
-        let err = get_retention_policy(Extension(state)).await.expect_err("503 expected");
+        let err = get_retention_policy(admin_auth(), Extension(state))
+            .await
+            .expect_err("503 expected");
         assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE.as_u16());
         assert_eq!(err.error_code, Some("retention_engine_unavailable"));
     }
@@ -250,7 +270,7 @@ mod tests {
             cold_action: ColdActionDto::Drop,
             archive_url: None,
         };
-        let doc = update_retention_policy(Extension(state), Json(req))
+        let doc = update_retention_policy(admin_auth(), Extension(state), Json(req))
             .await
             .expect("applied")
             .0;
@@ -269,7 +289,7 @@ mod tests {
             cold_action: ColdActionDto::Drop,
             archive_url: None,
         };
-        let err = update_retention_policy(Extension(state), Json(req))
+        let err = update_retention_policy(admin_auth(), Extension(state), Json(req))
             .await
             .expect_err("rejected");
         assert_eq!(err.status, StatusCode::BAD_REQUEST.as_u16());
@@ -280,7 +300,7 @@ mod tests {
     async fn run_once_executes_real_pass() {
         let state = hardened().await;
         let req = RunRetentionRequest { dry_run: false };
-        let dto = run_retention_policy(Extension(state), Json(req))
+        let dto = run_retention_policy(admin_auth(), Extension(state), Json(req))
             .await
             .expect("run ok")
             .0;
@@ -295,7 +315,7 @@ mod tests {
         let dry_pref_before = engine_before.current_config().dry_run;
 
         let req = RunRetentionRequest { dry_run: true };
-        let dto = run_retention_policy(Extension(state.clone()), Json(req))
+        let dto = run_retention_policy(admin_auth(), Extension(state.clone()), Json(req))
             .await
             .expect("dry run ok")
             .0;

--- a/aa-api/tests/admin.rs
+++ b/aa-api/tests/admin.rs
@@ -12,6 +12,7 @@ mod common;
 
 use std::sync::Arc;
 
+use aa_api::auth::scope::Scope;
 use aa_api::server::build_app;
 use aa_gateway::storage::backend::StorageBackend;
 use aa_gateway::storage::{RetentionConfig, RetentionEngine, SqliteBackend, SqliteConfig};
@@ -245,6 +246,102 @@ async fn post_run_returns_503_when_retention_engine_is_unconfigured() {
                 .uri("/api/v1/admin/retention-policy/run")
                 .header("content-type", "application/json")
                 .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+// ── AAASM-3844: function-level authorization regression tests ───────────────
+//
+// The retention handlers were registered under `require_authentication`
+// (authN only), so any authenticated caller — including a read-only key —
+// could read, mutate, or trigger a destructive retention pass. Each handler
+// now requires `RequireAdmin`; these tests pin the 403 for a non-admin caller
+// and confirm an admin caller still passes the authz gate.
+
+#[tokio::test]
+async fn get_retention_policy_rejects_read_only_caller_with_403() {
+    let (token, entry) = common::generate_test_api_key("ro-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/admin/retention-policy")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn put_retention_policy_rejects_read_only_caller_with_403() {
+    let (token, entry) = common::generate_test_api_key("ro-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+    let req_body = serde_json::json!({
+        "hot_days": 1,
+        "warm_days": 2,
+        "cold_action": "drop",
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/admin/retention-policy")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn post_run_retention_policy_rejects_read_only_caller_with_403() {
+    let (token, entry) = common::generate_test_api_key("ro-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+    let req_body = serde_json::json!({ "dry_run": true });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/admin/retention-policy/run")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn admin_caller_passes_authz_gate_on_retention_policy() {
+    // An admin caller must clear the authz gate — proving the new extractor
+    // is not a blanket deny. The engine is unconfigured in this fixture, so
+    // the request proceeds past authz and surfaces the 503 from
+    // `require_engine`, not a 403.
+    let (token, entry) = common::generate_test_api_key("admin-key", vec![Scope::Read, Scope::Write, Scope::Admin]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/admin/retention-policy")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
                 .unwrap(),
         )
         .await


### PR DESCRIPTION
## Description

The admin retention-policy REST handlers in `aa-api/src/routes/admin.rs` were
registered under the `require_authentication` gate (authN only — it resolves the
`AuthenticatedCaller` and discards it). None of them carried a scope/authz
extractor, so **any authenticated caller, including a read-only API key**, could:

- read the live retention configuration (`GET /api/v1/admin/retention-policy`),
- mutate retention thresholds / cold action / archive URL
  (`PUT /api/v1/admin/retention-policy`) — enabling **audit/governance-data
  exfiltration** (`cold_action: archive` + attacker-controlled `archive_url`) or
  **destruction** (`cold_action: drop`, shrunk `hot_days`), and
- trigger an immediate retention pass (`POST /api/v1/admin/retention-policy/run`).

This change adds the existing `RequireAdmin` extractor (same pattern as the
`RequireRead` / `RequireWrite` gates already used across the routes) to all three
handlers. A caller whose scopes do not include `admin` now receives `403
Forbidden` (via `AuthError::InsufficientScope`) before the handler body runs.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Non-admin callers that previously (incorrectly) reached these endpoints now
receive 403. This restores the intended authorization posture; it is a security
fix, not a public-API contract change. Request/response schemas are unchanged, so
the generated OpenAPI spec is unaffected.

## Related Issues

- Related Jira ticket: AAASM-3844

## Testing

- [x] Integration tests added / updated

Added to `aa-api/tests/admin.rs`:
- `get_retention_policy_rejects_read_only_caller_with_403`
- `put_retention_policy_rejects_read_only_caller_with_403`
- `post_run_retention_policy_rejects_read_only_caller_with_403`
- `admin_caller_passes_authz_gate_on_retention_policy` (control: an admin caller
  clears the authz gate and surfaces the engine-unconfigured 503, not a 403)

Validation (own `CARGO_TARGET_DIR`): `cargo build -p aa-api`,
`cargo nextest run -p aa-api`, `cargo fmt --all -- --check`,
`cargo clippy -p aa-api --all-targets -- -D warnings`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3844

🤖 Generated with [Claude Code](https://claude.com/claude-code)
