### PR TITLE
[AAASM-3867] 🔒 (aa-cli): Protect stored api_key file perms + argv

### DIFF
--- a/aa-cli/src/commands/context.rs
+++ b/aa-cli/src/commands/context.rs
@@ -165,3 +165,42 @@ fn run_use(args: UseArgs) -> ExitCode {
     println!("Switched to context '{}'.", args.name);
     ExitCode::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_key_flag_takes_precedence_over_env() {
+        let _guard = crate::test_support::env_guard();
+        std::env::set_var(API_KEY_ENV, "env-key");
+        let resolved = resolve_set_api_key(Some("flag-key".to_string()));
+        std::env::remove_var(API_KEY_ENV);
+        assert_eq!(resolved.as_deref(), Some("flag-key"));
+    }
+
+    #[test]
+    fn api_key_read_from_env_when_flag_absent() {
+        let _guard = crate::test_support::env_guard();
+        std::env::set_var(API_KEY_ENV, "env-key");
+        let resolved = resolve_set_api_key(None);
+        std::env::remove_var(API_KEY_ENV);
+        assert_eq!(resolved.as_deref(), Some("env-key"));
+    }
+
+    #[test]
+    fn api_key_none_when_neither_flag_nor_env_set() {
+        let _guard = crate::test_support::env_guard();
+        std::env::remove_var(API_KEY_ENV);
+        assert!(resolve_set_api_key(None).is_none());
+    }
+
+    #[test]
+    fn api_key_empty_env_treated_as_unset() {
+        let _guard = crate::test_support::env_guard();
+        std::env::set_var(API_KEY_ENV, "");
+        let resolved = resolve_set_api_key(None);
+        std::env::remove_var(API_KEY_ENV);
+        assert!(resolved.is_none());
+    }
+}

--- a/aa-cli/src/commands/context.rs
+++ b/aa-cli/src/commands/context.rs
@@ -6,6 +6,31 @@ use clap::{Args, Subcommand};
 
 use crate::config;
 
+/// Environment variable that supplies the API key for `aasm context set`
+/// without exposing it on the command line.
+///
+/// Argv is world-readable via `ps`, `/proc/<pid>/cmdline`, and shell history,
+/// so passing `--api-key` leaks the operator bearer token to any local user.
+const API_KEY_ENV: &str = "AASM_API_KEY";
+
+/// Resolve the API key for `context set`, preferring the `AASM_API_KEY`
+/// environment variable over the `--api-key` flag.
+///
+/// The flag still works to avoid breaking existing scripts, but because it
+/// leaks the secret into argv we emit a warning recommending the env var when
+/// it is used. An empty env var is treated as unset.
+fn resolve_set_api_key(flag: Option<String>) -> Option<String> {
+    if let Some(key) = flag {
+        eprintln!(
+            "warning: passing --api-key exposes the key in process listings \
+             (ps, /proc/<pid>/cmdline) and shell history; prefer the \
+             {API_KEY_ENV} environment variable instead"
+        );
+        return Some(key);
+    }
+    std::env::var(API_KEY_ENV).ok().filter(|key| !key.is_empty())
+}
+
 /// Arguments for the `aasm context` subcommand group.
 #[derive(Args)]
 pub struct ContextArgs {
@@ -32,7 +57,9 @@ pub struct SetArgs {
     /// API URL for this context.
     #[arg(long)]
     pub api_url: String,
-    /// API key for this context (optional).
+    /// API key for this context (optional). Prefer the `AASM_API_KEY`
+    /// environment variable: passing `--api-key` leaks the key into argv
+    /// (`ps`, `/proc/<pid>/cmdline`, shell history).
     #[arg(long)]
     pub api_key: Option<String>,
 }
@@ -91,7 +118,7 @@ fn run_set(args: SetArgs) -> ExitCode {
         args.name.clone(),
         config::ContextConfig {
             api_url: args.api_url,
-            api_key: args.api_key,
+            api_key: resolve_set_api_key(args.api_key),
         },
     );
 

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -279,6 +279,64 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn save_restricts_config_file_and_dir_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = crate::test_support::env_guard();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", tmp.path());
+
+        let result = save(&sample_config());
+        let dir = config_dir();
+        let path = config_path();
+        let dir_mode = std::fs::metadata(&dir).map(|m| m.permissions().mode() & 0o777);
+        let file_mode = std::fs::metadata(&path).map(|m| m.permissions().mode() & 0o777);
+
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+
+        result.unwrap();
+        assert_eq!(dir_mode.unwrap(), 0o700, "config dir must be owner-only (0700)");
+        assert_eq!(file_mode.unwrap(), 0o600, "config file must be owner-only (0600)");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_tightens_preexisting_loose_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = crate::test_support::env_guard();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", tmp.path());
+
+        // Simulate a config left world-readable by an older, vulnerable version.
+        let dir = config_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = config_path();
+        std::fs::write(&path, "{}").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let result = save(&sample_config());
+        let dir_mode = std::fs::metadata(&dir).map(|m| m.permissions().mode() & 0o777);
+        let file_mode = std::fs::metadata(&path).map(|m| m.permissions().mode() & 0o777);
+
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+
+        result.unwrap();
+        assert_eq!(dir_mode.unwrap(), 0o700, "save must tighten an existing dir to 0700");
+        assert_eq!(file_mode.unwrap(), 0o600, "save must tighten an existing file to 0600");
+    }
+
     #[test]
     fn config_round_trip_yaml() {
         let cfg = sample_config();

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -101,19 +101,95 @@ pub fn load() -> Result<CliConfig, CliError> {
 
 /// Save the CLI configuration to `~/.aa/config.yaml`.
 ///
-/// Creates the `~/.aa/` directory if it does not exist.
+/// Creates the `~/.aa/` directory if it does not exist. The file holds the
+/// operator bearer token (`api_key`), so on Unix the directory is locked to
+/// `0700` and the file to `0600` — otherwise any local user on a shared host
+/// could read the token from a world-readable `~/.aa/config.yaml`.
 pub fn save(config: &CliConfig) -> Result<(), CliError> {
     let dir = config_dir();
-    if !dir.exists() {
-        std::fs::create_dir_all(&dir).map_err(|e| CliError::Config {
-            path: dir.clone(),
-            source: e,
-        })?;
-    }
+    ensure_config_dir(&dir)?;
     let path = config_path();
     let yaml = serde_yaml::to_string(config)?;
-    std::fs::write(&path, yaml).map_err(|e| CliError::Config { path, source: e })?;
+    write_config_file(&path, &yaml)?;
     Ok(())
+}
+
+/// Create the config directory if missing, restricting it to `0700` on Unix.
+///
+/// `DirBuilder::mode` only applies when the directory is newly created, so an
+/// existing directory (e.g. one left at `0755` by an older version) is tightened
+/// explicitly.
+#[cfg(unix)]
+fn ensure_config_dir(dir: &std::path::Path) -> Result<(), CliError> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+    if dir.exists() {
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| CliError::Config {
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+        return Ok(());
+    }
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)
+        .map_err(|e| CliError::Config {
+            path: dir.to_path_buf(),
+            source: e,
+        })
+}
+
+/// Create the config directory if missing (non-Unix: no permission control).
+#[cfg(not(unix))]
+fn ensure_config_dir(dir: &std::path::Path) -> Result<(), CliError> {
+    if dir.exists() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir).map_err(|e| CliError::Config {
+        path: dir.to_path_buf(),
+        source: e,
+    })
+}
+
+/// Write the config file, restricting it to `0600` on Unix.
+///
+/// The file is created with `0600` via `OpenOptions::mode` (no world-readable
+/// window), and `set_permissions` then tightens any pre-existing file that an
+/// older, vulnerable version may have left at `0644`.
+#[cfg(unix)]
+fn write_config_file(path: &std::path::Path, yaml: &str) -> Result<(), CliError> {
+    use std::io::Write as _;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| CliError::Config {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))
+        .map_err(|e| CliError::Config {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+    file.write_all(yaml.as_bytes()).map_err(|e| CliError::Config {
+        path: path.to_path_buf(),
+        source: e,
+    })
+}
+
+/// Write the config file (non-Unix: no permission control).
+#[cfg(not(unix))]
+fn write_config_file(path: &std::path::Path, yaml: &str) -> Result<(), CliError> {
+    std::fs::write(path, yaml).map_err(|e| CliError::Config {
+        path: path.to_path_buf(),
+        source: e,
+    })
 }
 
 /// Resolved connection parameters after merging CLI flags and config file.


### PR DESCRIPTION
## Description

`aa-cli` persisted the operator gateway bearer token insecurely:

- **World-readable credential file** — `config::save` wrote `~/.aa/config.yaml` (which contains `api_key`) with the default umask (file `0644`, dir `0755`). Any local user on a shared host could read the operator token. Now, on Unix, the directory is created/tightened to `0700` and the file to `0600` (created directly with `0600` via `OpenOptions::mode`, and `set_permissions` tightens a file left loose by an older version). Non-Unix behaviour is unchanged; all permission code is gated behind `#[cfg(unix)]`.
- **argv leak of `--api-key`** — `aasm context set --api-key` exposed the key via `ps`, `/proc/<pid>/cmdline`, and shell history. `context set` now reads the key from the `AASM_API_KEY` environment variable when `--api-key` is absent, and emits a warning recommending the env var when the flag is used. The flag still works, so existing scripts are not broken.

## Type of Change

- [x] 🐛 Bug fix (security hardening)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3867
- Closes AAASM-3867

## Testing

- [x] Unit tests added / updated

Added Unix-gated tests asserting `save` writes dir `0700` / file `0600` and tightens pre-existing loose perms, plus tests covering `AASM_API_KEY` resolution precedence/fallback vs `--api-key`.

Validation (local):
- `cargo build -p aa-cli` — OK (protoc present)
- `cargo nextest run -p aa-cli` — 774 passed
- `cargo fmt --all` — clean
- `cargo clippy -p aa-cli --all-targets -- -D warnings` — clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
