### PR TITLE
[AAASM-3918] 🔒 (aa-ebpf): umask-tighten loaderd socket bind + peercred check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "aya-log",
  "bytes",
  "hex",
+ "libc",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -33,6 +33,9 @@ integration-test = []
 aa-core        = { path = "../aa-core", version = "0.0.1-rc.2" }
 aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.2", features = ["std"] }
 anyhow         = { workspace = true }
+# AAASM-3918: umask tightening + geteuid for the loaderd control-socket hardening
+# (umask-tightened bind, peer-credential UID check). Cross-platform crate.
+libc           = { workspace = true }
 bytes          = { workspace = true }
 hex            = { workspace = true }
 serde          = { workspace = true }

--- a/aa-ebpf/src/control/mod.rs
+++ b/aa-ebpf/src/control/mod.rs
@@ -22,5 +22,11 @@ pub use protocol::{ControlRequest, ControlResponse, PathRuleWire, ProbeSet, DEFA
 #[cfg(unix)]
 pub mod client;
 
+// AAASM-3918: peer-credential policy for the privileged control socket. Lives
+// in its own `#[cfg(unix)]` module so the pure UID check is unit-testable on
+// non-Linux dev hosts even though `server` (which enforces it) is Linux only.
+#[cfg(unix)]
+pub mod peercred;
+
 #[cfg(target_os = "linux")]
 pub mod server;

--- a/aa-ebpf/src/control/peercred.rs
+++ b/aa-ebpf/src/control/peercred.rs
@@ -1,0 +1,58 @@
+//! Peer-credential check for accepted loaderd control connections (AAASM-3918).
+//!
+//! The privileged `aa-ebpf-loaderd` control socket is owner-only (`0600`), but a
+//! peer-credential check is defence-in-depth: it makes the trust boundary
+//! explicit and testable and rejects any connection whose process UID does not
+//! match the UID the daemon itself runs as. Because [`dispatch`] performs no
+//! caller authentication of its own, the socket permission was previously the
+//! *entire* trust boundary; under a permissive daemon umask there is a window
+//! where the `0600` mode is not yet applied (closed separately by the umask-
+//! tightened bind), so this UID check closes the residual "another local process
+//! connects to the highest-privilege control socket and issues Detach / replaces
+//! deny rules" vector.
+//!
+//! This mirrors the runtime IPC hardening in
+//! `aa-runtime/src/ipc/peercred.rs` (AAASM-3579); the helper there is private to
+//! that crate, so the minimal policy is replicated here.
+//!
+//! Portability: the peer UID is read via tokio's `UnixStream::peer_cred`, which
+//! is backed by `SO_PEERCRED` on Linux and `getpeereid`/`LOCAL_PEERCRED` on
+//! macOS/BSD, so this module compiles and runs on every Unix target.
+
+/// Decide whether a peer connection should be admitted, given the peer UID and
+/// the daemon's own effective UID.
+///
+/// Returns `true` only when the peer UID equals the daemon UID. Kept as a pure
+/// function so the policy is unit-testable without opening a real socket.
+pub fn peer_uid_is_allowed(peer_uid: u32, daemon_uid: u32) -> bool {
+    peer_uid == daemon_uid
+}
+
+/// The effective UID of the current (daemon) process.
+#[cfg(unix)]
+pub fn current_daemon_uid() -> u32 {
+    // SAFETY: `geteuid` is always-successful and has no preconditions.
+    unsafe { libc::geteuid() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matching_uid_is_allowed() {
+        assert!(peer_uid_is_allowed(1000, 1000));
+    }
+
+    #[test]
+    fn mismatched_uid_is_rejected() {
+        assert!(!peer_uid_is_allowed(1001, 1000));
+    }
+
+    #[test]
+    fn nonroot_peer_against_root_daemon_is_rejected() {
+        // The common attack: an unprivileged agent process trying to reach the
+        // root-owned loaderd control socket.
+        assert!(!peer_uid_is_allowed(1000, 0));
+    }
+}

--- a/aa-ebpf/src/control/server.rs
+++ b/aa-ebpf/src/control/server.rs
@@ -110,7 +110,22 @@ pub fn bind_hardened(path: &Path) -> Result<UnixListener, EbpfError> {
     if path.exists() {
         let _ = std::fs::remove_file(path);
     }
-    let listener = UnixListener::bind(path)?;
+
+    // AAASM-3918: tighten the umask so the socket inode is created 0600 from the
+    // very first instant — closing the TOCTOU window where, under a permissive
+    // daemon umask (e.g. systemd `UMask=0000`), the highest-privilege control
+    // socket would be group/other-writable in world-traversable /run between
+    // bind and the explicit chmod below. Restore the prior umask immediately
+    // after bind, regardless of outcome, so we never leak it into the rest of
+    // the process. Mirrors `aa-runtime/src/ipc/server.rs` (AAASM-3581).
+    let listener = {
+        let prev_umask = unsafe { libc::umask(0o077) };
+        let result = UnixListener::bind(path);
+        unsafe { libc::umask(prev_umask) };
+        result?
+    };
+
+    // Belt-and-suspenders: assert the final owner-only mode explicitly.
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
     Ok(listener)
 }

--- a/aa-ebpf/src/control/server.rs
+++ b/aa-ebpf/src/control/server.rs
@@ -133,8 +133,39 @@ pub fn bind_hardened(path: &Path) -> Result<UnixListener, EbpfError> {
 /// Run the control server loop: accept connections and dispatch requests until
 /// the listener is closed. Each connection is handled on its own task.
 pub async fn serve(listener: UnixListener, manager: Arc<Mutex<ProbeManager>>) -> Result<(), EbpfError> {
+    // AAASM-3918: the UID every accepted peer must match — the daemon's own.
+    let daemon_uid = super::peercred::current_daemon_uid();
     loop {
         let (stream, _addr) = listener.accept().await?;
+
+        // AAASM-3918: reject any peer whose process UID does not match the
+        // daemon's own UID before doing any work for it. Defence-in-depth over
+        // the 0600 socket perms — `dispatch` performs no caller authentication,
+        // so without this the socket mode is the entire trust boundary. Closes
+        // the "other local process issues Detach / replaces deny rules" vector.
+        match stream.peer_cred() {
+            Ok(cred) => {
+                let peer_uid = cred.uid();
+                if !super::peercred::peer_uid_is_allowed(peer_uid, daemon_uid) {
+                    tracing::warn!(
+                        peer_uid,
+                        daemon_uid,
+                        "rejecting control connection — peer UID does not match daemon UID"
+                    );
+                    drop(stream);
+                    continue;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "rejecting control connection — could not read peer credentials"
+                );
+                drop(stream);
+                continue;
+            }
+        }
+
         let manager = Arc::clone(&manager);
         tokio::spawn(async move {
             if let Err(e) = handle_connection(stream, manager).await {
@@ -232,6 +263,32 @@ mod tests {
         let _listener = bind_hardened(&path).unwrap();
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "control socket must be owner-only");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// AAASM-3918: a same-UID peer (the test process connects to a socket it
+    /// owns) must pass the peer-credential gate in `serve` and reach `dispatch`.
+    /// The cross-UID reject path cannot be exercised in a unit test (it needs a
+    /// second user), but is covered by the pure `peercred` unit tests.
+    #[tokio::test]
+    async fn serve_admits_same_uid_peer() {
+        use super::super::client::LoaderControlClient;
+
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("aa-ebpf-loaderd-peercred-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        let listener = bind_hardened(&path).unwrap();
+        let manager = Arc::new(Mutex::new(ProbeManager::new()));
+        let server = tokio::spawn(serve(listener, manager));
+
+        let mut client = LoaderControlClient::connect(&path).await.unwrap();
+        client
+            .ping()
+            .await
+            .expect("same-UID peer must be admitted and answered");
+
+        server.abort();
         let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## Description

Hardens the privileged `aa-ebpf-loaderd` control socket — the highest-value
(CAP_BPF) IPC surface — by mirroring the runtime IPC hardening that already
protects the lower-value runtime socket.

Two gaps were closed in `aa-ebpf/src/control/server.rs`:

1. **TOCTOU permission window in `bind_hardened`** — `UnixListener::bind` created
   the inode under the ambient umask, then `set_permissions(0o600)` tightened it.
   Under a permissive daemon umask (e.g. systemd `UMask=0000`) the socket was
   briefly group/other-writable in world-traversable `/run`. Now the umask is set
   to `0o077` immediately around `bind` so the inode is owner-only from creation;
   the explicit `set_permissions` stays as belt-and-suspenders. Mirrors AAASM-3581.

2. **No caller authentication in the accept path** — `dispatch` does no auth, so
   the socket mode was the entire trust boundary; a local non-root process in the
   window could connect and issue `Detach` / replace deny rules. Added an
   `SO_PEERCRED` check (via tokio `peer_cred()`) that rejects any peer whose UID
   does not match the daemon's own UID, before any control command is handled.
   Mirrors AAASM-3579. The peercred policy lives in a new host-testable
   `control::peercred` module.

## Type of Change

- [x] 🐛 Bug fix (security hardening)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3918

## Testing

- [x] Unit tests added / updated — pure `peer_uid_is_allowed` policy tests
  (run on macOS dev host) + a Linux-only `serve_admits_same_uid_peer` test.
- Local (macOS): `cargo check -p aa-ebpf`, `cargo nextest run -p aa-ebpf control::`
  (13 passed), `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D warnings`,
  `cargo deny check` — all green.
- Deferred to Linux CI: the `#[cfg(target_os = "linux")]` `server` module (the
  umask bind, the peercred-enforcing accept loop, and the same-UID accept test)
  does not compile on macOS, so the probe-runtime / enforcement path is validated
  by Linux CI.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf