### PR TITLE
[AAASM-3892] 🔒 (aa-cli): Harden credential handling and sanitize server output

### DIFF
--- a/aa-cli/src/commands/agent/inspect.rs
+++ b/aa-cli/src/commands/agent/inspect.rs
@@ -9,6 +9,7 @@ use super::AgentResponse;
 use crate::client;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm agent inspect`.
 #[derive(Args)]
@@ -22,22 +23,31 @@ fn render_detail(agent: &AgentResponse) {
     let mut table = Table::new();
     table.set_header(vec!["Field", "Value"]);
 
-    table.add_row(vec!["ID", &agent.id]);
-    table.add_row(vec!["Name", &agent.name]);
-    table.add_row(vec!["Framework", &agent.framework]);
-    table.add_row(vec!["Version", &agent.version]);
+    // All free-text fields below are server-supplied; strip terminal escapes.
+    table.add_row(vec!["ID".to_string(), sanitize_terminal(&agent.id)]);
+    table.add_row(vec!["Name".to_string(), sanitize_terminal(&agent.name)]);
+    table.add_row(vec!["Framework".to_string(), sanitize_terminal(&agent.framework)]);
+    table.add_row(vec!["Version".to_string(), sanitize_terminal(&agent.version)]);
     let status_color = match agent.status.to_lowercase().as_str() {
         "active" => Color::Green,
         s if s.starts_with("suspended") => Color::Yellow,
         "deregistered" => Color::Red,
         _ => Color::Reset,
     };
-    table.add_row(vec![Cell::new("Status"), Cell::new(&agent.status).fg(status_color)]);
+    table.add_row(vec![
+        Cell::new("Status"),
+        Cell::new(sanitize_terminal(&agent.status)).fg(status_color),
+    ]);
 
     let tools = if agent.tool_names.is_empty() {
         "(none)".to_string()
     } else {
-        agent.tool_names.join(", ")
+        agent
+            .tool_names
+            .iter()
+            .map(|t| sanitize_terminal(t))
+            .collect::<Vec<_>>()
+            .join(", ")
     };
     table.add_row(vec!["Tools".to_string(), tools]);
 
@@ -47,7 +57,7 @@ fn render_detail(agent: &AgentResponse) {
     let sessions_str = agent.session_count.map_or("-".to_string(), |s| s.to_string());
     table.add_row(vec!["Sessions".to_string(), sessions_str]);
 
-    let last_event_str = agent.last_event.as_deref().unwrap_or("-").to_string();
+    let last_event_str = sanitize_terminal(agent.last_event.as_deref().unwrap_or("-"));
     table.add_row(vec!["Last Event".to_string(), last_event_str]);
 
     let violations_str = agent.policy_violations_count.map_or("-".to_string(), |v| v.to_string());
@@ -57,7 +67,7 @@ fn render_detail(agent: &AgentResponse) {
         let meta = agent
             .metadata
             .iter()
-            .map(|(k, v)| format!("{k}={v}"))
+            .map(|(k, v)| format!("{}={}", sanitize_terminal(k), sanitize_terminal(v)))
             .collect::<Vec<_>>()
             .join(", ");
         table.add_row(vec!["Metadata".to_string(), meta]);
@@ -72,9 +82,9 @@ fn render_detail(agent: &AgentResponse) {
         sessions_table.set_header(vec!["SESSION_ID", "STARTED_AT", "STATUS"]);
         for s in &agent.active_sessions {
             sessions_table.add_row(vec![
-                Cell::new(&s.session_id),
-                Cell::new(&s.started_at),
-                Cell::new(&s.status),
+                Cell::new(sanitize_terminal(&s.session_id)),
+                Cell::new(sanitize_terminal(&s.started_at)),
+                Cell::new(sanitize_terminal(&s.status)),
             ]);
         }
         println!("{sessions_table}");
@@ -87,9 +97,9 @@ fn render_detail(agent: &AgentResponse) {
         events_table.set_header(vec!["TYPE", "SUMMARY", "TIMESTAMP"]);
         for e in &agent.recent_events {
             events_table.add_row(vec![
-                Cell::new(&e.event_type),
-                Cell::new(&e.summary),
-                Cell::new(&e.timestamp),
+                Cell::new(sanitize_terminal(&e.event_type)),
+                Cell::new(sanitize_terminal(&e.summary)),
+                Cell::new(sanitize_terminal(&e.timestamp)),
             ]);
         }
         println!("{events_table}");
@@ -101,7 +111,10 @@ fn render_detail(agent: &AgentResponse) {
         let mut traces_table = Table::new();
         traces_table.set_header(vec!["SESSION_ID", "TIMESTAMP"]);
         for t in &agent.recent_traces {
-            traces_table.add_row(vec![Cell::new(&t.session_id), Cell::new(&t.timestamp)]);
+            traces_table.add_row(vec![
+                Cell::new(sanitize_terminal(&t.session_id)),
+                Cell::new(sanitize_terminal(&t.timestamp)),
+            ]);
         }
         println!("{traces_table}");
         println!("Tip: run `aasm trace <session-id>` to visualize a trace");

--- a/aa-cli/src/commands/agent/list.rs
+++ b/aa-cli/src/commands/agent/list.rs
@@ -11,6 +11,7 @@ use super::{AgentResponse, PaginatedResponse};
 use crate::client;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm agent list`.
 #[derive(Args)]
@@ -83,15 +84,18 @@ fn render_table(agents: &[AgentResponse]) {
         let sessions_str = agent.session_count.map_or("-".to_string(), |s| s.to_string());
         let last_event_str = agent.last_event.as_deref().unwrap_or("-");
 
+        // id/name/framework/version/status/last_event are server-supplied;
+        // strip terminal escapes (the colour is still chosen from the raw
+        // status string, which never reaches the terminal).
         table.add_row(vec![
-            Cell::new(&agent.id),
-            Cell::new(&agent.name),
-            Cell::new(&agent.framework),
-            Cell::new(&agent.version),
-            Cell::new(&agent.status).fg(status_color(&agent.status)),
+            Cell::new(sanitize_terminal(&agent.id)),
+            Cell::new(sanitize_terminal(&agent.name)),
+            Cell::new(sanitize_terminal(&agent.framework)),
+            Cell::new(sanitize_terminal(&agent.version)),
+            Cell::new(sanitize_terminal(&agent.status)).fg(status_color(&agent.status)),
             Cell::new(&pid_str),
             Cell::new(&sessions_str),
-            Cell::new(last_event_str),
+            Cell::new(sanitize_terminal(last_event_str)),
         ]);
     }
 

--- a/aa-cli/src/commands/agent/resume.rs
+++ b/aa-cli/src/commands/agent/resume.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::client;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm agent resume`.
 #[derive(Args)]
@@ -51,9 +52,10 @@ fn render(resp: &ResumeResponse, output: OutputFormat) {
 }
 
 fn render_table(resp: &ResumeResponse) {
-    println!("Agent {} resumed.", resp.agent_id);
-    println!("  Previous status: {}", resp.previous_status);
-    println!("  New status:      {}", resp.new_status);
+    // resp fields are echoed from the server response; strip terminal escapes.
+    println!("Agent {} resumed.", sanitize_terminal(&resp.agent_id));
+    println!("  Previous status: {}", sanitize_terminal(&resp.previous_status));
+    println!("  New status:      {}", sanitize_terminal(&resp.new_status));
 }
 
 fn render_json(resp: &ResumeResponse) {

--- a/aa-cli/src/commands/agent/suspend.rs
+++ b/aa-cli/src/commands/agent/suspend.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::client;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm agent suspend`.
 #[derive(Args)]
@@ -85,9 +86,10 @@ fn render(resp: &SuspendResponse, output: OutputFormat) {
 }
 
 fn render_table(resp: &SuspendResponse) {
-    println!("Agent {} suspended.", resp.agent_id);
-    println!("  Previous status: {}", resp.previous_status);
-    println!("  New status:      {}", resp.new_status);
+    // resp fields are echoed from the server response; strip terminal escapes.
+    println!("Agent {} suspended.", sanitize_terminal(&resp.agent_id));
+    println!("  Previous status: {}", sanitize_terminal(&resp.previous_status));
+    println!("  New status:      {}", sanitize_terminal(&resp.new_status));
 }
 
 fn render_json(resp: &SuspendResponse) {

--- a/aa-cli/src/commands/alerts/get.rs
+++ b/aa-cli/src/commands/alerts/get.rs
@@ -9,6 +9,7 @@ use super::models::{AlertResponse, AlertSeverity, AlertStatusKind};
 use crate::client;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm alerts get`.
 #[derive(Args)]
@@ -22,24 +23,32 @@ pub fn render_detail(alert: &AlertResponse) {
     let mut table = Table::new();
     table.set_header(vec!["Field", "Value"]);
 
-    table.add_row(vec!["ID", &alert.id]);
+    // All free-text fields are server-supplied; strip terminal escapes
+    // (severity/status colours come from the raw, never-printed strings).
+    table.add_row(vec!["ID".to_string(), sanitize_terminal(&alert.id)]);
 
     let agent = alert.agent_id.as_deref().unwrap_or("-");
-    table.add_row(vec!["Agent", agent]);
+    table.add_row(vec!["Agent".to_string(), sanitize_terminal(agent)]);
 
     let sev = AlertSeverity::parse(&alert.severity);
-    table.add_row(vec![Cell::new("Severity"), Cell::new(&alert.severity).fg(sev.color())]);
+    table.add_row(vec![
+        Cell::new("Severity"),
+        Cell::new(sanitize_terminal(&alert.severity)).fg(sev.color()),
+    ]);
 
-    table.add_row(vec!["Type", &alert.category]);
-    table.add_row(vec!["Message", &alert.message]);
+    table.add_row(vec!["Type".to_string(), sanitize_terminal(&alert.category)]);
+    table.add_row(vec!["Message".to_string(), sanitize_terminal(&alert.message)]);
 
     let status = AlertStatusKind::parse(&alert.status);
-    table.add_row(vec![Cell::new("Status"), Cell::new(&alert.status).fg(status.color())]);
+    table.add_row(vec![
+        Cell::new("Status"),
+        Cell::new(sanitize_terminal(&alert.status)).fg(status.color()),
+    ]);
 
-    table.add_row(vec!["Created", &alert.created_at]);
+    table.add_row(vec!["Created".to_string(), sanitize_terminal(&alert.created_at)]);
 
     let updated = alert.updated_at.as_deref().unwrap_or("-");
-    table.add_row(vec!["Updated", updated]);
+    table.add_row(vec!["Updated".to_string(), sanitize_terminal(updated)]);
 
     if let Some(ref ctx) = alert.context {
         let ctx_str = serde_json::to_string_pretty(ctx).unwrap_or_else(|_| ctx.to_string());

--- a/aa-cli/src/commands/alerts/list.rs
+++ b/aa-cli/src/commands/alerts/list.rs
@@ -10,6 +10,7 @@ use crate::client;
 use crate::commands::agent::PaginatedResponse;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm alerts list`.
 #[derive(Args)]
@@ -77,14 +78,16 @@ pub fn render_table(alerts: &[AlertResponse]) {
         let sev = AlertSeverity::parse(&alert.severity);
         let status = AlertStatusKind::parse(&alert.status);
 
+        // All fields are server-supplied; strip terminal escapes (severity/
+        // status colours are still chosen from the raw, never-printed strings).
         table.add_row(vec![
-            Cell::new(&alert.id),
-            Cell::new(agent),
-            Cell::new(&alert.severity).fg(sev.color()),
-            Cell::new(&alert.category),
-            Cell::new(&alert.message),
-            Cell::new(&alert.status).fg(status.color()),
-            Cell::new(&alert.created_at),
+            Cell::new(sanitize_terminal(&alert.id)),
+            Cell::new(sanitize_terminal(agent)),
+            Cell::new(sanitize_terminal(&alert.severity)).fg(sev.color()),
+            Cell::new(sanitize_terminal(&alert.category)),
+            Cell::new(sanitize_terminal(&alert.message)),
+            Cell::new(sanitize_terminal(&alert.status)).fg(status.color()),
+            Cell::new(sanitize_terminal(&alert.created_at)),
         ]);
     }
 

--- a/aa-cli/src/commands/alerts/resolve.rs
+++ b/aa-cli/src/commands/alerts/resolve.rs
@@ -9,6 +9,7 @@ use super::models::{AlertResponse, ResolveAlertRequest};
 use crate::client;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm alerts resolve`.
 #[derive(Args)]
@@ -56,7 +57,7 @@ pub fn run(args: ResolveArgs, ctx: &ResolvedContext, output: OutputFormat) -> Ex
     )) {
         Ok(alert) => {
             match output {
-                OutputFormat::Table => println!("Alert {} resolved.", alert.id),
+                OutputFormat::Table => println!("Alert {} resolved.", sanitize_terminal(&alert.id)),
                 OutputFormat::Json => match serde_json::to_string_pretty(&alert) {
                     Ok(json) => println!("{json}"),
                     Err(e) => eprintln!("error serializing JSON: {e}"),

--- a/aa-cli/src/commands/approvals/approve.rs
+++ b/aa-cli/src/commands/approvals/approve.rs
@@ -5,6 +5,7 @@ use std::process::ExitCode;
 use clap::Args;
 
 use crate::config::ResolvedContext;
+use crate::sanitize::sanitize_terminal;
 
 use super::client;
 
@@ -28,7 +29,12 @@ pub fn run_approve(args: ApproveArgs, ctx: &ResolvedContext) -> ExitCode {
 
     match result {
         Ok(resp) => {
-            println!("Approved: {} (status: {})", resp.id, resp.status);
+            // resp.id/status are server-supplied; strip terminal escapes.
+            println!(
+                "Approved: {} (status: {})",
+                sanitize_terminal(&resp.id),
+                sanitize_terminal(&resp.status)
+            );
             ExitCode::SUCCESS
         }
         Err(e) => {

--- a/aa-cli/src/commands/approvals/get.rs
+++ b/aa-cli/src/commands/approvals/get.rs
@@ -6,8 +6,10 @@ use clap::Args;
 
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 use super::client;
+use super::models::ApprovalResponse;
 
 /// Arguments for the `aasm approvals get` subcommand.
 #[derive(Debug, Args)]
@@ -18,6 +20,24 @@ pub struct GetArgs {
     /// Output format override for this subcommand.
     #[arg(long, value_enum)]
     pub output: Option<OutputFormat>,
+}
+
+/// Build the human-readable (table-mode) detail block for one approval.
+///
+/// Every field (`id`, `agent_id`, `action`, `reason`, `status`, `created_at`)
+/// is agent/server-controlled and printed verbatim, so each is run through
+/// [`sanitize_terminal`] to strip ANSI/OSC escapes and C0 control bytes before
+/// it reaches the operator's terminal.
+fn format_approval_detail(approval: &ApprovalResponse) -> String {
+    format!(
+        "ID:         {}\nAgent:      {}\nAction:     {}\nCondition:  {}\nStatus:     {}\nCreated at: {}",
+        sanitize_terminal(&approval.id),
+        sanitize_terminal(&approval.agent_id),
+        sanitize_terminal(&approval.action),
+        sanitize_terminal(&approval.reason),
+        sanitize_terminal(&approval.status),
+        sanitize_terminal(&approval.created_at),
+    )
 }
 
 /// Execute the `aasm approvals get` subcommand.
@@ -36,12 +56,7 @@ pub fn run_get(args: GetArgs, ctx: &ResolvedContext, global_output: OutputFormat
                     println!("{}", serde_yaml::to_string(&approval).unwrap_or_default());
                 }
                 OutputFormat::Table => {
-                    println!("ID:         {}", approval.id);
-                    println!("Agent:      {}", approval.agent_id);
-                    println!("Action:     {}", approval.action);
-                    println!("Condition:  {}", approval.reason);
-                    println!("Status:     {}", approval.status);
-                    println!("Created at: {}", approval.created_at);
+                    println!("{}", format_approval_detail(&approval));
                 }
             }
             ExitCode::SUCCESS

--- a/aa-cli/src/commands/approvals/get.rs
+++ b/aa-cli/src/commands/approvals/get.rs
@@ -67,3 +67,28 @@ pub fn run_get(args: GetArgs, ctx: &ResolvedContext, global_output: OutputFormat
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_approval_detail_strips_server_supplied_escapes() {
+        let approval = ApprovalResponse {
+            id: "id\x1b[2Kfake".to_string(),
+            agent_id: "bot\x1b]52;c;ZXZpbA==\x07".to_string(),
+            action: "delete\x1b[31m_all".to_string(),
+            reason: "ok\ninjected".to_string(),
+            status: "pending\x1b[0m".to_string(),
+            created_at: "2026-04-30T10:00:00Z".to_string(),
+        };
+        let detail = format_approval_detail(&approval);
+        assert!(!detail.contains('\x1b'), "no ESC must survive: {detail:?}");
+        assert!(detail.contains("ID:         idfake"));
+        assert!(detail.contains("Agent:      bot"));
+        assert!(detail.contains("Action:     delete_all"));
+        assert!(detail.contains("Condition:  okinjected"));
+        assert!(detail.contains("Status:     pending"));
+        assert!(detail.contains("Created at: 2026-04-30T10:00:00Z"));
+    }
+}

--- a/aa-cli/src/commands/approvals/list.rs
+++ b/aa-cli/src/commands/approvals/list.rs
@@ -8,6 +8,7 @@ use comfy_table::{Cell, Color, Table};
 
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 use super::client;
 
@@ -51,6 +52,23 @@ pub struct ListArgs {
     pub agent: Option<String>,
 }
 
+/// Build the sanitized text columns for one approval row (everything except
+/// the colour-coded TIMEOUT_IN cell).
+///
+/// `id`, `agent_id`, `action`, `reason`, and `created_at` are all
+/// agent/server-controlled and reach the operator's terminal verbatim, so each
+/// is run through [`sanitize_terminal`] to strip ANSI/OSC escapes and C0
+/// control bytes (comfy_table does not strip them).
+fn approval_row_text_cells(item: &ApprovalResponse) -> Vec<String> {
+    vec![
+        sanitize_terminal(&item.id),
+        sanitize_terminal(&item.agent_id),
+        sanitize_terminal(&item.action),
+        sanitize_terminal(&item.reason),
+        sanitize_terminal(&item.created_at),
+    ]
+}
+
 /// Render a list of approval responses as a colored table to stdout.
 ///
 /// Columns: ID, AGENT, ACTION, CONDITION, SUBMITTED_AT, TIMEOUT_IN.
@@ -72,14 +90,9 @@ pub fn render_approvals_table(items: &[ApprovalResponse], now_epoch: i64) {
             TimeoutColor::Green => Color::Green,
         };
 
-        table.add_row(vec![
-            Cell::new(&item.id),
-            Cell::new(&item.agent_id),
-            Cell::new(&item.action),
-            Cell::new(&item.reason),
-            Cell::new(&item.created_at),
-            Cell::new(format_countdown(remaining)).fg(color),
-        ]);
+        let mut cells: Vec<Cell> = approval_row_text_cells(item).into_iter().map(Cell::new).collect();
+        cells.push(Cell::new(format_countdown(remaining)).fg(color));
+        table.add_row(cells);
     }
 
     println!("{table}");

--- a/aa-cli/src/commands/approvals/list.rs
+++ b/aa-cli/src/commands/approvals/list.rs
@@ -128,3 +128,30 @@ pub fn run_list(args: ListArgs, ctx: &ResolvedContext, global_output: OutputForm
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn approval_row_text_cells_strips_server_supplied_escapes() {
+        let item = ApprovalResponse {
+            // A malicious agent embeds a CSI clear-line, an OSC-52 clipboard
+            // write, and a newline in the fields shown by `approvals list`.
+            id: "id\x1b[2Kfake".to_string(),
+            agent_id: "bot\x1b]52;c;ZXZpbA==\x07".to_string(),
+            action: "delete\x1b[31m_all".to_string(),
+            reason: "ok\ninjected".to_string(),
+            status: "pending".to_string(),
+            created_at: "2026-04-30T10:00:00Z".to_string(),
+        };
+        let cells = approval_row_text_cells(&item);
+        assert!(cells.iter().all(|c| !c.contains('\x1b')), "no ESC in {cells:?}");
+        assert!(cells.iter().all(|c| !c.contains('\n')), "no newline in {cells:?}");
+        assert_eq!(cells[0], "idfake");
+        assert_eq!(cells[1], "bot");
+        assert_eq!(cells[2], "delete_all");
+        assert_eq!(cells[3], "okinjected");
+        assert_eq!(cells[4], "2026-04-30T10:00:00Z");
+    }
+}

--- a/aa-cli/src/commands/approvals/reject.rs
+++ b/aa-cli/src/commands/approvals/reject.rs
@@ -5,6 +5,7 @@ use std::process::ExitCode;
 use clap::Args;
 
 use crate::config::ResolvedContext;
+use crate::sanitize::sanitize_terminal;
 
 use super::client;
 
@@ -50,7 +51,12 @@ pub fn run_reject(args: RejectArgs, ctx: &ResolvedContext) -> ExitCode {
 
     match result {
         Ok(resp) => {
-            println!("Rejected: {} (status: {})", resp.id, resp.status);
+            // resp.id/status are server-supplied; strip terminal escapes.
+            println!(
+                "Rejected: {} (status: {})",
+                sanitize_terminal(&resp.id),
+                sanitize_terminal(&resp.status)
+            );
             ExitCode::SUCCESS
         }
         Err(e) => {

--- a/aa-cli/src/commands/approvals/watch.rs
+++ b/aa-cli/src/commands/approvals/watch.rs
@@ -14,6 +14,7 @@ use super::models::{compute_timeout_color, format_countdown, TimeoutColor};
 
 use crate::config::ResolvedContext;
 use crate::error::CliError;
+use crate::sanitize::sanitize_terminal;
 
 use super::client;
 use super::models::ApprovalResponse;
@@ -167,11 +168,14 @@ pub fn render_interactive_view(state: &InteractiveState) {
         };
         let countdown = format_countdown(remaining);
 
+        // `agent_id` and `action` are server-supplied; strip terminal escapes
+        // so a malicious agent cannot repaint the line to spoof the operator.
+        let agent = sanitize_terminal(&item.agent_id);
+        let action = sanitize_terminal(&item.action);
+
         println!(
             "  {marker} {id}  {agent:<20} {action:<30} {color}{cd}\x1b[0m",
             id = &item.id[..8.min(item.id.len())],
-            agent = item.agent_id,
-            action = item.action,
             color = color_code,
             cd = countdown,
         );
@@ -189,9 +193,14 @@ pub async fn run_watch_stream(mut ws: WsStream) {
         match msg {
             Ok(Message::Text(text)) => {
                 if let Ok(approval) = serde_json::from_str::<ApprovalResponse>(&text) {
+                    // All four fields are server-supplied; strip terminal
+                    // escapes to prevent approve/reject decision spoofing.
                     println!(
                         "  \x1b[1;33mNEW\x1b[0m  {} | agent={} | action={} | condition={}",
-                        approval.id, approval.agent_id, approval.action, approval.reason
+                        sanitize_terminal(&approval.id),
+                        sanitize_terminal(&approval.agent_id),
+                        sanitize_terminal(&approval.action),
+                        sanitize_terminal(&approval.reason)
                     );
                     println!("        run: aasm approvals approve {} --reason \"...\"", approval.id);
                     println!();

--- a/aa-cli/src/commands/approvals/watch.rs
+++ b/aa-cli/src/commands/approvals/watch.rs
@@ -129,6 +129,16 @@ pub fn handle_keypress(key: KeyEvent, state: &mut InteractiveState) -> KeyAction
     }
 }
 
+/// Sanitize and shorten a server-supplied approval id for compact display.
+///
+/// Strips terminal escapes BEFORE truncation — a CSI such as `\x1b[2K` fits
+/// within 8 bytes, so truncating first would leave a live escape — then takes
+/// at most 8 *characters* (not bytes) so the result always lands on a UTF-8
+/// boundary; a raw byte slice could panic on multi-byte input.
+fn short_id(id: &str) -> String {
+    sanitize_terminal(id).chars().take(8).collect()
+}
+
 /// Render the interactive view to stdout.
 ///
 /// Clears the terminal and draws the approval list with the current selection
@@ -168,14 +178,15 @@ pub fn render_interactive_view(state: &InteractiveState) {
         };
         let countdown = format_countdown(remaining);
 
-        // `agent_id` and `action` are server-supplied; strip terminal escapes
-        // so a malicious agent cannot repaint the line to spoof the operator.
+        // `id`, `agent_id`, and `action` are server-supplied; strip terminal
+        // escapes so a malicious agent cannot repaint the line to spoof the
+        // operator.
+        let id = short_id(&item.id);
         let agent = sanitize_terminal(&item.agent_id);
         let action = sanitize_terminal(&item.action);
 
         println!(
             "  {marker} {id}  {agent:<20} {action:<30} {color}{cd}\x1b[0m",
-            id = &item.id[..8.min(item.id.len())],
             color = color_code,
             cd = countdown,
         );
@@ -202,7 +213,10 @@ pub async fn run_watch_stream(mut ws: WsStream) {
                         sanitize_terminal(&approval.action),
                         sanitize_terminal(&approval.reason)
                     );
-                    println!("        run: aasm approvals approve {} --reason \"...\"", approval.id);
+                    println!(
+                        "        run: aasm approvals approve {} --reason \"...\"",
+                        sanitize_terminal(&approval.id)
+                    );
                     println!();
                 }
             }

--- a/aa-cli/src/commands/approvals/watch.rs
+++ b/aa-cli/src/commands/approvals/watch.rs
@@ -366,3 +366,26 @@ pub fn run_watch(args: WatchArgs, ctx: &ResolvedContext) -> std::process::ExitCo
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_id_strips_escape_before_truncation() {
+        // A CSI clear-line fits within 8 bytes; truncating first would leave a
+        // live escape, so it must be stripped before the 8-char cut.
+        let out = short_id("\x1b[2K0123456789");
+        assert!(!out.contains('\x1b'), "escape must be stripped: {out:?}");
+        assert_eq!(out, "01234567");
+    }
+
+    #[test]
+    fn short_id_truncation_is_char_safe_on_multibyte_input() {
+        // A raw byte slice `[..8]` would panic mid-character on 3-byte chars;
+        // char truncation must keep 8 whole characters without panicking.
+        let out = short_id("世界世界世界世界世界");
+        assert_eq!(out.chars().count(), 8);
+        assert!(out.chars().all(|c| c == '世' || c == '界'));
+    }
+}

--- a/aa-cli/src/commands/audit/list.rs
+++ b/aa-cli/src/commands/audit/list.rs
@@ -10,6 +10,7 @@ use super::models::{AuditEntry, AuditResult, PaginatedAuditResponse};
 use crate::commands::logs::format::{is_within_time_range, parse_since, parse_until};
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm audit list`.
 #[derive(Debug, Args)]
@@ -158,17 +159,20 @@ pub fn render_table(entries: &[AuditEntry]) {
 
     for entry in entries {
         let result_raw = extract_result(entry).unwrap_or_else(|| "-".to_string());
-        let result_colored = colorize_result(&result_raw);
-        let tool = extract_tool(entry);
-        let policy = extract_policy(entry);
+        // All fields originate from the server audit entry / its payload JSON;
+        // strip terminal escapes (colour is applied after sanitization, and
+        // colorize_result matches the sanitized exact values allow/deny/pending).
+        let result_colored = colorize_result(&sanitize_terminal(&result_raw));
+        let tool = sanitize_terminal(&extract_tool(entry));
+        let policy = sanitize_terminal(&extract_policy(entry));
 
         table.add_row(vec![
-            &entry.timestamp,
-            &entry.agent_id,
-            &entry.event_type,
-            &tool,
-            &result_colored,
-            &policy,
+            sanitize_terminal(&entry.timestamp),
+            sanitize_terminal(&entry.agent_id),
+            sanitize_terminal(&entry.event_type),
+            tool,
+            result_colored,
+            policy,
         ]);
     }
     println!("{table}");

--- a/aa-cli/src/commands/budget.rs
+++ b/aa-cli/src/commands/budget.rs
@@ -11,6 +11,7 @@ use crate::client;
 use crate::config::ResolvedContext;
 use crate::error::CliError;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// One row of the rollup, mirroring `aa_api::routes::agents::BudgetRowResponse`.
 #[derive(Debug, Clone, Deserialize)]
@@ -101,17 +102,19 @@ fn render_text<W: std::io::Write>(rollup: &BudgetRollup, w: &mut W) -> std::io::
         .set_header(vec!["Scope", "Period", "Spent", "Limit", "Remaining", "Used %"]);
 
     for row in &rollup.rows {
+        // scope/period and the USD strings come from the server; strip terminal
+        // escapes (format_usd echoes the raw input on its malformed fallback).
         table.add_row(vec![
-            row.scope.clone(),
-            row.period.clone(),
-            format_usd(&row.spent_usd),
+            sanitize_terminal(&row.scope),
+            sanitize_terminal(&row.period),
+            sanitize_terminal(&format_usd(&row.spent_usd)),
             row.limit_usd
                 .as_deref()
-                .map(format_usd)
+                .map(|s| sanitize_terminal(&format_usd(s)))
                 .unwrap_or_else(|| "—".to_string()),
             row.remaining_usd
                 .as_deref()
-                .map(format_usd)
+                .map(|s| sanitize_terminal(&format_usd(s)))
                 .unwrap_or_else(|| "—".to_string()),
             row.percent_used
                 .map(|p| format!("{p:.1}%"))

--- a/aa-cli/src/commands/cost/forecast.rs
+++ b/aa-cli/src/commands/cost/forecast.rs
@@ -8,6 +8,7 @@ use super::client;
 use super::models::CostForecastDisplay;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm cost forecast`.
 #[derive(Args)]
@@ -116,15 +117,22 @@ fn render_yaml(forecast: &CostForecastDisplay) {
 fn render_table(forecast: &CostForecastDisplay) {
     println!("COST FORECAST");
     println!("─────────────");
-    println!("  Date:              {}", forecast.date);
+    // Server-supplied money/date strings; strip terminal escapes.
+    println!("  Date:              {}", sanitize_terminal(&forecast.date));
     println!(
         "  Day of month:      {}/{}",
         forecast.day_of_month, forecast.days_in_month
     );
-    println!("  Current daily:     ${}", forecast.current_daily_spend);
-    println!("  Projected monthly: ${}", forecast.projected_monthly_spend);
+    println!(
+        "  Current daily:     ${}",
+        sanitize_terminal(&forecast.current_daily_spend)
+    );
+    println!(
+        "  Projected monthly: ${}",
+        sanitize_terminal(&forecast.projected_monthly_spend)
+    );
     if let Some(ref limit) = forecast.monthly_limit_usd {
-        println!("  Monthly limit:     ${limit}");
+        println!("  Monthly limit:     ${}", sanitize_terminal(limit));
     }
     if let Some(ref pct) = forecast.projected_utilization_pct {
         println!("  Projected util:    {pct}");

--- a/aa-cli/src/commands/cost/summary.rs
+++ b/aa-cli/src/commands/cost/summary.rs
@@ -9,6 +9,7 @@ use super::client;
 use super::models::CostSummaryDisplay;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Time period for cost aggregation.
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -102,13 +103,15 @@ fn render_table(display: &CostSummaryDisplay, args: &SummaryArgs) {
     // Global summary
     println!("COST SUMMARY ({spend_label})");
     println!("──────────────────");
-    println!("  {spend_label} spend: ${spend_value}");
+    // spend_value/limit_val/date are server-supplied; strip terminal escapes
+    // (utilization is computed from the raw values, then itself is numeric).
+    println!("  {spend_label} spend: ${}", sanitize_terminal(spend_value));
     if let Some(limit_val) = limit {
         let pct = compute_utilization_pct(spend_value, limit_val);
-        println!("  Budget limit:  ${limit_val}");
+        println!("  Budget limit:  ${}", sanitize_terminal(limit_val));
         println!("  Utilization:   {pct}");
     }
-    println!("  Date:          {}", display.date);
+    println!("  Date:          {}", sanitize_terminal(&display.date));
     println!();
 }
 
@@ -124,13 +127,16 @@ fn render_agent_table(display: &CostSummaryDisplay, args: &SummaryArgs) {
                 .as_ref()
                 .map_or("N/A".to_string(), |v| format!("${v}")),
         };
+        // agent_id and the spend strings come from the server; sanitize them.
         table.add_row(vec![
-            &agent.agent_id,
-            &format!("${}", agent.daily_spend_usd),
-            &agent
-                .monthly_spend_usd
-                .as_ref()
-                .map_or("N/A".to_string(), |v| format!("${v}")),
+            sanitize_terminal(&agent.agent_id),
+            sanitize_terminal(&format!("${}", agent.daily_spend_usd)),
+            sanitize_terminal(
+                &agent
+                    .monthly_spend_usd
+                    .as_ref()
+                    .map_or("N/A".to_string(), |v| format!("${v}")),
+            ),
         ]);
         // Use spend to suppress unused warning in the match above
         let _ = spend;

--- a/aa-cli/src/commands/dashboard/feed.rs
+++ b/aa-cli/src/commands/dashboard/feed.rs
@@ -10,6 +10,7 @@ use tokio_tungstenite::tungstenite::Message;
 use crate::commands::status::client::StatusClient;
 use crate::commands::status::fetch;
 use crate::commands::status::models::{AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, RuntimeHealth};
+use crate::sanitize::sanitize_terminal;
 
 use super::state::EventEntry;
 
@@ -136,11 +137,13 @@ fn ws_event_to_entry(event: &WsEvent) -> EventEntry {
         serde_json::Value::String(s) => s.clone(),
         other => other.to_string(),
     };
+    // Every field is server-supplied; sanitize at ingestion so escapes can
+    // never reach the dashboard's rendered output.
     EventEntry {
-        timestamp: event.timestamp.clone(),
-        event_type: event.event_type.clone(),
-        agent_id: event.agent_id.clone(),
-        message,
+        timestamp: sanitize_terminal(&event.timestamp),
+        event_type: sanitize_terminal(&event.event_type),
+        agent_id: sanitize_terminal(&event.agent_id),
+        message: sanitize_terminal(&message),
     }
 }
 

--- a/aa-cli/src/commands/dashboard/feed.rs
+++ b/aa-cli/src/commands/dashboard/feed.rs
@@ -182,6 +182,22 @@ mod tests {
     }
 
     #[test]
+    fn ws_event_to_entry_sanitizes_server_fields() {
+        let event = WsEvent {
+            id: 3,
+            event_type: "viol\x1b[31mation".to_string(),
+            agent_id: "a\x1b]52;c;ZXZpbA==\x07b".to_string(),
+            payload: serde_json::Value::String("denied\ninjected".to_string()),
+            timestamp: "2026-04-30T10:00:00Z".to_string(),
+        };
+        let entry = ws_event_to_entry(&event);
+        assert_eq!(entry.event_type, "violation");
+        assert_eq!(entry.agent_id, "ab");
+        assert_eq!(entry.message, "deniedinjected");
+        assert!(!entry.agent_id.contains('\x1b'));
+    }
+
+    #[test]
     fn ws_event_object_payload() {
         let event = WsEvent {
             id: 2,

--- a/aa-cli/src/commands/gateway/logs.rs
+++ b/aa-cli/src/commands/gateway/logs.rs
@@ -16,6 +16,8 @@ use std::time::Duration;
 
 use clap::{Args, ValueEnum};
 
+use crate::sanitize::sanitize_terminal;
+
 const FOLLOW_POLL: Duration = Duration::from_millis(100);
 
 /// Log level filter for `--level`.
@@ -109,7 +111,8 @@ fn tail_logs(file: std::fs::File, n: u64, level_filter: Option<&str>) -> ExitCod
     }
 
     for line in &window {
-        println!("{line}");
+        // Log lines embed agent-supplied data; strip terminal escapes.
+        println!("{}", sanitize_terminal(line));
     }
     ExitCode::SUCCESS
 }
@@ -138,7 +141,7 @@ fn follow_logs(mut file: std::fs::File, level_filter: Option<&str>) -> ExitCode 
                             Ok(_) => {
                                 let line = buf.trim_end_matches('\n').trim_end_matches('\r');
                                 if matches_level(line, level_filter) {
-                                    println!("{line}");
+                                    println!("{}", sanitize_terminal(line));
                                     // Flush immediately: stdout is block-buffered
                                     // when redirected to a file (non-TTY), so without
                                     // an explicit flush each line would sit in the

--- a/aa-cli/src/commands/logs/format.rs
+++ b/aa-cli/src/commands/logs/format.rs
@@ -4,6 +4,8 @@ use chrono::{DateTime, Utc};
 use console::Style;
 use serde::{Deserialize, Serialize};
 
+use crate::sanitize::sanitize_terminal;
+
 /// Normalised log entry shared by both fetch (REST) and follow (WS) modes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogLineData {
@@ -24,17 +26,20 @@ pub struct LogLineData {
 /// When `use_color` is true the type tag is styled according to
 /// [`style_for_type`].
 pub fn format_log_line(entry: &LogLineData, use_color: bool) -> String {
-    let tag = format!("[{}]", entry.event_type.to_uppercase());
+    // All four fields are server-supplied; strip terminal escapes so a
+    // malicious agent cannot inject ANSI/OSC sequences into the operator's
+    // terminal. The original `event_type` still drives the colour lookup.
+    let timestamp = sanitize_terminal(&entry.timestamp);
+    let agent_id = sanitize_terminal(&entry.agent_id);
+    let message = sanitize_terminal(&entry.message);
+    let tag = format!("[{}]", sanitize_terminal(&entry.event_type).to_uppercase());
     let styled_tag = if use_color {
         let style = style_for_type(&entry.event_type);
         style.apply_to(&tag).to_string()
     } else {
         tag
     };
-    format!(
-        "{} {:12} {}  {}",
-        entry.timestamp, styled_tag, entry.agent_id, entry.message
-    )
+    format!("{} {:12} {}  {}", timestamp, styled_tag, agent_id, message)
 }
 
 /// Format a log entry as a single newline-delimited JSON object.

--- a/aa-cli/src/commands/logs/format.rs
+++ b/aa-cli/src/commands/logs/format.rs
@@ -165,6 +165,23 @@ mod tests {
     }
 
     #[test]
+    fn format_log_line_strips_server_supplied_escapes() {
+        let entry = LogLineData {
+            timestamp: "2026-04-30T10:00:00Z".to_string(),
+            event_type: "violation".to_string(),
+            // A malicious agent embeds a CSI clear-line and an OSC-52 clipboard
+            // write in the server-supplied fields.
+            agent_id: "a\x1b[2Kfake".to_string(),
+            message: "ok\x1b]52;c;ZXZpbA==\x07\ninjected".to_string(),
+        };
+        let line = format_log_line(&entry, false);
+        assert!(!line.contains('\x1b'), "no ESC must survive: {line:?}");
+        assert!(!line.contains('\n'), "no newline must survive: {line:?}");
+        assert!(line.contains("afake"));
+        assert!(line.contains("okinjected"));
+    }
+
+    #[test]
     fn format_log_json_produces_valid_json() {
         let json = format_log_json(&sample_entry());
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/aa-cli/src/commands/permissions.rs
+++ b/aa-cli/src/commands/permissions.rs
@@ -14,6 +14,7 @@ use crate::client;
 use crate::config::ResolvedContext;
 use crate::error::CliError;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Per-scope contribution mirroring `aa_api::routes::agents::PermissionSourceResponse`.
 #[derive(Debug, Clone, Deserialize)]
@@ -180,11 +181,12 @@ fn render_text<W: std::io::Write>(perms: &EffectivePermissions, w: &mut W) -> st
             .map(|s| s.scope.as_str())
             .collect();
         let effective = effective_for(cap, perms);
+        // Capability ids and source scopes are server-supplied; strip escapes.
         table.add_row(vec![
-            cap.to_string(),
+            sanitize_terminal(cap),
             effective.label().to_string(),
-            granted_by.join(", "),
-            denied_by.join(", "),
+            sanitize_terminal(&granted_by.join(", ")),
+            sanitize_terminal(&denied_by.join(", ")),
         ]);
     }
 

--- a/aa-cli/src/commands/policy/history.rs
+++ b/aa-cli/src/commands/policy/history.rs
@@ -10,6 +10,7 @@ use owo_colors::OwoColorize;
 use serde::{Deserialize, Serialize};
 
 use crate::config::ResolvedContext;
+use crate::sanitize::sanitize_terminal;
 
 /// Request body for `POST /api/v1/policies`.
 #[derive(Debug, Serialize)]
@@ -84,8 +85,9 @@ pub fn run_apply(args: ApplyArgs, ctx: &ResolvedContext) -> ExitCode {
         match crate::client::post_json::<_, PolicyApplyResponse>(ctx, "/api/v1/policies", &body).await {
             Ok(resp) => {
                 println!("Policy applied successfully.");
-                println!("  Version:    {}", resp.name);
-                println!("  Timestamp:  {}", resp.version);
+                // resp.name/version are echoed from the server; sanitize.
+                println!("  Version:    {}", sanitize_terminal(&resp.name));
+                println!("  Timestamp:  {}", sanitize_terminal(&resp.version));
                 println!("  Active:     {}", resp.active);
                 println!("  Rules:      {}", resp.rule_count);
                 ExitCode::SUCCESS

--- a/aa-cli/src/commands/policy/list.rs
+++ b/aa-cli/src/commands/policy/list.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::client;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Arguments for `aasm policy list`.
 #[derive(Args)]
@@ -69,10 +70,11 @@ fn render_table(policies: &[PolicyResponse]) {
     table.set_header(vec!["NAME", "STATUS", "UPDATED_AT", "RULES"]);
 
     for p in policies {
+        // name/version are server-supplied; strip terminal escapes.
         table.add_row(vec![
-            Cell::new(&p.name),
+            Cell::new(sanitize_terminal(&p.name)),
             Cell::new(status_label(p.active)).fg(status_color(p.active)),
-            Cell::new(&p.version),
+            Cell::new(sanitize_terminal(&p.version)),
             Cell::new(p.rule_count),
         ]);
     }

--- a/aa-cli/src/commands/policy/simulate.rs
+++ b/aa-cli/src/commands/policy/simulate.rs
@@ -9,6 +9,8 @@ use clap::Args;
 use aa_gateway::simulation::{HistoricalReplay, SimulationEngine, SimulationReport};
 use aa_gateway::PolicyEngine;
 
+use crate::sanitize::sanitize_terminal;
+
 /// Arguments for `aasm policy simulate`.
 #[derive(Args)]
 pub struct SimulateArgs {
@@ -119,10 +121,12 @@ fn print_report(report: &SimulationReport) {
         println!("{:<8} {:<20} {:<12} REASON", "EVENT#", "ACTION", "DECISION");
         println!("{}", "-".repeat(70));
         for outcome in &report.flagged_outcomes {
-            println!(
-                "{:<8} {:<20} {:<12} {}",
-                outcome.event_index, outcome.action, outcome.decision, outcome.reason
-            );
+            // action/reason derive from replayed agent events and decision is
+            // the engine verdict; strip terminal escapes from all three.
+            let action = sanitize_terminal(&outcome.action);
+            let decision = sanitize_terminal(&outcome.decision);
+            let reason = sanitize_terminal(&outcome.reason);
+            println!("{:<8} {action:<20} {decision:<12} {reason}", outcome.event_index);
         }
     }
 }

--- a/aa-cli/src/commands/proxy/logs.rs
+++ b/aa-cli/src/commands/proxy/logs.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 
 use clap::Args;
 
+use crate::sanitize::sanitize_terminal;
+
 /// Arguments for `aasm proxy logs`.
 #[derive(Debug, Args)]
 pub struct LogsArgs {
@@ -132,7 +134,8 @@ pub fn dispatch(args: LogsArgs) -> ExitCode {
     let tail = last_n_lines(&log_path, args.lines);
     for line in &tail {
         if should_print(line) {
-            println!("{line}");
+            // Log lines embed agent-supplied data; strip terminal escapes.
+            println!("{}", sanitize_terminal(line));
         }
     }
 
@@ -181,7 +184,7 @@ fn follow_log(log_path: &std::path::Path, should_print: &impl Fn(&str) -> bool) 
         while reader.read_line(&mut line).unwrap_or(0) > 0 {
             let trimmed = line.trim_end_matches('\n');
             if should_print(trimmed) {
-                println!("{trimmed}");
+                println!("{}", sanitize_terminal(trimmed));
             }
             line.clear();
         }

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -356,6 +356,30 @@ pub fn render_all(snapshot: &StatusSnapshot, format: OutputFormat) {
 mod tests {
     use super::*;
 
+    #[test]
+    fn agent_row_cells_strips_server_supplied_escapes() {
+        let agent = AgentRow {
+            // A malicious agent registers id/name/last_event carrying a CSI
+            // clear-line, an OSC-52 clipboard write, and a newline.
+            id: "a\x1b[2Kfake".to_string(),
+            name: "bot\x1b]52;c;ZXZpbA==\x07".to_string(),
+            framework: "lang\x1b[31mchain".to_string(),
+            status: "Running".to_string(),
+            sessions: 1,
+            violations_today: 0,
+            last_event: "evt\ninjected".to_string(),
+            layer: "sdk".to_string(),
+        };
+        let cells = agent_row_cells(&agent);
+        assert!(cells.iter().all(|c| !c.contains('\x1b')), "no ESC in {cells:?}");
+        assert!(cells.iter().all(|c| !c.contains('\n')), "no newline in {cells:?}");
+        assert_eq!(cells[0], "afake");
+        assert_eq!(cells[1], "bot");
+        assert_eq!(cells[2], "● Running");
+        assert_eq!(cells[3], "langchain");
+        assert_eq!(cells[5], "evtinjected");
+    }
+
     fn strip_ansi(s: &str) -> String {
         // The renderer wraps the health indicator in ANSI colour codes via the
         // `colored` crate. Strip a minimal subset (CSI escapes) so substring

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -7,6 +7,7 @@ use super::models::{
     AdminStorageHealthBlock, AgentRow, ApprovalsSummary, BudgetRow, DeploymentOverview, RuntimeHealth, StatusSnapshot,
 };
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Build the multi-line deployment-overview header block as a `String`.
 ///
@@ -167,6 +168,31 @@ fn format_duration(secs: u64) -> String {
     }
 }
 
+/// Build the sanitized display cells for one agent row.
+///
+/// `id`, `name`, `status`, `framework`, `last_event`, and `layer` are
+/// agent-controlled and reach the operator's terminal verbatim. A malicious
+/// agent could register a name/id containing ANSI/OSC escapes to repaint
+/// `aasm status` output, so every agent-supplied string is sanitized here.
+fn agent_row_cells(agent: &AgentRow) -> Vec<String> {
+    let status_icon = match agent.status.as_str() {
+        "Running" => "●",
+        "Idle" => "○",
+        "Suspended" => "⚠",
+        _ => "?",
+    };
+    vec![
+        sanitize_terminal(&agent.id),
+        sanitize_terminal(&agent.name),
+        format!("{status_icon} {}", sanitize_terminal(&agent.status)),
+        sanitize_terminal(&agent.framework),
+        agent.sessions.to_string(),
+        sanitize_terminal(&agent.last_event),
+        agent.violations_today.to_string(),
+        sanitize_terminal(&agent.layer),
+    ]
+}
+
 /// Render the Active Agents section as a table to stdout.
 pub fn render_agents_table(agents: &[AgentRow]) {
     println!("ACTIVE AGENTS");
@@ -190,22 +216,7 @@ pub fn render_agents_table(agents: &[AgentRow]) {
         "LAYER",
     ]);
     for agent in agents {
-        let status_icon = match agent.status.as_str() {
-            "Running" => "●",
-            "Idle" => "○",
-            "Suspended" => "⚠",
-            _ => "?",
-        };
-        table.add_row(vec![
-            &agent.id,
-            &agent.name,
-            &format!("{status_icon} {}", agent.status),
-            &agent.framework,
-            &agent.sessions.to_string(),
-            &agent.last_event,
-            &agent.violations_today.to_string(),
-            &agent.layer,
-        ]);
+        table.add_row(agent_row_cells(agent));
     }
     println!("{table}");
     println!();
@@ -301,7 +312,11 @@ pub fn render_budget_table(budget: &BudgetRow) {
         });
 
         for entry in &sorted {
-            table.add_row(vec![&entry.agent_id, &format!("${}", entry.daily_spend_usd)]);
+            // agent_id is agent-controlled; strip terminal escapes before display.
+            table.add_row(vec![
+                sanitize_terminal(&entry.agent_id),
+                format!("${}", entry.daily_spend_usd),
+            ]);
         }
         println!("{table}");
     }

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -3,6 +3,7 @@
 use comfy_table::{Cell, Color, Table};
 
 use super::{AgentLineage, TeamTopology, TopologyOverview, TopologyStats};
+use crate::sanitize::sanitize_terminal;
 
 /// Map an agent status string to a terminal colour.
 pub fn status_color(status: &str) -> Color {
@@ -26,7 +27,7 @@ pub fn render_overview_table(overview: &TopologyOverview) {
         table.set_header(vec!["TEAM_ID", "AGENTS", "ROOT_AGENTS"]);
         for t in &overview.teams {
             table.add_row(vec![
-                Cell::new(&t.team_id),
+                Cell::new(sanitize_terminal(&t.team_id)),
                 Cell::new(t.agent_count),
                 Cell::new(t.root_agent_count),
             ]);
@@ -40,9 +41,9 @@ pub fn render_overview_table(overview: &TopologyOverview) {
         table.set_header(vec!["AGENT_ID", "NAME", "STATUS"]);
         for a in &overview.standalone_root_agents {
             table.add_row(vec![
-                Cell::new(&a.id),
-                Cell::new(&a.name),
-                Cell::new(&a.status).fg(status_color(&a.status)),
+                Cell::new(sanitize_terminal(&a.id)),
+                Cell::new(sanitize_terminal(&a.name)),
+                Cell::new(sanitize_terminal(&a.status)).fg(status_color(&a.status)),
             ]);
         }
         println!("{table}");
@@ -51,7 +52,11 @@ pub fn render_overview_table(overview: &TopologyOverview) {
 
 /// Render a team topology as a comfy-table.
 pub fn render_team_table(team: &TeamTopology) {
-    println!("Team: {}  |  Agents: {}\n", team.team_id, team.agent_count);
+    println!(
+        "Team: {}  |  Agents: {}\n",
+        sanitize_terminal(&team.team_id),
+        team.agent_count
+    );
 
     if team.members.is_empty() {
         println!("(no members)");
@@ -65,10 +70,10 @@ pub fn render_team_table(team: &TeamTopology) {
     table.set_header(vec!["AGENT_ID", "NAME", "DEPTH", "STATUS"]);
     for a in &members {
         table.add_row(vec![
-            Cell::new(&a.id),
-            Cell::new(&a.name),
+            Cell::new(sanitize_terminal(&a.id)),
+            Cell::new(sanitize_terminal(&a.name)),
             Cell::new(a.depth),
-            Cell::new(&a.status).fg(status_color(&a.status)),
+            Cell::new(sanitize_terminal(&a.status)).fg(status_color(&a.status)),
         ]);
     }
     println!("{table}");
@@ -78,7 +83,8 @@ pub fn render_team_table(team: &TeamTopology) {
 pub fn render_lineage_table(lineage: &AgentLineage) {
     println!(
         "Agent: {}  |  Ancestors: {}\n",
-        lineage.agent_id, lineage.ancestor_count,
+        sanitize_terminal(&lineage.agent_id),
+        lineage.ancestor_count,
     );
 
     if lineage.ancestors.is_empty() {
@@ -89,17 +95,21 @@ pub fn render_lineage_table(lineage: &AgentLineage) {
     let mut table = Table::new();
     table.set_header(vec!["DEPTH", "AGENT_ID", "NAME", "TEAM", "DELEGATION_REASON"]);
     for step in &lineage.ancestors {
+        // id/name/team_id/delegation_reason are server-supplied; strip terminal
+        // escapes. delegation_reason is sanitized BEFORE truncation (an escape
+        // can fit in 60 bytes) and truncated by chars to stay UTF-8 safe — the
+        // old `&r[..60]` byte slice could panic on a non-char boundary.
+        let reason = step
+            .delegation_reason
+            .as_deref()
+            .map(|r| sanitize_terminal(r).chars().take(60).collect::<String>())
+            .unwrap_or_else(|| "-".to_string());
         table.add_row(vec![
             Cell::new(step.depth),
-            Cell::new(&step.id),
-            Cell::new(&step.name),
-            Cell::new(step.team_id.as_deref().unwrap_or("-")),
-            Cell::new(
-                step.delegation_reason
-                    .as_deref()
-                    .map(|r| if r.len() > 60 { &r[..60] } else { r })
-                    .unwrap_or("-"),
-            ),
+            Cell::new(sanitize_terminal(&step.id)),
+            Cell::new(sanitize_terminal(&step.name)),
+            Cell::new(sanitize_terminal(step.team_id.as_deref().unwrap_or("-"))),
+            Cell::new(reason),
         ]);
     }
     println!("{table}");
@@ -142,7 +152,8 @@ pub fn render_stats_table(stats: &TopologyStats) {
         let mut htable = Table::new();
         htable.set_header(vec!["DEPTH", "COUNT"]);
         for (depth, count) in &stats.depth_histogram {
-            htable.add_row(vec![Cell::new(depth), Cell::new(count)]);
+            // Histogram keys are server-supplied strings; sanitize them.
+            htable.add_row(vec![Cell::new(sanitize_terminal(depth)), Cell::new(count)]);
         }
         println!("{htable}");
     }
@@ -152,7 +163,8 @@ pub fn render_stats_table(stats: &TopologyStats) {
         let mut htable = Table::new();
         htable.set_header(vec!["TEAM_SIZE", "COUNT"]);
         for (size, count) in &stats.team_size_histogram {
-            htable.add_row(vec![Cell::new(size), Cell::new(count)]);
+            // Histogram keys are server-supplied strings; sanitize them.
+            htable.add_row(vec![Cell::new(sanitize_terminal(size)), Cell::new(count)]);
         }
         println!("{htable}");
     }

--- a/aa-cli/src/commands/topology/render/tree.rs
+++ b/aa-cli/src/commands/topology/render/tree.rs
@@ -1,13 +1,22 @@
 //! Tree-style rendering for AgentTree and AgentLineage.
 
 use super::{AgentLineage, AgentTree};
+use crate::sanitize::sanitize_terminal;
 
 /// Render an agent tree recursively using box-drawing characters.
 pub fn render_agent_tree(node: &AgentTree, prefix: &str, is_last: bool) {
     let connector = if is_last { "└── " } else { "├── " };
-    let status_tag = format!("[{}]", node.status);
-    let team_tag = node.team_id.as_deref().map(|t| format!(" <{t}>")).unwrap_or_default();
-    println!("{prefix}{connector}{} {status_tag}{team_tag}", node.name);
+    // status/team_id/name are server-supplied; strip terminal escapes.
+    let status_tag = format!("[{}]", sanitize_terminal(&node.status));
+    let team_tag = node
+        .team_id
+        .as_deref()
+        .map(|t| format!(" <{}>", sanitize_terminal(t)))
+        .unwrap_or_default();
+    println!(
+        "{prefix}{connector}{} {status_tag}{team_tag}",
+        sanitize_terminal(&node.name)
+    );
 
     let child_prefix = format!("{prefix}{}", if is_last { "    " } else { "│   " });
     let count = node.children.len();
@@ -18,17 +27,22 @@ pub fn render_agent_tree(node: &AgentTree, prefix: &str, is_last: bool) {
 
 /// Render an agent lineage chain using box-drawing characters.
 pub fn render_lineage_chain(lineage: &AgentLineage) {
-    println!("Lineage for agent: {}\n", lineage.agent_id);
+    println!("Lineage for agent: {}\n", sanitize_terminal(&lineage.agent_id));
     let count = lineage.ancestors.len();
     for (i, step) in lineage.ancestors.iter().enumerate() {
         let is_last = i + 1 == count;
         let connector = if is_last { "└── " } else { "├── " };
         let indent = "│   ".repeat(i);
+        // name/delegation_reason are server-supplied; strip terminal escapes.
         let reason = step
             .delegation_reason
             .as_deref()
-            .map(|r| format!(" ({r})"))
+            .map(|r| format!(" ({})", sanitize_terminal(r)))
             .unwrap_or_default();
-        println!("{indent}{connector}{} [depth={}]{reason}", step.name, step.depth);
+        println!(
+            "{indent}{connector}{} [depth={}]{reason}",
+            sanitize_terminal(&step.name),
+            step.depth
+        );
     }
 }

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -2,6 +2,7 @@
 
 use super::models::{SessionTrace, TraceEvent, TraceEventKind};
 use super::tree::format_duration;
+use crate::sanitize::sanitize_terminal;
 
 /// Find the maximum duration among a flat list of events.
 pub fn compute_max_duration(events: &[TraceEvent]) -> u64 {
@@ -29,7 +30,8 @@ fn timeline_label(event: &TraceEvent) -> String {
         TraceEventKind::PolicyAllow => "ALLOW",
         TraceEventKind::PolicyDeny => "DENY",
     };
-    format!("{kind_tag:<6} {:<20}", event.label)
+    // event.label is server-supplied; strip terminal escapes.
+    format!("{kind_tag:<6} {:<20}", sanitize_terminal(&event.label))
 }
 
 /// Render one row of the timeline: label | bar | duration.
@@ -53,7 +55,7 @@ fn flatten_events(events: &[TraceEvent]) -> Vec<&TraceEvent> {
 ///
 /// `max_width` controls the total line width (default 80).
 pub fn render_timeline(trace: &SessionTrace, max_width: usize) -> String {
-    let mut output = format!("Timeline: {}\n", trace.session_id);
+    let mut output = format!("Timeline: {}\n", sanitize_terminal(&trace.session_id));
 
     let flat = flatten_events(&trace.events);
     if flat.is_empty() {

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -182,6 +182,32 @@ mod tests {
     }
 
     #[test]
+    fn render_event_line_strips_server_supplied_escapes() {
+        let event = TraceEvent {
+            kind: TraceEventKind::ToolCall,
+            // A malicious agent embeds a CSI clear-line in the operation label.
+            label: "query\x1b[2K_db".to_string(),
+            duration_ms: 5,
+            children: vec![],
+            violation_reason: None,
+        };
+        let line = render_event_line(&event);
+        assert!(!line.contains('\x1b'), "no ESC must survive: {line:?}");
+        assert!(line.contains("query_db"));
+    }
+
+    #[test]
+    fn render_tree_strips_escapes_from_session_id() {
+        let trace = SessionTrace {
+            session_id: "sess\x1b]52;c;ZXZpbA==\x07-1".to_string(),
+            events: vec![],
+        };
+        let output = render_tree(&trace);
+        assert!(!output.contains('\x1b'), "no ESC must survive: {output:?}");
+        assert!(output.contains("Trace: sess-1"));
+    }
+
+    #[test]
     fn render_tree_single_event_no_children() {
         let trace = SessionTrace {
             session_id: "sess-solo".to_string(),

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -3,6 +3,7 @@
 use colored::Colorize;
 
 use super::models::{SessionTrace, TraceEvent, TraceEventKind};
+use crate::sanitize::sanitize_terminal;
 
 /// Format a duration in milliseconds into a human-readable string.
 ///
@@ -26,15 +27,16 @@ fn event_icon(kind: &TraceEventKind) -> &'static str {
 ///
 /// Policy denials are highlighted in red with the violation reason appended.
 pub fn render_event_line(event: &TraceEvent) -> String {
+    // label and violation_reason are server-supplied; strip terminal escapes.
     let line = format!(
         "{} {}  {}",
         event_icon(&event.kind),
-        event.label,
+        sanitize_terminal(&event.label),
         format_duration(event.duration_ms),
     );
 
     if event.kind == TraceEventKind::PolicyDeny {
-        let reason = event.violation_reason.as_deref().unwrap_or("no reason provided");
+        let reason = sanitize_terminal(event.violation_reason.as_deref().unwrap_or("no reason provided"));
         format!("{}", format!("{line}  ({reason})").red())
     } else {
         line
@@ -68,7 +70,7 @@ fn render_tree_recursive(events: &[TraceEvent], prefix: &str, output: &mut Strin
 
 /// Render a full session trace as an indented tree with box-drawing characters.
 pub fn render_tree(trace: &SessionTrace) -> String {
-    let mut output = format!("Trace: {}\n", trace.session_id);
+    let mut output = format!("Trace: {}\n", sanitize_terminal(&trace.session_id));
     render_tree_recursive(&trace.events, "", &mut output);
     output
 }

--- a/aa-cli/src/commands/version.rs
+++ b/aa-cli/src/commands/version.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use crate::sanitize::sanitize_terminal;
 
 /// Subset of the configured REST API `/api/v1/health` response used for
 /// version extraction.
@@ -96,7 +97,13 @@ fn render_table(rows: &[VersionRow]) {
     let mut table = Table::new();
     table.set_header(vec!["COMPONENT", "VERSION", "STATUS"]);
     for r in rows {
-        table.add_row(vec![&r.component, &r.version, &r.status]);
+        // version/status for the gateway/api rows come from the server health
+        // response; strip terminal escapes (component is a static label).
+        table.add_row(vec![
+            r.component.clone(),
+            sanitize_terminal(&r.version),
+            sanitize_terminal(&r.status),
+        ]);
     }
     println!("{table}");
 }

--- a/aa-cli/src/lib.rs
+++ b/aa-cli/src/lib.rs
@@ -40,3 +40,40 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: commands::Commands,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The global `--api-key` flag must fall back to `AASM_API_KEY` so the
+    /// operator bearer token need never appear in argv (ps/proc/shell history).
+    #[test]
+    fn api_key_resolves_from_env_when_flag_absent() {
+        let _guard = test_support::env_guard();
+        std::env::set_var("AASM_API_KEY", "env-secret");
+        let parsed = Cli::try_parse_from(["aasm", "version"]);
+        std::env::remove_var("AASM_API_KEY");
+        let cli = parsed.expect("parse must succeed");
+        assert_eq!(cli.api_key.as_deref(), Some("env-secret"));
+    }
+
+    /// An explicit `--api-key` flag still wins over the env var (back-compat).
+    #[test]
+    fn api_key_flag_takes_precedence_over_env() {
+        let _guard = test_support::env_guard();
+        std::env::set_var("AASM_API_KEY", "env-secret");
+        let parsed = Cli::try_parse_from(["aasm", "--api-key", "flag-secret", "version"]);
+        std::env::remove_var("AASM_API_KEY");
+        let cli = parsed.expect("parse must succeed");
+        assert_eq!(cli.api_key.as_deref(), Some("flag-secret"));
+    }
+
+    /// With neither flag nor env set, `--api-key` resolves to `None` (no panic).
+    #[test]
+    fn api_key_none_when_neither_flag_nor_env_set() {
+        let _guard = test_support::env_guard();
+        std::env::remove_var("AASM_API_KEY");
+        let cli = Cli::try_parse_from(["aasm", "version"]).expect("parse must succeed");
+        assert!(cli.api_key.is_none());
+    }
+}

--- a/aa-cli/src/lib.rs
+++ b/aa-cli/src/lib.rs
@@ -7,6 +7,7 @@ pub mod commands;
 pub mod config;
 pub mod error;
 pub mod output;
+pub mod sanitize;
 
 #[cfg(test)]
 mod test_support;

--- a/aa-cli/src/lib.rs
+++ b/aa-cli/src/lib.rs
@@ -28,7 +28,13 @@ pub struct Cli {
     pub api_url: Option<String>,
 
     /// Override the API key (takes precedence over context config).
-    #[arg(long, global = true)]
+    ///
+    /// Reads from the `AASM_API_KEY` environment variable when the flag is
+    /// absent. Prefer the env var: passing `--api-key` on the command line
+    /// leaks the operator bearer token into argv, which is world-readable via
+    /// `ps`, `/proc/<pid>/cmdline`, and shell history. The flag still wins when
+    /// both are set, so existing scripts keep working.
+    #[arg(long, global = true, env = "AASM_API_KEY")]
     pub api_key: Option<String>,
 
     #[command(subcommand)]

--- a/aa-cli/src/sanitize.rs
+++ b/aa-cli/src/sanitize.rs
@@ -1,0 +1,69 @@
+//! Terminal output sanitization for server-supplied text.
+
+/// Strip terminal control sequences from server-supplied text before it is
+/// printed to the operator's terminal.
+///
+/// Fields such as an approval's `agent_id`, `action`, or `reason` originate
+/// from a (potentially malicious) agent and are echoed verbatim by
+/// `aasm approvals watch`, `aasm logs`, and the dashboard feed. Without
+/// sanitization, an agent can embed ANSI/OSC escape sequences that repaint the
+/// line so a dangerous request looks benign (approve/reject decision spoofing)
+/// or drive the terminal directly (e.g. an OSC-52 clipboard write).
+///
+/// This removes:
+/// - the ESC (`0x1b`) introducer together with the rest of the escape
+///   sequence it begins — CSI (`ESC [` … final byte `0x40`–`0x7e`),
+///   OSC (`ESC ]` … terminated by BEL `0x07` or ST `ESC \`), and the
+///   shorter two-byte escapes (`ESC` + one byte); and
+/// - every remaining C0 control character (`0x00`–`0x1f`) and DEL (`0x7f`),
+///   which includes newlines and carriage returns that could otherwise inject
+///   extra lines into a single-line field.
+///
+/// Printable text (including multi-byte Unicode) is preserved unchanged.
+pub fn sanitize_terminal(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            // ESC: consume the escape sequence it introduces.
+            '\u{1b}' => match chars.peek() {
+                Some('[') => {
+                    // CSI: parameters/intermediates up to a final byte.
+                    chars.next();
+                    for tail in chars.by_ref() {
+                        if ('\u{40}'..='\u{7e}').contains(&tail) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    // OSC: data terminated by BEL or ST (ESC \).
+                    chars.next();
+                    while let Some(&t) = chars.peek() {
+                        if t == '\u{07}' {
+                            chars.next();
+                            break;
+                        }
+                        if t == '\u{1b}' {
+                            chars.next();
+                            if chars.peek() == Some(&'\\') {
+                                chars.next();
+                            }
+                            break;
+                        }
+                        chars.next();
+                    }
+                }
+                Some(_) => {
+                    // Other two-byte escape (e.g. `ESC c`, `ESC ( B`).
+                    chars.next();
+                }
+                None => {}
+            },
+            // Drop all other C0 control characters and DEL.
+            c if (c as u32) < 0x20 || c as u32 == 0x7f => {}
+            c => out.push(c),
+        }
+    }
+    out
+}

--- a/aa-cli/src/sanitize.rs
+++ b/aa-cli/src/sanitize.rs
@@ -67,3 +67,35 @@ pub fn sanitize_terminal(input: &str) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_csi_color_sequences() {
+        assert_eq!(sanitize_terminal("\x1b[31mred\x1b[0m"), "red");
+        assert_eq!(sanitize_terminal("a\x1b[1;33mb\x1b[0mc"), "abc");
+    }
+
+    #[test]
+    fn strips_osc_clipboard_write() {
+        // OSC-52 clipboard write, BEL-terminated.
+        assert_eq!(sanitize_terminal("a\x1b]52;c;ZXZpbA==\x07b"), "ab");
+        // OSC title set, ST-terminated (ESC \).
+        assert_eq!(sanitize_terminal("a\x1b]0;pwned\x1b\\b"), "ab");
+    }
+
+    #[test]
+    fn strips_c0_controls_and_del() {
+        // Newlines/carriage returns/tab/backspace/DEL are all removed so a
+        // single-line field cannot inject extra lines.
+        assert_eq!(sanitize_terminal("line1\nline2\r\t\x08\x7fx"), "line1line2x");
+    }
+
+    #[test]
+    fn preserves_plain_and_unicode_text() {
+        assert_eq!(sanitize_terminal("agent-7 working"), "agent-7 working");
+        assert_eq!(sanitize_terminal("héllo-β-世界"), "héllo-β-世界");
+    }
+}


### PR DESCRIPTION
## Description

Hardens `aa-cli` against two MEDIUM-severity issues (AAASM-3892):

1. **`--api-key` argv leak.** The global `--api-key` flag had no environment
   fallback (AAASM-3867 added `AASM_API_KEY` only to `context set`), so every
   `aasm <cmd> --api-key sk-…` leaked the operator bearer token via `ps`,
   `/proc/<pid>/cmdline`, and shell history. Added `env = "AASM_API_KEY"` to the
   global flag; an explicit flag still wins for back-compat.

2. **Terminal-escape injection.** Server-supplied, agent-controlled fields
   (`agent_id`, `action`, `reason`, `message`, agent `name`/`framework`/etc.)
   were printed verbatim, letting a malicious agent embed ANSI/OSC escapes to
   repaint the operator's view (approve/reject decision spoofing) or drive the
   terminal (e.g. OSC-52 clipboard writes). Added a shared, non-test
   `sanitize_terminal` helper that strips the ESC introducer + the CSI/OSC
   sequence it begins plus all C0 control chars and DEL, and applied it to all
   server-supplied display fields in `approvals watch`, `logs`, the dashboard
   `feed`, and the `status` agents/budget tables.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

The `--api-key` flag continues to work and still overrides the env var.

## Related Issues

- Related Jira ticket: AAASM-3892 (relates to AAASM-3867)

Closes AAASM-3892

## Testing

- [x] Unit tests added / updated

New regression tests:
- `--api-key` resolves from `AASM_API_KEY` when the flag is absent, the flag
  wins when both are set, and resolution is `None` (no panic) when neither set.
- `sanitize_terminal` strips CSI colour, OSC (BEL- and ST-terminated), and
  C0/DEL control chars while preserving Unicode.
- `logs`, dashboard `feed`, and `status` render sites drop ESC + newline
  injection from agent-controlled fields.

Validation (dedicated `CARGO_TARGET_DIR`): `cargo build -p aa-cli` OK;
`cargo nextest run -p aa-cli` 784/784 pass; `cargo fmt --all -- --check` clean;
`cargo clippy -p aa-cli --all-targets -- -D warnings` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
