### PR TITLE
[AAASM-3888] 🔒 (aa-gateway): Authorize gRPC batch_check + op-control plane

### DIFF
--- a/aa-gateway/src/ops/nats.rs
+++ b/aa-gateway/src/ops/nats.rs
@@ -128,6 +128,30 @@ pub fn subject_for(envelope: &OpControlWireEnvelope) -> String {
     format!("{SUBJECT_PREFIX}.{tenant}.{agent}")
 }
 
+/// AAASM-3889 — authorize a received op-control message by binding its payload
+/// target to the subject it was actually delivered on.
+///
+/// The NATS subject namespace is the access-control boundary: a publisher is only
+/// trusted to act on the tenant / agent encoded in the subject it published to.
+/// Without this check the bridge acts on the envelope's `global` / `org_id` /
+/// `team_id` / `agent_id` fields **verbatim**, so any publisher able to reach
+/// *any* op-control subject could embed a different tenant — or `global: true` —
+/// in the JSON body and trigger a cross-tenant or fleet-wide kill, nullifying any
+/// NATS subject ACL. We re-derive the subject the payload *would* have been
+/// published under ([`subject_for`]) and require it to equal the delivery subject;
+/// a `global` envelope is additionally required to arrive on [`GLOBAL_SUBJECT`].
+fn subject_authorizes_envelope(subject: &str, envelope: &OpControlWireEnvelope) -> bool {
+    if envelope.global {
+        // A fleet-wide halt is only honored on the dedicated global subject.
+        return subject == GLOBAL_SUBJECT;
+    }
+    // A per-agent envelope must arrive on exactly the (sanitized) tenant/agent
+    // subject its own fields map to. `subject_for` never returns GLOBAL_SUBJECT
+    // for a non-global envelope, so a non-global payload published on the global
+    // subject is rejected here too.
+    subject_for(envelope) == subject
+}
+
 /// Replace every character outside `[A-Za-z0-9_-]` with `_` so the result is a
 /// single valid NATS subject token (NATS reserves `.`, `*`, `>` and whitespace).
 fn sanitize_token(raw: &str) -> String {
@@ -663,8 +687,21 @@ async fn bridge_once(
         let message = message.map_err(|e| OpControlNatsError::Consumer(e.to_string()))?;
         match serde_json::from_slice::<OpControlWireEnvelope>(&message.payload) {
             Ok(envelope) => {
-                metrics::counter!("aa_op_control_bridge_forwarded_total").increment(1);
-                forward_to_broadcast(publisher, envelope);
+                // AAASM-3889: reject a payload whose target does not match the
+                // subject it was delivered on (a forged tenant / global flag).
+                if subject_authorizes_envelope(message.subject.as_str(), &envelope) {
+                    metrics::counter!("aa_op_control_bridge_forwarded_total").increment(1);
+                    forward_to_broadcast(publisher, envelope);
+                } else {
+                    metrics::counter!("aa_op_control_bridge_rejected_total").increment(1);
+                    tracing::warn!(
+                        subject = %message.subject,
+                        expected_subject = %subject_for(&envelope),
+                        global = envelope.global,
+                        "op-control bridge: dropping envelope whose payload target does not match its \
+                         delivery subject (possible forgery)"
+                    );
+                }
             }
             Err(err) => {
                 tracing::warn!(%err, "op-control bridge: dropping undecodable message");

--- a/aa-gateway/src/ops/nats.rs
+++ b/aa-gateway/src/ops/nats.rs
@@ -187,25 +187,103 @@ impl OpControlNatsError {
 }
 
 /// Runtime configuration for the op-control NATS bridge / publisher.
+///
+/// AAASM-3889 — the op-control bus is a **fleet kill switch**: anyone able to
+/// publish to it can pause / resume / terminate runtimes. The bus must therefore
+/// be treated as a trusted, authenticated channel, never a bare `nats://` URL on
+/// an open network. Authentication (a JWT credentials file or an nkey seed) and
+/// TLS are configured here and applied via [`async_nats::ConnectOptions`] for
+/// **both** the publisher (aa-api) and the consumer bridge (aa-gateway). They are
+/// **optional** so a single-host local/dev stack (a NATS server bound to
+/// loopback) still works unconfigured, but a production deployment MUST set
+/// `AA_OPCONTROL_NATS_CREDS` (or `AA_OPCONTROL_NATS_NKEY`) and
+/// `AA_OPCONTROL_NATS_TLS=1` so the bus is mutually-authenticated and encrypted.
+/// Payload-level forgery is additionally rejected at consume time
+/// ([`subject_authorizes_envelope`]).
 #[derive(Debug, Clone)]
 pub struct OpControlNatsConfig {
-    /// NATS server URL (e.g. `nats://127.0.0.1:4222`).
+    /// NATS server URL (e.g. `nats://127.0.0.1:4222` or `tls://host:4222`).
     pub url: String,
+    /// Path to a NATS JWT credentials file (`.creds`). `None` leaves the
+    /// connection unauthenticated (dev/local only). `AA_OPCONTROL_NATS_CREDS`.
+    pub creds_path: Option<String>,
+    /// NATS nkey seed for nkey authentication. Used when no credentials file is
+    /// set. `AA_OPCONTROL_NATS_NKEY`.
+    pub nkey: Option<String>,
+    /// Require TLS for the connection. `AA_OPCONTROL_NATS_TLS` (`1`/`true`).
+    pub tls: bool,
 }
 
 impl OpControlNatsConfig {
-    /// Build a config for the given NATS URL.
+    /// Build an unauthenticated, plaintext config for the given NATS URL
+    /// (local/dev). Production deployments use [`from_env`](Self::from_env) to
+    /// pick up credentials + TLS.
     pub fn new(url: impl Into<String>) -> Self {
-        Self { url: url.into() }
+        Self {
+            url: url.into(),
+            creds_path: None,
+            nkey: None,
+            tls: false,
+        }
     }
 
     /// Build a config from the environment, returning `None` (op-control NATS
     /// disabled) when `AA_OPCONTROL_NATS_URL` is unset — mirrors the audit
     /// consumer's `AA_AUDIT_NATS_URL` activation so both processes keep their
     /// existing in-process behavior unless explicitly configured.
+    ///
+    /// AAASM-3889: when the URL is set, the optional authentication / TLS knobs
+    /// are read too: `AA_OPCONTROL_NATS_CREDS` (JWT creds file path),
+    /// `AA_OPCONTROL_NATS_NKEY` (nkey seed), and `AA_OPCONTROL_NATS_TLS`
+    /// (`1`/`true` to require TLS). A production op-control bus should set the
+    /// credentials and TLS knobs; leaving them unset keeps the loopback dev path.
     pub fn from_env() -> Option<Self> {
         let url = std::env::var("AA_OPCONTROL_NATS_URL").ok().filter(|u| !u.is_empty())?;
-        Some(Self::new(url))
+        let creds_path = std::env::var("AA_OPCONTROL_NATS_CREDS").ok().filter(|c| !c.is_empty());
+        let nkey = std::env::var("AA_OPCONTROL_NATS_NKEY").ok().filter(|c| !c.is_empty());
+        let tls = std::env::var("AA_OPCONTROL_NATS_TLS")
+            .ok()
+            .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+            .unwrap_or(false);
+        Some(Self {
+            url,
+            creds_path,
+            nkey,
+            tls,
+        })
+    }
+
+    /// Build the [`async_nats::ConnectOptions`] described by this config, applying
+    /// the credentials file / nkey seed and TLS requirement (AAASM-3889).
+    ///
+    /// Enabling TLS requires a process-wide `rustls` crypto provider installed by
+    /// the host binary before [`connect`](Self::connect) is called.
+    async fn connect_options(&self) -> Result<async_nats::ConnectOptions, OpControlNatsError> {
+        let mut opts = async_nats::ConnectOptions::new();
+        if let Some(creds) = &self.creds_path {
+            opts = opts
+                .credentials_file(creds)
+                .await
+                .map_err(|e| OpControlNatsError::Connect(format!("loading NATS credentials file {creds}: {e}")))?;
+        } else if let Some(seed) = &self.nkey {
+            opts = opts.nkey(seed.clone());
+        }
+        if self.tls {
+            opts = opts.require_tls(true);
+        }
+        Ok(opts)
+    }
+
+    /// Connect to the configured NATS server, applying authentication + TLS
+    /// (AAASM-3889). Used by both the publisher and the consumer bridge so the
+    /// op-control bus is never reached over a bare, unauthenticated connection in
+    /// a configured deployment.
+    pub async fn connect(&self) -> Result<async_nats::Client, OpControlNatsError> {
+        self.connect_options()
+            .await?
+            .connect(self.url.clone())
+            .await
+            .map_err(|e| OpControlNatsError::Connect(e.to_string()))
     }
 }
 
@@ -365,10 +443,11 @@ impl OpControlNatsPublisher {
     }
 
     /// Connect to the server described by `config` and wrap the client.
+    ///
+    /// AAASM-3889: applies the configured NATS authentication (creds/nkey) + TLS
+    /// via [`OpControlNatsConfig::connect`] rather than a bare `connect(url)`.
     pub async fn connect(config: &OpControlNatsConfig) -> Result<Self, OpControlNatsError> {
-        let client = async_nats::connect(&config.url)
-            .await
-            .map_err(|e| OpControlNatsError::Connect(e.to_string()))?;
+        let client = config.connect().await?;
         Ok(Self::new(client))
     }
 
@@ -553,9 +632,9 @@ async fn bridge_once(
     publisher: &SharedOpControlPublisher,
     health: &OpControlBridgeHealth,
 ) -> Result<(), OpControlNatsError> {
-    let client = async_nats::connect(&config.url)
-        .await
-        .map_err(|e| OpControlNatsError::Connect(e.to_string()))?;
+    // AAASM-3889: connect with the configured auth (creds/nkey) + TLS, not a bare
+    // unauthenticated connection.
+    let client = config.connect().await?;
     let context = jetstream::new(client);
     let stream = ensure_op_control_stream(&context).await?;
     let consumer = stream

--- a/aa-gateway/src/ops/nats.rs
+++ b/aa-gateway/src/ops/nats.rs
@@ -783,6 +783,64 @@ mod tests {
         assert_eq!(subject_for(&g), GLOBAL_SUBJECT);
     }
 
+    // ── AAASM-3889: subject↔payload binding (anti-forgery on consume) ───────
+
+    #[test]
+    fn subject_authorizes_a_payload_published_under_its_own_subject() {
+        // A legitimately-published per-agent envelope arrives on exactly the
+        // subject `subject_for` produces — so it is authorized.
+        let e = env(
+            false,
+            "acme",
+            "payments",
+            "bot-7",
+            "agent:bot-7",
+            OpControlSignal::Terminate,
+        );
+        assert!(subject_authorizes_envelope(&subject_for(&e), &e));
+
+        // A legitimate global halt on the global subject is authorized.
+        let g = env(true, "", "", "", GLOBAL_HALT_OP_ID, OpControlSignal::Terminate);
+        assert!(subject_authorizes_envelope(GLOBAL_SUBJECT, &g));
+    }
+
+    #[test]
+    fn subject_rejects_a_forged_cross_tenant_payload() {
+        // Payload targets `victim-org/victim` but was delivered on the
+        // attacker's own subject — reject (cross-tenant forgery).
+        let forged = env(
+            false,
+            "victim-org",
+            "victim-team",
+            "victim",
+            "agent:victim",
+            OpControlSignal::Terminate,
+        );
+        assert!(!subject_authorizes_envelope(
+            "assembly.opcontrol.attacker.attacker",
+            &forged
+        ));
+    }
+
+    #[test]
+    fn subject_rejects_a_forged_global_payload_not_on_the_global_subject() {
+        // Payload claims `global: true` (fleet-wide kill) but was delivered on a
+        // tenant subject the attacker could publish to — reject.
+        let forged_global = env(true, "", "", "", GLOBAL_HALT_OP_ID, OpControlSignal::Terminate);
+        assert!(!subject_authorizes_envelope(
+            "assembly.opcontrol.attacker.bot",
+            &forged_global
+        ));
+    }
+
+    #[test]
+    fn subject_rejects_a_non_global_payload_on_the_global_subject() {
+        // The inverse: a per-agent payload smuggled onto the global subject must
+        // not be honored (it would otherwise broadcast to every subscriber).
+        let per_agent = env(false, "acme", "", "bot-7", "agent:bot-7", OpControlSignal::Terminate);
+        assert!(!subject_authorizes_envelope(GLOBAL_SUBJECT, &per_agent));
+    }
+
     #[test]
     fn wire_envelope_round_trips_through_json() {
         let original = env(

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1486,6 +1486,22 @@ impl PolicyService for PolicyServiceImpl {
         let mut responses = Vec::with_capacity(batch.requests.len());
 
         for req in &batch.requests {
+            // AAASM-3888: validate the supplied `credential_token` against the
+            // registered token for the claimed `agent_id` BEFORE any evaluation
+            // or side-effect (audit / spend / suspend), exactly as `check_action`
+            // does. PolicyService runs under the non-rejecting `enrich`
+            // interceptor, so the request-body `{org,team,agent}` triple and
+            // `credential_token` are attacker-controlled; without this check a
+            // peer at :50051 could forge a victim identity per batch entry and
+            // drive forged audit, budget-exhaustion spend, or agent suspension
+            // against the victim. On rejection, push the Deny and skip all
+            // side-effects for this request — `evaluate_one`'s tenancy-anchoring
+            // invariant (which assumes validation already ran) is thereby upheld.
+            if let Some(rejection) = self.validate_credential_token(req).await {
+                responses.push(rejection);
+                continue;
+            }
+
             let (eval, latency_us, policy_rule) = self.evaluate_one(req)?;
             self.maybe_emit_secret_alert(req, &eval);
 

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -31,6 +31,7 @@ use crate::approval::routing_config::RoutingConfigStore;
 use crate::engine::{
     resolve_enforcement_mode, transform_for_observe_mode, DenyAction, EvaluationResult, PolicyEngine, ShadowEvent,
 };
+use crate::iam::VerifiedCaller;
 use crate::ops::{OpsRegistry, SharedOpControlPublisher};
 use crate::registry::convert::proto_agent_id_to_key;
 use crate::registry::{AgentRegistry, SuspendReason};
@@ -1550,14 +1551,44 @@ impl PolicyService for PolicyServiceImpl {
     /// Returns `Status::unavailable` when no publisher is attached to the
     /// service (tests / partial wiring), and `Status::invalid_argument`
     /// when the request omits `agent_id`.
+    ///
+    /// AAASM-3889: the subscription is authorized before any signal is served.
+    /// When an [`AgentRegistry`] is attached (a tenanted deployment), the caller
+    /// MUST present a credential token that the `enrich` interceptor resolved to
+    /// a [`VerifiedCaller`] (absent → `Status::unauthenticated`), and the
+    /// requested `{org,team,agent}` triple MUST resolve to the caller's own
+    /// registered identity (mismatch → `Status::permission_denied`). Without this
+    /// a credential-less peer could subscribe with an arbitrary triple and read
+    /// another tenant's pause/resume/terminate signals + op_ids. The check is
+    /// skipped only when no registry is attached (test fixtures / untenanted
+    /// deployments), mirroring [`validate_credential_token`].
     async fn op_control_stream(
         &self,
         request: Request<OpControlSubscribeRequest>,
     ) -> Result<Response<Self::OpControlStreamStream>, Status> {
+        // Read the interceptor-injected caller BEFORE `into_inner` drops the
+        // request extensions.
+        let caller = request.extensions().get::<VerifiedCaller>().cloned();
         let req = request.into_inner();
         let Some(agent_id) = req.agent_id else {
             return Err(Status::invalid_argument("agent_id is required"));
         };
+
+        // AAASM-3889: bind the subscription to the authenticated caller's own
+        // identity when the registry layer is active.
+        if self.registry.is_some() {
+            let Some(caller) = caller else {
+                return Err(Status::unauthenticated(
+                    "op_control_stream requires a valid credential token",
+                ));
+            };
+            if proto_agent_id_to_key(&agent_id) != caller.agent_key {
+                return Err(Status::permission_denied(
+                    "op_control_stream subscription must match the caller's own agent identity",
+                ));
+            }
+        }
+
         let Some(publisher) = self.ops_publisher.clone() else {
             return Err(Status::unavailable("op control channel not configured"));
         };

--- a/aa-gateway/tests/batch_check_credential_validation_test.rs
+++ b/aa-gateway/tests/batch_check_credential_validation_test.rs
@@ -1,0 +1,292 @@
+//! AAASM-3888 regression — `batch_check` must validate the supplied
+//! `credential_token` against the claimed agent's registered token BEFORE any
+//! evaluation or side-effect (audit / spend / suspend), exactly as `check_action`
+//! does.
+//!
+//! PolicyService runs under the non-rejecting `enrich` interceptor, so the
+//! request-body `{org,team,agent}` triple and `credential_token` are
+//! attacker-controlled. Before the fix, `batch_check` looped
+//! `evaluate_one` + `record_audit` / `record_spend` / `maybe_suspend_agent`
+//! without ever calling `validate_credential_token`, letting a credential-less
+//! peer forge a victim identity per batch entry (forged audit, budget-exhaustion
+//! spend, victim suspension).
+//!
+//! These tests drive `batch_check` on the trait impl directly (no tonic server),
+//! so the registry, the audit channel, and the budget tracker can all be
+//! inspected for side-effects.
+
+use std::io::Write;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use aa_core::{AuditEntry, AuditEventType};
+use aa_gateway::registry::convert::proto_agent_id_to_key;
+use aa_gateway::registry::store::AgentRecord;
+use aa_gateway::registry::{AgentRegistry, AgentStatus};
+use aa_gateway::service::convert::hash_to_16;
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
+use aa_proto::assembly::policy::v1::{
+    action_context::Action, ActionContext, BatchCheckRequest, CheckActionRequest, ToolCallContext,
+};
+use tonic::Request;
+
+/// A tool is allowed but a `suspend`-on-exceed budget is in force, so if
+/// `batch_check` were to (wrongly) evaluate a forged request whose victim is
+/// already over budget, the victim would be **suspended** — the side-effect these
+/// tests assert never happens.
+const SUSPEND_POLICY: &str = r#"
+version: "1"
+tools:
+  any_tool:
+    allow: true
+budget:
+  daily_limit_usd: 1.0
+  action_on_exceed: suspend
+"#;
+
+const VICTIM_ORG: &str = "victim-org";
+const VICTIM_TEAM: &str = "victim-team";
+const VICTIM_AGENT: &str = "victim";
+const VICTIM_TOKEN: &str = "tok_victim";
+
+fn victim_triple() -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: VICTIM_ORG.into(),
+        team_id: VICTIM_TEAM.into(),
+        agent_id: VICTIM_AGENT.into(),
+    }
+}
+
+fn victim_record(agent_key: [u8; 16]) -> AgentRecord {
+    AgentRecord {
+        agent_id: agent_key,
+        name: "victim-agent".into(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "pk_victim".into(),
+        credential_token: VICTIM_TOKEN.into(),
+        metadata: std::collections::BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: std::collections::VecDeque::new(),
+        recent_traces: Vec::new(),
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+        children: Vec::new(),
+        parent_key: None,
+        enforcement_mode: None,
+        org_id: None,
+    }
+}
+
+/// A batch entry that claims the (public, non-secret) victim triple and presents
+/// `token` as the credential.
+fn forged_request(token: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(victim_triple()),
+        credential_token: token.into(),
+        trace_id: "forged-trace".into(),
+        span_id: "forged-span".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "any_tool".into(),
+                tool_source: "attacker".into(),
+                args_json: b"{}".to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+        caller_agent_id: None,
+    }
+}
+
+/// Build a service with an attached registry + a registered, over-budget victim,
+/// returning the service and the receiving end of the audit channel so emitted
+/// audit entries can be inspected.
+fn service_with_over_budget_victim() -> (
+    Arc<PolicyServiceImpl>,
+    Arc<AgentRegistry>,
+    [u8; 16],
+    tokio::sync::mpsc::Receiver<AuditEntry>,
+) {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", SUSPEND_POLICY).unwrap();
+    tmp.flush().unwrap();
+
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap());
+    let registry = Arc::new(AgentRegistry::new());
+    let (audit_tx, audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+
+    let agent_key = proto_agent_id_to_key(&victim_triple());
+    registry.register(victim_record(agent_key)).unwrap();
+
+    // Push the victim's budget over the daily limit. The budget key is derived
+    // from the request's `agent_id` string (`hash_to_16`), so this is exactly the
+    // bucket the forged request would charge.
+    let victim_ctx = aa_core::AgentContext {
+        agent_id: aa_core::identity::AgentId::from_bytes(hash_to_16(VICTIM_AGENT)),
+        session_id: aa_core::identity::SessionId::from_bytes([0u8; 16]),
+        pid: 0,
+        started_at: aa_core::time::Timestamp::from_nanos(0),
+        metadata: std::collections::BTreeMap::new(),
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+    };
+    engine.record_spend(&victim_ctx, 2.0); // exceeds the $1.0 daily limit
+
+    let service = PolicyServiceImpl::with_registry(engine, Arc::clone(&registry), audit_tx, audit_drops, [0u8; 32]);
+    (Arc::new(service), registry, agent_key, audit_rx)
+}
+
+/// Drain the audit channel, returning whether an impersonation entry and/or a
+/// tool-call / budget (policy-violation) entry were emitted.
+fn drain_audit(rx: &mut tokio::sync::mpsc::Receiver<AuditEntry>) -> (bool, bool) {
+    let mut saw_impersonation = false;
+    let mut saw_tool_or_violation = false;
+    while let Ok(entry) = rx.try_recv() {
+        match entry.event_type() {
+            AuditEventType::A2AImpersonationAttempted => saw_impersonation = true,
+            AuditEventType::ToolCallIntercepted | AuditEventType::PolicyViolation => saw_tool_or_violation = true,
+            _ => {}
+        }
+    }
+    (saw_impersonation, saw_tool_or_violation)
+}
+
+#[tokio::test]
+async fn batch_check_rejects_empty_credential_token_with_no_side_effects() {
+    let (service, registry, agent_key, mut audit_rx) = service_with_over_budget_victim();
+
+    let batch = BatchCheckRequest {
+        requests: vec![forged_request("")],
+    };
+    let resp = service
+        .batch_check(Request::new(batch))
+        .await
+        .expect("batch_check should return a response")
+        .into_inner();
+
+    // The forged entry is rejected as an impersonation attempt — never evaluated.
+    assert_eq!(resp.responses.len(), 1);
+    let r = &resp.responses[0];
+    assert_eq!(r.decision, Decision::Deny as i32);
+    assert_eq!(r.policy_rule, "a2a_identity_verification");
+    assert_eq!(r.reason, "missing credential token");
+
+    // No suspend side-effect: the over-budget victim is still Active. Had
+    // batch_check evaluated the forged request, action_on_exceed=suspend would
+    // have suspended the victim.
+    assert_eq!(
+        registry.agent_status(&agent_key).unwrap(),
+        AgentStatus::Active,
+        "a forged batch entry must not suspend the victim agent",
+    );
+
+    // No forged tool-call / budget audit attributed to the victim — only the
+    // impersonation rejection itself is recorded.
+    let (saw_impersonation, saw_tool_or_violation) = drain_audit(&mut audit_rx);
+    assert!(
+        saw_impersonation,
+        "the rejection must be audited as an impersonation attempt"
+    );
+    assert!(
+        !saw_tool_or_violation,
+        "a forged batch entry must not produce a tool-call / budget audit attributed to the victim",
+    );
+}
+
+#[tokio::test]
+async fn batch_check_rejects_mismatched_credential_token_with_no_side_effects() {
+    let (service, registry, agent_key, mut audit_rx) = service_with_over_budget_victim();
+
+    let batch = BatchCheckRequest {
+        requests: vec![forged_request("wrong-token")],
+    };
+    let resp = service
+        .batch_check(Request::new(batch))
+        .await
+        .expect("batch_check should return a response")
+        .into_inner();
+
+    assert_eq!(resp.responses.len(), 1);
+    let r = &resp.responses[0];
+    assert_eq!(r.decision, Decision::Deny as i32);
+    assert_eq!(r.policy_rule, "a2a_identity_verification");
+    assert_eq!(r.reason, "credential token mismatch");
+
+    assert_eq!(
+        registry.agent_status(&agent_key).unwrap(),
+        AgentStatus::Active,
+        "a forged batch entry must not suspend the victim agent",
+    );
+
+    let (saw_impersonation, saw_tool_or_violation) = drain_audit(&mut audit_rx);
+    assert!(
+        saw_impersonation,
+        "the rejection must be audited as an impersonation attempt"
+    );
+    assert!(
+        !saw_tool_or_violation,
+        "a forged batch entry must not produce a tool-call / budget audit attributed to the victim",
+    );
+}
+
+#[tokio::test]
+async fn batch_check_still_evaluates_a_request_with_a_valid_credential_token() {
+    // Positive control: the fix must not over-reject. A legitimate batch entry
+    // (correct token, agent under budget) is still evaluated and allowed.
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", SUSPEND_POLICY).unwrap();
+    tmp.flush().unwrap();
+
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap());
+    let registry = Arc::new(AgentRegistry::new());
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+
+    let agent_key = proto_agent_id_to_key(&victim_triple());
+    registry.register(victim_record(agent_key)).unwrap();
+
+    let service = PolicyServiceImpl::with_registry(engine, Arc::clone(&registry), audit_tx, audit_drops, [0u8; 32]);
+
+    let batch = BatchCheckRequest {
+        requests: vec![forged_request(VICTIM_TOKEN)],
+    };
+    let resp = service
+        .batch_check(Request::new(batch))
+        .await
+        .expect("batch_check should return a response")
+        .into_inner();
+
+    assert_eq!(resp.responses.len(), 1);
+    assert_eq!(
+        resp.responses[0].decision,
+        Decision::Allow as i32,
+        "a valid-token batch entry must still be evaluated and allowed",
+    );
+}

--- a/aa-gateway/tests/op_control_nats_bridge_test.rs
+++ b/aa-gateway/tests/op_control_nats_bridge_test.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use aa_gateway::ops::nats::spawn_bridge;
+use aa_gateway::ops::nats::{spawn_bridge, OpControlWireEnvelope};
 use aa_gateway::ops::{
     HaltDelivery, OpControlNatsConfig, OpControlNatsPublisher, OpControlPublisher, OpsRegistry,
     SharedOpControlPublisher,
@@ -297,6 +297,106 @@ async fn halt_published_with_no_consumer_is_delivered_to_a_later_subscriber() {
         store.state(&aa_runtime::op_control::agent_halt_op_id("agent-9")),
         Some(aa_runtime::op_control::OpState::Terminated),
     );
+}
+
+/// AAASM-3889 regression — the bridge drops an envelope whose payload target does
+/// not match the subject it was delivered on, so a publisher able to reach *some*
+/// op-control subject cannot forge a different tenant — or a fleet-wide `global`
+/// kill — in the JSON body. Two forged messages are published directly to the
+/// durable stream under attacker-chosen subjects (a cross-tenant per-agent payload
+/// and a `global: true` payload off the global subject), followed by one
+/// legitimately-published halt. Only the legitimate halt must reach the
+/// subscriber.
+#[tokio::test]
+async fn bridge_drops_envelopes_whose_payload_does_not_match_their_subject() {
+    let host_port = free_port();
+    let url = format!("nats://127.0.0.1:{host_port}");
+    let _nats = start_nats(host_port).await;
+    ensure_stream(&url).await;
+
+    // Forge directly onto the durable stream, under attacker-chosen subjects, so
+    // the messages exist before any gateway consumer attaches (DeliverPolicy::All
+    // replays them in publish order).
+    let raw = async_nats::connect(&url).await.expect("connect to NATS");
+    let js = async_nats::jetstream::new(raw);
+
+    // (a) Cross-tenant per-agent forgery: payload targets victim-7 but is
+    // published under an attacker subject.
+    let forged_per_agent = OpControlWireEnvelope {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "victim-7".into(),
+        op_id: aa_runtime::op_control::agent_halt_op_id("victim-7"),
+        signal: OpControlSignal::Terminate as i32,
+        global: false,
+    };
+    js.publish(
+        "assembly.opcontrol.attacker.attacker".to_string(),
+        serde_json::to_vec(&forged_per_agent).unwrap().into(),
+    )
+    .await
+    .expect("publish forged per-agent")
+    .await
+    .expect("ack forged per-agent");
+
+    // (b) Forged fleet-wide kill: payload claims global:true but is published on a
+    // tenant subject the attacker can reach (not the global subject).
+    let forged_global = OpControlWireEnvelope {
+        org_id: String::new(),
+        team_id: String::new(),
+        agent_id: String::new(),
+        op_id: aa_runtime::op_control::GLOBAL_HALT_OP_ID.to_string(),
+        signal: OpControlSignal::Terminate as i32,
+        global: true,
+    };
+    js.publish(
+        "assembly.opcontrol.attacker.bot".to_string(),
+        serde_json::to_vec(&forged_global).unwrap().into(),
+    )
+    .await
+    .expect("publish forged global")
+    .await
+    .expect("ack forged global");
+
+    // (c) A legitimately-published halt for victim-7, distinguishable by its Pause
+    // signal (the forged ones used Terminate).
+    let api_publisher = OpControlNatsPublisher::connect(&OpControlNatsConfig::new(url.clone()))
+        .await
+        .expect("aa-api side connects to NATS");
+    api_publisher
+        .publish_agent_halt(agent("victim-7"), OpControlSignal::Pause)
+        .await
+        .expect("legit halt is durably published");
+
+    // Bring up the gateway: in-process broadcast + gRPC server + victim subscriber,
+    // then the bridge that replays all three persisted messages.
+    let publisher = Arc::new(OpControlPublisher::new());
+    let addr = start_server(Arc::clone(&publisher)).await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let mut stream = client
+        .op_control_stream(OpControlSubscribeRequest {
+            agent_id: Some(agent("victim-7")),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    await_grpc_subscriber(&publisher).await;
+    let _bridge = spawn_bridge(OpControlNatsConfig::new(url.clone()), Arc::clone(&publisher));
+
+    // The first (and only) message reaching the subscriber must be the legitimate
+    // Pause halt — both forged messages were dropped at the subject-binding gate.
+    // Had they been honored, a Terminate would have arrived first.
+    let msg = timeout(Duration::from_secs(15), stream.message())
+        .await
+        .expect("the legitimate halt must be delivered")
+        .expect("stream ok")
+        .expect("stream yields the legitimate halt");
+    assert_eq!(
+        msg.signal,
+        OpControlSignal::Pause as i32,
+        "only the legitimately-published (Pause) halt may reach the subscriber; a forged Terminate must be dropped",
+    );
+    assert_eq!(msg.op_id, aa_runtime::op_control::agent_halt_op_id("victim-7"));
 }
 
 /// Honest-failure: with JetStream up but **no op-control stream created**, a

--- a/aa-gateway/tests/op_control_stream_authz_test.rs
+++ b/aa-gateway/tests/op_control_stream_authz_test.rs
@@ -1,0 +1,195 @@
+//! AAASM-3889 regression — `op_control_stream` must authorize the subscriber.
+//!
+//! Before the fix the endpoint ran under the non-rejecting `enrich` interceptor
+//! and never validated a credential nor bound the subscription to the caller, so
+//! a credential-less peer could subscribe with an arbitrary `{org,team,agent}`
+//! triple and read another tenant's pause/resume/terminate signals + op_ids.
+//!
+//! These tests wire the production `enrich_interceptor` the same way
+//! `server::serve_tcp` does, with an `AgentRegistry` attached, and assert:
+//!   * a tokenless subscribe is rejected `Unauthenticated`;
+//!   * a valid-token subscribe for a *different* tenant's triple is rejected
+//!     `PermissionDenied`; and
+//!   * a valid-token subscribe for the caller's own identity is admitted and
+//!     receives its agent's halt.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_gateway::iam::{enrich_interceptor, CREDENTIAL_METADATA_KEY};
+use aa_gateway::ops::{OpControlPublisher, SharedOpControlPublisher};
+use aa_gateway::registry::convert::proto_agent_id_to_key;
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::{AgentRecord, AgentRegistry, AgentStatus, PolicyEngine};
+use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{OpControlSignal, OpControlSubscribeRequest};
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+
+const TOKEN: &str = "tok_caller";
+
+fn caller_triple() -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "caller-org".into(),
+        team_id: "caller-team".into(),
+        agent_id: "caller-agent".into(),
+    }
+}
+
+fn victim_triple() -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "victim-org".into(),
+        team_id: "victim-team".into(),
+        agent_id: "victim-agent".into(),
+    }
+}
+
+fn record(triple: &ProtoAgentId, token: &str) -> AgentRecord {
+    AgentRecord {
+        agent_id: proto_agent_id_to_key(triple),
+        name: "test-agent".into(),
+        framework: "custom".into(),
+        version: "0.0.1".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "deadbeef".into(),
+        credential_token: token.into(),
+        metadata: BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: vec![],
+        recent_events: VecDeque::new(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: Some(triple.team_id.clone()),
+        org_id: Some(triple.org_id.clone()),
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+        children: vec![],
+        parent_key: None,
+        enforcement_mode: None,
+    }
+}
+
+/// Start a PolicyService behind the production `enrich` interceptor with `registry`
+/// attached and `publisher` serving `op_control_stream`.
+async fn start_server(registry: Arc<AgentRegistry>, publisher: SharedOpControlPublisher) -> SocketAddr {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    writeln!(tmp, "version: \"1\"").unwrap();
+    tmp.flush().unwrap();
+
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap());
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::with_registry(engine, Arc::clone(&registry), audit_tx, audit_drops, [0u8; 32])
+        .with_ops_publisher(publisher);
+
+    let enrich = enrich_interceptor(Arc::clone(&registry));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::with_interceptor(service, enrich))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    addr
+}
+
+fn subscribe_req(triple: ProtoAgentId, token: Option<&str>) -> tonic::Request<OpControlSubscribeRequest> {
+    let mut req = tonic::Request::new(OpControlSubscribeRequest { agent_id: Some(triple) });
+    if let Some(t) = token {
+        req.metadata_mut().insert(CREDENTIAL_METADATA_KEY, t.parse().unwrap());
+    }
+    req
+}
+
+#[tokio::test]
+async fn op_control_stream_without_a_credential_is_unauthenticated() {
+    let registry = Arc::new(AgentRegistry::new());
+    registry.register(record(&caller_triple(), TOKEN)).unwrap();
+    let publisher = Arc::new(OpControlPublisher::new());
+    let addr = start_server(Arc::clone(&registry), Arc::clone(&publisher)).await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    // No credential token in metadata → enrich injects no VerifiedCaller.
+    let err = client
+        .op_control_stream(subscribe_req(caller_triple(), None))
+        .await
+        .expect_err("a tokenless subscribe must be rejected");
+    assert_eq!(err.code(), tonic::Code::Unauthenticated);
+}
+
+#[tokio::test]
+async fn op_control_stream_cross_tenant_triple_is_permission_denied() {
+    let registry = Arc::new(AgentRegistry::new());
+    registry.register(record(&caller_triple(), TOKEN)).unwrap();
+    let publisher = Arc::new(OpControlPublisher::new());
+    let addr = start_server(Arc::clone(&registry), Arc::clone(&publisher)).await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    // Valid credential, but the subscription targets another tenant's triple.
+    let err = client
+        .op_control_stream(subscribe_req(victim_triple(), Some(TOKEN)))
+        .await
+        .expect_err("a cross-tenant subscribe must be rejected");
+    assert_eq!(err.code(), tonic::Code::PermissionDenied);
+}
+
+#[tokio::test]
+async fn op_control_stream_own_identity_is_admitted_and_receives_its_halt() {
+    let registry = Arc::new(AgentRegistry::new());
+    registry.register(record(&caller_triple(), TOKEN)).unwrap();
+    let publisher = Arc::new(OpControlPublisher::new());
+    let addr = start_server(Arc::clone(&registry), Arc::clone(&publisher)).await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    // Valid credential for the caller's own identity → admitted.
+    let mut stream = client
+        .op_control_stream(subscribe_req(caller_triple(), Some(TOKEN)))
+        .await
+        .expect("an own-identity subscribe with a valid credential must be admitted")
+        .into_inner();
+
+    // Wait for the server-side subscription to register, then publish a halt for
+    // the caller's agent and confirm it is delivered.
+    for _ in 0..40 {
+        if publisher.subscriber_count() >= 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let op_id = aa_runtime::op_control::agent_halt_op_id("caller-agent");
+    publisher.publish(caller_triple(), op_id.clone(), OpControlSignal::Terminate);
+
+    let msg = tokio::time::timeout(Duration::from_secs(5), stream.message())
+        .await
+        .expect("halt should be delivered to the admitted subscriber")
+        .expect("stream ok")
+        .expect("stream yields the halt");
+    assert_eq!(msg.op_id, op_id);
+    assert_eq!(msg.signal, OpControlSignal::Terminate as i32);
+}


### PR DESCRIPTION
## Description

Closes two HIGH gRPC control-plane authZ gaps that both live in `aa-gateway/src/service/policy_service.rs`, so they ship as one PR to avoid a self-conflict.

**AAASM-3888 — `batch_check` skipped credential validation → impersonation.**
`PolicyService` runs under the non-rejecting `enrich` interceptor, so the request-body `{org,team,agent}` triple and `credential_token` are attacker-controlled. `check_action` calls `validate_credential_token`, but `batch_check` looped `evaluate_one` + `record_audit` / `record_spend` / `maybe_suspend_agent` without it — a credential-less peer could forge a victim identity per batch entry (forged WORM audit, budget-exhaustion spend, victim suspension, approvals as the victim). Fix: `batch_check` now validates the credential token on each entry **before** any evaluation or side-effect, mirroring `check_action`; on failure it pushes the Deny and `continue`s (no side-effects), upholding `evaluate_one`'s tenancy-anchoring invariant.

**AAASM-3889 — op-control plane: NATS bridge forgery + `op_control_stream` zero-auth.**
- **NATS consume (subject↔payload binding):** the bridge acted on each envelope's `global`/`org`/`team`/`agent` fields verbatim, never comparing them to the subject the message was delivered on, so any publisher reaching one op-control subject could embed a different tenant — or `global:true` — in the JSON body (cross-tenant / fleet-wide kill, nullifying the subject ACL). New `subject_authorizes_envelope` drops any message whose payload does not map back to its delivery subject, and any `global` payload not on the global subject.
- **NATS connection auth/TLS:** the bridge and publisher connected with a bare `async_nats::connect(url)` (unauthenticated, plaintext). They now connect via `async_nats::ConnectOptions` driven by `OpControlNatsConfig` — JWT credentials file (`AA_OPCONTROL_NATS_CREDS`), nkey seed (`AA_OPCONTROL_NATS_NKEY`), and TLS (`AA_OPCONTROL_NATS_TLS`). Optional so loopback dev still works; production can require them. The op-control bus trust model is documented in the module/config docs.
- **`op_control_stream` subscriber authZ:** the endpoint validated no credential and bound the subscription to nothing, so a credential-less peer could subscribe with an arbitrary triple and read another tenant's pause/resume/terminate signals + op_ids. When an `AgentRegistry` is attached it now requires a `VerifiedCaller` (absent → `Unauthenticated`) and rejects any triple that does not resolve to the caller's own registered identity (→ `PermissionDenied`). Skipped only when no registry is attached (untenanted/test deployments), mirroring `validate_credential_token`.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] No

Behaviour change for hardening: in a tenanted deployment (registry attached) `op_control_stream` now requires a valid credential bound to the caller's identity. `OpControlNatsConfig` gained optional `creds_path`/`nkey`/`tls` fields (all default to the previous plaintext/no-auth behaviour). No proto/OpenAPI changes — gRPC-only.

## Related Issues

- Related Jira tickets: AAASM-3888, AAASM-3889
- Closes AAASM-3888
- Closes AAASM-3889

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

- `batch_check_credential_validation_test`: forged (empty / mismatched) credential is denied as `a2a_identity_verification`; over-budget victim is **not** suspended and **no** forged tool-call/budget audit is emitted; a valid-token entry is still allowed.
- `nats::tests::subject_*`: unit tests for `subject_authorizes_envelope` (own-subject OK; cross-tenant, forged-global, and per-agent-on-global all rejected).
- `op_control_stream_authz_test`: tokenless → `Unauthenticated`; cross-tenant triple → `PermissionDenied`; own identity → admitted and receives its halt.
- `op_control_nats_bridge_test::bridge_drops_envelopes_whose_payload_does_not_match_their_subject`: real-NATS JetStream testcontainer — forged per-agent + forged global dropped, legit halt delivered.

Validation gate (all green): `cargo build -p aa-gateway`; `cargo nextest run -p aa-gateway` (1311 passed incl. the NATS e2e testcontainer tests); `cargo fmt --all -- --check`; `cargo clippy -p aa-gateway --all-targets -- -D warnings`. No OpenAPI drift (gRPC-only).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
