### PR TITLE
[AAASM-3894] 🔒 (aa-api): Tighten alert-rules/destinations/tools/JWT scope

### DIFF
--- a/aa-api/src/routes/alert_rules.rs
+++ b/aa-api/src/routes/alert_rules.rs
@@ -24,7 +24,7 @@ use utoipa::ToSchema;
 
 use crate::alerts::rules::store::AlertRuleStoreError;
 use crate::alerts::rules::types::{AlertRule, AlertRuleValidationError, RuleMetric, RuleOperator, RuleSeverity};
-use crate::auth::scope::{RequireRead, RequireWrite};
+use crate::auth::scope::{RequireAdmin, RequireRead};
 use crate::error::ProblemDetail;
 use crate::state::AppState;
 
@@ -202,7 +202,11 @@ pub async fn list_rules(
     tag = "alert-rules"
 )]
 pub async fn create_rule(
-    _auth: RequireWrite,
+    // AAASM-3894: alert rules carry no team_id/org_id, so a Write-scope key in
+    // any tenant could otherwise mutate every tenant's alerting. Alerting is
+    // admin-managed infrastructure, so gate all mutations on admin scope.
+    // (Deeper per-object tenant tagging is tracked as a follow-up.)
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     Json(body): Json<AlertRuleRequest>,
 ) -> Result<(StatusCode, Json<AlertRuleResponse>), ProblemDetail> {
@@ -264,7 +268,8 @@ pub async fn get_rule(
     tag = "alert-rules"
 )]
 pub async fn update_rule(
-    _auth: RequireWrite,
+    // AAASM-3894: admin-gated — see `create_rule`.
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
     Json(body): Json<AlertRuleRequest>,
@@ -295,7 +300,8 @@ pub async fn update_rule(
     tag = "alert-rules"
 )]
 pub async fn delete_rule(
-    _auth: RequireWrite,
+    // AAASM-3894: admin-gated — see `create_rule`.
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ProblemDetail> {

--- a/aa-api/src/routes/auth.rs
+++ b/aa-api/src/routes/auth.rs
@@ -71,10 +71,21 @@ pub async fn issue_token(
         None => caller.scopes.clone(),
     };
 
-    let token = jwt_signer.sign(&caller.key_id, &token_scopes).map_err(|e| {
-        ProblemDetail::from_status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
-            .with_detail(format!("Failed to sign token: {e}"))
-    })?;
+    // AAASM-3894: carry the caller's tenant into the issued JWT. `sign` drops
+    // team_id/org_id, so a tenant-confined key's token would lose its tenant
+    // scope and fall back to admin-only cross-tenant gating on the per-tenant
+    // data endpoints. Propagate the tenant so the issued token stays confined.
+    let token = jwt_signer
+        .sign_with_tenant(
+            &caller.key_id,
+            &token_scopes,
+            caller.tenant.team_id.clone(),
+            caller.tenant.org_id.clone(),
+        )
+        .map_err(|e| {
+            ProblemDetail::from_status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+                .with_detail(format!("Failed to sign token: {e}"))
+        })?;
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -12,7 +12,7 @@ use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
-use crate::auth::scope::{RequireRead, RequireWrite};
+use crate::auth::scope::{RequireAdmin, RequireRead};
 use crate::destinations::connectors::slack::SlackConnector;
 use crate::destinations::connectors::webhook::WebhookConnector;
 use crate::destinations::connectors::{ConnectorError, DispatchRequest, NotificationConnector};
@@ -377,7 +377,12 @@ pub async fn list_destinations(
     tag = "alert-destinations"
 )]
 pub async fn create_destination(
-    _auth: RequireWrite,
+    // AAASM-3894: destinations carry no team_id/org_id, so a Write-scope key in
+    // any tenant could otherwise create/modify/delete/test-fire every tenant's
+    // notification targets. Destinations are admin-managed infrastructure, so
+    // gate all mutations (incl. the egressing test-fire) on admin scope.
+    // (Deeper per-object tenant tagging is tracked as a follow-up.)
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     body: Bytes,
 ) -> Result<(StatusCode, Json<DestinationResponse>), ProblemDetail> {
@@ -434,7 +439,8 @@ pub async fn get_destination(
     tag = "alert-destinations"
 )]
 pub async fn update_destination(
-    _auth: RequireWrite,
+    // AAASM-3894: admin-gated — see `create_destination`.
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
     body: Bytes,
@@ -488,7 +494,8 @@ pub async fn update_destination(
     tag = "alert-destinations"
 )]
 pub async fn delete_destination(
-    _auth: RequireWrite,
+    // AAASM-3894: admin-gated — see `create_destination`.
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ProblemDetail> {
@@ -518,7 +525,8 @@ pub async fn delete_destination(
     tag = "alert-destinations"
 )]
 pub async fn test_destination(
-    _auth: RequireWrite,
+    // AAASM-3894: admin-gated — see `create_destination`.
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
     body: Option<Json<TestDestinationRequest>>,
@@ -601,8 +609,8 @@ mod tests {
     use crate::auth::scope::Scope;
     use crate::auth::{AuthenticatedCaller, Tenant};
 
-    fn writer() -> RequireWrite {
-        RequireWrite(AuthenticatedCaller {
+    fn admin() -> RequireAdmin {
+        RequireAdmin(AuthenticatedCaller {
             key_id: "k".to_string(),
             scopes: vec![Scope::Admin],
             tenant: Tenant::default(),
@@ -651,7 +659,7 @@ mod tests {
             true,
         );
         // SSRF egress guard (AAASM-3789): a loopback target is refused before dispatch.
-        let failure = test_destination(writer(), Extension(state), Path(dest.id), None)
+        let failure = test_destination(admin(), Extension(state), Path(dest.id), None)
             .await
             .expect_err("loopback target rejected");
         assert_eq!(failure.into_response().status(), StatusCode::BAD_REQUEST);
@@ -675,7 +683,7 @@ mod tests {
                 },
                 true,
             );
-            let failure = test_destination(writer(), Extension(state), Path(dest.id), None)
+            let failure = test_destination(admin(), Extension(state), Path(dest.id), None)
                 .await
                 .expect_err("internal slack target rejected before dispatch");
             assert_eq!(
@@ -705,7 +713,7 @@ mod tests {
         }))
         .unwrap();
         let _ = update_destination(
-            writer(),
+            admin(),
             Extension(state.clone()),
             Path(dest.id.clone()),
             Bytes::from(body),
@@ -727,7 +735,7 @@ mod tests {
         let state = AppState::local_in_memory().expect("state builds");
         let body = serde_json::to_vec(&serde_json::json!({ "name": "x" })).unwrap();
         let err = update_destination(
-            writer(),
+            admin(),
             Extension(state),
             Path("dst_missing".to_string()),
             Bytes::from(body),

--- a/aa-api/src/routes/tools.rs
+++ b/aa-api/src/routes/tools.rs
@@ -4,6 +4,7 @@ use aa_core::DevToolInfo;
 use axum::{Extension, Json};
 use utoipa::ToSchema;
 
+use crate::auth::scope::RequireRead;
 use crate::error::ProblemDetail;
 use crate::state::AppState;
 
@@ -39,7 +40,13 @@ pub struct ToolInfoSchema {
         (status = 200, description = "Discovered tools", body = Vec<ToolInfoSchema>)
     )
 )]
-pub async fn list_tools(Extension(state): Extension<AppState>) -> Result<Json<Vec<DevToolInfo>>, ProblemDetail> {
+pub async fn list_tools(
+    // AAASM-3894: require read scope. The discovered tool list includes each
+    // tool's on-host `install_path`, which must not be enumerable by any
+    // unauthenticated/unscoped principal.
+    _auth: RequireRead,
+    Extension(state): Extension<AppState>,
+) -> Result<Json<Vec<DevToolInfo>>, ProblemDetail> {
     let tools = state.discovery.discover_all().await;
     Ok(Json(tools))
 }

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -361,3 +361,95 @@ async fn create_with_unknown_severity_returns_invalid_severity() {
     let json = read_json(resp).await;
     assert_eq!(json["error_code"], "invalid_severity");
 }
+
+// ── AAASM-3894 — alert-rule mutations require admin scope ─────────────────────
+//
+// Alert rules carry no team_id/org_id, so before this fix any Write-scope key —
+// in any tenant — could create/update/delete every tenant's alerting. Gate the
+// mutations on admin scope; a non-admin (write-only) caller must be rejected.
+
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
+
+fn bearer(method: &str, uri: &str, token: &str, body: Option<serde_json::Value>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"));
+    match body {
+        Some(b) => {
+            builder = builder.header("content-type", "application/json");
+            builder.body(Body::from(b.to_string())).unwrap()
+        }
+        None => builder.body(Body::empty()).unwrap(),
+    }
+}
+
+#[tokio::test]
+async fn create_rule_write_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    let resp = app
+        .oneshot(bearer("POST", "/api/v1/alerts/rules", &token, Some(valid_rule_body())))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-admin write caller must not create an alert rule"
+    );
+}
+
+#[tokio::test]
+async fn update_rule_write_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    let resp = app
+        .oneshot(bearer(
+            "PUT",
+            "/api/v1/alerts/rules/any-id",
+            &token,
+            Some(valid_rule_body()),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-admin write caller must not update an alert rule"
+    );
+}
+
+#[tokio::test]
+async fn delete_rule_write_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    let resp = app
+        .oneshot(bearer("DELETE", "/api/v1/alerts/rules/any-id", &token, None))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-admin write caller must not delete an alert rule"
+    );
+}
+
+#[tokio::test]
+async fn create_rule_admin_token_is_allowed() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt("admin", &[Scope::Admin]);
+    let resp = app
+        .oneshot(bearer("POST", "/api/v1/alerts/rules", &token, Some(valid_rule_body())))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "an admin caller must be able to create an alert rule"
+    );
+}

--- a/aa-api/tests/auth_jwt.rs
+++ b/aa-api/tests/auth_jwt.rs
@@ -131,3 +131,62 @@ async fn test_token_endpoint_respects_scope_subset() {
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
+
+// ── AAASM-3894 — issued JWT retains the caller's tenant ───────────────────────
+//
+// `issue_token` previously signed without the caller's tenant, so a
+// tenant-confined API key's issued JWT lost its team_id/org_id and fell back to
+// admin-only cross-tenant gating. The issued token must carry the caller's
+// tenant claims through verification.
+
+#[tokio::test]
+async fn issued_jwt_retains_caller_tenant() {
+    use aa_api::auth::api_key::{ApiKey, ApiKeyEntry};
+    use aa_api::auth::jwt::JwtVerifier;
+
+    // Must match the test harness JWT secret in `common`.
+    const TEST_SECRET: &[u8] = b"test-secret-key-that-is-at-least-32-bytes-long!!";
+
+    let key = ApiKey::generate();
+    let entry = ApiKeyEntry {
+        id: "key-tenant".to_string(),
+        key_hash: key.hash().expect("hashing should succeed"),
+        scopes: vec![Scope::Read, Scope::Write],
+        created_at: 1700000000,
+        label: Some("tenant key".to_string()),
+        team_id: Some("alpha".to_string()),
+        org_id: Some("org-1".to_string()),
+    };
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {}", key.as_str()))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let token = json["token"].as_str().expect("response carries a token");
+
+    // The issued JWT must still carry the caller's tenant claims.
+    let claims = JwtVerifier::new(TEST_SECRET).verify(token).expect("token verifies");
+    assert_eq!(
+        claims.team_id.as_deref(),
+        Some("alpha"),
+        "issued JWT dropped the caller's team_id"
+    );
+    assert_eq!(
+        claims.org_id.as_deref(),
+        Some("org-1"),
+        "issued JWT dropped the caller's org_id"
+    );
+}

--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -524,8 +524,9 @@ async fn webhook_secret_header_is_not_returned_in_cleartext() {
     let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
     let app = aa_api::build_app(state);
 
-    // A write caller creates a webhook destination with a secret.
-    let write_token = common::generate_test_jwt("w", &[Scope::Write]);
+    // An admin caller creates a webhook destination with a secret.
+    // AAASM-3894: destination mutations now require admin scope.
+    let write_token = common::generate_test_jwt("w", &[Scope::Admin]);
     let payload = json!({
         "name": "hook",
         "kind": "webhook",

--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -838,3 +838,110 @@ async fn update_destination_with_malformed_json_returns_400() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
+
+// ── AAASM-3894 — destination mutations require admin scope ────────────────────
+//
+// Destinations carry no team_id/org_id, so before this fix any Write-scope key —
+// in any tenant — could create/update/delete/test-fire every tenant's
+// notification targets. Gate the mutations on admin scope; a non-admin
+// (write-only) caller must be rejected, while an admin caller is allowed.
+
+#[tokio::test]
+async fn create_destination_write_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    let resp = app
+        .oneshot(bearer_json(
+            "POST",
+            "/api/v1/alerts/destinations",
+            &token,
+            webhook_payload("hook", "https://example.com/hook"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-admin write caller must not create a destination"
+    );
+}
+
+#[tokio::test]
+async fn update_destination_write_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    let resp = app
+        .oneshot(bearer_json(
+            "PUT",
+            "/api/v1/alerts/destinations/dst_x",
+            &token,
+            json!({ "enabled": false }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-admin write caller must not update a destination"
+    );
+}
+
+#[tokio::test]
+async fn delete_destination_write_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    let resp = app
+        .oneshot(bearer_empty("DELETE", "/api/v1/alerts/destinations/dst_x", &token))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-admin write caller must not delete a destination"
+    );
+}
+
+#[tokio::test]
+async fn test_destination_write_only_token_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    let resp = app
+        .oneshot(bearer_json(
+            "POST",
+            "/api/v1/alerts/destinations/dst_x/test",
+            &token,
+            json!({ "severity": "LOW" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-admin write caller must not test-fire a destination"
+    );
+}
+
+#[tokio::test]
+async fn create_destination_admin_token_is_allowed() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt("admin", &[Scope::Admin]);
+    let resp = app
+        .oneshot(bearer_json(
+            "POST",
+            "/api/v1/alerts/destinations",
+            &token,
+            webhook_payload("hook", "https://example.com/hook"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "an admin caller must be able to create a destination"
+    );
+}

--- a/aa-api/tests/tools.rs
+++ b/aa-api/tests/tools.rs
@@ -42,3 +42,53 @@ async fn get_tools_returns_empty_array_when_no_tools() {
         "expected empty array when no tools are installed"
     );
 }
+
+// ── AAASM-3894 — /tools requires read scope ───────────────────────────────────
+//
+// The discovered tool list exposes each tool's on-host `install_path`, so it
+// must not be enumerable without authentication. An unauthenticated caller is
+// rejected (401); a read-scoped caller is allowed (200).
+
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
+
+#[tokio::test]
+async fn get_tools_without_token_is_401() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/tools").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "an unauthenticated caller must not enumerate dev tools"
+    );
+}
+
+#[tokio::test]
+async fn get_tools_with_read_token_is_200() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("r", &[Scope::Read]);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/tools")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "a read-scoped caller must be able to list dev tools"
+    );
+}


### PR DESCRIPTION
## Description

Closes the LOW-severity aa-api tenant-isolation + scope gaps from AAASM-3894:

- **alert-rules mutations** (`create`/`update`/`delete`): were gated on `RequireWrite` with no tenant binding. `AlertRule` carries no `team_id`/`org_id`, so any Write-scope key in any tenant could list/modify/delete every tenant's alerting (cross-tenant tamper/DoS). **Decision:** require **admin** scope. Alerting is admin-managed infrastructure and the objects have no tenant dimension, so admin-gating is the clean, correct fix; reads stay `RequireRead`. Adding per-object tenant ownership (store + types + dashboard) is larger than this LOW ticket and is left as a follow-up (see below).
- **destinations mutations** (`create`/`update`/`delete`/`test`): same gap, same fix — require **admin**. The egressing `test`-fire is especially sensitive. Reads stay `RequireRead`.
- **`GET /api/v1/tools`**: had no scope extractor — any authenticated principal could enumerate installed dev tools and their on-host `install_path`. Added `RequireRead`.
- **`issue_token` (`POST /auth/token`)**: signed via `sign()` without the caller's tenant, so a tenant-confined key's issued JWT lost its `team_id`/`org_id`. Now uses `sign_with_tenant` to carry the caller's tenant into the issued token.

### Follow-up
Deeper per-object **tenant tagging** for alert rules and destinations (add `team_id`/`org_id` to the stored objects + filter reads/writes by tenant) would allow non-admin, tenant-scoped management. Tracked as a follow-up; out of scope for this LOW ticket.

## Type of Change

- [x] 🐛 Bug fix (security hardening)

## Breaking Changes

- [x] Yes — alert-rule and destination **mutations now require `admin` scope** (previously `write`). Read endpoints are unchanged. Bypass-mode and admin callers are unaffected.

## Related Issues

- Related Jira ticket: AAASM-3894

Closes AAASM-3894

## Testing

- [x] Integration tests added / updated
- Non-admin (write-only) callers are rejected (403) on alert-rule and destination mutations; admin callers succeed.
- `GET /tools` returns 401 without a token and 200 with a read-scoped token.
- A tenant-scoped API key's issued JWT retains its `team_id`/`org_id` through verification.
- Validation gate (run locally with a dedicated `CARGO_TARGET_DIR`): `cargo build -p aa-api`, `cargo nextest run -p aa-api` (852 passed), `cargo fmt --all --check`, `cargo clippy -p aa-api --all-targets -- -D warnings` (clean). OpenAPI: no drift (`generate_openapi` diff clean), so no spec/dashboard codegen change.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf