### PR TITLE
[AAASM-3885] ✨ (aa-gateway): Durable JetStream op-control delivery

### DIFF
--- a/aa-gateway/src/ops/nats.rs
+++ b/aa-gateway/src/ops/nats.rs
@@ -9,26 +9,35 @@
 //! the existing audit subsystem (`assembly.audit.>`) rather than inventing a
 //! parallel NATS stack. See ADR 0011.
 //!
-//! Two halves:
+//! Two halves, both running over **NATS JetStream** (AAASM-3885) so a halt is
+//! durably persisted and redelivered to a gateway that (re)subscribes — not merely
+//! "accepted onto the bus" (the at-most-once CORE-NATS behavior AAASM-3883 shipped):
 //!
 //! * **Publish** ([`OpControlNatsPublisher`]) — used by the aa-api halt handlers
 //!   to publish an [`OpControlWireEnvelope`] to `assembly.opcontrol.<tenant>.<agent>`
-//!   (or `assembly.opcontrol.global`). It `flush()`es after every publish so a
-//!   NATS outage surfaces as a real error, never a silent-drop `200`.
-//! * **Consume** ([`spawn_bridge`]) — a gateway boot task that subscribes to
-//!   `assembly.opcontrol.>` and forwards each received envelope into the gateway's
-//!   in-process [`OpControlPublisher`](super::OpControlPublisher), so the existing
+//!   (or `assembly.opcontrol.global`) **and await the JetStream publish ACK**, so a
+//!   successful return means the halt is persisted in the durable stream. A missing
+//!   stream / NATS outage / un-acked publish surfaces as a real error, never a
+//!   silent-drop `200`.
+//! * **Consume** ([`spawn_bridge`]) — a gateway boot task that ensures the durable
+//!   [`STREAM_NAME`] stream, creates a JetStream consumer over `assembly.opcontrol.>`
+//!   (replaying everything still within retention, so a halt published while this
+//!   gateway had no consumer attached is still delivered), and forwards each received
+//!   envelope into the gateway's in-process
+//!   [`OpControlPublisher`](super::OpControlPublisher) — acking it — so the existing
 //!   `op_control_stream` filtering / reserved-key matching delivers it to runtimes
 //!   unchanged.
 //!
 //! `async-nats` is already a non-optional dependency (via `aa-runtime`'s audit
 //! publisher), so this module is always compiled and activated purely by the
 //! `AA_OPCONTROL_NATS_URL` environment variable — matching the always-on runtime
-//! audit publisher rather than the feature-gated audit consumer.
+//! audit publisher rather than the feature-gated audit consumer. The configured NATS
+//! server **must have JetStream enabled** (a deployment requirement; see ADR 0011).
 
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_nats::jetstream;
 use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
@@ -54,6 +63,20 @@ const UNKNOWN_AGENT: &str = "unknown";
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 /// Upper bound on the bridge reconnect delay (1s → 2 → 4 → … → 32s cap).
 const MAX_BACKOFF: Duration = Duration::from_secs(32);
+
+/// Name of the durable JetStream stream that persists every op-control subject
+/// (AAASM-3885). All processes ensure this stream idempotently at boot.
+pub const STREAM_NAME: &str = "AA_OPCONTROL";
+/// Retention window for persisted op-control halts. Halts are tiny and
+/// time-sensitive, so a bounded max-age is the right retention: it covers a
+/// gateway restart / rollout window (a halt published in that gap is redelivered
+/// to the gateway that resubscribes within it) while keeping the stream small and
+/// preventing an indefinitely-replayed stale kill switch. See ADR 0011.
+pub const STREAM_MAX_AGE: Duration = Duration::from_secs(600);
+/// Upper bound on how long a publish waits for the JetStream server ACK before the
+/// halt endpoint reports an honest failure (`503`) rather than hanging. Keeps a
+/// missing-stream / JetStream-disabled server from blocking the operator surface.
+const PUBLISH_ACK_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Wire form of an op-control signal carried over NATS.
 ///
@@ -133,6 +156,12 @@ pub enum OpControlNatsError {
     /// Serializing the envelope to JSON failed.
     #[error("op-control envelope serialization failed: {0}")]
     Serialize(String),
+    /// Ensuring / fetching the durable JetStream stream failed (AAASM-3885).
+    #[error("op-control JetStream stream setup failed: {0}")]
+    Stream(String),
+    /// Creating or reading the JetStream consumer failed (AAASM-3885).
+    #[error("op-control JetStream consumer failed: {0}")]
+    Consumer(String),
 }
 
 /// Runtime configuration for the op-control NATS bridge / publisher.
@@ -158,16 +187,56 @@ impl OpControlNatsConfig {
     }
 }
 
-/// Publishes op-control signals onto the shared NATS subject (aa-api side).
+/// Idempotently create (or update) the durable JetStream stream that persists
+/// every op-control subject (AAASM-3885).
+///
+/// Bounded by [`STREAM_MAX_AGE`] with `Limits` retention and `File` storage so a
+/// halt published while no gateway consumer is attached is durably persisted and
+/// **redelivered** to a gateway that (re)subscribes within the retention window —
+/// the core durability guarantee of this ticket. Safe to call from every process
+/// at boot (create-or-update is idempotent). The NATS server must have JetStream
+/// enabled; if it does not, this call fails with [`OpControlNatsError::Stream`].
+pub async fn ensure_op_control_stream(
+    jetstream: &jetstream::Context,
+) -> Result<jetstream::stream::Stream, OpControlNatsError> {
+    jetstream
+        .create_or_update_stream(jetstream::stream::Config {
+            name: STREAM_NAME.to_string(),
+            subjects: vec![SUBJECT_WILDCARD.to_string()],
+            retention: jetstream::stream::RetentionPolicy::Limits,
+            max_age: STREAM_MAX_AGE,
+            storage: jetstream::stream::StorageType::File,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| OpControlNatsError::Stream(e.to_string()))?;
+    jetstream
+        .get_stream(STREAM_NAME)
+        .await
+        .map_err(|e| OpControlNatsError::Stream(e.to_string()))
+}
+
+/// Publishes op-control signals onto the durable JetStream stream (aa-api side).
 #[derive(Clone)]
 pub struct OpControlNatsPublisher {
-    client: async_nats::Client,
+    jetstream: jetstream::Context,
+    ack_timeout: Duration,
 }
 
 impl OpControlNatsPublisher {
-    /// Wrap an already-connected NATS client.
+    /// Wrap an already-connected NATS client in a JetStream context.
     pub fn new(client: async_nats::Client) -> Self {
-        Self { client }
+        Self {
+            jetstream: jetstream::new(client),
+            ack_timeout: PUBLISH_ACK_TIMEOUT,
+        }
+    }
+
+    /// Override the publish-ACK timeout (tests use a short bound so the
+    /// honest-failure path returns quickly).
+    pub fn with_ack_timeout(mut self, ack_timeout: Duration) -> Self {
+        self.ack_timeout = ack_timeout;
+        self
     }
 
     /// Connect to the server described by `config` and wrap the client.
@@ -178,21 +247,32 @@ impl OpControlNatsPublisher {
         Ok(Self::new(client))
     }
 
-    /// Publish `envelope` and flush so the write reaches the server before
-    /// returning. The flush is what makes a NATS outage an honest error rather
-    /// than a buffered success the operator would misread as a delivered halt.
+    /// Publish `envelope` to JetStream and **await the publish ACK**.
+    ///
+    /// The first `await` sends the publish; the second resolves the JetStream
+    /// server ACK, which only arrives once the message is persisted in the durable
+    /// stream. A successful return therefore means the halt is durably stored and
+    /// will reach any gateway that (re)subscribes within retention — not merely
+    /// that bytes reached the bus. A missing stream / JetStream-disabled server /
+    /// outage surfaces as an honest [`OpControlNatsError::Publish`] (the endpoint
+    /// maps it to `503`), never a silent-drop `200`. The ACK wait is bounded by
+    /// `ack_timeout` so the operator surface never hangs.
     pub async fn publish(&self, envelope: &OpControlWireEnvelope) -> Result<(), OpControlNatsError> {
         let subject = subject_for(envelope);
         let payload = serde_json::to_vec(envelope).map_err(|e| OpControlNatsError::Serialize(e.to_string()))?;
-        self.client
+        let ack = self
+            .jetstream
             .publish(subject, payload.into())
             .await
             .map_err(|e| OpControlNatsError::Publish(e.to_string()))?;
-        self.client
-            .flush()
-            .await
-            .map_err(|e| OpControlNatsError::Publish(e.to_string()))?;
-        Ok(())
+        match tokio::time::timeout(self.ack_timeout, ack).await {
+            Ok(Ok(_ack)) => Ok(()),
+            Ok(Err(e)) => Err(OpControlNatsError::Publish(e.to_string())),
+            Err(_) => Err(OpControlNatsError::Publish(format!(
+                "JetStream publish ACK timed out after {:?} (stream not ready or JetStream disabled?)",
+                self.ack_timeout
+            ))),
+        }
     }
 
     /// Publish an agent-wide halt under the reserved `agent:{agent_id}` op-id.
@@ -255,10 +335,12 @@ fn forward_to_broadcast(publisher: &SharedOpControlPublisher, envelope: OpContro
     }
 }
 
-/// Spawn the gateway-side bridge task: subscribe to `assembly.opcontrol.>` and
-/// forward every received halt into `publisher` (the in-process broadcast
-/// `op_control_stream` serves). Reconnects forever with exponential backoff so a
-/// transient NATS outage never permanently silences the cross-process kill switch.
+/// Spawn the gateway-side bridge task: ensure the durable JetStream stream,
+/// consume `assembly.opcontrol.>` (replaying everything still within retention),
+/// and forward every received halt into `publisher` (the in-process broadcast
+/// `op_control_stream` serves), acking each message. Reconnects forever with
+/// exponential backoff so a transient NATS outage never permanently silences the
+/// cross-process kill switch.
 pub fn spawn_bridge(config: OpControlNatsConfig, publisher: SharedOpControlPublisher) -> JoinHandle<()> {
     tokio::spawn(run_bridge(config, publisher))
 }
@@ -284,7 +366,20 @@ async fn run_bridge(config: OpControlNatsConfig, publisher: SharedOpControlPubli
     }
 }
 
-/// Open one subscription and forward messages until the stream ends or errors.
+/// Open one JetStream consumer and forward messages until the stream ends or errors.
+///
+/// Ensures the durable stream, then creates an **ephemeral** JetStream consumer
+/// with `DeliverPolicy::All` and explicit ack. Ephemeral + `All` is deliberate:
+///
+/// * each gateway replica gets its **own** consumer and therefore its own copy of
+///   every halt — preserving the AAASM-3883 multi-replica fan-out (a named durable
+///   consumer shared across replicas would queue-group halts to a single replica,
+///   so a runtime streamed from a different replica would miss its kill switch);
+/// * `DeliverPolicy::All` replays everything still in the stream when this consumer
+///   is (re)created, so a halt published while this gateway had **no** consumer
+///   attached is delivered once the bridge comes up — the AAASM-3885 durability
+///   property. Re-reading an already-applied halt after a restart is safe because
+///   `Terminate` is sticky/idempotent in the runtime `OpControlStore`.
 async fn bridge_once(
     config: &OpControlNatsConfig,
     publisher: &SharedOpControlPublisher,
@@ -292,18 +387,29 @@ async fn bridge_once(
     let client = async_nats::connect(&config.url)
         .await
         .map_err(|e| OpControlNatsError::Connect(e.to_string()))?;
-    let mut subscription = client
-        .subscribe(SUBJECT_WILDCARD)
+    let context = jetstream::new(client);
+    let stream = ensure_op_control_stream(&context).await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            deliver_policy: jetstream::consumer::DeliverPolicy::All,
+            ack_policy: jetstream::consumer::AckPolicy::Explicit,
+            filter_subject: SUBJECT_WILDCARD.to_string(),
+            ..Default::default()
+        })
         .await
-        .map_err(|e| OpControlNatsError::Subscribe(e.to_string()))?;
-    // Flush so the SUB is registered server-side before we report readiness.
-    client
-        .flush()
+        .map_err(|e| OpControlNatsError::Consumer(e.to_string()))?;
+    let mut messages = consumer
+        .messages()
         .await
-        .map_err(|e| OpControlNatsError::Subscribe(e.to_string()))?;
-    tracing::info!(subject = SUBJECT_WILDCARD, "op-control NATS bridge subscribed");
+        .map_err(|e| OpControlNatsError::Consumer(e.to_string()))?;
+    tracing::info!(
+        stream = STREAM_NAME,
+        subject = SUBJECT_WILDCARD,
+        "op-control JetStream bridge subscribed"
+    );
 
-    while let Some(message) = subscription.next().await {
+    while let Some(message) = messages.next().await {
+        let message = message.map_err(|e| OpControlNatsError::Consumer(e.to_string()))?;
         match serde_json::from_slice::<OpControlWireEnvelope>(&message.payload) {
             Ok(envelope) => {
                 metrics::counter!("aa_op_control_bridge_forwarded_total").increment(1);
@@ -312,6 +418,11 @@ async fn bridge_once(
             Err(err) => {
                 tracing::warn!(%err, "op-control bridge: dropping undecodable message");
             }
+        }
+        // Ack so the halt is removed from this consumer's pending set. A failed ack
+        // only risks a redelivery, which is safe (sticky/idempotent halts).
+        if let Err(err) = message.ack().await {
+            tracing::warn!(%err, "op-control bridge: failed to ack message");
         }
     }
     Ok(())

--- a/aa-gateway/tests/op_control_nats_bridge_test.rs
+++ b/aa-gateway/tests/op_control_nats_bridge_test.rs
@@ -20,14 +20,17 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aa_gateway::ops::nats::spawn_bridge;
-use aa_gateway::ops::{OpControlNatsConfig, OpControlNatsPublisher, OpControlPublisher, SharedOpControlPublisher};
+use aa_gateway::ops::{
+    HaltDelivery, OpControlNatsConfig, OpControlNatsPublisher, OpControlPublisher, OpsRegistry,
+    SharedOpControlPublisher,
+};
 use aa_gateway::service::PolicyServiceImpl;
 use aa_gateway::PolicyEngine;
 use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
 use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
 use aa_proto::assembly::policy::v1::{OpControlSignal, OpControlSubscribeRequest};
-use testcontainers_modules::nats::Nats;
+use testcontainers_modules::nats::{Nats, NatsServerCmd};
 use testcontainers_modules::testcontainers::core::IntoContainerPort;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
@@ -44,13 +47,29 @@ fn free_port() -> u16 {
         .port()
 }
 
-/// Start a NATS container with its client port pinned to `host_port`.
+/// Start a NATS container with **JetStream enabled** (`-js`) and its client port
+/// pinned to `host_port`. AAASM-3885 moved op-control onto a durable JetStream
+/// stream, so the server must run JetStream — a plain NATS server would never ACK
+/// the publish (the honest-failure path).
 async fn start_nats(host_port: u16) -> ContainerAsync<Nats> {
+    let cmd = NatsServerCmd::default().with_jetstream();
     Nats::default()
+        .with_cmd(&cmd)
         .with_mapped_port(host_port, 4222.tcp())
         .start()
         .await
         .expect("start nats testcontainer (is Docker running?)")
+}
+
+/// Idempotently create the durable op-control JetStream stream (what the gateway
+/// boot does). Used by the durability test to persist a halt **before** any
+/// gateway consumer exists.
+async fn ensure_stream(url: &str) {
+    let client = async_nats::connect(url).await.expect("connect to NATS");
+    let context = async_nats::jetstream::new(client);
+    aa_gateway::ops::nats::ensure_op_control_stream(&context)
+        .await
+        .expect("ensure op-control JetStream stream");
 }
 
 /// Start a PolicyService gRPC server with the given in-process publisher
@@ -134,7 +153,8 @@ async fn agent_halt_published_to_nats_reaches_op_control_stream_and_halts_runtim
     // the stream yields (Terminate is idempotent, so repeats are safe).
     let api_publisher = OpControlNatsPublisher::connect(&OpControlNatsConfig::new(url.clone()))
         .await
-        .expect("aa-api side connects to NATS");
+        .expect("aa-api side connects to NATS")
+        .with_ack_timeout(Duration::from_millis(500));
 
     let deadline = Instant::now() + Duration::from_secs(15);
     let msg = loop {
@@ -142,10 +162,12 @@ async fn agent_halt_published_to_nats_reaches_op_control_stream_and_halts_runtim
             Instant::now() < deadline,
             "halt never arrived over op_control_stream via NATS"
         );
-        api_publisher
+        // The bridge creates the JetStream stream asynchronously at startup, so an
+        // early publish may fail to be ACKed until the stream exists — tolerate that
+        // and retry (Terminate is idempotent, so repeats are safe).
+        let _ = api_publisher
             .publish_agent_halt(agent("agent-7"), OpControlSignal::Terminate)
-            .await
-            .expect("publish agent halt to NATS");
+            .await;
         match timeout(Duration::from_millis(400), stream.message()).await {
             Ok(Ok(Some(msg))) => break msg,
             _ => continue,
@@ -191,7 +213,8 @@ async fn global_halt_published_to_nats_reaches_all_op_control_streams() {
 
     let api_publisher = OpControlNatsPublisher::connect(&OpControlNatsConfig::new(url.clone()))
         .await
-        .expect("aa-api side connects to NATS");
+        .expect("aa-api side connects to NATS")
+        .with_ack_timeout(Duration::from_millis(500));
 
     let deadline = Instant::now() + Duration::from_secs(15);
     let msg = loop {
@@ -199,10 +222,8 @@ async fn global_halt_published_to_nats_reaches_all_op_control_streams() {
             Instant::now() < deadline,
             "global halt never arrived over op_control_stream via NATS"
         );
-        api_publisher
-            .publish_global_halt(OpControlSignal::Terminate)
-            .await
-            .expect("publish global halt to NATS");
+        // Tolerate an early pre-stream publish failure and retry (see above).
+        let _ = api_publisher.publish_global_halt(OpControlSignal::Terminate).await;
         match timeout(Duration::from_millis(400), stream.message()).await {
             Ok(Ok(Some(msg))) => break msg,
             _ => continue,
@@ -212,4 +233,103 @@ async fn global_halt_published_to_nats_reaches_all_op_control_streams() {
     assert_eq!(msg.op_id, aa_runtime::op_control::GLOBAL_HALT_OP_ID);
     assert_eq!(msg.op_id, "*");
     assert_eq!(msg.signal, OpControlSignal::Terminate as i32);
+}
+
+/// **The AAASM-3885 durability test.** A halt is published while **no** gateway
+/// consumer is subscribed; the bridge is started only afterwards. Because the halt
+/// was durably persisted to JetStream (publish ACK awaited), the late-subscribing
+/// bridge replays it (DeliverPolicy::All within retention) and delivers it over
+/// `op_control_stream` — proving 200 means persisted-and-will-be-delivered, not
+/// merely accepted onto the bus. This is the property CORE NATS (AAASM-3883) could
+/// not provide.
+#[tokio::test]
+async fn halt_published_with_no_consumer_is_delivered_to_a_later_subscriber() {
+    let host_port = free_port();
+    let url = format!("nats://127.0.0.1:{host_port}");
+    let _nats = start_nats(host_port).await;
+
+    // The durable stream exists (the gateway created it at boot) but NO consumer /
+    // bridge is reading it yet.
+    ensure_stream(&url).await;
+
+    // aa-api publishes an agent-wide terminate. The publish ACK is awaited, so a
+    // success here means the halt is durably persisted in the stream.
+    let api_publisher = OpControlNatsPublisher::connect(&OpControlNatsConfig::new(url.clone()))
+        .await
+        .expect("aa-api side connects to NATS");
+    api_publisher
+        .publish_agent_halt(agent("agent-9"), OpControlSignal::Terminate)
+        .await
+        .expect("durable publish of halt with no consumer must be ACKed");
+
+    // Only NOW does a gateway come up: in-process broadcast + gRPC server + a
+    // runtime subscriber, then the bridge that replays the persisted halt.
+    let publisher = Arc::new(OpControlPublisher::new());
+    let addr = start_server(Arc::clone(&publisher)).await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let mut stream = client
+        .op_control_stream(OpControlSubscribeRequest {
+            agent_id: Some(agent("agent-9")),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    await_grpc_subscriber(&publisher).await;
+
+    // Bridge starts after the halt was already published and persisted.
+    let _bridge = spawn_bridge(OpControlNatsConfig::new(url.clone()), Arc::clone(&publisher));
+
+    // The replayed, persisted halt is delivered over op_control_stream.
+    let msg = timeout(Duration::from_secs(15), stream.message())
+        .await
+        .expect("persisted halt should be delivered to the late subscriber")
+        .expect("stream ok")
+        .expect("stream yields the persisted halt");
+
+    assert_eq!(msg.op_id, aa_runtime::op_control::agent_halt_op_id("agent-9"));
+    assert_eq!(msg.signal, OpControlSignal::Terminate as i32);
+
+    // It records Terminated in the runtime store, independent of any trace_id.
+    let store = aa_runtime::op_control::OpControlStore::new();
+    store.apply(&msg.op_id, msg.signal());
+    assert_eq!(
+        store.state(&aa_runtime::op_control::agent_halt_op_id("agent-9")),
+        Some(aa_runtime::op_control::OpState::Terminated),
+    );
+}
+
+/// Honest-failure: with JetStream up but **no op-control stream created**, a
+/// publish is never ACKed, so the publisher returns an error and the registry maps
+/// it to `HaltDelivery::ChannelError` (the `503`) — never a silent-drop `200`.
+#[tokio::test]
+async fn publish_without_a_ready_stream_is_an_honest_failure_not_a_silent_200() {
+    let host_port = free_port();
+    let url = format!("nats://127.0.0.1:{host_port}");
+    let _nats = start_nats(host_port).await; // JetStream enabled, but no stream ensured.
+
+    let publisher = OpControlNatsPublisher::connect(&OpControlNatsConfig::new(url))
+        .await
+        .expect("connect to NATS")
+        .with_ack_timeout(Duration::from_millis(500));
+
+    // The raw publisher surfaces the un-acked publish as an error.
+    let result = publisher
+        .publish_agent_halt(agent("agent-x"), OpControlSignal::Terminate)
+        .await;
+    assert!(
+        result.is_err(),
+        "publish to a non-existent stream must be an honest error (-> 503), not a silent 200",
+    );
+
+    // And through the registry, the operator endpoint sees ChannelError (-> 503),
+    // never Delivered.
+    let registry = OpsRegistry::new().with_nats_publisher(Arc::new(publisher));
+    match registry
+        .halt_agent_delivery(agent("agent-x"), OpControlSignal::Terminate)
+        .await
+    {
+        HaltDelivery::ChannelError(_) => {}
+        other => panic!("expected ChannelError (503), got {other:?}"),
+    }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -142,4 +142,4 @@
   - [0008 - SaaS Host Routing, Auth & Cookie Boundaries](adr/0008-saas-host-routing-auth-cookie-boundaries.md)
   - [0009 - Versioned Base-Image Tags & SDK Pinning](adr/0009-versioned-base-image-tags-and-sdk-pinning.md)
   - [0010 - Gateway Distribution for Self-Host & Examples](adr/0010-gateway-distribution-self-host-examples.md)
-  - [0011 - Cross-Process Op-Control via NATS Subject](adr/0011-cross-process-op-control-nats-subject.md)
+  - [0011 - Cross-Process Op-Control via NATS Subject (durable JetStream)](adr/0011-cross-process-op-control-nats-subject.md)

--- a/docs/src/adr/0011-cross-process-op-control-nats-subject.md
+++ b/docs/src/adr/0011-cross-process-op-control-nats-subject.md
@@ -1,8 +1,18 @@
 # ADR 0011: Cross-Process Op-Control Delivery via a NATS Subject
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-06
-**Ticket**: [AAASM-3883](https://lightning-dust-mite.atlassian.net/browse/AAASM-3883)
+**Ticket**: [AAASM-3883](https://lightning-dust-mite.atlassian.net/browse/AAASM-3883),
+upgraded to durable JetStream by
+[AAASM-3885](https://lightning-dust-mite.atlassian.net/browse/AAASM-3885)
+
+> **Update (AAASM-3885).** The original design below shipped over **core NATS**
+> (at-most-once). The transport has since been upgraded to **NATS JetStream**
+> (durable stream + awaited publish ACK) so a halt `200` means *persisted and will
+> be delivered to a gateway that (re)subscribes within retention*, not merely
+> *accepted onto the bus*. See the
+> [AAASM-3885 update section](#update--aaasm-3885-durable-jetstream-delivery) at the
+> end; it supersedes the "Delivery semantics" consequence.
 
 ---
 
@@ -126,10 +136,11 @@ in-process behavior — no new mandatory config, no behavior change for local mo
   single-process deployment uses the in-process publisher unchanged. The two paths
   are mutually exclusive per process (NATS preferred when configured), so a halt is
   never double-delivered from one publisher.
-- **Delivery semantics.** Core NATS pub/sub is **at-most-once live** delivery — the
-  same semantics as the in-process broadcast it extends (which also drops when no
-  subscriber is connected). `flush()` makes NATS *unavailability* an honest error,
-  but a halt published while a gateway is momentarily disconnected from NATS is not
+- **Delivery semantics.** *(Superseded by AAASM-3885 — see the update section
+  below.)* Core NATS pub/sub is **at-most-once live** delivery — the same semantics
+  as the in-process broadcast it extends (which also drops when no subscriber is
+  connected). `flush()` makes NATS *unavailability* an honest error, but a halt
+  published while a gateway is momentarily disconnected from NATS is not
   redelivered. A JetStream-durable op-control stream is a deliberate **future**
   enhancement, out of scope for this additive-wiring fix.
 - **No new dependency / no new feature flag.** `async-nats` is already a
@@ -142,3 +153,100 @@ in-process behavior — no new mandatory config, no behavior change for local mo
   kill path is the agent-wide / global halt, which binds to the server-side agent
   identity and is what this ADR makes cross-process. Per-op `pause`/`terminate`
   remain same-process for now.
+
+---
+
+## Update — AAASM-3885: Durable JetStream Delivery
+
+**Ticket**: [AAASM-3885](https://lightning-dust-mite.atlassian.net/browse/AAASM-3885)
+(found in the AAASM-3883 review). This section **supersedes the "Delivery
+semantics" consequence** above; everything else (subject naming, envelope schema,
+fail-mode, multi-replica, per-op locality) is unchanged.
+
+### Problem
+
+Core NATS is **at-most-once**: a successful publish + `flush()` only confirms bytes
+reached the NATS server, not that any gateway bridge consumed the halt or that a
+runtime halted. If no gateway is subscribed at that instant (restart / rollout
+window, partition), the halt endpoint returns `200` while the halt reaches no
+runtime — wrong for a safety kill switch, where `200` should mean "the agent was
+provably told to halt."
+
+### Decision
+
+Carry op-control on a **durable NATS JetStream stream** instead of core pub/sub.
+The subject scheme, JSON envelope, and reserved keys are unchanged — only the
+transport guarantee changes.
+
+#### Stream
+
+- **Name**: `AA_OPCONTROL`.
+- **Subjects**: `assembly.opcontrol.>` (the same wildcard the bridge consumed before).
+- **Retention**: `Limits` with a bounded **`max_age` = 10 minutes**, **`File`
+  storage**. Halts are tiny and time-sensitive: a bounded max-age covers a gateway
+  restart / rollout window (a halt published in that gap is redelivered to the
+  gateway that resubscribes within it) while keeping the stream small and preventing
+  an indefinitely-replayed *stale* kill switch. File storage makes the halt survive
+  a NATS server restart as well.
+- **Created idempotently at boot** by every process via `create_or_update_stream`
+  (`ensure_op_control_stream`). The NATS server **must have JetStream enabled**
+  (`-js`) — a deployment requirement; without it, stream setup / publish ACK fails
+  and the halt endpoint honestly returns `503`.
+
+#### Publish (aa-api)
+
+`OpControlNatsPublisher` now holds a `jetstream::Context` and **awaits the publish
+ACK** (`context.publish(subject, payload).await?.await?`). The second await resolves
+the JetStream server ACK, which only arrives once the message is **persisted** in
+the stream. The ACK wait is bounded by a timeout so the operator surface never
+hangs. The aa-api process does **not** create the stream — that is the gateway's
+job — so a publish before the stream is ready is an honest failure (below).
+
+#### Consume (gateway)
+
+The bridge ensures the stream, then reads it via an **ephemeral JetStream consumer**
+with `DeliverPolicy::All` and **explicit ack**:
+
+- **Ephemeral, not a shared durable consumer.** A named durable consumer shared by
+  all gateway replicas would *queue-group* halts to a single replica, so a runtime
+  streamed from a different replica would miss its kill switch. An ephemeral
+  consumer per replica gives each replica its **own** copy of every halt —
+  preserving the AAASM-3883 multi-replica fan-out.
+- **`DeliverPolicy::All`** replays everything still within retention when the
+  consumer is (re)created. This is what delivers a halt **published while this
+  gateway had no consumer attached** — the durability property of this ticket. The
+  *stream's retention*, not consumer durability, is what makes the halt survive; the
+  consumer just replays from the start of the retained stream on each (re)subscribe.
+- Re-reading an already-applied halt after a gateway restart is **safe** because
+  `Terminate` is sticky/idempotent in the runtime `OpControlStore` (and `ack`
+  removes it from the consumer's pending set during steady state).
+
+### What a halt `200` now guarantees
+
+The halt was **durably persisted** to the `AA_OPCONTROL` JetStream stream (the
+server ACK was received). Every gateway whose bridge is subscribed receives it
+live, **and** any gateway that (re)subscribes **within the retention window
+(10 min)** is replayed the persisted halt. An operator is never told an agent was
+halted when the signal was dropped onto a bus with no consumer.
+
+### Residual caveats
+
+- **Not an end-to-end runtime-ack.** `200` means *durably persisted and will be
+  delivered to a (re)subscribing gateway within retention*, **not** a per-runtime
+  acknowledgement that a specific agent process applied the halt. A runtime that is
+  disconnected for longer than the 10-minute retention, or permanently gone, is not
+  tracked. A true end-to-end runtime-level ack would require a return path from the
+  runtime and is out of scope.
+- **Per-op vs agent-wide.** Unchanged from the base ADR: per-op `pause`/`terminate`
+  remain bounded by op→agent registry locality. The durable cross-process path is
+  the agent-wide / global halt, which binds to the server-side agent identity.
+- **Deployment requirement.** The op-control NATS server must run with JetStream
+  enabled (`-js`). This reuses the existing `AA_OPCONTROL_NATS_URL` connection — no
+  new config — but a non-JetStream server now degrades op-control to honest `503`s
+  rather than the previous best-effort core-NATS delivery.
+
+### Fail-mode (unchanged invariant, JetStream-specific triggers)
+
+- JetStream unavailable / stream not ready / **publish not ACKed** → real `503`
+  (`HaltDelivery::ChannelError`), never a false `200`.
+- No op-control channel configured at all → `503` (`HaltDelivery::NotConfigured`).

--- a/docs/src/adr/README.md
+++ b/docs/src/adr/README.md
@@ -17,4 +17,4 @@ The format follows a lightweight variant of [Michael Nygard's template](https://
 | [0008](0008-saas-host-routing-auth-cookie-boundaries.md) | SaaS Host Routing, Auth & Cookie Boundaries | Proposed |
 | [0009](0009-versioned-base-image-tags-and-sdk-pinning.md) | Versioned Base-Image Tags & Reproducible SDK Pinning | Proposed |
 | [0010](0010-gateway-distribution-self-host-examples.md) | Gateway Distribution for Self-Host & Examples | Proposed |
-| [0011](0011-cross-process-op-control-nats-subject.md) | Cross-Process Op-Control Delivery via a NATS Subject | Proposed |
+| [0011](0011-cross-process-op-control-nats-subject.md) | Cross-Process Op-Control Delivery via a NATS Subject (durable JetStream) | Accepted |


### PR DESCRIPTION
## Description

Upgrades the cross-process operator kill switch (shipped in AAASM-3883 / #1309 / ADR 0011 over **at-most-once CORE NATS**) to a **durable, acknowledged** transport on **NATS JetStream**, so an operator-halt `200` now means the halt is *durably persisted and will reach any gateway that (re)subscribes within retention* — not merely *accepted onto the bus*.

**Publish (aa-api).** `OpControlNatsPublisher` now holds a `jetstream::Context` and **awaits the publish ACK** (`publish().await?.await?`). The ACK only arrives once the message is persisted in the stream, so a successful publish is durable. Result maps to `HaltDelivery`: ACK ok → `Delivered` (200); publish/ack error or timeout → `ChannelError` (503); no NATS → `NotConfigured` (503). Subject scheme (`assembly.opcontrol.<tenant>.<agent>` / `.global`) and reserved keys are unchanged; the in-process path is preserved for single-process/local mode.

**Stream + consumer (gateway).** The bridge ensures (idempotent create-or-update) a durable JetStream stream `AA_OPCONTROL` bound to `assembly.opcontrol.>` at boot — `Limits` retention, **bounded 10-minute `max_age`**, `File` storage. It consumes via an **ephemeral `DeliverPolicy::All` consumer** with explicit ack and forwards into the in-process broadcast feeding `op_control_stream`. Ephemeral-per-replica preserves the AAASM-3883 multi-replica fan-out (a shared durable consumer would queue-group halts to a single replica); `DeliverPolicy::All` replays everything still within retention, so **a halt published while no gateway consumer is subscribed is delivered to a gateway that subscribes later** — the durability property of this ticket.

**Honest failure preserved.** JetStream unavailable / stream-not-ready / publish-not-acked → real `503`, never a silent-drop `200`.

**Deployment requirement.** Reuses the existing `AA_OPCONTROL_NATS_URL` connection, but the NATS server **must have JetStream enabled** (`-js`). The e2e testcontainer now runs NATS with `-js`.

ADR 0011 updated with the JetStream design (stream config, retention, consumer type, ack semantics, what `200` now guarantees, residual caveats); README/SUMMARY index kept consistent.

## Type of Change

- [x] ✨ New feature (transport upgrade of an existing kill switch)
- [x] 📝 Documentation update (ADR 0011)

## Breaking Changes

- [x] No

No public HTTP/gRPC API or OpenAPI changes (confirmed: no route/handler/schema files changed; `openapi/v1.yaml` unchanged). The op-control NATS server must now run JetStream (`-js`) — a deployment requirement, documented in the ADR and above.

## Related Issues

- Related Jira ticket: AAASM-3885 — Closes AAASM-3885
- Builds on AAASM-3883 (#1309), ADR [0011](docs/src/adr/0011-cross-process-op-control-nats-subject.md)

## Testing

Real NATS + JetStream via testcontainers (`-js`), no faking:

- e2e: operator agent-wide / global halt published (ACK awaited) → gateway JetStream consumer → `op_control_stream` → runtime `OpControlStore` records `Terminated`.
- **durability test (the point of this ticket):** publish a halt while **no** gateway consumer is subscribed, then start the bridge → it replays the persisted halt and delivers it. Asserted.
- honest-failure: JetStream up but stream not created → publish never ACKed → publisher errors and `OpsRegistry::halt_agent_delivery` returns `HaltDelivery::ChannelError` (503), not 200.

Validation: `cargo build --workspace` ✅ · `cargo nextest run -p aa-gateway -p aa-api` ✅ 2135 passed (incl. 4 JetStream e2e; 1 unrelated flaky retried green) · `cargo fmt --all --check` ✅ · `cargo clippy --workspace --all-targets -- -D warnings` ✅ · OpenAPI no-drift ✅.

- [x] Unit tests added / updated
- [x] Integration tests added / updated

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf