### PR TITLE
[AAASM-3923] 🔒 (storage): Redact DSN, warn on plaintext transport, tenant-key TODO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,7 @@ dependencies = [
  "testcontainers-modules",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "tracing",
  "uuid",
 ]
 

--- a/aa-storage-postgres/Cargo.toml
+++ b/aa-storage-postgres/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { workspace = true }
 uuid       = { workspace = true, features = ["v4", "serde"] }
 chrono     = { workspace = true, features = ["clock", "serde"] }
 thiserror  = { workspace = true }
+tracing    = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/aa-storage-postgres/src/config.rs
+++ b/aa-storage-postgres/src/config.rs
@@ -4,6 +4,8 @@
 //! file. Only the knobs an OSS operator needs to point the driver at their own
 //! Postgres are exposed here; TimescaleDB and retention tuning live elsewhere.
 
+use std::fmt;
+
 use serde::Deserialize;
 
 /// Default maximum pooled-connection count when unspecified.
@@ -22,7 +24,7 @@ const DEFAULT_STATEMENT_TIMEOUT_MS: u64 = 0;
 /// max_connections = 20
 /// statement_timeout_ms = 5000
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct PostgresPoolConfig {
     /// PostgreSQL connection URL (`postgres://user:pass@host:port/db`).
@@ -32,6 +34,42 @@ pub struct PostgresPoolConfig {
     /// Per-statement timeout in milliseconds, applied via `SET statement_timeout`
     /// on each connection. `0` leaves the server default in place.
     pub statement_timeout_ms: u64,
+}
+
+/// Custom `Debug` that redacts the password component of the connection URL.
+///
+/// The DSN carries `postgres://user:pass@host/db` credentials; the derived
+/// `Debug` would print the password verbatim, so any future log of this config
+/// would leak it. This impl renders the URL with the password replaced by `***`
+/// while leaving every other field untouched. It changes only diagnostic output
+/// — the unredacted [`url`](Self::url) is still what the pool connects with.
+impl fmt::Debug for PostgresPoolConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PostgresPoolConfig")
+            .field("url", &redact_dsn_password(&self.url))
+            .field("max_connections", &self.max_connections)
+            .field("statement_timeout_ms", &self.statement_timeout_ms)
+            .finish()
+    }
+}
+
+/// Replace the password component of a `scheme://user:pass@host/...` DSN with
+/// `***`, leaving the scheme, username, host, and path intact.
+///
+/// URLs without userinfo, or with userinfo but no password, are returned
+/// unchanged. Used only for redacted diagnostic rendering — never on the value
+/// handed to the connection layer.
+fn redact_dsn_password(url: &str) -> String {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return url.to_owned();
+    };
+    let Some((userinfo, host_part)) = rest.split_once('@') else {
+        return url.to_owned();
+    };
+    match userinfo.split_once(':') {
+        Some((user, _password)) => format!("{scheme}://{user}:***@{host_part}"),
+        None => url.to_owned(),
+    }
 }
 
 impl Default for PostgresPoolConfig {

--- a/aa-storage-postgres/src/config.rs
+++ b/aa-storage-postgres/src/config.rs
@@ -122,8 +122,14 @@ mod tests {
 
         let rendered = format!("{config:?}");
 
-        assert!(!rendered.contains("supersecret"), "password leaked in Debug: {rendered}");
-        assert!(rendered.contains("aasm:***@db.internal:5432/aasm"), "redacted URL missing: {rendered}");
+        assert!(
+            !rendered.contains("supersecret"),
+            "password leaked in Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("aasm:***@db.internal:5432/aasm"),
+            "redacted URL missing: {rendered}"
+        );
     }
 
     #[test]

--- a/aa-storage-postgres/src/config.rs
+++ b/aa-storage-postgres/src/config.rs
@@ -114,6 +114,29 @@ mod tests {
     }
 
     #[test]
+    fn debug_redacts_dsn_password() {
+        let config = PostgresPoolConfig {
+            url: "postgres://aasm:supersecret@db.internal:5432/aasm".to_owned(),
+            ..Default::default()
+        };
+
+        let rendered = format!("{config:?}");
+
+        assert!(!rendered.contains("supersecret"), "password leaked in Debug: {rendered}");
+        assert!(rendered.contains("aasm:***@db.internal:5432/aasm"), "redacted URL missing: {rendered}");
+    }
+
+    #[test]
+    fn debug_leaves_passwordless_dsn_untouched() {
+        let config = PostgresPoolConfig {
+            url: "postgres://localhost/aasm".to_owned(),
+            ..Default::default()
+        };
+
+        assert!(format!("{config:?}").contains("postgres://localhost/aasm"));
+    }
+
+    #[test]
     fn applies_defaults_for_omitted_knobs() {
         let doc = r#"
             [storage.postgres]

--- a/aa-storage-postgres/src/pool.rs
+++ b/aa-storage-postgres/src/pool.rs
@@ -161,7 +161,9 @@ fn is_loopback_host(host: &str) -> bool {
     if host.eq_ignore_ascii_case("localhost") {
         return true;
     }
-    host.parse::<std::net::IpAddr>().map(|ip| ip.is_loopback()).unwrap_or(false)
+    host.parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -183,13 +185,21 @@ mod tests {
 
     #[test]
     fn enforced_sslmode_does_not_warn() {
-        assert!(!should_warn_plaintext("postgres://aasm:pw@db.internal/aasm?sslmode=require"));
-        assert!(!should_warn_plaintext("postgres://aasm:pw@db.internal/aasm?sslmode=verify-full"));
+        assert!(!should_warn_plaintext(
+            "postgres://aasm:pw@db.internal/aasm?sslmode=require"
+        ));
+        assert!(!should_warn_plaintext(
+            "postgres://aasm:pw@db.internal/aasm?sslmode=verify-full"
+        ));
     }
 
     #[test]
     fn weak_sslmode_still_warns() {
-        assert!(should_warn_plaintext("postgres://aasm:pw@db.internal/aasm?sslmode=disable"));
-        assert!(should_warn_plaintext("postgres://aasm:pw@db.internal/aasm?sslmode=prefer"));
+        assert!(should_warn_plaintext(
+            "postgres://aasm:pw@db.internal/aasm?sslmode=disable"
+        ));
+        assert!(should_warn_plaintext(
+            "postgres://aasm:pw@db.internal/aasm?sslmode=prefer"
+        ));
     }
 }

--- a/aa-storage-postgres/src/pool.rs
+++ b/aa-storage-postgres/src/pool.rs
@@ -163,3 +163,33 @@ fn is_loopback_host(host: &str) -> bool {
     }
     host.parse::<std::net::IpAddr>().map(|ip| ip.is_loopback()).unwrap_or(false)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopback_hosts_do_not_warn() {
+        assert!(!should_warn_plaintext("postgres://aasm:pw@localhost:5432/aasm"));
+        assert!(!should_warn_plaintext("postgres://aasm:pw@127.0.0.1:5432/aasm"));
+        assert!(!should_warn_plaintext("postgres://aasm:pw@[::1]:5432/aasm"));
+    }
+
+    #[test]
+    fn non_loopback_plaintext_warns() {
+        assert!(should_warn_plaintext("postgres://aasm:pw@db.internal:5432/aasm"));
+        assert!(should_warn_plaintext("postgres://aasm:pw@10.0.0.5/aasm"));
+    }
+
+    #[test]
+    fn enforced_sslmode_does_not_warn() {
+        assert!(!should_warn_plaintext("postgres://aasm:pw@db.internal/aasm?sslmode=require"));
+        assert!(!should_warn_plaintext("postgres://aasm:pw@db.internal/aasm?sslmode=verify-full"));
+    }
+
+    #[test]
+    fn weak_sslmode_still_warns() {
+        assert!(should_warn_plaintext("postgres://aasm:pw@db.internal/aasm?sslmode=disable"));
+        assert!(should_warn_plaintext("postgres://aasm:pw@db.internal/aasm?sslmode=prefer"));
+    }
+}

--- a/aa-storage-postgres/src/pool.rs
+++ b/aa-storage-postgres/src/pool.rs
@@ -31,6 +31,14 @@ impl PostgresPool {
     /// When `statement_timeout_ms` is non-zero, every pooled connection runs
     /// `SET statement_timeout` on establishment so a runaway query is bounded.
     pub async fn connect(config: &PostgresPoolConfig) -> Result<Self, sqlx::Error> {
+        if should_warn_plaintext(&config.url) {
+            tracing::warn!(
+                "[storage.postgres] connecting to a non-loopback Postgres host without enforced TLS; \
+                 set `sslmode=require` (or verify-ca/verify-full) in the connection URL to protect \
+                 credentials and data in transit"
+            );
+        }
+
         let mut options = PgPoolOptions::new().max_connections(config.max_connections);
 
         let statement_timeout_ms = config.statement_timeout_ms;
@@ -105,4 +113,53 @@ async fn set_tenant_guc(tx: &mut Transaction<'static, Postgres>, org_id: Uuid) -
         .execute(&mut **tx)
         .await?;
     Ok(())
+}
+
+/// Decide whether [`connect`](PostgresPool::connect) should warn about plaintext
+/// transport: `true` when the URL points at a non-loopback host and TLS is not
+/// enforced via `sslmode`. Loopback hosts (and URLs with no resolvable host)
+/// stay silent. Pure predicate so the warning decision is unit-testable.
+fn should_warn_plaintext(url: &str) -> bool {
+    if ssl_enforced(url) {
+        return false;
+    }
+    match url_host(url) {
+        Some(host) => !is_loopback_host(host),
+        None => false,
+    }
+}
+
+/// `true` when the DSN query string sets `sslmode` to a value that actually
+/// enforces TLS (`require`, `verify-ca`, or `verify-full`). `disable`, `allow`,
+/// `prefer`, and an absent `sslmode` all count as *not enforced*.
+fn ssl_enforced(url: &str) -> bool {
+    let Some((_, query)) = url.split_once('?') else {
+        return false;
+    };
+    query.split('&').any(|pair| {
+        pair.strip_prefix("sslmode=")
+            .is_some_and(|v| matches!(v.to_ascii_lowercase().as_str(), "require" | "verify-ca" | "verify-full"))
+    })
+}
+
+/// Best-effort extraction of the host from a `scheme://[userinfo@]host[:port][/...]`
+/// URL. Returns `None` when there is no authority component.
+fn url_host(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://")?.1;
+    let authority = after_scheme.split(['/', '?']).next().unwrap_or(after_scheme);
+    let host_port = authority.rsplit_once('@').map_or(authority, |(_, hp)| hp);
+    if let Some(rest) = host_port.strip_prefix('[') {
+        // IPv6 literal: `[::1]:5432` -> `::1`.
+        return rest.split(']').next();
+    }
+    Some(host_port.split(':').next().unwrap_or(host_port))
+}
+
+/// `true` for loopback hosts: the literal `localhost` (any case) or any IP that
+/// parses as a loopback address (`127.0.0.0/8`, `::1`).
+fn is_loopback_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<std::net::IpAddr>().map(|ip| ip.is_loopback()).unwrap_or(false)
 }

--- a/aa-storage-redis/Cargo.toml
+++ b/aa-storage-redis/Cargo.toml
@@ -26,6 +26,8 @@ serde_json = { workspace = true }
 # `toml` (same pin as `aa-storage`) backs the driver-factory signatures,
 # which take the `[storage.redis]` subsection as a `toml::Value`.
 toml = { workspace = true }
+# Boot-time plaintext-transport warning.
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/aa-storage-redis/src/config.rs
+++ b/aa-storage-redis/src/config.rs
@@ -2,7 +2,9 @@
 //!
 //! Deserialized from the `[storage.redis]` TOML subsection.
 
-use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use serde::Deserialize;
 
 /// Settings for the `[storage.redis]` subsection of `agent-assembly.toml`.
 ///
@@ -14,7 +16,12 @@ use serde::{Deserialize, Serialize};
 /// ```
 ///
 /// All fields fall back to [`Default`] when omitted.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `Serialize` is intentionally **not** derived: the `url` carries
+/// `redis://user:pass@host` credentials, and a derived `Serialize` would
+/// round-trip the password in clear. `Debug` is implemented by hand below to
+/// redact it for the same reason.
+#[derive(Clone, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct RedisStorageConfig {
     /// Redis connection URL. A `redis://` scheme connects in the clear; a
@@ -35,6 +42,42 @@ impl Default for RedisStorageConfig {
             pool_size: 10,
             tls: false,
         }
+    }
+}
+
+/// Custom `Debug` that redacts the password component of the connection URL.
+///
+/// The DSN may carry `redis://user:pass@host` credentials; the derived `Debug`
+/// would print the password verbatim, so any future log of this config would
+/// leak it. This impl renders the URL with the password replaced by `***`,
+/// leaving every other field untouched. Diagnostic output only — the
+/// unredacted [`url`](Self::url) is still what the pool connects with.
+impl fmt::Debug for RedisStorageConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RedisStorageConfig")
+            .field("url", &redact_dsn_password(&self.url))
+            .field("pool_size", &self.pool_size)
+            .field("tls", &self.tls)
+            .finish()
+    }
+}
+
+/// Replace the password component of a `scheme://user:pass@host/...` DSN with
+/// `***`, leaving the scheme, username, host, and path intact.
+///
+/// URLs without userinfo, or with userinfo but no password, are returned
+/// unchanged. Used only for redacted diagnostic rendering — never on the value
+/// handed to the connection layer.
+fn redact_dsn_password(url: &str) -> String {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return url.to_owned();
+    };
+    let Some((userinfo, host_part)) = rest.split_once('@') else {
+        return url.to_owned();
+    };
+    match userinfo.split_once(':') {
+        Some((user, _password)) => format!("{scheme}://{user}:***@{host_part}"),
+        None => url.to_owned(),
     }
 }
 

--- a/aa-storage-redis/src/config.rs
+++ b/aa-storage-redis/src/config.rs
@@ -139,8 +139,14 @@ tls = true
 
         let rendered = format!("{cfg:?}");
 
-        assert!(!rendered.contains("supersecret"), "password leaked in Debug: {rendered}");
-        assert!(rendered.contains("cacheuser:***@cache.internal:6379"), "redacted URL missing: {rendered}");
+        assert!(
+            !rendered.contains("supersecret"),
+            "password leaked in Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("cacheuser:***@cache.internal:6379"),
+            "redacted URL missing: {rendered}"
+        );
     }
 
     #[test]

--- a/aa-storage-redis/src/config.rs
+++ b/aa-storage-redis/src/config.rs
@@ -131,6 +131,25 @@ tls = true
     }
 
     #[test]
+    fn debug_redacts_dsn_password() {
+        let cfg = RedisStorageConfig {
+            url: "redis://cacheuser:supersecret@cache.internal:6379".to_owned(),
+            ..Default::default()
+        };
+
+        let rendered = format!("{cfg:?}");
+
+        assert!(!rendered.contains("supersecret"), "password leaked in Debug: {rendered}");
+        assert!(rendered.contains("cacheuser:***@cache.internal:6379"), "redacted URL missing: {rendered}");
+    }
+
+    #[test]
+    fn debug_leaves_passwordless_dsn_untouched() {
+        let cfg = RedisStorageConfig::default();
+        assert!(format!("{cfg:?}").contains("redis://127.0.0.1:6379"));
+    }
+
+    #[test]
     fn tls_toggle_upgrades_scheme() {
         let cfg = RedisStorageConfig {
             tls: true,

--- a/aa-storage-redis/src/policy.rs
+++ b/aa-storage-redis/src/policy.rs
@@ -55,6 +55,12 @@ impl RedisPolicyStore {
     }
 }
 
+// TODO(AAASM-3919): namespace this key by the verified tenant/org id
+// (e.g. `aa:policy:<org_id>:<agent_id>`) once org context is threaded into the
+// PolicyStore path. The shared L2 cache currently has no tenant boundary; agent
+// ids are globally unique so there is no collision today, but also no isolation.
+// Deferred here because PolicyStore::get_policy/invalidate carry only an agent
+// id — adding a prefix without the org id would break lookups.
 fn policy_key(agent_id: &AgentId) -> String {
     format!("aa:policy:{}", hex16(agent_id.as_bytes()))
 }

--- a/aa-storage-redis/src/pool.rs
+++ b/aa-storage-redis/src/pool.rs
@@ -14,7 +14,53 @@ use crate::error::backend;
 /// [`StorageError::Backend`](aa_storage::StorageError::Backend) from the first
 /// store call.
 pub fn build_pool(config: &RedisStorageConfig) -> Result<deadpool_redis::Pool> {
-    let mut cfg = Config::from_url(config.connection_url());
+    let url = config.connection_url();
+
+    if should_warn_plaintext(&url, config.tls) {
+        tracing::warn!(
+            "[storage.redis] connecting to a non-loopback Redis host in the clear (redis://); \
+             enable TLS via `[storage.redis].tls = true` or a rediss:// URL to protect \
+             credentials and cached data in transit"
+        );
+    }
+
+    let mut cfg = Config::from_url(url);
     cfg.pool = Some(PoolConfig::new(config.pool_size));
     cfg.create_pool(Some(Runtime::Tokio1)).map_err(backend)
+}
+
+/// Decide whether [`build_pool`] should warn about plaintext transport: `true`
+/// when TLS is not in effect (neither the `tls` flag nor a `rediss://` scheme)
+/// and the URL points at a non-loopback host. Loopback hosts (and URLs with no
+/// resolvable host) stay silent. Pure predicate so the decision is unit-testable.
+fn should_warn_plaintext(url: &str, tls: bool) -> bool {
+    if tls || url.starts_with("rediss://") {
+        return false;
+    }
+    match url_host(url) {
+        Some(host) => !is_loopback_host(host),
+        None => false,
+    }
+}
+
+/// Best-effort extraction of the host from a `scheme://[userinfo@]host[:port][/...]`
+/// URL. Returns `None` when there is no authority component.
+fn url_host(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://")?.1;
+    let authority = after_scheme.split(['/', '?']).next().unwrap_or(after_scheme);
+    let host_port = authority.rsplit_once('@').map_or(authority, |(_, hp)| hp);
+    if let Some(rest) = host_port.strip_prefix('[') {
+        // IPv6 literal: `[::1]:6379` -> `::1`.
+        return rest.split(']').next();
+    }
+    Some(host_port.split(':').next().unwrap_or(host_port))
+}
+
+/// `true` for loopback hosts: the literal `localhost` (any case) or any IP that
+/// parses as a loopback address (`127.0.0.0/8`, `::1`).
+fn is_loopback_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<std::net::IpAddr>().map(|ip| ip.is_loopback()).unwrap_or(false)
 }

--- a/aa-storage-redis/src/pool.rs
+++ b/aa-storage-redis/src/pool.rs
@@ -62,7 +62,9 @@ fn is_loopback_host(host: &str) -> bool {
     if host.eq_ignore_ascii_case("localhost") {
         return true;
     }
-    host.parse::<std::net::IpAddr>().map(|ip| ip.is_loopback()).unwrap_or(false)
+    host.parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/aa-storage-redis/src/pool.rs
+++ b/aa-storage-redis/src/pool.rs
@@ -64,3 +64,29 @@ fn is_loopback_host(host: &str) -> bool {
     }
     host.parse::<std::net::IpAddr>().map(|ip| ip.is_loopback()).unwrap_or(false)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopback_plaintext_does_not_warn() {
+        assert!(!should_warn_plaintext("redis://127.0.0.1:6379", false));
+        assert!(!should_warn_plaintext("redis://localhost:6379", false));
+        assert!(!should_warn_plaintext("redis://user:pw@[::1]:6379", false));
+    }
+
+    #[test]
+    fn non_loopback_plaintext_warns() {
+        assert!(should_warn_plaintext("redis://cache.internal:6379", false));
+        assert!(should_warn_plaintext("redis://user:pw@10.0.0.5:6379", false));
+    }
+
+    #[test]
+    fn tls_in_effect_does_not_warn() {
+        // tls flag set
+        assert!(!should_warn_plaintext("redis://cache.internal:6379", true));
+        // rediss:// scheme already encrypts
+        assert!(!should_warn_plaintext("rediss://cache.internal:6379", false));
+    }
+}

--- a/aa-storage-redis/src/rate_limit.rs
+++ b/aa-storage-redis/src/rate_limit.rs
@@ -37,6 +37,13 @@ impl RedisRateLimitCounter {
     }
 }
 
+// TODO(AAASM-3919): namespace this key by the verified tenant/org id
+// (e.g. `aa:ratelimit:<org_id>:<key>`) once org context is threaded into the
+// RateLimitCounter path. The shared L2 cache currently has no tenant boundary;
+// caller-supplied keys are expected to be globally unique so there is no
+// collision today, but also no isolation. Deferred here because
+// RateLimitCounter::increment/current/reset carry only an opaque key — adding a
+// prefix without the org id would break lookups.
 fn counter_key(key: &str) -> String {
     format!("aa:ratelimit:{key}")
 }

--- a/aa-storage-redis/src/session.rs
+++ b/aa-storage-redis/src/session.rs
@@ -32,6 +32,12 @@ impl RedisSessionStore {
     }
 }
 
+// TODO(AAASM-3919): namespace this key by the verified tenant/org id
+// (e.g. `aa:session:<org_id>:<session_id>`) once org context is threaded into
+// the SessionStore path. The shared L2 cache currently has no tenant boundary;
+// session ids are globally unique so there is no collision today, but also no
+// isolation. Deferred here because SessionStore::save/load/delete carry only a
+// session id — adding a prefix without the org id would break lookups.
 fn session_key(id: &SessionId) -> String {
     format!("aa:session:{}", hex16(id.as_bytes()))
 }


### PR DESCRIPTION
## What changed

Storage transport / secret hygiene hardening for the `aa-storage-postgres` and `aa-storage-redis` drivers (AAASM-3923, LOW). Three sub-items:

1. **DSN redaction (DONE)** — `PostgresPoolConfig` and `RedisStorageConfig` carry a connection URL with `user:pass@host` credentials. The derived `Debug` printed the password verbatim, and `RedisStorageConfig` additionally derived `Serialize` which round-tripped it in clear (both latent — no live log today). Replaced both `Debug` derives with custom impls that render the password as `***`, and dropped the unused `Serialize` derive on `RedisStorageConfig`. The unredacted `url` is still what the pool connects with — only diagnostic/serialized output changes.

2. **Plaintext-transport warning (DONE)** — at pool build/connect time, emit a `tracing::warn!` when the host is **non-loopback** and TLS is not enforced (Redis: neither `tls = true` nor a `rediss://` scheme; Postgres: no `sslmode=require`/`verify-ca`/`verify-full`). Loopback hosts stay silent. This **does not hard-fail** — operators may have valid reasons to skip TLS; it only surfaces the sniffing risk. The warning decision is extracted into a pure `should_warn_plaintext` predicate so it is unit-testable, and the connection behavior is otherwise unchanged.

3. **Redis L2 tenant key prefix (DEFERRED → AAASM-3919)** — the shared Redis L2 cache keys (`aa:policy:<agent_id>`, `aa:session:<session_id>`, `aa:ratelimit:<key>`) carry no tenant/org prefix, so there is no tenant boundary at the cache layer. The ids are globally unique so there is **no collision today**, but also no isolation. The `PolicyStore`/`SessionStore`/`RateLimitCounter` trait methods carry only an agent/session id (or opaque key) — org context is **not threaded** into these paths, and that threading depends on the org-context work tracked under **AAASM-3919**. Prefixing without the org id would break lookups, so rather than ship a half-measure this PR adds a `TODO(AAASM-3919)` marker at each key builder. This sub-item remains open.

## Why

Hacker-POV: credential-bearing DSNs that round-trip through `Debug`/`Serialize` leak passwords into any future log/serialization; plaintext transport lets a network-adjacent attacker sniff storage traffic; un-namespaced L2 keys weaken cache-layer tenant isolation.

## How to verify

- `cargo nextest run -p aa-storage-postgres -p aa-storage-redis` — 41/41 pass (includes the testcontainers Postgres/Redis integration suites).
- New unit tests: `debug_redacts_dsn_password` / `debug_leaves_passwordless_dsn_untouched` (both crates) assert the password never appears in `Debug` output; `should_warn_plaintext` predicate tests cover loopback-silent, non-loopback-warn, and TLS-in-effect cases.
- `cargo fmt -p aa-storage-postgres -p aa-storage-redis -- --check` and `cargo clippy -p aa-storage-postgres -p aa-storage-redis --all-targets -- -D warnings` are clean.

## Ticket

Refs AAASM-3923 (sub-items 1 and 2 complete; sub-item 3 deferred to AAASM-3919, so the ticket is kept open intentionally).
Refs AAASM-3919 (tenant-key namespacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
