### PR TITLE
[AAASM-3919] 📝 (storage): Guardrail docs for SYSTEM_ORG audit path + tenant-safe store usage

### DIFF
--- a/aa-core/src/storage/mod.rs
+++ b/aa-core/src/storage/mod.rs
@@ -17,6 +17,19 @@
 //!
 //! The [`aa-storage`](https://docs.rs/aa-storage) crate re-exports this module
 //! verbatim, so `aa_storage::*` and `aa_core::storage::*` are interchangeable.
+//!
+//! # Tenant isolation guardrail (AAASM-3919)
+//!
+//! These traits carry **no `org_id`/tenant argument**: every method funnels to
+//! the reserved `SYSTEM_ORG` in the Postgres driver (the org-less trait impls in
+//! `aa-storage-postgres` delegate to `SYSTEM_ORG`). The RLS-enforcing,
+//! tenant-safe path is the concrete `*_for_tenant` inherent methods on the
+//! `Pg*` types — `get_policy_for_tenant`, `insert_audit_log_for_tenant`,
+//! `get_secret_for_tenant`, etc. — not this trait surface. Any **multi-tenant
+//! Postgres** deployment MUST call those concrete tenant methods (or thread
+//! `org_id` through these traits) before relying on the `0006`/`0007` RLS
+//! migrations; the trait path alone co-mingles every tenant under `SYSTEM_ORG`.
+//! Single-tenant/self-hosted use is unaffected.
 
 mod audit_sink;
 pub mod conformance;

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -108,6 +108,14 @@ redis-cache = ["dep:redis"]
 # strip-for-publish:begin audit-consumer
 # AAASM-2388: gateway-internal NATS->Postgres audit consumer worker. Default
 # OFF; enabled in dev/CI via `--all-features`. Stripped before crates.io publish.
+#
+# AAASM-3919 guardrail: do NOT enable this feature for a multi-tenant SaaS
+# Postgres deployment. The consumer persists every tenant's audit rows through
+# `PgAuditSink::insert_audit_logs`, which hardcodes the reserved `SYSTEM_ORG`
+# (see `audit_consumer.rs`) — all tenants' rows co-mingle under one org_id and
+# the 0006/0007 RLS migrations cannot isolate them. The tenant must first be
+# threaded from the `assembly.audit.<tenant>.<agent>` NATS subject into
+# `insert_audit_log_for_tenant`. Single-tenant/self-hosted use is unaffected.
 audit-consumer = ["dep:aa-storage-postgres"]
 # strip-for-publish:end audit-consumer
 

--- a/aa-gateway/src/audit_consumer.rs
+++ b/aa-gateway/src/audit_consumer.rs
@@ -204,6 +204,14 @@ pub async fn spawn(
         .await
         .map_err(AuditConsumerError::Postgres)?;
     pool.migrate().await.map_err(AuditConsumerError::Migrate)?;
+    // AAASM-3919 guardrail — TENANT ISOLATION: `PgAuditSink::insert_audit_logs`
+    // (called from `persist_audit_records`) routes through the org-less trait
+    // path, which hardcodes the reserved `SYSTEM_ORG`. Every tenant's audit rows
+    // therefore land under one org_id, defeating the 0006/0007 RLS migrations.
+    // Do NOT enable the `audit-consumer` feature for a multi-tenant SaaS
+    // deployment until the tenant is threaded from the per-message
+    // `assembly.audit.<tenant>.<agent>` NATS subject into
+    // `insert_audit_log_for_tenant`. Single-tenant/self-hosted use is unaffected.
     let sink = PgAuditSink::new(pool.clone());
     let lifecycle = PgLifecycleStore::new(pool);
 

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -24,6 +24,17 @@
 //! ```
 //! use aa_storage::{AgentId, AuditSink, PolicyDocument, PolicyStore};
 //! ```
+//!
+//! # Tenant isolation guardrail (AAASM-3919)
+//!
+//! The store traits re-exported here take **no tenant argument** — in the
+//! Postgres driver every trait method funnels to the reserved `SYSTEM_ORG`. The
+//! tenant-safe, RLS-enforcing path is the concrete `*_for_tenant` inherent
+//! methods on the `Pg*` types (`insert_audit_log_for_tenant`,
+//! `get_policy_for_tenant`, `get_secret_for_tenant`, …). Any multi-tenant
+//! Postgres deployment MUST use those concrete tenant methods (or thread
+//! `org_id` through the traits) before relying on the `0006`/`0007` RLS
+//! migrations; the trait path alone co-mingles all tenants under `SYSTEM_ORG`.
 
 #![warn(missing_docs)]
 

--- a/aa-storage/src/registry.rs
+++ b/aa-storage/src/registry.rs
@@ -1,5 +1,12 @@
 //! [`Registry`] — maps driver names to backend factories and resolves a
 //! [`StorageConfig`] into concrete stores.
+//!
+//! Tenant-isolation guardrail (AAASM-3919): the `Arc<dyn …>` stores built here
+//! expose only the org-less trait surface, which funnels to the reserved
+//! `SYSTEM_ORG` in the Postgres driver. Multi-tenant Postgres deployments MUST
+//! reach the concrete `*_for_tenant` inherent methods on the `Pg*` types (or
+//! thread `org_id` through the traits) to get RLS isolation — see the
+//! `aa_core::storage` module docs.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;


### PR DESCRIPTION
## What changed
Documentation/comment-only guardrails for the storage tenant-isolation inversion tracked in AAASM-3919. **No behavior, signatures, or `SYSTEM_ORG` fallbacks changed.**

- `aa-gateway/Cargo.toml` + `aa-gateway/src/audit_consumer.rs`: WARNING that the `audit-consumer` feature (default OFF) must not be enabled for a multi-tenant SaaS deployment — `PgAuditSink::insert_audit_logs` hardcodes `SYSTEM_ORG`, so all tenants' audit rows co-mingle under one org_id until the tenant is threaded from the `assembly.audit.<tenant>.<agent>` NATS subject into `insert_audit_log_for_tenant`.
- `aa-core/src/storage/mod.rs` (canonical trait defs), `aa-storage/src/lib.rs` (facade), `aa-storage/src/registry.rs`: doc note that the store traits carry no tenant arg and funnel to `SYSTEM_ORG`; the RLS-enforcing `*_for_tenant` inherent methods on the `Pg*` types are the tenant-safe path. Multi-tenant Postgres deployments MUST wire the concrete tenant methods (or thread `org_id`) before relying on the 0006/0007 RLS migrations.

## Why (scope downgrade)
A verify-first investigation confirmed the inversion is structurally real but **NOT exploitable in current wiring**: the `aa-storage` trait path has no production gateway callers, `*_for_tenant` is test-only, and the only Postgres write touch is `audit_consumer.rs` behind the default-OFF `audit-consumer` feature (metadata-only rows). The ticket was therefore downgraded to **Low (docs/guardrail)**; the full trait-tenant-threading refactor is **deferred**, and this PR installs guardrails so the latent path is not enabled unsafely in the meantime.

## How to verify
- `cargo check -p aa-storage` — pass
- `cargo check -p aa-gateway --features audit-consumer` — pass
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p aa-storage -p aa-gateway --all-targets --features audit-consumer -- -D warnings` — 0 errors

Closes AAASM-3919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf