### PR TITLE
[AAASM-3914] 🔒 (invalidation): Bind Subscribe assembly_id to authenticated caller

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2764,7 +2764,7 @@ mod tests {
 
         // A subscriber connected before the mutation should be notified.
         let hub = InvalidationHub::new();
-        let mut handle = hub.subscribe("asm-itest", None, 0);
+        let mut handle = hub.subscribe("asm-itest", None, 0).expect("subscribe succeeds");
         let engine = make_engine(empty_doc()).with_invalidation_hub(Arc::clone(&hub));
 
         let start = std::time::Instant::now();

--- a/aa-gateway/src/invalidation/hub.rs
+++ b/aa-gateway/src/invalidation/hub.rs
@@ -426,4 +426,65 @@ mod tests {
             "team-b replay ring must not contain team-a's event"
         );
     }
+
+    /// AAASM-3914 regression: a Subscribe whose `assembly_id` already belongs to
+    /// another tenant is refused, so the caller can neither attach to the
+    /// victim's broadcast channel nor trim its replay ring.
+    #[tokio::test]
+    async fn subscribe_rejects_cross_tenant_assembly_id_reuse() {
+        let hub = InvalidationHub::new();
+        let mut victim = hub
+            .subscribe("asm-shared", Some("team-a".to_string()), 0)
+            .expect("victim subscribe succeeds");
+
+        // Attacker in team-b knows team-a's assembly_id; binding is refused.
+        let attacker = hub.subscribe("asm-shared", Some("team-b".to_string()), 0);
+        assert!(matches!(attacker, Err(SubscribeError::TenantMismatch)));
+
+        // An untenanted caller likewise may not claim a tenanted slot.
+        let untenanted = hub.subscribe("asm-shared", None, 0);
+        assert!(matches!(untenanted, Err(SubscribeError::TenantMismatch)));
+
+        // The victim's own event still flows to the victim only; the rejected
+        // attacker never received a handle, so nothing leaked.
+        hub.broadcast_approval_resolved("req-a", Decision::Approved, Some("team-a"));
+        let event = tokio::time::timeout(Duration::from_millis(100), victim.receiver.recv())
+            .await
+            .expect("victim event delivered within 100 ms")
+            .expect("channel open");
+        assert_eq!(event.seq, 1);
+
+        // The attacker's rejection left no extra subscriber registered.
+        assert_eq!(hub.subscriber_count(), 1);
+    }
+
+    /// AAASM-3914 regression: the legitimate reconnect path — same tenant, same
+    /// assembly_id — is still permitted, resumes from `last_seq_seen`, and keeps
+    /// receiving its tenant's live events.
+    #[tokio::test]
+    async fn subscribe_allows_same_tenant_reconnect() {
+        let hub = InvalidationHub::new();
+        let first = hub
+            .subscribe("asm-a", Some("team-a".to_string()), 0)
+            .expect("first subscribe succeeds");
+        drop(first);
+
+        hub.broadcast_approval_resolved("req-1", Decision::Approved, Some("team-a"));
+        hub.broadcast_approval_resolved("req-2", Decision::Approved, Some("team-a"));
+
+        // Reconnect by the same tenant resumes after seq 1: only seq 2 replays.
+        let mut reconnect = hub
+            .subscribe("asm-a", Some("team-a".to_string()), 1)
+            .expect("same-tenant reconnect succeeds");
+        assert_eq!(reconnect.replay.len(), 1);
+        assert_eq!(reconnect.replay[0].seq, 2);
+
+        // It still receives this tenant's subsequent live events.
+        hub.broadcast_approval_resolved("req-3", Decision::Approved, Some("team-a"));
+        let event = tokio::time::timeout(Duration::from_millis(100), reconnect.receiver.recv())
+            .await
+            .expect("live event delivered within 100 ms")
+            .expect("channel open");
+        assert_eq!(event.seq, 3);
+    }
 }

--- a/aa-gateway/src/invalidation/hub.rs
+++ b/aa-gateway/src/invalidation/hub.rs
@@ -46,6 +46,17 @@ struct Subscriber {
     tenant: Option<String>,
 }
 
+/// Why [`InvalidationHub::subscribe`] refused to register a subscription.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubscribeError {
+    /// The `assembly_id` is already registered under a different tenant than the
+    /// authenticated caller. Reusing the slot would attach this caller's
+    /// receiver to the existing tenant's broadcast channel (leaking its events)
+    /// and let this caller's acks trim that tenant's replay ring. Fail-closed:
+    /// the subscription is refused (AAASM-3914).
+    TenantMismatch,
+}
+
 /// The result of [`InvalidationHub::subscribe`]: events the Assembly missed
 /// (to flush first) plus the live receiver for everything thereafter.
 pub struct SubscriptionHandle {
@@ -94,17 +105,33 @@ impl InvalidationHub {
     /// `tenant` is the verified caller's team, captured so [`Self::fan_out`] can
     /// scope tenant-bound events to their owning tenant. On reconnect the
     /// originally-registered tenant is retained.
+    ///
+    /// Returns [`SubscribeError::TenantMismatch`] when `assembly_id` is already
+    /// registered under a tenant other than `tenant` (AAASM-3914). The match is
+    /// exact: an untenanted slot (`None`) may not be claimed by a tenant, nor a
+    /// tenanted slot by an untenanted caller — any mismatch is fail-closed, so a
+    /// caller can never attach to another tenant's channel or trim its ring. A
+    /// reconnect by the same tenant (the common `None == None` cold-start case
+    /// included) is permitted and resumes from `last_seq_seen`.
     pub fn subscribe(
         &self,
         assembly_id: impl Into<AssemblyId>,
         tenant: Option<String>,
         last_seq_seen: u64,
-    ) -> SubscriptionHandle {
+    ) -> Result<SubscriptionHandle, SubscribeError> {
         let assembly_id = assembly_id.into();
         let mut subscribers = self
             .subscribers
             .write()
             .expect("invalidation subscribers lock poisoned");
+        // Fail-closed: an existing subscriber bound to a different tenant must
+        // not be re-bound to this caller, or its events would leak to — and its
+        // replay ring be trimmed by — the wrong tenant (AAASM-3914).
+        if let Some(existing) = subscribers.get(&assembly_id) {
+            if existing.tenant != tenant {
+                return Err(SubscribeError::TenantMismatch);
+            }
+        }
         let subscriber = subscribers
             .entry(assembly_id)
             .or_insert_with(|| {
@@ -133,7 +160,7 @@ impl InvalidationHub {
         }
         metrics::gauge!("aa_invalidation_subscribers").set(subscriber_count as f64);
 
-        SubscriptionHandle { replay, receiver }
+        Ok(SubscriptionHandle { replay, receiver })
     }
 
     /// Fan a `PolicyInvalidated` event out to every connected Assembly.
@@ -268,7 +295,7 @@ mod tests {
     #[tokio::test]
     async fn broadcast_reaches_live_subscriber_within_100ms() {
         let hub = InvalidationHub::new();
-        let mut handle = hub.subscribe("asm-1", None, 0);
+        let mut handle = hub.subscribe("asm-1", None, 0).expect("subscribe succeeds");
         assert!(handle.replay.is_empty());
 
         let start = std::time::Instant::now();
@@ -287,20 +314,20 @@ mod tests {
     async fn reconnect_replays_only_events_after_last_seq() {
         let hub = InvalidationHub::new();
         // First connection registers the subscriber, then disconnects.
-        let handle = hub.subscribe("asm-1", None, 0);
+        let handle = hub.subscribe("asm-1", None, 0).expect("subscribe succeeds");
         drop(handle);
 
         hub.broadcast_policy_invalidated("agent-a", 1);
         hub.broadcast_policy_invalidated("agent-b", 2);
 
         // Cold reconnect replays the full backlog.
-        let full = hub.subscribe("asm-1", None, 0);
+        let full = hub.subscribe("asm-1", None, 0).expect("subscribe succeeds");
         assert_eq!(full.replay.len(), 2);
         assert_eq!(full.replay[0].seq, 1);
         assert_eq!(full.replay[1].seq, 2);
 
         // Reconnect having already applied seq 1 replays only seq 2.
-        let partial = hub.subscribe("asm-1", None, 1);
+        let partial = hub.subscribe("asm-1", None, 1).expect("subscribe succeeds");
         assert_eq!(partial.replay.len(), 1);
         assert_eq!(partial.replay[0].seq, 2);
         assert_eq!(policy_agent(&partial.replay[0]), "agent-b");
@@ -309,14 +336,14 @@ mod tests {
     #[tokio::test]
     async fn ack_trims_replay_ring() {
         let hub = InvalidationHub::new();
-        let _handle = hub.subscribe("asm-1", None, 0);
+        let _handle = hub.subscribe("asm-1", None, 0).expect("subscribe succeeds");
         hub.broadcast_policy_invalidated("agent-a", 1);
         hub.broadcast_policy_invalidated("agent-b", 2);
 
         hub.ack("asm-1", 1);
 
         // After acking seq 1, a cold reconnect only replays seq 2.
-        let reconnect = hub.subscribe("asm-1", None, 0);
+        let reconnect = hub.subscribe("asm-1", None, 0).expect("subscribe succeeds");
         assert_eq!(reconnect.replay.len(), 1);
         assert_eq!(reconnect.replay[0].seq, 2);
     }
@@ -324,15 +351,15 @@ mod tests {
     #[test]
     fn each_subscriber_gets_independent_sequence() {
         let hub = InvalidationHub::new();
-        let _a = hub.subscribe("asm-1", None, 0);
-        let _b = hub.subscribe("asm-2", None, 0);
+        let _a = hub.subscribe("asm-1", None, 0).expect("subscribe succeeds");
+        let _b = hub.subscribe("asm-2", None, 0).expect("subscribe succeeds");
         assert_eq!(hub.subscriber_count(), 2);
 
         hub.broadcast_policy_invalidated("agent-a", 1);
 
         // Each subscriber independently records the event at its own seq 1.
-        let reconnect_a = hub.subscribe("asm-1", None, 0);
-        let reconnect_b = hub.subscribe("asm-2", None, 0);
+        let reconnect_a = hub.subscribe("asm-1", None, 0).expect("subscribe succeeds");
+        let reconnect_b = hub.subscribe("asm-2", None, 0).expect("subscribe succeeds");
         assert_eq!(reconnect_a.replay.len(), 1);
         assert_eq!(reconnect_b.replay.len(), 1);
         assert_eq!(reconnect_a.replay[0].seq, 1);
@@ -342,7 +369,7 @@ mod tests {
     #[tokio::test]
     async fn broadcast_approval_resolved_reaches_subscriber() {
         let hub = InvalidationHub::new();
-        let mut handle = hub.subscribe("asm-1", None, 0);
+        let mut handle = hub.subscribe("asm-1", None, 0).expect("subscribe succeeds");
 
         hub.broadcast_approval_resolved("req-42", Decision::Approved, None);
 
@@ -366,8 +393,12 @@ mod tests {
     #[tokio::test]
     async fn approval_fan_out_is_scoped_to_owning_tenant() {
         let hub = InvalidationHub::new();
-        let mut team_a = hub.subscribe("asm-a", Some("team-a".to_string()), 0);
-        let mut team_b = hub.subscribe("asm-b", Some("team-b".to_string()), 0);
+        let mut team_a = hub
+            .subscribe("asm-a", Some("team-a".to_string()), 0)
+            .expect("subscribe succeeds");
+        let mut team_b = hub
+            .subscribe("asm-b", Some("team-b".to_string()), 0)
+            .expect("subscribe succeeds");
 
         // Resolve an approval owned by team-a.
         hub.broadcast_approval_resolved("req-a", Decision::Approved, Some("team-a"));
@@ -387,7 +418,9 @@ mod tests {
         assert!(leaked.is_err(), "team-b must not receive team-a's approval event");
 
         // Nor may it surface via replay: team-b's ring never recorded the event.
-        let reconnect_b = hub.subscribe("asm-b", Some("team-b".to_string()), 0);
+        let reconnect_b = hub
+            .subscribe("asm-b", Some("team-b".to_string()), 0)
+            .expect("subscribe succeeds");
         assert!(
             reconnect_b.replay.is_empty(),
             "team-b replay ring must not contain team-a's event"

--- a/aa-gateway/src/invalidation/mod.rs
+++ b/aa-gateway/src/invalidation/mod.rs
@@ -8,5 +8,5 @@
 mod hub;
 mod service;
 
-pub use hub::{AssemblyId, InvalidationHub, SubscriptionHandle};
+pub use hub::{AssemblyId, InvalidationHub, SubscribeError, SubscriptionHandle};
 pub use service::InvalidationServiceImpl;

--- a/aa-gateway/src/invalidation/service.rs
+++ b/aa-gateway/src/invalidation/service.rs
@@ -79,12 +79,11 @@ impl InvalidationService for InvalidationServiceImpl {
         // Fail-closed (AAASM-3914): the hub refuses to bind this stream to an
         // `assembly_id` already registered under a different tenant, so a caller
         // cannot hijack another tenant's events or trim its replay ring.
-        let handle = self
-            .hub
-            .subscribe(assembly_id.clone(), tenant, last_seq_seen)
-            .map_err(|super::SubscribeError::TenantMismatch| {
+        let handle = self.hub.subscribe(assembly_id.clone(), tenant, last_seq_seen).map_err(
+            |super::SubscribeError::TenantMismatch| {
                 Status::permission_denied("assembly_id is registered to a different tenant")
-            })?;
+            },
+        )?;
 
         // Drain client→server Acks so the hub can trim each subscriber's ring.
         let hub = Arc::clone(&self.hub);

--- a/aa-gateway/src/invalidation/service.rs
+++ b/aa-gateway/src/invalidation/service.rs
@@ -76,7 +76,15 @@ impl InvalidationService for InvalidationServiceImpl {
             _ => 0,
         };
 
-        let handle = self.hub.subscribe(assembly_id.clone(), tenant, last_seq_seen);
+        // Fail-closed (AAASM-3914): the hub refuses to bind this stream to an
+        // `assembly_id` already registered under a different tenant, so a caller
+        // cannot hijack another tenant's events or trim its replay ring.
+        let handle = self
+            .hub
+            .subscribe(assembly_id.clone(), tenant, last_seq_seen)
+            .map_err(|super::SubscribeError::TenantMismatch| {
+                Status::permission_denied("assembly_id is registered to a different tenant")
+            })?;
 
         // Drain client→server Acks so the hub can trim each subscriber's ring.
         let hub = Arc::clone(&self.hub);


### PR DESCRIPTION
## Description

`InvalidationService::Subscribe` reused an existing per-assembly subscriber via `subscribers.entry(assembly_id).or_insert_with(...)`. On an **existing** entry the caller-supplied tenant was dropped and the caller's receiver (`subscriber.tx.subscribe()`) was attached to the existing — possibly victim — broadcast channel; the caller's `SubscribeAck`s then trimmed that subscriber's replay ring. There was no check that the request's `assembly_id` belonged to the authenticated caller's tenant.

So a caller authenticated in tenant B who knew victim tenant-A's `assembly_id` received A's `ApprovalResolved` events and could trim A's replay ring (driving A to run stale / just-revoked policy). This is a sibling gap to AAASM-3890, which scoped only the fan-out filter, not the subscription binding.

**Fix (fail-closed):** `InvalidationHub::subscribe` now returns `Result<SubscriptionHandle, SubscribeError>` and refuses (`SubscribeError::TenantMismatch`) any `assembly_id` already registered under a tenant other than the caller's. The match is exact, so an untenanted slot can't be claimed by a tenant nor vice-versa. The gRPC service maps the error to `Status::permission_denied`. A legitimate same-tenant reconnect still resumes from `last_seq_seen`, and the AAASM-3890 fan-out tenancy filter is untouched.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] No

`InvalidationHub::subscribe` is an internal crate API; its signature changed (now returns `Result`), but it has no external consumers. Wire protocol unchanged.

## Related Issues

- Related Jira ticket: AAASM-3914

Closes AAASM-3914

## Testing

- [x] Unit tests added / updated

Added two `aa-gateway` regression tests:
- `subscribe_rejects_cross_tenant_assembly_id_reuse` — a cross-tenant (and untenanted) Subscribe to an existing tenant's `assembly_id` is rejected with `TenantMismatch`, no extra subscriber is registered, and the victim still receives only its own event.
- `subscribe_allows_same_tenant_reconnect` — the same-tenant reconnect still resumes from `last_seq_seen` and keeps receiving live events.

Validation (worktree, `aa-gateway`):
- `cargo build -p aa-gateway` — ok
- `cargo nextest run -p aa-gateway` — 1325 passed, 0 failed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p aa-gateway --all-targets -- -D warnings` — clean (exit 0)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf