### PR TITLE
[AAASM-3869] 🔒 (aa-gateway): Bind audit events to verified caller

### DIFF
--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -14,6 +14,7 @@ use aa_proto::assembly::audit::v1::audit_service_server::AuditService;
 use aa_proto::assembly::audit::v1::{AuditEvent, ReportEventsRequest, ReportEventsResponse, StreamEventsResponse};
 use aa_proto::assembly::common::v1::Decision;
 
+use crate::iam::VerifiedCaller;
 use crate::registry::{convert as registry_convert, AgentRegistry};
 use crate::service::convert;
 
@@ -185,15 +186,52 @@ fn decision_to_audit_event_type(decision: i32) -> AuditEventType {
     }
 }
 
+/// Verify that an event is attributed to the authenticated caller's own agent
+/// identity (AAASM-3869).
+///
+/// `report_events`/`stream_events` run behind the fail-closed auth interceptor,
+/// but `event.agent_id` is attacker-supplied and drives WORM/hash-chained audit
+/// attribution + lineage. Without this check any registered agent could forge
+/// audit history under another agent/tenant. The event's composite `agent_id` is
+/// resolved to the same 16-byte registry key the interceptor derived for the
+/// caller ([`registry_convert::proto_agent_id_to_key`] ↔ [`VerifiedCaller::agent_key`]);
+/// the binding is *per-agent* (stricter than the sibling per-tenant reads) because
+/// audit attribution is inherently self-reported. An absent `agent_id` cannot
+/// identify the caller and is therefore also rejected.
+fn caller_owns_event(caller: &VerifiedCaller, event: &AuditEvent) -> bool {
+    event
+        .agent_id
+        .as_ref()
+        .map(registry_convert::proto_agent_id_to_key)
+        .is_some_and(|key| key == caller.agent_key)
+}
+
 #[tonic::async_trait]
 impl AuditService for AuditServiceImpl {
     async fn report_events(
         &self,
         request: Request<ReportEventsRequest>,
     ) -> Result<Response<ReportEventsResponse>, Status> {
+        // AAASM-3869 — read the verified caller (injected by the fail-closed auth
+        // interceptor) before consuming the request. Its absence means the request
+        // did not authenticate, so fail closed rather than ingest forgeable entries.
+        let caller = request.extensions().get::<VerifiedCaller>().cloned().ok_or_else(|| {
+            Status::unauthenticated("missing verified caller; audit reporting requires authentication")
+        })?;
         let batch = request.into_inner();
-        let mut event_ids = Vec::with_capacity(batch.events.len());
 
+        // AAASM-3869 — reject the whole batch if any event is attributed to a
+        // different agent, so a caller can never forge audit history under another
+        // agent/tenant. Checked before any ingest so a poisoned batch writes nothing.
+        for event in &batch.events {
+            if !caller_owns_event(&caller, event) {
+                return Err(Status::permission_denied(
+                    "audit event agent_id does not match the authenticated caller",
+                ));
+            }
+        }
+
+        let mut event_ids = Vec::with_capacity(batch.events.len());
         for event in &batch.events {
             let id = self.ingest_event(event).await;
             event_ids.push(id);
@@ -206,6 +244,11 @@ impl AuditService for AuditServiceImpl {
         &self,
         request: Request<tonic::Streaming<AuditEvent>>,
     ) -> Result<Response<StreamEventsResponse>, Status> {
+        // AAASM-3869 — read the verified caller before consuming the request and
+        // fail closed when absent; every streamed event must be attributed to it.
+        let caller = request.extensions().get::<VerifiedCaller>().cloned().ok_or_else(|| {
+            Status::unauthenticated("missing verified caller; audit streaming requires authentication")
+        })?;
         let mut stream = request.into_inner();
         let mut events_received: i64 = 0;
 
@@ -213,6 +256,13 @@ impl AuditService for AuditServiceImpl {
             tracing::error!(error = %e, "stream_events receive error");
             Status::internal(format!("stream receive error: {e}"))
         })? {
+            // AAASM-3869 — reject and terminate the stream if an event is
+            // attributed to another agent, preventing cross-agent audit forgery.
+            if !caller_owns_event(&caller, &event) {
+                return Err(Status::permission_denied(
+                    "audit event agent_id does not match the authenticated caller",
+                ));
+            }
             self.ingest_event(&event).await;
             events_received += 1;
         }

--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -270,3 +270,117 @@ impl AuditService for AuditServiceImpl {
         Ok(Response::new(StreamEventsResponse { events_received }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
+
+    /// Build a proto [`AgentId`](ProtoAgentId) for a given agent.
+    fn proto_agent(agent: &str) -> ProtoAgentId {
+        ProtoAgentId {
+            org_id: "org-x".into(),
+            team_id: "team-a".into(),
+            agent_id: agent.into(),
+        }
+    }
+
+    /// Build a [`VerifiedCaller`] whose `agent_key` matches `proto`, mirroring how
+    /// the auth interceptor derives the caller key from the registration identity.
+    fn caller_for(proto: &ProtoAgentId) -> VerifiedCaller {
+        VerifiedCaller {
+            agent_key: registry_convert::proto_agent_id_to_key(proto),
+            team_id: Some("team-a".into()),
+            org_id: Some("org-x".into()),
+        }
+    }
+
+    /// Build a minimal audit event attributed to `proto`.
+    fn event_for(proto: &ProtoAgentId) -> AuditEvent {
+        AuditEvent {
+            event_id: "evt-1".into(),
+            agent_id: Some(proto.clone()),
+            ..Default::default()
+        }
+    }
+
+    /// Fresh service with a roomy audit channel so `try_send` never drops.
+    fn service() -> AuditServiceImpl {
+        let (tx, _rx) = mpsc::channel(64);
+        AuditServiceImpl::new(tx, Arc::new(AtomicU64::new(0)), [0u8; 32])
+    }
+
+    #[tokio::test]
+    async fn report_events_rejects_cross_agent_forgery() {
+        // Agent A submits an event attributed to victim B → permission_denied.
+        let attacker = proto_agent("did:key:zAttacker");
+        let victim = proto_agent("did:key:zVictim");
+
+        let mut req = Request::new(ReportEventsRequest {
+            events: vec![event_for(&victim)],
+        });
+        req.extensions_mut().insert(caller_for(&attacker));
+
+        let err = service().report_events(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn report_events_admits_self_attributed_event() {
+        // Agent A submits its own agent_id → ok.
+        let agent = proto_agent("did:key:zSelf");
+
+        let mut req = Request::new(ReportEventsRequest {
+            events: vec![event_for(&agent)],
+        });
+        req.extensions_mut().insert(caller_for(&agent));
+
+        let resp = service().report_events(req).await.unwrap().into_inner();
+        assert_eq!(resp.event_ids, vec!["evt-1".to_owned()]);
+    }
+
+    #[tokio::test]
+    async fn report_events_missing_caller_is_unauthenticated() {
+        // No VerifiedCaller in extensions ⇒ fail closed.
+        let agent = proto_agent("did:key:zSelf");
+        let req = Request::new(ReportEventsRequest {
+            events: vec![event_for(&agent)],
+        });
+
+        let err = service().report_events(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[tokio::test]
+    async fn report_events_rejects_event_without_agent_id() {
+        // An absent agent_id cannot identify the caller ⇒ rejected.
+        let agent = proto_agent("did:key:zSelf");
+        let mut req = Request::new(ReportEventsRequest {
+            events: vec![AuditEvent {
+                event_id: "evt-1".into(),
+                agent_id: None,
+                ..Default::default()
+            }],
+        });
+        req.extensions_mut().insert(caller_for(&agent));
+
+        let err = service().report_events(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn report_events_rejects_mixed_batch_atomically() {
+        // A batch mixing a self-attributed event with a forged one is rejected
+        // wholesale so the poisoned entry is never ingested.
+        let agent = proto_agent("did:key:zSelf");
+        let victim = proto_agent("did:key:zVictim");
+
+        let mut req = Request::new(ReportEventsRequest {
+            events: vec![event_for(&agent), event_for(&victim)],
+        });
+        req.extensions_mut().insert(caller_for(&agent));
+
+        let err = service().report_events(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+}

--- a/aa-gateway/tests/audit_integration_test.rs
+++ b/aa-gateway/tests/audit_integration_test.rs
@@ -7,6 +7,9 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use aa_core::{AuditEntry, AuditEventType};
+use aa_gateway::iam::{auth_interceptor, CREDENTIAL_METADATA_KEY};
+use aa_gateway::registry::convert::proto_agent_id_to_key;
+use aa_gateway::registry::{AgentRecord, AgentRegistry, AgentStatus};
 use aa_gateway::service::{AuditServiceImpl, PolicyServiceImpl};
 use aa_gateway::PolicyEngine;
 use aa_proto::assembly::audit::v1::audit_service_client::AuditServiceClient;
@@ -30,6 +33,67 @@ tools:
     allow: false
 "#;
 
+// AAASM-3869 — the audit RPCs now bind events to the verified caller, so the
+// e2e tests must authenticate. These agents are registered with the test server
+// and their credential tokens presented by the client.
+const AGENT_1_TOKEN: &str = "tok-agent-1";
+const AGENT_S_TOKEN: &str = "tok-agent-s";
+
+fn proto_agent(agent_id: &str) -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: agent_id.into(),
+    }
+}
+
+/// Build a minimal active [`AgentRecord`] keyed by `proto`'s composite identity
+/// and addressable by `token` via the credential reverse-index.
+fn audit_caller_record(proto: &ProtoAgentId, token: &str) -> AgentRecord {
+    AgentRecord {
+        agent_id: proto_agent_id_to_key(proto),
+        name: proto.agent_id.clone(),
+        framework: "test".into(),
+        version: "0.0.1".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "pk".into(),
+        credential_token: token.into(),
+        metadata: std::collections::BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: vec![],
+        recent_events: std::collections::VecDeque::new(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: Some(proto.team_id.clone()),
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+        children: vec![],
+        parent_key: None,
+        enforcement_mode: None,
+        org_id: Some(proto.org_id.clone()),
+    }
+}
+
+/// Attach a credential token to a unary request so the auth interceptor resolves
+/// a [`VerifiedCaller`](aa_gateway::iam::VerifiedCaller).
+fn with_token<T>(message: T, token: &str) -> tonic::Request<T> {
+    let mut req = tonic::Request::new(message);
+    req.metadata_mut()
+        .insert(CREDENTIAL_METADATA_KEY, token.parse().unwrap());
+    req
+}
+
 /// Start a server wired to an audit channel where the receiver is returned so
 /// the test can consume and inspect entries.
 async fn start_server_with_audit_rx() -> (SocketAddr, mpsc::Receiver<AuditEntry>, Arc<AtomicU64>) {
@@ -44,6 +108,16 @@ async fn start_server_with_audit_rx() -> (SocketAddr, mpsc::Receiver<AuditEntry>
     let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops), [0u8; 32]);
     let audit_svc = AuditServiceImpl::new(audit_tx, Arc::clone(&audit_drops), [0u8; 32]);
 
+    // AAASM-3869 — register the audit callers and front the audit service with the
+    // fail-closed auth interceptor so the e2e tests exercise the caller binding.
+    let registry = Arc::new(AgentRegistry::new());
+    registry
+        .register(audit_caller_record(&proto_agent("agent-1"), AGENT_1_TOKEN))
+        .unwrap();
+    registry
+        .register(audit_caller_record(&proto_agent("agent-s"), AGENT_S_TOKEN))
+        .unwrap();
+
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
@@ -52,7 +126,10 @@ async fn start_server_with_audit_rx() -> (SocketAddr, mpsc::Receiver<AuditEntry>
         let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
         Server::builder()
             .add_service(PolicyServiceServer::new(policy_svc))
-            .add_service(AuditServiceServer::new(audit_svc))
+            .add_service(AuditServiceServer::with_interceptor(
+                audit_svc,
+                auth_interceptor(Arc::clone(&registry)),
+            ))
             .serve_with_incoming(incoming)
             .await
             .unwrap();
@@ -183,7 +260,7 @@ async fn report_events_ingests_batch() {
     ];
 
     let resp = client
-        .report_events(ReportEventsRequest { events })
+        .report_events(with_token(ReportEventsRequest { events }, AGENT_1_TOKEN))
         .await
         .unwrap()
         .into_inner();
@@ -274,7 +351,11 @@ async fn stream_events_ingests_client_stream() {
     ];
 
     let stream = tokio_stream::iter(events);
-    let resp = client.stream_events(stream).await.unwrap().into_inner();
+    let resp = client
+        .stream_events(with_token(stream, AGENT_S_TOKEN))
+        .await
+        .unwrap()
+        .into_inner();
 
     assert_eq!(resp.events_received, 3);
 
@@ -375,7 +456,14 @@ async fn audit_service_populates_lineage_from_registry() {
         ..Default::default()
     };
 
-    let req = tonic::Request::new(ReportEventsRequest { events: vec![event] });
+    // AAASM-3869 — inject the verified caller bound to the event's own agent
+    // identity, as the fail-closed auth interceptor would in production.
+    let mut req = tonic::Request::new(ReportEventsRequest { events: vec![event] });
+    req.extensions_mut().insert(aa_gateway::iam::VerifiedCaller {
+        agent_key: agent_registry_key,
+        team_id: Some("team-alpha".into()),
+        org_id: None,
+    });
     svc.report_events(req).await.unwrap();
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/aa-gateway/tests/audit_service_seq_recovery_test.rs
+++ b/aa-gateway/tests/audit_service_seq_recovery_test.rs
@@ -12,6 +12,8 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use aa_core::AuditEntry;
+use aa_gateway::iam::VerifiedCaller;
+use aa_gateway::registry::convert::proto_agent_id_to_key;
 use aa_gateway::service::AuditServiceImpl;
 use aa_proto::assembly::audit::v1::audit_service_server::AuditService;
 use aa_proto::assembly::audit::v1::{AuditEvent, ReportEventsRequest};
@@ -19,21 +21,37 @@ use aa_proto::assembly::common::v1::{AgentId as ProtoAgentId, Decision};
 use tokio::sync::mpsc;
 use tonic::Request;
 
+fn proto_agent() -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "agent-1".into(),
+    }
+}
+
 fn report_request() -> ReportEventsRequest {
     ReportEventsRequest {
         events: vec![AuditEvent {
             event_id: "evt-seq".into(),
-            agent_id: Some(ProtoAgentId {
-                org_id: "org".into(),
-                team_id: "team".into(),
-                agent_id: "agent-1".into(),
-            }),
+            agent_id: Some(proto_agent()),
             decision: Decision::Allow as i32,
             trace_id: "trace-seq".into(),
             span_id: "span-seq".into(),
             ..Default::default()
         }],
     }
+}
+
+/// Wrap a `report_request` in a `Request` carrying a `VerifiedCaller` bound to the
+/// same agent identity, as the fail-closed auth interceptor would (AAASM-3869).
+fn authed_report_request() -> Request<ReportEventsRequest> {
+    let mut req = Request::new(report_request());
+    req.extensions_mut().insert(VerifiedCaller {
+        agent_key: proto_agent_id_to_key(&proto_agent()),
+        team_id: Some("team".into()),
+        org_id: Some("org".into()),
+    });
+    req
 }
 
 #[tokio::test]
@@ -43,8 +61,8 @@ async fn audit_service_seq_continues_monotonically_after_restart() {
     let drops = Arc::new(AtomicU64::new(0));
     let svc = AuditServiceImpl::new(audit_tx, drops, [0u8; 32]);
 
-    svc.report_events(Request::new(report_request())).await.unwrap();
-    svc.report_events(Request::new(report_request())).await.unwrap();
+    svc.report_events(authed_report_request()).await.unwrap();
+    svc.report_events(authed_report_request()).await.unwrap();
     drop(svc); // close the tx so the receiver drains to completion
 
     let mut first_run_seqs = Vec::new();
@@ -59,7 +77,7 @@ async fn audit_service_seq_continues_monotonically_after_restart() {
     let drops2 = Arc::new(AtomicU64::new(0));
     let svc2 = AuditServiceImpl::new(audit_tx2, drops2, [0u8; 32]).with_initial_seq(last_seq + 1);
 
-    svc2.report_events(Request::new(report_request())).await.unwrap();
+    svc2.report_events(authed_report_request()).await.unwrap();
     drop(svc2);
 
     let mut second_run_seqs = Vec::new();
@@ -83,7 +101,7 @@ async fn audit_service_without_recovery_seq_would_duplicate() {
     let (audit_tx, mut audit_rx) = mpsc::channel::<AuditEntry>(4096);
     let drops = Arc::new(AtomicU64::new(0));
     let svc = AuditServiceImpl::new(audit_tx, drops, [0u8; 32]);
-    svc.report_events(Request::new(report_request())).await.unwrap();
+    svc.report_events(authed_report_request()).await.unwrap();
     drop(svc);
     let first = audit_rx.recv().await.unwrap().seq();
     assert_eq!(first, 0);
@@ -91,7 +109,7 @@ async fn audit_service_without_recovery_seq_would_duplicate() {
     let (audit_tx2, mut audit_rx2) = mpsc::channel::<AuditEntry>(4096);
     let drops2 = Arc::new(AtomicU64::new(0));
     let svc2 = AuditServiceImpl::new(audit_tx2, drops2, [0u8; 32]);
-    svc2.report_events(Request::new(report_request())).await.unwrap();
+    svc2.report_events(authed_report_request()).await.unwrap();
     drop(svc2);
     let second = audit_rx2.recv().await.unwrap().seq();
 


### PR DESCRIPTION
## Description

The gRPC `AuditService` RPCs (`report_events`, `stream_events`, `ingest_event`) run behind the fail-closed `auth_interceptor` (which injects a `VerifiedCaller` into request extensions) but never read it. `event.agent_id` is fully attacker-supplied yet drives WORM/hash-chained audit **attribution + lineage**, so any registered agent could submit events with `agent_id = victim` and forge audit history under another agent/tenant (AAASM-3869).

This binds every ingested event to the authenticated caller. The handlers now read the `VerifiedCaller` from the request extensions **before** `into_inner()` and reject any event whose composite `agent_id` does not resolve to the caller's own identity, mirroring how sibling services (`topology`/`approval`/`secrets`, AAASM-3845/3846) bind the caller.

**Binding predicate — per-agent (not per-tenant).** The event's composite `agent_id` is hashed to the same 16-byte registry key the interceptor derived for the caller (`registry::convert::proto_agent_id_to_key` ↔ `VerifiedCaller::agent_key`) and compared for equality. This is **stricter** than the sibling per-tenant reads, deliberately: audit attribution is inherently *self-reported* — an agent writes WORM entries only about its own activity — so per-tenant binding would still permit cross-agent forgery within a tenant, which corrupts the hash-chained log. Per-agent binding closes that gap entirely.

Failure modes (fail closed):
- Missing `VerifiedCaller` → `unauthenticated`.
- `agent_id` belongs to another agent, or is absent → `permission_denied`.
- `report_events` validates the whole batch before ingesting any event, so a poisoned batch writes nothing.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

A correctly-behaving SDK already reports events under its own authenticated identity, so legitimate self-attribution is unaffected.

## Related Issues

- Related Jira ticket: AAASM-3869

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

New `audit_service` unit tests: cross-agent forgery → `permission_denied`; self-attributed event → ok; missing caller → `unauthenticated`; absent `agent_id` → denied; mixed batch rejected atomically. The seq-recovery and lineage integration tests now inject the `VerifiedCaller`, and the e2e server is fronted with the `auth_interceptor` so report/stream exercise the binding end to end with credential tokens.

Validation (gRPC only — no openapi/dashboard regen):
- `cargo build -p aa-gateway` ✅
- `cargo nextest run -p aa-gateway` ✅ (1250 passed; `policy_latency_test` flaky-passed on retry, known macOS flake)
- `cargo fmt --all` ✅
- `cargo clippy -p aa-gateway --all-targets -- -D warnings` ✅

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3869

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
