### PR TITLE
[AAASM-3828] 🔒 (aa-gateway): Authenticate InvalidationService::Subscribe

### DIFF
--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -537,9 +537,10 @@ pub async fn serve_tcp(
         .add_service(ApprovalServiceServer::with_interceptor(approval_svc, auth.clone()))
         .add_service(TopologyServiceServer::with_interceptor(topology_svc, auth.clone()))
         .add_service(SecretsServiceServer::with_interceptor(secrets_svc, auth.clone()))
-        .add_service(InvalidationServiceServer::new(InvalidationServiceImpl::new(
-            Arc::clone(&invalidation_hub),
-        )))
+        .add_service(InvalidationServiceServer::with_interceptor(
+            InvalidationServiceImpl::new(Arc::clone(&invalidation_hub)),
+            auth.clone(),
+        ))
         .serve_with_shutdown(addr, async move {
             shutdown_signal().await;
             db_token.cancel();
@@ -634,9 +635,10 @@ pub async fn serve_uds(
         .add_service(ApprovalServiceServer::with_interceptor(approval_svc, auth.clone()))
         .add_service(TopologyServiceServer::with_interceptor(topology_svc, auth.clone()))
         .add_service(SecretsServiceServer::with_interceptor(secrets_svc, auth.clone()))
-        .add_service(InvalidationServiceServer::new(InvalidationServiceImpl::new(
-            Arc::clone(&invalidation_hub),
-        )))
+        .add_service(InvalidationServiceServer::with_interceptor(
+            InvalidationServiceImpl::new(Arc::clone(&invalidation_hub)),
+            auth.clone(),
+        ))
         .serve_with_incoming_shutdown(incoming, async move {
             shutdown_signal().await;
             db_token.cancel();

--- a/aa-gateway/tests/grpc_auth_test.rs
+++ b/aa-gateway/tests/grpc_auth_test.rs
@@ -13,6 +13,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use aa_gateway::iam::{auth_interceptor, CREDENTIAL_METADATA_KEY};
+use aa_gateway::invalidation::{InvalidationHub, InvalidationServiceImpl};
 use aa_gateway::secrets::{InMemorySecretsStore, Secret, SecretsStore, TenantScopedStore};
 use aa_gateway::service::{ApprovalServiceImpl, SecretsServiceImpl, TopologyServiceImpl};
 use aa_gateway::{AgentRecord, AgentRegistry, AgentStatus};
@@ -20,6 +21,9 @@ use aa_gateway::{AgentRecord, AgentRegistry, AgentStatus};
 use aa_proto::assembly::approval::v1::approval_service_client::ApprovalServiceClient;
 use aa_proto::assembly::approval::v1::approval_service_server::ApprovalServiceServer;
 use aa_proto::assembly::approval::v1::{ApprovalDecisionType, DecideRequest, ListPendingRequest};
+use aa_proto::assembly::gateway::v1::invalidation_service_client::InvalidationServiceClient;
+use aa_proto::assembly::gateway::v1::invalidation_service_server::InvalidationServiceServer;
+use aa_proto::assembly::gateway::v1::{subscribe_request::Kind, SubscribeInitial, SubscribeRequest};
 use aa_proto::assembly::secrets::v1::secrets_service_client::SecretsServiceClient;
 use aa_proto::assembly::secrets::v1::secrets_service_server::SecretsServiceServer;
 use aa_proto::assembly::secrets::v1::DispatchToolRequest;
@@ -303,5 +307,52 @@ async fn topology_get_team_members_without_token_is_rejected() {
         })
         .await
         .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::Unauthenticated);
+}
+
+/// Start a gRPC server wiring the `InvalidationService` behind the production
+/// fail-closed auth interceptor (AAASM-3828), matching `server::serve_tcp`.
+async fn start_invalidation_server(registry: Arc<AgentRegistry>) -> SocketAddr {
+    let invalidation_svc = InvalidationServiceImpl::new(InvalidationHub::new());
+    let auth = auth_interceptor(Arc::clone(&registry));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(InvalidationServiceServer::with_interceptor(
+                invalidation_svc,
+                auth.clone(),
+            ))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    addr
+}
+
+#[tokio::test]
+async fn invalidation_subscribe_without_token_is_rejected() {
+    let registry = Arc::new(AgentRegistry::new());
+    let addr = start_invalidation_server(registry).await;
+
+    let mut client = InvalidationServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+    let initial = SubscribeRequest {
+        assembly_id: "assembly-1".to_string(),
+        kind: Some(Kind::Initial(SubscribeInitial { last_seq_seen: 0 })),
+    };
+    // The fail-closed interceptor rejects the unauthenticated stream. Depending
+    // on flush timing the rejection surfaces either when opening the stream or
+    // on the first inbound read; both must be `Unauthenticated`.
+    let err = match client.subscribe(tokio_stream::once(initial)).await {
+        Err(status) => status,
+        Ok(response) => response.into_inner().message().await.unwrap_err(),
+    };
     assert_eq!(err.code(), tonic::Code::Unauthenticated);
 }


### PR DESCRIPTION
## Description

After AAASM-3788 added the fail-closed `auth_interceptor` to the agent-plane gRPC services (audit/approval/topology/secrets) and enrich-validation to policy/lifecycle, `InvalidationServiceServer` was the one agent-plane RPC left with **no interceptor** in `aa-gateway/src/server.rs`. An unauthenticated subscriber could open `InvalidationService::Subscribe` and receive policy-invalidation events (agent_id + policy_version).

This PR wraps `InvalidationServiceServer` with the same fail-closed `auth_interceptor` (`with_interceptor(..., auth.clone())`) in **both** `serve_tcp` and `serve_uds`, exactly matching how the sibling agent-plane services are wired. The Subscribe handler only calls `request.into_inner()` and never reads request extensions, so it tolerates the `VerifiedCaller` extension the interceptor injects.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Subscribe clients (the `aa-runtime` invalidation client) already attach a credential token on registered transports; only unauthenticated callers are now rejected.

## Related Issues

- Related Jira ticket: AAASM-3828
- Relates to: AAASM-3788

## Testing

- [x] Integration tests added / updated

Added `invalidation_subscribe_without_token_is_rejected` in `aa-gateway/tests/grpc_auth_test.rs`: a wire-level Subscribe call with no credential token is rejected `Unauthenticated`, mirroring the existing agent-plane no-token-rejection tests.

Validation gate (all green):
- `cargo build -p aa-gateway`
- `cargo nextest run -p aa-gateway` — 1267 passed (Register/CheckAction and the other services unaffected)
- `cargo fmt --all`
- `cargo clippy -p aa-gateway --all-targets -- -D warnings`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
