### PR TITLE
[AAASM-3912] ♻️ (auth): Align halt_global scope + accurate Scope doc + AA_GATEWAY_AUTH truthy

### DIFF
--- a/aa-api/src/routes/ops.rs
+++ b/aa-api/src/routes/ops.rs
@@ -21,7 +21,7 @@ use utoipa::ToSchema;
 
 use aa_proto::assembly::policy::v1::OpControlSignal;
 
-use crate::auth::scope::{RequireRead, RequireWrite, Scope};
+use crate::auth::scope::{RequireAdmin, RequireRead, RequireWrite, Scope};
 use crate::auth::AuthenticatedCaller;
 use crate::error::ProblemDetail;
 use crate::events::OpsChangeBroadcast;
@@ -394,15 +394,13 @@ pub async fn halt_agent_for_op(
     )
 )]
 pub async fn halt_global(
-    RequireWrite(caller): RequireWrite,
+    // A fleet-wide kill switch is an escalated capability — admin only. The
+    // `RequireAdmin` extractor rejects non-admin callers with 403 before the
+    // handler body runs, mirroring the admin routes (e.g. `update_retention_policy`).
+    _auth: RequireAdmin,
     Extension(state): Extension<AppState>,
     Json(req): Json<OpHaltRequest>,
 ) -> Result<impl IntoResponse, ProblemDetail> {
-    // A fleet-wide kill switch is an escalated capability — admin only.
-    if !caller.scopes.contains(&Scope::Admin) {
-        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
-            .with_detail("A global halt requires admin scope".to_string()));
-    }
     let signal = parse_halt_action(&req.action)?;
     // AAASM-3883: cross-process NATS delivery when configured (see halt_agent_for_op).
     match state.ops_registry.halt_global_delivery(signal).await {

--- a/aa-api/tests/ops_lifecycle.rs
+++ b/aa-api/tests/ops_lifecycle.rs
@@ -234,7 +234,7 @@ async fn halt_global_without_publisher_returns_503() {
 #[tokio::test]
 async fn halt_global_requires_admin_scope() {
     // A write-but-not-admin caller may drive per-op lifecycle, but the
-    // fleet-wide kill switch is gated to admins.
+    // fleet-wide kill switch is gated to admins by the `RequireAdmin` extractor.
     let (plaintext, entry) = common::generate_test_api_key("writer", vec![Scope::Read, Scope::Write]);
     let app = common::test_app_with_auth(&[entry], 1000);
     let response = app
@@ -250,4 +250,27 @@ async fn halt_global_requires_admin_scope() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn halt_global_admin_passes_scope_gate() {
+    // An admin-scoped caller clears the `RequireAdmin` gate and proceeds into
+    // the handler body. The test app attaches no op-control publisher, so the
+    // request gets past the 403 gate and surfaces 503 (channel not configured)
+    // rather than being rejected at the scope check.
+    let (plaintext, entry) = common::generate_test_api_key("admin", vec![Scope::Admin]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/ops/global/halt")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"action":"terminate"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/aa-auth/src/scope.rs
+++ b/aa-auth/src/scope.rs
@@ -17,7 +17,10 @@ pub enum Scope {
     Read,
     /// Read and write access (create, update, delete).
     Write,
-    /// Full administrative access including agent kill.
+    /// Global / cross-tenant administrative access — e.g. fleet-wide halt,
+    /// retention policy, and IAM key management. Per-tenant destructive actions
+    /// (agent suspend/resume/delete, op lifecycle) are gated by Write plus
+    /// tenant ownership, not flat Admin.
     Admin,
 }
 

--- a/aa-gateway/src/auth.rs
+++ b/aa-gateway/src/auth.rs
@@ -113,15 +113,28 @@ impl AuthExtensions {
 
 /// Whether the operator has explicitly opted the gateway into enforcing auth.
 ///
-/// True when `AA_GATEWAY_AUTH` is `on` (case-insensitive), or when
-/// `AA_JWT_SECRET` is set (a JWT secret is meaningless unless auth is
-/// enforced). Otherwise the gateway runs in bypass mode so a bare
-/// `aasm status` keeps working with no credential.
+/// True when `AA_GATEWAY_AUTH` is a truthy value (case-insensitive: `on`,
+/// `true`, `1`, `yes`, `enabled`), or when `AA_JWT_SECRET` is set (a JWT
+/// secret is meaningless unless auth is enforced). Otherwise the gateway runs
+/// in bypass mode so a bare `aasm status` keeps working with no credential.
+///
+/// Note: `AA_GATEWAY_AUTH` is the *gateway* opt-in knob, distinct from
+/// `aa-api`'s separate `AA_AUTH` toggle — they govern independent processes
+/// and are read independently.
 fn auth_opted_in() -> bool {
-    let flag_on = std::env::var("AA_GATEWAY_AUTH")
-        .map(|v| v.eq_ignore_ascii_case("on"))
-        .unwrap_or(false);
+    let flag_on = std::env::var("AA_GATEWAY_AUTH").map(|v| is_truthy(&v)).unwrap_or(false);
     flag_on || std::env::var("AA_JWT_SECRET").is_ok()
+}
+
+/// Whether an env-var string is a common truthy value (case-insensitive):
+/// `on`, `true`, `1`, `yes`, or `enabled`.
+fn is_truthy(value: &str) -> bool {
+    let v = value.trim();
+    v.eq_ignore_ascii_case("on")
+        || v.eq_ignore_ascii_case("true")
+        || v.eq_ignore_ascii_case("1")
+        || v.eq_ignore_ascii_case("yes")
+        || v.eq_ignore_ascii_case("enabled")
 }
 
 #[cfg(test)]
@@ -182,5 +195,19 @@ mod tests {
         let ext = AuthExtensions::from_env();
         clear_auth_env();
         assert_eq!(ext.config.mode, AuthMode::On, "AA_GATEWAY_AUTH=on must enable auth");
+    }
+
+    /// `AA_GATEWAY_AUTH` accepts common truthy spellings (case-insensitive);
+    /// anything else is treated as not-opted-in.
+    #[test]
+    fn is_truthy_accepts_common_values_and_rejects_others() {
+        for v in [
+            "on", "ON", "On", "true", "TRUE", "1", "yes", "YES", "enabled", "Enabled", " on ",
+        ] {
+            assert!(is_truthy(v), "{v:?} should be truthy");
+        }
+        for v in ["off", "false", "0", "no", "disabled", "", "onn", "enable"] {
+            assert!(!is_truthy(v), "{v:?} should not be truthy");
+        }
     }
 }


### PR DESCRIPTION
## Description

Low-risk auth-hardening cleanup with **no meaningful behavior change**. Three items:

1. **`aa-api` `halt_global`** — replace the `RequireWrite` extractor + in-handler `Scope::Admin` check with the `RequireAdmin` extractor, mirroring the admin routes (`update_retention_policy`). Effective behavior is identical: still admin-only, still `403` for non-admin, `503` when no op-control channel is configured. The gate now lives in the extractor rather than the handler body.
2. **`aa-auth` `Scope::Admin` doc** — doc-only. Clarify Admin as global / cross-tenant administrative access (fleet-wide halt, retention policy, IAM key management). Per-tenant destructive actions (agent suspend/resume/delete, op lifecycle) are gated by `Write` + tenant ownership, not flat Admin.
3. **`aa-gateway` `AA_GATEWAY_AUTH`** — broaden the opt-in check to accept common truthy values case-insensitively (`on`, `true`, `1`, `yes`, `enabled`). Doc added distinguishing this gateway knob from `aa-api`'s separate `AA_AUTH`. The `AA_JWT_SECRET`-implies-opt-in and bypass-default semantics are unchanged.

No schema changes. No endpoints other than `halt_global` touched — the Write+ownership model for per-tenant ops (suspend/resume/delete, pause/resume/terminate) is intentional and untouched.

## Type of Change

- [x] ♻️ Refactoring
- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3912

Closes AAASM-3912

## Testing

- [x] Unit tests added / updated

- `halt_global`: kept non-admin → `403` regression, added admin → passes-gate (`503`, past the scope check).
- `AA_GATEWAY_AUTH`: added `is_truthy` parsing test (accepts truthy spellings, rejects others).
- `cargo build/nextest/fmt --check/clippy -D warnings` clean for `aa-api`, `aa-gateway`, `aa-auth` (2176 tests pass).
- OpenAPI regenerated (`generate_openapi`) and diffed against `openapi/v1.yaml` — **no drift** (the `403` response was already documented; the utoipa annotation was not changed).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
