### PR TITLE
[AAASM-3883] 🔌 (aa-gateway): Cross-process op-control via NATS subject

### DIFF
--- a/aa-api/src/routes/ops.rs
+++ b/aa-api/src/routes/ops.rs
@@ -26,7 +26,7 @@ use crate::auth::AuthenticatedCaller;
 use crate::error::ProblemDetail;
 use crate::events::OpsChangeBroadcast;
 use crate::models::ws_payloads::OpsChangePayload;
-use crate::ops::{OpRecord, OpsError};
+use crate::ops::{HaltDelivery, OpRecord, OpsError};
 use crate::state::AppState;
 
 /// Parse a hex-encoded 16-byte agent id, or `None` if it is not 32 hex chars.
@@ -338,9 +338,19 @@ pub async fn halt_agent_for_op(
             .with_detail("Operation has no resolvable owning agent to halt".to_string())
     })?;
     let target = agent_id.agent_id.clone();
-    if !state.ops_registry.halt_agent(agent_id, signal) {
-        return Err(ProblemDetail::from_status(StatusCode::SERVICE_UNAVAILABLE)
-            .with_detail("Op-control channel not configured".to_string()));
+    // AAASM-3883: prefer the cross-process NATS channel when configured so the
+    // halt reaches the gateway process that owns op_control_stream; a publish
+    // failure is surfaced honestly as 503 rather than a silent-drop 200.
+    match state.ops_registry.halt_agent_delivery(agent_id, signal).await {
+        HaltDelivery::Delivered => {}
+        HaltDelivery::NotConfigured => {
+            return Err(ProblemDetail::from_status(StatusCode::SERVICE_UNAVAILABLE)
+                .with_detail("Op-control channel not configured".to_string()));
+        }
+        HaltDelivery::ChannelError(err) => {
+            return Err(ProblemDetail::from_status(StatusCode::SERVICE_UNAVAILABLE)
+                .with_detail(format!("Op-control channel error: {err}")));
+        }
     }
     tracing::info!(
         target: "aa_api::ops",
@@ -394,9 +404,17 @@ pub async fn halt_global(
             .with_detail("A global halt requires admin scope".to_string()));
     }
     let signal = parse_halt_action(&req.action)?;
-    if !state.ops_registry.halt_global(signal) {
-        return Err(ProblemDetail::from_status(StatusCode::SERVICE_UNAVAILABLE)
-            .with_detail("Op-control channel not configured".to_string()));
+    // AAASM-3883: cross-process NATS delivery when configured (see halt_agent_for_op).
+    match state.ops_registry.halt_global_delivery(signal).await {
+        HaltDelivery::Delivered => {}
+        HaltDelivery::NotConfigured => {
+            return Err(ProblemDetail::from_status(StatusCode::SERVICE_UNAVAILABLE)
+                .with_detail("Op-control channel not configured".to_string()));
+        }
+        HaltDelivery::ChannelError(err) => {
+            return Err(ProblemDetail::from_status(StatusCode::SERVICE_UNAVAILABLE)
+                .with_detail(format!("Op-control channel error: {err}")));
+        }
     }
     tracing::info!(target: "aa_api::ops", action = %req.action, "fleet-wide op-control halt emitted");
     Ok((

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -479,6 +479,32 @@ impl AppState {
         let retention_cfg = aa_gateway::storage::RetentionConfig::default();
         state.retention_engine = Some(Arc::new(RetentionEngine::new(storage, retention_cfg)));
 
+        // --- Cross-process op-control kill switch (AAASM-3883). ---
+        // When AA_OPCONTROL_NATS_URL is set, attach a NATS op-control publisher to
+        // the ops registry so the operator halt endpoints publish onto the shared
+        // subject the gateway process bridges into op_control_stream (ADR 0011).
+        // Without it the registry keeps its in-process-only behavior. A connect
+        // failure is logged and left disconnected (the halt endpoints then return
+        // an honest 503) rather than blocking startup.
+        if let Some(cfg) = crate::ops::OpControlNatsConfig::from_env() {
+            match crate::ops::OpControlNatsPublisher::connect(&cfg).await {
+                Ok(publisher) => {
+                    state.ops_registry = Arc::new(OpsRegistry::new().with_nats_publisher(Arc::new(publisher)));
+                    tracing::info!(
+                        url = %cfg.url,
+                        "op-control NATS publisher connected — operator halts will be delivered cross-process"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        url = %cfg.url,
+                        "op-control NATS publisher disabled — halt endpoints will return 503 until NATS is reachable"
+                    );
+                }
+            }
+        }
+
         Ok(state)
     }
 }

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -58,12 +58,19 @@ axum-server  = { version = "0.8", features = ["tls-rustls"] }
 tower-http   = { workspace = true, features = ["fs"] }
 x509-parser  = "0.18"
 redis        = { workspace = true, features = ["tokio-comp", "connection-manager"], optional = true }
+# AAASM-3883: cross-process op-control delivery over a NATS subject (ADR 0011).
+# async-nats is a regular (non-optional) dependency here because it is already a
+# non-optional transitive dependency via aa-runtime's audit publisher — so it is
+# in the crates.io publish set regardless. The op-control bridge/publisher is
+# therefore always compiled and activated at runtime by AA_OPCONTROL_NATS_URL,
+# matching the always-on runtime audit publisher rather than the feature-gated
+# audit consumer.
+async-nats   = { workspace = true }
 # strip-for-publish:begin audit-consumer
 # AAASM-2388: gateway-side NATS JetStream audit consumer. Held back from the
 # crates.io publish set — aa-storage-postgres is `publish = false`, so cargo
 # would reject the published gateway for depending on it. This whole block is
 # removed by .ci/strip-for-publish.sh before `cargo workspaces publish`.
-async-nats   = { workspace = true, optional = true }
 aa-storage-postgres = { path = "../aa-storage-postgres", optional = true }
 # strip-for-publish:end audit-consumer
 
@@ -97,7 +104,7 @@ redis-cache = ["dep:redis"]
 # strip-for-publish:begin audit-consumer
 # AAASM-2388: gateway-internal NATS->Postgres audit consumer worker. Default
 # OFF; enabled in dev/CI via `--all-features`. Stripped before crates.io publish.
-audit-consumer = ["dep:async-nats", "dep:aa-storage-postgres"]
+audit-consumer = ["dep:aa-storage-postgres"]
 # strip-for-publish:end audit-consumer
 
 [[bin]]

--- a/aa-gateway/src/ops/mod.rs
+++ b/aa-gateway/src/ops/mod.rs
@@ -17,8 +17,13 @@
 //! `OpsError::InvalidTransition`. See
 //! `docs/src/operations/ops-registry-architecture.md` for the full diagram.
 
+pub mod nats;
 pub mod publisher;
 
+pub use nats::{
+    OpControlNatsConfig, OpControlNatsError, OpControlNatsPublisher, OpControlWireEnvelope,
+    SharedOpControlNatsPublisher,
+};
 pub use publisher::{OpControlEnvelope, OpControlPublisher, SharedOpControlPublisher};
 
 use aa_proto::assembly::common::v1::AgentId;
@@ -65,6 +70,25 @@ pub enum OpsError {
     InvalidTransition,
 }
 
+/// Outcome of an operator halt-delivery attempt (AAASM-3883).
+///
+/// Returned by [`OpsRegistry::halt_agent_delivery`] /
+/// [`OpsRegistry::halt_global_delivery`] so the HTTP endpoint can distinguish a
+/// real delivery from an honest failure and never report a silent-drop `200` for
+/// a kill switch.
+#[derive(Debug, PartialEq, Eq)]
+pub enum HaltDelivery {
+    /// The halt was published (cross-process NATS publish + flush succeeded, or
+    /// the in-process broadcast accepted it).
+    Delivered,
+    /// No op-control channel is configured — neither a NATS publisher nor an
+    /// in-process broadcast. The endpoint should respond `503`.
+    NotConfigured,
+    /// A NATS op-control channel is configured but the publish/flush failed —
+    /// an honest error the endpoint should surface as `503`, carrying the cause.
+    ChannelError(String),
+}
+
 /// Thread-safe in-memory store for in-flight operation lifecycle state.
 ///
 /// Backed by [`DashMap`] for concurrent, lock-free read access and
@@ -84,6 +108,13 @@ pub struct OpsRegistry {
     /// Wire via [`OpsRegistry::with_publisher`]. `None` means transitions
     /// only update local state — no SDK push happens.
     publisher: Option<SharedOpControlPublisher>,
+    /// Optional **cross-process** op-control publisher over NATS (AAASM-3883).
+    /// Wire via [`OpsRegistry::with_nats_publisher`]. When set, the operator
+    /// halt-delivery methods publish to the shared NATS subject so a halt issued
+    /// in the aa-api process reaches the gateway process that serves
+    /// `op_control_stream`. `None` keeps the in-process-only behavior. See
+    /// ADR 0011.
+    nats_publisher: Option<SharedOpControlNatsPublisher>,
 }
 
 impl Default for OpsRegistry {
@@ -98,6 +129,7 @@ impl OpsRegistry {
             ops: DashMap::new(),
             agents: DashMap::new(),
             publisher: None,
+            nats_publisher: None,
         }
     }
 
@@ -109,6 +141,19 @@ impl OpsRegistry {
     /// agent_id the publisher has nothing to route to.
     pub fn with_publisher(mut self, publisher: SharedOpControlPublisher) -> Self {
         self.publisher = Some(publisher);
+        self
+    }
+
+    /// Attach a **cross-process** [`OpControlNatsPublisher`] (AAASM-3883).
+    ///
+    /// When set, [`halt_agent_delivery`](Self::halt_agent_delivery) and
+    /// [`halt_global_delivery`](Self::halt_global_delivery) publish the operator
+    /// halt to the shared NATS subject instead of the in-process broadcast, so a
+    /// halt issued in the aa-api process reaches the gateway process that owns
+    /// `op_control_stream`. This is the seam that makes the kill switch work in
+    /// the real two-process deployment (ADR 0011).
+    pub fn with_nats_publisher(mut self, publisher: SharedOpControlNatsPublisher) -> Self {
+        self.nats_publisher = Some(publisher);
         self
     }
 
@@ -202,6 +247,49 @@ impl OpsRegistry {
                 true
             }
             None => false,
+        }
+    }
+
+    /// AAASM-3883: emit an **agent-wide** halt, preferring the cross-process NATS
+    /// publisher when one is attached, falling back to the in-process broadcast.
+    ///
+    /// This is the delivery method the aa-api operator endpoints call. When a
+    /// NATS publisher is configured the halt is published to the shared subject
+    /// (and flushed), so it reaches the gateway process serving
+    /// `op_control_stream`; a publish/flush failure is surfaced as
+    /// [`HaltDelivery::ChannelError`] so the endpoint returns a real error rather
+    /// than a silent-drop `200`. Without a NATS publisher the existing in-process
+    /// path is used (co-located / local mode). With neither channel configured
+    /// the result is [`HaltDelivery::NotConfigured`].
+    pub async fn halt_agent_delivery(&self, agent_id: AgentId, signal: OpControlSignal) -> HaltDelivery {
+        if let Some(nats) = self.nats_publisher.as_ref() {
+            return match nats.publish_agent_halt(agent_id, signal).await {
+                Ok(()) => HaltDelivery::Delivered,
+                Err(err) => HaltDelivery::ChannelError(err.to_string()),
+            };
+        }
+        if self.halt_agent(agent_id, signal) {
+            HaltDelivery::Delivered
+        } else {
+            HaltDelivery::NotConfigured
+        }
+    }
+
+    /// AAASM-3883: emit a **fleet-wide** halt, preferring the cross-process NATS
+    /// publisher when one is attached, falling back to the in-process broadcast.
+    /// See [`halt_agent_delivery`](Self::halt_agent_delivery) for the
+    /// channel-selection and failure semantics.
+    pub async fn halt_global_delivery(&self, signal: OpControlSignal) -> HaltDelivery {
+        if let Some(nats) = self.nats_publisher.as_ref() {
+            return match nats.publish_global_halt(signal).await {
+                Ok(()) => HaltDelivery::Delivered,
+                Err(err) => HaltDelivery::ChannelError(err.to_string()),
+            };
+        }
+        if self.halt_global(signal) {
+            HaltDelivery::Delivered
+        } else {
+            HaltDelivery::NotConfigured
         }
     }
 
@@ -644,6 +732,45 @@ mod tests {
         let registry = OpsRegistry::new();
         assert!(!registry.halt_agent(agent("a1"), OpControlSignal::Terminate));
         assert!(!registry.halt_global(OpControlSignal::Terminate));
+    }
+
+    // ── AAASM-3883: halt delivery (in-process fallback + honest failure) ────
+
+    #[tokio::test]
+    async fn halt_delivery_reports_not_configured_without_any_channel() {
+        // Neither an in-process broadcast nor a NATS publisher → NotConfigured,
+        // which the endpoint maps to an honest 503 rather than a silent 200.
+        let registry = OpsRegistry::new();
+        assert_eq!(
+            registry
+                .halt_agent_delivery(agent("a1"), OpControlSignal::Terminate)
+                .await,
+            HaltDelivery::NotConfigured,
+        );
+        assert_eq!(
+            registry.halt_global_delivery(OpControlSignal::Terminate).await,
+            HaltDelivery::NotConfigured,
+        );
+    }
+
+    #[tokio::test]
+    async fn halt_delivery_uses_in_process_broadcast_when_no_nats() {
+        // With only the in-process publisher (co-located / local mode) the halt
+        // is Delivered and reaches a subscriber under the reserved key.
+        let publisher = std::sync::Arc::new(OpControlPublisher::new());
+        let registry = OpsRegistry::new().with_publisher(std::sync::Arc::clone(&publisher));
+        let mut rx = publisher.subscribe();
+
+        assert_eq!(
+            registry
+                .halt_agent_delivery(agent("a1"), OpControlSignal::Terminate)
+                .await,
+            HaltDelivery::Delivered,
+        );
+
+        let envelope = rx.recv().await.unwrap();
+        assert_eq!(envelope.message.op_id, "agent:a1");
+        assert_eq!(envelope.message.signal, OpControlSignal::Terminate as i32);
     }
 
     #[test]

--- a/aa-gateway/src/ops/nats.rs
+++ b/aa-gateway/src/ops/nats.rs
@@ -1,0 +1,460 @@
+//! Cross-process op-control delivery over a NATS subject (AAASM-3883).
+//!
+//! [`OpControlPublisher`](super::OpControlPublisher) is an **in-process**
+//! `tokio::sync::broadcast`. In the shipped product the operator halt endpoints
+//! (`AppState.ops_registry`, aa-api-server process) and the gRPC
+//! `PolicyService.op_control_stream` that runtimes subscribe to (aa-gateway
+//! process) run in **separate processes**, so an in-process publish reaches no
+//! subscriber. This module bridges the gap with a shared NATS subject, mirroring
+//! the existing audit subsystem (`assembly.audit.>`) rather than inventing a
+//! parallel NATS stack. See ADR 0011.
+//!
+//! Two halves:
+//!
+//! * **Publish** ([`OpControlNatsPublisher`]) — used by the aa-api halt handlers
+//!   to publish an [`OpControlWireEnvelope`] to `assembly.opcontrol.<tenant>.<agent>`
+//!   (or `assembly.opcontrol.global`). It `flush()`es after every publish so a
+//!   NATS outage surfaces as a real error, never a silent-drop `200`.
+//! * **Consume** ([`spawn_bridge`]) — a gateway boot task that subscribes to
+//!   `assembly.opcontrol.>` and forwards each received envelope into the gateway's
+//!   in-process [`OpControlPublisher`](super::OpControlPublisher), so the existing
+//!   `op_control_stream` filtering / reserved-key matching delivers it to runtimes
+//!   unchanged.
+//!
+//! `async-nats` is already a non-optional dependency (via `aa-runtime`'s audit
+//! publisher), so this module is always compiled and activated purely by the
+//! `AA_OPCONTROL_NATS_URL` environment variable — matching the always-on runtime
+//! audit publisher rather than the feature-gated audit consumer.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::task::JoinHandle;
+use tokio_stream::StreamExt;
+
+use aa_proto::assembly::common::v1::AgentId;
+use aa_proto::assembly::policy::v1::OpControlSignal;
+use aa_runtime::op_control::{agent_halt_op_id, GLOBAL_HALT_OP_ID};
+
+use super::SharedOpControlPublisher;
+
+/// Subject prefix shared by every op-control message (mirrors `assembly.audit`).
+pub const SUBJECT_PREFIX: &str = "assembly.opcontrol";
+/// Subject a fleet-wide halt is published under.
+pub const GLOBAL_SUBJECT: &str = "assembly.opcontrol.global";
+/// Wildcard the gateway bridge subscribes to, capturing every op-control subject.
+pub const SUBJECT_WILDCARD: &str = "assembly.opcontrol.>";
+/// Token used when a tenant identifier is unavailable on the envelope.
+const UNKNOWN_TENANT: &str = "default";
+/// Token used when an agent identifier is empty.
+const UNKNOWN_AGENT: &str = "unknown";
+
+/// First reconnect delay for the bridge; doubles on each consecutive failure.
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+/// Upper bound on the bridge reconnect delay (1s → 2 → 4 → … → 32s cap).
+const MAX_BACKOFF: Duration = Duration::from_secs(32);
+
+/// Wire form of an op-control signal carried over NATS.
+///
+/// Reuses the reserved-key semantics of the in-process path: `op_id` is the same
+/// reserved key the gateway and runtime already agree on (`agent:{id}` for an
+/// agent-wide halt, `"*"` for a fleet-wide halt, or `"{trace}:{span}"` for a
+/// per-op signal), and `signal` is the [`OpControlSignal`] discriminant. `global`
+/// marks a fleet-wide halt so the gateway forwards it to every subscriber.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpControlWireEnvelope {
+    /// Owning org of the targeted agent (empty for a global halt).
+    pub org_id: String,
+    /// Owning team of the targeted agent (empty for a global halt).
+    pub team_id: String,
+    /// Targeted agent id (empty for a global halt).
+    pub agent_id: String,
+    /// Reserved op-id the runtime consults (`agent:{id}` / `"*"` / `"{trace}:{span}"`).
+    pub op_id: String,
+    /// Wire [`OpControlSignal`] discriminant.
+    pub signal: i32,
+    /// Fleet-wide halt marker: when `true` the gateway forwards to every subscriber.
+    pub global: bool,
+}
+
+/// Build the NATS subject for `envelope`.
+///
+/// Fleet-wide halts use [`GLOBAL_SUBJECT`]; per-agent envelopes use
+/// `assembly.opcontrol.<tenant>.<agent>` where `<tenant>` is the org id, falling
+/// back to the team id, then `default`, and `<agent>` is the agent id. Both tokens
+/// are sanitized so the subject contains only subject-safe characters.
+pub fn subject_for(envelope: &OpControlWireEnvelope) -> String {
+    if envelope.global {
+        return GLOBAL_SUBJECT.to_string();
+    }
+    let tenant = [&envelope.org_id, &envelope.team_id]
+        .into_iter()
+        .map(|raw| sanitize_token(raw))
+        .find(|token| !token.is_empty())
+        .unwrap_or_else(|| UNKNOWN_TENANT.to_string());
+    let agent = {
+        let token = sanitize_token(&envelope.agent_id);
+        if token.is_empty() {
+            UNKNOWN_AGENT.to_string()
+        } else {
+            token
+        }
+    };
+    format!("{SUBJECT_PREFIX}.{tenant}.{agent}")
+}
+
+/// Replace every character outside `[A-Za-z0-9_-]` with `_` so the result is a
+/// single valid NATS subject token (NATS reserves `.`, `*`, `>` and whitespace).
+fn sanitize_token(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Errors raised by the op-control NATS publisher and bridge.
+#[derive(Debug, thiserror::Error)]
+pub enum OpControlNatsError {
+    /// Connecting to the NATS server failed.
+    #[error("op-control NATS connect failed: {0}")]
+    Connect(String),
+    /// Publishing or flushing a message failed.
+    #[error("op-control NATS publish failed: {0}")]
+    Publish(String),
+    /// Subscribing to the op-control subject failed.
+    #[error("op-control NATS subscribe failed: {0}")]
+    Subscribe(String),
+    /// Serializing the envelope to JSON failed.
+    #[error("op-control envelope serialization failed: {0}")]
+    Serialize(String),
+}
+
+/// Runtime configuration for the op-control NATS bridge / publisher.
+#[derive(Debug, Clone)]
+pub struct OpControlNatsConfig {
+    /// NATS server URL (e.g. `nats://127.0.0.1:4222`).
+    pub url: String,
+}
+
+impl OpControlNatsConfig {
+    /// Build a config for the given NATS URL.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+
+    /// Build a config from the environment, returning `None` (op-control NATS
+    /// disabled) when `AA_OPCONTROL_NATS_URL` is unset — mirrors the audit
+    /// consumer's `AA_AUDIT_NATS_URL` activation so both processes keep their
+    /// existing in-process behavior unless explicitly configured.
+    pub fn from_env() -> Option<Self> {
+        let url = std::env::var("AA_OPCONTROL_NATS_URL").ok().filter(|u| !u.is_empty())?;
+        Some(Self::new(url))
+    }
+}
+
+/// Publishes op-control signals onto the shared NATS subject (aa-api side).
+#[derive(Clone)]
+pub struct OpControlNatsPublisher {
+    client: async_nats::Client,
+}
+
+impl OpControlNatsPublisher {
+    /// Wrap an already-connected NATS client.
+    pub fn new(client: async_nats::Client) -> Self {
+        Self { client }
+    }
+
+    /// Connect to the server described by `config` and wrap the client.
+    pub async fn connect(config: &OpControlNatsConfig) -> Result<Self, OpControlNatsError> {
+        let client = async_nats::connect(&config.url)
+            .await
+            .map_err(|e| OpControlNatsError::Connect(e.to_string()))?;
+        Ok(Self::new(client))
+    }
+
+    /// Publish `envelope` and flush so the write reaches the server before
+    /// returning. The flush is what makes a NATS outage an honest error rather
+    /// than a buffered success the operator would misread as a delivered halt.
+    pub async fn publish(&self, envelope: &OpControlWireEnvelope) -> Result<(), OpControlNatsError> {
+        let subject = subject_for(envelope);
+        let payload = serde_json::to_vec(envelope).map_err(|e| OpControlNatsError::Serialize(e.to_string()))?;
+        self.client
+            .publish(subject, payload.into())
+            .await
+            .map_err(|e| OpControlNatsError::Publish(e.to_string()))?;
+        self.client
+            .flush()
+            .await
+            .map_err(|e| OpControlNatsError::Publish(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Publish an agent-wide halt under the reserved `agent:{agent_id}` op-id.
+    pub async fn publish_agent_halt(
+        &self,
+        agent_id: AgentId,
+        signal: OpControlSignal,
+    ) -> Result<(), OpControlNatsError> {
+        let envelope = OpControlWireEnvelope {
+            op_id: agent_halt_op_id(&agent_id.agent_id),
+            org_id: agent_id.org_id,
+            team_id: agent_id.team_id,
+            agent_id: agent_id.agent_id,
+            signal: signal as i32,
+            global: false,
+        };
+        self.publish(&envelope).await
+    }
+
+    /// Publish a fleet-wide halt under the reserved global op-id `"*"`.
+    pub async fn publish_global_halt(&self, signal: OpControlSignal) -> Result<(), OpControlNatsError> {
+        let envelope = OpControlWireEnvelope {
+            org_id: String::new(),
+            team_id: String::new(),
+            agent_id: String::new(),
+            op_id: GLOBAL_HALT_OP_ID.to_string(),
+            signal: signal as i32,
+            global: true,
+        };
+        self.publish(&envelope).await
+    }
+}
+
+/// Forward one received wire envelope into the gateway's in-process broadcast.
+///
+/// Reconstructs the exact envelope the in-process path would have produced: a
+/// global halt goes through `publish_global_halt` (so it is marked global and
+/// reaches every subscriber); a per-agent envelope goes through `publish`, which
+/// preserves the reserved `op_id`. An `Unspecified` / unknown signal is dropped.
+fn forward_to_broadcast(publisher: &SharedOpControlPublisher, envelope: OpControlWireEnvelope) {
+    let signal = match OpControlSignal::try_from(envelope.signal) {
+        Ok(OpControlSignal::Unspecified) | Err(_) => {
+            tracing::warn!(
+                signal = envelope.signal,
+                "op-control bridge: dropping unspecified/unknown signal"
+            );
+            return;
+        }
+        Ok(signal) => signal,
+    };
+    if envelope.global {
+        publisher.publish_global_halt(signal);
+    } else {
+        let agent = AgentId {
+            org_id: envelope.org_id,
+            team_id: envelope.team_id,
+            agent_id: envelope.agent_id,
+        };
+        publisher.publish(agent, envelope.op_id, signal);
+    }
+}
+
+/// Spawn the gateway-side bridge task: subscribe to `assembly.opcontrol.>` and
+/// forward every received halt into `publisher` (the in-process broadcast
+/// `op_control_stream` serves). Reconnects forever with exponential backoff so a
+/// transient NATS outage never permanently silences the cross-process kill switch.
+pub fn spawn_bridge(config: OpControlNatsConfig, publisher: SharedOpControlPublisher) -> JoinHandle<()> {
+    tokio::spawn(run_bridge(config, publisher))
+}
+
+/// Reconnect loop for the bridge.
+async fn run_bridge(config: OpControlNatsConfig, publisher: SharedOpControlPublisher) {
+    let mut backoff = INITIAL_BACKOFF;
+    loop {
+        match bridge_once(&config, &publisher).await {
+            // The subscription ended cleanly — reconnect promptly.
+            Ok(()) => backoff = INITIAL_BACKOFF,
+            Err(err) => {
+                metrics::counter!("aa_op_control_bridge_reconnects_total").increment(1);
+                tracing::warn!(
+                    error = %err,
+                    backoff_secs = backoff.as_secs(),
+                    "op-control NATS bridge dropped; reconnecting after backoff"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+        }
+    }
+}
+
+/// Open one subscription and forward messages until the stream ends or errors.
+async fn bridge_once(
+    config: &OpControlNatsConfig,
+    publisher: &SharedOpControlPublisher,
+) -> Result<(), OpControlNatsError> {
+    let client = async_nats::connect(&config.url)
+        .await
+        .map_err(|e| OpControlNatsError::Connect(e.to_string()))?;
+    let mut subscription = client
+        .subscribe(SUBJECT_WILDCARD)
+        .await
+        .map_err(|e| OpControlNatsError::Subscribe(e.to_string()))?;
+    // Flush so the SUB is registered server-side before we report readiness.
+    client
+        .flush()
+        .await
+        .map_err(|e| OpControlNatsError::Subscribe(e.to_string()))?;
+    tracing::info!(subject = SUBJECT_WILDCARD, "op-control NATS bridge subscribed");
+
+    while let Some(message) = subscription.next().await {
+        match serde_json::from_slice::<OpControlWireEnvelope>(&message.payload) {
+            Ok(envelope) => {
+                metrics::counter!("aa_op_control_bridge_forwarded_total").increment(1);
+                forward_to_broadcast(publisher, envelope);
+            }
+            Err(err) => {
+                tracing::warn!(%err, "op-control bridge: dropping undecodable message");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Convenience alias for the shared-ownership shape used when threading the
+/// publisher into `OpsRegistry`.
+pub type SharedOpControlNatsPublisher = Arc<OpControlNatsPublisher>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(
+        global: bool,
+        org: &str,
+        team: &str,
+        agent: &str,
+        op_id: &str,
+        signal: OpControlSignal,
+    ) -> OpControlWireEnvelope {
+        OpControlWireEnvelope {
+            org_id: org.into(),
+            team_id: team.into(),
+            agent_id: agent.into(),
+            op_id: op_id.into(),
+            signal: signal as i32,
+            global,
+        }
+    }
+
+    #[test]
+    fn subject_prefers_org_then_team_then_default() {
+        let with_org = env(
+            false,
+            "acme",
+            "payments",
+            "bot-7",
+            "agent:bot-7",
+            OpControlSignal::Terminate,
+        );
+        assert_eq!(subject_for(&with_org), "assembly.opcontrol.acme.bot-7");
+
+        let team_only = env(false, "", "payments", "bot-7", "agent:bot-7", OpControlSignal::Pause);
+        assert_eq!(subject_for(&team_only), "assembly.opcontrol.payments.bot-7");
+
+        let neither = env(false, "", "", "bot-7", "agent:bot-7", OpControlSignal::Pause);
+        assert_eq!(subject_for(&neither), "assembly.opcontrol.default.bot-7");
+    }
+
+    #[test]
+    fn subject_sanitizes_unsafe_tokens_and_falls_back_for_empty_agent() {
+        let dotted = env(
+            false,
+            "acme corp.eu",
+            "",
+            "bot.7",
+            "agent:bot.7",
+            OpControlSignal::Terminate,
+        );
+        assert_eq!(subject_for(&dotted), "assembly.opcontrol.acme_corp_eu.bot_7");
+
+        let no_agent = env(false, "acme", "", "", "*", OpControlSignal::Terminate);
+        assert_eq!(subject_for(&no_agent), "assembly.opcontrol.acme.unknown");
+    }
+
+    #[test]
+    fn global_envelope_uses_the_global_subject() {
+        let g = env(true, "", "", "", GLOBAL_HALT_OP_ID, OpControlSignal::Terminate);
+        assert_eq!(subject_for(&g), GLOBAL_SUBJECT);
+    }
+
+    #[test]
+    fn wire_envelope_round_trips_through_json() {
+        let original = env(
+            false,
+            "acme",
+            "payments",
+            "bot-7",
+            "agent:bot-7",
+            OpControlSignal::Terminate,
+        );
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let decoded: OpControlWireEnvelope = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded, original);
+        assert_eq!(decoded.signal, OpControlSignal::Terminate as i32);
+    }
+
+    #[tokio::test]
+    async fn forward_reconstructs_per_agent_envelope_into_broadcast() {
+        let publisher = Arc::new(super::super::OpControlPublisher::new());
+        let mut rx = publisher.subscribe();
+
+        forward_to_broadcast(
+            &publisher,
+            env(
+                false,
+                "org",
+                "team",
+                "a1",
+                &agent_halt_op_id("a1"),
+                OpControlSignal::Terminate,
+            ),
+        );
+
+        let envelope = rx.recv().await.unwrap();
+        assert!(!envelope.global);
+        assert_eq!(envelope.agent_id.agent_id, "a1");
+        assert_eq!(envelope.message.op_id, "agent:a1");
+        assert_eq!(envelope.message.signal, OpControlSignal::Terminate as i32);
+    }
+
+    #[tokio::test]
+    async fn forward_reconstructs_global_envelope_into_broadcast() {
+        let publisher = Arc::new(super::super::OpControlPublisher::new());
+        let mut rx = publisher.subscribe();
+
+        forward_to_broadcast(
+            &publisher,
+            env(true, "", "", "", GLOBAL_HALT_OP_ID, OpControlSignal::Pause),
+        );
+
+        let envelope = rx.recv().await.unwrap();
+        assert!(envelope.global);
+        assert_eq!(envelope.message.op_id, "*");
+        assert_eq!(envelope.message.signal, OpControlSignal::Pause as i32);
+    }
+
+    #[tokio::test]
+    async fn forward_drops_unspecified_signal() {
+        let publisher = Arc::new(super::super::OpControlPublisher::new());
+        let mut rx = publisher.subscribe();
+
+        forward_to_broadcast(
+            &publisher,
+            env(false, "org", "team", "a1", "agent:a1", OpControlSignal::Unspecified),
+        );
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), rx.recv())
+                .await
+                .is_err(),
+            "an unspecified signal must not be forwarded",
+        );
+    }
+}

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -264,6 +264,37 @@ fn setup_anomaly() -> (
     (detector, event_tx, event_rx)
 }
 
+/// Build the in-process op-control broadcast for the gRPC `op_control_stream`,
+/// and — when cross-process delivery is configured — spawn the NATS bridge that
+/// feeds it (AAASM-3883).
+///
+/// The returned [`SharedOpControlPublisher`] is attached to
+/// [`PolicyServiceImpl::with_ops_publisher`] so `op_control_stream` is live (no
+/// longer `Unavailable`) for in-process / co-located halts. When
+/// `AA_OPCONTROL_NATS_URL` is set, a bridge task subscribes to
+/// `assembly.opcontrol.>` and forwards every halt published by the aa-api process
+/// into this broadcast, so an operator halt issued on the HTTP endpoints reaches
+/// the runtimes streamed from this gateway. See ADR 0011.
+fn setup_op_control() -> crate::ops::SharedOpControlPublisher {
+    let publisher = Arc::new(crate::ops::OpControlPublisher::new());
+    match crate::ops::OpControlNatsConfig::from_env() {
+        Some(config) => {
+            tracing::info!(
+                url = %config.url,
+                "op-control NATS bridge enabled — cross-process halts will be delivered to op_control_stream"
+            );
+            crate::ops::nats::spawn_bridge(config, Arc::clone(&publisher));
+        }
+        None => {
+            tracing::info!(
+                "op-control NATS bridge disabled (AA_OPCONTROL_NATS_URL unset) — \
+                 op_control_stream serves in-process halts only"
+            );
+        }
+    }
+    publisher
+}
+
 /// Select the registration-challenge store backend from the gateway's Redis
 /// config (AAASM-3884).
 ///
@@ -529,6 +560,10 @@ pub async fn serve_tcp(
     // AAASM-3378: enable the live anomaly detector on the shipped serve path.
     let (anomaly_detector, anomaly_tx, _anomaly_rx) = setup_anomaly();
 
+    // AAASM-3883: attach the op-control broadcast so `op_control_stream` is live,
+    // and (when AA_OPCONTROL_NATS_URL is set) bridge cross-process halts into it.
+    let op_control_publisher = setup_op_control();
+
     let policy_svc = PolicyServiceImpl::with_registry_approval_and_escalation(
         Arc::clone(&engine),
         Arc::clone(&registry),
@@ -540,7 +575,8 @@ pub async fn serve_tcp(
     )
     .with_initial_seq(initial_seq)
     .with_db_scheduler(db_scheduler.clone())
-    .with_anomaly_detection(anomaly_detector, anomaly_tx);
+    .with_anomaly_detection(anomaly_detector, anomaly_tx)
+    .with_ops_publisher(op_control_publisher);
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry))
         .with_initial_seq(initial_seq);
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
@@ -658,6 +694,10 @@ pub async fn serve_uds(
     // AAASM-3378: enable the live anomaly detector on the shipped serve path.
     let (anomaly_detector, anomaly_tx, _anomaly_rx) = setup_anomaly();
 
+    // AAASM-3883: attach the op-control broadcast so `op_control_stream` is live,
+    // and (when AA_OPCONTROL_NATS_URL is set) bridge cross-process halts into it.
+    let op_control_publisher = setup_op_control();
+
     let policy_svc = PolicyServiceImpl::with_registry_approval_and_escalation(
         Arc::clone(&engine),
         Arc::clone(&registry),
@@ -669,7 +709,8 @@ pub async fn serve_uds(
     )
     .with_initial_seq(initial_seq)
     .with_db_scheduler(db_scheduler.clone())
-    .with_anomaly_detection(anomaly_detector, anomaly_tx);
+    .with_anomaly_detection(anomaly_detector, anomaly_tx)
+    .with_ops_publisher(op_control_publisher);
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry))
         .with_initial_seq(initial_seq);
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));

--- a/aa-gateway/tests/op_control_nats_bridge_test.rs
+++ b/aa-gateway/tests/op_control_nats_bridge_test.rs
@@ -1,0 +1,215 @@
+//! Cross-process op-control end-to-end test (AAASM-3883, ADR 0011).
+//!
+//! Proves the full kill-switch path across the real two-process split, with a
+//! **real NATS server** via `testcontainers-modules` (requires Docker — no
+//! delivery is faked):
+//!
+//! 1. an operator halt is published to the NATS op-control subject (the aa-api
+//!    side, [`OpControlNatsPublisher`]);
+//! 2. the gateway bridge ([`spawn_bridge`]) receives it and forwards it into the
+//!    in-process [`OpControlPublisher`] that `op_control_stream` serves;
+//! 3. a gRPC `op_control_stream` subscriber receives the halt under the reserved
+//!    op-id; and
+//! 4. fed into the runtime's [`OpControlStore`], it records `Terminated` — the
+//!    state the per-request check consults regardless of any `trace_id`.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aa_gateway::ops::nats::spawn_bridge;
+use aa_gateway::ops::{OpControlNatsConfig, OpControlNatsPublisher, OpControlPublisher, SharedOpControlPublisher};
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{OpControlSignal, OpControlSubscribeRequest};
+use testcontainers_modules::nats::Nats;
+use testcontainers_modules::testcontainers::core::IntoContainerPort;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
+use tokio::net::TcpListener;
+use tokio::time::timeout;
+use tonic::transport::Server;
+
+/// Reserve an ephemeral host port, then release it so the container can bind it.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+/// Start a NATS container with its client port pinned to `host_port`.
+async fn start_nats(host_port: u16) -> ContainerAsync<Nats> {
+    Nats::default()
+        .with_mapped_port(host_port, 4222.tcp())
+        .start()
+        .await
+        .expect("start nats testcontainer (is Docker running?)")
+}
+
+/// Start a PolicyService gRPC server with the given in-process publisher
+/// attached, returning the bound address (mirrors `op_control_stream_test`).
+async fn start_server(publisher: SharedOpControlPublisher) -> SocketAddr {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    writeln!(tmp, "version: \"1\"").unwrap();
+    tmp.flush().unwrap();
+
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap();
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service =
+        PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32]).with_ops_publisher(publisher);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    addr
+}
+
+fn agent(id: &str) -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: id.into(),
+    }
+}
+
+/// Block until the in-process publisher reports at least one subscriber (the
+/// gRPC `op_control_stream` has registered server-side).
+async fn await_grpc_subscriber(publisher: &SharedOpControlPublisher) {
+    for _ in 0..40 {
+        if publisher.subscriber_count() >= 1 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("gRPC op_control_stream subscriber never registered");
+}
+
+/// An operator halt published to the NATS op-control subject is bridged into the
+/// gateway broadcast, delivered over `op_control_stream` under the reserved
+/// `agent:{id}` key, and recorded as `Terminated` by the runtime store.
+#[tokio::test]
+async fn agent_halt_published_to_nats_reaches_op_control_stream_and_halts_runtime() {
+    let host_port = free_port();
+    let url = format!("nats://127.0.0.1:{host_port}");
+    let _nats = start_nats(host_port).await;
+
+    // Gateway process: in-process broadcast + NATS bridge feeding it + gRPC server.
+    let publisher = Arc::new(OpControlPublisher::new());
+    let _bridge = spawn_bridge(OpControlNatsConfig::new(url.clone()), Arc::clone(&publisher));
+    let addr = start_server(Arc::clone(&publisher)).await;
+
+    // Runtime: subscribe to op_control_stream for agent-7.
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let mut stream = client
+        .op_control_stream(OpControlSubscribeRequest {
+            agent_id: Some(agent("agent-7")),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    await_grpc_subscriber(&publisher).await;
+
+    // aa-api process: publish an agent-wide terminate onto the NATS subject. The
+    // bridge's subscription registers asynchronously, so retry the publish until
+    // the stream yields (Terminate is idempotent, so repeats are safe).
+    let api_publisher = OpControlNatsPublisher::connect(&OpControlNatsConfig::new(url.clone()))
+        .await
+        .expect("aa-api side connects to NATS");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let msg = loop {
+        assert!(
+            Instant::now() < deadline,
+            "halt never arrived over op_control_stream via NATS"
+        );
+        api_publisher
+            .publish_agent_halt(agent("agent-7"), OpControlSignal::Terminate)
+            .await
+            .expect("publish agent halt to NATS");
+        match timeout(Duration::from_millis(400), stream.message()).await {
+            Ok(Ok(Some(msg))) => break msg,
+            _ => continue,
+        }
+    };
+
+    assert_eq!(msg.op_id, aa_runtime::op_control::agent_halt_op_id("agent-7"));
+    assert_eq!(msg.op_id, "agent:agent-7");
+    assert_eq!(msg.signal, OpControlSignal::Terminate as i32);
+
+    // The runtime applies the delivered signal to its op-control store; the
+    // reserved agent key reads as Terminated, which the per-request check honors
+    // independently of any trace_id.
+    let store = aa_runtime::op_control::OpControlStore::new();
+    store.apply(&msg.op_id, msg.signal());
+    assert_eq!(
+        store.state(&aa_runtime::op_control::agent_halt_op_id("agent-7")),
+        Some(aa_runtime::op_control::OpState::Terminated),
+    );
+}
+
+/// A fleet-wide halt published to the NATS global subject is bridged and
+/// delivered to a subscriber under the reserved global op-id `"*"`.
+#[tokio::test]
+async fn global_halt_published_to_nats_reaches_all_op_control_streams() {
+    let host_port = free_port();
+    let url = format!("nats://127.0.0.1:{host_port}");
+    let _nats = start_nats(host_port).await;
+
+    let publisher = Arc::new(OpControlPublisher::new());
+    let _bridge = spawn_bridge(OpControlNatsConfig::new(url.clone()), Arc::clone(&publisher));
+    let addr = start_server(Arc::clone(&publisher)).await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let mut stream = client
+        .op_control_stream(OpControlSubscribeRequest {
+            agent_id: Some(agent("agent-a")),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    await_grpc_subscriber(&publisher).await;
+
+    let api_publisher = OpControlNatsPublisher::connect(&OpControlNatsConfig::new(url.clone()))
+        .await
+        .expect("aa-api side connects to NATS");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let msg = loop {
+        assert!(
+            Instant::now() < deadline,
+            "global halt never arrived over op_control_stream via NATS"
+        );
+        api_publisher
+            .publish_global_halt(OpControlSignal::Terminate)
+            .await
+            .expect("publish global halt to NATS");
+        match timeout(Duration::from_millis(400), stream.message()).await {
+            Ok(Ok(Some(msg))) => break msg,
+            _ => continue,
+        }
+    };
+
+    assert_eq!(msg.op_id, aa_runtime::op_control::GLOBAL_HALT_OP_ID);
+    assert_eq!(msg.op_id, "*");
+    assert_eq!(msg.signal, OpControlSignal::Terminate as i32);
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -142,3 +142,4 @@
   - [0008 - SaaS Host Routing, Auth & Cookie Boundaries](adr/0008-saas-host-routing-auth-cookie-boundaries.md)
   - [0009 - Versioned Base-Image Tags & SDK Pinning](adr/0009-versioned-base-image-tags-and-sdk-pinning.md)
   - [0010 - Gateway Distribution for Self-Host & Examples](adr/0010-gateway-distribution-self-host-examples.md)
+  - [0011 - Cross-Process Op-Control via NATS Subject](adr/0011-cross-process-op-control-nats-subject.md)

--- a/docs/src/adr/0011-cross-process-op-control-nats-subject.md
+++ b/docs/src/adr/0011-cross-process-op-control-nats-subject.md
@@ -1,0 +1,144 @@
+# ADR 0011: Cross-Process Op-Control Delivery via a NATS Subject
+
+**Status**: Proposed
+**Date**: 2026-06
+**Ticket**: [AAASM-3883](https://lightning-dust-mite.atlassian.net/browse/AAASM-3883)
+
+---
+
+## Context
+
+The operator **kill switch** for a running agent is delivered end-to-end by three
+pieces that already exist and are component-tested:
+
+- **Emission** ([AAASM-3881](https://lightning-dust-mite.atlassian.net/browse/AAASM-3881)) —
+  the HTTP operator endpoints `POST /api/v1/ops/{id}/halt-agent` and
+  `POST /api/v1/ops/global/halt` record a halt on `AppState.ops_registry` and call
+  `OpsRegistry::halt_agent` / `halt_global`, which publish an op-control signal under
+  a **reserved** op-id (`agent:{agent_id}` for an agent-wide halt, `"*"` for a
+  fleet-wide halt).
+- **Transport** — `OpControlPublisher`, a single `tokio::sync::broadcast` channel.
+- **Consumption** ([AAASM-3873](https://lightning-dust-mite.atlassian.net/browse/AAASM-3873)) —
+  the gRPC `PolicyService.op_control_stream` RPC subscribes to that broadcast and
+  forwards each matching envelope to the runtime, which records it in
+  `OpControlStore` and fast-fails / blocks the agent's next per-tool check.
+
+### The topology gap
+
+`OpControlPublisher` is an **in-process** broadcast. In the shipped product the two
+halves run in **separate processes** (verified definitively under AAASM-3883):
+
+| Half | Process | Detail |
+| --- | --- | --- |
+| HTTP halt endpoints (`AppState.ops_registry`) | **aa-api-server** | `aasm start --mode local` launches this |
+| gRPC `PolicyService.op_control_stream` | **aa-gateway** | the only process runtimes subscribe to (`aa-runtime/src/op_control.rs`) |
+
+`op_control_stream` reads **only** from the gateway's in-process `ops_publisher`.
+There is no shared cross-process bus for op-control today — NATS carries **audit
+only** (`assembly.audit.>`), and the L1 invalidation channel does not carry
+op-control.
+
+A previous attempt ([PR #1308](https://github.com/ai-agent-assembly/agent-assembly/pull/1308),
+reverted) injected one in-process `OpControlPublisher` into both halves. That works
+only inside a single process; across the real two-process split, the aa-api publisher
+broadcasts to a channel **with no subscriber**, so the HTTP halt would return `200`
+while silently dropping the halt — strictly worse than the honest `503` for a kill
+switch. The wiring was reverted and the ticket moved back for design.
+
+## Decision
+
+Introduce a **shared NATS subject** that carries op-control signals between the two
+processes, mirroring the existing NATS audit subsystem rather than inventing a
+parallel one.
+
+### Subject naming
+
+Mirrors the audit convention `assembly.audit.<tenant>.<agent>`:
+
+- Agent-wide / per-op halt → `assembly.opcontrol.<tenant>.<agent>`
+  - `<tenant>` = the agent's `org_id`, falling back to `team_id`, then `default`.
+  - `<agent>` = the agent id (subject-token-sanitized; non-`[A-Za-z0-9_-]` → `_`).
+- Fleet-wide halt → `assembly.opcontrol.global`.
+
+The gateway subscribes with the wildcard `assembly.opcontrol.>`, so subject tokens
+are for routing/observability only; the gateway filters per subscriber exactly as it
+does for the in-process broadcast.
+
+### Message schema
+
+A small JSON envelope, reusing the existing op-control reserved-key semantics so
+producer and consumer can never drift:
+
+```json
+{ "org_id": "...", "team_id": "...", "agent_id": "...",
+  "op_id": "agent:{id}" | "*" | "{trace}:{span}",
+  "signal": 1, "global": false }
+```
+
+- `op_id` carries the same reserved key the in-process path uses
+  (`aa_runtime::op_control::agent_halt_op_id` / `GLOBAL_HALT_OP_ID`).
+- `signal` is the wire `OpControlSignal` discriminant (`Pause` / `Resume` / `Terminate`).
+- `global` marks a fleet-wide halt so the gateway forwards it to every subscriber.
+
+### Publish side (aa-api)
+
+`OpsRegistry` gains an optional `OpControlNatsPublisher`. The halt handlers call
+`halt_agent_delivery` / `halt_global_delivery`, which:
+
+1. publish the envelope to NATS **and `flush()`** (forcing the write to the server)
+   when a NATS publisher is attached, then
+2. fall back to the in-process publisher only when **no** NATS publisher is
+   configured (single-process / co-located mode).
+
+### Consume side (gateway)
+
+The gateway boot (`serve_tcp` / `serve_uds`) always constructs the in-process
+`OpControlPublisher` and attaches it to `PolicyServiceImpl` via `with_ops_publisher`
+— this alone un-inerts `op_control_stream` (it no longer returns `Unavailable`). When
+NATS is configured it additionally spawns a **bridge** task that subscribes to
+`assembly.opcontrol.>` and forwards every received envelope into that same in-process
+broadcast (`publish` for per-agent, `publish_global_halt` for global). The runtime
+filtering, reserved-key matching, and sticky-terminate semantics are unchanged.
+
+### Configuration
+
+Reuses the existing NATS deployment. Activated by `AA_OPCONTROL_NATS_URL`
+(`OpControlNatsConfig::from_env`), exactly mirroring the audit consumer's
+`AA_AUDIT_NATS_URL` env activation. When unset, both processes keep their existing
+in-process behavior — no new mandatory config, no behavior change for local mode.
+
+### Fail-mode (never a silent-drop 200)
+
+- NATS configured, publish/flush **fails** → the halt endpoint returns a real `503`
+  (`HaltDelivery::ChannelError`), never a false `200`.
+- No op-control channel configured at all → `503` (`HaltDelivery::NotConfigured`) —
+  the pre-existing honest behavior.
+- This restores the kill switch's core invariant: an operator is never told an agent
+  was halted when it was not.
+
+## Consequences
+
+- **Multi-replica.** Any aa-api replica can publish; every gateway replica's bridge
+  subscribes, so a horizontally-scaled gateway delivers the halt to whichever replica
+  a given runtime is streamed to. (A runtime is connected to exactly one gateway
+  replica's `op_control_stream`; the NATS fan-out reaches all replicas.)
+- **Co-located / local mode coexistence.** With no `AA_OPCONTROL_NATS_URL`, a
+  single-process deployment uses the in-process publisher unchanged. The two paths
+  are mutually exclusive per process (NATS preferred when configured), so a halt is
+  never double-delivered from one publisher.
+- **Delivery semantics.** Core NATS pub/sub is **at-most-once live** delivery — the
+  same semantics as the in-process broadcast it extends (which also drops when no
+  subscriber is connected). `flush()` makes NATS *unavailability* an honest error,
+  but a halt published while a gateway is momentarily disconnected from NATS is not
+  redelivered. A JetStream-durable op-control stream is a deliberate **future**
+  enhancement, out of scope for this additive-wiring fix.
+- **No new dependency / no new feature flag.** `async-nats` is already a
+  non-optional dependency via `aa-runtime` (the audit publisher), so the op-control
+  module is always compiled and activated purely by runtime config — matching the
+  always-on runtime audit publisher rather than the postgres-coupled, feature-gated
+  audit *consumer*.
+- **Per-op cross-process delivery is bounded by registry locality.** The op→agent
+  map populated by `check_action` lives in the gateway process; the robust operator
+  kill path is the agent-wide / global halt, which binds to the server-side agent
+  identity and is what this ADR makes cross-process. Per-op `pause`/`terminate`
+  remain same-process for now.

--- a/docs/src/adr/README.md
+++ b/docs/src/adr/README.md
@@ -17,3 +17,4 @@ The format follows a lightweight variant of [Michael Nygard's template](https://
 | [0008](0008-saas-host-routing-auth-cookie-boundaries.md) | SaaS Host Routing, Auth & Cookie Boundaries | Proposed |
 | [0009](0009-versioned-base-image-tags-and-sdk-pinning.md) | Versioned Base-Image Tags & Reproducible SDK Pinning | Proposed |
 | [0010](0010-gateway-distribution-self-host-examples.md) | Gateway Distribution for Self-Host & Examples | Proposed |
+| [0011](0011-cross-process-op-control-nats-subject.md) | Cross-Process Op-Control Delivery via a NATS Subject | Proposed |


### PR DESCRIPTION
## Description

Cross-process delivery for the operator op-control **kill switch** (AAASM-3883), implemented via the **NATS op-control subject** design (owner decision; see ADR 0011).

`OpControlPublisher` is an in-process `tokio::sync::broadcast`. In the shipped product the two halves run in **separate processes**: the HTTP halt endpoints (`POST /api/v1/ops/{id}/halt-agent`, `/global/halt`) live in the **aa-api-server** process (`AppState.ops_registry`), while the gRPC `PolicyService.op_control_stream` that runtimes subscribe to runs in the **aa-gateway** process. An in-process publish therefore reached no subscriber — a previous in-process attempt (PR #1308, reverted) would have returned `200` while silently dropping the halt. This PR adds the shared bus:

- **Publish (aa-api):** the halt handlers publish the op-control envelope (and `flush()`) to `assembly.opcontrol.<tenant>.<agent>` / `assembly.opcontrol.global` when `AA_OPCONTROL_NATS_URL` is configured.
- **Consume (gateway):** `serve_tcp`/`serve_uds` attach the in-process `OpControlPublisher` to `PolicyServiceImpl` (so `op_control_stream` is no longer `Unavailable`) and, when NATS is configured, spawn a bridge that subscribes to `assembly.opcontrol.>` and forwards every received halt into that broadcast — reusing the reserved-key semantics (`agent:{id}`, `*`).
- **Honest failure:** if NATS is configured but the publish/flush fails, the halt endpoint returns a real `503` (`HaltDelivery::ChannelError`), never a silent-drop `200`. With no NATS configured, the existing in-process path is preserved for single-process/local mode.

`async-nats` is already a non-optional dependency via aa-runtime's audit publisher, so the op-control module is always compiled and activated purely by runtime config (no new feature flag) — matching the always-on runtime audit publisher.

ADR: [`docs/src/adr/0011-cross-process-op-control-nats-subject.md`](docs/src/adr/0011-cross-process-op-control-nats-subject.md) (Proposed).

## Type of Change

- [x] 🐛 Bug fix (control-plane effectiveness — inert kill switch end-to-end)
- [x] 🔌 Integration (new NATS op-control subsystem)
- [x] 📝 Documentation update (ADR 0011)

## Breaking Changes

- [x] No — additive. With `AA_OPCONTROL_NATS_URL` unset, behavior is unchanged (in-process path / honest 503). No new HTTP endpoints (the halt endpoints exist from AAASM-3881); OpenAPI `v1.yaml` unchanged (verified no drift).

## Related Issues

- Related Jira ticket: AAASM-3883
- Pairs with AAASM-3881 (gateway emission) and AAASM-3873 (runtime consumption).

Closes AAASM-3883

## Testing

- [x] Unit tests added (subject derivation, wire-envelope JSON round-trip, bridge reconstruction of per-agent/global/unspecified envelopes, `HaltDelivery` not-configured + in-process-fallback)
- [x] Integration tests added — **real NATS via testcontainers** (`op_control_nats_bridge_test`): a halt published to the NATS subject is bridged into `op_control_stream`, delivered under the reserved key, and recorded as `Terminated` in the runtime `OpControlStore`; both agent-wide and global paths. No delivery is faked.
- Validation: `cargo build --workspace`; `cargo nextest run -p aa-gateway -p aa-api` (2133 passed); `cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings` (+ aa-gateway `--features redis-cache`); OpenAPI regen diff = no drift.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated (ADR 0011)
- [x] All CI checks passing (validated locally)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
