### PR TITLE
[AAASM-3865] 🔒 (aa-api): Gate list_agents/register_op/policies reads

### DIFF
--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -233,15 +233,32 @@ pub struct ResumeResponse {
     tag = "agents"
 )]
 pub async fn list_agents(
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     axum::extract::Query(params): axum::extract::Query<PaginationParams>,
 ) -> impl IntoResponse {
-    let all = state.agent_registry.list();
-    let total = all.len() as u64;
+    // AAASM-3865: confine the listing to agents the caller's tenant owns. The
+    // single-record sibling `get_agent` gates on `authorize_agent_access`
+    // (AAASM-3790); the collection path was missed, letting any authenticated
+    // key enumerate every tenant's agents. Filter BEFORE pagination so `total`
+    // reflects only the caller's own agents. An admin sees all; a team-scoped
+    // caller sees only its team's agents; an agent with no team is visible only
+    // to an admin.
+    let is_admin = caller.scopes.contains(&Scope::Admin);
+    let visible: Vec<_> = state
+        .agent_registry
+        .list()
+        .into_iter()
+        .filter(|r| match r.team_id.as_deref() {
+            Some(team) => caller.can_access_team(team),
+            None => is_admin,
+        })
+        .collect();
+    let total = visible.len() as u64;
     let offset = params.offset();
     let per_page = params.per_page();
 
-    let items: Vec<AgentResponse> = all
+    let items: Vec<AgentResponse> = visible
         .into_iter()
         .skip(offset)
         .take(per_page as usize)

--- a/aa-api/src/routes/ops.rs
+++ b/aa-api/src/routes/ops.rs
@@ -295,6 +295,10 @@ pub struct RegisterOpRequest {
     )
 )]
 pub async fn register_op(
+    // AAASM-3865: registering an op is a mutation; its lifecycle siblings
+    // (pause/resume/terminate) all require write scope, but the register path
+    // was missed, letting any read-only key create ops.
+    RequireWrite(_caller): RequireWrite,
     Extension(state): Extension<AppState>,
     Json(req): Json<RegisterOpRequest>,
 ) -> Result<impl IntoResponse, ProblemDetail> {

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -10,6 +10,7 @@ use aa_gateway::policy::rbac::MutationKind;
 use aa_gateway::policy::scope::PolicyScope;
 
 use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
+use crate::auth::scope::RequireRead;
 use crate::error::ProblemDetail;
 use crate::pagination::{PaginatedResponse, PaginationParams};
 use crate::state::AppState;
@@ -54,6 +55,9 @@ pub struct PolicyListFilter {
     tag = "policies"
 )]
 pub async fn list_policies(
+    // AAASM-3865: governance policy YAML is sensitive; require read scope so an
+    // unauthenticated caller cannot dump the full policy set.
+    RequireRead(_caller): RequireRead,
     Extension(state): Extension<AppState>,
     axum::extract::Query(params): axum::extract::Query<PaginationParams>,
     axum::extract::Query(filter): axum::extract::Query<PolicyListFilter>,
@@ -217,6 +221,8 @@ impl IntoResponse for PolicyCreateError {
     tag = "policies"
 )]
 pub async fn get_active_policy(
+    // AAASM-3865: the active policy YAML is sensitive; require read scope.
+    RequireRead(_caller): RequireRead,
     Extension(state): Extension<AppState>,
 ) -> Result<(StatusCode, Json<PolicyResponse>), ProblemDetail> {
     let info = state.policy_engine.active_policy_info();

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -960,6 +960,212 @@ async fn silence_alert_cross_tenant_is_403() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// AAASM-3865 — post-authN scope/tenant gaps round 2. list_agents leaked every
+// tenant's agents (no RequireRead, no filter); register_op took no write scope;
+// the policy reads took no caller at all.
+// ---------------------------------------------------------------------------
+
+/// list_agents must confine the listing to the caller's own team: an
+/// alpha-scoped read caller sees its own agent and not a beta agent, with
+/// `total` counting only its own.
+#[tokio::test]
+async fn list_agents_is_scoped_to_caller_team() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x01, "alpha")).unwrap();
+    state.agent_registry.register(agent_with_team(0x02, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let response = app.oneshot(bearer("/api/v1/agents", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["total"], 1, "total must count only the caller's team's agents");
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1, "an alpha caller sees only its own agent");
+    assert_eq!(
+        items[0]["id"],
+        hex_id(0x01),
+        "the beta agent must not leak to an alpha caller"
+    );
+}
+
+/// A non-admin caller with no team scope at all sees an empty agent list, never
+/// a cross-tenant dump.
+#[tokio::test]
+async fn list_agents_unscoped_caller_sees_nothing() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x03, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[Scope::Read]);
+    let response = app.oneshot(bearer("/api/v1/agents", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["total"], 0, "an unscoped non-admin caller sees no agents");
+}
+
+/// Positive control: an admin sees every tenant's agents.
+#[tokio::test]
+async fn list_agents_admin_sees_all_teams() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x04, "alpha")).unwrap();
+    state.agent_registry.register(agent_with_team(0x05, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("admin", &[Scope::Admin]);
+    let response = app.oneshot(bearer("/api/v1/agents", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["total"], 2, "an admin sees every team's agents");
+}
+
+/// register_op is a mutation; a read-only caller must be denied.
+#[tokio::test]
+async fn register_op_read_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let response = app
+        .oneshot(json_bearer("POST", "/api/v1/ops", &token, r#"{"op_id":"op-x"}"#))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "a read-only caller must not register an op"
+    );
+}
+
+/// Positive control: a write caller may register an op.
+#[tokio::test]
+async fn register_op_write_token_is_allowed() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Write], "alpha");
+    let response = app
+        .oneshot(json_bearer("POST", "/api/v1/ops", &token, r#"{"op_id":"op-y"}"#))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "a write caller may register an op"
+    );
+}
+
+/// The policy list read must reject an unauthenticated caller (it previously
+/// took no caller, so any request could dump the policy YAML).
+#[tokio::test]
+async fn list_policies_requires_authentication() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/policies")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "the policy list must reject an unauthenticated caller"
+    );
+}
+
+/// The active-policy read must reject an unauthenticated caller.
+#[tokio::test]
+async fn get_active_policy_requires_authentication() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/policies/active")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "the active-policy read must reject an unauthenticated caller"
+    );
+}
+
+/// Positive control: an authenticated read caller may list policies.
+#[tokio::test]
+async fn list_policies_authenticated_read_caller_is_ok() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[Scope::Read]);
+    let response = app.oneshot(bearer("/api/v1/policies", &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "an authenticated read caller may list policies"
+    );
+}
+
+/// An authenticated caller with no read scope is denied the agent listing —
+/// the deny-by-default gate authenticates, but RequireRead enforces the scope.
+#[tokio::test]
+async fn list_agents_no_read_scope_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x06, "alpha")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[]);
+    let response = app.oneshot(bearer("/api/v1/agents", &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "a caller with no read scope must not list agents"
+    );
+}
+
+/// An authenticated caller with no read scope is denied the policy list — this
+/// is the gap the global auth gate alone did not close (it never checks scope).
+#[tokio::test]
+async fn list_policies_no_read_scope_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[]);
+    let response = app.oneshot(bearer("/api/v1/policies", &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "a caller with no read scope must not list policies"
+    );
+}
+
+/// An authenticated caller with no read scope is denied the active policy read.
+#[tokio::test]
+async fn get_active_policy_no_read_scope_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[]);
+    let response = app.oneshot(bearer("/api/v1/policies/active", &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "a caller with no read scope must not read the active policy"
+    );
+}
+
 // AAASM-3824 — get_agent_capabilities exposed any team's effective-permission
 // cascade with no auth. An alpha-scoped caller must not read a beta agent's
 // capabilities; the gate fires before any existence check, so there is no


### PR DESCRIPTION
## Description

Closes round 2 of the post-authN scope/tenant gaps in `aa-api` (AAASM-3865, HIGH). The single-record `get_agent` path was gated by AAASM-3790, but three collection/mutation siblings were missed, letting any authenticated key (any tenant/scope) enumerate every tenant's agents, read the full governance policy YAML, or create ops:

- `routes/agents.rs::list_agents` — added `RequireRead` and per-tenant filtering BEFORE pagination, mirroring `authorize_agent_access`. An admin sees all; a team-scoped caller sees only its own team's agents; agents with no team are admin-only; `total` reflects only the visible set.
- `routes/ops.rs::register_op` — added `RequireWrite` to match its lifecycle siblings (pause/resume/terminate).
- `routes/policies.rs::list_policies` and `get_active_policy` — added `RequireRead` so an authenticated caller with no read scope can no longer dump policy YAML.

Note: the deny-by-default global gate (AAASM-3125) already returns 401 for unauthenticated requests on these routes; this change adds the per-handler scope/tenant authorization that the gate does not perform.

OpenAPI/dashboard codegen: regenerated `openapi/v1.yaml` after the change — it is byte-identical (utoipa does not auto-inject 401/403 from extractors, and the global 401 is not reflected per-path), so there is no drift and no dashboard codegen change. Verified `git diff --exit-code openapi/v1.yaml` and `dashboard/src/api/generated/` are both clean.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3865

Closes AAASM-3865

## Testing

- [x] Integration tests added / updated

Added regression tests in `aa-api/tests/tenant_scope.rs`: list_agents scoped-to-team / unscoped-empty / admin-sees-all / no-read-scope→403; register_op read-only→403 and write→201; policy reads unauth→401, no-read-scope→403, and authenticated read→200.

Validation: `cargo build -p aa-api`, `cargo nextest run -p aa-api` (827 passed), `cargo fmt --all`, `cargo clippy -p aa-api --all-targets -- -D warnings` all green.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
