### PR TITLE
[AAASM-3886] 🔒 (aa-gateway): Fail loud on op-control JetStream stream-config mismatch

### DIFF
--- a/aa-gateway/src/ops/mod.rs
+++ b/aa-gateway/src/ops/mod.rs
@@ -21,8 +21,8 @@ pub mod nats;
 pub mod publisher;
 
 pub use nats::{
-    OpControlNatsConfig, OpControlNatsError, OpControlNatsPublisher, OpControlWireEnvelope,
-    SharedOpControlNatsPublisher,
+    BridgeHealthState, OpControlBridgeHealth, OpControlNatsConfig, OpControlNatsError, OpControlNatsPublisher,
+    OpControlWireEnvelope, SharedOpControlNatsPublisher,
 };
 pub use publisher::{OpControlEnvelope, OpControlPublisher, SharedOpControlPublisher};
 

--- a/aa-gateway/src/ops/nats.rs
+++ b/aa-gateway/src/ops/nats.rs
@@ -34,6 +34,7 @@
 //! audit publisher rather than the feature-gated audit consumer. The configured NATS
 //! server **must have JetStream enabled** (a deployment requirement; see ADR 0011).
 
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -164,6 +165,27 @@ pub enum OpControlNatsError {
     Consumer(String),
 }
 
+impl OpControlNatsError {
+    /// `true` when this error means the durable stream / consumer could not be
+    /// established **after a successful connection** — a non-transient
+    /// misconfiguration that retrying alone cannot fix (AAASM-3886).
+    ///
+    /// The canonical trigger is an operator who pre-provisioned an
+    /// [`STREAM_NAME`] stream with an **incompatible immutable config**
+    /// (different storage type / retention policy / non-overlapping subjects):
+    /// `create_or_update_stream` can never reconcile it, so the bridge would
+    /// otherwise loop forever setting up the stream **without ever consuming**,
+    /// while op-control publishes keep ACKing against the existing stream — a
+    /// silent non-delivery of a kill switch. JetStream being disabled or the
+    /// stream being otherwise unconsumable lands here too.
+    ///
+    /// [`Connect`](Self::Connect) (server unreachable) is genuinely transient and
+    /// returns `false` — that is the ordinary reconnect path, not a fail-loud one.
+    pub fn is_stream_setup_failure(&self) -> bool {
+        matches!(self, Self::Stream(_) | Self::Consumer(_))
+    }
+}
+
 /// Runtime configuration for the op-control NATS bridge / publisher.
 #[derive(Debug, Clone)]
 pub struct OpControlNatsConfig {
@@ -184,6 +206,109 @@ impl OpControlNatsConfig {
     pub fn from_env() -> Option<Self> {
         let url = std::env::var("AA_OPCONTROL_NATS_URL").ok().filter(|u| !u.is_empty())?;
         Some(Self::new(url))
+    }
+}
+
+/// Liveness of the gateway-side op-control bridge (AAASM-3886).
+///
+/// Reported by [`OpControlBridgeHealth`] so the bridge's structural ability to
+/// deliver halts is observable rather than buried in a silent retry loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeHealthState {
+    /// Initial state, before the first connect + consumer attempt completes.
+    Connecting,
+    /// A JetStream consumer is established; halts are being delivered. Healthy.
+    Subscribed,
+    /// A transient connection drop; reconnecting with backoff. Not fail-loud —
+    /// op-control delivery resumes automatically once NATS is reachable again.
+    Reconnecting,
+    /// **Fail-loud.** The durable stream / consumer could not be established
+    /// after connecting — op-control delivery is **DOWN** and will not recover by
+    /// retrying (e.g. a pre-provisioned [`STREAM_NAME`] stream with an
+    /// incompatible immutable config, or JetStream disabled). A halt may still be
+    /// ACKed by the publisher against the existing stream yet never reach a
+    /// runtime, so this state must be surfaced, not silently looped on.
+    StreamUnavailable,
+}
+
+impl BridgeHealthState {
+    const CONNECTING: u8 = 0;
+    const SUBSCRIBED: u8 = 1;
+    const RECONNECTING: u8 = 2;
+    const STREAM_UNAVAILABLE: u8 = 3;
+
+    const fn to_u8(self) -> u8 {
+        match self {
+            Self::Connecting => Self::CONNECTING,
+            Self::Subscribed => Self::SUBSCRIBED,
+            Self::Reconnecting => Self::RECONNECTING,
+            Self::StreamUnavailable => Self::STREAM_UNAVAILABLE,
+        }
+    }
+
+    const fn from_u8(raw: u8) -> Self {
+        match raw {
+            Self::SUBSCRIBED => Self::Subscribed,
+            Self::RECONNECTING => Self::Reconnecting,
+            Self::STREAM_UNAVAILABLE => Self::StreamUnavailable,
+            _ => Self::Connecting,
+        }
+    }
+}
+
+/// Cheap, cloneable, thread-safe handle to the op-control bridge's current
+/// [`BridgeHealthState`] (AAASM-3886).
+///
+/// The bridge task owns one clone and updates it as it (re)connects; callers
+/// (the gateway boot, tests, a future readiness probe) hold other clones to read
+/// it. Reading is lock-free. This is the **observable** half of the fail-loud
+/// behaviour — the loud `tracing::error!` is the operator-facing half.
+#[derive(Clone)]
+pub struct OpControlBridgeHealth {
+    state: Arc<AtomicU8>,
+}
+
+impl Default for OpControlBridgeHealth {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OpControlBridgeHealth {
+    /// A fresh handle in the [`BridgeHealthState::Connecting`] state.
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(AtomicU8::new(BridgeHealthState::Connecting.to_u8())),
+        }
+    }
+
+    /// Record the bridge's current state, mirroring it onto the
+    /// `aa_op_control_bridge_up` gauge (`1.0` only when delivering).
+    pub fn set(&self, state: BridgeHealthState) {
+        self.state.store(state.to_u8(), Ordering::Relaxed);
+        let up = if state == BridgeHealthState::Subscribed {
+            1.0
+        } else {
+            0.0
+        };
+        metrics::gauge!("aa_op_control_bridge_up").set(up);
+    }
+
+    /// Read the bridge's current state.
+    pub fn get(&self) -> BridgeHealthState {
+        BridgeHealthState::from_u8(self.state.load(Ordering::Relaxed))
+    }
+
+    /// `true` only when a consumer is established and halts are being delivered.
+    pub fn is_healthy(&self) -> bool {
+        self.get() == BridgeHealthState::Subscribed
+    }
+
+    /// `true` when op-control delivery is structurally **down** (the fail-loud
+    /// [`BridgeHealthState::StreamUnavailable`] state) — a misconfiguration that
+    /// will not recover by retrying.
+    pub fn is_delivery_down(&self) -> bool {
+        self.get() == BridgeHealthState::StreamUnavailable
     }
 }
 
@@ -342,18 +467,61 @@ fn forward_to_broadcast(publisher: &SharedOpControlPublisher, envelope: OpContro
 /// exponential backoff so a transient NATS outage never permanently silences the
 /// cross-process kill switch.
 pub fn spawn_bridge(config: OpControlNatsConfig, publisher: SharedOpControlPublisher) -> JoinHandle<()> {
-    tokio::spawn(run_bridge(config, publisher))
+    spawn_bridge_with_health(config, publisher).0
+}
+
+/// Like [`spawn_bridge`] but also returns an [`OpControlBridgeHealth`] handle so
+/// the caller can observe whether the bridge is actually delivering halts
+/// (AAASM-3886) — in particular to detect the fail-loud
+/// [`BridgeHealthState::StreamUnavailable`] state. The handle is independent of
+/// the [`JoinHandle`]; dropping either does not stop the bridge task.
+pub fn spawn_bridge_with_health(
+    config: OpControlNatsConfig,
+    publisher: SharedOpControlPublisher,
+) -> (JoinHandle<()>, OpControlBridgeHealth) {
+    let health = OpControlBridgeHealth::new();
+    let handle = tokio::spawn(run_bridge(config, publisher, health.clone()));
+    (handle, health)
 }
 
 /// Reconnect loop for the bridge.
-async fn run_bridge(config: OpControlNatsConfig, publisher: SharedOpControlPublisher) {
+async fn run_bridge(config: OpControlNatsConfig, publisher: SharedOpControlPublisher, health: OpControlBridgeHealth) {
     let mut backoff = INITIAL_BACKOFF;
     loop {
-        match bridge_once(&config, &publisher).await {
+        match bridge_once(&config, &publisher, &health).await {
             // The subscription ended cleanly — reconnect promptly.
             Ok(()) => backoff = INITIAL_BACKOFF,
-            Err(err) => {
+            Err(err) if err.is_stream_setup_failure() => {
+                // FAIL LOUD (AAASM-3886): the durable stream / consumer could not
+                // be established after connecting. This does not recover by
+                // retrying — the dominant cause is a pre-provisioned AA_OPCONTROL
+                // stream with an incompatible immutable config — so op-control
+                // delivery is structurally DOWN. Publishes may still ACK against
+                // the existing stream and return 200 while NO halt reaches a
+                // runtime. Surface it loudly and as unhealthy rather than burying
+                // it in a quiet reconnect warning. We keep retrying (an operator
+                // may repair the stream), but every attempt screams.
                 metrics::counter!("aa_op_control_bridge_reconnects_total").increment(1);
+                health.set(BridgeHealthState::StreamUnavailable);
+                tracing::error!(
+                    error = %err,
+                    stream = STREAM_NAME,
+                    subject = SUBJECT_WILDCARD,
+                    backoff_secs = backoff.as_secs(),
+                    "op-control JetStream bridge cannot establish its stream/consumer — \
+                     OP-CONTROL DELIVERY IS DOWN: operator halts may be ACKed (200) yet \
+                     never reach any runtime. The AA_OPCONTROL stream likely exists with an \
+                     INCOMPATIBLE immutable config (storage/retention/subjects) or JetStream \
+                     is disabled. Reconcile the stream (delete/recreate, or align its config) \
+                     to restore the kill switch."
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+            Err(err) => {
+                // Transient (e.g. NATS unreachable) — reconnect quietly with backoff.
+                metrics::counter!("aa_op_control_bridge_reconnects_total").increment(1);
+                health.set(BridgeHealthState::Reconnecting);
                 tracing::warn!(
                     error = %err,
                     backoff_secs = backoff.as_secs(),
@@ -383,6 +551,7 @@ async fn run_bridge(config: OpControlNatsConfig, publisher: SharedOpControlPubli
 async fn bridge_once(
     config: &OpControlNatsConfig,
     publisher: &SharedOpControlPublisher,
+    health: &OpControlBridgeHealth,
 ) -> Result<(), OpControlNatsError> {
     let client = async_nats::connect(&config.url)
         .await
@@ -402,6 +571,9 @@ async fn bridge_once(
         .messages()
         .await
         .map_err(|e| OpControlNatsError::Consumer(e.to_string()))?;
+    // The stream and consumer are established and we are about to deliver —
+    // healthy (AAASM-3886).
+    health.set(BridgeHealthState::Subscribed);
     tracing::info!(
         stream = STREAM_NAME,
         subject = SUBJECT_WILDCARD,

--- a/aa-gateway/src/ops/nats.rs
+++ b/aa-gateway/src/ops/nats.rs
@@ -723,6 +723,63 @@ mod tests {
         assert_eq!(envelope.message.signal, OpControlSignal::Pause as i32);
     }
 
+    // ── AAASM-3886: fail-loud classification + bridge health handle ─────────
+
+    #[test]
+    fn stream_and_consumer_setup_failures_are_fail_loud() {
+        // A stream/consumer setup failure (after a successful connect) is the
+        // non-transient fail-loud condition — the canonical trigger is a
+        // pre-provisioned stream with an incompatible immutable config.
+        assert!(OpControlNatsError::Stream("immutable field".into()).is_stream_setup_failure());
+        assert!(OpControlNatsError::Consumer("cannot create".into()).is_stream_setup_failure());
+    }
+
+    #[test]
+    fn connect_and_other_errors_are_transient_not_fail_loud() {
+        // Server-unreachable / publish / serialize / subscribe are NOT fail-loud
+        // — they are the ordinary transient reconnect path.
+        assert!(!OpControlNatsError::Connect("refused".into()).is_stream_setup_failure());
+        assert!(!OpControlNatsError::Publish("no ack".into()).is_stream_setup_failure());
+        assert!(!OpControlNatsError::Subscribe("nope".into()).is_stream_setup_failure());
+        assert!(!OpControlNatsError::Serialize("bad json".into()).is_stream_setup_failure());
+    }
+
+    #[test]
+    fn bridge_health_starts_connecting_and_tracks_transitions() {
+        let health = OpControlBridgeHealth::new();
+        assert_eq!(health.get(), BridgeHealthState::Connecting);
+        assert!(!health.is_healthy());
+        assert!(!health.is_delivery_down());
+
+        health.set(BridgeHealthState::Subscribed);
+        assert_eq!(health.get(), BridgeHealthState::Subscribed);
+        assert!(health.is_healthy());
+        assert!(!health.is_delivery_down());
+
+        health.set(BridgeHealthState::Reconnecting);
+        assert!(!health.is_healthy());
+        assert!(!health.is_delivery_down());
+
+        health.set(BridgeHealthState::StreamUnavailable);
+        assert!(!health.is_healthy());
+        assert!(
+            health.is_delivery_down(),
+            "the fail-loud state must report op-control delivery as down",
+        );
+    }
+
+    #[test]
+    fn bridge_health_handle_clones_share_one_state() {
+        // The bridge task owns one clone and updates it; callers read another.
+        let writer = OpControlBridgeHealth::new();
+        let reader = writer.clone();
+        writer.set(BridgeHealthState::StreamUnavailable);
+        assert!(
+            reader.is_delivery_down(),
+            "a clone must observe the writer's StreamUnavailable transition",
+        );
+    }
+
     #[tokio::test]
     async fn forward_drops_unspecified_signal() {
         let publisher = Arc::new(super::super::OpControlPublisher::new());

--- a/aa-gateway/tests/op_control_stream_config_mismatch_test.rs
+++ b/aa-gateway/tests/op_control_stream_config_mismatch_test.rs
@@ -1,0 +1,145 @@
+//! Fail-loud-on-stream-config-mismatch test (AAASM-3886, ADR 0011).
+//!
+//! Reproduces the operational edge found in the AAASM-3885 review: an operator
+//! pre-provisions the `AA_OPCONTROL` JetStream stream with an **incompatible
+//! immutable config** (here: `Memory` storage instead of the gateway's `File`).
+//! `create_or_update_stream` can never reconcile that, so the gateway bridge
+//! cannot establish its consumer.
+//!
+//! Before AAASM-3886 the bridge looped on stream/consumer setup **without ever
+//! consuming**, logging only a quiet reconnect warning, while op-control
+//! publishes kept ACKing (200) against the existing stream — a silent
+//! non-delivery of a kill switch. This test proves the bridge now **fails loud**:
+//! it surfaces [`BridgeHealthState::StreamUnavailable`] instead of silently
+//! looping (and never reports `Subscribed`).
+//!
+//! It also demonstrates the cross-process boundary documented in ADR 0011: the
+//! publisher (a different process) **cannot** know the stream is unconsumable —
+//! its publish still ACKs against the incompatible stream — which is exactly why
+//! the gateway-side fail-loud/unhealthy signal is the only honest one available.
+//!
+//! Uses a **real NATS server** via `testcontainers-modules` (requires Docker, `-js`
+//! enabled), matching the AAASM-3885 e2e — nothing is faked.
+
+use std::time::{Duration, Instant};
+
+use aa_gateway::ops::nats::{spawn_bridge_with_health, STREAM_NAME, SUBJECT_WILDCARD};
+use aa_gateway::ops::{BridgeHealthState, OpControlNatsConfig, OpControlNatsPublisher, OpControlPublisher};
+use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
+use aa_proto::assembly::policy::v1::OpControlSignal;
+use async_nats::jetstream;
+use std::sync::Arc;
+use testcontainers_modules::nats::{Nats, NatsServerCmd};
+use testcontainers_modules::testcontainers::core::IntoContainerPort;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
+
+/// Reserve an ephemeral host port, then release it so the container can bind it.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+/// Start a NATS container with JetStream enabled (`-js`), pinned to `host_port`.
+async fn start_nats(host_port: u16) -> ContainerAsync<Nats> {
+    let cmd = NatsServerCmd::default().with_jetstream();
+    Nats::default()
+        .with_cmd(&cmd)
+        .with_mapped_port(host_port, 4222.tcp())
+        .start()
+        .await
+        .expect("start nats testcontainer (is Docker running?)")
+}
+
+/// Pre-provision an `AA_OPCONTROL` stream with an **incompatible immutable
+/// config**: `Memory` storage (the gateway ensures `File`). The subjects still
+/// cover `assembly.opcontrol.>` so a publish keeps ACKing against it — modelling
+/// the dangerous silent-non-delivery case, not a trivially-missing stream.
+async fn preprovision_incompatible_stream(url: &str) {
+    let client = async_nats::connect(url).await.expect("connect to NATS");
+    let context = jetstream::new(client);
+    context
+        .create_stream(jetstream::stream::Config {
+            name: STREAM_NAME.to_string(),
+            subjects: vec![SUBJECT_WILDCARD.to_string()],
+            retention: jetstream::stream::RetentionPolicy::Limits,
+            // Immutable mismatch vs the gateway's File storage.
+            storage: jetstream::stream::StorageType::Memory,
+            ..Default::default()
+        })
+        .await
+        .expect("pre-provision incompatible AA_OPCONTROL stream");
+}
+
+fn agent(id: &str) -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: id.into(),
+    }
+}
+
+/// With a pre-provisioned, incompatible `AA_OPCONTROL` stream the gateway bridge
+/// must fail loud: it surfaces `StreamUnavailable` (op-control delivery DOWN)
+/// rather than silently looping, and never reports `Subscribed`.
+#[tokio::test]
+async fn incompatible_preprovisioned_stream_makes_bridge_fail_loud_not_silently_loop() {
+    let host_port = free_port();
+    let url = format!("nats://127.0.0.1:{host_port}");
+    let _nats = start_nats(host_port).await;
+
+    // Operator pre-provisioned the stream with an irreconcilable immutable config.
+    preprovision_incompatible_stream(&url).await;
+
+    // Start the gateway bridge against it, observing its health.
+    let publisher = Arc::new(OpControlPublisher::new());
+    let (_bridge, health) = spawn_bridge_with_health(OpControlNatsConfig::new(url.clone()), Arc::clone(&publisher));
+
+    // The bridge must reach the fail-loud StreamUnavailable state — it can never
+    // reconcile the stream, so it surfaces delivery-down instead of looping silently.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        assert!(
+            Instant::now() < deadline,
+            "bridge never surfaced StreamUnavailable; last state = {:?}",
+            health.get(),
+        );
+        // It must NEVER report healthy against an unconsumable stream.
+        assert_ne!(
+            health.get(),
+            BridgeHealthState::Subscribed,
+            "bridge must not report Subscribed for an incompatible/unconsumable stream",
+        );
+        if health.is_delivery_down() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Cross-process boundary (ADR 0011): the publisher is a different process and
+    // CANNOT know the stream is unconsumable — its publish still ACKs (the silent
+    // 200) against the incompatible-but-present stream. This is precisely why the
+    // gateway-side fail-loud signal above is the only honest indicator available.
+    let api_publisher = OpControlNatsPublisher::connect(&OpControlNatsConfig::new(url.clone()))
+        .await
+        .expect("aa-api side connects to NATS")
+        .with_ack_timeout(Duration::from_secs(2));
+    let publish_result = api_publisher
+        .publish_agent_halt(agent("agent-x"), OpControlSignal::Terminate)
+        .await;
+    assert!(
+        publish_result.is_ok(),
+        "the publisher cannot detect the gateway's config mismatch — its ACK against \
+         the present (incompatible) stream still succeeds, which is why the gateway must \
+         fail loud; got {publish_result:?}",
+    );
+
+    // And the gateway still reports delivery-down despite that successful publish.
+    assert!(
+        health.is_delivery_down(),
+        "op-control delivery must remain down while the stream stays incompatible",
+    );
+}

--- a/docs/src/adr/0011-cross-process-op-control-nats-subject.md
+++ b/docs/src/adr/0011-cross-process-op-control-nats-subject.md
@@ -250,3 +250,80 @@ halted when the signal was dropped onto a bus with no consumer.
 - JetStream unavailable / stream not ready / **publish not ACKed** → real `503`
   (`HaltDelivery::ChannelError`), never a false `200`.
 - No op-control channel configured at all → `503` (`HaltDelivery::NotConfigured`).
+
+---
+
+## Update — AAASM-3886: Fail Loud on a Stream-Config Mismatch
+
+**Ticket**: [AAASM-3886](https://lightning-dust-mite.atlassian.net/browse/AAASM-3886)
+(found in the AAASM-3885 review). Hardens the gateway bridge against an operator
+misconfiguration; the transport guarantees above are unchanged.
+
+### Problem
+
+JetStream stream config is **partly immutable** (storage type, retention policy;
+subjects are mutable). If an operator **pre-provisions** the `AA_OPCONTROL` stream
+with an incompatible immutable config, `create_or_update_stream`
+(`ensure_op_control_stream`) can never reconcile it. Before this change the bridge
+reconnect loop treated that failure exactly like a transient NATS outage — a quiet
+`warn!` + backoff — so it looped on stream/consumer setup **without ever
+consuming**, while op-control publishes kept ACKing (`200`) against the existing
+stream. Net result: an operator halt is persisted and returns `200`, yet **no
+runtime is ever told to halt** — a silent non-delivery of the kill switch.
+
+### Decision
+
+The bridge now **classifies** its setup failures
+(`OpControlNatsError::is_stream_setup_failure`): a `Stream` / `Consumer` failure
+**after a successful connect** is a non-transient *fail-loud* condition (the
+canonical trigger is the incompatible pre-provisioned stream; JetStream-disabled
+and otherwise-unconsumable streams land here too), whereas a `Connect` failure
+stays the ordinary transient reconnect path.
+
+On the fail-loud condition the bridge:
+
+- emits a prominent, actionable **`tracing::error!`** — it states that *op-control
+  delivery is DOWN* (halts may be ACKed yet never reach a runtime) and names the
+  likely cause (incompatible immutable stream config / JetStream disabled) and the
+  remedy (reconcile the stream);
+- records **`BridgeHealthState::StreamUnavailable`** on the new cloneable
+  `OpControlBridgeHealth` handle and drives the `aa_op_control_bridge_up` gauge to
+  `0`, so the condition is observable (and assertable in tests / wireable to a
+  future readiness probe) rather than buried in a retry loop.
+
+It still retries with backoff so that repairing the stream recovers delivery
+automatically — but every failed attempt now *screams* instead of whispering.
+
+### Why publish is not made honest-fail in this state
+
+The dangerous case is structurally a **cross-process** one. The publisher lives in
+the **aa-api** process and, by this ADR's design, does **not** own or validate the
+stream — that is the gateway's job. When an incompatible stream exists whose
+subjects still cover `assembly.opcontrol.>`, the publisher's `publish + ACK`
+**succeeds** against that present-but-unconsumable stream; the publisher has no way
+to know the gateway cannot consume it. (The pre-existing honest-`503` paths still
+fire when the stream is *absent* or the publish is genuinely un-ACKed — see the
+AAASM-3885 fail-mode above.) Making publish honest-fail here would require the
+publisher to validate the gateway's consume-side stream config, which crosses the
+process boundary this ADR deliberately keeps clean. The accepted contract is
+therefore: **the gateway fails loud / reports unhealthy**; the publisher's `200`
+in this specific misconfiguration is a known residual, surfaced by the gateway's
+loud error and `StreamUnavailable` health rather than by the publish call.
+
+### Benign per-reconnect full-window replay (note)
+
+`DeliverPolicy::All` on an **ephemeral** consumer means the replay catch-up
+described in the AAASM-3885 consume section happens on **every NATS reconnect**,
+not only on a process restart: each time `bridge_once` re-creates its consumer it
+replays everything still within the stream's retention window (≤ 10 min). This is
+**safe and intended**, not a bug:
+
+- `Terminate` is sticky/idempotent in the runtime `OpControlStore`, so re-reading
+  an already-applied halt is a no-op;
+- `Pause` / `Resume` converge by FIFO order — the stream preserves publish order,
+  so replaying the retained window re-applies the last intended state;
+- the bounded `max_age` keeps the replayed window small and prevents an
+  indefinitely-replayed *stale* kill switch.
+
+So a flapping NATS connection costs at most a brief, idempotent re-application of
+the last few minutes of halts — never a missed or contradictory one.


### PR DESCRIPTION
## Description

Hardens the JetStream op-control delivery shipped in AAASM-3885 (#1310) against an operator misconfiguration.

JetStream stream config is partly **immutable** (storage type, retention policy). If an operator pre-provisions the `AA_OPCONTROL` stream with an **incompatible immutable config** (different storage/retention/subjects), `create_or_update_stream` can never reconcile it. Before this change the gateway bridge treated that exactly like a transient NATS outage — a quiet `warn!` + backoff — so it looped on stream/consumer setup **without ever consuming**, while op-control publishes kept ACKing (`200`) against the existing stream. Net result: an operator halt is persisted and returns `200`, yet **no runtime is ever told to halt** — a silent non-delivery of a kill switch.

**The fix (gateway-side, fail loud):**
- New `OpControlNatsError::is_stream_setup_failure()` classifies a `Stream`/`Consumer` failure **after a successful connect** as a non-transient *fail-loud* condition (incompatible pre-provisioned stream, JetStream disabled, otherwise-unconsumable stream), distinct from a transient `Connect` drop.
- On that condition the bridge now emits a prominent, actionable `tracing::error!` ("OP-CONTROL DELIVERY IS DOWN", names the likely cause + remedy) instead of a quiet reconnect warning, and records `BridgeHealthState::StreamUnavailable` on a new cloneable `OpControlBridgeHealth` handle (also driving the `aa_op_control_bridge_up` gauge to `0`). It keeps retrying so an operator repair recovers it automatically.
- **Happy path unchanged** — a compatible/auto-created stream works exactly as in 3885 (3885 e2e tests still green).

**Publish honest-fail boundary:** the dangerous case is cross-process. The publisher lives in the **aa-api** process and (by ADR 0011's design) does not own/validate the stream; when an incompatible stream still covers `assembly.opcontrol.>`, its publish ACKs (`200`) against that present-but-unconsumable stream and it has no way to know the gateway cannot consume it. So per the ticket's fallback, the gateway fails loud / reports unhealthy and the boundary is documented in the ADR. (The pre-existing honest-`503` paths still fire when the stream is *absent* or the publish is genuinely un-ACKed.)

## Type of Change

- [x] 🐛 Bug fix
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

`spawn_bridge` keeps its signature; a new `spawn_bridge_with_health` variant returns the health handle.

## Related Issues

- Related Jira ticket: AAASM-3886
- Hardens: AAASM-3885 (#1310)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

- **Unit** (`aa-gateway/src/ops/nats.rs`): `is_stream_setup_failure` classification (Stream/Consumer = fail-loud; Connect/Publish/Subscribe/Serialize = transient); `OpControlBridgeHealth` starts `Connecting`, tracks transitions, clones share one state.
- **E2e** (`aa-gateway/tests/op_control_stream_config_mismatch_test.rs`, real NATS via testcontainers `-js`): pre-provision an `AA_OPCONTROL` stream with an incompatible immutable config (Memory storage vs the gateway's File) but overlapping subjects; assert the bridge surfaces `StreamUnavailable` (never `Subscribed`) instead of silently looping, and that the publisher's halt still ACKs against the present stream (documenting why the gateway-side signal is the only honest one).

Validation gate (local): `cargo build --workspace`, `cargo nextest run -p aa-gateway -p aa-api` (2140 passed, incl. JetStream + `openapi_spec`), `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`. No new endpoints → OpenAPI no-drift.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (ADR 0011)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## ADR

ADR 0011 gains a section documenting (a) the fail-loud-on-stream-config-mismatch behavior and the publish cross-process boundary, and (b) the benign per-reconnect full-window replay (`DeliverPolicy::All` replays on every NATS reconnect — safe due to terminate idempotency + pause/resume FIFO convergence and the bounded `max_age`).

Closes AAASM-3886

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
