### PR TITLE
[AAASM-3875] 🔒 (aa-gateway): Fail-closed on invalid budget timezone

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2445,6 +2445,57 @@ mod tests {
         assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
     }
 
+    // ── budget timezone fail-closed (AAASM-3875) ──────────────────────────────
+
+    #[test]
+    fn parse_budget_tz_none_defaults_to_utc() {
+        // No timezone configured is a deliberate default, not a misconfig —
+        // keep the documented UTC fallback.
+        assert_eq!(parse_budget_tz(None).unwrap(), chrono_tz::UTC);
+    }
+
+    #[test]
+    fn parse_budget_tz_valid_string_parses() {
+        assert_eq!(parse_budget_tz(Some("Asia/Tokyo")).unwrap(), chrono_tz::Asia::Tokyo);
+    }
+
+    #[test]
+    fn parse_budget_tz_invalid_fails_closed() {
+        // AAASM-3875: an unparseable budget timezone must NOT silently fall back
+        // to UTC (which would shift the daily/monthly reset boundaries). It is a
+        // hard configuration error, mirroring the schedule fix (AAASM-3847).
+        match parse_budget_tz(Some("Not/AZone")) {
+            Err(PolicyLoadError::Validation(errs)) => {
+                assert!(
+                    errs.iter().any(|e| e.field == "budget.timezone"),
+                    "expected a budget.timezone validation error, got: {errs:?}"
+                );
+            }
+            other => panic!("expected fail-closed Validation error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_from_file_invalid_budget_tz_fails_closed() {
+        // AAASM-3875: loading a policy whose budget timezone does not parse must
+        // abort the load rather than degrade silently to UTC.
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            tmp,
+            "version: \"1\"\nbudget:\n  daily_limit_usd: 10.0\n  timezone: \"Not/AZone\"\n"
+        )
+        .unwrap();
+        tmp.flush().unwrap();
+        let (alert_tx, _) = tokio::sync::broadcast::channel::<crate::budget::BudgetAlert>(64);
+        let result = PolicyEngine::load_from_file(tmp.path(), alert_tx);
+        assert!(
+            matches!(result, Err(PolicyLoadError::Validation(_))),
+            "expected fail-closed Validation error, got: {:?}",
+            result.err()
+        );
+    }
+
     // ── PolicyEvaluator trait impl ────────────────────────────────────────────
 
     #[test]

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -242,6 +242,30 @@ pub enum PolicyLoadError {
     History(crate::policy::history::PolicyHistoryError),
 }
 
+/// Parse the optional `budget.timezone`, **failing closed** on a misconfigured
+/// value (AAASM-3875).
+///
+/// The budget timezone governs the daily/monthly reset boundaries, not an
+/// allow/deny decision directly — but silently falling back to UTC on an
+/// unparseable value (the former `parse().ok().unwrap_or(UTC)` behavior)
+/// shifted those boundaries without warning, masking the operator's
+/// misconfiguration. Mirroring the schedule fix (AAASM-3847,
+/// `eval_schedule_stage`), a present-but-unparseable timezone is now a hard
+/// configuration error that aborts the policy load rather than degrading
+/// silently to UTC. `None` (no timezone configured) keeps the documented UTC
+/// default, since absence is a deliberate choice, not a misconfiguration.
+fn parse_budget_tz(timezone: Option<&str>) -> Result<chrono_tz::Tz, PolicyLoadError> {
+    match timezone {
+        None => Ok(chrono_tz::UTC),
+        Some(s) => s.parse::<chrono_tz::Tz>().map_err(|_| {
+            PolicyLoadError::Validation(vec![crate::policy::ValidationError::new(
+                "budget.timezone",
+                format!("invalid budget timezone: {s}"),
+            )])
+        }),
+    }
+}
+
 /// Stage 6 outcome for [`PolicyEngine::apply_credential_scan`]: either a
 /// hard-block deny (the `credential_action: block` short-circuit) or the
 /// redacted payload + findings to carry into the remaining stages.
@@ -308,13 +332,7 @@ impl PolicyEngine {
                     .collect()
             })
             .unwrap_or_default();
-        let budget_tz = output
-            .document
-            .budget
-            .as_ref()
-            .and_then(|bp| bp.timezone.as_deref())
-            .and_then(|s| s.parse::<chrono_tz::Tz>().ok())
-            .unwrap_or(chrono_tz::UTC);
+        let budget_tz = parse_budget_tz(output.document.budget.as_ref().and_then(|bp| bp.timezone.as_deref()))?;
         let daily_limit = output
             .document
             .budget
@@ -541,12 +559,7 @@ impl PolicyEngine {
                             .collect()
                     })
                     .unwrap_or_default();
-                budget_tz = doc
-                    .budget
-                    .as_ref()
-                    .and_then(|bp| bp.timezone.as_deref())
-                    .and_then(|s| s.parse::<chrono_tz::Tz>().ok())
-                    .unwrap_or(chrono_tz::UTC);
+                budget_tz = parse_budget_tz(doc.budget.as_ref().and_then(|bp| bp.timezone.as_deref()))?;
                 daily_limit = doc
                     .budget
                     .as_ref()


### PR DESCRIPTION
## Description

The budget timezone parse at both load sites in `aa-gateway/src/engine/mod.rs` (`load_from_file` ~317 and `read_cascade_dir` ~549) used `...parse().ok().unwrap_or(chrono_tz::UTC)` — the last fail-open timezone parse left after the schedule path was hardened in AAASM-3847. On a misconfigured (unparseable) `budget.timezone`, the engine silently fell back to UTC, shifting the daily/monthly budget reset boundaries without any signal to the operator.

**Fix:** a new shared `parse_budget_tz` helper that fails closed — a present-but-unparseable `budget.timezone` aborts the policy load with a `PolicyLoadError::Validation` error (mirroring `eval_schedule_stage`'s deny-on-invalid-tz semantics, adapted to the load-time config path), instead of degrading to UTC. An **absent** timezone keeps the documented UTC default, since absence is a deliberate choice rather than a misconfiguration. Both load sites now route through this one helper so they cannot diverge again.

This is defense-in-depth: the YAML validator (`policy/validator.rs`) already rejects an invalid `budget.timezone`, so the engine fallback was effectively dead code — but it was dead code in fail-open *form*. The fix removes that fail-open form so the engine stays fail-closed even if the validator check is ever bypassed.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

A previously-accepted-but-broken config (invalid budget tz) now fails the load loudly instead of silently using UTC — this is the intended hardening, and the validator already rejected such configs.

## Related Issues

- Related Jira ticket: AAASM-3875

## Testing

- [x] Unit tests added / updated

Added regression tests in `engine::tests` mirroring `schedule_invalid_timezone_fails_closed`:
- `parse_budget_tz_none_defaults_to_utc` — absent tz keeps UTC default
- `parse_budget_tz_valid_string_parses` — valid IANA name parses
- `parse_budget_tz_invalid_fails_closed` — invalid tz returns a `budget.timezone` validation error
- `load_from_file_invalid_budget_tz_fails_closed` — end-to-end load aborts on invalid budget tz

Validation gate (worktree, isolated `CARGO_TARGET_DIR`):
- `cargo build -p aa-gateway` — clean
- `cargo nextest run -p aa-gateway` — 1249 passed, 0 failed
- `cargo fmt --all` — clean
- `cargo clippy -p aa-gateway --all-targets -- -D warnings` — clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3875

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf