### PR TITLE
[AAASM-3826] 🔒 (aa-api): Pin SSRF-vetted IP + stop connector body reflection

### DIFF
--- a/aa-api/src/destinations/connectors/mod.rs
+++ b/aa-api/src/destinations/connectors/mod.rs
@@ -5,6 +5,7 @@
 //! sub-modules; PagerDuty and OpsGenie are gated behind cargo features so
 //! the binary footprint stays small when only webhook / Slack are needed.
 
+use std::net::SocketAddr;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -84,11 +85,35 @@ pub enum ConnectorError {
 #[async_trait::async_trait]
 pub trait NotificationConnector: Send + Sync {
     /// Dispatch `req` to `destination` and return the outcome.
+    ///
+    /// `pinned` carries the socket addresses the SSRF egress guard already
+    /// vetted for this destination's caller-controlled URL (AAASM-3826).
+    /// Connectors that egress to a caller-controlled host (webhook, Slack)
+    /// MUST pin their outbound connection to exactly these addresses so a
+    /// DNS-rebind between the guard's check and the actual connect cannot
+    /// redirect traffic to an internal target. An empty slice means "no
+    /// pinning" — used for hard-coded vendor hosts (PagerDuty / OpsGenie) and
+    /// when the operator has opted out of the egress guard.
     async fn dispatch(
         &self,
         destination: &Destination,
         req: &DispatchRequest,
+        pinned: &[SocketAddr],
     ) -> Result<DispatchOutcome, ConnectorError>;
+}
+
+/// Common `reqwest::ClientBuilder` carrying the connectors' shared hardening:
+/// bounded connect/overall timeouts and a no-redirect policy.
+///
+/// AAASM-3789: never follow redirects. A redirect can bounce an
+/// otherwise-allowlisted destination to an internal address (cloud metadata,
+/// loopback, RFC1918), re-opening the SSRF the egress guard closes. A 3xx is
+/// surfaced to the caller as a non-2xx outcome instead of being chased inward.
+fn client_builder() -> reqwest::ClientBuilder {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(8))
+        .timeout(Duration::from_secs(15))
+        .redirect(reqwest::redirect::Policy::none())
 }
 
 /// Shared `reqwest::Client` used by every connector. Constructed once so
@@ -96,19 +121,26 @@ pub trait NotificationConnector: Send + Sync {
 #[allow(dead_code)] // wired up by per-kind connectors in subsequent commits
 pub(crate) fn shared_client() -> &'static Client {
     static CLIENT: OnceLock<Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        Client::builder()
-            .connect_timeout(Duration::from_secs(8))
-            .timeout(Duration::from_secs(15))
-            // AAASM-3789: never follow redirects. A redirect can bounce an
-            // otherwise-allowlisted destination to an internal address (cloud
-            // metadata, loopback, RFC1918), re-opening the SSRF the egress
-            // guard closes. A 3xx is surfaced to the caller as a non-2xx
-            // outcome instead of being chased inward.
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .expect("reqwest client construction failed")
-    })
+    CLIENT.get_or_init(|| client_builder().build().expect("reqwest client construction failed"))
+}
+
+/// Build the client a caller-controlled-host connector (webhook / Slack) uses
+/// to egress, pinning DNS resolution for `host` to the SSRF-vetted `pinned`
+/// addresses (AAASM-3826).
+///
+/// When `pinned` is non-empty the returned client resolves `host` only to those
+/// exact addresses, so the connection lands on the address the egress guard
+/// already vetted — a DNS-rebind to an internal target after the check cannot
+/// take effect. An empty `pinned` (vendor hosts, or the guard opt-out) returns
+/// the shared pooled client unchanged.
+pub(crate) fn egress_client(host: &str, pinned: &[SocketAddr]) -> Client {
+    if pinned.is_empty() {
+        return shared_client().clone();
+    }
+    client_builder()
+        .resolve_to_addrs(host, pinned)
+        .build()
+        .expect("reqwest pinned client construction failed")
 }
 
 /// Cap a response body at 2048 bytes so error envelopes stay bounded.

--- a/aa-api/src/destinations/connectors/opsgenie.rs
+++ b/aa-api/src/destinations/connectors/opsgenie.rs
@@ -34,6 +34,9 @@ impl NotificationConnector for OpsGenieConnector {
         &self,
         destination: &Destination,
         req: &DispatchRequest,
+        // OpsGenie POSTs to a hard-coded vendor host, so there is no
+        // caller-controlled SSRF surface to pin (AAASM-3826).
+        _pinned: &[std::net::SocketAddr],
     ) -> Result<DispatchOutcome, ConnectorError> {
         let (api_key, team_id) = match &destination.config {
             DestinationConfig::OpsGenie { api_key, team_id } => (api_key.clone(), team_id.clone()),

--- a/aa-api/src/destinations/connectors/pagerduty.rs
+++ b/aa-api/src/destinations/connectors/pagerduty.rs
@@ -22,6 +22,9 @@ impl NotificationConnector for PagerDutyConnector {
         &self,
         destination: &Destination,
         req: &DispatchRequest,
+        // PagerDuty POSTs to a hard-coded vendor host, so there is no
+        // caller-controlled SSRF surface to pin (AAASM-3826).
+        _pinned: &[std::net::SocketAddr],
     ) -> Result<DispatchOutcome, ConnectorError> {
         let (routing_key, severity_map) = match &destination.config {
             DestinationConfig::PagerDuty {

--- a/aa-api/src/destinations/connectors/slack.rs
+++ b/aa-api/src/destinations/connectors/slack.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 use chrono::Utc;
 
 use crate::destinations::connectors::{
-    egress_client, truncate_body, ConnectorError, DispatchOutcome, DispatchRequest, NotificationConnector,
+    egress_client, ConnectorError, DispatchOutcome, DispatchRequest, NotificationConnector,
 };
 use crate::destinations::types::{Destination, DestinationConfig};
 
@@ -60,19 +60,23 @@ impl NotificationConnector for SlackConnector {
             .await
             .map_err(|e| ConnectorError::Transport(e.to_string()))?;
         let status = resp.status().as_u16();
-        let resp_body = resp.text().await.unwrap_or_default();
-        let resp_body = truncate_body(resp_body);
+        // AAASM-3827: do NOT capture or reflect the upstream response body. The
+        // Slack `webhook_url` is caller-controlled, so reflecting the origin's
+        // body back to the caller is an SSRF data-exfiltration sink (mirrors the
+        // webhook connector). Drain and discard the body; only the observed
+        // status conveys the /test success/failure signal.
+        drop(resp.bytes().await);
 
         if (200..300).contains(&status) {
             Ok(DispatchOutcome {
                 delivered_at: Utc::now().to_rfc3339(),
                 connector_response_status: status,
-                connector_response_body: resp_body,
+                connector_response_body: String::new(),
             })
         } else {
             Err(ConnectorError::Http {
                 status,
-                body: resp_body,
+                body: String::new(),
             })
         }
     }

--- a/aa-api/src/destinations/connectors/slack.rs
+++ b/aa-api/src/destinations/connectors/slack.rs
@@ -5,10 +5,12 @@
 //! as the generic webhook connector so connection pooling and rustls
 //! configuration are shared.
 
+use std::net::SocketAddr;
+
 use chrono::Utc;
 
 use crate::destinations::connectors::{
-    shared_client, truncate_body, ConnectorError, DispatchOutcome, DispatchRequest, NotificationConnector,
+    egress_client, truncate_body, ConnectorError, DispatchOutcome, DispatchRequest, NotificationConnector,
 };
 use crate::destinations::types::{Destination, DestinationConfig};
 
@@ -21,6 +23,7 @@ impl NotificationConnector for SlackConnector {
         &self,
         destination: &Destination,
         req: &DispatchRequest,
+        pinned: &[SocketAddr],
     ) -> Result<DispatchOutcome, ConnectorError> {
         let (webhook_url, channel_override) = match &destination.config {
             DestinationConfig::Slack {
@@ -41,7 +44,16 @@ impl NotificationConnector for SlackConnector {
             body["channel"] = serde_json::Value::String(channel);
         }
 
-        let resp = shared_client()
+        // AAASM-3826: the Slack `webhook_url` is caller-controlled and egresses
+        // on test-fire, so pin the connection to the SSRF-vetted address — a
+        // DNS-rebind after the egress check cannot redirect this POST inward.
+        let host = url::Url::parse(&webhook_url)
+            .ok()
+            .and_then(|u| u.host_str().map(str::to_owned))
+            .unwrap_or_default();
+        let client = egress_client(&host, pinned);
+
+        let resp = client
             .post(&webhook_url)
             .json(&body)
             .send()

--- a/aa-api/src/destinations/connectors/webhook.rs
+++ b/aa-api/src/destinations/connectors/webhook.rs
@@ -5,10 +5,12 @@
 //! `X-AAASM-Token` header so the receiving service can authenticate the
 //! webhook before acting on it.
 
+use std::net::SocketAddr;
+
 use chrono::Utc;
 
 use crate::destinations::connectors::{
-    shared_client, ConnectorError, DispatchOutcome, DispatchRequest, NotificationConnector,
+    egress_client, ConnectorError, DispatchOutcome, DispatchRequest, NotificationConnector,
 };
 use crate::destinations::types::{Destination, DestinationConfig};
 
@@ -21,6 +23,7 @@ impl NotificationConnector for WebhookConnector {
         &self,
         destination: &Destination,
         req: &DispatchRequest,
+        pinned: &[SocketAddr],
     ) -> Result<DispatchOutcome, ConnectorError> {
         let (url, secret_header) = match &destination.config {
             DestinationConfig::Webhook { url, secret_header } => (url.clone(), secret_header.clone()),
@@ -31,7 +34,16 @@ impl NotificationConnector for WebhookConnector {
             }
         };
 
-        let mut builder = shared_client().post(&url).json(&serde_json::json!({
+        // AAASM-3826: pin the connection to the SSRF-vetted address so a
+        // DNS-rebind after the egress check cannot redirect this POST to an
+        // internal host. The host is extracted from the already-validated URL.
+        let host = url::Url::parse(&url)
+            .ok()
+            .and_then(|u| u.host_str().map(str::to_owned))
+            .unwrap_or_default();
+        let client = egress_client(&host, pinned);
+
+        let mut builder = client.post(&url).json(&serde_json::json!({
             "severity": req.severity,
             "message": req.message,
             "sent_at": Utc::now().to_rfc3339(),

--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -360,6 +360,31 @@ mod tests {
     }
 
     #[test]
+    fn egress_returns_vetted_addr_for_pinning() {
+        // AAASM-3826: the guard hands back the exact vetted socket address(es)
+        // so the connector can pin its connection to them rather than
+        // re-resolving the host at connect time (the DNS-rebinding window).
+        let addrs = validate_webhook_egress(&url::Url::parse("http://8.8.8.8:80/hook").expect("url parses"))
+            .expect("public literal IP is allowed");
+        assert_eq!(addrs, vec![SocketAddr::from(([8, 8, 8, 8], 80))]);
+
+        // The default https port is filled in for scheme-default URLs.
+        let https = validate_webhook_egress(&url::Url::parse("https://1.1.1.1/hook").expect("url parses"))
+            .expect("public literal IP is allowed");
+        assert_eq!(https, vec![SocketAddr::from(([1, 1, 1, 1], 443))]);
+    }
+
+    #[test]
+    fn egress_opt_out_returns_no_pin() {
+        // With the self-host opt-out set, the guard is disabled and returns an
+        // empty vetted set, signalling the connector not to pin.
+        std::env::set_var(ALLOW_PRIVATE_EGRESS_ENV, "1");
+        let addrs = validate_webhook_egress(&url::Url::parse("http://127.0.0.1/hook").expect("url parses"));
+        std::env::remove_var(ALLOW_PRIVATE_EGRESS_ENV);
+        assert_eq!(addrs, Ok(Vec::new()));
+    }
+
+    #[test]
     fn egress_env_escape_allows_private() {
         // The documented self-host opt-out disables the guard.
         std::env::set_var(ALLOW_PRIVATE_EGRESS_ENV, "1");

--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -4,7 +4,7 @@
 //! connector relies on at dispatch time (URL parse, https-only for Slack,
 //! non-empty PagerDuty routing key, OpsGenie key + team).
 
-use std::net::{IpAddr, ToSocketAddrs};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 
 use crate::destinations::types::{Destination, DestinationConfig};
 
@@ -147,40 +147,56 @@ fn check_egress_addr(ip: IpAddr) -> Result<(), ValidationError> {
     }
 }
 
-/// Guard a webhook URL against SSRF before it is dispatched (AAASM-3789).
+/// Guard a webhook URL against SSRF before it is dispatched (AAASM-3789) and
+/// return the **vetted socket addresses** the dispatch must pin to (AAASM-3826).
 ///
 /// Rejects a URL whose host — or any address it resolves to — falls in a
 /// loopback / private / link-local / ULA / metadata range. Literal-IP hosts are
 /// checked directly; hostnames are resolved and *every* returned address must be
 /// allowed, so a single internal answer rejects the whole host (defeating
-/// DNS-rebinding to an internal target). Honors [`ALLOW_PRIVATE_EGRESS_ENV`].
+/// DNS-rebinding to an internal target).
+///
+/// To close the DNS-rebinding TOCTOU, the connector must connect to exactly the
+/// addresses returned here rather than re-resolving the host at connect time
+/// (where a low-TTL name could have flipped to an internal address after this
+/// check). The returned vector carries every vetted [`SocketAddr`] for the
+/// host; an **empty** vector means "do not pin" — returned only when the
+/// operator has opted out via [`ALLOW_PRIVATE_EGRESS_ENV`].
 ///
 /// Performs a **blocking** DNS lookup for hostname targets, so call it from a
 /// blocking context (e.g. `tokio::task::spawn_blocking`) rather than directly
 /// on an async task.
-pub fn validate_webhook_egress(url: &url::Url) -> Result<(), ValidationError> {
+pub fn validate_webhook_egress(url: &url::Url) -> Result<Vec<SocketAddr>, ValidationError> {
     if private_egress_allowed() {
-        return Ok(());
+        return Ok(Vec::new());
     }
     let host = url
         .host()
         .ok_or(ValidationError::InvalidConfig("webhook.url has no host"))?;
+    let port = url.port_or_known_default().unwrap_or(443);
     match host {
-        url::Host::Ipv4(ip) => check_egress_addr(IpAddr::V4(ip)),
-        url::Host::Ipv6(ip) => check_egress_addr(IpAddr::V6(ip)),
+        url::Host::Ipv4(ip) => {
+            let addr = IpAddr::V4(ip);
+            check_egress_addr(addr)?;
+            Ok(vec![SocketAddr::new(addr, port)])
+        }
+        url::Host::Ipv6(ip) => {
+            let addr = IpAddr::V6(ip);
+            check_egress_addr(addr)?;
+            Ok(vec![SocketAddr::new(addr, port)])
+        }
         url::Host::Domain(domain) => {
-            let port = url.port_or_known_default().unwrap_or(443);
-            let mut resolved = (domain, port)
+            let resolved: Vec<SocketAddr> = (domain, port)
                 .to_socket_addrs()
                 .map_err(|_| ValidationError::InvalidConfig("webhook.url host could not be resolved"))?
-                .peekable();
-            if resolved.peek().is_none() {
+                .collect();
+            if resolved.is_empty() {
                 return Err(ValidationError::InvalidConfig("webhook.url host did not resolve"));
             }
-            for sa in resolved {
+            for sa in &resolved {
                 check_egress_addr(sa.ip())?;
             }
-            Ok(())
+            Ok(resolved)
         }
     }
 }
@@ -311,7 +327,7 @@ mod tests {
     // ── Egress guard (AAASM-3789) ────────────────────────────────────────────
 
     fn egress(url: &str) -> Result<(), ValidationError> {
-        validate_webhook_egress(&url::Url::parse(url).expect("test url parses"))
+        validate_webhook_egress(&url::Url::parse(url).expect("test url parses")).map(|_| ())
     }
 
     #[test]

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -300,6 +300,7 @@ impl NotificationConnector for UnsupportedConnector {
         &self,
         _destination: &Destination,
         _req: &DispatchRequest,
+        _pinned: &[std::net::SocketAddr],
     ) -> Result<crate::destinations::connectors::DispatchOutcome, ConnectorError> {
         Err(ConnectorError::Transport(format!(
             "connector kind '{}' not enabled in this build",
@@ -549,7 +550,10 @@ pub async fn test_destination(
         })?),
         DestinationConfig::PagerDuty { .. } | DestinationConfig::OpsGenie { .. } => None,
     };
-    if let Some(parsed) = egress_url {
+    // Vetted addresses the dispatch must pin to (AAASM-3826). Empty for vendor
+    // hosts (PagerDuty / OpsGenie) and when the operator has opted out of the
+    // egress guard — both mean "resolve normally, do not pin".
+    let pinned: Vec<std::net::SocketAddr> = if let Some(parsed) = egress_url {
         let egress = tokio::task::spawn_blocking(move || validate_webhook_egress(&parsed))
             .await
             .map_err(|_| {
@@ -557,8 +561,10 @@ pub async fn test_destination(
                     ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail("egress_check_failed"),
                 )
             })?;
-        egress.map_err(|e| TestDestinationFailure::Rejected(validation_error_to_problem(e)))?;
-    }
+        egress.map_err(|e| TestDestinationFailure::Rejected(validation_error_to_problem(e)))?
+    } else {
+        Vec::new()
+    };
 
     let req_in = body.map(|Json(b)| b).unwrap_or_default();
     let dispatch = DispatchRequest {
@@ -567,7 +573,7 @@ pub async fn test_destination(
     };
 
     let connector = connector_for(destination.config.kind());
-    match connector.dispatch(&destination, &dispatch).await {
+    match connector.dispatch(&destination, &dispatch, &pinned).await {
         Ok(outcome) => Ok((
             StatusCode::OK,
             Json(TestDestinationResponse {
@@ -630,7 +636,7 @@ mod tests {
             severity: "LOW".to_string(),
             message: "m".to_string(),
         };
-        assert!(conn.dispatch(&dest, &req).await.is_err());
+        assert!(conn.dispatch(&dest, &req, &[]).await.is_err());
     }
 
     #[tokio::test]

--- a/aa-api/tests/connectors.rs
+++ b/aa-api/tests/connectors.rs
@@ -61,7 +61,7 @@ async fn webhook_dispatch_posts_payload_and_returns_outcome_on_2xx() {
     });
 
     let outcome = WebhookConnector
-        .dispatch(&dst, &request("HIGH", "disk full"))
+        .dispatch(&dst, &request("HIGH", "disk full"), &[])
         .await
         .expect("2xx is a success");
 
@@ -89,7 +89,7 @@ async fn webhook_dispatch_includes_secret_header_when_configured() {
     });
 
     WebhookConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .expect("authenticated webhook succeeds");
 
@@ -111,7 +111,7 @@ async fn webhook_dispatch_maps_non_2xx_to_http_error() {
     });
 
     let err = WebhookConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .expect_err("500 must surface as an error");
 
@@ -143,7 +143,7 @@ async fn webhook_dispatch_never_reflects_response_body() {
     });
 
     let outcome = WebhookConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .unwrap();
 
@@ -162,7 +162,7 @@ async fn webhook_dispatch_transport_error_on_unreachable_host() {
     });
 
     let err = WebhookConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .expect_err("unreachable host must be a transport error");
 
@@ -177,7 +177,7 @@ async fn webhook_connector_rejects_non_webhook_destination() {
     });
 
     let err = WebhookConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .expect_err("wrong destination kind must be rejected");
 
@@ -206,7 +206,7 @@ async fn webhook_dispatch_does_not_follow_redirects() {
     });
 
     let err = WebhookConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .expect_err("a redirect must surface as a non-2xx error, not be followed");
 
@@ -238,7 +238,7 @@ async fn slack_dispatch_posts_text_payload_and_returns_outcome() {
     });
 
     let outcome = SlackConnector
-        .dispatch(&dst, &request("CRITICAL", "pipeline down"))
+        .dispatch(&dst, &request("CRITICAL", "pipeline down"), &[])
         .await
         .expect("slack 200 is a success");
 
@@ -265,7 +265,7 @@ async fn slack_dispatch_includes_channel_override_when_configured() {
     });
 
     SlackConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .unwrap();
 
@@ -286,7 +286,7 @@ async fn slack_dispatch_maps_non_2xx_to_http_error() {
     });
 
     let err = SlackConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .expect_err("404 must surface as an error");
 
@@ -304,7 +304,7 @@ async fn slack_connector_rejects_non_slack_destination() {
     });
 
     let err = SlackConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .expect_err("wrong destination kind must be rejected");
 
@@ -330,7 +330,7 @@ async fn pagerduty_connector_rejects_non_pagerduty_destination() {
     });
 
     let err = PagerDutyConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .expect_err("wrong destination kind must be rejected");
 
@@ -348,7 +348,7 @@ async fn opsgenie_connector_rejects_non_opsgenie_destination() {
     });
 
     let err = OpsGenieConnector
-        .dispatch(&dst, &DispatchRequest::default())
+        .dispatch(&dst, &DispatchRequest::default(), &[])
         .await
         .expect_err("wrong destination kind must be rejected");
 

--- a/aa-api/tests/connectors.rs
+++ b/aa-api/tests/connectors.rs
@@ -290,7 +290,11 @@ async fn slack_dispatch_posts_text_payload_and_returns_outcome() {
 
     mock.assert();
     assert_eq!(outcome.connector_response_status, 200);
-    assert_eq!(outcome.connector_response_body, "ok");
+    // AAASM-3827: the upstream Slack body is no longer reflected to the caller.
+    assert!(
+        outcome.connector_response_body.is_empty(),
+        "upstream Slack body must not be reflected"
+    );
 }
 
 #[tokio::test]

--- a/aa-api/tests/connectors.rs
+++ b/aa-api/tests/connectors.rs
@@ -347,6 +347,55 @@ async fn slack_dispatch_maps_non_2xx_to_http_error() {
 }
 
 #[tokio::test]
+async fn slack_dispatch_never_reflects_response_body() {
+    // AAASM-3827: the Slack `webhook_url` is caller-controlled, so no part of
+    // the upstream response body may leak back to the caller — on success or on
+    // failure — otherwise the test-fire is an SSRF data-exfiltration sink.
+    let big = "x".repeat(3000);
+
+    // 2xx: the success outcome carries no upstream body.
+    let ok_server = MockServer::start();
+    ok_server.mock(|when, then| {
+        when.method(MOCK_POST).path("/slack");
+        then.status(200).body(&big);
+    });
+    let ok_dst = destination(DestinationConfig::Slack {
+        webhook_url: ok_server.url("/slack"),
+        channel_override: None,
+    });
+    let outcome = SlackConnector
+        .dispatch(&ok_dst, &DispatchRequest::default(), &[])
+        .await
+        .expect("2xx is a success");
+    assert!(
+        outcome.connector_response_body.is_empty(),
+        "no part of the upstream Slack body may be reflected on success"
+    );
+
+    // non-2xx: the error envelope carries no upstream body either.
+    let err_server = MockServer::start();
+    err_server.mock(|when, then| {
+        when.method(MOCK_POST).path("/slack");
+        then.status(500).body(&big);
+    });
+    let err_dst = destination(DestinationConfig::Slack {
+        webhook_url: err_server.url("/slack"),
+        channel_override: None,
+    });
+    let err = SlackConnector
+        .dispatch(&err_dst, &DispatchRequest::default(), &[])
+        .await
+        .expect_err("500 must surface as an error");
+    match err {
+        ConnectorError::Http { status, body } => {
+            assert_eq!(status, 500);
+            assert!(body.is_empty(), "upstream Slack error body must not be reflected");
+        }
+        other => panic!("expected Http error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn slack_connector_rejects_non_slack_destination() {
     let dst = destination(DestinationConfig::Webhook {
         url: "https://example.test/hook".to_string(),

--- a/aa-api/tests/connectors.rs
+++ b/aa-api/tests/connectors.rs
@@ -217,6 +217,52 @@ async fn webhook_dispatch_does_not_follow_redirects() {
     mock.assert();
 }
 
+#[tokio::test]
+async fn webhook_dispatch_pins_to_vetted_addr() {
+    // AAASM-3826: the connector must connect to the SSRF-vetted address handed
+    // to it rather than re-resolving the host (the DNS-rebinding window). We
+    // point a host that can never resolve via DNS (`.invalid`, RFC 2606) at the
+    // mock's address through `pinned`; the request can only land if the pin is
+    // honored — exactly the rebinding defense (connect to the vetted address,
+    // not a freshly-resolved one).
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(MOCK_POST).path("/hook");
+        then.status(200);
+    });
+    let addr = *server.address();
+
+    let dst = destination(DestinationConfig::Webhook {
+        url: format!("http://pinned.aaasm.invalid:{}/hook", addr.port()),
+        secret_header: None,
+    });
+
+    WebhookConnector
+        .dispatch(&dst, &DispatchRequest::default(), &[addr])
+        .await
+        .expect("a request pinned to the vetted address reaches it");
+
+    mock.assert();
+}
+
+#[tokio::test]
+async fn webhook_dispatch_without_pin_cannot_resolve_invalid_host() {
+    // Counterpart to the pinning test: the same unresolvable `.invalid` host
+    // with no pin must fail at connect time (DNS resolution), proving the pin —
+    // not some other fallback — is what made the pinned request succeed.
+    let dst = destination(DestinationConfig::Webhook {
+        url: "http://pinned.aaasm.invalid:9/hook".to_string(),
+        secret_header: None,
+    });
+
+    let err = WebhookConnector
+        .dispatch(&dst, &DispatchRequest::default(), &[])
+        .await
+        .expect_err("an unresolvable host with no pin cannot connect");
+
+    assert!(matches!(err, ConnectorError::Transport(_)));
+}
+
 // ── Slack connector ────────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Description

Harden the alert-destination egress path against two related SSRF findings in the connector layer (one combined PR because both touch `destinations/validate.rs` and the connectors).

**AAASM-3826 — DNS-rebinding TOCTOU (resolved IP not pinned).** The egress guard resolved the host and checked the IPs, but `reqwest` re-resolved at connect time, so a low-TTL name could flip to `169.254.169.254` / loopback / RFC1918 **after** the check. `validate_webhook_egress` now returns the vetted socket addresses, and the webhook + Slack connectors pin their outbound connection to exactly those (via `reqwest` `resolve_to_addrs`), so the address connected always equals the address vetted. A shared `egress_client(host, pinned)` helper builds the pinned client while preserving the existing no-redirect SSRF hardening.

**AAASM-3827 residual — Slack upstream body reflection.** The Slack `webhook_url` is caller-controlled and egresses on test-fire, so reflecting the origin's response body back to the caller was an SSRF data-exfiltration sink. The Slack connector now drains and discards the upstream body (mirroring the webhook connector); only the observed HTTP status conveys the `/test` success/failure signal.

PagerDuty / OpsGenie POST to hard-coded vendor hosts (no caller-controlled SSRF surface), so they are left unpinned and their behaviour is unchanged.

Note: the prior **AAASM-3868** work (Slack `webhook_url` routed through `validate_webhook_egress`, anchored `slack_host_allowed` host check) is already on master and is not re-done here — this PR builds on it.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] No

(Internal `NotificationConnector::dispatch` gains a `pinned: &[SocketAddr]` argument; no public HTTP API change — OpenAPI spec is unchanged.)

## Related Issues

- Related Jira tickets: AAASM-3826, AAASM-3827

Closes AAASM-3826
Closes AAASM-3827

## Testing

- [x] Unit tests added / updated — `validate_webhook_egress` returns vetted addrs / empty under opt-out
- [x] Integration tests added / updated — connection pins to the vetted address (unresolvable `.invalid` host reached only via the pin; same host fails to connect without a pin); Slack connector reflects no upstream body on success or failure
- Full gate green: `cargo build -p aa-api`, `cargo nextest run -p aa-api` (834 passed), `cargo fmt --all`, `cargo clippy -p aa-api --all-targets -- -D warnings` (clean), OpenAPI no-drift.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
