### PR TITLE
[AAASM-3868] 🔒 (aa-api): Apply SSRF egress guard to Slack destination /test

### DIFF
--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -27,6 +27,16 @@ pub fn validate_destination(d: &Destination) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// Whether `host` is an allowed Slack incoming-webhook host.
+///
+/// Anchored so a look-alike domain like `evil-slack.com` cannot satisfy the
+/// check: only the apex `slack.com` or a genuine `*.slack.com` subdomain is
+/// accepted. A bare `host.ends_with("slack.com")` matched `evil-slack.com`
+/// (AAASM-3868).
+fn slack_host_allowed(host: &str) -> bool {
+    host == "slack.com" || host.ends_with(".slack.com")
+}
+
 /// Validate the configuration body in isolation.
 pub fn validate_config(c: &DestinationConfig) -> Result<(), ValidationError> {
     match c {
@@ -50,9 +60,9 @@ pub fn validate_config(c: &DestinationConfig) -> Result<(), ValidationError> {
             // Allow loopback in cfg(test) so integration tests can stand up
             // an httpmock server. Production builds enforce slack.com host.
             #[cfg(not(test))]
-            if !host.ends_with("slack.com") {
+            if !slack_host_allowed(host) {
                 return Err(ValidationError::InvalidConfig(
-                    "slack.webhook_url host must end with slack.com",
+                    "slack.webhook_url host must be slack.com or a slack.com subdomain",
                 ));
             }
             #[cfg(test)]

--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -235,6 +235,18 @@ mod tests {
     }
 
     #[test]
+    fn slack_host_allowed_anchors_suffix() {
+        // AAASM-3868: the anchored host check accepts the apex and true
+        // subdomains but rejects look-alike domains that the old
+        // `ends_with("slack.com")` suffix matched.
+        assert!(slack_host_allowed("hooks.slack.com"));
+        assert!(slack_host_allowed("slack.com"));
+        assert!(!slack_host_allowed("evil-slack.com"));
+        assert!(!slack_host_allowed("slack.com.evil.com"));
+        assert!(!slack_host_allowed("notslack.com"));
+    }
+
+    #[test]
     fn slack_http_rejected() {
         assert_eq!(
             validate_config(&slack("http://hooks.slack.com/services/X")),

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -652,6 +652,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_destination_rejects_internal_slack_target() {
+        // AAASM-3868: the Slack `webhook_url` is attacker-controlled and must be
+        // routed through the same SSRF egress guard as the generic webhook. A
+        // loopback / cloud-metadata target is refused (400) before dispatch.
+        for url in [
+            "http://127.0.0.1:9/services/x",
+            "http://169.254.169.254/latest/meta-data/",
+        ] {
+            let state = AppState::local_in_memory().expect("state builds");
+            let dest = state.destination_store.create(
+                "internal-slack".to_string(),
+                DestinationConfig::Slack {
+                    webhook_url: url.to_string(),
+                    channel_override: None,
+                },
+                true,
+            );
+            let failure = test_destination(writer(), Extension(state), Path(dest.id), None)
+                .await
+                .expect_err("internal slack target rejected before dispatch");
+            assert_eq!(
+                failure.into_response().status(),
+                StatusCode::BAD_REQUEST,
+                "{url} must be rejected with 400"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn update_preserves_stored_secret_when_masked() {
         let state = AppState::local_in_memory().expect("state builds");
         let dest = state.destination_store.create(

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -527,16 +527,29 @@ pub async fn test_destination(
         .get(&id)
         .ok_or_else(|| TestDestinationFailure::NotFound(not_found_problem()))?;
 
-    // AAASM-3789: SSRF egress guard. Before dispatching a webhook test-fire,
+    // AAASM-3789 / AAASM-3868: SSRF egress guard. Before dispatching a test-fire,
     // reject targets that resolve to an internal address (loopback / RFC1918 /
     // link-local incl. the cloud-metadata endpoint / ULA). The resolution does
     // a blocking DNS lookup, so it runs on the blocking pool.
-    if let DestinationConfig::Webhook { url, .. } = &destination.config {
-        let parsed = url::Url::parse(url).map_err(|_| {
+    //
+    // Both the generic webhook `url` and the Slack `webhook_url` are
+    // attacker-controlled targets that egress on test-fire and must pass the
+    // guard. PagerDuty / OpsGenie POST to hard-coded vendor endpoints, so they
+    // carry no caller-controlled SSRF surface and are exempt.
+    let egress_url = match &destination.config {
+        DestinationConfig::Webhook { url, .. } => Some(url::Url::parse(url).map_err(|_| {
             TestDestinationFailure::Rejected(validation_error_to_problem(ValidationError::InvalidConfig(
                 "webhook.url is not a valid URL",
             )))
-        })?;
+        })?),
+        DestinationConfig::Slack { webhook_url, .. } => Some(url::Url::parse(webhook_url).map_err(|_| {
+            TestDestinationFailure::Rejected(validation_error_to_problem(ValidationError::InvalidConfig(
+                "slack.webhook_url is not a valid URL",
+            )))
+        })?),
+        DestinationConfig::PagerDuty { .. } | DestinationConfig::OpsGenie { .. } => None,
+    };
+    if let Some(parsed) = egress_url {
         let egress = tokio::task::spawn_blocking(move || validate_webhook_egress(&parsed))
             .await
             .map_err(|_| {


### PR DESCRIPTION
## Description

`aa-api` `test_destination` (`POST /api/v1/alerts/destinations/{id}/test`) applied the AAASM-3789 SSRF egress guard (`validate_webhook_egress`) only inside the `DestinationConfig::Webhook` arm. The Slack variant carries an attacker-controlled `webhook_url` that egresses on test-fire, so a write-scoped caller could register `kind=slack` pointing at an internal/loopback/cloud-metadata target and have the response reflected — an SSRF bypass. The only barrier was a weak `host.ends_with("slack.com")` suffix that also matched look-alike domains like `evil-slack.com`.

This PR:
- Routes the Slack `webhook_url` (alongside the generic webhook `url`) through the same `validate_webhook_egress` SSRF guard before dispatch. PagerDuty / OpsGenie POST to hard-coded vendor endpoints and carry no caller-controlled SSRF surface, so they remain exempt.
- Anchors the Slack host allow-check to the apex `slack.com` or a genuine `*.slack.com` subdomain via a `slack_host_allowed` helper, so `evil-slack.com` no longer satisfies it.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

`test_destination` already returns 400 on a rejected target; OpenAPI spec regenerated with no diff, so no documented response codes or dashboard codegen changed.

## Related Issues

- Related Jira ticket: AAASM-3868

## Testing

- [x] Unit tests added / updated

- `test_destination_rejects_internal_slack_target` — a Slack destination with a loopback / `169.254.169.254` `webhook_url` is rejected with 400 before dispatch.
- `slack_host_allowed_anchors_suffix` — `hooks.slack.com` / `slack.com` pass; `evil-slack.com`, `slack.com.evil.com`, `notslack.com` are rejected.
- Full `cargo nextest run -p aa-api`: 818 passed. `cargo fmt --all`, `cargo clippy -p aa-api --all-targets -- -D warnings` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
