### PR TITLE
[AAASM-3925] 🔒 (aa-cli): Strip C1 control chars in sanitize_terminal

### DIFF
--- a/aa-cli/src/sanitize.rs
+++ b/aa-cli/src/sanitize.rs
@@ -98,8 +98,19 @@ mod tests {
     }
 
     #[test]
+    fn strips_c1_controls() {
+        // U+009B is the 8-bit CSI introducer; some terminals act on it as if it
+        // were `ESC [`, so it must be dropped even though it carries no ESC.
+        assert_eq!(sanitize_terminal("a\u{9b}31mred"), "a31mred");
+        // Full C1 range boundaries (0x80 and 0x9f) are removed too.
+        assert_eq!(sanitize_terminal("x\u{80}y\u{9f}z"), "xyz");
+    }
+
+    #[test]
     fn preserves_plain_and_unicode_text() {
         assert_eq!(sanitize_terminal("agent-7 working"), "agent-7 working");
-        assert_eq!(sanitize_terminal("héllo-β-世界"), "héllo-β-世界");
+        // Accented Latin, Greek, CJK, and an emoji are all printable and kept —
+        // C1 stripping must not touch code points at or above U+00A0.
+        assert_eq!(sanitize_terminal("héllo-β-世界-🚀"), "héllo-β-世界-🚀");
     }
 }

--- a/aa-cli/src/sanitize.rs
+++ b/aa-cli/src/sanitize.rs
@@ -17,7 +17,10 @@
 ///   shorter two-byte escapes (`ESC` + one byte); and
 /// - every remaining C0 control character (`0x00`–`0x1f`) and DEL (`0x7f`),
 ///   which includes newlines and carriage returns that could otherwise inject
-///   extra lines into a single-line field.
+///   extra lines into a single-line field; and
+/// - the C1 control range (`0x80`–`0x9f`), which includes `U+009B` — the 8-bit
+///   CSI introducer that some terminals interpret as an escape sequence start
+///   even without a leading `ESC`, reopening the spoofing vector above.
 ///
 /// Printable text (including multi-byte Unicode) is preserved unchanged.
 pub fn sanitize_terminal(input: &str) -> String {
@@ -60,8 +63,9 @@ pub fn sanitize_terminal(input: &str) -> String {
                 }
                 None => {}
             },
-            // Drop all other C0 control characters and DEL.
-            c if (c as u32) < 0x20 || c as u32 == 0x7f => {}
+            // Drop all other C0 control characters, DEL, and C1 controls
+            // (`0x80`–`0x9f`, e.g. `U+009B` 8-bit CSI).
+            c if (c as u32) < 0x20 || c as u32 == 0x7f || (0x80..=0x9f).contains(&(c as u32)) => {}
             c => out.push(c),
         }
     }


### PR DESCRIPTION
## Description

`sanitize_terminal` stripped C0 controls (`< 0x20`) and DEL (`0x7f`) but left the **C1 control range** (`0x80`–`0x9f`) intact. That range includes `U+009B`, the 8-bit CSI introducer, which some terminals act on as an escape-sequence start even without a leading `ESC` — reopening the approve/reject decision-spoofing vector this function exists to close. This drops the C1 range alongside C0 and DEL. Printable Unicode (code points ≥ U+00A0) is unaffected.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3925

## Testing

- [x] Unit tests added / updated

`strips_c1_controls` asserts `U+009B`, `0x80`, and `0x9f` are removed; `preserves_plain_and_unicode_text` extended with an emoji to confirm printable Unicode survives. `cargo nextest run -p aa-cli` (793 pass), `cargo fmt --all -- --check`, `cargo clippy -p aa-cli --all-targets -- -D warnings` all clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

Refs AAASM-3925 (this ticket spans two repos — node-sdk PR is filed separately; the ticket stays open until both merge).