### PR TITLE
[AAASM-3900] 🔒 (aa-gateway): Wire aa-auth and guard /admin/status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ version = "0.0.1-rc.2"
 name = "aa-gateway"
 version = "0.0.1-rc.2"
 dependencies = [
+ "aa-auth",
  "aa-core",
  "aa-proto",
  "aa-runtime",

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -12,15 +12,27 @@ use crate::error::CliError;
 pub struct StatusClient {
     base_url: String,
     http: Client,
+    /// Optional bearer credential sent on the admin-gated `/api/v1/admin/status`
+    /// call (AAASM-3910). `None` for an unauthenticated client — which still
+    /// works against a bypass-default gateway (AAASM-1591).
+    api_key: Option<String>,
 }
 
 impl StatusClient {
-    /// Create a new `StatusClient` targeting the given gateway base URL.
+    /// Create a new `StatusClient` targeting the given gateway base URL with no
+    /// credential. Use [`with_api_key`](Self::with_api_key) to attach one.
     pub fn new(base_url: &str) -> Self {
         Self {
             base_url: base_url.trim_end_matches('/').to_string(),
             http: Client::new(),
+            api_key: None,
         }
+    }
+
+    /// Attach an optional bearer credential, sent on admin-gated requests.
+    pub fn with_api_key(mut self, api_key: Option<String>) -> Self {
+        self.api_key = api_key;
+        self
     }
 
     /// Build a full URL for the given API path.
@@ -51,7 +63,14 @@ impl StatusClient {
     /// missing storage section in `aasm status` rather than surfacing
     /// the error directly.
     pub async fn fetch_admin_status(&self) -> Result<AdminStatusResponse, CliError> {
-        let resp = self.http.get(self.url("/api/v1/admin/status")).send().await?;
+        // AAASM-3910: `/api/v1/admin/status` is admin-gated (AAASM-3895). Send
+        // the configured bearer credential when present; the public `/healthz`
+        // and `/api/v1/health` probes stay unauthenticated.
+        let mut req = self.http.get(self.url("/api/v1/admin/status"));
+        if let Some(ref key) = self.api_key {
+            req = req.bearer_auth(key);
+        }
+        let resp = req.send().await?;
         let body = resp.json::<AdminStatusResponse>().await?;
         Ok(body)
     }
@@ -98,5 +117,61 @@ impl StatusClient {
         let resp = self.http.get(self.url("/api/v1/costs")).send().await?;
         let body = resp.json::<CostResponse>().await?;
         Ok(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Minimal valid `/api/v1/admin/status` body the CLI can decode.
+    fn admin_status_body() -> serde_json::Value {
+        serde_json::json!({
+            "mode": "remote",
+            "version": "0.0.1",
+            "uptime_secs": 1,
+            "storage": {
+                "backend": "sqlite",
+                "health": "ok",
+                "latency_ms": 1,
+                "row_counts": { "audit_events_hot": 0, "agents": 0, "policy_versions": 0 }
+            }
+        })
+    }
+
+    /// AAASM-3910: with a configured key, the admin-status fetch must carry the
+    /// bearer credential. The mock only matches when the header is present, so a
+    /// 200 proves it was sent.
+    #[tokio::test]
+    async fn fetch_admin_status_sends_bearer_when_key_set() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/status"))
+            .and(header("authorization", "Bearer aa_test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(admin_status_body()))
+            .mount(&server)
+            .await;
+
+        let client = StatusClient::new(&server.uri()).with_api_key(Some("aa_test_key".to_string()));
+        let resp = client.fetch_admin_status().await.expect("admin status decodes");
+        assert_eq!(resp.mode, "remote");
+    }
+
+    /// With no key configured the fetch still works (bypass-default gateway):
+    /// no `Authorization` header is required by the mock.
+    #[tokio::test]
+    async fn fetch_admin_status_works_without_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(admin_status_body()))
+            .mount(&server)
+            .await;
+
+        let client = StatusClient::new(&server.uri());
+        let resp = client.fetch_admin_status().await.expect("admin status decodes");
+        assert_eq!(resp.mode, "remote");
     }
 }

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -65,7 +65,7 @@ pub fn compute_exit_code(snapshot: &StatusSnapshot) -> ExitCode {
 pub fn dispatch(args: StatusArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async {
-        let api_client = client::StatusClient::new(&ctx.api_url);
+        let api_client = client::StatusClient::new(&ctx.api_url).with_api_key(ctx.api_key.clone());
 
         if args.watch {
             watch::run_watch_loop(&api_client, output).await;

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -8,6 +8,10 @@ description = "Control plane — policy enforcement engine and agent registry fo
 
 [dependencies]
 aa-core      = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
+# AAASM-3907: the shared HTTP auth framework (AuthConfig / ApiKeyStore /
+# JwtVerifier / RateLimiter / RequireAdmin) extracted to a leaf crate by
+# AAASM-3899. Path-only like aa-api — the gateway never publishes against it.
+aa-auth      = { path = "../aa-auth" }
 aa-security  = { path = "../aa-security", version = "0.0.1-rc.2", features = ["serde"] }
 aa-proto     = { path = "../aa-proto", version = "0.0.1-rc.2" }
 aa-runtime   = { path = "../aa-runtime", version = "0.0.1-rc.2" }

--- a/aa-gateway/src/auth.rs
+++ b/aa-gateway/src/auth.rs
@@ -1,0 +1,186 @@
+//! Gateway auth bootstrap (AAASM-3907).
+//!
+//! Builds the four request-extension objects the shared `aa-auth` extractors
+//! ([`aa_auth::AuthenticatedCaller`], [`aa_auth::scope::RequireAdmin`], …) read
+//! from request parts: [`AuthConfig`], [`ApiKeyStore`], [`JwtVerifier`], and
+//! [`RateLimiter`]. A guarded route fails to resolve unless all four are
+//! layered, so both gateway routers apply [`AuthExtensions`] uniformly.
+//!
+//! ## BYPASS-DEFAULT — the safety contract
+//!
+//! A bare gateway must keep booting and answering `aasm status` with no
+//! credentials (the AAASM-1591 zero-config contract). [`AuthConfig::from_env`]
+//! defaults to [`AuthMode::On`] and *hard-errors* without `AA_JWT_SECRET`, so
+//! calling it unconditionally would make a zero-config gateway fail to boot and
+//! return 401. Instead the gateway constructs an [`AuthMode::Off`] (bypass)
+//! config **unless** auth is explicitly opted into — in bypass mode
+//! `RequireAdmin` resolves to the synthetic admin caller and every guarded
+//! route stays reachable. When an operator *does* opt in (`AA_GATEWAY_AUTH=on`
+//! or `AA_JWT_SECRET` set) the bootstrap fails closed: a misconfigured auth-on
+//! posture refuses to boot rather than serving open.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use aa_auth::api_key::ApiKeyStore;
+use aa_auth::config::{AuthConfig, AuthMode};
+use aa_auth::jwt::JwtVerifier;
+use aa_auth::rate_limit::RateLimiter;
+use axum::{Extension, Router};
+
+/// Default per-key requests-per-minute in bypass mode, matching the local
+/// single-process default in `aa-api` (`AppState::local_in_memory`).
+const BYPASS_RATE_LIMIT_RPM: u32 = 1000;
+
+/// The four auth objects layered as request extensions so the `aa-auth`
+/// extractors can resolve them. Cloning is cheap — every field is an `Arc`.
+#[derive(Clone)]
+pub struct AuthExtensions {
+    /// Auth mode + credential config consulted by every extractor.
+    pub config: Arc<AuthConfig>,
+    /// API-key store for `aa_…` bearer credentials.
+    pub key_store: Arc<ApiKeyStore>,
+    /// HMAC-SHA256 JWT verifier for bearer JWT credentials.
+    pub jwt_verifier: Arc<JwtVerifier>,
+    /// Per-key rate limiter.
+    pub rate_limiter: Arc<RateLimiter>,
+}
+
+impl AuthExtensions {
+    /// Build the gateway's auth objects from the environment, BYPASS-DEFAULT.
+    ///
+    /// Returns an [`AuthMode::Off`] bypass posture unless auth is explicitly
+    /// opted into (see [`auth_opted_in`]). When opted in, defers to
+    /// [`AuthConfig::from_env`] and *panics* if the resulting config is invalid
+    /// (e.g. `AA_GATEWAY_AUTH=on` without a valid `AA_JWT_SECRET`) — a
+    /// misconfigured auth-on gateway must refuse to boot rather than serve open.
+    pub fn from_env() -> Self {
+        if auth_opted_in() {
+            let config = AuthConfig::from_env().unwrap_or_else(|e| {
+                panic!(
+                    "gateway auth was explicitly enabled (AA_GATEWAY_AUTH/AA_JWT_SECRET) but its \
+                     configuration is invalid: {e}; refusing to boot in an insecure state"
+                )
+            });
+            Self::from_config(config)
+        } else {
+            Self::bypass()
+        }
+    }
+
+    /// Build an [`AuthMode::Off`] (bypass) posture: `RequireAdmin` resolves to
+    /// the synthetic admin caller and every guarded route stays reachable with
+    /// no credential. This is the zero-config default (AAASM-1591).
+    pub fn bypass() -> Self {
+        Self::from_config(AuthConfig {
+            mode: AuthMode::Off,
+            jwt_secret: None,
+            // Unused in bypass mode — no key file is consulted.
+            api_keys_path: PathBuf::from("/nonexistent-aa-gateway-bypass-keys"),
+            rate_limit_rpm: BYPASS_RATE_LIMIT_RPM,
+        })
+    }
+
+    /// Build the four objects from an already-resolved [`AuthConfig`].
+    pub fn from_config(config: AuthConfig) -> Self {
+        let rate_limiter = Arc::new(RateLimiter::new(config.rate_limit_rpm));
+        // In Off mode the verifier is never consulted; an empty secret is fine.
+        let jwt_verifier = Arc::new(JwtVerifier::new(config.jwt_secret.as_deref().unwrap_or(&[])));
+        // `load` on a missing path returns an empty store (infallible). In Off
+        // mode the store is never consulted; in On mode operators point
+        // `AA_API_KEYS_PATH` at their key file.
+        let key_store = Arc::new(
+            ApiKeyStore::load(&config.api_keys_path).unwrap_or_else(|_| ApiKeyStore::from_entries(Vec::new())),
+        );
+        Self {
+            config: Arc::new(config),
+            key_store,
+            jwt_verifier,
+            rate_limiter,
+        }
+    }
+
+    /// Layer the four extensions onto `router` so the `aa-auth` extractors can
+    /// resolve them from request parts. All four are required by `RequireAdmin`.
+    pub fn apply(&self, router: Router) -> Router {
+        router
+            .layer(Extension(self.config.clone()))
+            .layer(Extension(self.key_store.clone()))
+            .layer(Extension(self.jwt_verifier.clone()))
+            .layer(Extension(self.rate_limiter.clone()))
+    }
+}
+
+/// Whether the operator has explicitly opted the gateway into enforcing auth.
+///
+/// True when `AA_GATEWAY_AUTH` is `on` (case-insensitive), or when
+/// `AA_JWT_SECRET` is set (a JWT secret is meaningless unless auth is
+/// enforced). Otherwise the gateway runs in bypass mode so a bare
+/// `aasm status` keeps working with no credential.
+fn auth_opted_in() -> bool {
+    let flag_on = std::env::var("AA_GATEWAY_AUTH")
+        .map(|v| v.eq_ignore_ascii_case("on"))
+        .unwrap_or(false);
+    flag_on || std::env::var("AA_JWT_SECRET").is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serialize env-var-dependent tests under `cargo test`. (Under
+    /// `cargo nextest` each test runs in its own process, so this is redundant
+    /// there — it only guards the shared-process `cargo test` path.)
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_auth_env() {
+        std::env::remove_var("AA_GATEWAY_AUTH");
+        std::env::remove_var("AA_JWT_SECRET");
+        std::env::remove_var("AA_AUTH");
+    }
+
+    #[test]
+    fn bypass_yields_off_mode() {
+        let ext = AuthExtensions::bypass();
+        assert_eq!(ext.config.mode, AuthMode::Off);
+        assert!(ext.config.jwt_secret.is_none());
+    }
+
+    /// The AAASM-1591 zero-config contract: with no auth env set, the gateway
+    /// must default to bypass so a bare `aasm status` keeps working.
+    #[test]
+    fn from_env_defaults_to_bypass_when_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_auth_env();
+        let ext = AuthExtensions::from_env();
+        assert_eq!(
+            ext.config.mode,
+            AuthMode::Off,
+            "a zero-config gateway must default to bypass"
+        );
+    }
+
+    /// `AA_JWT_SECRET` alone is enough to opt the gateway into enforcing auth.
+    #[test]
+    fn from_env_opts_in_when_jwt_secret_set() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_auth_env();
+        std::env::set_var("AA_JWT_SECRET", "a-secret-that-is-at-least-32-bytes-long!!");
+        let ext = AuthExtensions::from_env();
+        clear_auth_env();
+        assert_eq!(ext.config.mode, AuthMode::On, "an explicit JWT secret must enable auth");
+    }
+
+    /// `AA_GATEWAY_AUTH=on` (with a valid secret) opts in explicitly.
+    #[test]
+    fn from_env_opts_in_when_gateway_auth_flag_on() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_auth_env();
+        std::env::set_var("AA_GATEWAY_AUTH", "ON");
+        std::env::set_var("AA_JWT_SECRET", "a-secret-that-is-at-least-32-bytes-long!!");
+        let ext = AuthExtensions::from_env();
+        clear_auth_env();
+        assert_eq!(ext.config.mode, AuthMode::On, "AA_GATEWAY_AUTH=on must enable auth");
+    }
+}

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -16,6 +16,7 @@ pub mod audit;
 pub mod audit_consumer;
 // strip-for-publish:end audit-consumer
 pub mod audit_reader;
+pub mod auth;
 pub mod budget;
 pub mod dashboard_server;
 pub mod edges;

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -17,6 +17,7 @@ use sqlx::sqlite::SqlitePool;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 
+use crate::auth::AuthExtensions;
 use crate::dashboard_server::{dashboard_router, find_dashboard_dist};
 use crate::routes::admin_status::{admin_status, AdminStatusState};
 use crate::routes::api_health::{api_health, ApiHealthState};
@@ -297,7 +298,11 @@ pub(crate) fn router_with_resolved_dist(
             ),
         }
     }
-    app
+    // AAASM-3909: layer the four `aa-auth` extensions so the `RequireAdmin`
+    // guard on `/api/v1/admin/status` can resolve. BYPASS-DEFAULT — with no
+    // auth env set this builds an `AuthMode::Off` config so a bare local-mode
+    // gateway keeps answering `aasm status` with no credential (AAASM-1591).
+    AuthExtensions::from_env().apply(app)
 }
 
 /// Create the parent directory tree for `path` if it does not yet exist.

--- a/aa-gateway/src/remote_mode/server.rs
+++ b/aa-gateway/src/remote_mode/server.rs
@@ -15,6 +15,7 @@ use axum_server::Handle;
 
 use super::error::GatewayError;
 use super::tls::{self, TlsValidation};
+use crate::auth::AuthExtensions;
 use crate::routes::admin_status::{admin_status, AdminStatusState};
 use crate::routes::healthz::{healthz, HealthzState};
 use crate::storage::{open_postgres_backend, PostgresConfig, StorageBackend};
@@ -42,7 +43,11 @@ pub fn router(storage: Option<Arc<dyn StorageBackend>>, database_url: Option<Str
             .route("/api/v1/admin/status", get(admin_status))
             .layer(Extension(admin_state));
     }
-    app
+    // AAASM-3908: layer the four `aa-auth` extensions so the `RequireAdmin`
+    // guard on `/api/v1/admin/status` can resolve. BYPASS-DEFAULT — with no
+    // auth env set this builds an `AuthMode::Off` config so a bare gateway keeps
+    // answering `aasm status` with no credential (AAASM-1591).
+    AuthExtensions::from_env().apply(app)
 }
 
 /// Print the operator-facing startup banner via `tracing::info!`.

--- a/aa-gateway/src/routes/admin_status.rs
+++ b/aa-gateway/src/routes/admin_status.rs
@@ -7,8 +7,12 @@
 //! storage section delivered by AAASM-1591 / Epic 18 S-J.
 //!
 //! Unlike `/healthz`, this handler performs a backend round-trip per call
-//! and is **not** intended for high-frequency load-balancer probes; mount
-//! it behind admin-only access (Epic 17 S-G IAM gating, to land).
+//! and is **not** intended for high-frequency load-balancer probes; it is
+//! gated behind admin-only access via the [`aa_auth::scope::RequireAdmin`]
+//! extractor (AAASM-3895). The gateway routers layer the four `aa-auth`
+//! extensions that back the extractor with BYPASS-DEFAULT, so a zero-config
+//! gateway resolves the guard to the synthetic admin caller and keeps serving
+//! `aasm status` with no credential (AAASM-1591).
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -89,7 +93,16 @@ impl AdminStatusState {
 /// Returning a 5xx instead would force the CLI to distinguish transport
 /// failures from logical health failures — splitting one signal into two
 /// for no operator benefit.
-pub async fn admin_status(Extension(state): Extension<AdminStatusState>) -> Json<AdminStatusBody> {
+///
+/// AAASM-3895: the [`aa_auth::scope::RequireAdmin`] extractor runs before the
+/// body is computed. In an auth-enabled gateway an unauthenticated caller gets
+/// `401`, a non-admin caller gets `403`, and only admin callers reach the
+/// storage probe. In a bypass-default gateway the extractor resolves to the
+/// synthetic admin caller, so the endpoint stays reachable with no credential.
+pub async fn admin_status(
+    _admin: aa_auth::scope::RequireAdmin,
+    Extension(state): Extension<AdminStatusState>,
+) -> Json<AdminStatusBody> {
     let storage_block = match state.storage.healthcheck().await {
         Ok(health) => {
             StorageHealthBlock::from_health(&health, state.sqlite_path.as_deref(), state.database_url.as_deref())
@@ -300,6 +313,18 @@ mod tests {
     use super::*;
     use crate::storage::{HealthStatus, RowCounts, StorageHealth, TimescaleStats};
 
+    /// A synthetic admin `RequireAdmin` for exercising the handler directly,
+    /// bypassing the extractor's request-parts path (AAASM-3895). The
+    /// extension-driven 401/403/bypass behaviour is covered by the
+    /// router-level tests in `auth_guard_tests`.
+    fn admin_guard() -> aa_auth::scope::RequireAdmin {
+        aa_auth::scope::RequireAdmin(aa_auth::AuthenticatedCaller {
+            key_id: "test-admin".to_string(),
+            scopes: vec![aa_auth::scope::Scope::Admin],
+            tenant: aa_auth::Tenant::default(),
+        })
+    }
+
     fn sample_health(backend: &'static str, timescale: Option<TimescaleStats>) -> StorageHealth {
         StorageHealth {
             status: HealthStatus::Ok,
@@ -480,7 +505,7 @@ mod tests {
     #[tokio::test]
     async fn handler_returns_documented_body_against_sqlite_backend() {
         let (_tmp, state) = sqlite_state().await;
-        let Json(body) = admin_status(Extension(state.clone())).await;
+        let Json(body) = admin_status(admin_guard(), Extension(state.clone())).await;
         assert_eq!(body.mode, "local");
         assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
         assert_eq!(body.storage.backend, "sqlite");
@@ -495,7 +520,7 @@ mod tests {
         let (_tmp, mut state) = sqlite_state().await;
         // Back-date started_at so uptime_secs is non-zero without sleeping.
         state.started_at = Instant::now() - std::time::Duration::from_secs(5);
-        let Json(body) = admin_status(Extension(state)).await;
+        let Json(body) = admin_status(admin_guard(), Extension(state)).await;
         assert!(body.uptime_secs >= 5, "expected uptime ≥ 5s, got {}", body.uptime_secs);
     }
 
@@ -522,5 +547,114 @@ mod tests {
             json["storage"]["database_url"],
             "postgresql://aasm:***@db.internal:5432/aasm"
         );
+    }
+}
+
+/// AAASM-3895: end-to-end auth behaviour of `/api/v1/admin/status` driven
+/// through a real router with the four `aa-auth` extensions layered. Proves the
+/// `RequireAdmin` guard's bypass / 401 / 403 / 200 matrix at the wire level.
+#[cfg(test)]
+mod auth_guard_tests {
+    use super::*;
+    use crate::auth::AuthExtensions;
+    use crate::storage::{SqliteBackend, SqliteConfig};
+    use aa_auth::config::{AuthConfig, AuthMode};
+    use aa_auth::jwt::JwtSigner;
+    use aa_auth::scope::Scope;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    /// HMAC secret shared between the test `JwtSigner` and the On-mode
+    /// `AuthExtensions` so minted tokens verify.
+    const TEST_SECRET: &[u8] = b"gateway-admin-guard-test-secret-32bytes!";
+
+    /// Open a real SQLite-backed `StorageBackend` under a per-test tempdir.
+    async fn sqlite_backend() -> (tempfile::TempDir, Arc<dyn StorageBackend>) {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let path = tmp.path().join("local.db");
+        let backend = SqliteBackend::open(&SqliteConfig { path })
+            .await
+            .expect("open sqlite backend");
+        backend.migrate().await.expect("migrate");
+        (tmp, Arc::new(backend))
+    }
+
+    /// Mount `/api/v1/admin/status` with its state and layer the supplied auth
+    /// extensions — mirrors what the gateway routers do in production.
+    fn admin_router(storage: Arc<dyn StorageBackend>, auth: AuthExtensions) -> Router {
+        let admin_state = AdminStatusState::new("remote", storage, None, None);
+        let app = Router::new()
+            .route("/api/v1/admin/status", get(admin_status))
+            .layer(Extension(admin_state));
+        auth.apply(app)
+    }
+
+    /// An `AuthMode::On` posture whose verifier accepts tokens signed with
+    /// [`TEST_SECRET`].
+    fn on_mode_auth() -> AuthExtensions {
+        AuthExtensions::from_config(AuthConfig {
+            mode: AuthMode::On,
+            jwt_secret: Some(TEST_SECRET.to_vec()),
+            api_keys_path: std::path::PathBuf::from("/nonexistent-aa-test-keys"),
+            rate_limit_rpm: 1000,
+        })
+    }
+
+    fn request_with_token(token: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder().uri("/api/v1/admin/status");
+        if let Some(token) = token {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        builder.body(Body::empty()).expect("build request")
+    }
+
+    /// Zero-config smoke: in bypass mode the guard resolves to the synthetic
+    /// admin caller, so an unauthenticated request returns 200 (AAASM-1591).
+    #[tokio::test]
+    async fn bypass_mode_serves_unauthenticated_request() {
+        let (_tmp, storage) = sqlite_backend().await;
+        let app = admin_router(storage, AuthExtensions::bypass());
+        let resp = app.oneshot(request_with_token(None)).await.expect("oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "bypass-default must keep /admin/status reachable with no credential"
+        );
+    }
+
+    /// In On mode an unauthenticated request is rejected with 401.
+    #[tokio::test]
+    async fn on_mode_rejects_unauthenticated_request() {
+        let (_tmp, storage) = sqlite_backend().await;
+        let app = admin_router(storage, on_mode_auth());
+        let resp = app.oneshot(request_with_token(None)).await.expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// In On mode a valid non-admin (read-only) credential is rejected with 403.
+    #[tokio::test]
+    async fn on_mode_rejects_non_admin_credential() {
+        let (_tmp, storage) = sqlite_backend().await;
+        let app = admin_router(storage, on_mode_auth());
+        let token = JwtSigner::new(TEST_SECRET)
+            .sign("reader-1", &[Scope::Read])
+            .expect("sign read token");
+        let resp = app.oneshot(request_with_token(Some(&token))).await.expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// In On mode an admin credential reaches the handler and returns 200.
+    #[tokio::test]
+    async fn on_mode_accepts_admin_credential() {
+        let (_tmp, storage) = sqlite_backend().await;
+        let app = admin_router(storage, on_mode_auth());
+        let token = JwtSigner::new(TEST_SECRET)
+            .sign("admin-1", &[Scope::Admin])
+            .expect("sign admin token");
+        let resp = app.oneshot(request_with_token(Some(&token))).await.expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
## Description

Wires the shared `aa-auth` leaf crate (extracted by Story A / AAASM-3899, #1317) into the gateway and applies the `RequireAdmin` guard to the previously-unauthenticated `GET /api/v1/admin/status` endpoint (the AAASM-3895 capstone), plus updates the `aasm status` CLI to send a bearer credential.

Stories B (AAASM-3900) and C (AAASM-3901) ship as **one PR** because Story B alone is inert: the four auth request-extensions are not consumed until Story C applies `RequireAdmin`. A wiring-only PR would add unused bootstrap, so they land together as one cohesive, testable security change — mirroring why Story A was one PR.

### What changed

- **B1 (AAASM-3907)** — `aa-auth` added as an `aa-gateway` dependency; new `AuthExtensions` bootstrap that builds the four objects the `aa-auth` extractors read (`AuthConfig`, `ApiKeyStore`, `JwtVerifier`, `RateLimiter`) and layers them onto a router.
- **B2 (AAASM-3908)** — the four extensions are layered onto the **remote-mode** router (`remote_mode/server.rs`).
- **B3 (AAASM-3909)** — same on the **local-mode** router (`local_mode.rs`).
- **C2 = AAASM-3895** — `admin_status` handler now takes `RequireAdmin` before `Extension(state)`. Auth-enabled gateway: unauthenticated → 401, non-admin → 403, admin → 200.
- **C1 (AAASM-3910)** — `StatusClient` stores an `Option<String>` api_key and sends `.bearer_auth(key)` on the admin-gated `/api/v1/admin/status` call; `/healthz` and `/api/v1/health` stay public.

### BYPASS-DEFAULT — preserves the AAASM-1591 zero-config contract

`AuthConfig::from_env()` defaults to `AuthMode::On` and **hard-errors without `AA_JWT_SECRET`**. Using it directly would make a bare gateway fail to boot and return 401 on `aasm status`, breaking zero-config. So `AuthExtensions::from_env()` builds an `AuthMode::Off` (bypass) config **UNLESS** auth is explicitly opted in:

```
fn auth_opted_in() -> bool {
    AA_GATEWAY_AUTH == "on" (case-insensitive)  ||  AA_JWT_SECRET is set
}
```

In bypass mode the `aa-auth` extractor resolves `RequireAdmin` to the synthetic admin caller, so every guarded route stays reachable with no credential. When auth **is** opted in, the bootstrap fails closed — a misconfigured auth-on posture panics rather than booting insecure.

## Type of Change

- [x] 🐛 Bug fix (closes the AAASM-3895 information-disclosure gap)
- [x] ✨ New feature (gateway auth wiring)

## Breaking Changes

- [x] No — default behaviour is unchanged. A zero-config gateway stays in bypass mode and `aasm status` works with or without a key. Auth enforcement is strictly opt-in via `AA_GATEWAY_AUTH=on` / `AA_JWT_SECRET`.

## Related Issues

- Closes AAASM-3900
- Closes AAASM-3907
- Closes AAASM-3908
- Closes AAASM-3909
- Closes AAASM-3901
- Closes AAASM-3910
- Closes AAASM-3895

## Testing

- [x] Unit tests added / updated

New gateway tests (`routes::admin_status::auth_guard_tests`) drive the full wire-level matrix through a real router with the four extensions layered: bypass → 200 (zero-config smoke), On + no credential → 401, On + non-admin JWT → 403, On + admin JWT → 200. Bootstrap unit tests (`auth::tests`) assert `from_env` defaults to bypass when unset and opts in on `AA_GATEWAY_AUTH=on` / `AA_JWT_SECRET`. New CLI tests assert the bearer is sent when a key is configured and the fetch still works without one.

Validation (in worktree, `aa-cli` built with protoc):

- `cargo build -p aa-gateway -p aa-cli` — clean
- `cargo nextest run -p aa-gateway -p aa-cli` — 2114 passed, 0 failed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p aa-gateway -p aa-cli --all-targets -- -D warnings` — clean

## OpenAPI

No spec drift: `/api/v1/admin/status` is gateway-served and carries no `utoipa::path` annotation; it does not appear in any `openapi/*.yaml` or in `aa-api`'s OpenAPI surface. No spec to regenerate.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (handler + bootstrap doc comments)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf