### PR TITLE
[AAASM-3891] 🔒 (aa-proxy): Cap body allocation + drop per-request leak

### DIFF
--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -583,6 +583,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_request_content_length_over_cap_without_allocating() {
+        // AAASM-3891: a Content-Length far above MAX_BODY_LEN (here ~2 GB, the
+        // exploit value) must be rejected at the header stage — before any
+        // `vec![0u8; content_length]` allocation — so a single hostile request
+        // cannot OOM the proxy. The reader holds only the header bytes, proving
+        // the rejection happens before the (absent) 2 GB body is touched.
+        let raw = b"POST /v1/chat/completions HTTP/1.1\r\n\
+                    Host: api.openai.com\r\n\
+                    Content-Length: 2000000000\r\n\
+                    \r\n";
+        let mut reader = make_reader(raw);
+        let err = read_http_request(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(&err, ProxyError::Config(msg) if msg.contains("exceeds maximum")),
+            "expected over-cap rejection, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_request_content_length_at_cap_boundary() {
+        // A Content-Length exactly at the cap is allowed (the boundary is
+        // inclusive); only values strictly greater are rejected. The body bytes
+        // are absent here, so the parse fails on EOF *after* passing the cap
+        // check — proving the cap itself did not reject the boundary value.
+        let raw = format!("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: {MAX_BODY_LEN}\r\n\r\n");
+        let mut reader = make_reader(raw.as_bytes());
+        let err = read_http_request(&mut reader).await.unwrap_err();
+        assert!(
+            !matches!(&err, ProxyError::Config(msg) if msg.contains("exceeds maximum")),
+            "cap boundary must not be rejected by the cap check, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_response_content_length_over_cap_without_allocating() {
+        // AAASM-3891: the response side applies the same reject-before-alloc cap
+        // so a hostile upstream response cannot OOM the proxy.
+        let raw = b"HTTP/1.1 200 OK\r\n\
+                    Content-Length: 2000000000\r\n\
+                    \r\n";
+        let mut reader = make_reader(raw);
+        let err = read_http_response(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(&err, ProxyError::Config(msg) if msg.contains("exceeds maximum")),
+            "expected over-cap rejection, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn unexpected_eof_reading_request_headers_is_error() {
         // Stream ends after the request line, before the header-terminating
         // blank line — this is a truncated request, not a clean inter-request

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -16,6 +16,19 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 
 use crate::error::ProxyError;
 
+/// Maximum accepted HTTP body size, in bytes (64 MiB).
+///
+/// `Content-Length` is attacker-controlled: a compromised agent can send
+/// `Content-Length: 2000000000`, and `vec![0u8; content_length]` would attempt
+/// to allocate ~2 GB per connection *before* a single body byte is read — a
+/// trivial OOM against the always-on egress proxy, and absurd values abort the
+/// task outright (AAASM-3891). The parser rejects any body larger than this
+/// bound *before* allocating, mirroring the IPC codec's `MAX_FRAME_LEN`
+/// reject-before-alloc guard (AAASM-3132). 64 MiB comfortably exceeds any
+/// legitimate LLM request — including multimodal payloads with base64 image
+/// data — while keeping one hostile request from exhausting memory.
+pub const MAX_BODY_LEN: usize = 64 * 1024 * 1024;
+
 /// A parsed HTTP request from the proxy's MitM tunnel.
 #[derive(Debug, Clone)]
 pub struct HttpRequest {
@@ -108,6 +121,15 @@ where
         .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
         .and_then(|(_, v)| v.parse().ok())
         .unwrap_or(0);
+
+    // AAASM-3891 (fail-closed): reject an over-cap Content-Length *before*
+    // allocating. The header is attacker-controlled, so allocating a buffer
+    // sized to it lets a single request OOM the proxy.
+    if content_length > MAX_BODY_LEN {
+        return Err(ProxyError::Config(format!(
+            "request Content-Length {content_length} exceeds maximum {MAX_BODY_LEN}; refusing (fail-closed)"
+        )));
+    }
 
     let mut body = vec![0u8; content_length];
     if content_length > 0 {
@@ -267,6 +289,15 @@ where
         .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
         .and_then(|(_, v)| v.parse().ok())
         .unwrap_or(0);
+
+    // AAASM-3891 (fail-closed): reject an over-cap Content-Length *before*
+    // allocating, so a hostile upstream response cannot OOM the proxy the same
+    // way a hostile request could.
+    if content_length > MAX_BODY_LEN {
+        return Err(ProxyError::Config(format!(
+            "response Content-Length {content_length} exceeds maximum {MAX_BODY_LEN}; refusing (fail-closed)"
+        )));
+    }
 
     let mut body = vec![0u8; content_length];
     if content_length > 0 {

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -1039,6 +1039,38 @@ mod tests {
         ProxyServer::new(config, ca, tx)
     }
 
+    #[test]
+    fn parse_plain_http_host_from_origin_form_target() {
+        // Origin-form `http://host/path` targets resolve the host from the URL.
+        let host = parse_plain_http_host("http://api.openai.com/v1/chat", &[]);
+        assert_eq!(host, "api.openai.com");
+    }
+
+    #[test]
+    fn parse_plain_http_host_falls_back_to_host_header() {
+        // A bare path target resolves the host from the (case-insensitive) Host
+        // header instead.
+        let headers = vec!["HOST: api.example.com\r\n".to_string()];
+        let host = parse_plain_http_host("/v1/chat", &headers);
+        assert_eq!(host, "api.example.com");
+    }
+
+    #[test]
+    fn parse_plain_http_host_returns_owned_string_not_leaked() {
+        // AAASM-3891 regression: the host must be an owned `String` rather than a
+        // `&'static str` produced by `.leak()`. Owned values are reclaimed when
+        // dropped, so repeated plain-HTTP requests no longer leak one host per
+        // request. Two calls returning equal-but-independent owned values (the
+        // second freed on drop) demonstrate no static interning/leak is in play.
+        let headers = vec!["Host: api.example.com\r\n".to_string()];
+        let first = parse_plain_http_host("/x", &headers);
+        let second = parse_plain_http_host("/x", &headers);
+        assert_eq!(first, "api.example.com");
+        assert_eq!(first, second);
+        drop(second); // an owned String drops here; a leaked &'static str could not.
+        assert_eq!(first, "api.example.com");
+    }
+
     #[tokio::test]
     async fn connect_deny_reason_blocks_metadata_ip_literal() {
         // SSRF: the cloud metadata endpoint as an IP literal must be denied

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -923,27 +923,19 @@ impl ProxyServer {
         }
 
         // Parse host from the target URL or Host header.
-        let host = if let Some(url_host) = target.strip_prefix("http://") {
-            url_host.split('/').next().unwrap_or(url_host)
-        } else {
-            headers
-                .iter()
-                .find_map(|h| {
-                    let lower = h.to_ascii_lowercase();
-                    lower
-                        .starts_with("host:")
-                        .then(|| h["host:".len()..].trim().to_string())
-                })
-                .unwrap_or_default()
-                .leak()
-        };
+        //
+        // AAASM-3891: this is owned (`String`) rather than `&'static str` via
+        // `.leak()`. The previous `.leak()` permanently leaked one host string
+        // per plain-HTTP request, so a steered agent issuing repeated origin-form
+        // `http://` requests caused unbounded memory growth.
+        let host: String = parse_plain_http_host(target, &headers);
 
         // AAASM-3864 (b): enforce the same egress denylist + network allowlist
         // the CONNECT path applies. Without this an `http://` scheme-downgrade
         // bypasses `denied_hosts`/`network_allowlist` — the SSRF resolved-IP
         // recheck below only guards address ranges, not policy hosts. Deny here
         // (before any upstream dial), mirroring the CONNECT path's 403.
-        let deny_host = host.split(':').next().unwrap_or(host);
+        let deny_host = host.split(':').next().unwrap_or(&host);
         if let Some(reason) = self.connect_deny_reason(deny_host) {
             tracing::info!(host = %deny_host, "plain-HTTP egress denied: {reason}");
             self.interceptor.emit_policy_decision(deny_host, true).await;
@@ -993,6 +985,30 @@ impl ProxyServer {
         }
 
         Ok(())
+    }
+}
+
+/// Parse the upstream host for a plain (non-CONNECT) HTTP request from the
+/// origin-form target (`http://host/...`) or, failing that, the `Host:` header.
+///
+/// AAASM-3891: returns an **owned** `String`. The previous inline implementation
+/// produced a `&'static str` via `.leak()` so both branches shared a type, which
+/// permanently leaked one host string per request and let repeated plain-HTTP
+/// requests grow proxy memory without bound. Returning an owned value keeps the
+/// host on the stack frame and frees it when the request completes.
+fn parse_plain_http_host(target: &str, headers: &[String]) -> String {
+    if let Some(url_host) = target.strip_prefix("http://") {
+        url_host.split('/').next().unwrap_or(url_host).to_string()
+    } else {
+        headers
+            .iter()
+            .find_map(|h| {
+                let lower = h.to_ascii_lowercase();
+                lower
+                    .starts_with("host:")
+                    .then(|| h["host:".len()..].trim().to_string())
+            })
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
## Description

Hardens the always-on `aa-proxy` data path against two memory-exhaustion DoS vectors (AAASM-3891):

1. **Unbounded body allocation** — `read_http_request` / `read_http_response` did `let mut body = vec![0u8; content_length]` with `content_length` taken straight from the attacker-controlled `Content-Length` header. A compromised agent sending `Content-Length: 2000000000` pinned ~2 GB per connection before any body byte arrived (OOM), and absurd values aborted the task. Fixed by introducing `MAX_BODY_LEN` (64 MiB) and rejecting any over-cap length with a fail-closed `ProxyError::Config` **before** allocating — mirroring the IPC codec's `MAX_FRAME_LEN` reject-before-alloc guard (AAASM-3132).

2. **Per-request `String` leak** — the plain-HTTP path resolved the upstream host via `…unwrap_or_default().leak()`, permanently leaking one host `String` per request so repeated origin-form `http://` requests grew proxy memory without bound. Extracted `parse_plain_http_host` returning an **owned** `String` (freed on drop); no `.leak()`.

64 MiB comfortably exceeds any legitimate LLM request (including multimodal base64 image payloads) while keeping one hostile request from exhausting memory.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3891 (Relates to AAASM-3864)

Closes AAASM-3891

## Testing

- [x] Unit tests added / updated

New regression tests:
- over-cap (~2 GB) request and response `Content-Length` rejected at the header stage before allocation
- a `Content-Length` exactly at `MAX_BODY_LEN` is not rejected by the cap check (inclusive boundary)
- `parse_plain_http_host` parses origin-form target and `Host:` header, and returns an owned `String` (freed on drop), not a leaked `&'static str`

Validation (`CARGO_TARGET_DIR` isolated):
- `cargo build -p aa-proxy` — clean
- `cargo nextest run -p aa-proxy` — 177 passed, 3 skipped
- `cargo fmt --all` — clean
- `cargo clippy -p aa-proxy --all-targets -- -D warnings` — clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
