### PR TITLE
[AAASM-3915] 🔒 (aa-cli): Sanitize REST-polled dashboard data at ingestion

### DIFF
--- a/aa-cli/src/commands/dashboard/feed.rs
+++ b/aa-cli/src/commands/dashboard/feed.rs
@@ -12,6 +12,62 @@ use crate::commands::status::fetch;
 use crate::commands::status::models::{AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, RuntimeHealth};
 use crate::sanitize::sanitize_terminal;
 
+/// Sanitize every server/agent-controlled string field of an [`AgentRow`] so
+/// terminal escape sequences can never reach the dashboard's rendered output.
+/// Numeric fields (`sessions`, `violations_today`) are left untouched.
+fn sanitize_agent_row(mut row: AgentRow) -> AgentRow {
+    row.id = sanitize_terminal(&row.id);
+    row.name = sanitize_terminal(&row.name);
+    row.framework = sanitize_terminal(&row.framework);
+    row.status = sanitize_terminal(&row.status);
+    row.last_event = sanitize_terminal(&row.last_event);
+    row.layer = sanitize_terminal(&row.layer);
+    row
+}
+
+/// Sanitize every server/agent-controlled string field of an [`ApprovalResponse`].
+/// Covers both the approve/reject confirmation dialog and the approvals panel.
+fn sanitize_approval(mut ap: ApprovalResponse) -> ApprovalResponse {
+    ap.id = sanitize_terminal(&ap.id);
+    ap.agent_id = sanitize_terminal(&ap.agent_id);
+    ap.action = sanitize_terminal(&ap.action);
+    ap.reason = sanitize_terminal(&ap.reason);
+    ap.status = sanitize_terminal(&ap.status);
+    ap.created_at = sanitize_terminal(&ap.created_at);
+    ap.team_id = sanitize_terminal(&ap.team_id);
+    ap.routing_status = sanitize_terminal(&ap.routing_status);
+    ap
+}
+
+/// Sanitize every server-supplied string field of a [`BudgetRow`], including the
+/// per-agent cost breakdown. Numeric ratios are computed downstream by parsing
+/// these strings, so stripped escapes leave well-formed amounts intact.
+fn sanitize_budget(mut budget: BudgetRow) -> BudgetRow {
+    budget.daily_spend_usd = sanitize_terminal(&budget.daily_spend_usd);
+    budget.monthly_spend_usd = budget.monthly_spend_usd.as_deref().map(sanitize_terminal);
+    budget.daily_limit_usd = budget.daily_limit_usd.as_deref().map(sanitize_terminal);
+    budget.monthly_limit_usd = budget.monthly_limit_usd.as_deref().map(sanitize_terminal);
+    budget.date = sanitize_terminal(&budget.date);
+    for entry in &mut budget.per_agent {
+        entry.agent_id = sanitize_terminal(&entry.agent_id);
+        entry.daily_spend_usd = sanitize_terminal(&entry.daily_spend_usd);
+    }
+    budget
+}
+
+/// Sanitize the server-supplied `status` string of [`RuntimeHealth`], which is
+/// rendered raw in the agents-panel health header. Numeric fields are untouched.
+fn sanitize_runtime(mut runtime: RuntimeHealth) -> RuntimeHealth {
+    runtime.status = sanitize_terminal(&runtime.status);
+    runtime
+}
+
+/// Sanitize the string field of an [`ApprovalsSummary`]. The count is numeric.
+fn sanitize_approvals_summary(mut summary: ApprovalsSummary) -> ApprovalsSummary {
+    summary.oldest_pending_age = summary.oldest_pending_age.as_deref().map(sanitize_terminal);
+    summary
+}
+
 use super::state::EventEntry;
 
 /// Messages sent from background data tasks to the main event loop.
@@ -56,20 +112,23 @@ pub fn spawn_rest_poller(api_url: &str, tx: mpsc::UnboundedSender<FeedMessage>) 
             let snapshot = fetch::fetch_all(&client).await;
 
             // Fetch the raw approvals list so we have individual pending items.
+            // Sanitize every server/agent-controlled field at ingestion (mirroring
+            // the WebSocket path) so escape sequences can never reach a render.
             let pending_approvals = client
                 .list_approvals()
                 .await
                 .unwrap_or_default()
                 .into_iter()
                 .filter(|a| a.status == "pending")
+                .map(sanitize_approval)
                 .collect();
 
             let msg = FeedMessage::StatusUpdate {
-                runtime: snapshot.runtime,
-                agents: snapshot.agents,
-                approvals_summary: snapshot.approvals,
+                runtime: sanitize_runtime(snapshot.runtime),
+                agents: snapshot.agents.into_iter().map(sanitize_agent_row).collect(),
+                approvals_summary: sanitize_approvals_summary(snapshot.approvals),
                 pending_approvals,
-                budget: snapshot.budget,
+                budget: sanitize_budget(snapshot.budget),
             };
 
             if tx.send(msg).is_err() {

--- a/aa-cli/src/commands/dashboard/feed.rs
+++ b/aa-cli/src/commands/dashboard/feed.rs
@@ -270,6 +270,113 @@ mod tests {
         assert!(entry.message.contains("100"));
     }
 
+    use crate::commands::status::models::AgentCostEntry;
+
+    /// An ESC-introduced CSI colour sequence plus an OSC-52 clipboard write and a
+    /// newline — exactly the escapes an agent would embed to spoof an
+    /// approve/reject decision or hijack the operator's clipboard.
+    const ATTACK: &str = "\x1b[31mEVIL\x1b]52;c;ZXZpbA==\x07\ndrop";
+    const ATTACK_CLEAN: &str = "EVILdrop";
+
+    #[test]
+    fn sanitize_approval_strips_escapes_from_every_field() {
+        let ap = ApprovalResponse {
+            id: format!("id{ATTACK}"),
+            agent_id: format!("agent{ATTACK}"),
+            action: format!("action{ATTACK}"),
+            reason: format!("reason{ATTACK}"),
+            status: "pending".to_string(),
+            created_at: format!("ts{ATTACK}"),
+            team_id: format!("team{ATTACK}"),
+            routing_status: format!("route{ATTACK}"),
+        };
+        let clean = sanitize_approval(ap);
+        for field in [
+            &clean.id,
+            &clean.agent_id,
+            &clean.action,
+            &clean.reason,
+            &clean.created_at,
+            &clean.team_id,
+            &clean.routing_status,
+        ] {
+            assert!(!field.contains('\x1b'), "ESC must be stripped: {field:?}");
+            assert!(!field.contains('\n'), "newline must be stripped: {field:?}");
+        }
+        assert_eq!(clean.action, format!("action{ATTACK_CLEAN}"));
+        assert_eq!(clean.reason, format!("reason{ATTACK_CLEAN}"));
+    }
+
+    #[test]
+    fn sanitize_agent_row_strips_escapes_from_every_field() {
+        let row = AgentRow {
+            id: format!("id{ATTACK}"),
+            name: format!("name{ATTACK}"),
+            framework: format!("fw{ATTACK}"),
+            status: format!("status{ATTACK}"),
+            sessions: 3,
+            violations_today: 1,
+            last_event: format!("evt{ATTACK}"),
+            layer: format!("layer{ATTACK}"),
+        };
+        let clean = sanitize_agent_row(row);
+        for field in [
+            &clean.id,
+            &clean.name,
+            &clean.framework,
+            &clean.status,
+            &clean.last_event,
+            &clean.layer,
+        ] {
+            assert!(!field.contains('\x1b'), "ESC must be stripped: {field:?}");
+            assert!(!field.contains('\n'), "newline must be stripped: {field:?}");
+        }
+        assert_eq!(clean.name, format!("name{ATTACK_CLEAN}"));
+        // Numeric fields are untouched.
+        assert_eq!(clean.sessions, 3);
+        assert_eq!(clean.violations_today, 1);
+    }
+
+    #[test]
+    fn sanitize_budget_strips_escapes_including_per_agent() {
+        let budget = BudgetRow {
+            daily_spend_usd: format!("1{ATTACK}"),
+            monthly_spend_usd: Some(format!("2{ATTACK}")),
+            daily_limit_usd: Some(format!("3{ATTACK}")),
+            monthly_limit_usd: None,
+            date: format!("d{ATTACK}"),
+            per_agent: vec![AgentCostEntry {
+                agent_id: format!("a{ATTACK}"),
+                daily_spend_usd: format!("4{ATTACK}"),
+            }],
+        };
+        let clean = sanitize_budget(budget);
+        assert!(!clean.daily_spend_usd.contains('\x1b'));
+        assert!(!clean.monthly_spend_usd.as_deref().unwrap().contains('\x1b'));
+        assert!(!clean.date.contains('\n'));
+        let entry = &clean.per_agent[0];
+        assert!(!entry.agent_id.contains('\x1b'), "per-agent id must be stripped");
+        assert!(!entry.daily_spend_usd.contains('\x1b'));
+        assert_eq!(entry.agent_id, format!("a{ATTACK_CLEAN}"));
+    }
+
+    #[test]
+    fn sanitize_runtime_strips_escapes_from_status() {
+        let runtime = RuntimeHealth {
+            reachable: true,
+            status: format!("ok{ATTACK}"),
+            uptime_secs: 10,
+            active_connections: 2,
+            pipeline_lag_ms: 1,
+        };
+        let clean = sanitize_runtime(runtime);
+        assert!(!clean.status.contains('\x1b'));
+        assert!(!clean.status.contains('\n'));
+        assert_eq!(clean.status, format!("ok{ATTACK_CLEAN}"));
+        // Numeric fields untouched.
+        assert_eq!(clean.uptime_secs, 10);
+    }
+
     // Port 1 is reserved and never listened on, so both background tasks hit
     // their connection-failure paths fast and deterministically. The REST
     // poller still emits a (degraded) StatusUpdate even when the gateway is


### PR DESCRIPTION
## What changed

The `aasm dashboard` REST poller (`spawn_rest_poller`, `aa-cli/src/commands/dashboard/feed.rs`) forwarded raw `agents` / `approvals` / `pending_approvals` / `budget` snapshots straight into `DashboardState`, while the WebSocket path (`ws_event_to_entry`) already sanitized every field via `sanitize_terminal`. This change adds ingestion-time sanitizers that mirror the WS choke point and wires them into the poller, so every server/agent-controlled **string** field of `AgentRow`, `ApprovalResponse`, `BudgetRow` (incl. per-agent cost entries), `ApprovalsSummary`, and `RuntimeHealth.status` is stripped of terminal escapes before it can reach any render. Numeric fields and the JSON/YAML output paths are untouched.

## Why

AAASM-3915 (Med, security). Continuation-miss from the AAASM-3892 terminal-sanitization sweep, which covered the WS event feed but not the REST-polled dashboard data. Agent-controlled fields (`action`, `reason`, `id`, `name`, `agent_id`, `framework`, …) reached the approve/reject confirmation dialog (`dialog.rs`) and the agents/approvals/budget panels and overlays (`ui.rs`) unsanitized, enabling ANSI/OSC escape injection — approve/reject decision spoofing and OSC-52 clipboard hijack. Sanitizing at one ingestion choke point covers all downstream `ui.rs` / `dialog.rs` sinks. (The policy-viewer overlay renders local, operator-owned policy YAML, not REST-polled agent data, so it is out of scope.)

## How to verify

- `cargo nextest run -p aa-cli` — 796 pass, including 4 new tests in `commands::dashboard::feed::tests` (`sanitize_approval_*`, `sanitize_agent_row_*`, `sanitize_budget_*`, `sanitize_runtime_*`) that assert an injected CSI colour sequence + OSC-52 clipboard write + newline are stripped from every field before reaching state, and numeric fields are preserved.
- `cargo fmt --all -- --check`, `cargo clippy -p aa-cli --all-targets -- -D warnings` — clean.

Closes AAASM-3915

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf