### PR TITLE
[AAASM-3893] 🔒 (policy): Fail-closed on schedule cache + numeric parse

### DIFF
--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -39,11 +39,16 @@ impl PolicyDecision {
 }
 
 /// Evaluate a single `PolicyDocument` against `(ctx, action)` and return the
-/// decision for stages 1–3 and 5 (schedule, network, tool-allow, approval-condition).
+/// decision for the *cacheable* stages 2–3 and 5 (network, tool-allow,
+/// capability, approval-condition).
 ///
-/// Stages 4 (rate-limit) and 7 (budget) are stateful at engine level and are
-/// evaluated separately after merging. Stage 6 (credential scan) does not
-/// produce a decision — it is handled at the engine level.
+/// Stage 1 (schedule) is deliberately **excluded** here: it is time-dependent
+/// and must be evaluated fresh on every request via [`evaluate_schedule_cascade`]
+/// so that a cached `Allow` computed inside an active-hours window cannot be
+/// served after the window closes (AAASM-3893). Stages 4 (rate-limit) and 7
+/// (budget) are stateful at engine level and are evaluated separately after
+/// merging. Stage 6 (credential scan) does not produce a decision — it is
+/// handled at the engine level.
 ///
 /// Returns `Deny` on the first matching deny rule, `RequireApproval` for approval
 /// conditions, and `Allow` if no rule fires.
@@ -53,9 +58,6 @@ pub(crate) fn evaluate_single_doc(
     action: &aa_core::GovernanceAction,
     policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
 ) -> PolicyDecision {
-    if let Some(d) = stage_schedule(doc) {
-        return d;
-    }
     if let Some(d) = stage_network(doc, action) {
         return d;
     }
@@ -70,6 +72,20 @@ pub(crate) fn evaluate_single_doc(
     }
 
     PolicyDecision::Allow
+}
+
+/// Stage 1 — Schedule, evaluated **fresh** across the whole cascade.
+///
+/// Returns the first schedule-based `Deny` (current time outside a doc's
+/// active-hours window, or an unparseable timezone), or `None` when every doc's
+/// window currently permits the request.
+///
+/// AAASM-3893: this stage is time-dependent and is intentionally kept out of
+/// [`evaluate_single_doc`] (and therefore out of the engine's decision cache).
+/// The caller runs it on every request so a cached verdict computed inside an
+/// active-hours window cannot outlive that window.
+pub(crate) fn evaluate_schedule_cascade(cascade: &[Arc<PolicyDocument>]) -> Option<PolicyDecision> {
+    cascade.iter().find_map(|doc| stage_schedule(doc))
 }
 
 /// Stage 1 — Schedule: deny when the current time is outside the doc's

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1194,7 +1194,22 @@ impl PolicyEngine {
         ctx: &aa_core::AgentContext,
         action: &aa_core::GovernanceAction,
     ) -> EvaluationResult {
-        // Cache lookup: stateless stages only (1–3, 5). Stateful stages (4, 7),
+        // Stage 1 — Schedule: time-dependent, evaluated FRESH on every request
+        // and never cached. The decision cache below stores only the stateless
+        // stages (2–3, 5); a cached `Allow` computed inside an active-hours
+        // window must not be served once the window has closed, so the schedule
+        // stage is run here, outside the cache, like the stateful stages 4 and 7
+        // (AAASM-3893).
+        if let Some(PolicyDecision::Deny { reason, .. }) = decision::evaluate_schedule_cascade(&cascade) {
+            return EvaluationResult {
+                decision: aa_core::PolicyResult::Deny { reason },
+                redacted_payload: None,
+                credential_findings: vec![],
+                deny_action: None,
+            };
+        }
+
+        // Cache lookup: stateless stages only (2–3, 5). Stateful stages (4, 7),
         // the capability guard, and the credential scan always run.
         let epoch = self.policy_epoch.load(Ordering::Relaxed);
         let cache_key = CacheKey::new(ctx.agent_id.as_bytes(), epoch, action);

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2139,6 +2139,45 @@ mod tests {
     }
 
     #[test]
+    fn cascade_schedule_denies_despite_stale_cached_allow() {
+        // AAASM-3893 regression: the schedule stage is time-dependent and must
+        // be evaluated FRESH on every cascade request. A decision cached while
+        // the active-hours window was open must NOT be served once the window
+        // has closed. We pre-seed the cache with the stale Allow a prior
+        // in-window evaluation would have stored, then evaluate against a
+        // now-closed window: the request must be DENIED, not served the cached
+        // Allow.
+        let mut doc = empty_doc();
+        doc.schedule = Some(SchedulePolicy {
+            active_hours: Some(ActiveHours {
+                start: "00:00".to_string(),
+                // An empty window (start == end == "00:00"): `current >= end`
+                // is always true, so this window is closed at every wall-clock
+                // time — the test is deterministic regardless of when it runs.
+                end: "00:00".to_string(),
+                timezone: "UTC".to_string(),
+            }),
+        });
+        let engine = make_engine(empty_doc());
+        let ctx = make_ctx();
+        let action = tool_call("any", "");
+
+        // Pre-seed the cache with the stale Allow a prior in-window eval stored.
+        let epoch = engine.policy_epoch.load(Ordering::Relaxed);
+        let key = CacheKey::new(ctx.agent_id.as_bytes(), epoch, &action);
+        engine.decision_cache.insert(key, PolicyDecision::Allow);
+
+        let cascade = vec![Arc::new(doc)];
+        assert_eq!(
+            engine.evaluate_with_cascade(cascade, &ctx, &action).decision,
+            PolicyResult::Deny {
+                reason: "outside active hours".into()
+            },
+            "a cached Allow must not survive the active-hours window closing",
+        );
+    }
+
+    #[test]
     fn data_pattern_redacts_on_custom_match() {
         // Stage 6 no longer denies — it redacts in-memory and sets credential_findings.
         let mut doc = empty_doc();

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -731,13 +731,23 @@ fn eval_string_equality(lhs: &str, op: &OpKind, literal: &LiteralVal) -> bool {
     }
 }
 
-/// Ordered numeric operators on a generic string field. Both sides must resolve
-/// to a number (`lhs` parsed from the string, `rhs` via [`numeric_literal`]);
-/// otherwise the comparison is a null-safe no-match (`false`).
+/// Ordered numeric operators (`> >= < <=`) on a generic string field. Both
+/// sides must resolve to a number (`lhs` parsed from the string, `rhs` via
+/// [`numeric_literal`]).
+///
+/// AAASM-3893: when either operand cannot be coerced to a number the magnitude
+/// comparison is undefined. This evaluator drives `requires_approval_if`, where
+/// a returned `false` means "no approval required" — so silently returning
+/// `false` on a coercion failure let a security guard not-match and the action
+/// proceed unguarded, a fail-open. Fail CLOSED instead: an unresolvable ordered
+/// comparison fires the predicate (requires approval), consistent with the
+/// module-level fail-safe-true posture for ambiguous evaluation. (Equality is
+/// unaffected — a non-numeric string is genuinely not equal to a number, so
+/// `eval_string_equality` correctly returns `false`.)
 fn eval_string_numeric(lhs: &str, op: &OpKind, literal: &LiteralVal) -> bool {
     match (lhs.parse::<f64>().ok(), numeric_literal(literal)) {
         (Some(l), Some(r)) => compare_ord(l, r, op),
-        _ => false,
+        _ => true,
     }
 }
 

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1305,6 +1305,20 @@ mod tests {
     }
 
     #[test]
+    fn ordered_numeric_comparison_on_unparseable_field_fails_closed() {
+        // AAASM-3893: an ordered numeric comparison whose operand cannot be
+        // coerced to a number is undefined. Because this evaluator drives
+        // `requires_approval_if` (where `false` = "no approval required"), a
+        // silent `false` here would let a security guard not-match and the
+        // action run unguarded — a fail-open. The undefined comparison must
+        // fail CLOSED: fire the predicate (require approval).
+        assert!(evaluate("command > 1000", &process("/usr/bin/deploy"), None, None));
+        // Equality is unaffected: a non-numeric command genuinely is not the
+        // number 5, so `==` correctly does not fire.
+        assert!(!evaluate("command == 5", &process("/usr/bin/deploy"), None, None));
+    }
+
+    #[test]
     fn field_absent_for_action_variant_returns_false() {
         // `tool` field is "" for ProcessExec → should NOT match "foo"
         assert!(!evaluate(r#"tool == "foo""#, &process("ls"), None, None));


### PR DESCRIPTION
## Description

Closes two Low-severity policy-evaluation fail-open residuals in `aa-gateway` (AAASM-3893):

1. **Cached schedule stage → post-window fail-open.** The cascade evaluation path cached the full `merge_decisions` verdict (which ran the time-dependent `stage_schedule` first) in a 60s-TTL `DecisionCache`. An `Allow` computed inside an active-hours window was therefore served for up to ~60s after the window closed. Fix: the schedule stage is removed from the cached merge unit (`evaluate_single_doc`) and run **fresh on every request** via a new `evaluate_schedule_cascade`, outside the cache — alongside the other uncached stateful stages (rate-limit, budget). The non-cascade `evaluate_primary` path already ran its schedule check uncached, so it was unaffected.

2. **Numeric ordered-comparison parse failure → silent no-match.** `policy/expr.rs::eval_string_numeric` returned `false` when an ordered comparison (`> >= < <=`) operand on a generic string field could not be coerced to a number. This evaluator drives `requires_approval_if`, where `false` means "no approval required", so a coercion failure silently let a security guard not-match and the action proceed unguarded. Fix: an unresolvable ordered comparison now **fails closed** (fires the predicate → require approval), consistent with the module's documented fail-safe-true posture.
   - Equality (`==`/`!=`, line 724) is intentionally left unchanged: a non-numeric string is genuinely not equal to a number, so `false` is the correct result there — flipping it would break every legitimate `field ==/!= N` policy. This was verified to not be a genuine fail-open.

## Type of Change

- [x] 🐛 Bug fix (security hardening — fail-closed)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3893
- Closes AAASM-3893

## Testing

- [x] Unit tests added / updated
- `cargo nextest run -p aa-gateway` — 1302 passed, 0 failed.
- New regressions:
  - `engine::tests::cascade_schedule_denies_despite_stale_cached_allow` — pre-seeds the decision cache with an `Allow`, then evaluates against a closed active-hours window; asserts the request is denied (schedule evaluated fresh, not from cache).
  - `policy::expr::tests::ordered_numeric_comparison_on_unparseable_field_fails_closed` — `command > 1000` on a non-numeric field fires (fail-closed); `command == 5` correctly stays false.
- `cargo build -p aa-gateway`, `cargo fmt --all -- --check`, `cargo clippy -p aa-gateway --all-targets -- -D warnings` all clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc-comments on the changed functions)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
