### PR TITLE
[AAASM-3882] ♻️ (aa-gateway): Make registration ChallengeStore replica-shared

### DIFF
--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -31,15 +31,29 @@ use crate::registry::{AgentRegistry, AgentStatus, LineageError, OrphanMode, Regi
 const DEFAULT_HEARTBEAT_INTERVAL_SEC: i64 = 30;
 
 /// Length in bytes of a server-issued registration-challenge nonce (AAASM-3866).
-const CHALLENGE_NONCE_LEN: usize = 32;
+pub(crate) const CHALLENGE_NONCE_LEN: usize = 32;
 
 /// How long a registration-challenge nonce stays valid after it is issued
 /// (AAASM-3866). Short enough to bound replay/precompute windows, long enough to
 /// cover a client's RequestChallenge → Register round-trip.
-const CHALLENGE_TTL: Duration = Duration::from_secs(30);
+pub(crate) const CHALLENGE_TTL: Duration = Duration::from_secs(30);
 
-/// A single outstanding registration challenge, keyed in [`ChallengeStore`] by
-/// its random nonce bytes.
+/// Draw a fresh, unpredictable challenge nonce from the OS-seeded thread CSPRNG.
+///
+/// Shared by every [`ChallengeStoreLike`] implementation so the nonce is
+/// generated identically regardless of where it is stored.
+pub(crate) fn fresh_nonce() -> Vec<u8> {
+    rand::random::<[u8; CHALLENGE_NONCE_LEN]>().to_vec()
+}
+
+/// Absolute expiry of a freshly-issued nonce, as Unix-epoch milliseconds — the
+/// value returned to the client in `ChallengeResponse.expires_at_unix_ms`.
+pub(crate) fn challenge_expiry_unix_ms() -> i64 {
+    Utc::now().timestamp_millis() + CHALLENGE_TTL.as_millis() as i64
+}
+
+/// A single outstanding registration challenge, keyed in
+/// [`InMemoryChallengeStore`] by its random nonce bytes.
 struct IssuedChallenge {
     /// did:key the nonce was issued for — re-checked at Register so a nonce
     /// cannot be redirected to a different identity.
@@ -51,25 +65,67 @@ struct IssuedChallenge {
     expires_at: Instant,
 }
 
-/// In-memory store of outstanding registration-challenge nonces (AAASM-3866).
+/// Replica-shared store of outstanding registration-challenge nonces
+/// (AAASM-3866, made replica-shared by AAASM-3882).
 ///
 /// The store is the single-use + time-bound + identity-binding gate that makes
 /// the registration possession proof non-replayable: a nonce is unpredictable
 /// (CSPRNG), removed the first time it is consumed, rejected once expired, and
 /// only accepted for the exact agent_id + public_key it was issued for.
-#[derive(Default)]
-struct ChallengeStore {
-    issued: StdMutex<HashMap<Vec<u8>, IssuedChallenge>>,
-}
-
-impl ChallengeStore {
+///
+/// AAASM-3866 shipped only the [`InMemoryChallengeStore`] implementation, which
+/// keeps nonces in process-local memory and so assumes a **single gateway
+/// replica**: behind a multi-replica load balancer, `RequestChallenge` and
+/// `Register` can land on different replicas, so a nonce issued by replica A is
+/// unknown to replica B and `Register` fails closed (`Unauthenticated`). This
+/// trait abstracts the store so a horizontally-scaled, production gateway can
+/// inject a shared backend — the Redis-backed `RedisChallengeStore` in
+/// [`crate::storage::challenge`] — via [`AgentLifecycleServiceImpl::with_challenge_store`],
+/// while dev/single-replica keeps the zero-dependency in-memory default.
+///
+/// Every implementation MUST preserve all three guarantees **across replicas**:
+///
+/// * **single-use** — [`consume`] removes the nonce atomically, before the
+///   binding/expiry checks, so any attempt (even a replay or a redirect to a
+///   different identity) permanently burns it;
+/// * **time-bound** — a nonce is rejected once [`CHALLENGE_TTL`] has elapsed;
+/// * **identity-binding** — a nonce is only accepted for the exact `agent_id` +
+///   `public_key` it was issued for.
+///
+/// [`consume`]: ChallengeStoreLike::consume
+#[async_trait::async_trait]
+pub trait ChallengeStoreLike: Send + Sync {
     /// Issue a fresh random nonce bound to `agent_id` + `public_key`, returning
     /// the nonce bytes and its absolute expiry as Unix-epoch milliseconds.
-    ///
+    /// Errors (e.g. a shared backend being unreachable) fail closed so no
+    /// challenge is handed out that cannot later be consumed.
+    async fn issue(&self, agent_id: &str, public_key: &str) -> Result<(Vec<u8>, i64), Status>;
+
+    /// Consume the nonce: verify it was issued (single-use — removed on
+    /// consume), not expired, and bound to this `agent_id` + `public_key`.
+    /// Returns `Status::unauthenticated` otherwise so Register fails closed.
+    async fn consume(&self, nonce: &[u8], agent_id: &str, public_key: &str) -> Result<(), Status>;
+}
+
+/// In-memory, process-local [`ChallengeStoreLike`] (AAASM-3866).
+///
+/// The default store: correct for single-replica / dev deployments and for
+/// tests. The backing map lives behind an [`Arc`] so cheap clones share one
+/// backend — modelling, within a single process, the "one shared store fronted
+/// by N replicas" topology a production [`ChallengeStoreLike`] must support. For
+/// an actually cross-process shared store, inject the Redis-backed
+/// implementation instead.
+#[derive(Clone, Default)]
+pub struct InMemoryChallengeStore {
+    issued: Arc<StdMutex<HashMap<Vec<u8>, IssuedChallenge>>>,
+}
+
+#[async_trait::async_trait]
+impl ChallengeStoreLike for InMemoryChallengeStore {
     /// Opportunistically purges already-expired entries so the map cannot grow
     /// unbounded under a flood of challenge requests that never register.
-    fn issue(&self, agent_id: &str, public_key: &str) -> (Vec<u8>, i64) {
-        let nonce = rand::random::<[u8; CHALLENGE_NONCE_LEN]>().to_vec();
+    async fn issue(&self, agent_id: &str, public_key: &str) -> Result<(Vec<u8>, i64), Status> {
+        let nonce = fresh_nonce();
         let now = Instant::now();
         let expires_at = now + CHALLENGE_TTL;
         {
@@ -84,18 +140,13 @@ impl ChallengeStore {
                 },
             );
         }
-        let expires_at_unix_ms = Utc::now().timestamp_millis() + CHALLENGE_TTL.as_millis() as i64;
-        (nonce, expires_at_unix_ms)
+        Ok((nonce, challenge_expiry_unix_ms()))
     }
 
-    /// Consume the nonce: verify it was issued (single-use — removed on lookup),
-    /// not expired, and bound to this `agent_id` + `public_key`. Returns
-    /// `Status::unauthenticated` otherwise so Register fails closed.
-    ///
     /// The nonce is removed before the binding/expiry checks so any consumption
     /// attempt — including a replay or a redirect to a different identity —
     /// permanently burns it.
-    fn consume(&self, nonce: &[u8], agent_id: &str, public_key: &str) -> Result<(), Status> {
+    async fn consume(&self, nonce: &[u8], agent_id: &str, public_key: &str) -> Result<(), Status> {
         if nonce.is_empty() {
             return Err(Status::unauthenticated(
                 "missing registration_nonce — call RequestChallenge before Register (AAASM-3866)",
@@ -126,7 +177,7 @@ impl ChallengeStore {
 ///
 /// `proof` must be a raw 64-byte Ed25519 signature over `challenge` that
 /// verifies under `verifying_key`. `challenge` is the server-issued, single-use
-/// [`ChallengeStore`] nonce (no longer the public, deterministic `agent_id`),
+/// [`ChallengeStoreLike`] nonce (no longer the public, deterministic `agent_id`),
 /// so the proof cannot be precomputed or replayed. Returns
 /// `Status::unauthenticated` when the proof is missing, malformed, or does not
 /// verify — so no `credential_token` is minted for a caller that merely presents
@@ -161,8 +212,11 @@ pub struct AgentLifecycleServiceImpl {
     audit_tx: Option<mpsc::Sender<AuditEntry>>,
     audit_seq: Arc<AtomicU64>,
     audit_last_hash: Arc<Mutex<[u8; 32]>>,
-    /// Outstanding registration-challenge nonces (AAASM-3866).
-    challenges: Arc<ChallengeStore>,
+    /// Replica-shared store of outstanding registration-challenge nonces
+    /// (AAASM-3866; made replica-shared by AAASM-3882). Defaults to the
+    /// process-local [`InMemoryChallengeStore`]; a horizontally-scaled gateway
+    /// injects a shared backend via [`Self::with_challenge_store`].
+    challenges: Arc<dyn ChallengeStoreLike>,
 }
 
 impl AgentLifecycleServiceImpl {
@@ -174,7 +228,7 @@ impl AgentLifecycleServiceImpl {
             audit_tx: None,
             audit_seq: Arc::new(AtomicU64::new(0)),
             audit_last_hash: Arc::new(Mutex::new([0u8; 32])),
-            challenges: Arc::new(ChallengeStore::default()),
+            challenges: Arc::new(InMemoryChallengeStore::default()),
         }
     }
 
@@ -189,7 +243,7 @@ impl AgentLifecycleServiceImpl {
             audit_tx: None,
             audit_seq: Arc::new(AtomicU64::new(0)),
             audit_last_hash: Arc::new(Mutex::new([0u8; 32])),
-            challenges: Arc::new(ChallengeStore::default()),
+            challenges: Arc::new(InMemoryChallengeStore::default()),
         }
     }
 
@@ -197,6 +251,20 @@ impl AgentLifecycleServiceImpl {
     /// `AgentForceDeregistered` audit entries during heartbeat processing.
     pub fn with_audit_tx(mut self, audit_tx: mpsc::Sender<AuditEntry>) -> Self {
         self.audit_tx = Some(audit_tx);
+        self
+    }
+
+    /// Replace the default in-memory registration-challenge store with a shared
+    /// one (AAASM-3882).
+    ///
+    /// A multi-replica gateway behind a load balancer MUST inject a replica-
+    /// shared store (e.g. the Redis-backed `RedisChallengeStore` in
+    /// [`crate::storage::challenge`]) here so a nonce issued by `RequestChallenge`
+    /// on one replica can be consumed by `Register` on another. Without this the
+    /// default [`InMemoryChallengeStore`] is process-local and cross-replica
+    /// registration fails closed.
+    pub fn with_challenge_store(mut self, challenges: Arc<dyn ChallengeStoreLike>) -> Self {
+        self.challenges = challenges;
         self
     }
 }
@@ -237,7 +305,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
         ed25519_dalek::VerifyingKey::from_bytes(&pk_array)
             .map_err(|_| Status::invalid_argument("invalid Ed25519 public key"))?;
 
-        let (nonce, expires_at_unix_ms) = self.challenges.issue(&proto_id.agent_id, &req.public_key);
+        let (nonce, expires_at_unix_ms) = self.challenges.issue(&proto_id.agent_id, &req.public_key).await?;
 
         tracing::debug!(agent_id = ?proto_id.agent_id, "registration challenge issued");
 
@@ -286,7 +354,8 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
         // minimal credential_token possession gate; a future authn interceptor
         // layers on top of (does not replace) it.
         self.challenges
-            .consume(&req.registration_nonce, &proto_id.agent_id, &req.public_key)?;
+            .consume(&req.registration_nonce, &proto_id.agent_id, &req.public_key)
+            .await?;
         verify_possession_proof(&verifying_key, &req.registration_nonce, &req.possession_proof)?;
 
         let agent_key = proto_agent_id_to_key(proto_id);
@@ -572,60 +641,60 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 
-    // ── ChallengeStore (AAASM-3866) ──────────────────────────────────────────
+    // ── InMemoryChallengeStore (AAASM-3866) ──────────────────────────────────
 
     const DID: &str = "did:key:z6MkExampleAgent";
     const PK: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
-    #[test]
-    fn issued_nonce_is_random_and_consumable_once() {
-        let store = ChallengeStore::default();
-        let (n1, _) = store.issue(DID, PK);
-        let (n2, _) = store.issue(DID, PK);
+    #[tokio::test]
+    async fn issued_nonce_is_random_and_consumable_once() {
+        let store = InMemoryChallengeStore::default();
+        let (n1, _) = store.issue(DID, PK).await.unwrap();
+        let (n2, _) = store.issue(DID, PK).await.unwrap();
         assert_eq!(n1.len(), CHALLENGE_NONCE_LEN);
         assert_ne!(n1, n2, "two issued nonces must differ (CSPRNG)");
 
         // First consume succeeds; the same nonce is now burned (single-use).
-        assert!(store.consume(&n1, DID, PK).is_ok());
-        let replay = store.consume(&n1, DID, PK).unwrap_err();
+        assert!(store.consume(&n1, DID, PK).await.is_ok());
+        let replay = store.consume(&n1, DID, PK).await.unwrap_err();
         assert_eq!(replay.code(), tonic::Code::Unauthenticated);
     }
 
-    #[test]
-    fn empty_nonce_is_rejected() {
-        let store = ChallengeStore::default();
-        let err = store.consume(&[], DID, PK).unwrap_err();
+    #[tokio::test]
+    async fn empty_nonce_is_rejected() {
+        let store = InMemoryChallengeStore::default();
+        let err = store.consume(&[], DID, PK).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 
-    #[test]
-    fn unknown_nonce_is_rejected() {
-        let store = ChallengeStore::default();
-        let err = store.consume(&[9u8; CHALLENGE_NONCE_LEN], DID, PK).unwrap_err();
+    #[tokio::test]
+    async fn unknown_nonce_is_rejected() {
+        let store = InMemoryChallengeStore::default();
+        let err = store.consume(&[9u8; CHALLENGE_NONCE_LEN], DID, PK).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 
-    #[test]
-    fn nonce_bound_to_a_different_identity_is_rejected() {
-        let store = ChallengeStore::default();
-        let (nonce, _) = store.issue(DID, PK);
+    #[tokio::test]
+    async fn nonce_bound_to_a_different_identity_is_rejected() {
+        let store = InMemoryChallengeStore::default();
+        let (nonce, _) = store.issue(DID, PK).await.unwrap();
         // Wrong agent_id.
-        let err = store.consume(&nonce, "did:key:z6MkOther", PK).unwrap_err();
+        let err = store.consume(&nonce, "did:key:z6MkOther", PK).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 
-    #[test]
-    fn nonce_bound_to_a_different_public_key_is_rejected() {
-        let store = ChallengeStore::default();
-        let (nonce, _) = store.issue(DID, PK);
+    #[tokio::test]
+    async fn nonce_bound_to_a_different_public_key_is_rejected() {
+        let store = InMemoryChallengeStore::default();
+        let (nonce, _) = store.issue(DID, PK).await.unwrap();
         let other_pk = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-        let err = store.consume(&nonce, DID, other_pk).unwrap_err();
+        let err = store.consume(&nonce, DID, other_pk).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 
-    #[test]
-    fn expired_nonce_is_rejected() {
-        let store = ChallengeStore::default();
+    #[tokio::test]
+    async fn expired_nonce_is_rejected() {
+        let store = InMemoryChallengeStore::default();
         let nonce = vec![1u8; CHALLENGE_NONCE_LEN];
         // Insert a nonce that already expired one second ago.
         store.issued.lock().unwrap().insert(
@@ -636,14 +705,14 @@ mod tests {
                 expires_at: Instant::now() - Duration::from_secs(1),
             },
         );
-        let err = store.consume(&nonce, DID, PK).unwrap_err();
+        let err = store.consume(&nonce, DID, PK).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 
-    #[test]
-    fn expires_at_unix_ms_is_in_the_future() {
-        let store = ChallengeStore::default();
-        let (_, expires_at_unix_ms) = store.issue(DID, PK);
+    #[tokio::test]
+    async fn expires_at_unix_ms_is_in_the_future() {
+        let store = InMemoryChallengeStore::default();
+        let (_, expires_at_unix_ms) = store.issue(DID, PK).await.unwrap();
         assert!(expires_at_unix_ms > Utc::now().timestamp_millis());
     }
 }

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -715,4 +715,48 @@ mod tests {
         let (_, expires_at_unix_ms) = store.issue(DID, PK).await.unwrap();
         assert!(expires_at_unix_ms > Utc::now().timestamp_millis());
     }
+
+    // ── Cross-replica behaviour (AAASM-3882) ─────────────────────────────────
+    //
+    // Two `InMemoryChallengeStore` clones share one Arc-backed map, modelling
+    // two gateway replicas pointed at a single shared store. This is the exact
+    // RequestChallenge-on-A → Register-on-B handshake that a process-local store
+    // would break behind a multi-replica load balancer.
+
+    #[tokio::test]
+    async fn nonce_issued_on_one_handle_is_consumable_on_another_exactly_once() {
+        let replica_a = InMemoryChallengeStore::default();
+        let replica_b = replica_a.clone();
+
+        // Replica A issues the challenge…
+        let (nonce, _) = replica_a.issue(DID, PK).await.unwrap();
+        // …and replica B (a different handle over the same backend) consumes it.
+        assert!(
+            replica_b.consume(&nonce, DID, PK).await.is_ok(),
+            "a nonce issued on replica A must be consumable on replica B"
+        );
+        // Single-use holds across handles: B already burned it, so A cannot reuse it.
+        let replay = replica_a.consume(&nonce, DID, PK).await.unwrap_err();
+        assert_eq!(replay.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[tokio::test]
+    async fn expiry_is_enforced_across_handles() {
+        let replica_a = InMemoryChallengeStore::default();
+        let replica_b = replica_a.clone();
+
+        let nonce = vec![2u8; CHALLENGE_NONCE_LEN];
+        // Replica A's backend holds a nonce that already expired.
+        replica_a.issued.lock().unwrap().insert(
+            nonce.clone(),
+            IssuedChallenge {
+                agent_id: DID.to_owned(),
+                public_key: PK.to_owned(),
+                expires_at: Instant::now() - Duration::from_secs(1),
+            },
+        );
+        // Replica B sees the same backend and still rejects the expired nonce.
+        let err = replica_b.consume(&nonce, DID, PK).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
 }

--- a/aa-gateway/src/storage/challenge.rs
+++ b/aa-gateway/src/storage/challenge.rs
@@ -1,0 +1,199 @@
+//! Replica-shared, Redis-backed registration challenge store (AAASM-3882).
+//!
+//! AAASM-3866 backed agent-registration challenge nonces with a process-local
+//! map ([`InMemoryChallengeStore`](crate::service::lifecycle_service::InMemoryChallengeStore)),
+//! which is correct only for a single gateway replica: behind a multi-replica
+//! load balancer a nonce issued by `RequestChallenge` on one replica is unknown
+//! to `Register` on another, so registration fails closed.
+//!
+//! [`RedisChallengeStore`] is a drop-in shared backend — inject it via
+//! [`AgentLifecycleServiceImpl::with_challenge_store`](crate::service::AgentLifecycleServiceImpl::with_challenge_store)
+//! so any replica can issue and any replica can consume. It reuses the gateway's
+//! existing optional `redis` dependency (the same one behind
+//! [`RedisPolicyCache`](super::cache::RedisPolicyCache)); no new dependency is
+//! added, and like the policy cache it is gated behind the `redis-cache` Cargo
+//! feature. The `redis` driver is confined to the `storage` module per the
+//! driver-isolation rule (see [`super`]).
+//!
+//! # Cross-replica guarantees
+//!
+//! The three security properties of the AAASM-3866 possession proof are
+//! preserved across replicas by leaning on Redis primitives:
+//!
+//! * **single-use** — `consume` uses `GETDEL`, which atomically returns *and*
+//!   deletes the key, so exactly one caller (on any replica) can ever consume a
+//!   given nonce; a replay or an identity-redirect attempt still burns it.
+//! * **time-bound** — `issue` writes the key with `SET … EX 30` (the shared
+//!   `CHALLENGE_TTL`); once it lapses Redis drops the key, so `GETDEL` returns
+//!   nil and consume fails.
+//! * **identity-binding** — the stored value is the issuing `agent_id` +
+//!   `public_key`; `consume` re-checks it so a nonce cannot be redirected to a
+//!   different identity.
+//!
+//! `GETDEL` requires Redis (or Valkey) 6.2 or newer.
+
+#[cfg(feature = "redis-cache")]
+use redis::aio::ConnectionManager;
+#[cfg(feature = "redis-cache")]
+use tonic::Status;
+
+#[cfg(feature = "redis-cache")]
+use super::cache::RedisConfig;
+#[cfg(feature = "redis-cache")]
+use super::error::{StorageError, StorageResult};
+#[cfg(feature = "redis-cache")]
+use crate::service::lifecycle_service::{
+    challenge_expiry_unix_ms, fresh_nonce, ChallengeStoreLike, CHALLENGE_TTL,
+};
+
+/// Lower-case hex encoding of the nonce bytes, namespaced under `aa:challenge:`.
+#[cfg(feature = "redis-cache")]
+fn challenge_key(nonce: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut hex = String::with_capacity(4 + nonce.len() * 2);
+    hex.push_str("aa:challenge:");
+    for byte in nonce {
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// Value stored against a nonce: the issuing identity, so `consume` can re-check
+/// the binding. `agent_id` (a `did:key`) and `public_key` (hex) are joined by an
+/// ASCII unit separator (`0x1F`), which cannot appear in either, so the split is
+/// unambiguous and no field can be smuggled across the boundary.
+#[cfg(feature = "redis-cache")]
+fn binding_value(agent_id: &str, public_key: &str) -> String {
+    format!("{agent_id}\u{1f}{public_key}")
+}
+
+/// Redis-backed, replica-shared [`ChallengeStoreLike`] (AAASM-3882).
+///
+/// Holds a cloneable [`ConnectionManager`] (the redis-rs multiplexed handle).
+/// Only available with the `redis-cache` Cargo feature.
+#[cfg(feature = "redis-cache")]
+pub struct RedisChallengeStore {
+    conn: ConnectionManager,
+}
+
+#[cfg(feature = "redis-cache")]
+impl RedisChallengeStore {
+    /// Establish a Redis connection from `config` and wrap it in a
+    /// [`ConnectionManager`].
+    ///
+    /// Returns [`StorageError::ConnectionFailed`] when `config.url` is `None`,
+    /// the URL cannot be parsed, or the manager cannot complete its initial
+    /// handshake. Mirrors [`RedisPolicyCache::connect`](super::cache::RedisPolicyCache::connect)
+    /// so both shared stores share one connection convention.
+    pub async fn connect(config: &RedisConfig) -> StorageResult<Self> {
+        let url = config.url.as_deref().ok_or_else(|| {
+            StorageError::ConnectionFailed("storage.redis.url is required when redis.enabled = true".into())
+        })?;
+        let client = redis::Client::open(url).map_err(|e| StorageError::ConnectionFailed(e.to_string()))?;
+        let conn = client
+            .get_connection_manager()
+            .await
+            .map_err(|e| StorageError::ConnectionFailed(e.to_string()))?;
+        Ok(Self { conn })
+    }
+}
+
+#[cfg(feature = "redis-cache")]
+#[async_trait::async_trait]
+impl ChallengeStoreLike for RedisChallengeStore {
+    async fn issue(&self, agent_id: &str, public_key: &str) -> Result<(Vec<u8>, i64), Status> {
+        use redis::AsyncCommands;
+        let nonce = fresh_nonce();
+        let key = challenge_key(&nonce);
+        let value = binding_value(agent_id, public_key);
+        let mut conn = self.conn.clone();
+        // SET key value EX 30 — TTL enforced by Redis and visible to every
+        // replica. Fail closed: never hand out a nonce we could not persist, or
+        // Register would later reject a legitimate agent.
+        let result: redis::RedisResult<()> = conn.set_ex(&key, value, CHALLENGE_TTL.as_secs()).await;
+        result.map_err(|err| {
+            tracing::warn!(error = %err, "redis registration challenge issue failed");
+            Status::internal("could not issue registration challenge")
+        })?;
+        Ok((nonce, challenge_expiry_unix_ms()))
+    }
+
+    async fn consume(&self, nonce: &[u8], agent_id: &str, public_key: &str) -> Result<(), Status> {
+        if nonce.is_empty() {
+            return Err(Status::unauthenticated(
+                "missing registration_nonce — call RequestChallenge before Register (AAASM-3866)",
+            ));
+        }
+        let key = challenge_key(nonce);
+        let mut conn = self.conn.clone();
+        // GETDEL atomically reads and removes the key — single-use across
+        // replicas. A driver error fails closed (Unauthenticated) so a Redis
+        // outage cannot let an unverified registration through.
+        let stored: redis::RedisResult<Option<String>> =
+            redis::cmd("GETDEL").arg(&key).query_async(&mut conn).await;
+        let stored = stored
+            .map_err(|err| {
+                tracing::warn!(error = %err, "redis registration challenge consume failed");
+                Status::unauthenticated("registration challenge store unavailable")
+            })?
+            .ok_or_else(|| Status::unauthenticated("unknown or already-used registration nonce"))?;
+
+        // The key is already gone (GETDEL), so any mismatch still burns the
+        // nonce — matching the in-memory store's "any attempt burns it".
+        if stored != binding_value(agent_id, public_key) {
+            return Err(Status::unauthenticated(
+                "registration nonce was not issued for this agent_id + public_key",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "redis-cache"))]
+mod tests {
+    use super::*;
+
+    const DID: &str = "did:key:z6MkExampleAgent";
+    const PK: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn challenge_key_is_namespaced_lowercase_hex() {
+        let key = challenge_key(&[0x0a, 0xff, 0x01]);
+        assert_eq!(key, "aa:challenge:0aff01");
+    }
+
+    #[test]
+    fn binding_value_round_trips_via_unit_separator() {
+        let value = binding_value(DID, PK);
+        let mut parts = value.split('\u{1f}');
+        assert_eq!(parts.next(), Some(DID));
+        assert_eq!(parts.next(), Some(PK));
+        assert_eq!(parts.next(), None);
+    }
+
+    #[tokio::test]
+    async fn connect_with_none_url_returns_connection_failed() {
+        let config = RedisConfig {
+            enabled: true,
+            url: None,
+            ..RedisConfig::default()
+        };
+        match RedisChallengeStore::connect(&config).await {
+            Ok(_) => panic!("None URL must surface as ConnectionFailed"),
+            Err(err) => assert!(matches!(err, StorageError::ConnectionFailed(_))),
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_with_malformed_url_returns_connection_failed() {
+        let config = RedisConfig {
+            enabled: true,
+            url: Some("not-a-redis-url".into()),
+            ..RedisConfig::default()
+        };
+        match RedisChallengeStore::connect(&config).await {
+            Ok(_) => panic!("malformed URL must surface as ConnectionFailed"),
+            Err(err) => assert!(matches!(err, StorageError::ConnectionFailed(_))),
+        }
+    }
+}

--- a/aa-gateway/src/storage/challenge.rs
+++ b/aa-gateway/src/storage/challenge.rs
@@ -42,9 +42,7 @@ use super::cache::RedisConfig;
 #[cfg(feature = "redis-cache")]
 use super::error::{StorageError, StorageResult};
 #[cfg(feature = "redis-cache")]
-use crate::service::lifecycle_service::{
-    challenge_expiry_unix_ms, fresh_nonce, ChallengeStoreLike, CHALLENGE_TTL,
-};
+use crate::service::lifecycle_service::{challenge_expiry_unix_ms, fresh_nonce, ChallengeStoreLike, CHALLENGE_TTL};
 
 /// Lower-case hex encoding of the nonce bytes, namespaced under `aa:challenge:`.
 #[cfg(feature = "redis-cache")]
@@ -129,8 +127,7 @@ impl ChallengeStoreLike for RedisChallengeStore {
         // GETDEL atomically reads and removes the key — single-use across
         // replicas. A driver error fails closed (Unauthenticated) so a Redis
         // outage cannot let an unverified registration through.
-        let stored: redis::RedisResult<Option<String>> =
-            redis::cmd("GETDEL").arg(&key).query_async(&mut conn).await;
+        let stored: redis::RedisResult<Option<String>> = redis::cmd("GETDEL").arg(&key).query_async(&mut conn).await;
         let stored = stored
             .map_err(|err| {
                 tracing::warn!(error = %err, "redis registration challenge consume failed");

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -28,6 +28,7 @@ pub mod audit_bridge;
 pub mod backend;
 pub mod boot;
 pub mod cache;
+pub mod challenge;
 pub mod error;
 pub mod health;
 pub mod metric;
@@ -48,6 +49,8 @@ pub use audit_bridge::audit_entry_to_storage_event;
 pub use backend::StorageBackend;
 pub use boot::{open_postgres_backend, open_sqlite_backend};
 pub use cache::{PolicyCache, PolicyCacheLike, RedisConfig};
+#[cfg(feature = "redis-cache")]
+pub use challenge::RedisChallengeStore;
 pub use error::{StorageError, StorageResult};
 pub use health::{HealthStatus, RowCounts, StorageHealth};
 pub use metric::{Metric, MetricPoint, MetricQuery};


### PR DESCRIPTION
## Description

AAASM-3866 hardened agent registration with a server-issued nonce challenge (`RequestChallenge` → sign nonce → `Register`) backed by an **in-memory** `ChallengeStore` in `aa-gateway/src/service/lifecycle_service.rs`. That store is process-local, so behind a multi-replica load balancer a nonce issued by `RequestChallenge` on replica A is unknown to `Register` on replica B and registration fails closed (`Unauthenticated`) — broken for any horizontally-scaled gateway.

This PR makes the challenge store **replica-shared**:

- Extracts a `ChallengeStoreLike` async trait (issue + atomic consume) preserving the three AAASM-3866 guarantees: **single-use**, **30s TTL**, and **agent_id + public_key identity-binding**.
- `InMemoryChallengeStore` remains the default (single-replica / dev); its backing map now sits behind an `Arc` so handles can share one backend.
- Adds `RedisChallengeStore` (`aa-gateway/src/storage/challenge.rs`), a shared backend that enforces single-use via atomic `GETDEL`, TTL via `SET … EX 30`, and identity-binding by re-checking the stored value. Driver errors fail closed.
- `AgentLifecycleServiceImpl::with_challenge_store(...)` lets a production, horizontally-scaled gateway inject the shared store via constructor injection — default behaviour and `server.rs` wiring are unchanged.

**Approach note:** reuses the gateway's existing optional `redis` dependency (the same one behind `RedisPolicyCache`) — **no new dependency**, gated behind the existing `redis-cache` Cargo feature, with the `redis` driver kept inside the `storage` module per the driver-isolation rule. The trait abstraction additionally keeps the in-memory default for deployments that do not run Redis.

## Type of Change

- [x] ♻️ Refactoring
- [x] 🐛 Bug fix (multi-replica registration availability)

## Breaking Changes

- [x] No

Default construction (`AgentLifecycleServiceImpl::new` / `with_policy_engine`) keeps the in-memory store; the trait object and builder are additive.

## Related Issues

- Related Jira ticket: AAASM-3882
- Related: AAASM-3866 (nonce challenge, merged via #1295)

## Testing

- [x] Unit tests added / updated
- Cross-replica test: a nonce issued via handle A is consumable via handle B exactly once (single-use survives the handle boundary); expiry is enforced across handles.
- Existing in-memory challenge tests converted to the async API; identity-binding / replay / empty / unknown / expiry coverage retained.
- `RedisChallengeStore` key/binding-value and connect-failure tests (gated by `redis-cache`).

Validation (gateway): `cargo build -p aa-gateway`; `cargo nextest run -p aa-gateway` (1268 passed) and `--features redis-cache` challenge tests; `cargo fmt --all`; `cargo clippy -p aa-gateway --all-targets -- -D warnings` (default and `redis-cache`).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3882

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
