### PR TITLE
[AAASM-3845] 🔒 (aa-api): Scope/tenant-gate secret-injection dispatch_tool

### DIFF
--- a/aa-api/src/routes/dispatch.rs
+++ b/aa-api/src/routes/dispatch.rs
@@ -28,7 +28,7 @@
 
 use aa_core::audit::AuditEntry;
 use aa_core::{AgentId, SessionId};
-use aa_gateway::secrets::{resolver::resolve_placeholders, SecretInjectionError};
+use aa_gateway::secrets::{resolver::resolve_placeholders, SecretInjectionError, TenantScopedStore};
 use aa_sandbox::error::SandboxError;
 use aa_sandbox::registry::ToolKind;
 use aa_sandbox::wasm_dispatch::{dispatch_wasm_tool, WasmDispatchResult};
@@ -38,6 +38,7 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use crate::auth::scope::RequireWrite;
 use crate::error::ProblemDetail;
 use crate::state::AppState;
 
@@ -113,6 +114,8 @@ pub struct SandboxDispatchOutcome {
     request_body = DispatchToolRequest,
     responses(
         (status = 200, description = "Tool dispatch resolved (native) or sandboxed (WASM)", body = DispatchToolResponse),
+        (status = 401, description = "Missing or invalid credentials", body = ProblemDetail),
+        (status = 403, description = "Caller lacks the write scope required to dispatch", body = ProblemDetail),
         (status = 422, description = "Unknown placeholder referenced in args", body = ProblemDetail),
         (status = 500, description = "Sandbox dispatch task panicked", body = ProblemDetail),
         (status = 503, description = "Audit pipeline is not connected", body = ProblemDetail),
@@ -121,6 +124,10 @@ pub struct SandboxDispatchOutcome {
 )]
 pub async fn dispatch_tool(
     Extension(state): Extension<AppState>,
+    // AAASM-3845 — dispatching a tool (and resolving `${SECRET}` placeholders)
+    // is a privileged write action: require an authenticated caller holding the
+    // write scope. The caller's verified tenant then scopes secret resolution.
+    RequireWrite(caller): RequireWrite,
     Json(body): Json<DispatchToolRequest>,
 ) -> Result<Json<DispatchToolResponse>, ProblemDetail> {
     // ── WASM dispatch branch ────────────────────────────────────────
@@ -131,7 +138,15 @@ pub async fn dispatch_tool(
     }
 
     // ── Native / secret-injection branch (existing AAASM-1920 path) ──
-    let outcome = resolve_placeholders(&body.args, state.secrets_store.as_ref()).map_err(|e| match e {
+    // Resolve only within the caller's verified tenant namespace so a caller
+    // can never resolve a `${NAME}` owned by another tenant — the tenant is
+    // taken from the authenticated identity, never from the request body.
+    let scoped = TenantScopedStore::for_tenant(
+        state.secrets_store.as_ref(),
+        caller.tenant.org_id.as_deref(),
+        caller.tenant.team_id.as_deref(),
+    );
+    let outcome = resolve_placeholders(&body.args, &scoped).map_err(|e| match e {
         SecretInjectionError::UnknownPlaceholder { name } => {
             ProblemDetail::from_status(StatusCode::UNPROCESSABLE_ENTITY)
                 .with_detail(format!("Unknown placeholder: ${{{name}}}"))
@@ -300,12 +315,42 @@ fn unix_now_ns() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aa_gateway::secrets::Secret;
+    use crate::auth::scope::Scope;
+    use crate::auth::{AuthenticatedCaller, Tenant};
+    use aa_gateway::secrets::{Secret, SecretsStore, TenantScopedStore};
     use tokio::sync::mpsc;
 
     /// Build the fully-wired in-memory AppState used by the native dispatch path.
     fn state() -> AppState {
         AppState::local_in_memory().expect("in-memory state builds")
+    }
+
+    /// A write-scoped caller bound to a fixed tenant (`org-a` / `team-1`), as
+    /// the auth extractor produces in production (AAASM-3845).
+    fn writer() -> RequireWrite {
+        RequireWrite(AuthenticatedCaller {
+            key_id: "test-writer".to_string(),
+            scopes: vec![Scope::Read, Scope::Write],
+            tenant: Tenant {
+                team_id: Some("team-1".to_string()),
+                org_id: Some("org-a".to_string()),
+            },
+        })
+    }
+
+    /// Register `name`→`value` in `st`'s store under `caller`'s tenant namespace
+    /// so the scoped dispatch path can resolve it.
+    fn register_for(st: &AppState, caller: &AuthenticatedCaller, name: &str, value: &str) {
+        TenantScopedStore::for_tenant(
+            st.secrets_store.as_ref(),
+            caller.tenant.org_id.as_deref(),
+            caller.tenant.team_id.as_deref(),
+        )
+        .register(Secret {
+            name: name.to_string(),
+            value: value.to_string(),
+        })
+        .expect("register secret");
     }
 
     fn req(args: serde_json::Value) -> DispatchToolRequest {
@@ -319,7 +364,7 @@ mod tests {
     async fn passthrough_args_without_placeholders() {
         let st = state();
         let body = req(serde_json::json!({"query": "SELECT 1"}));
-        let resp = dispatch_tool(Extension(st), Json(body)).await.expect("ok").0;
+        let resp = dispatch_tool(Extension(st), writer(), Json(body)).await.expect("ok").0;
         // No `${...}` tokens: args echoed verbatim, nothing substituted, no sandbox.
         assert_eq!(resp.resolved_args, serde_json::json!({"query": "SELECT 1"}));
         assert!(resp.names_substituted.is_empty());
@@ -329,15 +374,11 @@ mod tests {
     #[tokio::test]
     async fn resolves_registered_placeholder() {
         let st = state();
-        st.secrets_store
-            .register(Secret {
-                name: "DB_PASSWORD".to_string(),
-                value: "real-secret".to_string(),
-            })
-            .expect("register secret");
+        let caller = writer();
+        register_for(&st, &caller.0, "DB_PASSWORD", "real-secret");
 
         let body = req(serde_json::json!({"password": "${DB_PASSWORD}"}));
-        let resp = dispatch_tool(Extension(st), Json(body)).await.expect("ok").0;
+        let resp = dispatch_tool(Extension(st), caller, Json(body)).await.expect("ok").0;
 
         assert_eq!(resp.resolved_args, serde_json::json!({"password": "real-secret"}));
         assert_eq!(resp.names_substituted, vec!["DB_PASSWORD".to_string()]);
@@ -347,11 +388,37 @@ mod tests {
     async fn unknown_placeholder_is_422() {
         let st = state();
         let body = req(serde_json::json!({"token": "${MISSING}"}));
-        let err = dispatch_tool(Extension(st), Json(body))
+        let err = dispatch_tool(Extension(st), writer(), Json(body))
             .await
             .expect_err("unknown placeholder rejected");
         assert_eq!(err.status, StatusCode::UNPROCESSABLE_ENTITY.as_u16());
         assert!(err.detail.unwrap().contains("MISSING"));
+    }
+
+    /// AAASM-3845 regression: a secret registered by one tenant must not resolve
+    /// for a caller in a different tenant — it surfaces as an unknown placeholder
+    /// (422) rather than leaking the other tenant's credential.
+    #[tokio::test]
+    async fn cross_tenant_placeholder_is_not_resolved() {
+        let st = state();
+        // org-a / team-1 owns DB_PASSWORD.
+        register_for(&st, &writer().0, "DB_PASSWORD", "real-secret");
+
+        // A different tenant references the same bare name.
+        let attacker = RequireWrite(AuthenticatedCaller {
+            key_id: "attacker".to_string(),
+            scopes: vec![Scope::Read, Scope::Write],
+            tenant: Tenant {
+                team_id: Some("team-1".to_string()),
+                org_id: Some("org-b".to_string()),
+            },
+        });
+        let body = req(serde_json::json!({"password": "${DB_PASSWORD}"}));
+        let err = dispatch_tool(Extension(st), attacker, Json(body))
+            .await
+            .expect_err("cross-tenant placeholder must not resolve");
+        assert_eq!(err.status, StatusCode::UNPROCESSABLE_ENTITY.as_u16());
+        assert!(err.detail.unwrap().contains("DB_PASSWORD"));
     }
 
     #[tokio::test]
@@ -361,7 +428,7 @@ mod tests {
         st.audit_sender = Some(tx);
 
         let body = req(serde_json::json!({"q": "noop"}));
-        let resp = dispatch_tool(Extension(st), Json(body)).await.expect("ok").0;
+        let resp = dispatch_tool(Extension(st), writer(), Json(body)).await.expect("ok").0;
         assert!(resp.names_substituted.is_empty());
 
         // The audit path runs only when audit_sender is wired; an entry must be queued.

--- a/aa-api/tests/dispatch_tool.rs
+++ b/aa-api/tests/dispatch_tool.rs
@@ -8,24 +8,36 @@
 
 mod common;
 
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
 use aa_api::server::build_app;
-use aa_gateway::secrets::Secret;
+use aa_gateway::secrets::{Secret, SecretsStore, TenantScopedStore};
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use serde_json::json;
 use tower::ServiceExt;
 
-/// POST a dispatch request and return (status, parsed-JSON-body).
+/// POST a dispatch request (no auth header) and return (status, parsed-JSON-body).
 async fn post_dispatch(app: axum::Router, body: serde_json::Value) -> (StatusCode, serde_json::Value) {
+    post_dispatch_opt_auth(app, None, body).await
+}
+
+/// POST a dispatch request, optionally carrying a `Bearer <token>` header, and
+/// return (status, parsed-JSON-body).
+async fn post_dispatch_opt_auth(
+    app: axum::Router,
+    token: Option<&str>,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/api/v1/dispatch_tool")
+        .header("content-type", "application/json");
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
     let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/v1/dispatch_tool")
-                .header("content-type", "application/json")
-                .body(Body::from(body.to_string()))
-                .unwrap(),
-        )
+        .oneshot(builder.body(Body::from(body.to_string())).unwrap())
         .await
         .unwrap();
     let status = response.status();
@@ -55,9 +67,11 @@ async fn dispatch_passes_through_args_without_placeholders() {
 #[tokio::test]
 async fn dispatch_resolves_registered_placeholder() {
     // Seed a secret, then reference it via a `${DB_PASSWORD}` placeholder.
+    // `test_state()` is bypass mode (admin, untenanted), so the secret must be
+    // registered under the untenanted namespace for the scoped resolver to find
+    // it (AAASM-3845).
     let state = common::test_state();
-    state
-        .secrets_store
+    TenantScopedStore::for_tenant(state.secrets_store.as_ref(), None, None)
         .register(Secret {
             name: "DB_PASSWORD".to_string(),
             value: "s3cr3t-value".to_string(),
@@ -94,5 +108,78 @@ async fn dispatch_unknown_placeholder_returns_422() {
     assert!(
         detail.contains("MISSING_SECRET"),
         "422 detail should name the unknown placeholder, got: {detail}"
+    );
+}
+
+// ── AAASM-3845 regression: authorization + tenant scoping ───────────────
+
+/// An unauthenticated dispatch (auth enabled, no credential) is rejected before
+/// any secret resolution can occur.
+#[tokio::test]
+async fn dispatch_unauthenticated_is_rejected() {
+    let app = common::test_app_with_auth(&[], 1000);
+    let (status, _body) = post_dispatch_opt_auth(
+        app,
+        None,
+        json!({ "tool": "call_database", "args": { "password": "${DB_PASSWORD}" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+/// A caller with only the read scope cannot dispatch (write scope required).
+#[tokio::test]
+async fn dispatch_requires_write_scope() {
+    let app = common::test_app_with_auth(&[], 1000);
+    let read_only = common::generate_test_jwt("reader", &[Scope::Read]);
+    let (status, _body) = post_dispatch_opt_auth(
+        app,
+        Some(&read_only),
+        json!({ "tool": "call_database", "args": { "query": "SELECT 1" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+/// A secret registered by one tenant is invisible to another tenant: the
+/// cross-tenant reference fails closed as an unknown placeholder (422), while
+/// the owning tenant resolves it (200).
+#[tokio::test]
+async fn dispatch_does_not_resolve_another_tenants_secret() {
+    // Auth enabled; seed DB_PASSWORD under org-a's namespace.
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    TenantScopedStore::for_tenant(state.secrets_store.as_ref(), Some("org-a"), None)
+        .register(Secret {
+            name: "DB_PASSWORD".to_string(),
+            value: "org-a-secret".to_string(),
+        })
+        .expect("register secret");
+    let app = build_app(state);
+
+    // The owning tenant (org-a, write) resolves its secret.
+    let org_a = common::generate_test_jwt_for_tenant("owner", &[Scope::Write], None, Some("org-a"));
+    let (status, body) = post_dispatch_opt_auth(
+        app.clone(),
+        Some(&org_a),
+        json!({ "tool": "call_database", "args": { "password": "${DB_PASSWORD}" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["resolved_args"]["password"], "org-a-secret");
+
+    // A different tenant (org-b, write) references the same bare name and must
+    // not resolve it — no cross-tenant credential disclosure.
+    let org_b = common::generate_test_jwt_for_tenant("intruder", &[Scope::Write], None, Some("org-b"));
+    let (status, body) = post_dispatch_opt_auth(
+        app,
+        Some(&org_b),
+        json!({ "tool": "call_database", "args": { "password": "${DB_PASSWORD}" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    let detail = body["detail"].as_str().unwrap_or_default();
+    assert!(
+        detail.contains("DB_PASSWORD"),
+        "cross-tenant ref must fail closed as unknown placeholder, got: {detail}"
     );
 }

--- a/aa-gateway/src/secrets/mod.rs
+++ b/aa-gateway/src/secrets/mod.rs
@@ -17,9 +17,11 @@
 
 pub mod error;
 pub mod resolver;
+pub mod scope;
 pub mod store;
 pub mod types;
 
 pub use error::{SecretInjectionError, SecretsError};
+pub use scope::{tenant_namespace, TenantScopedStore};
 pub use store::{InMemorySecretsStore, SecretsStore};
 pub use types::Secret;

--- a/aa-gateway/src/secrets/scope.rs
+++ b/aa-gateway/src/secrets/scope.rs
@@ -1,0 +1,202 @@
+//! Tenant scoping for Secret Injection (AAASM-3845).
+//!
+//! The [`SecretsStore`] surface is a flat `name → value` registry with no
+//! per-tenant ownership (per-team scoping is an explicit non-goal of the
+//! AAASM-1920 v0.0.1 stub). On its own that means `dispatch_tool` resolves any
+//! registered `${NAME}` placeholder for *any* caller — a cross-tenant secret
+//! disclosure once more than one tenant shares a gateway.
+//!
+//! [`TenantScopedStore`] closes that gap at the resolution boundary: it wraps a
+//! shared `&dyn SecretsStore` and binds every operation to a single tenant
+//! namespace derived from the *verified* caller. A placeholder registered by
+//! tenant A is stored under A's namespace, so a tenant-B caller resolving the
+//! same bare name looks in B's namespace, misses, and the resolver surfaces
+//! [`SecretInjectionError::UnknownPlaceholder`](crate::secrets::SecretInjectionError::UnknownPlaceholder)
+//! rather than leaking A's credential. Because it implements [`SecretsStore`]
+//! itself, it drops straight into
+//! [`resolve_placeholders`](crate::secrets::resolver::resolve_placeholders)
+//! with no resolver change.
+//!
+//! The tenant identity is taken **only** from the authenticated caller
+//! (HTTP `AuthenticatedCaller::tenant`, gRPC `VerifiedCaller`), never from the
+//! request body — a client cannot widen its scope by naming a different tenant.
+
+use crate::secrets::{Secret, SecretsError, SecretsStore};
+
+/// Field separator used when composing a scoped storage key.
+///
+/// ASCII Unit Separator (`0x1F`): it cannot appear in a valid placeholder name
+/// (`[A-Z][A-Z0-9_]*`), so `"<org>\u{1f}<team>\u{1f}<name>"` is unambiguous and
+/// no `(org, team, name)` triple can collide with a different one.
+const SEP: char = '\u{1f}';
+
+/// Derive a stable tenant namespace from a caller's verified `(org_id, team_id)`.
+///
+/// The namespace is the isolation boundary for secret resolution: two callers
+/// resolve the *same* secrets iff they produce the *same* namespace. Both
+/// fields participate so that two teams within one org — or one team across two
+/// orgs — never share a secret namespace.
+///
+/// A caller with neither field (an untenanted / single-tenant-deployment caller)
+/// maps to the shared empty namespace, mirroring the untenanted-fallback
+/// convention used by the approval and topology tenancy guards (AAASM-3788).
+/// The tenant values are read only from the authenticated identity, never from
+/// request input, so this cannot be redirected by a client.
+pub fn tenant_namespace(org_id: Option<&str>, team_id: Option<&str>) -> String {
+    format!("{}{SEP}{}", org_id.unwrap_or(""), team_id.unwrap_or(""))
+}
+
+/// A tenant-bound view over a shared [`SecretsStore`].
+///
+/// Every operation transparently rewrites the bare placeholder name to a
+/// namespaced storage key (`"<namespace>\u{1f}<name>"`) before delegating to the
+/// inner store, so a tenant can only register, look up, list, or delete secrets
+/// within its own namespace. Construct one per request from the verified
+/// caller's tenant and hand it to the resolver.
+pub struct TenantScopedStore<'a> {
+    inner: &'a dyn SecretsStore,
+    namespace: String,
+}
+
+impl<'a> TenantScopedStore<'a> {
+    /// Bind `inner` to `namespace` (typically from [`tenant_namespace`]).
+    pub fn new(inner: &'a dyn SecretsStore, namespace: impl Into<String>) -> Self {
+        Self {
+            inner,
+            namespace: namespace.into(),
+        }
+    }
+
+    /// Bind `inner` to the namespace derived from a caller's `(org_id, team_id)`.
+    pub fn for_tenant(inner: &'a dyn SecretsStore, org_id: Option<&str>, team_id: Option<&str>) -> Self {
+        Self::new(inner, tenant_namespace(org_id, team_id))
+    }
+
+    /// Compose the namespaced storage key for a bare placeholder name.
+    fn scoped_key(&self, name: &str) -> String {
+        format!("{}{SEP}{}", self.namespace, name)
+    }
+
+    /// The key prefix (`"<namespace>\u{1f}"`) that every key in this tenant's
+    /// namespace starts with — used to filter [`SecretsStore::list`].
+    fn prefix(&self) -> String {
+        format!("{}{SEP}", self.namespace)
+    }
+}
+
+impl SecretsStore for TenantScopedStore<'_> {
+    fn register(&self, secret: Secret) -> Result<(), SecretsError> {
+        self.inner.register(Secret {
+            name: self.scoped_key(&secret.name),
+            value: secret.value,
+        })
+    }
+
+    fn lookup(&self, name: &str) -> Option<String> {
+        self.inner.lookup(&self.scoped_key(name))
+    }
+
+    fn list(&self) -> Vec<String> {
+        let prefix = self.prefix();
+        self.inner
+            .list()
+            .into_iter()
+            .filter_map(|k| k.strip_prefix(&prefix).map(str::to_owned))
+            .collect()
+    }
+
+    fn delete(&self, name: &str) -> Result<(), SecretsError> {
+        self.inner.delete(&self.scoped_key(name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secrets::resolver::resolve_placeholders;
+    use crate::secrets::{InMemorySecretsStore, SecretInjectionError};
+    use serde_json::json;
+
+    fn secret(name: &str, value: &str) -> Secret {
+        Secret {
+            name: name.to_owned(),
+            value: value.to_owned(),
+        }
+    }
+
+    #[test]
+    fn distinct_tenants_produce_distinct_namespaces() {
+        let a = tenant_namespace(Some("org-a"), Some("team-1"));
+        let b = tenant_namespace(Some("org-b"), Some("team-1"));
+        let c = tenant_namespace(Some("org-a"), Some("team-2"));
+        assert_ne!(a, b, "different org must isolate");
+        assert_ne!(a, c, "different team must isolate");
+    }
+
+    #[test]
+    fn untenanted_callers_share_one_namespace() {
+        assert_eq!(tenant_namespace(None, None), tenant_namespace(None, None));
+    }
+
+    #[test]
+    fn same_tenant_resolves_its_own_secret() {
+        let backing = InMemorySecretsStore::new();
+        let store = TenantScopedStore::for_tenant(&backing, Some("org-a"), Some("team-1"));
+        store.register(secret("DB_PASSWORD", "real-secret-a")).unwrap();
+
+        let out = resolve_placeholders(&json!("${DB_PASSWORD}"), &store).unwrap();
+        assert_eq!(out.resolved, json!("real-secret-a"));
+        assert_eq!(out.names_substituted, vec!["DB_PASSWORD"]);
+    }
+
+    #[test]
+    fn cross_tenant_lookup_does_not_resolve() {
+        let backing = InMemorySecretsStore::new();
+        // Tenant A registers a secret.
+        TenantScopedStore::for_tenant(&backing, Some("org-a"), Some("team-1"))
+            .register(secret("DB_PASSWORD", "real-secret-a"))
+            .unwrap();
+
+        // Tenant B references the same bare name and must NOT resolve it.
+        let tenant_b = TenantScopedStore::for_tenant(&backing, Some("org-b"), Some("team-1"));
+        assert_eq!(tenant_b.lookup("DB_PASSWORD"), None);
+
+        let err = resolve_placeholders(&json!("${DB_PASSWORD}"), &tenant_b)
+            .expect_err("cross-tenant placeholder must not resolve");
+        assert_eq!(
+            err,
+            SecretInjectionError::UnknownPlaceholder {
+                name: "DB_PASSWORD".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn list_returns_only_this_tenants_names_unwrapped() {
+        let backing = InMemorySecretsStore::new();
+        TenantScopedStore::for_tenant(&backing, Some("org-a"), None)
+            .register(secret("A_SECRET", "va"))
+            .unwrap();
+        TenantScopedStore::for_tenant(&backing, Some("org-b"), None)
+            .register(secret("B_SECRET", "vb"))
+            .unwrap();
+
+        let a = TenantScopedStore::for_tenant(&backing, Some("org-a"), None);
+        assert_eq!(a.list(), vec!["A_SECRET"]);
+    }
+
+    #[test]
+    fn delete_is_scoped_to_the_tenant() {
+        let backing = InMemorySecretsStore::new();
+        let tenant_a = TenantScopedStore::for_tenant(&backing, Some("org-a"), None);
+        tenant_a.register(secret("DB_PASSWORD", "va")).unwrap();
+
+        // Tenant B cannot delete tenant A's secret (different namespace → NotFound).
+        let tenant_b = TenantScopedStore::for_tenant(&backing, Some("org-b"), None);
+        assert!(tenant_b.delete("DB_PASSWORD").is_err());
+
+        // Tenant A can.
+        assert!(tenant_a.delete("DB_PASSWORD").is_ok());
+        assert_eq!(tenant_a.lookup("DB_PASSWORD"), None);
+    }
+}

--- a/aa-gateway/src/service/secrets_service.rs
+++ b/aa-gateway/src/service/secrets_service.rs
@@ -15,8 +15,9 @@ use aa_proto::assembly::secrets::v1::secrets_service_server::SecretsService;
 use aa_proto::assembly::secrets::v1::{DispatchToolRequest, DispatchToolResponse};
 use tonic::{Request, Response, Status};
 
+use crate::iam::VerifiedCaller;
 use crate::secrets::resolver::resolve_placeholders;
-use crate::secrets::{SecretInjectionError, SecretsStore};
+use crate::secrets::{SecretInjectionError, SecretsStore, TenantScopedStore};
 
 /// gRPC service implementation for the `DispatchTool` RPC.
 ///
@@ -39,14 +40,31 @@ impl SecretsService for SecretsServiceImpl {
         &self,
         request: Request<DispatchToolRequest>,
     ) -> Result<Response<DispatchToolResponse>, Status> {
+        // AAASM-3845 — bind secret resolution to the verified caller's tenant.
+        // The agent-plane auth interceptor (AAASM-3788) injects a
+        // `VerifiedCaller` for this service; its absence means the request did
+        // not pass authentication, so we fail closed rather than resolve
+        // secrets for an unauthenticated peer (defense-in-depth — the
+        // interceptor already rejects, but the handler must not assume it).
+        let caller = request.extensions().get::<VerifiedCaller>().cloned().ok_or_else(|| {
+            Status::unauthenticated("missing verified caller; secret dispatch requires authentication")
+        })?;
+
         let req = request.into_inner();
 
         // Decode the placeholder-form args from canonical JSON bytes.
         let placeholder_args: serde_json::Value = serde_json::from_slice(&req.args_json)
             .map_err(|e| Status::invalid_argument(format!("args_json is not valid JSON: {e}")))?;
 
-        // Resolve placeholders against the shared store.
-        let outcome = resolve_placeholders(&placeholder_args, self.secrets_store.as_ref()).map_err(|e| match e {
+        // Resolve only within the caller's tenant namespace, so a caller can
+        // never resolve a `${NAME}` owned by another tenant — a cross-tenant
+        // reference misses and surfaces as `UnknownPlaceholder`.
+        let scoped = TenantScopedStore::for_tenant(
+            self.secrets_store.as_ref(),
+            caller.org_id.as_deref(),
+            caller.team_id.as_deref(),
+        );
+        let outcome = resolve_placeholders(&placeholder_args, &scoped).map_err(|e| match e {
             SecretInjectionError::UnknownPlaceholder { name } => {
                 Status::failed_precondition(format!("Unknown placeholder: ${{{name}}}"))
             }
@@ -71,29 +89,51 @@ impl SecretsService for SecretsServiceImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::secrets::{InMemorySecretsStore, Secret};
+    use crate::secrets::{InMemorySecretsStore, Secret, TenantScopedStore};
     use serde_json::json;
 
-    fn populated_store(entries: &[(&str, &str)]) -> Arc<dyn SecretsStore> {
-        let store = InMemorySecretsStore::new();
+    /// Tenant identity used by the happy-path tests.
+    fn caller(org: Option<&str>, team: Option<&str>) -> VerifiedCaller {
+        VerifiedCaller {
+            agent_key: [7u8; 16],
+            team_id: team.map(str::to_owned),
+            org_id: org.map(str::to_owned),
+        }
+    }
+
+    /// Build a shared backing store and pre-register `entries` under the given
+    /// caller's tenant namespace (the only way a `dispatch_tool` for that caller
+    /// can resolve them after AAASM-3845).
+    fn store_for(owner: &VerifiedCaller, entries: &[(&str, &str)]) -> Arc<dyn SecretsStore> {
+        let backing = Arc::new(InMemorySecretsStore::new());
+        let scoped = TenantScopedStore::for_tenant(backing.as_ref(), owner.org_id.as_deref(), owner.team_id.as_deref());
         for (name, value) in entries {
-            store
+            scoped
                 .register(Secret {
                     name: (*name).to_owned(),
                     value: (*value).to_owned(),
                 })
                 .expect("register synthetic test secret");
         }
-        Arc::new(store)
+        backing
+    }
+
+    /// A `DispatchTool` request carrying a verified caller in its extensions,
+    /// as the AAASM-3788 auth interceptor injects in production.
+    fn req_as(caller: &VerifiedCaller, args: serde_json::Value) -> Request<DispatchToolRequest> {
+        let mut req = Request::new(DispatchToolRequest {
+            tool: "call_database".to_owned(),
+            args_json: serde_json::to_vec(&args).unwrap(),
+        });
+        req.extensions_mut().insert(caller.clone());
+        req
     }
 
     #[tokio::test]
     async fn dispatch_tool_returns_resolved_args_on_success() {
-        let svc = SecretsServiceImpl::new(populated_store(&[("DB_PASSWORD", "real-secret-abc")]));
-        let req = Request::new(DispatchToolRequest {
-            tool: "call_database".to_owned(),
-            args_json: serde_json::to_vec(&json!({"connection_string": "${DB_PASSWORD}"})).unwrap(),
-        });
+        let owner = caller(Some("org-a"), Some("team-1"));
+        let svc = SecretsServiceImpl::new(store_for(&owner, &[("DB_PASSWORD", "real-secret-abc")]));
+        let req = req_as(&owner, json!({"connection_string": "${DB_PASSWORD}"}));
 
         let resp = svc.dispatch_tool(req).await.expect("dispatch ok").into_inner();
         let resolved: serde_json::Value = serde_json::from_slice(&resp.resolved_args_json).unwrap();
@@ -103,11 +143,9 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_tool_returns_failed_precondition_on_unknown_placeholder() {
-        let svc = SecretsServiceImpl::new(populated_store(&[("DB_PASSWORD", "real-secret-abc")]));
-        let req = Request::new(DispatchToolRequest {
-            tool: "call_database".to_owned(),
-            args_json: serde_json::to_vec(&json!({"x": "${UNKNOWN_SECRET}"})).unwrap(),
-        });
+        let owner = caller(Some("org-a"), Some("team-1"));
+        let svc = SecretsServiceImpl::new(store_for(&owner, &[("DB_PASSWORD", "real-secret-abc")]));
+        let req = req_as(&owner, json!({"x": "${UNKNOWN_SECRET}"}));
 
         let err = svc
             .dispatch_tool(req)
@@ -119,13 +157,52 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_tool_returns_invalid_argument_on_malformed_json() {
-        let svc = SecretsServiceImpl::new(populated_store(&[]));
-        let req = Request::new(DispatchToolRequest {
+        let owner = caller(Some("org-a"), None);
+        let svc = SecretsServiceImpl::new(store_for(&owner, &[]));
+        let mut req = Request::new(DispatchToolRequest {
             tool: "x".to_owned(),
             args_json: b"\xff\xff not json \xff".to_vec(),
         });
+        req.extensions_mut().insert(owner);
 
         let err = svc.dispatch_tool(req).await.expect_err("malformed args must error");
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    // ── AAASM-3845 regression: authorization + tenant scoping ───────────
+
+    #[tokio::test]
+    async fn dispatch_tool_rejects_request_without_verified_caller() {
+        // No `VerifiedCaller` in extensions ⇒ unauthenticated peer ⇒ fail closed,
+        // and a registered secret is never resolved.
+        let owner = caller(Some("org-a"), Some("team-1"));
+        let svc = SecretsServiceImpl::new(store_for(&owner, &[("DB_PASSWORD", "real-secret-abc")]));
+        let req = Request::new(DispatchToolRequest {
+            tool: "call_database".to_owned(),
+            args_json: serde_json::to_vec(&json!({"connection_string": "${DB_PASSWORD}"})).unwrap(),
+        });
+
+        let err = svc
+            .dispatch_tool(req)
+            .await
+            .expect_err("unauthenticated dispatch must be rejected");
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[tokio::test]
+    async fn dispatch_tool_does_not_resolve_another_tenants_secret() {
+        // Tenant A owns DB_PASSWORD; tenant B references the same bare name.
+        let owner = caller(Some("org-a"), Some("team-1"));
+        let svc = SecretsServiceImpl::new(store_for(&owner, &[("DB_PASSWORD", "real-secret-abc")]));
+
+        let attacker = caller(Some("org-b"), Some("team-1"));
+        let req = req_as(&attacker, json!({"connection_string": "${DB_PASSWORD}"}));
+
+        let err = svc
+            .dispatch_tool(req)
+            .await
+            .expect_err("cross-tenant placeholder must not resolve");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("DB_PASSWORD"));
     }
 }

--- a/aa-gateway/tests/grpc_auth_test.rs
+++ b/aa-gateway/tests/grpc_auth_test.rs
@@ -13,7 +13,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use aa_gateway::iam::{auth_interceptor, CREDENTIAL_METADATA_KEY};
-use aa_gateway::secrets::{InMemorySecretsStore, Secret, SecretsStore};
+use aa_gateway::secrets::{InMemorySecretsStore, Secret, SecretsStore, TenantScopedStore};
 use aa_gateway::service::{ApprovalServiceImpl, SecretsServiceImpl, TopologyServiceImpl};
 use aa_gateway::{AgentRecord, AgentRegistry, AgentStatus};
 
@@ -262,7 +262,10 @@ async fn secrets_dispatch_with_valid_token_resolves() {
         .register(agent_record([0x07u8; 16], "tok-secrets", None))
         .unwrap();
     let store = InMemorySecretsStore::new();
-    store
+    // AAASM-3845: resolution is scoped to the caller's tenant. The "tok-secrets"
+    // agent is untenanted (team_id/org_id = None), so register the secret under
+    // the untenanted namespace for the dispatch to resolve it.
+    TenantScopedStore::for_tenant(&store, None, None)
         .register(Secret {
             name: "DB_PASSWORD".to_owned(),
             value: "real-secret-abc".to_owned(),

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -76,7 +76,7 @@ use aa_gateway::engine::PolicyEngine;
 use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig};
 use aa_gateway::registry::{AgentRegistry, OrphanMode};
 use aa_gateway::routes::healthz::{healthz, HealthzState};
-use aa_gateway::secrets::{InMemorySecretsStore, Secret, SecretsStore};
+use aa_gateway::secrets::{InMemorySecretsStore, Secret, SecretsStore, TenantScopedStore};
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
 use aa_sandbox::registry::ToolRegistry;
@@ -247,12 +247,19 @@ impl TopologyTestEnv {
         let (mut state, audit_dir, alert_store, key_store) = build_test_state()?;
 
         // Replace the empty store with one pre-populated for this scenario.
+        // AAASM-3845: secret resolution is now scoped to the caller's tenant.
+        // The harness runs in bypass mode (untenanted admin), so the secrets
+        // must be registered under the untenanted namespace for the
+        // `dispatch_tool` route to resolve them.
         let populated = Arc::new(InMemorySecretsStore::new());
-        for (name, value) in entries {
-            (*populated).register(Secret {
-                name: (*name).to_owned(),
-                value: (*value).to_owned(),
-            })?;
+        {
+            let scoped = TenantScopedStore::for_tenant(populated.as_ref(), None, None);
+            for (name, value) in entries {
+                scoped.register(Secret {
+                    name: (*name).to_owned(),
+                    value: (*value).to_owned(),
+                })?;
+            }
         }
         state.secrets_store = populated as Arc<dyn SecretsStore>;
 

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -4950,6 +4950,24 @@ export interface operations {
                     "application/json": components["schemas"]["DispatchToolResponse"];
                 };
             };
+            /** @description Missing or invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Caller lacks the write scope required to dispatch */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
             /** @description Unknown placeholder referenced in args */
             422: {
                 headers: {

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1442,6 +1442,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DispatchToolResponse'
+        '401':
+          description: Missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '403':
+          description: Caller lacks the write scope required to dispatch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
         '422':
           description: Unknown placeholder referenced in args
           content:


### PR DESCRIPTION
## Description

`dispatch_tool` resolves `${SECRET}` placeholders against a shared, flat
`SecretsStore` with **no authorization or tenant binding** on either transport,
so any caller that reaches the endpoint can resolve **any** registered secret —
a cross-tenant credential-disclosure / governance-bypass (AAASM-3845, High).

This PR closes the gap on both planes:

- **HTTP** `POST /api/v1/dispatch_tool` (`aa-api`): the handler now requires the
  `RequireWrite` scope (authenticated + write), and resolves placeholders only
  within the caller's **verified** tenant namespace
  (`AuthenticatedCaller::tenant`). Unauthenticated → 401, read-only → 403,
  cross-tenant reference → 422 (unknown placeholder, fail-closed).
- **gRPC** `SecretsService::dispatch_tool` (`aa-gateway`): the handler reads the
  `VerifiedCaller` injected by the AAASM-3788 auth interceptor, fails closed
  (`unauthenticated`) if it is absent, and scopes resolution to the caller's
  tenant. A cross-tenant reference returns `failed_precondition`.

Tenant binding is implemented by a new `TenantScopedStore` adapter that
namespaces every store operation by the caller's `(org_id, team_id)`, derived
**only** from the authenticated identity (never from the request body). A
secret registered by tenant A lives in A's namespace, so a tenant-B caller
referencing the same bare `${NAME}` misses and is rejected rather than served
A's credential. The underlying store remains the AAASM-1920 stub; the gate is
enforced regardless, at the resolution boundary.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] No

The HTTP route already sat behind the deny-by-default `require_authentication`
gate; this adds the write-scope + tenant requirement on top. Secret resolution
is now tenant-scoped, so secrets must be registered under the resolving
tenant's namespace (the v0.0.1 store has no production registration path yet —
secrets are seeded only in tests/fixtures, which are updated here).

## Related Issues

- Related Jira ticket: AAASM-3845
- Closes AAASM-3845

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

- `aa-gateway/src/secrets/scope.rs`: tenant-namespace isolation, scoped
  register/lookup/list/delete, cross-tenant miss via the resolver.
- `aa-gateway` gRPC handler: rejects a request with no `VerifiedCaller`
  (`unauthenticated`); rejects a cross-tenant reference (`failed_precondition`);
  same-tenant resolves.
- `aa-api` HTTP handler (unit) + `tests/dispatch_tool.rs` (integration):
  unauthenticated → 401, read-only → 403, cross-tenant → 422, owning tenant
  resolves (200).

Validation (worktree, `-p aa-api -p aa-gateway`): `cargo build`,
`cargo nextest run`, `cargo fmt --all`, `cargo clippy --all-targets -D warnings`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
