### PR TITLE
[AAASM-3846] 🔒 (aa-api): Close post-authN function-level/tenant authz gaps

### DIFF
--- a/aa-api/src/routes/audit.rs
+++ b/aa-api/src/routes/audit.rs
@@ -13,7 +13,27 @@ use utoipa::{IntoParams, ToSchema};
 use aa_core::AgentId;
 use aa_core::AuditEntry;
 
+use crate::auth::scope::{RequireRead, Scope};
+use crate::auth::AuthenticatedCaller;
 use crate::state::AppState;
+
+/// AAASM-3846 — confine audit aggregation to the caller's tenant.
+///
+/// The audit log is per-tenant data. Mirrors the org scoping `logs.rs` applies
+/// to `GET /api/v1/logs`: an admin sees every org's entries; a tenant-scoped
+/// caller sees only its own org; a non-admin caller with no org scope sees
+/// nothing (rather than a cross-tenant dump). Entries with `org_id = None`
+/// never match an explicit org filter, so multi-tenancy isolation requires
+/// explicit org tagging on the entry at write time.
+fn scope_entries_to_caller(caller: &AuthenticatedCaller, entries: Vec<AuditEntry>) -> Vec<AuditEntry> {
+    if caller.scopes.contains(&Scope::Admin) {
+        return entries;
+    }
+    match caller.tenant.org_id.as_deref() {
+        Some(org) => entries.into_iter().filter(|e| e.org_id() == Some(org)).collect(),
+        None => Vec::new(),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Response types
@@ -128,11 +148,13 @@ pub struct SandboxSummaryParams {
     params(ViolationsParams),
     responses(
         (status = 200, description = "Violation heatmap nodes", body = ViolationsByLineageResponse),
-        (status = 400, description = "Invalid query parameter")
+        (status = 400, description = "Invalid query parameter"),
+        (status = 401, description = "Missing or invalid credentials")
     ),
     tag = "audit"
 )]
 pub async fn get_violations_by_lineage(
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     axum::extract::Query(params): axum::extract::Query<ViolationsParams>,
 ) -> impl IntoResponse {
@@ -150,6 +172,9 @@ pub async fn get_violations_by_lineage(
         .list_violations(since_ns, root_agent)
         .await
         .unwrap_or_default();
+
+    // AAASM-3846 — bind the aggregation to the caller's tenant.
+    let entries = scope_entries_to_caller(&caller, entries);
 
     let nodes = aggregate_violations(&entries);
 
@@ -176,11 +201,13 @@ pub async fn get_violations_by_lineage(
     params(SandboxSummaryParams),
     responses(
         (status = 200, description = "Sandbox / observe-mode aggregate counts", body = SandboxSummaryResponse),
-        (status = 400, description = "Invalid query parameter")
+        (status = 400, description = "Invalid query parameter"),
+        (status = 401, description = "Missing or invalid credentials")
     ),
     tag = "audit"
 )]
 pub async fn get_sandbox_summary(
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     axum::extract::Query(params): axum::extract::Query<SandboxSummaryParams>,
 ) -> impl IntoResponse {
@@ -198,6 +225,9 @@ pub async fn get_sandbox_summary(
         .list_dry_run(since_ns, root_agent)
         .await
         .unwrap_or_default();
+
+    // AAASM-3846 — bind the aggregation to the caller's tenant.
+    let entries = scope_entries_to_caller(&caller, entries);
 
     let (counts, top_rule) = aggregate_sandbox_summary(&entries);
 

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -24,6 +24,7 @@ use aa_gateway::policy::rbac::MutationKind;
 use aa_gateway::policy::scope::PolicyScope;
 
 use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
+use crate::auth::scope::RequireRead;
 use crate::error::ProblemDetail;
 use crate::models::capability::{
     AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, CapabilityOverrideRequest,
@@ -293,11 +294,15 @@ pub struct MatrixQueryParams {
     path = "/api/v1/capability/matrix",
     params(MatrixQueryParams),
     responses(
-        (status = 200, description = "Capability matrix snapshot (filtered)", body = CapabilityMatrix)
+        (status = 200, description = "Capability matrix snapshot (filtered)", body = CapabilityMatrix),
+        (status = 401, description = "Missing or invalid credentials")
     ),
     tag = "capability"
 )]
 pub async fn get_matrix(
+    // AAASM-3846 — the capability matrix is sensitive policy state; require an
+    // authenticated reader rather than serving it unauthenticated.
+    RequireRead(_caller): RequireRead,
     Query(params): Query<MatrixQueryParams>,
     Extension(state): Extension<AppState>,
 ) -> (StatusCode, Json<CapabilityMatrix>) {
@@ -410,11 +415,15 @@ pub struct ListOverridesParams {
     path = "/api/v1/capability/override",
     params(("agent_id" = Option<String>, Query, description = "Filter results to overrides that affect this agent id")),
     responses(
-        (status = 200, description = "Active override records", body = Vec<OverrideRecord>)
+        (status = 200, description = "Active override records", body = Vec<OverrideRecord>),
+        (status = 401, description = "Missing or invalid credentials")
     ),
     tag = "capability"
 )]
 pub async fn list_overrides(
+    // AAASM-3846 — require an authenticated reader before disclosing the
+    // override log.
+    RequireRead(_caller): RequireRead,
     Query(params): Query<ListOverridesParams>,
     Extension(state): Extension<AppState>,
 ) -> (StatusCode, Json<Vec<OverrideRecord>>) {
@@ -436,11 +445,23 @@ pub async fn list_overrides(
     ),
     responses(
         (status = 204, description = "Override revoked; cells restored to base policy"),
+        (status = 403, description = "Caller lacks the role required to mutate capability state"),
         (status = 404, description = "No active override with this id", body = ProblemDetail)
     ),
     tag = "capability"
 )]
-pub async fn revoke_override(Extension(state): Extension<AppState>, Path(id): Path<String>) -> impl IntoResponse {
+pub async fn revoke_override(
+    // AAASM-3846 — revoking an override mutates capability state, so it must be
+    // gated identically to `apply_override` (a `Global`-scope policy update),
+    // not left open to any caller.
+    policy_auth: PolicyWriteAuth,
+    Extension(state): Extension<AppState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if let Err(denied) = policy_auth.check_mutation(&PolicyScope::Global, MutationKind::Update) {
+        return denied.into_response();
+    }
+
     match state.capability_store.revoke_override(&id).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(RevokeOverrideError::NotFound) => ProblemDetail::from_status(StatusCode::NOT_FOUND)

--- a/aa-api/src/routes/iam.rs
+++ b/aa-api/src/routes/iam.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
+use crate::auth::scope::RequireAdmin;
 use crate::error::ProblemDetail;
 use crate::state::AppState;
 
@@ -173,11 +174,18 @@ pub struct GenerateApiKeyRequest {
     get,
     path = "/api/v1/iam/api-keys",
     responses(
-        (status = 200, description = "All API keys, newest first", body = [ApiKeyResponse])
+        (status = 200, description = "All API keys, newest first", body = [ApiKeyResponse]),
+        (status = 403, description = "Caller lacks the admin role required to read IAM state")
     ),
     tag = "iam"
 )]
-pub async fn list_api_keys(Extension(state): Extension<AppState>) -> (StatusCode, Json<Vec<ApiKeyResponse>>) {
+pub async fn list_api_keys(
+    // AAASM-3846 — listing API keys discloses sensitive IAM state (labels,
+    // scopes, owners, activity), so it requires the same admin authority as the
+    // generate / revoke / rotate mutations rather than being open to any caller.
+    RequireAdmin(_caller): RequireAdmin,
+    Extension(state): Extension<AppState>,
+) -> (StatusCode, Json<Vec<ApiKeyResponse>>) {
     let keys = state
         .iam_api_key_store
         .list()

--- a/aa-api/tests/audit_sandbox_summary.rs
+++ b/aa-api/tests/audit_sandbox_summary.rs
@@ -6,9 +6,67 @@
 
 mod common;
 
+use std::sync::Arc;
+
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
+use aa_core::audit::{AuditEntry, AuditEventType, Lineage};
+use aa_core::{AgentId, SessionId};
+use aa_gateway::AuditReader;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
+
+/// Build a dry-run shadow `deny` audit entry tagged with an org tenant.
+fn dry_run_deny_entry(agent_byte: u8, org: &str) -> AuditEntry {
+    AuditEntry::new_with_lineage(
+        0,
+        1_900_000_000_000_000_000,
+        AuditEventType::ToolCallIntercepted,
+        AgentId::from_bytes([agent_byte; 16]),
+        SessionId::from_bytes([0xEE; 16]),
+        r#"{"dry_run":true,"shadow_decision":"deny"}"#.to_string(),
+        [0u8; 32],
+        Lineage {
+            org_id: Some(org.to_string()),
+            ..Lineage::default()
+        },
+    )
+}
+
+fn audit_dir_with(entries: &[AuditEntry]) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("aa-sandbox-test-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut contents = String::new();
+    for e in entries {
+        contents.push_str(&serde_json::to_string(e).unwrap());
+        contents.push('\n');
+    }
+    std::fs::write(dir.join("audit.jsonl"), contents).unwrap();
+    dir
+}
+
+fn app_with_auth_and_audit(dir: &std::path::Path) -> axum::Router {
+    let mut state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.audit_reader = Arc::new(AuditReader::new(dir.to_path_buf()));
+    aa_api::build_app(state)
+}
+
+fn bearer(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
 
 #[tokio::test]
 async fn sandbox_summary_returns_zero_counts_when_no_audit_entries() {
@@ -81,4 +139,70 @@ async fn sandbox_summary_falls_back_to_24h_for_invalid_window() {
     // Default is 24h = 86_400 seconds — invalid input degrades to default,
     // matching the violations-by-lineage handler's behaviour.
     assert_eq!(json["window_secs"], 86_400);
+}
+
+// ── AAASM-3846 — function-level/tenant authz on the sandbox summary ──────────
+
+/// The endpoint previously took no caller; it must now reject an unauthenticated
+/// request rather than serving every tenant's shadow-mode aggregate.
+#[tokio::test]
+async fn sandbox_summary_unauthenticated_is_401() {
+    let app = aa_api::build_app(common::test_state_with_auth(AuthMode::On, &[], 1000));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/audit/sandbox-summary")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// A tenant-scoped caller's aggregate counts only its own org's shadow events,
+/// never another org's.
+#[tokio::test]
+async fn sandbox_summary_tenant_caller_counts_only_own_org() {
+    let dir = audit_dir_with(&[
+        dry_run_deny_entry(0x11, "acme"),
+        dry_run_deny_entry(0x22, "globex"),
+        dry_run_deny_entry(0x23, "globex"),
+    ]);
+    let app = app_with_auth_and_audit(&dir);
+
+    let token = common::generate_test_jwt_for_tenant("u", &[Scope::Read], None, Some("acme"));
+    let response = app
+        .oneshot(bearer("/api/v1/audit/sandbox-summary", &token))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["counts"]["would_be_denies"], 1,
+        "an acme-scoped caller must count only acme's one shadow deny, not globex's two"
+    );
+}
+
+/// An admin caller still aggregates every org's shadow events.
+#[tokio::test]
+async fn sandbox_summary_admin_counts_all_orgs() {
+    let dir = audit_dir_with(&[
+        dry_run_deny_entry(0x11, "acme"),
+        dry_run_deny_entry(0x22, "globex"),
+        dry_run_deny_entry(0x23, "globex"),
+    ]);
+    let app = app_with_auth_and_audit(&dir);
+
+    let token = common::generate_test_jwt("admin", &[Scope::Admin]);
+    let response = app
+        .oneshot(bearer("/api/v1/audit/sandbox-summary", &token))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["counts"]["would_be_denies"], 3,
+        "admin counts every org's shadow denies"
+    );
 }

--- a/aa-api/tests/audit_violations.rs
+++ b/aa-api/tests/audit_violations.rs
@@ -2,9 +2,69 @@
 
 mod common;
 
+use std::sync::Arc;
+
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
+use aa_core::audit::{AuditEntry, AuditEventType, Lineage};
+use aa_core::{AgentId, SessionId};
+use aa_gateway::AuditReader;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
+
+/// Build a `PolicyViolation` audit entry tagged with an org tenant.
+fn violation_entry(agent_byte: u8, org: &str) -> AuditEntry {
+    AuditEntry::new_with_lineage(
+        0,
+        1_900_000_000_000_000_000,
+        AuditEventType::PolicyViolation,
+        AgentId::from_bytes([agent_byte; 16]),
+        SessionId::from_bytes([0xEE; 16]),
+        r#"{"policy_rule":"rule-x"}"#.to_string(),
+        [0u8; 32],
+        Lineage {
+            org_id: Some(org.to_string()),
+            ..Lineage::default()
+        },
+    )
+}
+
+/// Write JSONL entries to a fresh temp dir and return its path.
+fn audit_dir_with(entries: &[AuditEntry]) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("aa-violations-test-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut contents = String::new();
+    for e in entries {
+        contents.push_str(&serde_json::to_string(e).unwrap());
+        contents.push('\n');
+    }
+    std::fs::write(dir.join("audit.jsonl"), contents).unwrap();
+    dir
+}
+
+/// Build an auth-enabled app whose audit reader is backed by `dir`.
+fn app_with_auth_and_audit(dir: &std::path::Path) -> axum::Router {
+    let mut state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.audit_reader = Arc::new(AuditReader::new(dir.to_path_buf()));
+    aa_api::build_app(state)
+}
+
+fn bearer(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
 
 #[tokio::test]
 async fn violations_by_lineage_returns_200_with_empty_set() {
@@ -42,4 +102,62 @@ async fn violations_by_lineage_accepts_window_param() {
     let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(json["window_secs"], 3600);
+}
+
+// ── AAASM-3846 — function-level/tenant authz on the audit heatmap ────────────
+
+/// The endpoint previously took no caller; it must now reject an unauthenticated
+/// request rather than serving every tenant's violation heatmap.
+#[tokio::test]
+async fn violations_by_lineage_unauthenticated_is_401() {
+    let app = aa_api::build_app(common::test_state_with_auth(AuthMode::On, &[], 1000));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/audit/violations-by-lineage")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// A tenant-scoped caller's heatmap is pinned to its own org: a `globex`
+/// violation must never appear for an `acme`-scoped caller.
+#[tokio::test]
+async fn violations_by_lineage_tenant_caller_sees_only_own_org() {
+    let dir = audit_dir_with(&[violation_entry(0x11, "acme"), violation_entry(0x22, "globex")]);
+    let app = app_with_auth_and_audit(&dir);
+
+    let token = common::generate_test_jwt_for_tenant("u", &[Scope::Read], None, Some("acme"));
+    let resp = app
+        .oneshot(bearer("/api/v1/audit/violations-by-lineage", &token))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let nodes = json["nodes"].as_array().unwrap();
+    assert_eq!(
+        nodes.len(),
+        1,
+        "an acme-scoped caller must see only acme's violation node"
+    );
+    assert_eq!(nodes[0]["agent_id"], hex::encode([0x11; 16]));
+}
+
+/// An admin caller still sees every org's violations.
+#[tokio::test]
+async fn violations_by_lineage_admin_sees_all_orgs() {
+    let dir = audit_dir_with(&[violation_entry(0x11, "acme"), violation_entry(0x22, "globex")]);
+    let app = app_with_auth_and_audit(&dir);
+
+    let token = common::generate_test_jwt("admin", &[Scope::Admin]);
+    let resp = app
+        .oneshot(bearer("/api/v1/audit/violations-by-lineage", &token))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["nodes"].as_array().unwrap().len(), 2, "admin sees every org");
 }

--- a/aa-api/tests/capability.rs
+++ b/aa-api/tests/capability.rs
@@ -22,6 +22,67 @@ fn post_override_request(body: serde_json::Value, token: Option<&str>) -> Reques
     builder.body(Body::from(serde_json::to_vec(&body).unwrap())).unwrap()
 }
 
+// ── AAASM-3846 — function-level authz on the read + revoke gates ─────────────
+
+/// `GET /capability/matrix` previously served sensitive policy state with no
+/// auth; it must now reject an unauthenticated caller.
+#[tokio::test]
+async fn get_matrix_unauthenticated_is_401() {
+    let app = common::test_app_with_auth(&[], 1000);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/capability/matrix")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// `GET /capability/override` previously disclosed the override log with no
+/// auth; it must now reject an unauthenticated caller.
+#[tokio::test]
+async fn list_overrides_unauthenticated_is_401() {
+    let app = common::test_app_with_auth(&[], 1000);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/capability/override")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// `DELETE /capability/override/{id}` mutates capability state, so a viewer
+/// (read-only) caller must be denied with 403 — matching `apply_override`.
+#[tokio::test]
+async fn revoke_override_rejects_viewer_scope_with_403() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/v1/capability/override/some-id")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a read-only caller must not revoke a capability override"
+    );
+}
+
 #[tokio::test]
 async fn get_matrix_returns_200_with_dashboard_shape() {
     let app = common::test_app();

--- a/aa-api/tests/iam.rs
+++ b/aa-api/tests/iam.rs
@@ -36,6 +36,35 @@ fn post_empty_request(uri: &str, token: Option<&str>) -> Request<Body> {
     builder.body(Body::empty()).unwrap()
 }
 
+// ── AAASM-3846 — function-level authz on the api-key listing ─────────────────
+
+/// `GET /iam/api-keys` previously disclosed sensitive IAM state with no auth;
+/// it must now reject an unauthenticated caller.
+#[tokio::test]
+async fn list_api_keys_unauthenticated_is_401() {
+    let app = common::test_app_with_auth(&[], 1000);
+    let resp = app.oneshot(get_request("/api/v1/iam/api-keys", None)).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// Listing API keys requires the admin authority that generate / revoke /
+/// rotate already enforce, so a read-only caller must be denied with 403.
+#[tokio::test]
+async fn list_api_keys_rejects_read_only_scope_with_403() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let resp = app
+        .oneshot(get_request("/api/v1/iam/api-keys", Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a read-only caller must not list IAM api keys"
+    );
+}
+
 #[tokio::test]
 async fn list_api_keys_returns_seeded_entries_newest_first() {
     let app = common::test_app();

--- a/aa-gateway/src/service/topology_service.rs
+++ b/aa-gateway/src/service/topology_service.rs
@@ -13,6 +13,7 @@ use aa_proto::assembly::topology::v1::{
 };
 
 use crate::edges::InMemoryEdgeRepo;
+use crate::iam::VerifiedCaller;
 use crate::registry::{AgentRecord, AgentRegistry, AgentStatus};
 
 /// gRPC service implementation for topology queries.
@@ -38,6 +39,27 @@ fn parse_agent_id(hex: &str) -> Result<[u8; 16], Status> {
 
 fn format_id(id: &[u8; 16]) -> String {
     hex::encode(id)
+}
+
+/// Tenant-authorization rule for a topology read (AAASM-3846).
+///
+/// The `auth_interceptor` authenticates the caller and injects a
+/// [`VerifiedCaller`], but the handlers previously discarded it and returned any
+/// agent to any authenticated caller (a post-authN function-level/tenant authz
+/// gap). This mirrors `approval_service::caller_may_act_on`, extended to also
+/// bind the caller's `org_id`: a tenanted caller (a `Some` team/org) may only
+/// read a resource in the same team and org; when either side is untenanted the
+/// read is allowed (the untenanted/single-tenant deployment fallback).
+fn caller_may_read(caller: &VerifiedCaller, resource_team: Option<&str>, resource_org: Option<&str>) -> bool {
+    let team_ok = match (caller.team_id.as_deref(), resource_team) {
+        (Some(caller_team), Some(resource_team)) => caller_team == resource_team,
+        _ => true,
+    };
+    let org_ok = match (caller.org_id.as_deref(), resource_org) {
+        (Some(caller_org), Some(resource_org)) => caller_org == resource_org,
+        _ => true,
+    };
+    team_ok && org_ok
 }
 
 fn status_str(status: AgentStatus) -> &'static str {
@@ -90,6 +112,10 @@ impl TopologyService for TopologyServiceImpl {
         &self,
         request: Request<GetAgentTreeRequest>,
     ) -> Result<Response<GetAgentTreeResponse>, Status> {
+        // AAASM-3846 — read the verified caller (injected by the auth
+        // interceptor) before consuming the request, so the lookup can be bound
+        // to the caller's tenant.
+        let caller = request.extensions().get::<VerifiedCaller>().cloned();
         let req = request.into_inner();
         let agent_id = parse_agent_id(&req.agent_id)?;
 
@@ -97,6 +123,14 @@ impl TopologyService for TopologyServiceImpl {
             .registry
             .get(&agent_id)
             .ok_or_else(|| Status::not_found(format!("agent not found: {}", req.agent_id)))?;
+
+        // AAASM-3846 — confine a tenanted caller to its own team/org so one team
+        // cannot read another team's delegation tree.
+        if let Some(caller) = &caller {
+            if !caller_may_read(caller, record.team_id.as_deref(), record.org_id.as_deref()) {
+                return Err(Status::permission_denied("agent belongs to a different tenant"));
+            }
+        }
 
         if record.parent_key.is_some() {
             return Err(Status::failed_precondition(format!(
@@ -113,6 +147,8 @@ impl TopologyService for TopologyServiceImpl {
     }
 
     async fn get_lineage(&self, request: Request<GetLineageRequest>) -> Result<Response<GetLineageResponse>, Status> {
+        // AAASM-3846 — read the verified caller before consuming the request.
+        let caller = request.extensions().get::<VerifiedCaller>().cloned();
         let req = request.into_inner();
         let agent_id = parse_agent_id(&req.agent_id)?;
 
@@ -120,6 +156,14 @@ impl TopologyService for TopologyServiceImpl {
             .registry
             .get(&agent_id)
             .ok_or_else(|| Status::not_found(format!("agent not found: {}", req.agent_id)))?;
+
+        // AAASM-3846 — a tenanted caller may only trace lineage for an agent in
+        // its own team/org.
+        if let Some(caller) = &caller {
+            if !caller_may_read(caller, record.team_id.as_deref(), record.org_id.as_deref()) {
+                return Err(Status::permission_denied("agent belongs to a different tenant"));
+            }
+        }
 
         // ancestors[0] is the agent itself; ancestors[last] is the root.
         let mut ancestors = vec![record_to_topology_agent(&record)];
@@ -136,10 +180,22 @@ impl TopologyService for TopologyServiceImpl {
         &self,
         request: Request<GetTeamMembersRequest>,
     ) -> Result<Response<GetTeamMembersResponse>, Status> {
+        // AAASM-3846 — read the verified caller before consuming the request.
+        let caller = request.extensions().get::<VerifiedCaller>().cloned();
         let req = request.into_inner();
 
         if req.team_id.is_empty() {
             return Err(Status::invalid_argument("team_id must not be empty"));
+        }
+
+        // AAASM-3846 — a tenanted caller may only enumerate its own team's
+        // members, never another team's roster.
+        if let Some(caller) = &caller {
+            if let Some(caller_team) = caller.team_id.as_deref() {
+                if caller_team != req.team_id {
+                    return Err(Status::permission_denied("team belongs to a different tenant"));
+                }
+            }
         }
 
         let member_ids = self.registry.team_members(&req.team_id);

--- a/aa-gateway/src/service/topology_service.rs
+++ b/aa-gateway/src/service/topology_service.rs
@@ -251,3 +251,144 @@ impl TopologyService for TopologyServiceImpl {
         Ok(Response::new(ReportEdgeResponse { id }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{BTreeMap, VecDeque};
+
+    use aa_proto::assembly::topology::v1::topology_service_server::TopologyService;
+
+    /// Build a minimal active [`AgentRecord`] with an explicit tenant.
+    fn make_record(
+        id: [u8; 16],
+        name: &str,
+        parent_key: Option<[u8; 16]>,
+        team_id: Option<&str>,
+        org_id: Option<&str>,
+    ) -> AgentRecord {
+        AgentRecord {
+            agent_id: id,
+            name: name.into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: "pk_test".into(),
+            credential_token: format!("tok_{}", hex::encode(id)),
+            metadata: BTreeMap::new(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: vec![],
+            recent_events: VecDeque::new(),
+            recent_traces: vec![],
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: team_id.map(str::to_owned),
+            depth: if parent_key.is_some() { 1 } else { 0 },
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: Some(id),
+            children: vec![],
+            parent_key,
+            enforcement_mode: None,
+            org_id: org_id.map(str::to_owned),
+        }
+    }
+
+    fn caller(team: Option<&str>, org: Option<&str>) -> VerifiedCaller {
+        VerifiedCaller {
+            agent_key: [1u8; 16],
+            team_id: team.map(str::to_owned),
+            org_id: org.map(str::to_owned),
+        }
+    }
+
+    fn service_with(records: Vec<AgentRecord>) -> TopologyServiceImpl {
+        let registry = Arc::new(AgentRegistry::new());
+        for r in records {
+            registry.register(r).unwrap();
+        }
+        TopologyServiceImpl::new(registry, InMemoryEdgeRepo::new())
+    }
+
+    #[tokio::test]
+    async fn get_agent_tree_cross_tenant_is_permission_denied() {
+        let root: [u8; 16] = [0xa0; 16];
+        let svc = service_with(vec![make_record(root, "root", None, Some("team-b"), Some("org-b"))]);
+
+        let mut req = Request::new(GetAgentTreeRequest {
+            agent_id: format_id(&root),
+            max_depth: 0,
+        });
+        req.extensions_mut().insert(caller(Some("team-a"), Some("org-a")));
+
+        let err = svc.get_agent_tree(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn get_agent_tree_same_tenant_is_allowed() {
+        let root: [u8; 16] = [0xa1; 16];
+        let svc = service_with(vec![make_record(root, "root", None, Some("team-a"), Some("org-a"))]);
+
+        let mut req = Request::new(GetAgentTreeRequest {
+            agent_id: format_id(&root),
+            max_depth: 0,
+        });
+        req.extensions_mut().insert(caller(Some("team-a"), Some("org-a")));
+
+        let resp = svc.get_agent_tree(req).await.unwrap().into_inner();
+        assert_eq!(resp.root.unwrap().agent.unwrap().id, format_id(&root));
+    }
+
+    #[tokio::test]
+    async fn get_lineage_cross_tenant_is_permission_denied() {
+        let root: [u8; 16] = [0xb0; 16];
+        let svc = service_with(vec![make_record(root, "root", None, Some("team-b"), Some("org-b"))]);
+
+        let mut req = Request::new(GetLineageRequest {
+            agent_id: format_id(&root),
+        });
+        req.extensions_mut().insert(caller(Some("team-a"), Some("org-a")));
+
+        let err = svc.get_lineage(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn get_team_members_cross_tenant_is_permission_denied() {
+        let agent: [u8; 16] = [0xc0; 16];
+        let svc = service_with(vec![make_record(agent, "a", None, Some("team-b"), None)]);
+
+        let mut req = Request::new(GetTeamMembersRequest {
+            team_id: "team-b".into(),
+        });
+        req.extensions_mut().insert(caller(Some("team-a"), None));
+
+        let err = svc.get_team_members(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn untenanted_caller_is_allowed_cross_team() {
+        // Single-tenant deployment fallback: an untenanted caller is not confined.
+        let root: [u8; 16] = [0xd0; 16];
+        let svc = service_with(vec![make_record(root, "root", None, Some("team-b"), Some("org-b"))]);
+
+        let mut req = Request::new(GetAgentTreeRequest {
+            agent_id: format_id(&root),
+            max_depth: 0,
+        });
+        req.extensions_mut().insert(caller(None, None));
+
+        let resp = svc.get_agent_tree(req).await.unwrap().into_inner();
+        assert_eq!(resp.root.unwrap().agent.unwrap().id, format_id(&root));
+    }
+}

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -4688,6 +4688,13 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Missing or invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     get_violations_by_lineage: {
@@ -4715,6 +4722,13 @@ export interface operations {
             };
             /** @description Invalid query parameter */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid credentials */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4799,6 +4813,13 @@ export interface operations {
                     "application/json": components["schemas"]["CapabilityMatrix"];
                 };
             };
+            /** @description Missing or invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     list_overrides: {
@@ -4821,6 +4842,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["OverrideRecord"][];
                 };
+            };
+            /** @description Missing or invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -4885,6 +4913,13 @@ export interface operations {
         responses: {
             /** @description Override revoked; cells restored to base policy */
             204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller lacks the role required to mutate capability state */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5034,6 +5069,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ApiKeyResponse"][];
                 };
+            };
+            /** @description Caller lacks the admin role required to read IAM state */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1172,6 +1172,8 @@ paths:
                 $ref: '#/components/schemas/SandboxSummaryResponse'
         '400':
           description: Invalid query parameter
+        '401':
+          description: Missing or invalid credentials
   /api/v1/audit/violations-by-lineage:
     get:
       tags:
@@ -1209,6 +1211,8 @@ paths:
                 $ref: '#/components/schemas/ViolationsByLineageResponse'
         '400':
           description: Invalid query parameter
+        '401':
+          description: Missing or invalid credentials
   /api/v1/auth/token:
     post:
       tags:
@@ -1297,6 +1301,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CapabilityMatrix'
+        '401':
+          description: Missing or invalid credentials
   /api/v1/capability/override:
     get:
       tags:
@@ -1326,6 +1332,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/OverrideRecord'
+        '401':
+          description: Missing or invalid credentials
     post:
       tags:
       - capability
@@ -1389,6 +1397,8 @@ paths:
       responses:
         '204':
           description: Override revoked; cells restored to base policy
+        '403':
+          description: Caller lacks the role required to mutate capability state
         '404':
           description: No active override with this id
           content:
@@ -1507,6 +1517,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiKeyResponse'
+        '403':
+          description: Caller lacks the admin role required to read IAM state
     post:
       tags:
       - iam


### PR DESCRIPTION
## Description

Closes the **AAASM-3846** family of post-authN function-level / tenant authorization gaps. Each handler authenticated the caller (`require_authentication` / the gRPC `auth_interceptor`) but then discarded the verified caller and served or mutated data with no per-function or per-tenant check. This PR adds the missing authorization to each, mirroring the already-gated siblings.

**gRPC topology (`aa-gateway/src/service/topology_service.rs`)** — `get_agent_tree`, `get_lineage`, `get_team_members` now read the injected `VerifiedCaller` from request extensions and confine a tenanted caller to its own team/org (new `caller_may_read`, mirroring `approval_service::caller_may_act_on`, extended to org). Cross-tenant reads return `permission_denied`.

**`aa-api` audit (`routes/audit.rs`)** — `get_violations_by_lineage` and `get_sandbox_summary` now require `RequireRead` and bind the aggregation to the caller's org, mirroring `logs.rs` org scoping (admin sees all, tenant-scoped sees only its own org, unscoped non-admin sees none).

**`aa-api` capability (`routes/capability.rs`)** — `revoke_override` now enforces `PolicyWriteAuth.check_mutation(Global, Update)` matching `apply_override`; `get_matrix` and `list_overrides` now require `RequireRead`.

**`aa-api` iam (`routes/iam.rs`)** — `list_api_keys` now requires `RequireAdmin`, matching generate / revoke / rotate.

## Type of Change

- [x] 🐛 Bug fix (security — broken function-level/object-level authorization)

## Breaking Changes

- [x] No

These endpoints were always intended to be authorized; in `AuthMode::On` deployments clients already send credentials. Unauthenticated/under-privileged callers that previously got data now correctly get 401/403.

## Related Issues

- Related Jira ticket: AAASM-3846

## Testing

- [x] Unit tests added / updated (gRPC topology cross-tenant `permission_denied`)
- [x] Integration tests added / updated (audit / capability / iam 401 + 403 + tenant-scoping)

Per-handler cross-tenant / forbidden regression tests added. Validated locally:

- `cargo build -p aa-api -p aa-gateway`
- `cargo nextest run -p aa-api -p aa-gateway` — 2040 passed, 0 failed
- `cargo fmt --all` clean
- `cargo clippy -p aa-api -p aa-gateway --all-targets -- -D warnings` clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
