### PR TITLE
[AAASM-3843] 🔒 (aa-api): Mask all connector secrets on alert-destination read

### DIFF
--- a/aa-api/src/destinations/connectors/mod.rs
+++ b/aa-api/src/destinations/connectors/mod.rs
@@ -130,3 +130,26 @@ pub(crate) fn truncate_body(body: String) -> String {
         body
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_body_handles_multibyte_boundary() {
+        // 683 × 3-byte '€' = 2049 bytes, so the 2048-byte cap lands mid-character.
+        // A naive `body[..2048]` slice would panic (AAASM-3843 remote DoS). The
+        // truncation must back up to a valid char boundary at or below the cap.
+        let over = "€".repeat(683);
+        assert_eq!(over.len(), 2049);
+        let out = truncate_body(over);
+        assert!(out.len() <= 2048);
+        assert!(out.is_char_boundary(out.len()));
+        assert_eq!(out.chars().count(), 682);
+    }
+
+    #[test]
+    fn truncate_body_leaves_short_body_untouched() {
+        assert_eq!(truncate_body("hi".to_string()), "hi");
+    }
+}

--- a/aa-api/src/destinations/connectors/mod.rs
+++ b/aa-api/src/destinations/connectors/mod.rs
@@ -112,10 +112,20 @@ pub(crate) fn shared_client() -> &'static Client {
 }
 
 /// Cap a response body at 2048 bytes so error envelopes stay bounded.
+///
+/// Truncates on a UTF-8 char boundary at or below the 2048-byte cap. A naive
+/// `body[..2048]` byte slice panics when 2048 lands in the middle of a
+/// multibyte character, which a connector `/test` could trigger with a crafted
+/// >2048-byte response body (remote DoS, AAASM-3843).
 #[allow(dead_code)] // wired up by per-kind connectors in subsequent commits
 pub(crate) fn truncate_body(body: String) -> String {
-    if body.len() > 2048 {
-        body[..2048].to_string()
+    const MAX: usize = 2048;
+    if body.len() > MAX {
+        let mut end = MAX;
+        while !body.is_char_boundary(end) {
+            end -= 1;
+        }
+        body[..end].to_string()
     } else {
         body
     }

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -688,4 +688,119 @@ mod tests {
         .expect_err("not found");
         assert_eq!(err.status, StatusCode::NOT_FOUND.as_u16());
     }
+
+    #[test]
+    fn from_destination_masks_every_connector_secret() {
+        // AAASM-3843: every connector kind's secret-bearing field is masked on
+        // read; non-secret fields are preserved.
+        let cases = [
+            DestinationConfig::Webhook {
+                url: "https://example.com/hook".to_string(),
+                secret_header: Some("real-secret".to_string()),
+            },
+            DestinationConfig::Slack {
+                webhook_url: "https://hooks.slack.com/services/T/B/secret".to_string(),
+                channel_override: Some("#ops".to_string()),
+            },
+            DestinationConfig::PagerDuty {
+                routing_key: "real-routing-key".to_string(),
+                severity_map: None,
+            },
+            DestinationConfig::OpsGenie {
+                api_key: "real-api-key".to_string(),
+                team_id: "team-1".to_string(),
+            },
+        ];
+        for config in cases {
+            let dest = Destination {
+                id: "dst_1".to_string(),
+                name: "d".to_string(),
+                config,
+                enabled: true,
+                created_at: String::new(),
+                updated_at: String::new(),
+            };
+            match DestinationResponse::from(dest).config {
+                DestinationConfig::Webhook { secret_header, .. } => {
+                    assert_eq!(secret_header.as_deref(), Some(SECRET_MASK));
+                }
+                DestinationConfig::Slack {
+                    webhook_url,
+                    channel_override,
+                } => {
+                    assert_eq!(webhook_url, SECRET_MASK);
+                    assert_eq!(channel_override.as_deref(), Some("#ops"));
+                }
+                DestinationConfig::PagerDuty { routing_key, .. } => {
+                    assert_eq!(routing_key, SECRET_MASK);
+                }
+                DestinationConfig::OpsGenie { api_key, team_id } => {
+                    assert_eq!(api_key, SECRET_MASK);
+                    assert_eq!(team_id, "team-1");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn restore_masked_secrets_preserves_stored_for_all_kinds() {
+        // AAASM-3843: a masked sentinel on PUT is restored from the stored
+        // secret for every kind; a genuinely-rotated value is left untouched.
+        let mut slack = DestinationConfig::Slack {
+            webhook_url: SECRET_MASK.to_string(),
+            channel_override: None,
+        };
+        restore_masked_secrets(
+            &mut slack,
+            Some(DestinationConfig::Slack {
+                webhook_url: "https://hooks.slack.com/services/real".to_string(),
+                channel_override: None,
+            }),
+        );
+        assert!(matches!(slack, DestinationConfig::Slack { webhook_url, .. }
+            if webhook_url == "https://hooks.slack.com/services/real"));
+
+        let mut pd = DestinationConfig::PagerDuty {
+            routing_key: SECRET_MASK.to_string(),
+            severity_map: None,
+        };
+        restore_masked_secrets(
+            &mut pd,
+            Some(DestinationConfig::PagerDuty {
+                routing_key: "real-key".to_string(),
+                severity_map: None,
+            }),
+        );
+        assert!(matches!(pd, DestinationConfig::PagerDuty { routing_key, .. }
+            if routing_key == "real-key"));
+
+        let mut og = DestinationConfig::OpsGenie {
+            api_key: SECRET_MASK.to_string(),
+            team_id: "t".to_string(),
+        };
+        restore_masked_secrets(
+            &mut og,
+            Some(DestinationConfig::OpsGenie {
+                api_key: "real-genie".to_string(),
+                team_id: "t".to_string(),
+            }),
+        );
+        assert!(matches!(og, DestinationConfig::OpsGenie { api_key, .. }
+            if api_key == "real-genie"));
+
+        // A non-masked incoming secret is a genuine rotation and must survive.
+        let mut rotated = DestinationConfig::OpsGenie {
+            api_key: "rotated-key".to_string(),
+            team_id: "t".to_string(),
+        };
+        restore_masked_secrets(
+            &mut rotated,
+            Some(DestinationConfig::OpsGenie {
+                api_key: "old-key".to_string(),
+                team_id: "t".to_string(),
+            }),
+        );
+        assert!(matches!(rotated, DestinationConfig::OpsGenie { api_key, .. }
+            if api_key == "rotated-key"));
+    }
 }

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -80,6 +80,59 @@ impl From<Destination> for DestinationResponse {
     }
 }
 
+/// Restore masked secrets on an incoming update from the stored config.
+///
+/// AAASM-3751 / AAASM-3843: every secret-bearing field is returned as
+/// [`SECRET_MASK`] on read. A GET → edit → PUT round-trip would otherwise
+/// write that literal sentinel back, clobbering the real stored secret. When an
+/// incoming secret field equals the mask, replace it with the value already
+/// persisted so the round-trip preserves the stored secret. Applied to every
+/// connector kind's secret-bearing field, not just the webhook `secret_header`.
+fn restore_masked_secrets(incoming: &mut DestinationConfig, stored: Option<DestinationConfig>) {
+    match incoming {
+        DestinationConfig::Webhook { secret_header, .. } => {
+            if secret_header.as_deref() == Some(SECRET_MASK) {
+                *secret_header = match stored {
+                    Some(DestinationConfig::Webhook { secret_header, .. }) => secret_header,
+                    _ => None,
+                };
+            }
+        }
+        DestinationConfig::Slack { webhook_url, .. } => {
+            if webhook_url == SECRET_MASK {
+                if let Some(DestinationConfig::Slack {
+                    webhook_url: stored_url,
+                    ..
+                }) = stored
+                {
+                    *webhook_url = stored_url;
+                }
+            }
+        }
+        DestinationConfig::PagerDuty { routing_key, .. } => {
+            if routing_key == SECRET_MASK {
+                if let Some(DestinationConfig::PagerDuty {
+                    routing_key: stored_key,
+                    ..
+                }) = stored
+                {
+                    *routing_key = stored_key;
+                }
+            }
+        }
+        DestinationConfig::OpsGenie { api_key, .. } => {
+            if api_key == SECRET_MASK {
+                if let Some(DestinationConfig::OpsGenie {
+                    api_key: stored_key, ..
+                }) = stored
+                {
+                    *api_key = stored_key;
+                }
+            }
+        }
+    }
+}
+
 /// Body for `POST /api/v1/alerts/destinations`.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateDestinationRequest {
@@ -372,9 +425,6 @@ pub async fn update_destination(
     body: Bytes,
 ) -> Result<Json<DestinationResponse>, ProblemDetail> {
     let mut req = parse_update_body(&body)?;
-    if let Some(cfg) = &req.config {
-        validate_config(cfg).map_err(validation_error_to_problem)?;
-    }
     if let Some(name) = &req.name {
         if name.trim().is_empty() {
             return Err(validation_error_to_problem(ValidationError::InvalidConfig(
@@ -383,25 +433,17 @@ pub async fn update_destination(
         }
     }
 
-    // AAASM-3751: `get_destination` masks the webhook `secret_header` to
-    // `SECRET_MASK`. A GET → edit → PUT round-trip would otherwise write that
-    // literal sentinel back, clobbering the real stored secret. When the
-    // incoming secret equals the mask, preserve the existing stored secret
-    // instead of overwriting it.
-    if let Some(DestinationConfig::Webhook {
-        secret_header: Some(incoming),
-        ..
-    }) = &req.config
-    {
-        if incoming == SECRET_MASK {
-            let stored_secret = match state.destination_store.get(&id).map(|d| d.config) {
-                Some(DestinationConfig::Webhook { secret_header, .. }) => secret_header,
-                _ => None,
-            };
-            if let Some(DestinationConfig::Webhook { secret_header, .. }) = &mut req.config {
-                *secret_header = stored_secret;
-            }
-        }
+    // AAASM-3751 / AAASM-3843: restore any masked secret field from the stored
+    // config *before* validation. A masked Slack `webhook_url` (the sentinel)
+    // would otherwise fail URL validation, and a masked value of any kind must
+    // never overwrite the real stored secret on a GET → edit → PUT round-trip.
+    if let Some(cfg) = &mut req.config {
+        let stored = state.destination_store.get(&id).map(|d| d.config);
+        restore_masked_secrets(cfg, stored);
+    }
+
+    if let Some(cfg) = &req.config {
+        validate_config(cfg).map_err(validation_error_to_problem)?;
     }
 
     let updated = state

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -56,9 +56,11 @@ const SECRET_MASK: &str = "********";
 
 impl From<Destination> for DestinationResponse {
     fn from(d: Destination) -> Self {
-        // AAASM-3688: never return the webhook `secret_header` in cleartext.
-        // Mask it to a fixed sentinel when set so the response still signals
-        // that a secret is configured, without leaking the value.
+        // AAASM-3688 / AAASM-3843: never return a connector secret in cleartext.
+        // Mask each kind's secret-bearing field to a fixed sentinel so the
+        // response still signals that a secret is configured without leaking
+        // the value: webhook `secret_header`, Slack `webhook_url` (bearer-grade),
+        // PagerDuty `routing_key`, OpsGenie `api_key`.
         let config = match d.config {
             DestinationConfig::Webhook {
                 url,
@@ -66,6 +68,18 @@ impl From<Destination> for DestinationResponse {
             } => DestinationConfig::Webhook {
                 url,
                 secret_header: Some(SECRET_MASK.to_string()),
+            },
+            DestinationConfig::Slack { channel_override, .. } => DestinationConfig::Slack {
+                webhook_url: SECRET_MASK.to_string(),
+                channel_override,
+            },
+            DestinationConfig::PagerDuty { severity_map, .. } => DestinationConfig::PagerDuty {
+                routing_key: SECRET_MASK.to_string(),
+                severity_map,
+            },
+            DestinationConfig::OpsGenie { team_id, .. } => DestinationConfig::OpsGenie {
+                api_key: SECRET_MASK.to_string(),
+                team_id,
             },
             other => other,
         };


### PR DESCRIPTION
## Description

Closes AAASM-3843.

The alert-destination read path (`From<Destination> for DestinationResponse`) masked only the webhook `secret_header`, so a `GET /api/v1/alerts/destinations` returned **cleartext secrets** for every other connector kind: Slack `webhook_url` (bearer-grade), PagerDuty `routing_key`, and OpsGenie `api_key`. This PR masks each kind's secret-bearing field to the existing `********` sentinel.

Two companion fixes in the same secret-handling path:
- **Masked PUT round-trip:** generalized the AAASM-3751 webhook-only "restore stored secret when the incoming value is the mask" logic into `restore_masked_secrets`, covering all four kinds, and moved it **before** `validate_config` so a masked Slack `webhook_url` sentinel no longer fails URL validation. A genuine secret rotation (non-masked value) is left untouched.
- **`truncate_body` DoS:** the connector `/test` error-body cap used a raw `body[..2048]` byte slice that panics when 2048 lands mid-multibyte-character; replaced with a UTF-8 char-boundary backoff.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

API responses already returned `********` for webhook secrets; this extends the same masking to other kinds. The real values remain write-only (accepted on create/update, never returned).

## Related Issues

- Related Jira ticket: AAASM-3843

## Testing

- [x] Unit tests added / updated

New regression tests (all green; `cargo fmt`/`clippy -D warnings` clean):
- `from_destination_masks_every_connector_secret` — secret masked on read for all four kinds; non-secret fields preserved.
- `restore_masked_secrets_preserves_stored_for_all_kinds` — masked sentinel restored from stored secret per kind; genuine rotation survives.
- `truncate_body_handles_multibyte_boundary` / `truncate_body_leaves_short_body_untouched` — 2049-byte input whose cap lands mid-`€` truncates to a valid char boundary without panic.

`cargo nextest run -p aa-api`: full destinations suite 43/43 pass.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
