### PR TITLE
[AAASM-3917] 🔒 (aa-ebpf): Make bytecode integrity check meaningful (or accurate doc)

### DIFF
--- a/aa-ebpf/build.rs
+++ b/aa-ebpf/build.rs
@@ -112,12 +112,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // AAASM-3602: emit the sha256 of each embedded probe object as a
-        // compile-time env var so the load-time integrity check can pin the
-        // bytecode against the digest CI signed (EBPF_SHA256SUMS, AAASM-3601).
-        // The digest is sourced from the *actual compiled object*, never
-        // hand-written. A stub (empty file) hashes to the well-known empty
-        // digest, which the runtime treats as "unverifiable stub" and refuses
-        // to load — fail-closed, never degrade-to-allow.
+        // compile-time env var so the load-time integrity check can detect
+        // post-build, in-binary corruption of the embedded bytecode. The digest
+        // is sourced from the *same* compiled object that is embedded, so it is
+        // NOT an independent supply-chain anchor (see aa-ebpf/src/integrity.rs):
+        // tampering before the build moves both the bytes and this digest
+        // together. The cosign-signed EBPF_SHA256SUMS (AAASM-3601) is a separate
+        // download-time artifact and is not consumed here.
+        // TODO(AAASM-3601): bake the digest from an independently-signed
+        // SHA256SUMS to make the load-time check a real supply-chain guarantee.
+        // A stub (empty file) hashes to the well-known empty digest, which the
+        // runtime treats as "unverifiable stub" and refuses to load —
+        // fail-closed, never degrade-to-allow.
         emit_object_digest(&release_dir, "aa-file-io", "AA_FILE_IO_BPF_SHA256")?;
         emit_object_digest(&release_dir, "aa-exec-probes", "AA_EXEC_BPF_SHA256")?;
         emit_object_digest(&release_dir, "aa-tls-probes", "AA_TLS_BPF_SHA256")?;

--- a/aa-ebpf/src/error.rs
+++ b/aa-ebpf/src/error.rs
@@ -59,11 +59,13 @@ pub enum EbpfError {
         detail: String,
     },
 
-    /// The embedded BPF bytecode did not match the digest CI signed
-    /// (AAASM-3602). This is a hard, fail-closed error: a probe whose bytecode
-    /// has been tampered with — or is an empty stub — is refused, never loaded
-    /// blindly. Closes the "loads and emits plausible telemetry but is
-    /// deliberately blind" supply-chain scenario.
+    /// The embedded BPF bytecode did not match the digest baked in at build
+    /// time (AAASM-3602). This is a hard, fail-closed error: a probe whose
+    /// embedded bytecode has been corrupted in-binary — or is an empty stub —
+    /// is refused, never loaded blindly. Note this detects post-build
+    /// corruption only; the baked digest is derived from the same embedded
+    /// object, so it is not a supply-chain guarantee against a tampered build
+    /// (see the `integrity` module docs / TODO(AAASM-3601)).
     #[error("eBPF bytecode integrity check failed for `{object}`: expected sha256 {expected}, got {actual}")]
     IntegrityMismatch {
         /// The probe object whose digest mismatched.

--- a/aa-ebpf/src/integrity.rs
+++ b/aa-ebpf/src/integrity.rs
@@ -1,16 +1,36 @@
 //! Load-time eBPF bytecode integrity verification (AAASM-3602).
 //!
-//! Each embedded probe object carries a sha256 digest baked in at build time
-//! (`build.rs` emits `cargo:rustc-env=AA_*_BPF_SHA256=…`, sourced from the
-//! signed `EBPF_SHA256SUMS` produced by CI in AAASM-3601). Before any bytes are
-//! handed to `aya::Ebpf::load`, [`verify_bytecode`] recomputes the digest over
-//! the embedded bytes and refuses to proceed on a mismatch.
+//! Each embedded probe object carries a sha256 digest baked in at build time:
+//! `build.rs` recomputes the digest over the compiled probe object it is about
+//! to embed and emits it as `cargo:rustc-env=AA_*_BPF_SHA256=…`. Before any
+//! bytes are handed to `aya::Ebpf::load`, [`verify_bytecode`] recomputes the
+//! digest over the embedded bytes and refuses to proceed on a mismatch.
 //!
-//! This is the last line of defense against the swapped-`.o` supply-chain
-//! attack: even if a tampered object is somehow embedded, the binary will not
-//! load a probe whose digest does not match what CI signed. The check is
-//! **fail-closed** — a mismatch (or an empty / unverifiable stub) returns
-//! [`EbpfError::IntegrityMismatch`], never a silent degrade-to-allow.
+//! ## What this check does — and does NOT — guarantee
+//!
+//! The baked-in expected digest is derived from the **same** object that is
+//! embedded, so the comparison is self-referential. It is therefore **not** a
+//! supply-chain guarantee and **not** "the last line of defense against the
+//! swapped-`.o` attack": an attacker who tampers with the probe source or the
+//! compiled `.o` before the build moves both the embedded bytes and the baked
+//! digest together, and the check still passes.
+//!
+//! What it *does* catch is post-build, in-binary corruption of the embedded
+//! bytecode region that leaves the baked digest string intact — e.g. bit-rot or
+//! a partial in-place patch of the bytecode that does not also rewrite the
+//! constant. It also rejects the empty / unverifiable stub emitted when the BPF
+//! toolchain is absent. The check is **fail-closed**: a mismatch (or an empty
+//! stub) returns [`EbpfError::IntegrityMismatch`], never a silent
+//! degrade-to-allow.
+//!
+//! The cosign-signed `EBPF_SHA256SUMS` manifest produced at release time
+//! (AAASM-3601) is an independent *download-time* verification artifact; it is
+//! generated from these same objects and is not consumed by this build, so it
+//! does not anchor the digest baked here.
+//
+// TODO(AAASM-3601): source the expected digest from an independently-signed
+// SHA256SUMS (verified separately from the embedded artifact) so this becomes a
+// real supply-chain guarantee rather than in-binary corruption detection.
 
 use sha2::{Digest, Sha256};
 
@@ -28,9 +48,12 @@ pub const AA_SYSCALL_GUARD_BPF_SHA256: &str = env!("AA_SYSCALL_GUARD_BPF_SHA256"
 /// Verify `bytes` hashes to `expected_hex`, returning
 /// [`EbpfError::IntegrityMismatch`] on any divergence.
 ///
-/// `object` names the probe for diagnostics. An empty `expected_hex` (the
-/// placeholder emitted on non-Linux or when no digest was produced) is treated
-/// as **unverifiable** and rejected — we never load bytecode we cannot pin.
+/// This detects post-build, in-binary corruption of the embedded bytecode (and
+/// the empty / unverifiable stub); it is **not** a supply-chain guarantee — see
+/// the module-level docs. `object` names the probe for diagnostics. An empty
+/// `expected_hex` (the placeholder emitted on non-Linux or when no digest was
+/// produced) is treated as **unverifiable** and rejected — we never load
+/// bytecode we cannot pin.
 pub fn verify_bytecode(object: &str, bytes: &[u8], expected_hex: &str) -> Result<(), EbpfError> {
     let actual = hex::encode(Sha256::digest(bytes));
 
@@ -55,6 +78,11 @@ pub fn verify_bytecode(object: &str, bytes: &[u8], expected_hex: &str) -> Result
 
 #[cfg(test)]
 mod tests {
+    // These tests cover what `verify_bytecode` actually provides: detecting a
+    // digest mismatch (post-build in-binary corruption) and rejecting the empty
+    // / unverifiable stub. They do NOT — and cannot — assert a supply-chain
+    // guarantee, since the baked digest is derived from the embedded object
+    // itself (see module docs / TODO(AAASM-3601)).
     use super::*;
 
     #[test]
@@ -65,9 +93,11 @@ mod tests {
     }
 
     #[test]
-    fn mismatched_digest_is_rejected() {
-        let bytes = b"tampered bytecode";
-        // digest of *different* bytes
+    fn corrupted_bytecode_is_rejected() {
+        // Embedded bytes differ from what the baked digest was computed over
+        // (the in-binary-corruption case this check guards against).
+        let bytes = b"corrupted bytecode";
+        // digest of the *original*, uncorrupted bytes
         let wrong = hex::encode(Sha256::digest(b"original bytecode"));
         let err = verify_bytecode("aa-test", bytes, &wrong).unwrap_err();
         match err {


### PR DESCRIPTION
## What changed

Corrects the overstated security claims around the eBPF load-time bytecode integrity check (`aa-ebpf/src/integrity.rs`, `aa-ebpf/build.rs`, `aa-ebpf/src/error.rs`). The docs are reworded to accurately describe what the check provides; an explicit `TODO(AAASM-3601)` marks the path to a real supply-chain guarantee. No runtime logic changed.

## Why (the bug)

`verify_bytecode` recomputes the SHA-256 of the embedded probe bytes and compares it to a baked-in constant. That constant is emitted by `build.rs::emit_object_digest`, which hashes the **same** compiled object that `lib.rs` then embeds. The comparison is therefore self-referential (a tautology): an attacker who tampers with the probe source or the compiled `.o` before the build moves both the embedded bytes **and** the baked digest together, and the check still passes. The module doc nonetheless claimed it was "the last line of defense against the swapped-`.o` supply-chain attack" — false assurance.

## Which fix path, and why

**The honest-doc path.** I investigated whether the independently-produced, cosign-signed `EBPF_SHA256SUMS` referenced by AAASM-3601 could anchor the digest:

- It **does** exist — `release.yml` builds the probe objects, writes `EBPF_SHA256SUMS`, and cosign-signs it (keyless OIDC) at publish time.
- **But** it is generated by hashing the *same* compiled objects in the *same* CI run and signed afterward; it is **not checked into the tree** and is **not consumed by `build.rs`** (which cannot reference it — signing happens after the build that embeds the bytecode). It serves *download-time* verification (`cosign verify-blob`), not the *load-time* in-binary check.

So there is no independent root of trust available **to the build** that I could wire in without a larger CI/build change — that is genuinely AAASM-3601's scope. Per the "do not pretend to fix the crypto if the independent root of trust isn't available" guidance, I took the honest path:

- Rewrote the `integrity.rs` module + `verify_bytecode` docs to state the check detects **post-build, in-binary corruption** of the embedded bytecode (and rejects the empty/unverifiable stub), and is explicitly **not** a supply-chain guarantee. Removed the "last line of defense against the swapped-`.o` attack" claim.
- Softened the `IntegrityMismatch` error doc (`error.rs`) and the `build.rs` digest-emit comment with the same accurate framing.
- Left `// TODO(AAASM-3601): ... source the expected digest from an independently-signed SHA256SUMS` in both `integrity.rs` and `build.rs`.
- Renamed the mismatch test to `corrupted_bytecode_is_rejected` and added a tests-module note clarifying the tests assert in-binary corruption detection, not a supply-chain guarantee.

## How verified

eBPF probes compile Linux-only; on macOS the userspace `aa-ebpf` crate (which contains `integrity.rs`/`error.rs`) builds host-side. Validated locally:

- `cargo check -p aa-ebpf` — clean
- `cargo nextest run -p aa-ebpf integrity` — 4/4 pass
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p aa-ebpf --all-targets -- -D warnings` — exit 0
- lefthook pre-commit (full-workspace fmt + clippy) — passed on every commit

Full eBPF probe build/runtime (kernel load path) is **deferred to Linux CI**.

This is a doc/accuracy fix, so no runtime behavior changed.

Closes AAASM-3917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf