### PR TITLE
[AAASM-3877] 🔧 (ci): Tighten docs.yml perms + SHA-pin third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,7 +630,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # full history needed for buf breaking --against
-      - uses: bufbuild/buf-setup-action@v1.50.0
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint proto files
@@ -733,7 +733,7 @@ jobs:
         # Required by aa-proto (transitive dep of aa-runtime) for the
         # multi-layer integration test step.
         run: sudo apt-get install -y protobuf-compiler
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly branch @ 2026-06-27
         with:
           # Do NOT add bpfel-unknown-none to targets: there is no precompiled rust-std
           # for this target. BPF programs are built from source via -Zbuild-std=core
@@ -843,7 +843,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y curl
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly branch @ 2026-06-27
         with:
           # Same justification as the `ebpf-build` job: bpfel-unknown-none has
           # no precompiled rust-std, so the BPF probes build via

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,10 @@
 name: Docs
 
+# Least-privilege default for every job. The PR/master-push `build` and
+# `verify-commands` jobs only read the repo; the elevated `pages: write` +
+# `id-token: write` scopes are granted to the `deploy` job alone (AAASM-3877).
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 on:
   pull_request:
@@ -281,6 +282,11 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
+    # Pages deployment needs the elevated scopes; scoped here so the
+    # PR-triggered build/verify jobs run with contents:read only (AAASM-3877).
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch @ 2026-06-27
 
       - name: Cache mdBook binaries
         uses: actions/cache@v6
@@ -309,10 +309,10 @@ jobs:
           sudo apt-get install -y protobuf-compiler pkg-config libssl-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch @ 2026-06-27
 
       - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Verify README "Getting Started" build command
         run: cargo build --workspace --exclude aa-ebpf

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -96,7 +96,7 @@ jobs:
         uses: taiki-e/install-action@83c419a40a2e48673b2c523337e57f602dfe53c9 # cargo-nextest
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 10
 


### PR DESCRIPTION
## Description

Hardens the monorepo GitHub Actions workflows per AAASM-3877 (MEDIUM):

1. **`docs.yml` least-privilege permissions** — the top-level `permissions` block granted `pages: write` + `id-token: write` to *every* job, including the PR-triggered `build` and `verify-commands` jobs that only read the repo. The default is now `contents: read`; the two elevated scopes are scoped to the `deploy` job alone (which is event-gated to non-PR). Deploy keeps exactly the scopes it needs.

2. **SHA-pin mutable third-party action refs** — pinned to full 40-char commit SHAs with `# version` comments, matching the repo's existing pinning style (Dependabot does not convert branch refs):
   - `ci.yml`: `bufbuild/buf-setup-action@v1.50.0` → `a47c93e0…`; two `dtolnay/rust-toolchain@nightly` (root/eBPF sudo jobs — worst-case exposure) → `5b842231…` (nightly branch @ 2026-06-27)
   - `docs.yml`: two `dtolnay/rust-toolchain@stable` → `29eef336…` (stable branch @ 2026-06-27); `Swatinem/rust-cache@v2` → `e18b4977…`
   - `integration-tests.yml`: `pnpm/action-setup@v6` → `0e279bb9…` (v6.0.8, matching the existing pin used across the other workflows)

The `@nightly`/`@stable` mutable branch pins use a branch+date comment as requested. The `stable`, `rust-cache`, and `pnpm` SHAs match the pins already used elsewhere in the repo.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3877
- Closes AAASM-3877

## Testing

- [x] No tests required (YAML-only CI hardening). Validated with `actionlint` on all three changed workflows (clean) and confirmed no remaining mutable refs among the targeted actions.

## Checklist

- [x] Self-review of the diff completed
- [x] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf