### PR TITLE
[AAASM-3922] 🔒 (gateway): Cap proxy headers, constant-time token compare, handshake doc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "similar 3.1.1",
  "sqlx",
  "strsim",
+ "subtle",
  "tempfile",
  "testcontainers-modules",
  "thiserror 2.0.18",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -40,6 +40,10 @@ dirs         = { workspace = true }
 async-stream = "0.3"
 async-trait  = { workspace = true }
 sha2         = { workspace = true }
+# AAASM-3922: constant-time byte comparison for credential-token validation
+# (defence-in-depth against a timing side-channel). Tiny, BSD-licensed, already
+# present in the dependency graph via the ed25519/curve crates.
+subtle       = "2"
 similar      = "3"
 tokio-stream = { workspace = true }
 tonic        = { workspace = true }

--- a/aa-gateway/src/registry/token.rs
+++ b/aa-gateway/src/registry/token.rs
@@ -103,7 +103,10 @@ mod tests {
         let mut wrong = token.clone();
         let last = wrong.pop().unwrap();
         wrong.push(if last == 'a' { 'b' } else { 'a' });
-        assert!(matches!(validate_token(&reg, &id, &wrong), Err(TokenError::InvalidToken)));
+        assert!(matches!(
+            validate_token(&reg, &id, &wrong),
+            Err(TokenError::InvalidToken)
+        ));
     }
 
     #[test]
@@ -115,7 +118,10 @@ mod tests {
         let token = generate_credential_token();
         reg.register(record_with_token(id, &token)).unwrap();
         let prefix = &token[..token.len() - 1];
-        assert!(matches!(validate_token(&reg, &id, prefix), Err(TokenError::InvalidToken)));
+        assert!(matches!(
+            validate_token(&reg, &id, prefix),
+            Err(TokenError::InvalidToken)
+        ));
     }
 
     #[test]

--- a/aa-gateway/src/registry/token.rs
+++ b/aa-gateway/src/registry/token.rs
@@ -39,3 +39,91 @@ pub fn validate_token(registry: &AgentRegistry, agent_id: &[u8; 16], token: &str
         Err(TokenError::InvalidToken)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::store::AgentRecord;
+    use crate::registry::AgentStatus;
+
+    fn record_with_token(id: [u8; 16], token: &str) -> AgentRecord {
+        AgentRecord {
+            agent_id: id,
+            name: "test".into(),
+            framework: "test".into(),
+            version: "0.0.1".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: "deadbeef".into(),
+            credential_token: token.into(),
+            metadata: Default::default(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: vec![],
+            recent_events: Default::default(),
+            recent_traces: vec![],
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: None,
+            children: vec![],
+            parent_key: None,
+            enforcement_mode: None,
+            org_id: None,
+        }
+    }
+
+    #[test]
+    fn accepts_matching_token() {
+        // The constant-time compare must still accept the genuine token.
+        let reg = AgentRegistry::new();
+        let id = [7u8; 16];
+        let token = generate_credential_token();
+        reg.register(record_with_token(id, &token)).unwrap();
+        assert!(validate_token(&reg, &id, &token).is_ok());
+    }
+
+    #[test]
+    fn rejects_wrong_token_of_same_length() {
+        // A same-length but differing token is rejected — the compare returns
+        // false on mismatch just like `==` did, only without the timing leak.
+        let reg = AgentRegistry::new();
+        let id = [7u8; 16];
+        let token = generate_credential_token();
+        reg.register(record_with_token(id, &token)).unwrap();
+        let mut wrong = token.clone();
+        let last = wrong.pop().unwrap();
+        wrong.push(if last == 'a' { 'b' } else { 'a' });
+        assert!(matches!(validate_token(&reg, &id, &wrong), Err(TokenError::InvalidToken)));
+    }
+
+    #[test]
+    fn rejects_prefix_of_real_token() {
+        // `ConstantTimeEq::ct_eq` reports false for differing lengths, so a
+        // truncated prefix of the real token must not be accepted.
+        let reg = AgentRegistry::new();
+        let id = [7u8; 16];
+        let token = generate_credential_token();
+        reg.register(record_with_token(id, &token)).unwrap();
+        let prefix = &token[..token.len() - 1];
+        assert!(matches!(validate_token(&reg, &id, prefix), Err(TokenError::InvalidToken)));
+    }
+
+    #[test]
+    fn unknown_agent_is_not_found() {
+        let reg = AgentRegistry::new();
+        assert!(matches!(
+            validate_token(&reg, &[9u8; 16], "anything"),
+            Err(TokenError::AgentNotFound(_))
+        ));
+    }
+}

--- a/aa-gateway/src/registry/token.rs
+++ b/aa-gateway/src/registry/token.rs
@@ -4,6 +4,8 @@
 //! RPC (heartbeat, deregister, control stream). The current implementation uses
 //! UUID v4 random tokens; a future iteration may switch to HMAC-SHA256 signed tokens.
 
+use subtle::ConstantTimeEq;
+
 use super::store::AgentRegistry;
 
 /// Errors returned by token validation.
@@ -23,10 +25,15 @@ pub fn generate_credential_token() -> String {
 }
 
 /// Validate that `token` matches the credential stored for `agent_id` in the registry.
+///
+/// The comparison is constant-time (AAASM-3922): a plain `String ==` short-circuits
+/// on the first differing byte, leaking a timing side-channel. Tokens are 122-bit
+/// random so this is not practically exploitable, but a constant-time compare
+/// removes the side-channel as defence-in-depth.
 pub fn validate_token(registry: &AgentRegistry, agent_id: &[u8; 16], token: &str) -> Result<(), TokenError> {
     let record = registry.get(agent_id).ok_or(TokenError::AgentNotFound(*agent_id))?;
 
-    if record.credential_token == token {
+    if bool::from(record.credential_token.as_bytes().ct_eq(token.as_bytes())) {
         Ok(())
     } else {
         Err(TokenError::InvalidToken)

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1029,7 +1029,11 @@ impl PolicyServiceImpl {
             // triple. Standard validation: empty / mismatched token rejects.
             if req.credential_token.is_empty() {
                 "missing credential token"
-            } else if req.credential_token != record.credential_token {
+            } else if !bool::from(subtle::ConstantTimeEq::ct_eq(
+                req.credential_token.as_bytes(),
+                record.credential_token.as_bytes(),
+            )) {
+                // AAASM-3922: constant-time compare (defence-in-depth timing side-channel).
                 "credential token mismatch"
             } else {
                 return None;

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -91,8 +91,7 @@ where
         }
     }
     let n = line.len();
-    let text =
-        String::from_utf8(line).map_err(|_| ProxyError::Config("invalid UTF-8 in HTTP header line".into()))?;
+    let text = String::from_utf8(line).map_err(|_| ProxyError::Config("invalid UTF-8 in HTTP header line".into()))?;
     out.push_str(&text);
     Ok(n)
 }

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -29,6 +29,74 @@ use crate::error::ProxyError;
 /// data — while keeping one hostile request from exhausting memory.
 pub const MAX_BODY_LEN: usize = 64 * 1024 * 1024;
 
+/// Maximum accepted size of a single HTTP line — the request/status line or one
+/// header line, in bytes (8 KiB).
+///
+/// AAASM-3922 (fail-closed): the head was previously read with
+/// [`AsyncBufReadExt::read_line`], which grows its target `String` without
+/// bound. Only request/response *bodies* were capped (`MAX_BODY_LEN`), so a
+/// steered agent could send one multi-GB header line and OOM the always-on
+/// proxy *before* a single body byte was read — the same reject-before-alloc gap
+/// the body cap already closes, but on the header path. This bounds each line as
+/// it is read.
+pub const MAX_HEADER_LINE_LEN: usize = 8 * 1024;
+
+/// Maximum accepted total size of an HTTP head — the request/status line plus
+/// every header line combined, in bytes (64 KiB) (AAASM-3922). Bounds the head
+/// even against many individually-small lines.
+pub const MAX_HEADER_BYTES: usize = 64 * 1024;
+
+/// Maximum accepted number of header lines in one HTTP head (AAASM-3922).
+pub const MAX_HEADER_COUNT: usize = 200;
+
+/// Read a single `\n`-terminated line from `reader`, appending it to `out`,
+/// while enforcing both a per-line cap (`max_line`) and the caller's remaining
+/// total-head byte budget (`remaining`). Returns the number of bytes consumed
+/// (0 on a clean EOF before any byte is read).
+///
+/// AAASM-3922 (fail-closed): unlike [`AsyncBufReadExt::read_line`], this bounds
+/// the line *as it is read* — it pulls bytes through `fill_buf`/`consume` so an
+/// oversized line is never materialised in memory — and fails closed with
+/// [`ProxyError::Config`] the instant the line would exceed the cap, mirroring
+/// the body cap's reject-before-alloc guard.
+pub(crate) async fn read_line_capped<R>(
+    reader: &mut BufReader<R>,
+    out: &mut String,
+    max_line: usize,
+    remaining: usize,
+) -> Result<usize, ProxyError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let cap = max_line.min(remaining);
+    let mut line: Vec<u8> = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            break; // EOF
+        }
+        let (chunk_len, done) = match available.iter().position(|&b| b == b'\n') {
+            Some(pos) => (pos + 1, true),
+            None => (available.len(), false),
+        };
+        if line.len() + chunk_len > cap {
+            return Err(ProxyError::Config(format!(
+                "HTTP header line exceeds maximum {cap} bytes; refusing (fail-closed)"
+            )));
+        }
+        line.extend_from_slice(&available[..chunk_len]);
+        reader.consume(chunk_len);
+        if done {
+            break;
+        }
+    }
+    let n = line.len();
+    let text =
+        String::from_utf8(line).map_err(|_| ProxyError::Config("invalid UTF-8 in HTTP header line".into()))?;
+    out.push_str(&text);
+    Ok(n)
+}
+
 /// A parsed HTTP request from the proxy's MitM tunnel.
 #[derive(Debug, Clone)]
 pub struct HttpRequest {
@@ -71,11 +139,16 @@ pub async fn read_http_request<R>(reader: &mut BufReader<R>) -> Result<Option<Ht
 where
     R: tokio::io::AsyncRead + Unpin,
 {
+    // AAASM-3922: cap the head (request line + headers) so an unbounded header
+    // read cannot OOM the proxy. `head_budget` tracks the remaining total-head
+    // allowance; each line is additionally bounded by `MAX_HEADER_LINE_LEN`.
+    let mut head_budget = MAX_HEADER_BYTES;
     let mut request_line = String::new();
-    let n = reader.read_line(&mut request_line).await?;
+    let n = read_line_capped(reader, &mut request_line, MAX_HEADER_LINE_LEN, head_budget).await?;
     if n == 0 {
         return Ok(None);
     }
+    head_budget -= n;
     let trimmed = request_line.trim_end_matches(['\r', '\n']);
     let parts: Vec<&str> = trimmed.splitn(3, ' ').collect();
     if parts.len() != 3 {
@@ -88,13 +161,19 @@ where
     let mut headers: Vec<(String, String)> = Vec::new();
     loop {
         let mut line = String::new();
-        let n = reader.read_line(&mut line).await?;
+        let n = read_line_capped(reader, &mut line, MAX_HEADER_LINE_LEN, head_budget).await?;
         if n == 0 {
             return Err(ProxyError::Config("unexpected EOF reading headers".into()));
         }
+        head_budget -= n;
         let trimmed = line.trim_end_matches(['\r', '\n']);
         if trimmed.is_empty() {
             break;
+        }
+        if headers.len() >= MAX_HEADER_COUNT {
+            return Err(ProxyError::Config(format!(
+                "HTTP request exceeds maximum {MAX_HEADER_COUNT} header lines; refusing (fail-closed)"
+            )));
         }
         if let Some((k, v)) = trimmed.split_once(':') {
             headers.push((k.trim().to_string(), v.trim().to_string()));
@@ -250,11 +329,15 @@ pub async fn read_http_response<R>(reader: &mut BufReader<R>) -> Result<Option<H
 where
     R: tokio::io::AsyncRead + Unpin,
 {
+    // AAASM-3922: bound the response head the same way as the request head so a
+    // hostile upstream cannot OOM the proxy with an unbounded header read.
+    let mut head_budget = MAX_HEADER_BYTES;
     let mut status_line = String::new();
-    let n = reader.read_line(&mut status_line).await?;
+    let n = read_line_capped(reader, &mut status_line, MAX_HEADER_LINE_LEN, head_budget).await?;
     if n == 0 {
         return Ok(None);
     }
+    head_budget -= n;
     let trimmed = status_line.trim_end_matches(['\r', '\n']);
     let parts: Vec<&str> = trimmed.splitn(3, ' ').collect();
     if parts.len() < 2 {
@@ -267,13 +350,19 @@ where
     let mut headers: Vec<(String, String)> = Vec::new();
     loop {
         let mut line = String::new();
-        let n = reader.read_line(&mut line).await?;
+        let n = read_line_capped(reader, &mut line, MAX_HEADER_LINE_LEN, head_budget).await?;
         if n == 0 {
             return Err(ProxyError::Config("unexpected EOF reading response headers".into()));
         }
+        head_budget -= n;
         let trimmed = line.trim_end_matches(['\r', '\n']);
         if trimmed.is_empty() {
             break;
+        }
+        if headers.len() >= MAX_HEADER_COUNT {
+            return Err(ProxyError::Config(format!(
+                "HTTP response exceeds maximum {MAX_HEADER_COUNT} header lines; refusing (fail-closed)"
+            )));
         }
         if let Some((k, v)) = trimmed.split_once(':') {
             headers.push((k.trim().to_string(), v.trim().to_string()));

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -846,4 +846,65 @@ mod tests {
             "no trailing reason space: {text:?}"
         );
     }
+
+    // ── header-cap (OOM) guards (AAASM-3922) ────────────────────────────────
+
+    #[tokio::test]
+    async fn rejects_oversized_request_header_line_before_oom() {
+        // AAASM-3922: a single header line larger than MAX_HEADER_LINE_LEN must
+        // be rejected *as it is read* — before the old unbounded read_line could
+        // buffer a multi-GB line and OOM the proxy. The over-cap line here is
+        // ~8 KiB+1; the reader holds only the head, proving the cap fires at the
+        // header stage rather than after a giant allocation.
+        let big_value = "a".repeat(MAX_HEADER_LINE_LEN + 1);
+        let raw = format!("GET / HTTP/1.1\r\nX-Big: {big_value}\r\n\r\n");
+        let mut reader = make_reader(raw.as_bytes());
+        let err = read_http_request(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(&err, ProxyError::Config(msg) if msg.contains("exceeds maximum")),
+            "expected over-cap header rejection, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_request_with_too_many_headers() {
+        // AAASM-3922: more than MAX_HEADER_COUNT header lines is refused,
+        // bounding the head against a flood of individually-small lines.
+        let mut raw = String::from("GET / HTTP/1.1\r\n");
+        for i in 0..=MAX_HEADER_COUNT {
+            raw.push_str(&format!("X-H{i}: v\r\n"));
+        }
+        raw.push_str("\r\n");
+        let mut reader = make_reader(raw.as_bytes());
+        let err = read_http_request(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(&err, ProxyError::Config(msg) if msg.contains("header lines")),
+            "expected too-many-headers rejection, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn header_within_caps_still_parses() {
+        // Regression: a normal-sized header well under every cap must still
+        // parse — the OOM guard must not reject legitimate traffic.
+        let raw = b"POST / HTTP/1.1\r\nHost: api.openai.com\r\nContent-Length: 2\r\n\r\nhi";
+        let mut reader = make_reader(raw);
+        let req = read_http_request(&mut reader).await.unwrap().expect("request present");
+        assert_eq!(req.header("host"), Some("api.openai.com"));
+        assert_eq!(&req.body, b"hi");
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_response_header_line_before_oom() {
+        // AAASM-3922: the response side applies the same per-line cap so a
+        // hostile upstream cannot OOM the proxy with an unbounded header read.
+        let big_value = "a".repeat(MAX_HEADER_LINE_LEN + 1);
+        let raw = format!("HTTP/1.1 200 OK\r\nX-Big: {big_value}\r\n\r\n");
+        let mut reader = make_reader(raw.as_bytes());
+        let err = read_http_response(&mut reader).await.unwrap_err();
+        assert!(
+            matches!(&err, ProxyError::Config(msg) if msg.contains("exceeds maximum")),
+            "expected over-cap header rejection, got: {err:?}"
+        );
+    }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -11,7 +11,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime};
 use rustls::{DigitallySignedStruct, ServerConfig, SignatureScheme};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{broadcast, mpsc, Mutex, OnceCell};
 use tokio_rustls::{TlsAcceptor, TlsConnector};
@@ -29,8 +29,9 @@ use crate::intercept::mcp::parse_mcp_request;
 use crate::intercept::{InterceptVerdict, Interceptor, VerdictDecision};
 use crate::mcp_enforce::{evaluate_mcp_call, McpDecision};
 use crate::proxy::http::{
-    read_http_request, read_http_response, serialize_http_request, serialize_http_request_with_auth,
-    serialize_http_response, HttpRequest,
+    read_http_request, read_http_response, read_line_capped, serialize_http_request,
+    serialize_http_request_with_auth, serialize_http_response, HttpRequest, MAX_HEADER_BYTES, MAX_HEADER_COUNT,
+    MAX_HEADER_LINE_LEN,
 };
 use crate::tls::{CaStore, CertCache};
 
@@ -753,8 +754,10 @@ impl ProxyServer {
         let mut reader = BufReader::new(stream);
 
         // Read the first request line, e.g. "CONNECT api.openai.com:443 HTTP/1.1\r\n"
+        // AAASM-3922: bound the line so an unbounded read cannot OOM the proxy
+        // before CONNECT/plain-HTTP routing even begins.
         let mut request_line = String::new();
-        reader.read_line(&mut request_line).await?;
+        read_line_capped(&mut reader, &mut request_line, MAX_HEADER_LINE_LEN, MAX_HEADER_BYTES).await?;
         let request_line = request_line.trim_end();
 
         let parts: Vec<&str> = request_line.split_whitespace().collect();
@@ -781,12 +784,23 @@ impl ProxyServer {
         target: &str,
     ) -> Result<(), ProxyError> {
         // Consume remaining headers (we only need the request line for CONNECT).
+        // AAASM-3922: cap the drained head (per-line + total budget + count) so an
+        // unbounded header read cannot OOM the proxy.
+        let mut head_budget = MAX_HEADER_BYTES;
+        let mut header_count = 0usize;
         let mut header_line = String::new();
         loop {
             header_line.clear();
-            reader.read_line(&mut header_line).await?;
+            let n = read_line_capped(&mut reader, &mut header_line, MAX_HEADER_LINE_LEN, head_budget).await?;
+            head_budget -= n;
             if header_line.trim().is_empty() {
                 break;
+            }
+            header_count += 1;
+            if header_count > MAX_HEADER_COUNT {
+                return Err(ProxyError::Config(format!(
+                    "CONNECT request exceeds maximum {MAX_HEADER_COUNT} header lines; refusing (fail-closed)"
+                )));
             }
         }
 
@@ -911,13 +925,22 @@ impl ProxyServer {
         tracing::debug!(method = method, target = target, "plain HTTP request");
 
         // Consume remaining request headers.
+        // AAASM-3922: cap the head (per-line + total budget + count) so an
+        // unbounded header read cannot OOM the proxy.
         let mut headers = Vec::new();
+        let mut head_budget = MAX_HEADER_BYTES;
         let mut header_line = String::new();
         loop {
             header_line.clear();
-            reader.read_line(&mut header_line).await?;
+            let n = read_line_capped(&mut reader, &mut header_line, MAX_HEADER_LINE_LEN, head_budget).await?;
+            head_budget -= n;
             if header_line.trim().is_empty() {
                 break;
+            }
+            if headers.len() >= MAX_HEADER_COUNT {
+                return Err(ProxyError::Config(format!(
+                    "plain-HTTP request exceeds maximum {MAX_HEADER_COUNT} header lines; refusing (fail-closed)"
+                )));
             }
             headers.push(header_line.clone());
         }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -29,9 +29,8 @@ use crate::intercept::mcp::parse_mcp_request;
 use crate::intercept::{InterceptVerdict, Interceptor, VerdictDecision};
 use crate::mcp_enforce::{evaluate_mcp_call, McpDecision};
 use crate::proxy::http::{
-    read_http_request, read_http_response, read_line_capped, serialize_http_request,
-    serialize_http_request_with_auth, serialize_http_response, HttpRequest, MAX_HEADER_BYTES, MAX_HEADER_COUNT,
-    MAX_HEADER_LINE_LEN,
+    read_http_request, read_http_response, read_line_capped, serialize_http_request, serialize_http_request_with_auth,
+    serialize_http_response, HttpRequest, MAX_HEADER_BYTES, MAX_HEADER_COUNT, MAX_HEADER_LINE_LEN,
 };
 use crate::tls::{CaStore, CertCache};
 

--- a/aa-runtime/src/ipc/handshake.rs
+++ b/aa-runtime/src/ipc/handshake.rs
@@ -1,16 +1,34 @@
 //! IPC session handshake verification (AAASM-3585).
 //!
 //! On every accepted UDS connection the runtime issues a fresh random nonce and
-//! requires the SDK to reply with an Ed25519 signature over it, proving the peer
-//! holds the agent's private key. Reaching the socket is not enough — a local
-//! attacker who connects still cannot answer "allow" for everything or flood
-//! forged audit events, because it cannot produce a valid signature.
+//! requires the SDK to reply with an Ed25519 signature over `nonce ||
+//! sdk_version`. This binds the session to a consistent, replay-resistant SDK
+//! identity and authenticates the *claimed SDK version* (AAASM-3666) so a
+//! downgraded build cannot silently present a current version string.
 //!
-//! The expected verifying key is derived **deterministically from the runtime's
-//! configured agent id**, mirroring `aa-sdk-client`'s `AgentKeypair::derive`
-//! (seed = `SHA-256(agent_id)` → `SigningKey` → `VerifyingKey`). The SDK and the
-//! runtime are configured with the same `AA_AGENT_ID`, so both sides arrive at
-//! the same keypair without sharing key material.
+//! ## Trust boundary (AAASM-3922)
+//!
+//! This handshake is **not** an authentication secret and must not be relied on
+//! as one. The expected verifying key is derived deterministically from the
+//! configured **agent id** (seed = `SHA-256(agent_id)` → `SigningKey` →
+//! `VerifyingKey`), and the agent id is the UDS socket filename — a public,
+//! non-secret identifier. Any local process that can reach the socket can
+//! recompute the same keypair and produce a valid signature, so the signature
+//! proves *integrity and version-binding*, not possession of a secret.
+//!
+//! The real trust boundary for the IPC channel is enforced elsewhere:
+//!   * the socket is created with `0600` permissions, and
+//!   * the runtime checks the connecting peer's credentials (peercred UID)
+//!     against the expected owner.
+//!
+//! Those two controls — not this signature — are what stop an unrelated local
+//! user from connecting and answering "allow" for everything or flooding forged
+//! audit events. The handshake adds defence-in-depth (a consistent identity and
+//! an authenticated version) *within* that boundary.
+//!
+//! The SDK (`aa-sdk-client`'s `AgentKeypair::derive`) and the runtime are both
+//! configured with the same `AA_AGENT_ID`, so both sides arrive at the same
+//! keypair without exchanging key material.
 
 use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
 use sha2::{Digest, Sha256};
@@ -21,12 +39,18 @@ use aa_security::sdk_identity::VerifiedSdkIdentity;
 /// Number of random bytes in a per-session challenge nonce.
 pub const NONCE_LEN: usize = 32;
 
-/// Derive the Ed25519 verifying key the runtime expects an SDK to prove
-/// possession of, from the configured agent id.
+/// Derive the Ed25519 verifying key the runtime expects an SDK handshake to be
+/// signed with, from the configured agent id.
 ///
 /// Mirrors `aa-sdk-client::keypair::AgentKeypair::derive`: the seed is
 /// `SHA-256(agent_id)`, which is always a valid 32-byte Ed25519 secret scalar
 /// seed, so derivation never fails.
+///
+/// Note (AAASM-3922): the agent id is the public UDS socket filename, so this
+/// "key" is not a secret — any local peer that can reach the socket can derive
+/// it too. The signature it verifies provides integrity + version-binding, not
+/// authentication; the socket's `0600` perms + peercred UID check are the true
+/// trust boundary (see the module docs).
 pub fn expected_verifying_key(agent_id: &str) -> VerifyingKey {
     let seed: [u8; 32] = Sha256::digest(agent_id.as_bytes()).into();
     SigningKey::from_bytes(&seed).verifying_key()
@@ -61,7 +85,7 @@ fn signed_payload(nonce: &[u8], sdk_version: &str) -> Vec<u8> {
 }
 
 /// Verify a `HandshakeProof` against the challenge `nonce` and the expected
-/// verifying key for this agent, returning the **authenticated** SDK identity.
+/// verifying key for this agent, returning the verified SDK identity.
 ///
 /// Returns `Some(VerifiedSdkIdentity)` only when the signature is a valid
 /// Ed25519 signature over `nonce || proof.sdk_version` AND the proof's
@@ -69,6 +93,12 @@ fn signed_payload(nonce: &[u8], sdk_version: &str) -> Vec<u8> {
 /// self-controlled key it does hold). Any malformed field (wrong-length
 /// signature, non-hex / mismatched public key, bad signature) returns `None`
 /// (fail closed).
+///
+/// Note (AAASM-3922): because the expected key is derived from the non-secret
+/// agent id, a local peer that already passes the socket's `0600` perms +
+/// peercred UID check could itself produce a valid proof. This verification
+/// therefore provides integrity and version-binding *within* that trust
+/// boundary — it is not, on its own, proof that the peer holds a secret.
 ///
 /// Because the version is part of the verified payload, the returned identity's
 /// version is trustworthy: an empty version yields


### PR DESCRIPTION
## What

Low-severity gateway/runtime hardening batch (AAASM-3922) — three independent sub-fixes in one cohesive PR.

### 1. 🔒 aa-proxy: cap HTTP header reads (OOM)
The proxy read the request/status line and headers with the unbounded `AsyncBufReadExt::read_line`; only request/response *bodies* were capped (`MAX_BODY_LEN`). A steered agent could send one multi-GB header line and OOM the always-on egress proxy before a single body byte was read. Added a bounded `read_line_capped` helper (pulls bytes via `fill_buf`/`consume`, never materialising an oversized line) plus `MAX_HEADER_LINE_LEN` (8 KiB/line), `MAX_HEADER_BYTES` (64 KiB total head) and `MAX_HEADER_COUNT` (200). Applied to `read_http_request`, `read_http_response`, and the `handle_connection`/CONNECT/plain-HTTP header drains — failing closed with `ProxyError::Config`, consistent with the body-cap pattern.

### 2. 📝 aa-runtime: correct IPC handshake trust-boundary docs
The handshake key is derived from `SHA-256(agent_id)`, and the agent id is the public UDS socket filename — not a secret. The module/doc over-claimed that the signature proves the peer holds the agent's private key and that a local attacker "cannot produce a valid signature". **Chosen fix: the lightweight doc-accuracy fix** (per Low severity). Downgraded the claims to state accurately that the handshake provides integrity + version-binding only, and that the socket's `0600` permissions + peercred UID check are the true trust boundary. No behaviour change — the verification logic (key-pinning, version authentication, fail-closed) is unchanged. A real per-deployment key-provisioning scheme was intentionally left out of scope (it would require coordinated `aa-sdk-client` changes, which is over-engineering for a Low).

### 3. 🔒 aa-gateway: constant-time credential-token compare
`registry::token::validate_token` and the registered-agent branch of `policy_service::validate_credential_token` used `String ==`, which short-circuits on the first differing byte (timing side-channel). Tokens are 122-bit random so not practically exploitable; switched to `subtle::ConstantTimeEq` as defence-in-depth. **`subtle` was added** as a direct dep of `aa-gateway` — tiny, BSD-3-Clause, already present transitively in the graph (so the lockfile change is one line; `cargo deny check` passes). The `policy_service.rs` edit is minimal (one compare, fully-qualified call, no new import) since another ticket may touch that file.

## Why
Three low-severity hardening gaps flagged in a security sweep: proxy memory-exhaustion via unbounded header reads, an over-claimed handshake security guarantee, and a non-constant-time token compare.

## How to verify
- `cargo nextest run -p aa-proxy -p aa-runtime -p aa-gateway` — 1870 passed (incl. new tests).
  - New: proxy rejects oversized/too-many headers before OOM (request + response sides); constant-time compare still accepts a valid token and rejects an invalid/prefix token.
- `cargo build -p aa-proxy -p aa-runtime -p aa-gateway`, `cargo fmt --all -- --check`, `cargo clippy -p aa-proxy -p aa-runtime -p aa-gateway --all-targets -- -D warnings`, `cargo deny check` — all clean.

Closes AAASM-3922

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf