### PR TITLE
[AAASM-3864] 🔒 (aa-proxy): Close egress enforcement bypasses

### DIFF
--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -489,6 +489,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_chunked_transfer_encoding_request() {
+        // AAASM-3864: a request advertising a chunked body cannot be inspected
+        // by this Content-Length-only parser, so it must fail closed rather than
+        // yield an empty body that forwards an un-scanned payload upstream.
+        let raw = b"POST /v1/chat/completions HTTP/1.1\r\n\
+                    Host: api.openai.com\r\n\
+                    Transfer-Encoding: chunked\r\n\
+                    \r\n\
+                    5\r\nhello\r\n0\r\n\r\n";
+        let mut reader = make_reader(raw);
+        let err = read_http_request(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(&err, ProxyError::Config(msg) if msg.contains("chunked")),
+            "expected fail-closed chunked rejection, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn unexpected_eof_reading_request_headers_is_error() {
         // Stream ends after the request line, before the header-terminating
         // blank line — this is a truncated request, not a clean inter-request

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -7,9 +7,10 @@
 //!
 //! Scope is intentionally small: only requests with a literal
 //! `Content-Length` header are fully supported. Requests using
-//! `Transfer-Encoding: chunked` parse the head but leave the body empty —
-//! that variant is rare for LLM POSTs and can be added when needed without
-//! breaking this API.
+//! `Transfer-Encoding: chunked` cannot be inspected by this parser, so the
+//! request side rejects them (fail-closed, AAASM-3864) rather than forwarding
+//! an un-scanned body. The response side still parses the head and leaves a
+//! chunked body empty (the MCP path falls back to a transparent relay).
 
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 
@@ -43,8 +44,13 @@ impl HttpRequest {
 /// Read and parse an HTTP/1.1 request from `reader`.
 ///
 /// Reads the request line and headers off the stream, then reads exactly
-/// `Content-Length` bytes of body. Requests without `Content-Length` and
-/// without `Transfer-Encoding: chunked` are treated as having an empty body.
+/// `Content-Length` bytes of body. Requests without `Content-Length` are
+/// treated as having an empty body.
+///
+/// A request advertising `Transfer-Encoding: chunked` is **rejected** with a
+/// [`ProxyError::Config`] error (AAASM-3864): this parser cannot decode a
+/// chunked body, so forwarding it would let an un-scanned body slip past the
+/// credential and MCP gates. Failing closed drops the connection instead.
 ///
 /// Returns `Ok(None)` on a clean EOF before any bytes are read — that
 /// indicates the peer closed the connection between requests.
@@ -82,6 +88,19 @@ where
         } else {
             return Err(ProxyError::Config(format!("malformed header line: {trimmed:?}")));
         }
+    }
+
+    // AAASM-3864 (fail-closed): a chunked body cannot be parsed here, so the
+    // credential scanner and `parse_mcp_request` would see an empty body while
+    // the real payload was forwarded un-inspected. Refuse such requests rather
+    // than silently passing an un-scanned body upstream.
+    if headers
+        .iter()
+        .any(|(k, v)| k.eq_ignore_ascii_case("transfer-encoding") && v.to_ascii_lowercase().contains("chunked"))
+    {
+        return Err(ProxyError::Config(
+            "transfer-encoding: chunked request bodies are not inspectable; refusing (fail-closed)".into(),
+        ));
     }
 
     let content_length: usize = headers
@@ -362,14 +381,22 @@ mod tests {
         assert!(text.ends_with("\r\n\r\nshort"));
     }
 
-    #[tokio::test]
-    async fn serialize_drops_transfer_encoding_header() {
-        let raw = b"POST / HTTP/1.1\r\n\
-                    Host: x.example.com\r\n\
-                    Transfer-Encoding: chunked\r\n\
-                    \r\n";
-        let mut reader = make_reader(raw);
-        let req = read_http_request(&mut reader).await.unwrap().unwrap();
+    #[test]
+    fn serialize_drops_transfer_encoding_header() {
+        // `read_http_request` now rejects chunked requests (AAASM-3864), so the
+        // serializer's Transfer-Encoding stripping is exercised by constructing
+        // the request directly — it remains defence-in-depth for any caller that
+        // hands the serializer a request carrying a stale framing header.
+        let req = HttpRequest {
+            method: "POST".into(),
+            target: "/".into(),
+            version: "HTTP/1.1".into(),
+            headers: vec![
+                ("Host".into(), "x.example.com".into()),
+                ("Transfer-Encoding".into(), "chunked".into()),
+            ],
+            body: Vec::new(),
+        };
         let wire = serialize_http_request(&req, b"hi");
         let text = std::str::from_utf8(&wire).unwrap();
         assert!(

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -153,6 +153,12 @@ pub fn serialize_http_request(req: &HttpRequest, new_body: &[u8]) -> Vec<u8> {
 ///
 /// When `injected_auth` is `None` the agent's own headers are forwarded
 /// verbatim (the historical, backward-compatible behaviour).
+///
+/// AAASM-3864: any inbound `Connection` header is dropped and a single
+/// `Connection: close` is emitted so the upstream tears the connection down
+/// after one request/response. Combined with the proxy's single-exchange
+/// relay this prevents a second request being pipelined onto the same tunnel
+/// and reaching upstream un-inspected.
 pub fn serialize_http_request_with_auth(req: &HttpRequest, new_body: &[u8], injected_auth: Option<&[u8]>) -> Vec<u8> {
     let mut out = Vec::with_capacity(req.body.len() + new_body.len() + 256);
     out.extend_from_slice(req.method.as_bytes());
@@ -163,7 +169,10 @@ pub fn serialize_http_request_with_auth(req: &HttpRequest, new_body: &[u8], inje
     out.extend_from_slice(b"\r\n");
 
     for (k, v) in &req.headers {
-        if k.eq_ignore_ascii_case("content-length") || k.eq_ignore_ascii_case("transfer-encoding") {
+        if k.eq_ignore_ascii_case("content-length")
+            || k.eq_ignore_ascii_case("transfer-encoding")
+            || k.eq_ignore_ascii_case("connection")
+        {
             continue;
         }
         // When injecting, strip any agent-supplied credential header so it
@@ -181,6 +190,9 @@ pub fn serialize_http_request_with_auth(req: &HttpRequest, new_body: &[u8], inje
         out.extend_from_slice(auth);
         out.extend_from_slice(b"\r\n");
     }
+    // AAASM-3864 (a): force a single request/response per upstream connection so
+    // a follow-up request cannot be pipelined onto the tunnel un-inspected.
+    out.extend_from_slice(b"Connection: close\r\n");
     out.extend_from_slice(b"Content-Length: ");
     out.extend_from_slice(new_body.len().to_string().as_bytes());
     out.extend_from_slice(b"\r\n\r\n");

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -418,6 +418,39 @@ mod tests {
         assert!(text.contains("Content-Length: 2\r\n"));
     }
 
+    #[test]
+    fn serialize_forces_connection_close_and_strips_inbound_connection() {
+        // AAASM-3864 (a): every forwarded request must carry exactly one
+        // `Connection: close` so upstream tears the tunnel down after one
+        // exchange, and any inbound Connection header the agent supplied (e.g.
+        // keep-alive) must be dropped.
+        let req = HttpRequest {
+            method: "POST".into(),
+            target: "/v1/x".into(),
+            version: "HTTP/1.1".into(),
+            headers: vec![
+                ("Host".into(), "api.openai.com".into()),
+                ("Connection".into(), "keep-alive".into()),
+            ],
+            body: Vec::new(),
+        };
+        let wire = serialize_http_request(&req, b"hi");
+        let text = std::str::from_utf8(&wire).unwrap();
+        assert_eq!(
+            text.to_ascii_lowercase().matches("connection:").count(),
+            1,
+            "exactly one Connection header expected: {text}"
+        );
+        assert!(
+            text.contains("Connection: close\r\n"),
+            "must force Connection: close: {text}"
+        );
+        assert!(
+            !text.to_ascii_lowercase().contains("keep-alive"),
+            "inbound keep-alive Connection header must be dropped: {text}"
+        );
+    }
+
     #[tokio::test]
     async fn inject_auth_strips_agent_header_and_appends_real_key() {
         // AAASM-3578: an agent request carrying its own (bogus) Authorization

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -489,7 +489,7 @@ impl ProxyServer {
         // Forward the (consumed) request body to upstream.
         let upstream_tls = self.dial_upstream_tls(host, target).await?;
         let outgoing = serialize_http_request(&req, &req.body);
-        let (mut client_read, mut client_write) = tokio::io::split(client_reader.into_inner());
+        let mut client_tls = client_reader.into_inner();
         let (upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
         upstream_write.write_all(&outgoing).await?;
 
@@ -521,39 +521,36 @@ impl ProxyServer {
                         None => resp.body.clone(),
                     };
                     let modified = serialize_http_response(&resp, &body_to_forward);
-                    client_write.write_all(&modified).await?;
+                    client_tls.write_all(&modified).await?;
                 }
                 Ok(None) => {
                     // Upstream closed without writing a response — nothing to forward.
                 }
                 Err(e) => {
                     // Could not parse the response (e.g. chunked, malformed) —
-                    // fall back to transparent copy from where we left off.
+                    // relay the remaining upstream bytes to the client. AAASM-3864
+                    // (a): we relay only upstream→client, never copying further
+                    // client bytes upstream, so no follow-up request can reach
+                    // upstream un-inspected.
                     tracing::warn!(
                         tool_name = %call.tool_name,
                         error = %e,
-                        "MCP response parse failed, falling back to transparent copy",
+                        "MCP response parse failed, relaying remaining upstream bytes",
                     );
                     let mut upstream_read = upstream_reader.into_inner();
-                    let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
-                    let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
-                    tokio::select! {
-                        r = client_to_upstream => { r?; }
-                        r = upstream_to_client => { r?; }
-                    }
+                    tokio::io::copy(&mut upstream_read, &mut client_tls).await?;
                 }
             }
         } else {
-            // Not MCP (or RPC failed) — transparent bidirectional copy for
-            // any remaining stream activity (mirrors the historical behaviour).
+            // Not MCP (or RPC failed) — relay only the upstream response back to
+            // the client. AAASM-3864 (a): we never copy further client bytes
+            // upstream, so a follow-up request pipelined on the tunnel cannot
+            // reach upstream un-inspected. The serialized request carries
+            // `Connection: close`, bounding this relay.
             let mut upstream_read = upstream_read;
-            let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
-            let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
-            tokio::select! {
-                r = client_to_upstream => { r?; }
-                r = upstream_to_client => { r?; }
-            }
+            tokio::io::copy(&mut upstream_read, &mut client_tls).await?;
         }
+        let _ = client_tls.shutdown().await;
         Ok(())
     }
 
@@ -734,18 +731,17 @@ impl ProxyServer {
             _ => serialize_http_request_with_auth(&req, &req.body, injected_auth_ref),
         };
 
-        let (mut client_read, mut client_write) = tokio::io::split(client_reader.into_inner());
-        let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
+        let mut upstream_tls = upstream_tls;
+        upstream_tls.write_all(&outgoing_bytes).await?;
 
-        upstream_write.write_all(&outgoing_bytes).await?;
-
-        let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
-        let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
-
-        tokio::select! {
-            r = client_to_upstream => { r?; }
-            r = upstream_to_client => { r?; }
-        }
+        // AAASM-3864 (a): relay only the upstream response back to the client,
+        // then tear the tunnel down. We never copy further client bytes upstream,
+        // so a second request pipelined on this keep-alive tunnel cannot reach
+        // upstream un-inspected. The serialized request carries `Connection:
+        // close`, so upstream closes after one response (bounding this copy).
+        let mut client_tls = client_reader.into_inner();
+        tokio::io::copy(&mut upstream_tls, &mut client_tls).await?;
+        let _ = client_tls.shutdown().await;
         Ok(())
     }
 

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -938,6 +938,23 @@ impl ProxyServer {
                 .leak()
         };
 
+        // AAASM-3864 (b): enforce the same egress denylist + network allowlist
+        // the CONNECT path applies. Without this an `http://` scheme-downgrade
+        // bypasses `denied_hosts`/`network_allowlist` — the SSRF resolved-IP
+        // recheck below only guards address ranges, not policy hosts. Deny here
+        // (before any upstream dial), mirroring the CONNECT path's 403.
+        let deny_host = host.split(':').next().unwrap_or(host);
+        if let Some(reason) = self.connect_deny_reason(deny_host) {
+            tracing::info!(host = %deny_host, "plain-HTTP egress denied: {reason}");
+            self.interceptor.emit_policy_decision(deny_host, true).await;
+            let mut stream = reader.into_inner();
+            stream
+                .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
+                .await?;
+            let _ = stream.shutdown().await;
+            return Ok(());
+        }
+
         // Connect to upstream via plain TCP.
         let upstream_addr = if host.contains(':') {
             host.to_string()
@@ -1091,11 +1108,12 @@ mod tests {
 
     #[tokio::test]
     async fn plain_http_forward_blocks_ssrf_resolved_ip() {
-        // AAASM-3140 regression: a plain-HTTP (non-CONNECT) request whose host
-        // resolves to a denied IP (here, loopback) must be refused by the same
-        // SSRF resolved-IP re-validation that guards the CONNECT/tunnel paths.
-        // Before the fix the plain-HTTP path dialed the upstream directly,
-        // bypassing the denylist.
+        // AAASM-3140 / AAASM-3864 regression: a plain-HTTP (non-CONNECT) request
+        // targeting an internal-address literal must be refused. With the egress
+        // denylist now enforced on the plain-HTTP path the loopback literal is
+        // caught by the SSRF guard inside `connect_deny_reason`, returning an
+        // explicit 403 (fail-closed) before any upstream dial.
+        use tokio::io::AsyncReadExt;
         let server = server_with(vec![], vec![]).await;
 
         let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
@@ -1109,11 +1127,16 @@ mod tests {
             .await
             .unwrap();
 
-        let result = server.handle_connection(server_stream).await;
-        let err = result.expect_err("plain-HTTP request to a blocked IP must be refused");
+        server
+            .handle_connection(server_stream)
+            .await
+            .expect("denied request returns Ok after writing 403");
+
+        let mut buf = String::new();
+        client.read_to_string(&mut buf).await.unwrap();
         assert!(
-            matches!(&err, ProxyError::Config(msg) if msg.contains("ssrf")),
-            "expected SSRF denial, got: {err:?}"
+            buf.contains("403"),
+            "plain-HTTP request to a blocked IP must be refused with 403, got: {buf:?}"
         );
     }
 }

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -179,6 +179,33 @@ async fn plain_http_request_is_forwarded_to_upstream() {
 }
 
 #[tokio::test]
+async fn plain_http_request_to_denied_host_is_rejected_with_403() {
+    // AAASM-3864 (b): the plain-HTTP forward path must enforce the egress
+    // denylist that the CONNECT path applies. A request to a denied host is
+    // refused with 403 before any upstream dial, so an `http://` scheme
+    // downgrade cannot bypass denied_hosts.
+    let dir = tempfile::TempDir::new().unwrap();
+    let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+    let mut config = test_config(dir.path());
+    config.denied_hosts = vec!["denied.example.com".to_string()];
+    let (proxy_addr, _handle) = start_proxy(config, ca).await;
+
+    let mut stream = TcpStream::connect(proxy_addr).await.unwrap();
+    stream
+        .write_all(b"GET http://denied.example.com/secret HTTP/1.1\r\nHost: denied.example.com\r\n\r\n")
+        .await
+        .unwrap();
+
+    let mut reader = BufReader::new(stream);
+    let mut response = String::new();
+    reader.read_line(&mut response).await.unwrap();
+    assert!(
+        response.contains("403"),
+        "plain-HTTP request to a denied host must be refused with 403, got: {response}"
+    );
+}
+
+#[tokio::test]
 async fn connect_to_llm_host_triggers_interception_without_crash() {
     // This test verifies that a CONNECT to a known LLM API host
     // (api.openai.com) goes through the detect_api → Interceptor path

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -330,6 +330,53 @@ mod attacker {
         (addr, log)
     }
 
+    /// Start a TLS mock upstream that counts every HTTP request it receives
+    /// across all connections. Each upstream connection is read in a loop, so a
+    /// (buggy) second request pipelined onto the same upstream connection would
+    /// be counted too. Returns the address and the shared request counter.
+    async fn start_counting_tls_upstream(body: &'static str) -> (SocketAddr, Arc<std::sync::atomic::AtomicUsize>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count_task = Arc::clone(&count);
+
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let cert_der = CertificateDer::from(cert.cert.der().to_vec());
+        let key_der = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der()));
+        let server_config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert_der], key_der)
+            .unwrap();
+        let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let acceptor = acceptor.clone();
+                let count = Arc::clone(&count_task);
+                tokio::spawn(async move {
+                    let Ok(tls) = acceptor.accept(stream).await else { return };
+                    let mut reader = BufReader::new(tls);
+                    // Count every request that arrives on this upstream connection.
+                    while let Ok(Some(_req)) = read_http_request(&mut reader).await {
+                        count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        let resp = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        let _ = reader.get_mut().write_all(resp.as_bytes()).await;
+                    }
+                    let mut tls = reader.into_inner();
+                    let _ = tls.shutdown().await;
+                });
+            }
+        });
+        (addr, count)
+    }
+
     /// Build a proxy config whose upstream dial is redirected to `upstream`,
     /// with `allowlist` enforced and the given provider credentials injected.
     fn proxy_config(ca_dir: &std::path::Path, upstream: SocketAddr, allowlist: Vec<String>) -> ProxyConfig {
@@ -500,6 +547,66 @@ mod attacker {
         assert!(
             !response_str.contains(REAL_KEY),
             "proxy echoed its configured provider key to the client: {response_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn keep_alive_second_request_is_not_forwarded_uninspected() {
+        // AAASM-3864 (a): after the proxy inspects and forwards the FIRST request
+        // on a MitM tunnel it forces the exchange closed (Connection: close +
+        // single-direction relay). A second request pipelined onto the same
+        // tunnel must NOT reach upstream un-inspected — the counting upstream
+        // must observe exactly one request.
+        use tokio::io::AsyncBufReadExt;
+        install_crypto();
+        let dir = tempfile::TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let (upstream, count) = start_counting_tls_upstream("{\"ok\":true}").await;
+        let config = proxy_config(dir.path(), upstream, vec![ALLOWED_HOST.to_string()]);
+        let creds = CredentialStore::from_pairs(Vec::<(String, Vec<u8>)>::new());
+        let (proxy, _h) = start_proxy_with_creds(config, ca, creds).await;
+
+        // Manual CONNECT + MitM handshake so we can keep the TLS stream open and
+        // attempt to pipeline a second request on it.
+        let mut stream = TcpStream::connect(proxy).await.unwrap();
+        let connect = format!("CONNECT {ALLOWED_HOST}:443 HTTP/1.1\r\nHost: {ALLOWED_HOST}:443\r\n\r\n");
+        stream.write_all(connect.as_bytes()).await.unwrap();
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        assert!(line.contains("200"), "tunnel not established: {line}");
+        loop {
+            let mut hl = String::new();
+            reader.read_line(&mut hl).await.unwrap();
+            if hl.trim().is_empty() {
+                break;
+            }
+        }
+        let stream = reader.into_inner();
+        let client_config = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(AcceptAnyCert))
+            .with_no_client_auth();
+        let connector = TlsConnector::from(Arc::new(client_config));
+        let server_name = ServerName::try_from(ALLOWED_HOST.to_string()).unwrap();
+        let mut tls = connector.connect(server_name, stream).await.unwrap();
+
+        let req1 = format!("POST /v1/chat/completions HTTP/1.1\r\nHost: {ALLOWED_HOST}\r\nContent-Length: 2\r\n\r\nhi");
+        tls.write_all(req1.as_bytes()).await.unwrap();
+        // Immediately attempt to pipeline a second request onto the same tunnel.
+        let req2 = format!("POST /v1/chat/completions HTTP/1.1\r\nHost: {ALLOWED_HOST}\r\nContent-Length: 2\r\n\r\nby");
+        let _ = tls.write_all(req2.as_bytes()).await;
+
+        // Drain whatever the proxy relays; the connection then closes.
+        let mut out = Vec::new();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(3), tls.read_to_end(&mut out)).await;
+
+        // Settle, then assert the upstream saw exactly one (inspected) request.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the pipelined second request must not be forwarded; upstream must see exactly one request"
         );
     }
 }


### PR DESCRIPTION
## Description

Closes three egress-enforcement bypasses in the `aa-proxy` layer-2 interceptor (all on code paths that are **not** behind any default-off config):

**(a) Keep-alive request pipelining.** `handle_llm_mitm` and the non-MCP branch of `handle_non_llm_with_gateway` inspected only the *first* request on a connection and then dropped into an unconditional bidirectional `tokio::io::copy`. On a persistent HTTP/1.1 tunnel, requests #2..N skipped the credential scan and MCP CheckAction. **Fix chosen: force `Connection: close` + single-exchange relay.** The request serializer now drops any inbound `Connection` header and emits exactly one `Connection: close`, so the upstream tears the connection down after one response. The data path relays **only** upstream→client and never copies further client bytes upstream — so a pipelined second request can never reach upstream un-inspected. I chose this over a per-request inspection loop because it is materially simpler, has no realistic regression surface (the proxy already opens one upstream dial per client connection, so upstream keep-alive was never reused across requests anyway), and is unambiguously fail-closed.

**(b) Plain-HTTP allowlist/denylist bypass.** `handle_plain_http` only re-validated resolved IPs (SSRF) and never called `connect_deny_reason`, so an `http://` scheme-downgrade bypassed `denied_hosts` and the network allowlist that the CONNECT path enforces. It now calls `connect_deny_reason` on the parsed host (port stripped) before any upstream dial and returns `403` on deny, mirroring the CONNECT path.

**(c) Chunked-body inspection gap.** `read_http_request` reads bodies by `Content-Length` only; a `Transfer-Encoding: chunked` request yielded an empty parsed body, so the credential scanner and `parse_mcp_request` saw nothing while the real payload was forwarded un-inspected. The parser now **fails closed**: it rejects chunked requests with a `ProxyError::Config` error, dropping the connection rather than forwarding an un-scanned body.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Forwarded requests now always carry `Connection: close` and chunked request bodies are refused; both are intended fail-closed enforcement behaviours, not public-API changes.

## Related Issues

- Related Jira ticket: AAASM-3864

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Regression coverage (all pass via `cargo nextest run -p aa-proxy`, 171 tests):
- (a) `serialize_forces_connection_close_and_strips_inbound_connection` (unit) and `attacker::keep_alive_second_request_is_not_forwarded_uninspected` (integration — pipelines a 2nd request on a MitM tunnel, asserts the counting upstream sees exactly one request).
- (b) `plain_http_request_to_denied_host_is_rejected_with_403` (integration) and the updated loopback-literal SSRF unit test now asserting the explicit 403.
- (c) `rejects_chunked_transfer_encoding_request` (unit).

Validation gate: `cargo build -p aa-proxy`, `cargo nextest run -p aa-proxy` (171 passed), `cargo fmt --all`, `cargo clippy -p aa-proxy --all-targets -- -D warnings` — all clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
