### PR TITLE
[AAASM-3866] 🔒 (aa-gateway): Server-nonce possession proof for registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "proptest",
+ "rand 0.10.1",
  "rcgen",
  "redis",
  "regex",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -20,6 +20,11 @@ arc-swap     = "1"
 bs58         = "0.5"
 dashmap      = { workspace = true }
 ed25519-dalek = { version = "2", features = ["std"] }
+# CSPRNG for server-issued, single-use registration-challenge nonces
+# (AAASM-3866). `rand::random` draws from an OS-seeded ChaCha thread CSPRNG, so
+# the nonce is unpredictable and the possession proof cannot be precomputed.
+# Same major version aa-runtime / aa-sdk-client already use for handshake nonces.
+rand         = "0.10"
 hex          = { workspace = true }
 notify       = { version = "8", features = [] }
 chrono       = { workspace = true, features = ["clock", "serde"] }

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -1,10 +1,10 @@
 //! `AgentLifecycleService` tonic trait implementation wiring gRPC RPCs to [`AgentRegistry`].
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::time::SystemTime;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant, SystemTime};
 
 use chrono::Utc;
 use tokio::sync::{mpsc, Mutex};
@@ -15,8 +15,8 @@ use aa_core::time::Timestamp;
 use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleService;
 use aa_proto::assembly::agent::v1::{
-    ControlCommand, ControlStreamRequest, DeregisterRequest, DeregisterResponse, HeartbeatRequest, HeartbeatResponse,
-    RegisterRequest, RegisterResponse,
+    ChallengeRequest, ChallengeResponse, ControlCommand, ControlStreamRequest, DeregisterRequest, DeregisterResponse,
+    HeartbeatRequest, HeartbeatResponse, RegisterRequest, RegisterResponse,
 };
 use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
 
@@ -30,12 +30,107 @@ use crate::registry::{AgentRegistry, AgentStatus, LineageError, OrphanMode, Regi
 /// Default heartbeat interval returned to agents at registration (seconds).
 const DEFAULT_HEARTBEAT_INTERVAL_SEC: i64 = 30;
 
-/// Verify an agent's proof of possession of its registering key (AAASM-3591).
+/// Length in bytes of a server-issued registration-challenge nonce (AAASM-3866).
+const CHALLENGE_NONCE_LEN: usize = 32;
+
+/// How long a registration-challenge nonce stays valid after it is issued
+/// (AAASM-3866). Short enough to bound replay/precompute windows, long enough to
+/// cover a client's RequestChallenge → Register round-trip.
+const CHALLENGE_TTL: Duration = Duration::from_secs(30);
+
+/// A single outstanding registration challenge, keyed in [`ChallengeStore`] by
+/// its random nonce bytes.
+struct IssuedChallenge {
+    /// did:key the nonce was issued for — re-checked at Register so a nonce
+    /// cannot be redirected to a different identity.
+    agent_id: String,
+    /// Hex public key the nonce was issued for — re-checked at Register so a
+    /// nonce cannot be replayed to register a different key.
+    public_key: String,
+    /// Monotonic instant after which the nonce is rejected as expired.
+    expires_at: Instant,
+}
+
+/// In-memory store of outstanding registration-challenge nonces (AAASM-3866).
+///
+/// The store is the single-use + time-bound + identity-binding gate that makes
+/// the registration possession proof non-replayable: a nonce is unpredictable
+/// (CSPRNG), removed the first time it is consumed, rejected once expired, and
+/// only accepted for the exact agent_id + public_key it was issued for.
+#[derive(Default)]
+struct ChallengeStore {
+    issued: StdMutex<HashMap<Vec<u8>, IssuedChallenge>>,
+}
+
+impl ChallengeStore {
+    /// Issue a fresh random nonce bound to `agent_id` + `public_key`, returning
+    /// the nonce bytes and its absolute expiry as Unix-epoch milliseconds.
+    ///
+    /// Opportunistically purges already-expired entries so the map cannot grow
+    /// unbounded under a flood of challenge requests that never register.
+    fn issue(&self, agent_id: &str, public_key: &str) -> (Vec<u8>, i64) {
+        let nonce = rand::random::<[u8; CHALLENGE_NONCE_LEN]>().to_vec();
+        let now = Instant::now();
+        let expires_at = now + CHALLENGE_TTL;
+        {
+            let mut issued = self.issued.lock().unwrap_or_else(|e| e.into_inner());
+            issued.retain(|_, c| c.expires_at > now);
+            issued.insert(
+                nonce.clone(),
+                IssuedChallenge {
+                    agent_id: agent_id.to_owned(),
+                    public_key: public_key.to_owned(),
+                    expires_at,
+                },
+            );
+        }
+        let expires_at_unix_ms = Utc::now().timestamp_millis() + CHALLENGE_TTL.as_millis() as i64;
+        (nonce, expires_at_unix_ms)
+    }
+
+    /// Consume the nonce: verify it was issued (single-use — removed on lookup),
+    /// not expired, and bound to this `agent_id` + `public_key`. Returns
+    /// `Status::unauthenticated` otherwise so Register fails closed.
+    ///
+    /// The nonce is removed before the binding/expiry checks so any consumption
+    /// attempt — including a replay or a redirect to a different identity —
+    /// permanently burns it.
+    fn consume(&self, nonce: &[u8], agent_id: &str, public_key: &str) -> Result<(), Status> {
+        if nonce.is_empty() {
+            return Err(Status::unauthenticated(
+                "missing registration_nonce — call RequestChallenge before Register (AAASM-3866)",
+            ));
+        }
+        let entry = {
+            let mut issued = self.issued.lock().unwrap_or_else(|e| e.into_inner());
+            issued.remove(nonce)
+        }
+        .ok_or_else(|| Status::unauthenticated("unknown or already-used registration nonce"))?;
+
+        if Instant::now() > entry.expires_at {
+            return Err(Status::unauthenticated(
+                "registration nonce expired — request a fresh challenge",
+            ));
+        }
+        if entry.agent_id != agent_id || entry.public_key != public_key {
+            return Err(Status::unauthenticated(
+                "registration nonce was not issued for this agent_id + public_key",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Verify an agent's proof of possession of its registering key (AAASM-3591,
+/// hardened by AAASM-3866).
 ///
 /// `proof` must be a raw 64-byte Ed25519 signature over `challenge` that
-/// verifies under `verifying_key`. Returns `Status::unauthenticated` when the
-/// proof is missing, malformed, or does not verify — so no `credential_token`
-/// is minted for a caller that merely presents a public key it does not hold.
+/// verifies under `verifying_key`. `challenge` is the server-issued, single-use
+/// [`ChallengeStore`] nonce (no longer the public, deterministic `agent_id`),
+/// so the proof cannot be precomputed or replayed. Returns
+/// `Status::unauthenticated` when the proof is missing, malformed, or does not
+/// verify — so no `credential_token` is minted for a caller that merely presents
+/// a public key it does not hold.
 fn verify_possession_proof(
     verifying_key: &ed25519_dalek::VerifyingKey,
     challenge: &[u8],
@@ -66,6 +161,8 @@ pub struct AgentLifecycleServiceImpl {
     audit_tx: Option<mpsc::Sender<AuditEntry>>,
     audit_seq: Arc<AtomicU64>,
     audit_last_hash: Arc<Mutex<[u8; 32]>>,
+    /// Outstanding registration-challenge nonces (AAASM-3866).
+    challenges: Arc<ChallengeStore>,
 }
 
 impl AgentLifecycleServiceImpl {
@@ -77,6 +174,7 @@ impl AgentLifecycleServiceImpl {
             audit_tx: None,
             audit_seq: Arc::new(AtomicU64::new(0)),
             audit_last_hash: Arc::new(Mutex::new([0u8; 32])),
+            challenges: Arc::new(ChallengeStore::default()),
         }
     }
 
@@ -91,6 +189,7 @@ impl AgentLifecycleServiceImpl {
             audit_tx: None,
             audit_seq: Arc::new(AtomicU64::new(0)),
             audit_last_hash: Arc::new(Mutex::new([0u8; 32])),
+            challenges: Arc::new(ChallengeStore::default()),
         }
     }
 
@@ -106,6 +205,48 @@ type ControlStreamOutput = Pin<Box<dyn tokio_stream::Stream<Item = Result<Contro
 
 #[tonic::async_trait]
 impl AgentLifecycleService for AgentLifecycleServiceImpl {
+    /// AAASM-3866: issue a fresh, single-use, server-random nonce bound to the
+    /// caller's `agent_id` + `public_key`. The agent signs this nonce and returns
+    /// it as `RegisterRequest.possession_proof` / `registration_nonce`. Issuing
+    /// the challenge server-side is what stops a caller who merely *knows* an
+    /// agent_id from precomputing a valid proof — the signed value is now
+    /// unpredictable.
+    async fn request_challenge(
+        &self,
+        request: Request<ChallengeRequest>,
+    ) -> Result<Response<ChallengeResponse>, Status> {
+        let req = request.into_inner();
+
+        let proto_id = req
+            .agent_id
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing agent_id"))?;
+        validate_proto_agent_id(proto_id).map_err(|e| Status::invalid_argument(e.to_string()))?;
+
+        // Validate public_key shape here too so a challenge is only ever issued
+        // for a well-formed key — the same key the proof must later verify under.
+        if req.public_key.is_empty() {
+            return Err(Status::invalid_argument("missing public_key"));
+        }
+        let pk_bytes =
+            hex::decode(&req.public_key).map_err(|_| Status::invalid_argument("public_key is not valid hex"))?;
+        let pk_array: [u8; 32] = pk_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| Status::invalid_argument("public_key must be 32 bytes (64 hex chars)"))?;
+        ed25519_dalek::VerifyingKey::from_bytes(&pk_array)
+            .map_err(|_| Status::invalid_argument("invalid Ed25519 public key"))?;
+
+        let (nonce, expires_at_unix_ms) = self.challenges.issue(&proto_id.agent_id, &req.public_key);
+
+        tracing::debug!(agent_id = ?proto_id.agent_id, "registration challenge issued");
+
+        Ok(Response::new(ChallengeResponse {
+            nonce,
+            expires_at_unix_ms,
+        }))
+    }
+
     async fn register(&self, request: Request<RegisterRequest>) -> Result<Response<RegisterResponse>, Status> {
         let req = request.into_inner();
 
@@ -130,17 +271,23 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
         )
         .map_err(|_| Status::invalid_argument("invalid Ed25519 public key"))?;
 
-        // AAASM-3591: prove the caller actually HOLDS the private key for
-        // `public_key` before minting a credential_token. Without this, anyone
-        // who can reach the unauthenticated gRPC port can present any valid
-        // Ed25519 public key and mint a token. The proof is an Ed25519 signature
-        // over the registering did:key (`proto_id.agent_id`) bytes; it both
-        // proves possession and binds the key to the claimed identity.
+        // AAASM-3591 / AAASM-3866: prove the caller actually HOLDS the private
+        // key for `public_key` before minting a credential_token. Without this,
+        // anyone who can reach the unauthenticated gRPC port can present any
+        // valid Ed25519 public key and mint a token.
+        //
+        // The proof must sign the *server-issued nonce* the caller obtained from
+        // RequestChallenge — NOT the public, deterministic `agent_id` (which any
+        // attacker who knows the id could sign in advance, then replay). Consume
+        // the nonce first (single-use, time-bound, bound to this exact
+        // agent_id + public_key); only then verify the signature over it.
         //
         // Coordinates with AAASM-3416 (broad per-endpoint authn): this is the
         // minimal credential_token possession gate; a future authn interceptor
         // layers on top of (does not replace) it.
-        verify_possession_proof(&verifying_key, proto_id.agent_id.as_bytes(), &req.possession_proof)?;
+        self.challenges
+            .consume(&req.registration_nonce, &proto_id.agent_id, &req.public_key)?;
+        verify_possession_proof(&verifying_key, &req.registration_nonce, &req.possession_proof)?;
 
         let agent_key = proto_agent_id_to_key(proto_id);
         let credential_token = generate_credential_token();
@@ -423,5 +570,80 @@ mod tests {
         let sk = key();
         let err = verify_possession_proof(&sk.verifying_key(), b"did", &[1, 2, 3]).unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    // ── ChallengeStore (AAASM-3866) ──────────────────────────────────────────
+
+    const DID: &str = "did:key:z6MkExampleAgent";
+    const PK: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn issued_nonce_is_random_and_consumable_once() {
+        let store = ChallengeStore::default();
+        let (n1, _) = store.issue(DID, PK);
+        let (n2, _) = store.issue(DID, PK);
+        assert_eq!(n1.len(), CHALLENGE_NONCE_LEN);
+        assert_ne!(n1, n2, "two issued nonces must differ (CSPRNG)");
+
+        // First consume succeeds; the same nonce is now burned (single-use).
+        assert!(store.consume(&n1, DID, PK).is_ok());
+        let replay = store.consume(&n1, DID, PK).unwrap_err();
+        assert_eq!(replay.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn empty_nonce_is_rejected() {
+        let store = ChallengeStore::default();
+        let err = store.consume(&[], DID, PK).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn unknown_nonce_is_rejected() {
+        let store = ChallengeStore::default();
+        let err = store.consume(&[9u8; CHALLENGE_NONCE_LEN], DID, PK).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn nonce_bound_to_a_different_identity_is_rejected() {
+        let store = ChallengeStore::default();
+        let (nonce, _) = store.issue(DID, PK);
+        // Wrong agent_id.
+        let err = store.consume(&nonce, "did:key:z6MkOther", PK).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn nonce_bound_to_a_different_public_key_is_rejected() {
+        let store = ChallengeStore::default();
+        let (nonce, _) = store.issue(DID, PK);
+        let other_pk = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let err = store.consume(&nonce, DID, other_pk).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn expired_nonce_is_rejected() {
+        let store = ChallengeStore::default();
+        let nonce = vec![1u8; CHALLENGE_NONCE_LEN];
+        // Insert a nonce that already expired one second ago.
+        store.issued.lock().unwrap().insert(
+            nonce.clone(),
+            IssuedChallenge {
+                agent_id: DID.to_owned(),
+                public_key: PK.to_owned(),
+                expires_at: Instant::now() - Duration::from_secs(1),
+            },
+        );
+        let err = store.consume(&nonce, DID, PK).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn expires_at_unix_ms_is_in_the_future() {
+        let store = ChallengeStore::default();
+        let (_, expires_at_unix_ms) = store.issue(DID, PK);
+        assert!(expires_at_unix_ms > Utc::now().timestamp_millis());
     }
 }

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -10,10 +10,12 @@ use aa_gateway::registry::AgentRegistry;
 use aa_gateway::service::AgentLifecycleServiceImpl;
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_client::AgentLifecycleServiceClient;
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
-use aa_proto::assembly::agent::v1::{ControlStreamRequest, DeregisterRequest, HeartbeatRequest, RegisterRequest};
+use aa_proto::assembly::agent::v1::{
+    ChallengeRequest, ControlStreamRequest, DeregisterRequest, HeartbeatRequest, RegisterRequest, RegisterResponse,
+};
 use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
 use tokio::net::TcpListener;
-use tonic::transport::Server;
+use tonic::transport::{Channel, Server};
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -28,12 +30,30 @@ fn test_ed25519_public_key_hex() -> String {
     hex::encode(test_signing_key().verifying_key().as_bytes())
 }
 
-/// AAASM-3591: build a valid possession proof — an Ed25519 signature over the
-/// registering did (`agent_id.agent_id`) with the test signing key — so Register
-/// admits the request and mints a credential_token.
-fn test_possession_proof(did: &str) -> Vec<u8> {
+/// AAASM-3866: drive the two-step registration handshake against a live server.
+///
+/// Requests a fresh server nonce for `req`'s `agent_id` + `public_key`, signs it
+/// with the test key, and submits Register with the nonce + proof. Any
+/// `possession_proof` / `registration_nonce` already set on `req` is overwritten
+/// — the server-issued nonce is authoritative. Negative cases where the server
+/// rejects the challenge itself (e.g. malformed key/id) surface that error.
+async fn register_with_challenge(
+    client: &mut AgentLifecycleServiceClient<Channel>,
+    mut req: RegisterRequest,
+) -> Result<tonic::Response<RegisterResponse>, tonic::Status> {
     use ed25519_dalek::Signer;
-    test_signing_key().sign(did.as_bytes()).to_bytes().to_vec()
+    let agent_id = req.agent_id.clone().expect("agent_id must be set for challenge");
+    let public_key = req.public_key.clone();
+    let challenge = client
+        .request_challenge(ChallengeRequest {
+            agent_id: Some(agent_id),
+            public_key,
+        })
+        .await?
+        .into_inner();
+    req.possession_proof = test_signing_key().sign(&challenge.nonce).to_bytes().to_vec();
+    req.registration_nonce = challenge.nonce;
+    client.register(req).await
 }
 
 fn test_agent_id() -> ProtoAgentId {
@@ -112,8 +132,9 @@ async fn full_lifecycle_register_heartbeat_control_stream_deregister() {
     let public_key = test_ed25519_public_key_hex();
 
     // 1. Register
-    let reg_resp = client
-        .register(RegisterRequest {
+    let reg_resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(agent_id.clone()),
             name: "lifecycle-test-agent".into(),
             framework: "custom".into(),
@@ -122,12 +143,12 @@ async fn full_lifecycle_register_heartbeat_control_stream_deregister() {
             tool_names: vec!["tool_a".into()],
             public_key: public_key.clone(),
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap()
-        .into_inner();
+        },
+    )
+    .await
+    .unwrap()
+    .into_inner();
 
     let token = reg_resp.credential_token;
     assert!(!token.is_empty());
@@ -179,8 +200,9 @@ async fn register_with_invalid_public_key_returns_error() {
         .await
         .unwrap();
 
-    let status = client
-        .register(RegisterRequest {
+    let status = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(test_agent_id()),
             name: "bad-key-agent".into(),
             framework: "custom".into(),
@@ -190,9 +212,10 @@ async fn register_with_invalid_public_key_returns_error() {
             public_key: "not_valid_hex_key".into(),
             metadata: Default::default(),
             ..Default::default()
-        })
-        .await
-        .unwrap_err();
+        },
+    )
+    .await
+    .unwrap_err();
 
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
 }
@@ -206,8 +229,9 @@ async fn register_with_non_did_agent_id_returns_invalid_argument() {
         .await
         .unwrap();
 
-    let status = client
-        .register(RegisterRequest {
+    let status = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(ProtoAgentId {
                 org_id: "org-test".into(),
                 team_id: "team-test".into(),
@@ -222,9 +246,10 @@ async fn register_with_non_did_agent_id_returns_invalid_argument() {
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
             ..Default::default()
-        })
-        .await
-        .unwrap_err();
+        },
+    )
+    .await
+    .unwrap_err();
 
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
     assert!(
@@ -251,8 +276,9 @@ async fn register_with_sdk_derived_did_key_is_accepted() {
     let did = aa_sdk_client::agent_id_to_did_key(plain_agent_id);
     assert!(did.starts_with("did:key:z"), "derived DID must be a did:key, got {did}");
 
-    let resp = client
-        .register(RegisterRequest {
+    let resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(ProtoAgentId {
                 org_id: "org-test".into(),
                 team_id: "team-test".into(),
@@ -265,12 +291,12 @@ async fn register_with_sdk_derived_did_key_is_accepted() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            possession_proof: test_possession_proof(&did),
             ..Default::default()
-        })
-        .await
-        .expect("SDK-derived did:key must be accepted by Register")
-        .into_inner();
+        },
+    )
+    .await
+    .expect("SDK-derived did:key must be accepted by Register")
+    .into_inner();
 
     assert!(!resp.credential_token.is_empty());
 }
@@ -285,8 +311,9 @@ async fn heartbeat_with_wrong_token_returns_unauthenticated() {
     let agent_id = test_agent_id();
 
     // Register first
-    client
-        .register(RegisterRequest {
+    register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(agent_id.clone()),
             name: "auth-test-agent".into(),
             framework: "custom".into(),
@@ -295,11 +322,11 @@ async fn heartbeat_with_wrong_token_returns_unauthenticated() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap();
+        },
+    )
+    .await
+    .unwrap();
 
     // Heartbeat with wrong token
     let status = client
@@ -350,13 +377,12 @@ async fn duplicate_register_returns_already_exists() {
         tool_names: vec![],
         public_key: test_ed25519_public_key_hex(),
         metadata: Default::default(),
-        possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
         ..Default::default()
     };
 
-    client.register(req.clone()).await.unwrap();
+    register_with_challenge(&mut client, req.clone()).await.unwrap();
 
-    let status = client.register(req).await.unwrap_err();
+    let status = register_with_challenge(&mut client, req).await.unwrap_err();
     assert_eq!(status.code(), tonic::Code::AlreadyExists);
 }
 
@@ -374,8 +400,9 @@ async fn heartbeat_returns_should_suspend_true_for_suspended_agent() {
     let agent_id = test_agent_id();
     let public_key = test_ed25519_public_key_hex();
 
-    let reg_resp = client
-        .register(RegisterRequest {
+    let reg_resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(agent_id.clone()),
             name: "suspend-test-agent".into(),
             framework: "custom".into(),
@@ -384,12 +411,12 @@ async fn heartbeat_returns_should_suspend_true_for_suspended_agent() {
             tool_names: vec![],
             public_key,
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap()
-        .into_inner();
+        },
+    )
+    .await
+    .unwrap()
+    .into_inner();
 
     let token = reg_resp.credential_token;
 
@@ -425,8 +452,9 @@ async fn heartbeat_returns_should_suspend_false_for_active_agent() {
     let agent_id = test_agent_id();
     let public_key = test_ed25519_public_key_hex();
 
-    let reg_resp = client
-        .register(RegisterRequest {
+    let reg_resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(agent_id.clone()),
             name: "active-test-agent".into(),
             framework: "custom".into(),
@@ -435,12 +463,12 @@ async fn heartbeat_returns_should_suspend_false_for_active_agent() {
             tool_names: vec![],
             public_key,
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap()
-        .into_inner();
+        },
+    )
+    .await
+    .unwrap()
+    .into_inner();
 
     let token = reg_resp.credential_token;
 
@@ -473,8 +501,9 @@ async fn heartbeat_auto_resumes_budget_suspended_agent_when_budget_reset() {
         .unwrap();
 
     let agent_id = test_agent_id();
-    let reg_resp = client
-        .register(RegisterRequest {
+    let reg_resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(agent_id.clone()),
             name: "auto-resume-agent".into(),
             framework: "custom".into(),
@@ -483,12 +512,12 @@ async fn heartbeat_auto_resumes_budget_suspended_agent_when_budget_reset() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap()
-        .into_inner();
+        },
+    )
+    .await
+    .unwrap()
+    .into_inner();
     let token = reg_resp.credential_token;
 
     // Suspend the agent as if budget was exceeded
@@ -529,8 +558,9 @@ async fn heartbeat_does_not_resume_manually_suspended_agent() {
         .unwrap();
 
     let agent_id = test_agent_id();
-    let reg_resp = client
-        .register(RegisterRequest {
+    let reg_resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(agent_id.clone()),
             name: "manual-suspend-agent".into(),
             framework: "custom".into(),
@@ -539,12 +569,12 @@ async fn heartbeat_does_not_resume_manually_suspended_agent() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap()
-        .into_inner();
+        },
+    )
+    .await
+    .unwrap()
+    .into_inner();
     let token = reg_resp.credential_token;
 
     // Manually suspend the agent
@@ -584,8 +614,9 @@ async fn register_echoes_parent_agent_id_and_team_id() {
         team_id: "team-echo".into(),
         agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into(),
     };
-    client
-        .register(RegisterRequest {
+    register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(parent_id),
             name: "parent-agent".into(),
             framework: "custom".into(),
@@ -594,11 +625,11 @@ async fn register_echoes_parent_agent_id_and_team_id() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T"),
             ..Default::default()
-        })
-        .await
-        .unwrap();
+        },
+    )
+    .await
+    .unwrap();
 
     let agent_id = ProtoAgentId {
         org_id: "org-echo".into(),
@@ -606,8 +637,9 @@ async fn register_echoes_parent_agent_id_and_team_id() {
         agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T".into(),
     };
 
-    let reg_resp = client
-        .register(RegisterRequest {
+    let reg_resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(agent_id),
             name: "echo-agent".into(),
             framework: "custom".into(),
@@ -617,12 +649,12 @@ async fn register_echoes_parent_agent_id_and_team_id() {
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
             parent_agent_id: Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into()),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T"),
             ..Default::default()
-        })
-        .await
-        .unwrap()
-        .into_inner();
+        },
+    )
+    .await
+    .unwrap()
+    .into_inner();
 
     assert_eq!(
         reg_resp.parent_agent_id,
@@ -647,8 +679,9 @@ async fn register_without_topology_returns_none_echo_fields() {
         agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
     };
 
-    let reg_resp = client
-        .register(RegisterRequest {
+    let reg_resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(agent_id),
             name: "no-topo-agent".into(),
             framework: "custom".into(),
@@ -657,12 +690,12 @@ async fn register_without_topology_returns_none_echo_fields() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap()
-        .into_inner();
+        },
+    )
+    .await
+    .unwrap()
+    .into_inner();
 
     assert_eq!(reg_resp.parent_agent_id, None);
     assert_eq!(reg_resp.team_id, None, "empty team_id must normalize to None");
@@ -684,8 +717,9 @@ async fn root_agent_id_for_root_agent_is_set_to_self() {
     };
     let expected_key = aa_gateway::registry::convert::proto_agent_id_to_key(&agent_proto_id);
 
-    let resp = client
-        .register(RegisterRequest {
+    let resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(agent_proto_id),
             name: "root-A".into(),
             framework: "custom".into(),
@@ -694,12 +728,12 @@ async fn root_agent_id_for_root_agent_is_set_to_self() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap()
-        .into_inner();
+        },
+    )
+    .await
+    .unwrap()
+    .into_inner();
 
     let echoed = resp.root_agent_id.expect("root agent must receive root_agent_id");
     assert_eq!(
@@ -726,8 +760,9 @@ async fn root_agent_id_chains_3_levels() {
         agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into(),
     };
     let key_a = aa_gateway::registry::convert::proto_agent_id_to_key(&proto_a);
-    client
-        .register(RegisterRequest {
+    register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(proto_a),
             name: "A".into(),
             framework: "custom".into(),
@@ -736,11 +771,11 @@ async fn root_agent_id_chains_3_levels() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T"),
             ..Default::default()
-        })
-        .await
-        .unwrap();
+        },
+    )
+    .await
+    .unwrap();
 
     // Register B (parent = A).
     let proto_b = ProtoAgentId {
@@ -748,8 +783,9 @@ async fn root_agent_id_chains_3_levels() {
         team_id: team.into(),
         agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T".into(),
     };
-    client
-        .register(RegisterRequest {
+    register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(proto_b),
             name: "B".into(),
             framework: "custom".into(),
@@ -759,11 +795,11 @@ async fn root_agent_id_chains_3_levels() {
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
             parent_agent_id: Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into()),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T"),
             ..Default::default()
-        })
-        .await
-        .unwrap();
+        },
+    )
+    .await
+    .unwrap();
 
     // Register C (parent = B). C's root_agent_id must equal A's key.
     let proto_c = ProtoAgentId {
@@ -771,8 +807,9 @@ async fn root_agent_id_chains_3_levels() {
         team_id: team.into(),
         agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD4T".into(),
     };
-    let resp_c = client
-        .register(RegisterRequest {
+    let resp_c = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(proto_c),
             name: "C".into(),
             framework: "custom".into(),
@@ -782,12 +819,12 @@ async fn root_agent_id_chains_3_levels() {
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
             parent_agent_id: Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T".into()),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD4T"),
             ..Default::default()
-        })
-        .await
-        .unwrap()
-        .into_inner();
+        },
+    )
+    .await
+    .unwrap()
+    .into_inner();
 
     let c_root = resp_c.root_agent_id.expect("C must receive root_agent_id");
     assert_eq!(
@@ -966,8 +1003,9 @@ async fn root_agent_id_when_parent_unknown_returns_invalid_argument() {
         .await
         .unwrap();
 
-    let err = client
-        .register(RegisterRequest {
+    let err = register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(ProtoAgentId {
                 org_id: "unknown-org".into(),
                 team_id: "unknown-team".into(),
@@ -981,11 +1019,11 @@ async fn root_agent_id_when_parent_unknown_returns_invalid_argument() {
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
             parent_agent_id: Some("does-not-exist".into()),
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap_err();
+        },
+    )
+    .await
+    .unwrap_err();
 
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
     assert!(
@@ -1014,8 +1052,9 @@ async fn register_persists_enforcement_mode_observe_override_on_agent_record() {
         agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
     };
 
-    client
-        .register(RegisterRequest {
+    register_with_challenge(
+        &mut client,
+        RegisterRequest {
             agent_id: Some(proto_id.clone()),
             name: "experimental-agent".into(),
             framework: "custom".into(),
@@ -1025,11 +1064,11 @@ async fn register_persists_enforcement_mode_observe_override_on_agent_record() {
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
             enforcement_mode: ProtoMode::Observe as i32,
-            possession_proof: test_possession_proof("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T"),
             ..Default::default()
-        })
-        .await
-        .unwrap();
+        },
+    )
+    .await
+    .unwrap();
 
     // Reach into the registry and confirm the override landed on the record.
     let stored = registry
@@ -1038,4 +1077,168 @@ async fn register_persists_enforcement_mode_observe_override_on_agent_record() {
         .find(|r| r.name == "experimental-agent")
         .expect("registered agent must be present in registry");
     assert_eq!(stored.enforcement_mode, Some(aa_core::EnforcementMode::Observe));
+}
+
+// ── AAASM-3866: server-nonce possession proof ────────────────────────────────
+//
+// The possession proof must sign a fresh, server-issued, single-use nonce — not
+// the public, deterministic agent_id. These tests drive the raw client so they
+// can submit stale/replayed/unknown/wrong nonces the `register_with_challenge`
+// helper would never produce.
+
+async fn connect(addr: SocketAddr) -> AgentLifecycleServiceClient<Channel> {
+    AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap()
+}
+
+/// Sign `payload` with the test key and return the raw 64-byte proof.
+fn sign(payload: &[u8]) -> Vec<u8> {
+    use ed25519_dalek::Signer;
+    test_signing_key().sign(payload).to_bytes().to_vec()
+}
+
+#[tokio::test]
+async fn register_with_fresh_challenge_response_succeeds() {
+    let (addr, _registry) = start_server().await;
+    let mut client = connect(addr).await;
+
+    let resp = register_with_challenge(
+        &mut client,
+        RegisterRequest {
+            agent_id: Some(test_agent_id()),
+            name: "nonce-ok-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            public_key: test_ed25519_public_key_hex(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("a fresh valid challenge-response must mint a credential_token")
+    .into_inner();
+
+    assert!(!resp.credential_token.is_empty());
+}
+
+#[tokio::test]
+async fn register_without_nonce_is_rejected() {
+    // No RequestChallenge round-trip. Signing the public agent_id (the old,
+    // attacker-derivable challenge) must NOT be accepted any more.
+    let (addr, _registry) = start_server().await;
+    let mut client = connect(addr).await;
+    let agent_id = test_agent_id();
+
+    let status = client
+        .register(RegisterRequest {
+            agent_id: Some(agent_id.clone()),
+            name: "no-nonce-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            public_key: test_ed25519_public_key_hex(),
+            possession_proof: sign(agent_id.agent_id.as_bytes()),
+            registration_nonce: vec![],
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::Unauthenticated);
+}
+
+#[tokio::test]
+async fn register_with_unknown_nonce_is_rejected() {
+    // A nonce the server never issued — even with a proof that signs it.
+    let (addr, _registry) = start_server().await;
+    let mut client = connect(addr).await;
+    let bogus = vec![9u8; 32];
+
+    let status = client
+        .register(RegisterRequest {
+            agent_id: Some(test_agent_id()),
+            name: "unknown-nonce-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            public_key: test_ed25519_public_key_hex(),
+            possession_proof: sign(&bogus),
+            registration_nonce: bogus,
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::Unauthenticated);
+}
+
+#[tokio::test]
+async fn register_proof_over_a_different_value_than_the_issued_nonce_is_rejected() {
+    // Obtain a real, server-issued nonce but sign something else.
+    let (addr, _registry) = start_server().await;
+    let mut client = connect(addr).await;
+    let agent_id = test_agent_id();
+    let public_key = test_ed25519_public_key_hex();
+
+    let challenge = client
+        .request_challenge(ChallengeRequest {
+            agent_id: Some(agent_id.clone()),
+            public_key: public_key.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let status = client
+        .register(RegisterRequest {
+            agent_id: Some(agent_id),
+            name: "wrong-proof-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            public_key,
+            // Proof over a value that is NOT the issued nonce.
+            possession_proof: sign(b"not-the-issued-nonce"),
+            registration_nonce: challenge.nonce,
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::Unauthenticated);
+}
+
+#[tokio::test]
+async fn register_with_a_replayed_nonce_is_rejected() {
+    // A nonce is single-use: the first register consumes it; a replay (same
+    // nonce + proof) must fail as Unauthenticated, not surface AlreadyExists.
+    let (addr, _registry) = start_server().await;
+    let mut client = connect(addr).await;
+    let agent_id = test_agent_id();
+    let public_key = test_ed25519_public_key_hex();
+
+    let challenge = client
+        .request_challenge(ChallengeRequest {
+            agent_id: Some(agent_id.clone()),
+            public_key: public_key.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let req = RegisterRequest {
+        agent_id: Some(agent_id),
+        name: "replay-agent".into(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        public_key,
+        possession_proof: sign(&challenge.nonce),
+        registration_nonce: challenge.nonce,
+        ..Default::default()
+    };
+
+    client
+        .register(req.clone())
+        .await
+        .expect("first register with a fresh nonce must succeed");
+
+    let status = client.register(req).await.unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unauthenticated);
 }

--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -14,7 +14,7 @@ use zeroize::Zeroizing;
 
 use crate::config::AssemblyConfig;
 use crate::error::SdkClientError;
-use crate::gateway::{build_register_request, GatewayRegistrationClient};
+use crate::gateway::{build_challenge_request, build_register_request, GatewayRegistrationClient};
 use crate::ipc::{IpcCommand, IpcHandle};
 #[cfg(feature = "preflight")]
 use crate::preflight::Preflight;
@@ -111,9 +111,14 @@ impl AssemblyClient {
         framework: String,
     ) -> Result<String, SdkClientError> {
         let endpoint = config.resolve_gateway_endpoint();
-        let request = build_register_request(config, name, framework);
-
         let mut client = GatewayRegistrationClient::connect(endpoint).await?;
+
+        // AAASM-3866: obtain a fresh server-issued nonce, then sign it in the
+        // register request. This round-trip is what makes the possession proof
+        // non-replayable — the gateway rejects any proof over a stale, reused, or
+        // attacker-derivable challenge.
+        let challenge = client.request_challenge(build_challenge_request(config)).await?;
+        let request = build_register_request(config, name, framework, &challenge.nonce);
         let response = client.register(request).await?;
 
         {

--- a/aa-sdk-client/src/gateway.rs
+++ b/aa-sdk-client/src/gateway.rs
@@ -13,7 +13,7 @@
 //! subsequent `CheckActionRequest`s (see `query_policy`).
 
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_client::AgentLifecycleServiceClient;
-use aa_proto::assembly::agent::v1::{RegisterRequest, RegisterResponse};
+use aa_proto::assembly::agent::v1::{ChallengeRequest, ChallengeResponse, RegisterRequest, RegisterResponse};
 use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
 use tonic::transport::Channel;
 
@@ -36,6 +36,20 @@ impl GatewayRegistrationClient {
         Ok(Self { client })
     }
 
+    /// Call `AgentLifecycleService.RequestChallenge` to obtain a fresh
+    /// server-issued possession-proof nonce (AAASM-3866). The agent signs the
+    /// returned `nonce` and submits it via [`build_register_request`] so the
+    /// gateway can verify possession over an unpredictable value rather than the
+    /// public, deterministic `agent_id`.
+    pub async fn request_challenge(&mut self, request: ChallengeRequest) -> Result<ChallengeResponse, SdkClientError> {
+        let resp = self
+            .client
+            .request_challenge(request)
+            .await
+            .map_err(|status| SdkClientError::RegisterFailed(status.message().to_string()))?;
+        Ok(resp.into_inner())
+    }
+
     /// Call `AgentLifecycleService.Register` and return the response.
     pub async fn register(&mut self, request: RegisterRequest) -> Result<RegisterResponse, SdkClientError> {
         let resp = self
@@ -47,18 +61,47 @@ impl GatewayRegistrationClient {
     }
 }
 
+/// Build the `ChallengeRequest` for the registration possession-proof handshake
+/// (AAASM-3866).
+///
+/// Derives the same deterministic [`AgentKeypair`] as [`build_register_request`]
+/// so the `agent_id` + `public_key` the challenge is bound to match the ones the
+/// agent later registers with.
+pub fn build_challenge_request(config: &AssemblyConfig) -> ChallengeRequest {
+    let keypair = AgentKeypair::derive(&config.agent_id);
+    ChallengeRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: String::new(),
+            team_id: config.team_id.clone().unwrap_or_default(),
+            agent_id: config.registration_did(),
+        }),
+        public_key: keypair.public_key_hex(),
+    }
+}
+
 /// Build the `RegisterRequest` the gateway requires from the SDK config.
 ///
 /// Derives a deterministic [`AgentKeypair`] from `config.agent_id` so the
 /// `agent_id` did:key and the `public_key` hex encode the *same* valid Ed25519
 /// key — both of which the gateway validates at registration.
-pub fn build_register_request(config: &AssemblyConfig, name: String, framework: String) -> RegisterRequest {
+///
+/// `nonce` is the server-issued challenge from [`build_challenge_request`] +
+/// `request_challenge` (AAASM-3866); the possession proof signs it (not the
+/// public, deterministic did:key) so the proof cannot be precomputed or
+/// replayed.
+pub fn build_register_request(
+    config: &AssemblyConfig,
+    name: String,
+    framework: String,
+    nonce: &[u8],
+) -> RegisterRequest {
     let keypair = AgentKeypair::derive(&config.agent_id);
     let registration_did = config.registration_did();
 
-    // AAASM-3591: prove possession of the private key by signing the registering
-    // did:key. The gateway verifies this before minting a credential_token.
-    let possession_proof = keypair.sign(registration_did.as_bytes()).to_vec();
+    // AAASM-3591 / AAASM-3866: prove possession of the private key by signing the
+    // server-issued nonce. The gateway verifies this over the same nonce before
+    // minting a credential_token.
+    let possession_proof = keypair.sign(nonce).to_vec();
 
     RegisterRequest {
         agent_id: Some(ProtoAgentId {
@@ -72,6 +115,7 @@ pub fn build_register_request(config: &AssemblyConfig, name: String, framework: 
         public_key: keypair.public_key_hex(),
         parent_agent_id: config.parent_agent_id.clone(),
         possession_proof,
+        registration_nonce: nonce.to_vec(),
         ..Default::default()
     }
 }
@@ -91,10 +135,12 @@ mod tests {
         }
     }
 
+    const TEST_NONCE: &[u8] = &[7u8; 32];
+
     #[test]
     fn register_request_carries_did_and_consistent_public_key() {
         let config = cfg("my-agent");
-        let req = build_register_request(&config, "My Agent".into(), "custom".into());
+        let req = build_register_request(&config, "My Agent".into(), "custom".into(), TEST_NONCE);
 
         let agent_id = req.agent_id.expect("agent_id must be set");
         assert!(agent_id.agent_id.starts_with("did:key:z"), "got {}", agent_id.agent_id);
@@ -114,12 +160,44 @@ mod tests {
     }
 
     #[test]
+    fn register_request_signs_the_server_nonce() {
+        // AAASM-3866: the proof must verify as an Ed25519 signature over the
+        // server-issued nonce (not the agent_id), and the nonce must be echoed
+        // back so the gateway can re-derive the signed payload.
+        use ed25519_dalek::{Signature, VerifyingKey};
+
+        let config = cfg("my-agent");
+        let req = build_register_request(&config, "My Agent".into(), "custom".into(), TEST_NONCE);
+
+        assert_eq!(req.registration_nonce, TEST_NONCE);
+
+        let pk_bytes: [u8; 32] = hex::decode(&req.public_key).unwrap().try_into().unwrap();
+        let vk = VerifyingKey::from_bytes(&pk_bytes).unwrap();
+        let sig = Signature::from_bytes(&req.possession_proof.as_slice().try_into().unwrap());
+        // Verifies over the nonce …
+        assert!(vk.verify_strict(TEST_NONCE, &sig).is_ok());
+        // … and NOT over the did:key (the old, replayable challenge).
+        let did = req.agent_id.unwrap().agent_id;
+        assert!(vk.verify_strict(did.as_bytes(), &sig).is_err());
+    }
+
+    #[test]
+    fn challenge_request_binds_same_did_and_public_key_as_register() {
+        let config = cfg("my-agent");
+        let challenge = build_challenge_request(&config);
+        let req = build_register_request(&config, "My Agent".into(), "custom".into(), TEST_NONCE);
+
+        assert_eq!(challenge.agent_id, req.agent_id);
+        assert_eq!(challenge.public_key, req.public_key);
+    }
+
+    #[test]
     fn register_request_forwards_team_id_and_parent_agent_id() {
         let mut config = cfg("child-agent");
         config.team_id = Some("team-payments".into());
         config.parent_agent_id = Some("11111111-2222-3333-4444-555555555555".into());
 
-        let req = build_register_request(&config, "Child".into(), "custom".into());
+        let req = build_register_request(&config, "Child".into(), "custom".into(), TEST_NONCE);
 
         assert_eq!(req.agent_id.expect("agent_id must be set").team_id, "team-payments");
         assert_eq!(
@@ -131,7 +209,7 @@ mod tests {
     #[test]
     fn register_request_omits_lineage_when_unset() {
         let config = cfg("root-agent");
-        let req = build_register_request(&config, "Root".into(), "custom".into());
+        let req = build_register_request(&config, "Root".into(), "custom".into(), TEST_NONCE);
 
         assert_eq!(req.agent_id.expect("agent_id must be set").team_id, "");
         assert_eq!(req.parent_agent_id, None);

--- a/aa-sdk-client/tests/gateway_register_with_core.rs
+++ b/aa-sdk-client/tests/gateway_register_with_core.rs
@@ -18,8 +18,8 @@ use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::{
     AgentLifecycleService, AgentLifecycleServiceServer,
 };
 use aa_proto::assembly::agent::v1::{
-    ControlCommand, ControlStreamRequest, DeregisterRequest, DeregisterResponse, HeartbeatRequest, HeartbeatResponse,
-    RegisterRequest, RegisterResponse,
+    ChallengeRequest, ChallengeResponse, ControlCommand, ControlStreamRequest, DeregisterRequest, DeregisterResponse,
+    HeartbeatRequest, HeartbeatResponse, RegisterRequest, RegisterResponse,
 };
 use aa_proto::assembly::common::v1::Decision;
 use aa_proto::assembly::policy::v1::policy_service_server::{PolicyService, PolicyServiceServer};
@@ -42,6 +42,15 @@ struct MockLifecycle;
 
 #[tonic::async_trait]
 impl AgentLifecycleService for MockLifecycle {
+    async fn request_challenge(&self, _: Request<ChallengeRequest>) -> Result<Response<ChallengeResponse>, Status> {
+        // The real gateway issues a random single-use nonce here (AAASM-3866); a
+        // fixed value is enough for this test, which only checks the token flow.
+        Ok(Response::new(ChallengeResponse {
+            nonce: vec![1u8; 32],
+            expires_at_unix_ms: 0,
+        }))
+    }
+
     async fn register(&self, request: Request<RegisterRequest>) -> Result<Response<RegisterResponse>, Status> {
         let req = request.into_inner();
         let agent_id = req

--- a/conformance/tests/message_serialization.rs
+++ b/conformance/tests/message_serialization.rs
@@ -247,6 +247,7 @@ fn register_request_topology_fields_round_trip() {
         max_child_depth: Some(3),
         enforcement_mode: 0,
         possession_proof: vec![1, 2, 3, 4],
+        registration_nonce: vec![5, 6, 7, 8],
     };
     let bytes = original.encode_to_vec();
     let decoded = RegisterRequest::decode(bytes.as_slice()).expect("decode RegisterRequest");

--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -12,6 +12,14 @@ import "common.proto";
 // Consumed by: aa-runtime/src/gateway_client.rs (client side)
 //              aa-gateway/src/registry.rs        (server side)
 service AgentLifecycleService {
+  // RequestChallenge issues a fresh, single-use, server-random nonce that the
+  // agent must sign and return in Register (AAASM-3866). Issuing the challenge
+  // server-side is what makes the possession proof non-replayable and
+  // non-precomputable: the signed payload is no longer a deterministic, public
+  // value (the agent_id did:key) that anyone who knows the id could sign in
+  // advance, but an unpredictable nonce the agent cannot know until it asks.
+  rpc RequestChallenge(ChallengeRequest) returns (ChallengeResponse);
+
   // Register is called once on agent startup to join the governance gateway.
   rpc Register(RegisterRequest) returns (RegisterResponse);
 
@@ -24,6 +32,35 @@ service AgentLifecycleService {
   // ControlStream is a server-streaming RPC: the runtime opens a persistent
   // connection and receives gateway-initiated commands (suspend, resume, kill, etc.).
   rpc ControlStream(ControlStreamRequest) returns (stream ControlCommand);
+}
+
+// ── Challenge ─────────────────────────────────────────────────────────────────
+
+// ChallengeRequest asks the gateway to issue a fresh possession-proof nonce
+// before Register (AAASM-3866).
+message ChallengeRequest {
+  // Composite agent identity the challenge is being requested for. The issued
+  // nonce is bound to this identity so a challenge cannot be redirected to a
+  // different agent at Register time.
+  assembly.common.v1.AgentId agent_id   = 1;
+  // Ed25519 public key (lowercase hex, 64 chars) the agent will register with.
+  // The nonce is bound to this key, so a challenge issued for one key cannot be
+  // replayed to register a different key.
+  string                     public_key = 2;
+  // next: 3
+}
+
+// ChallengeResponse carries the server-issued nonce the agent must sign.
+message ChallengeResponse {
+  // Server-issued, cryptographically-random, single-use nonce. The agent signs
+  // exactly these bytes with its Ed25519 key and returns the signature as
+  // RegisterRequest.possession_proof plus the nonce as
+  // RegisterRequest.registration_nonce.
+  bytes nonce              = 1;
+  // Unix-epoch milliseconds after which the gateway rejects the nonce as
+  // expired. Advisory for the client; the gateway is authoritative.
+  int64 expires_at_unix_ms = 2;
+  // next: 3
 }
 
 // ── Register ─────────────────────────────────────────────────────────────────
@@ -58,15 +95,21 @@ message RegisterRequest {
   // scope. Enables gradual rollout — trusted agents stay in ENFORCE while
   // new / experimental ones run under OBSERVE under the same policy.
   assembly.common.v1.EnforcementMode enforcement_mode = 13;
-  // Proof of possession of the private key matching `public_key` (AAASM-3591):
-  // a raw 64-byte Ed25519 signature over the registering `agent_id.agent_id`
-  // (the did:key) bytes. The gateway verifies this before minting a
-  // credential_token, so reaching the unauthenticated gRPC port is not enough
-  // to mint one — the caller must hold the agent's key. Coordinates with
-  // AAASM-3416 (broad per-endpoint authn); this field is the credential_token
-  // possession gate.
+  // Proof of possession of the private key matching `public_key`
+  // (AAASM-3591, hardened by AAASM-3866): a raw 64-byte Ed25519 signature over
+  // the server-issued `registration_nonce` (NOT over the public `agent_id`,
+  // which would be replayable/precomputable). The gateway verifies this before
+  // minting a credential_token, so reaching the unauthenticated gRPC port is
+  // not enough to mint one — the caller must hold the agent's key AND have just
+  // obtained a fresh nonce. Coordinates with AAASM-3416 (broad per-endpoint
+  // authn); this field is the credential_token possession gate.
   bytes                          possession_proof  = 14;
-  // next: 15
+  // Server-issued nonce from a preceding RequestChallenge call that
+  // `possession_proof` signs (AAASM-3866). The gateway rejects a Register whose
+  // nonce is unknown, expired, already used, or was not issued for this
+  // agent_id + public_key.
+  bytes                          registration_nonce = 15;
+  // next: 16
 }
 
 message RegisterResponse {


### PR DESCRIPTION
## Description

The gateway registration possession-proof signed the **public, deterministic** `agent_id`, and the agent key is `SHA-256(agent_id)` — so anyone who knew/guessed an `agent_id` could precompute the keypair **and** a valid proof, then mint a `credential_token` as that agent over the unauthenticated gRPC port (AAASM-3866).

This PR replaces that replayable challenge with a **server-issued random nonce challenge–response** (the full fix, not the minimal fallback):

- New `AgentLifecycleService.RequestChallenge` RPC issues a cryptographically-random, **single-use**, **time-bound (30s)** nonce, **bound to** the caller's `agent_id` + `public_key`.
- `Register` now **consumes** that nonce (rejecting unknown / expired / reused / mis-bound nonces, fail-closed) and verifies the possession proof **over the nonce** instead of over `agent_id`. The proof can no longer be precomputed or replayed.
- `aa-sdk-client` performs the round-trip (`RequestChallenge` → sign nonce → `Register`).
- Proto adds `ChallengeRequest` / `ChallengeResponse` and `RegisterRequest.registration_nonce` (field 15); `aa-proto` regenerates at build time via `build.rs` (no committed codegen).

**Out of scope (per ticket):** the IPC handshake (`aa-runtime/src/ipc/handshake.rs`) is protected by SO_PEERCRED + 0600 and is untouched.

**Residual:** identity key material is still derived deterministically (`SHA-256(agent_id)`); the nonce challenge–response removes the replay/precompute exploit, but non-deterministic key provisioning remains a separate follow-up.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] Yes (describe below)

gRPC `Register` now **requires** a server-issued `registration_nonce` (obtained via the new `RequestChallenge` RPC); a proof over the bare `agent_id` is no longer accepted. Clients must perform the challenge round-trip — the bundled `aa-sdk-client` already does. Wire-compatible additive proto change (new RPC + new field 15).

## Related Issues

- Related Jira ticket: AAASM-3866

Closes AAASM-3866

## Testing

- [x] Unit tests added / updated — `ChallengeStore` issue/consume/expiry/replay/binding; `aa-sdk-client` proof-over-nonce
- [x] Integration tests added / updated — fresh valid challenge–response succeeds; missing / unknown / replayed / wrong-payload nonce rejected as `Unauthenticated`
- Validation: `cargo nextest run -p aa-gateway` (1257 passed), `-p aa-sdk-client` (60 passed), conformance round-trip passed; `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --all` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (proto/doc comments)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
