### PR TITLE
[AAASM-3916] 🔒 (aa-ebpf): Propagate syscall-guard to descendants + path/ppid probe correctness

### DIFF
--- a/aa-ebpf-probes/src/exec_probes.rs
+++ b/aa-ebpf-probes/src/exec_probes.rs
@@ -219,7 +219,21 @@ fn try_sched_process_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
     let pid_tgid = bpf_get_current_pid_tgid();
     let tgid = (pid_tgid >> 32) as u32;
 
-    if !pid_allowed(tgid) {
+    // Capture monitoring status BEFORE cleanup (cleanup may remove this tgid's
+    // own filter entry, which `pid_allowed` would otherwise consult).
+    let allowed = pid_allowed(tgid);
+
+    // Unconditionally release this tgid's parent-cache and propagated-filter
+    // entries (AAASM-3921c). The fork handler records `PARENT_TGID` for *every*
+    // fork (so the exec handler can always resolve the real ppid), so the
+    // exit-side cleanup must also be unconditional — otherwise the map would
+    // grow without bound and reused pids could inherit a stale parent / filter
+    // membership. The wildcard key (0) is never an exiting tgid.
+    let _ = PARENT_TGID.remove(&tgid);
+    let _ = EXEC_PID_FILTER.remove(&tgid);
+
+    // Only emit the exit event for monitored processes (lineage cleanup).
+    if !allowed {
         return Ok(0);
     }
 
@@ -233,13 +247,6 @@ fn try_sched_process_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
     }
 
     entry.submit(0);
-
-    // Bound the fork-propagated maps and avoid pid-reuse staleness: drop this
-    // tgid's parent record and its propagated filter membership on exit
-    // (AAASM-3921c). The original target PID re-added by userspace is unaffected
-    // on the next load; the wildcard key (0) is never an exiting tgid.
-    let _ = PARENT_TGID.remove(&tgid);
-    let _ = EXEC_PID_FILTER.remove(&tgid);
     Ok(0)
 }
 

--- a/aa-ebpf-probes/src/exec_probes.rs
+++ b/aa-ebpf-probes/src/exec_probes.rs
@@ -22,10 +22,19 @@
 //! pid, not its parent. Reading it into `ppid` produced `ppid == pid`, which
 //! made the userspace `ProcessLineageTracker::is_descendant_of` walk terminate
 //! immediately (it treats `ppid == pid` as a self-cycle) and always return
-//! false. The real parent is captured at `sched_process_fork` time (the
-//! tracepoint carries `parent_pid`/`child_pid`) and stashed in `PARENT_TGID`;
-//! the exec handler now reads `ppid` from there, falling back to `0` (unknown
-//! root) when the fork was not observed — never the bogus self-parent.
+//! false.
+//!
+//! The exec handler now resolves the real parent with a CO-RE read of
+//! `current->real_parent->tgid` at exec time (see [`real_parent_tgid`]), using
+//! `task_struct` field byte-offsets that the userspace loader resolves from the
+//! running kernel's BTF and publishes in [`TASK_OFFSETS`]. This is independent
+//! of the fork tracepoint: the earlier map-based path (reading `PARENT_TGID`,
+//! populated at `sched_process_fork`) proved unreliable under load — the map
+//! could fill or the specific child entry be missing — leaving `ppid == 0`.
+//! `PARENT_TGID` is kept only as a fallback for kernels without BTF; the final
+//! fallback is `0` (unknown root), never the bogus self-parent. The fork
+//! tracepoint is retained purely for AAASM-3916 descendant confinement (the
+//! `EXEC_PID_FILTER` propagation), decoupled from exec-ppid resolution.
 //!
 //! ## Stack-limit workaround
 //!
@@ -38,9 +47,12 @@
 
 use aa_ebpf_common::exec::{ExecEvent, ProcessExitEvent, MAX_ARGS_LEN, MAX_FILENAME_LEN};
 use aya_ebpf::{
-    helpers::{bpf_get_current_pid_tgid, bpf_get_current_uid_gid, bpf_ktime_get_ns, bpf_probe_read_kernel_str_bytes},
+    helpers::{
+        bpf_get_current_pid_tgid, bpf_get_current_task, bpf_get_current_uid_gid, bpf_ktime_get_ns,
+        bpf_probe_read_kernel, bpf_probe_read_kernel_str_bytes,
+    },
     macros::{map, tracepoint},
-    maps::{HashMap, RingBuf},
+    maps::{Array, HashMap, RingBuf},
     programs::TracePointContext,
     EbpfContext,
 };
@@ -69,6 +81,26 @@ static EXEC_PID_FILTER: HashMap<u32, u8> = HashMap::with_max_entries(256, 0);
 /// the `sched_process_exec` tracepoint only exposes the new process's own pid.
 #[map]
 static PARENT_TGID: HashMap<u32, u32> = HashMap::with_max_entries(1024, 0);
+
+/// `task_struct` field byte-offsets, resolved from the running kernel's BTF by
+/// the userspace loader (AAASM-3921c CO-RE). The `sched_process_exec`
+/// tracepoint only carries the new process's own pid, and the fork-populated
+/// `PARENT_TGID` map is unreliable under load (it fills / races), so the exec
+/// handler reads the real parent directly from `current->real_parent->tgid` at
+/// exec time using these offsets.
+///
+/// - index [`TASK_OFFSET_REAL_PARENT`] — byte offset of `task_struct.real_parent`
+/// - index [`TASK_OFFSET_TGID`] — byte offset of `task_struct.tgid`
+///
+/// A value of `0` means "unresolved" (BTF unavailable); the handler then falls
+/// back to the fork-populated `PARENT_TGID` map, and finally to `0`.
+#[map]
+static TASK_OFFSETS: Array<u32> = Array::with_max_entries(2, 0);
+
+/// `TASK_OFFSETS` index of the `task_struct.real_parent` byte offset.
+const TASK_OFFSET_REAL_PARENT: u32 = 0;
+/// `TASK_OFFSETS` index of the `task_struct.tgid` byte offset.
+const TASK_OFFSET_TGID: u32 = 1;
 
 /// `sched:sched_process_fork` layout — byte offset of the `child_pid` field:
 ///
@@ -101,6 +133,41 @@ fn pid_allowed(tgid: u32) -> bool {
             return true;
         }
         EXEC_PID_FILTER.get(&tgid).is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Real-parent resolution (AAASM-3921c CO-RE)
+// ---------------------------------------------------------------------------
+
+/// Resolve the real parent tgid of the current task at exec time by walking
+/// `current->real_parent->tgid` with BTF-resolved byte offsets.
+///
+/// Returns `None` when the offsets are unresolved (BTF unavailable — both
+/// offsets left `0` by the loader) or when either kernel read fails, so the
+/// caller can fall back to the fork-populated `PARENT_TGID` map. This does not
+/// depend on the fork tracepoint having observed the fork, which is why it is
+/// robust where the map-based path was not.
+#[inline(always)]
+fn real_parent_tgid() -> Option<u32> {
+    let real_parent_off = *TASK_OFFSETS.get(TASK_OFFSET_REAL_PARENT)? as usize;
+    let tgid_off = *TASK_OFFSETS.get(TASK_OFFSET_TGID)? as usize;
+    if real_parent_off == 0 || tgid_off == 0 {
+        return None;
+    }
+
+    unsafe {
+        let task = bpf_get_current_task() as *const u8;
+        if task.is_null() {
+            return None;
+        }
+        // task->real_parent is a `struct task_struct *`.
+        let parent = bpf_probe_read_kernel(task.add(real_parent_off) as *const *const u8).ok()?;
+        if parent.is_null() {
+            return None;
+        }
+        // real_parent->tgid is a `pid_t` (i32); read as u32.
+        bpf_probe_read_kernel(parent.add(tgid_off) as *const u32).ok()
     }
 }
 
@@ -145,7 +212,14 @@ fn try_sched_process_exec(ctx: &TracePointContext) -> Result<u32, i64> {
     // `PARENT_TGID`; resolve it here, falling back to 0 (unknown root) rather
     // than the bogus self-parent when the fork was not observed.
     //   __data_loc is a u32 (low 16 bits = offset, high 16 bits = length).
-    let ppid = unsafe { PARENT_TGID.get(&tgid) }.copied().unwrap_or(0);
+    //
+    // Prefer the CO-RE `current->real_parent->tgid` read (AAASM-3921c): it is
+    // resolved directly from the current task at exec time and does not depend
+    // on the fork tracepoint having observed (and still holding) the child's
+    // entry, which the map-based path could not guarantee under load. Fall back
+    // to the fork-populated `PARENT_TGID` map when BTF offsets are unavailable,
+    // and finally to 0 (unknown root) — never the bogus self-parent.
+    let ppid = real_parent_tgid().unwrap_or_else(|| unsafe { PARENT_TGID.get(&tgid) }.copied().unwrap_or(0));
     let data_loc: u32 = unsafe { ctx.read_at(8) }.map_err(|_| -1i64)?;
     // ctx.command() returns [u8; 16] — already raw bytes, not a string.
     let comm = ctx.command().map_err(|_| -1i64)?;

--- a/aa-ebpf-probes/src/exec_probes.rs
+++ b/aa-ebpf-probes/src/exec_probes.rs
@@ -280,10 +280,12 @@ fn try_sched_process_exec(ctx: &TracePointContext) -> Result<u32, i64> {
 // sched_process_exit tracepoint
 // ---------------------------------------------------------------------------
 
-/// Tracepoint on `sched/sched_process_exit`: fires when a process exits.
+/// Tracepoint on `sched/sched_process_exit`: fires on every *thread* exit.
 ///
-/// Emits a [`ProcessExitEvent`] so the userspace `ProcessLineageTracker`
-/// can remove the PID from the lineage map.
+/// Only whole-process exits (the thread-group leader, `pid == tgid`) trigger
+/// cleanup + a [`ProcessExitEvent`] so the userspace `ProcessLineageTracker`
+/// removes the PID from the lineage map. Non-leader thread exits are ignored so
+/// a live multithreaded process is not torn down mid-flight (AAASM-3921c).
 #[tracepoint]
 pub fn handle_sched_process_exit(ctx: TracePointContext) -> u32 {
     try_sched_process_exit(&ctx).unwrap_or_default()
@@ -292,17 +294,30 @@ pub fn handle_sched_process_exit(ctx: TracePointContext) -> u32 {
 fn try_sched_process_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
     let pid_tgid = bpf_get_current_pid_tgid();
     let tgid = (pid_tgid >> 32) as u32;
+    let pid = pid_tgid as u32;
+
+    // `sched_process_exit` fires PER-THREAD. Only act on whole-process exit —
+    // the thread-group leader, where `pid == tgid`. A non-leader thread of a
+    // multithreaded monitored process (Go/Node/Python agents are all
+    // multithreaded) exiting must NOT tear down the still-live process's
+    // tgid-keyed map entries: removing `EXEC_PID_FILTER[tgid]` would stop the
+    // process's own future execs and fork-propagation from being observed, and
+    // emitting a process-exit event would make the lineage tracker drop a live
+    // process (AAASM-3921c). Bare thread exits are ignored entirely.
+    if pid != tgid {
+        return Ok(0);
+    }
 
     // Capture monitoring status BEFORE cleanup (cleanup may remove this tgid's
     // own filter entry, which `pid_allowed` would otherwise consult).
     let allowed = pid_allowed(tgid);
 
-    // Unconditionally release this tgid's parent-cache and propagated-filter
-    // entries (AAASM-3921c). The fork handler records `PARENT_TGID` for *every*
-    // fork (so the exec handler can always resolve the real ppid), so the
-    // exit-side cleanup must also be unconditional — otherwise the map would
-    // grow without bound and reused pids could inherit a stale parent / filter
-    // membership. The wildcard key (0) is never an exiting tgid.
+    // Release this tgid's parent-cache and propagated-filter entries on whole-
+    // process exit (AAASM-3921c). The fork handler records `PARENT_TGID` for
+    // *every* fork (so the exec handler can always resolve the real ppid), so
+    // the leader-exit cleanup runs unconditionally for the leader — otherwise
+    // the map would grow without bound and reused pids could inherit a stale
+    // parent / filter membership. The wildcard key (0) is never an exiting tgid.
     let _ = PARENT_TGID.remove(&tgid);
     let _ = EXEC_PID_FILTER.remove(&tgid);
 

--- a/aa-ebpf-probes/src/exec_probes.rs
+++ b/aa-ebpf-probes/src/exec_probes.rs
@@ -1,8 +1,13 @@
 //! BPF tracepoint programs for process exec monitoring (AAASM-39).
 //!
-//! Two tracepoints share a single ring buffer (`EVENTS`) and a PID
+//! Three tracepoints share a single ring buffer (`EVENTS`) and a PID
 //! filter map (`EXEC_PID_FILTER`):
 //!
+//! - `handle_sched_process_fork` — fires on every `fork`/`clone`. When the
+//!   parent is monitored it records the child→parent tgid mapping in
+//!   `PARENT_TGID` and propagates `EXEC_PID_FILTER` membership to the child
+//!   (AAASM-3916/3921). This is what supplies the **real** parent pid to the
+//!   exec event below.
 //! - `handle_sched_process_exec` — fires on every `execve`/`execveat` and
 //!   emits an [`ExecEvent`] with pid, ppid, uid, filename, and a best-effort
 //!   `args` field. NOTE (AAASM-3872): this tracepoint does not expose argv, so
@@ -10,6 +15,17 @@
 //!   see the in-body comment for the `sys_enter_execve` follow-up.
 //! - `handle_sched_process_exit` — fires on process exit and emits a
 //!   [`ProcessExitEvent`] so userspace can clean up the lineage map.
+//!
+//! ## Parent pid resolution (AAASM-3921c)
+//!
+//! The `sched_process_exec` tracepoint's `pid` field is the *new* process's own
+//! pid, not its parent. Reading it into `ppid` produced `ppid == pid`, which
+//! made the userspace `ProcessLineageTracker::is_descendant_of` walk terminate
+//! immediately (it treats `ppid == pid` as a self-cycle) and always return
+//! false. The real parent is captured at `sched_process_fork` time (the
+//! tracepoint carries `parent_pid`/`child_pid`) and stashed in `PARENT_TGID`;
+//! the exec handler now reads `ppid` from there, falling back to `0` (unknown
+//! root) when the fork was not observed — never the bogus self-parent.
 //!
 //! ## Stack-limit workaround
 //!
@@ -47,6 +63,22 @@ static EVENTS: RingBuf = RingBuf::with_byte_size(262_144, 0);
 /// the wildcard before relying on events.
 #[map]
 static EXEC_PID_FILTER: HashMap<u32, u8> = HashMap::with_max_entries(256, 0);
+
+/// Child tgid → parent tgid, populated by the `sched_process_fork` tracepoint
+/// (AAASM-3921c). The exec handler reads the real parent pid from here because
+/// the `sched_process_exec` tracepoint only exposes the new process's own pid.
+#[map]
+static PARENT_TGID: HashMap<u32, u32> = HashMap::with_max_entries(1024, 0);
+
+/// `sched:sched_process_fork` layout — byte offset of the `child_pid` field:
+///
+/// ```text
+/// field:char  parent_comm[16]; offset:8;  size:16;
+/// field:pid_t parent_pid;      offset:24; size:4;
+/// field:char  child_comm[16];  offset:28; size:16;
+/// field:pid_t child_pid;       offset:44; size:4;
+/// ```
+const SCHED_FORK_CHILD_PID_OFFSET: usize = 44;
 
 // ---------------------------------------------------------------------------
 // PID filter helper
@@ -107,9 +139,13 @@ fn try_sched_process_exec(ctx: &TracePointContext) -> Result<u32, i64> {
     //   field:pid_t pid;                       offset:12; size:4;
     //   field:pid_t old_pid;                   offset:16; size:4;
     //
-    // We read the parent PID from the tracepoint pid field at offset 12;
-    // __data_loc is a u32 (low 16 bits = offset, high 16 bits = length).
-    let tp_pid: i32 = unsafe { ctx.read_at(12) }.map_err(|_| -1i64)?;
+    // NOTE (AAASM-3921c): the `pid` field at offset 12 is the *new* process's
+    // own pid, NOT its parent — reading it into `ppid` produced `ppid == pid`
+    // and broke lineage walks. The real parent tgid is recorded at fork time in
+    // `PARENT_TGID`; resolve it here, falling back to 0 (unknown root) rather
+    // than the bogus self-parent when the fork was not observed.
+    //   __data_loc is a u32 (low 16 bits = offset, high 16 bits = length).
+    let ppid = unsafe { PARENT_TGID.get(&tgid) }.copied().unwrap_or(0);
     let data_loc: u32 = unsafe { ctx.read_at(8) }.map_err(|_| -1i64)?;
     // ctx.command() returns [u8; 16] — already raw bytes, not a string.
     let comm = ctx.command().map_err(|_| -1i64)?;
@@ -123,7 +159,7 @@ fn try_sched_process_exec(ctx: &TracePointContext) -> Result<u32, i64> {
         (*event_ptr).pid = tgid;
         (*event_ptr).uid = uid;
         (*event_ptr)._pad = 0;
-        (*event_ptr).ppid = tp_pid as u32;
+        (*event_ptr).ppid = ppid;
 
         let filename_offset = (data_loc & 0xFFFF) as usize;
 
@@ -197,6 +233,46 @@ fn try_sched_process_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
     }
 
     entry.submit(0);
+
+    // Bound the fork-propagated maps and avoid pid-reuse staleness: drop this
+    // tgid's parent record and its propagated filter membership on exit
+    // (AAASM-3921c). The original target PID re-added by userspace is unaffected
+    // on the next load; the wildcard key (0) is never an exiting tgid.
+    let _ = PARENT_TGID.remove(&tgid);
+    let _ = EXEC_PID_FILTER.remove(&tgid);
+    Ok(0)
+}
+
+// ---------------------------------------------------------------------------
+// sched_process_fork tracepoint (AAASM-3921c / AAASM-3916)
+// ---------------------------------------------------------------------------
+
+/// Tracepoint on `sched/sched_process_fork`: records the child→parent tgid
+/// mapping so the exec handler can report the real parent pid, and propagates
+/// `EXEC_PID_FILTER` membership to children of monitored processes so the
+/// lineage tree covers the whole family.
+#[tracepoint]
+pub fn handle_sched_process_fork(ctx: TracePointContext) -> u32 {
+    try_sched_process_fork(&ctx).unwrap_or_default()
+}
+
+fn try_sched_process_fork(ctx: &TracePointContext) -> Result<u32, i64> {
+    // The fork tracepoint fires in the parent's context, so the current tgid is
+    // the parent's. Only track children of monitored processes.
+    let parent_tgid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    if !pid_allowed(parent_tgid) {
+        return Ok(0);
+    }
+
+    // For a real new process `child_pid == child_tgid` (the key used by the
+    // exec handler and the filter); for a thread the tgid is already the
+    // monitored parent's, so the extra key is inert.
+    let child_pid: u32 = unsafe { ctx.read_at(SCHED_FORK_CHILD_PID_OFFSET) }.map_err(|_| -1i64)?;
+
+    // Record the real parent for the exec handler, and confine the child to the
+    // exec filter so its own exec is observed (descendant coverage).
+    let _ = PARENT_TGID.insert(&child_pid, &parent_tgid, 0);
+    let _ = EXEC_PID_FILTER.insert(&child_pid, &1u8, 0);
     Ok(0)
 }
 

--- a/aa-ebpf-probes/src/maps.rs
+++ b/aa-ebpf-probes/src/maps.rs
@@ -81,15 +81,36 @@ pub static RENAME_TMP: HashMap<u64, [u8; MAX_PATH_LEN]> =
 #[map]
 pub static RENAME_ENTRY_TS: HashMap<u64, u64> = HashMap::with_max_entries(MAX_ENTRIES, 0);
 
-/// Path pattern blocklist: paths that should trigger an alert.
-/// Key is a hash of the path prefix, value is 1 (deny).
+/// Path blocklist: paths whose access should be flagged as sensitive.
+///
+/// **Match contract (AAASM-3921a/b — corrected).** The key is the **exact,
+/// NUL-padded full path** as captured from the syscall argument, and the kprobe
+/// does an **exact `HashMap::get` equality** match — NOT a hash of a prefix and
+/// NOT a directory-prefix match. Earlier docs claimed "hash of the path prefix"
+/// / prefix matching; the implementation never did either, so directory deny
+/// rules (e.g. `/etc/`) silently never fired and non-canonical paths
+/// (`/etc//shadow`, `/etc/../etc/shadow`, symlinks) evaded the in-kernel check.
+///
+/// Because this layer is **OBSERVE-ONLY** (it sets an alert flag; it does not
+/// deny), prefix and canonicalization matching are reconciled in userspace:
+/// [`SensitivePathDetector`](../../aa_ebpf/alert/struct.SensitivePathDetector.html)
+/// canonicalizes each event path and does boundary-aware prefix matching, and
+/// the final `is_sensitive` verdict is the OR of the kernel exact-match flag
+/// and the userspace canonical-prefix match.
+///
+/// **Deferred (needs Linux):** moving canonicalization / prefix matching into
+/// the kernel requires a `d_path` / dentry walk, which cannot be written or
+/// verifier-validated without a Linux kernel target — tracked under AAASM-3921.
 #[map]
 pub static PATH_BLOCKLIST: HashMap<[u8; MAX_PATH_LEN], u8> =
     HashMap::with_max_entries(MAX_PATH_PATTERNS, 0);
 
-/// Path pattern allowlist: paths whose events should be suppressed.
-/// If a path matches this map, the kprobe skips event emission entirely.
-/// Key is the path (null-padded), value is 1 (allow / suppress).
+/// Path allowlist: paths whose events should be suppressed.
+///
+/// If a path matches this map the kprobe skips event emission entirely. Same
+/// **exact, NUL-padded full-path equality** contract as [`PATH_BLOCKLIST`]
+/// (see its docs for the prefix/canonicalization reconciliation and the
+/// deferred in-kernel `d_path` work). Value is `1` (allow / suppress).
 #[map]
 pub static PATH_ALLOWLIST: HashMap<[u8; MAX_PATH_LEN], u8> =
     HashMap::with_max_entries(MAX_PATH_PATTERNS, 0);

--- a/aa-ebpf-probes/src/syscall_guard.rs
+++ b/aa-ebpf-probes/src/syscall_guard.rs
@@ -23,6 +23,21 @@
 //! `PID_FILTER`) are never inspected, so the probe is a no-op for the rest of
 //! the system.
 //!
+//! ## Descendant confinement (AAASM-3916)
+//!
+//! Confinement must follow the process family, not just the single launched
+//! PID. Without propagation a monitored process could `fork()`/`exec()` a
+//! child whose new tgid is absent from `PID_FILTER`, and the guard would
+//! early-return for that child — letting it run **unconfined**, defeating the
+//! post-escape guarantee. The [`aa_syscall_guard_fork`] tracepoint closes this
+//! by copying `PID_FILTER` membership from a monitored parent to each newly
+//! forked child at `sched/sched_process_fork`, so the child is confined from
+//! its first syscall.
+//!
+//! Note the `SYSCALL_ALLOWLIST` is a single global map keyed by syscall number
+//! (not per-PID), so it already applies to every monitored tgid — there is no
+//! per-PID allowlist entry to copy, only the `PID_FILTER` membership.
+//!
 //! ## Best-effort limitations (AAASM-3872)
 //!
 //! This probe is a *best-effort* second line, not a synchronous syscall
@@ -39,6 +54,15 @@
 //!   [`aa_ebpf_common::abi::native_syscall_nr`] so a compat number cannot
 //!   alias an allow-listed native one; i386 `int 0x80` compat remains
 //!   undetectable from the tracepoint `id` alone (documented in `abi`).
+//! - **Fork-vs-thread (AAASM-3916).** Propagation keys on the fork
+//!   tracepoint's `child_pid`. For a real `fork()`/`clone()` of a new process
+//!   `child_pid == child_tgid`, so the child tgid is confined. For a new
+//!   *thread* (`CLONE_THREAD`) `child_pid` is a new tid while the thread's tgid
+//!   equals the already-confined parent tgid — so threads are covered by the
+//!   parent's existing membership; the extra tid key is inert (lookups are by
+//!   tgid). A child that forks *before* the guard observes the parent (TOCTOU
+//!   at attach time) is not covered — attach the guard before launching the
+//!   confined process.
 
 #![no_std]
 #![no_main]
@@ -69,6 +93,20 @@ const SIGKILL: u32 = 9;
 /// `raw_syscalls:sys_enter` layout: the syscall number is the second field
 /// (`long id`) after the 8-byte common tracepoint header.
 const SYS_ENTER_ID_OFFSET: usize = 8;
+
+/// `sched:sched_process_fork` layout — byte offset of the `child_pid` field:
+///
+/// ```text
+/// field:char  parent_comm[16]; offset:8;  size:16;
+/// field:pid_t parent_pid;      offset:24; size:4;
+/// field:char  child_comm[16];  offset:28; size:16;
+/// field:pid_t child_pid;       offset:44; size:4;
+/// ```
+const SCHED_FORK_CHILD_PID_OFFSET: usize = 44;
+
+/// `PID_FILTER` map value marking a tgid as monitored/confined. Only the
+/// presence of the key matters to the enforcement tracepoint.
+const PID_MONITORED: u8 = 1;
 
 /// Enforcement tracepoint: deny-unexpected for monitored PIDs.
 ///
@@ -125,6 +163,37 @@ fn try_syscall_guard(ctx: &TracePointContext) -> Result<(), i64> {
     unsafe {
         bpf_send_signal(SIGKILL);
     }
+    Ok(())
+}
+
+/// Descendant-confinement tracepoint (AAASM-3916): at `sched_process_fork`,
+/// copy `PID_FILTER` membership from a monitored parent to the new child so the
+/// child is confined from its first syscall.
+///
+/// Returns `0` always; the propagation is a best-effort map write and any
+/// failure (map full) leaves the child unconfined — fail-open is unavoidable
+/// here because the tracepoint cannot block the fork.
+#[tracepoint]
+pub fn aa_syscall_guard_fork(ctx: TracePointContext) -> u32 {
+    let _ = try_fork_propagate(&ctx);
+    0
+}
+
+fn try_fork_propagate(ctx: &TracePointContext) -> Result<(), i64> {
+    // The fork tracepoint fires in the *parent's* context, so the current
+    // tgid is the parent's. Only propagate when the parent is confined.
+    let parent_tgid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    if unsafe { PID_FILTER.get(&parent_tgid) }.is_none() {
+        return Ok(());
+    }
+
+    // Read the child's pid. For a real new process `child_pid == child_tgid`,
+    // which is the key the enforcement tracepoint looks up; for a thread the
+    // tgid is already the (confined) parent's, so the extra key is inert.
+    let child_pid = unsafe { ctx.read_at::<u32>(SCHED_FORK_CHILD_PID_OFFSET) }?;
+
+    // Confine the child by mirroring the parent's PID_FILTER membership.
+    let _ = PID_FILTER.insert(&child_pid, &PID_MONITORED, 0);
     Ok(())
 }
 

--- a/aa-ebpf-probes/src/syscall_guard.rs
+++ b/aa-ebpf-probes/src/syscall_guard.rs
@@ -32,7 +32,10 @@
 //! post-escape guarantee. The [`aa_syscall_guard_fork`] tracepoint closes this
 //! by copying `PID_FILTER` membership from a monitored parent to each newly
 //! forked child at `sched/sched_process_fork`, so the child is confined from
-//! its first syscall.
+//! its first syscall. The paired [`aa_syscall_guard_exit`] tracepoint releases
+//! each tgid's `PID_FILTER` entry at `sched/sched_process_exit` so the map
+//! (cap 1024) cannot exhaust — which would make later descendants fail open —
+//! and so a reused pid cannot inherit stale confinement (AAASM-3921c).
 //!
 //! Note the `SYSCALL_ALLOWLIST` is a single global map keyed by syscall number
 //! (not per-PID), so it already applies to every monitored tgid — there is no
@@ -194,6 +197,32 @@ fn try_fork_propagate(ctx: &TracePointContext) -> Result<(), i64> {
 
     // Confine the child by mirroring the parent's PID_FILTER membership.
     let _ = PID_FILTER.insert(&child_pid, &PID_MONITORED, 0);
+    Ok(())
+}
+
+/// Descendant-confinement cleanup tracepoint (AAASM-3921c): at
+/// `sched_process_exit`, remove the exiting tgid from `PID_FILTER`.
+///
+/// Without this the fork-propagated `PID_FILTER` entries (cap 1024) are never
+/// released, so the map exhausts under a forking workload — after which
+/// [`try_fork_propagate`]'s `insert` fails and further descendants run
+/// **unconfined** (fail-open), defeating the post-escape guarantee. Worse, a
+/// stale entry whose tgid is later reused by an unrelated process would cause
+/// the enforcement tracepoint to `SIGKILL` that innocent process. Releasing the
+/// entry on exit bounds the map and closes the pid-reuse hole; this mirrors the
+/// exec probe's own exit-side cleanup.
+///
+/// Returns `0` always; the removal is best-effort and a miss (the tgid was
+/// never confined) is a harmless no-op.
+#[tracepoint]
+pub fn aa_syscall_guard_exit(ctx: TracePointContext) -> u32 {
+    let _ = try_exit_cleanup(&ctx);
+    0
+}
+
+fn try_exit_cleanup(_ctx: &TracePointContext) -> Result<(), i64> {
+    let tgid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let _ = PID_FILTER.remove(&tgid);
     Ok(())
 }
 

--- a/aa-ebpf-probes/src/syscall_guard.rs
+++ b/aa-ebpf-probes/src/syscall_guard.rs
@@ -33,9 +33,12 @@
 //! by copying `PID_FILTER` membership from a monitored parent to each newly
 //! forked child at `sched/sched_process_fork`, so the child is confined from
 //! its first syscall. The paired [`aa_syscall_guard_exit`] tracepoint releases
-//! each tgid's `PID_FILTER` entry at `sched/sched_process_exit` so the map
-//! (cap 1024) cannot exhaust — which would make later descendants fail open —
-//! and so a reused pid cannot inherit stale confinement (AAASM-3921c).
+//! a tgid's `PID_FILTER` entry at `sched/sched_process_exit` — but only on
+//! whole-process (thread-group-leader) exit, since that tracepoint fires
+//! per-thread and tearing the entry down on a non-leader thread exit would
+//! unconfine a still-live multithreaded process. Leader-gated cleanup keeps the
+//! map (cap 1024) from exhausting — which would make later descendants fail
+//! open — and stops a reused pid inheriting stale confinement (AAASM-3921c).
 //!
 //! Note the `SYSCALL_ALLOWLIST` is a single global map keyed by syscall number
 //! (not per-PID), so it already applies to every monitored tgid — there is no
@@ -201,16 +204,26 @@ fn try_fork_propagate(ctx: &TracePointContext) -> Result<(), i64> {
 }
 
 /// Descendant-confinement cleanup tracepoint (AAASM-3921c): at
-/// `sched_process_exit`, remove the exiting tgid from `PID_FILTER`.
+/// `sched_process_exit`, remove the exiting tgid from `PID_FILTER` — but ONLY on
+/// whole-process exit (the thread-group leader, `pid == tgid`).
 ///
-/// Without this the fork-propagated `PID_FILTER` entries (cap 1024) are never
-/// released, so the map exhausts under a forking workload — after which
+/// `sched_process_exit` fires per-thread. A monitored process is confined by
+/// tgid, so removing `PID_FILTER[tgid]` when a non-leader thread of a
+/// multithreaded confined process (Go/Node/Python agents are all multithreaded)
+/// exits would unconfine the still-live process — it would run its remaining
+/// syscalls **unconfined** and its forks would no longer be propagated (the
+/// fork handler's parent check would see the tgid absent). The `pid == tgid`
+/// guard keeps confinement live for the whole process lifetime and cleans up
+/// only when the process itself exits.
+///
+/// Without any cleanup the fork-propagated `PID_FILTER` entries (cap 1024) are
+/// never released, so the map exhausts under a forking workload — after which
 /// [`try_fork_propagate`]'s `insert` fails and further descendants run
 /// **unconfined** (fail-open), defeating the post-escape guarantee. Worse, a
 /// stale entry whose tgid is later reused by an unrelated process would cause
 /// the enforcement tracepoint to `SIGKILL` that innocent process. Releasing the
-/// entry on exit bounds the map and closes the pid-reuse hole; this mirrors the
-/// exec probe's own exit-side cleanup.
+/// entry on leader exit bounds the map and closes the pid-reuse hole; this
+/// mirrors the exec probe's own leader-gated exit-side cleanup.
 ///
 /// Returns `0` always; the removal is best-effort and a miss (the tgid was
 /// never confined) is a harmless no-op.
@@ -221,7 +234,14 @@ pub fn aa_syscall_guard_exit(ctx: TracePointContext) -> u32 {
 }
 
 fn try_exit_cleanup(_ctx: &TracePointContext) -> Result<(), i64> {
-    let tgid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    // sched_process_exit is per-thread; only clean up on whole-process exit so a
+    // non-leader thread exit does not unconfine a live multithreaded process.
+    let pid_tgid = bpf_get_current_pid_tgid();
+    let tgid = (pid_tgid >> 32) as u32;
+    let pid = pid_tgid as u32;
+    if pid != tgid {
+        return Ok(());
+    }
     let _ = PID_FILTER.remove(&tgid);
     Ok(())
 }

--- a/aa-ebpf/src/alert.rs
+++ b/aa-ebpf/src/alert.rs
@@ -6,6 +6,63 @@
 
 use crate::events::FileIoEvent;
 
+/// Lexically canonicalize a filesystem path for **alert matching** (AAASM-3921a).
+///
+/// Collapses repeated `/`, drops `.` segments, and resolves `..` segments
+/// against earlier components without touching the filesystem. This defeats the
+/// trivial non-canonical evasions the in-kernel exact-match blocklist cannot
+/// see (`/etc//shadow`, `/etc/./shadow`, `/etc/../etc/shadow`, trailing-dot
+/// forms).
+///
+/// This is a **lexical** normalization only: it does NOT resolve symlinks or
+/// the process's mount namespace / CWD, so a symlink pointing at a sensitive
+/// file still evades detection. True path resolution requires an in-kernel
+/// `d_path` / dentry walk, which is deferred (it cannot be written or validated
+/// without a Linux kernel target) — see the AAASM-3921a notes in
+/// `aa-ebpf-probes/src/maps.rs`.
+///
+/// A leading `/` (absolute) and a single trailing `/` (a directory-prefix
+/// boundary, e.g. `/root/.ssh/`) are preserved so boundary-aware prefix rules
+/// keep their semantics (`/home/` must not match `/homestead`).
+#[must_use]
+pub fn canonicalize_lexical(path: &str) -> String {
+    let is_absolute = path.starts_with('/');
+    let had_trailing_slash = path.len() > 1 && path.ends_with('/');
+
+    let mut stack: Vec<&str> = Vec::new();
+    for seg in path.split('/') {
+        match seg {
+            "" | "." => continue,
+            ".." => match stack.last() {
+                // Pop a real parent component.
+                Some(&last) if last != ".." => {
+                    stack.pop();
+                }
+                // At root (absolute) a `..` is ignored; for a relative path we
+                // must preserve leading `..` segments.
+                _ => {
+                    if !is_absolute {
+                        stack.push("..");
+                    }
+                }
+            },
+            other => stack.push(other),
+        }
+    }
+
+    let mut out = String::with_capacity(path.len());
+    if is_absolute {
+        out.push('/');
+    }
+    out.push_str(&stack.join("/"));
+    // Restore a directory-boundary trailing slash, but never for the bare root
+    // (already `/`).
+    if had_trailing_slash && !stack.is_empty() {
+        out.push('/');
+    }
+    out
+}
+
 /// Detects whether a file I/O event targets a sensitive path.
 ///
 /// Maintains a list of path prefixes. Any event whose path starts with
@@ -88,5 +145,43 @@ mod tests {
         detector.add_prefix("/opt/secrets/".into());
         assert!(detector.is_sensitive(&make_event("/opt/secrets/key.pem")));
         assert!(!detector.is_sensitive(&make_event("/opt/app/config")));
+    }
+
+    #[test]
+    fn canonicalize_collapses_repeated_slashes() {
+        assert_eq!(canonicalize_lexical("/etc//shadow"), "/etc/shadow");
+        assert_eq!(canonicalize_lexical("/etc///foo//bar"), "/etc/foo/bar");
+    }
+
+    #[test]
+    fn canonicalize_drops_dot_segments() {
+        assert_eq!(canonicalize_lexical("/etc/./shadow"), "/etc/shadow");
+        assert_eq!(canonicalize_lexical("/./etc/shadow"), "/etc/shadow");
+    }
+
+    #[test]
+    fn canonicalize_resolves_dotdot_segments() {
+        assert_eq!(canonicalize_lexical("/etc/../etc/shadow"), "/etc/shadow");
+        assert_eq!(canonicalize_lexical("/a/b/../c"), "/a/c");
+    }
+
+    #[test]
+    fn canonicalize_dotdot_cannot_escape_root() {
+        assert_eq!(canonicalize_lexical("/etc/../../shadow"), "/shadow");
+        assert_eq!(canonicalize_lexical("/../../x"), "/x");
+    }
+
+    #[test]
+    fn canonicalize_preserves_root_and_directory_trailing_slash() {
+        assert_eq!(canonicalize_lexical("/"), "/");
+        assert_eq!(canonicalize_lexical("/root/.ssh/"), "/root/.ssh/");
+        assert_eq!(canonicalize_lexical("/home//"), "/home/");
+    }
+
+    #[test]
+    fn canonicalize_keeps_relative_leading_dotdot() {
+        assert_eq!(canonicalize_lexical("../etc/shadow"), "../etc/shadow");
+        assert_eq!(canonicalize_lexical("a/./b/../c"), "a/c");
+        assert_eq!(canonicalize_lexical(""), "");
     }
 }

--- a/aa-ebpf/src/alert.rs
+++ b/aa-ebpf/src/alert.rs
@@ -74,8 +74,14 @@ pub struct SensitivePathDetector {
 
 impl SensitivePathDetector {
     /// Create a detector with the given path prefixes.
+    ///
+    /// Prefixes are stored in lexically-canonical form (see
+    /// [`canonicalize_lexical`]) so they match canonicalized event paths
+    /// regardless of how the rule was written.
     pub fn new(prefixes: Vec<String>) -> Self {
-        Self { prefixes }
+        Self {
+            prefixes: prefixes.into_iter().map(|p| canonicalize_lexical(&p)).collect(),
+        }
     }
 
     /// Create a detector with default sensitive paths.
@@ -90,13 +96,19 @@ impl SensitivePathDetector {
     }
 
     /// Check whether the given event targets a sensitive path.
+    ///
+    /// The event path is lexically canonicalized before matching so trivial
+    /// non-canonical evasions (`/etc//shadow`, `/etc/../etc/shadow`, …) are
+    /// still caught (AAASM-3921a).
     pub fn is_sensitive(&self, event: &FileIoEvent) -> bool {
-        self.prefixes.iter().any(|p| event.path.starts_with(p))
+        let canonical = canonicalize_lexical(&event.path);
+        self.prefixes.iter().any(|p| canonical.starts_with(p))
     }
 
-    /// Add a path prefix to the detector.
+    /// Add a path prefix to the detector. The prefix is stored in
+    /// lexically-canonical form (see [`canonicalize_lexical`]).
     pub fn add_prefix(&mut self, prefix: String) {
-        self.prefixes.push(prefix);
+        self.prefixes.push(canonicalize_lexical(&prefix));
     }
 
     /// Return the current list of sensitive path prefixes.
@@ -145,6 +157,33 @@ mod tests {
         detector.add_prefix("/opt/secrets/".into());
         assert!(detector.is_sensitive(&make_event("/opt/secrets/key.pem")));
         assert!(!detector.is_sensitive(&make_event("/opt/app/config")));
+    }
+
+    #[test]
+    fn detects_noncanonical_sensitive_path() {
+        let detector = SensitivePathDetector::with_defaults();
+        // Evasions that the in-kernel exact-match blocklist would miss but the
+        // canonicalizing userspace detector catches (AAASM-3921a).
+        assert!(detector.is_sensitive(&make_event("/etc//shadow")));
+        assert!(detector.is_sensitive(&make_event("/etc/./shadow")));
+        assert!(detector.is_sensitive(&make_event("/etc/../etc/shadow")));
+        assert!(detector.is_sensitive(&make_event("/root/.ssh/../.ssh/id_rsa")));
+    }
+
+    #[test]
+    fn directory_prefix_boundary_is_respected() {
+        let detector = SensitivePathDetector::with_defaults();
+        // `/home/` must match files under it but not a sibling like `/homestead`.
+        assert!(detector.is_sensitive(&make_event("/home//user/.bashrc")));
+        assert!(!detector.is_sensitive(&make_event("/homestead/config")));
+    }
+
+    #[test]
+    fn collapse_slashes_in_added_prefix() {
+        let mut detector = SensitivePathDetector::new(vec![]);
+        detector.add_prefix("/opt//secrets/".into());
+        assert_eq!(detector.prefixes(), ["/opt/secrets/"]);
+        assert!(detector.is_sensitive(&make_event("/opt/secrets/key.pem")));
     }
 
     #[test]

--- a/aa-ebpf/src/btf_offsets.rs
+++ b/aa-ebpf/src/btf_offsets.rs
@@ -1,0 +1,283 @@
+//! Resolve `task_struct` field byte-offsets from the running kernel's BTF
+//! (AAASM-3921c).
+//!
+//! The exec probe reads `current->real_parent->tgid` directly at exec time to
+//! report the real parent pid (the `sched_process_exec` tracepoint only carries
+//! the new process's own pid, and the fork-populated map path is unreliable
+//! under load). `aya-ebpf` 0.1 ships an *opaque* `task_struct` binding, so the
+//! probe cannot emit true CO-RE field relocations; instead the loader resolves
+//! the field offsets from the kernel's own BTF at load time and publishes them
+//! into the probe's `TASK_OFFSETS` map. This is equivalent to CO-RE — the
+//! offsets always match the running kernel — without depending on
+//! compile-time-generated `vmlinux` bindings.
+//!
+//! Only two offsets are needed: `task_struct.real_parent` (a
+//! `struct task_struct *`) and `task_struct.tgid` (a `pid_t`). The parser
+//! ([`parse_task_offsets`]) is a small, self-contained BTF walker so it can be
+//! unit-tested off-Linux; [`task_offsets_from_sys`] is the thin wrapper that
+//! reads `/sys/kernel/btf/vmlinux` on the running host.
+
+/// Byte offsets of the `task_struct` fields the exec probe walks to resolve the
+/// real parent tgid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TaskOffsets {
+    /// Byte offset of `task_struct.real_parent`.
+    pub real_parent: u32,
+    /// Byte offset of `task_struct.tgid`.
+    pub tgid: u32,
+}
+
+// --- BTF on-disk constants -------------------------------------------------
+
+/// BTF header magic (`0xEB9F`), read in the file's own endianness.
+const BTF_MAGIC: u16 = 0xEB9F;
+/// Size of `struct btf_type` (name_off, info, size/type — three `u32`s).
+const BTF_TYPE_HDR_LEN: usize = 12;
+/// Size of `struct btf_member` (name_off, type, offset — three `u32`s).
+const BTF_MEMBER_LEN: usize = 12;
+
+// BTF kind codes (`info >> 24 & 0x1f`).
+const BTF_KIND_INT: u32 = 1;
+const BTF_KIND_ARRAY: u32 = 3;
+const BTF_KIND_STRUCT: u32 = 4;
+const BTF_KIND_UNION: u32 = 5;
+const BTF_KIND_ENUM: u32 = 6;
+const BTF_KIND_FUNC_PROTO: u32 = 13;
+const BTF_KIND_VAR: u32 = 14;
+const BTF_KIND_DATASEC: u32 = 15;
+const BTF_KIND_DECL_TAG: u32 = 17;
+const BTF_KIND_ENUM64: u32 = 19;
+
+/// Endianness-aware `u32` reader over a raw BTF blob.
+struct Reader<'a> {
+    bytes: &'a [u8],
+    little_endian: bool,
+}
+
+impl<'a> Reader<'a> {
+    fn u16_at(&self, off: usize) -> Option<u16> {
+        let s = self.bytes.get(off..off + 2)?;
+        let arr = [s[0], s[1]];
+        Some(if self.little_endian {
+            u16::from_le_bytes(arr)
+        } else {
+            u16::from_be_bytes(arr)
+        })
+    }
+
+    fn u32_at(&self, off: usize) -> Option<u32> {
+        let s = self.bytes.get(off..off + 4)?;
+        let arr = [s[0], s[1], s[2], s[3]];
+        Some(if self.little_endian {
+            u32::from_le_bytes(arr)
+        } else {
+            u32::from_be_bytes(arr)
+        })
+    }
+}
+
+/// Trailing bytes that follow the 12-byte `btf_type` header for `kind`/`vlen`.
+///
+/// Kinds not listed carry no trailing data (PTR, FWD, TYPEDEF, VOLATILE,
+/// CONST, RESTRICT, FUNC, FLOAT, TYPE_TAG).
+fn trailing_len(kind: u32, vlen: usize) -> usize {
+    match kind {
+        BTF_KIND_INT => 4,
+        BTF_KIND_ARRAY => 12,
+        BTF_KIND_STRUCT | BTF_KIND_UNION => vlen * BTF_MEMBER_LEN,
+        BTF_KIND_ENUM => vlen * 8,
+        BTF_KIND_FUNC_PROTO => vlen * 8,
+        BTF_KIND_VAR => 4,
+        BTF_KIND_DATASEC => vlen * 12,
+        BTF_KIND_DECL_TAG => 4,
+        BTF_KIND_ENUM64 => vlen * 12,
+        _ => 0,
+    }
+}
+
+/// Read a NUL-terminated string at `name_off` within the BTF string section.
+fn read_str(str_section: &[u8], name_off: u32) -> Option<&str> {
+    let start = name_off as usize;
+    let rest = str_section.get(start..)?;
+    let end = rest.iter().position(|&b| b == 0).unwrap_or(rest.len());
+    core::str::from_utf8(&rest[..end]).ok()
+}
+
+/// Parse a raw BTF blob and return the `task_struct` field byte-offsets the
+/// exec probe needs, or `None` if the blob is malformed or `task_struct` (with
+/// both `real_parent` and `tgid`) is not present.
+pub fn parse_task_offsets(btf: &[u8]) -> Option<TaskOffsets> {
+    // Detect endianness from the magic, trying little then big.
+    let little_endian = {
+        let le = Reader {
+            bytes: btf,
+            little_endian: true,
+        };
+        if le.u16_at(0)? == BTF_MAGIC {
+            true
+        } else {
+            let be = Reader {
+                bytes: btf,
+                little_endian: false,
+            };
+            if be.u16_at(0)? == BTF_MAGIC {
+                false
+            } else {
+                return None;
+            }
+        }
+    };
+    let r = Reader {
+        bytes: btf,
+        little_endian,
+    };
+
+    // struct btf_header: magic(u16) version(u8) flags(u8) hdr_len(u32)
+    //   type_off(u32) type_len(u32) str_off(u32) str_len(u32)
+    let hdr_len = r.u32_at(4)? as usize;
+    let type_off = r.u32_at(8)? as usize;
+    let type_len = r.u32_at(12)? as usize;
+    let str_off = r.u32_at(16)? as usize;
+    let str_len = r.u32_at(20)? as usize;
+
+    let type_start = hdr_len.checked_add(type_off)?;
+    let type_end = type_start.checked_add(type_len)?;
+    let str_start = hdr_len.checked_add(str_off)?;
+    let str_end = str_start.checked_add(str_len)?;
+    let str_section = btf.get(str_start..str_end)?;
+
+    let mut pos = type_start;
+    while pos + BTF_TYPE_HDR_LEN <= type_end {
+        let name_off = r.u32_at(pos)?;
+        let info = r.u32_at(pos + 4)?;
+        let vlen = (info & 0xffff) as usize;
+        let kind = (info >> 24) & 0x1f;
+
+        let trailing = trailing_len(kind, vlen);
+        let members_start = pos + BTF_TYPE_HDR_LEN;
+        let next = members_start.checked_add(trailing)?;
+
+        if kind == BTF_KIND_STRUCT && read_str(str_section, name_off) == Some("task_struct") {
+            let mut real_parent: Option<u32> = None;
+            let mut tgid: Option<u32> = None;
+            for i in 0..vlen {
+                let m = members_start + i * BTF_MEMBER_LEN;
+                let m_name_off = r.u32_at(m)?;
+                // m + 4 is the member type id (unused — we only need offsets).
+                let m_offset_bits = r.u32_at(m + 8)?;
+                // Mask off the bitfield-size high byte (kind_flag structs); the
+                // fields we want are not bitfields, so the low 24 bits are the
+                // plain bit offset.
+                let byte_off = (m_offset_bits & 0x00ff_ffff) / 8;
+                match read_str(str_section, m_name_off) {
+                    Some("real_parent") => real_parent = Some(byte_off),
+                    Some("tgid") => tgid = Some(byte_off),
+                    _ => {}
+                }
+            }
+            if let (Some(real_parent), Some(tgid)) = (real_parent, tgid) {
+                return Some(TaskOffsets { real_parent, tgid });
+            }
+            // A `task_struct` STRUCT without both fields is unexpected; keep
+            // scanning in case another definition carries them.
+        }
+
+        pos = next;
+    }
+
+    None
+}
+
+/// Resolve the `task_struct` offsets from the running kernel's BTF at
+/// `/sys/kernel/btf/vmlinux`. Returns `None` if BTF is unavailable or cannot be
+/// parsed, in which case the exec probe falls back to its map-based path.
+pub fn task_offsets_from_sys() -> Option<TaskOffsets> {
+    let bytes = std::fs::read("/sys/kernel/btf/vmlinux").ok()?;
+    parse_task_offsets(&bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal little-endian BTF blob containing a single
+    /// `task_struct` STRUCT with `real_parent` and `tgid` members at known
+    /// byte offsets, then round-trip it through the parser.
+    #[test]
+    fn parses_task_struct_member_offsets() {
+        // --- string section ---
+        // offset 0 is the conventional empty string.
+        let mut strs: Vec<u8> = vec![0];
+        let off_task = strs.len() as u32;
+        strs.extend_from_slice(b"task_struct\0");
+        let off_real_parent = strs.len() as u32;
+        strs.extend_from_slice(b"real_parent\0");
+        let off_tgid = strs.len() as u32;
+        strs.extend_from_slice(b"tgid\0");
+
+        // --- type section: one STRUCT with two members ---
+        let real_parent_byte: u32 = 1408;
+        let tgid_byte: u32 = 2464;
+        let vlen: u32 = 2;
+        let info = (BTF_KIND_STRUCT << 24) | (vlen & 0xffff);
+
+        let mut types: Vec<u8> = Vec::new();
+        types.extend_from_slice(&off_task.to_le_bytes()); // name_off
+        types.extend_from_slice(&info.to_le_bytes()); // info
+        types.extend_from_slice(&0u32.to_le_bytes()); // size
+                                                      // member 0: real_parent
+        types.extend_from_slice(&off_real_parent.to_le_bytes());
+        types.extend_from_slice(&0u32.to_le_bytes()); // type id (unused)
+        types.extend_from_slice(&(real_parent_byte * 8).to_le_bytes()); // bit offset
+                                                                        // member 1: tgid
+        types.extend_from_slice(&off_tgid.to_le_bytes());
+        types.extend_from_slice(&0u32.to_le_bytes());
+        types.extend_from_slice(&(tgid_byte * 8).to_le_bytes());
+
+        // --- header ---
+        let hdr_len: u32 = 24;
+        let type_off: u32 = 0;
+        let type_len = types.len() as u32;
+        let str_off = type_len;
+        let str_len = strs.len() as u32;
+
+        let mut blob: Vec<u8> = Vec::new();
+        blob.extend_from_slice(&BTF_MAGIC.to_le_bytes()); // magic
+        blob.push(1); // version
+        blob.push(0); // flags
+        blob.extend_from_slice(&hdr_len.to_le_bytes());
+        blob.extend_from_slice(&type_off.to_le_bytes());
+        blob.extend_from_slice(&type_len.to_le_bytes());
+        blob.extend_from_slice(&str_off.to_le_bytes());
+        blob.extend_from_slice(&str_len.to_le_bytes());
+        blob.extend_from_slice(&types);
+        blob.extend_from_slice(&strs);
+
+        let got = parse_task_offsets(&blob).expect("should parse task_struct");
+        assert_eq!(got.real_parent, real_parent_byte);
+        assert_eq!(got.tgid, tgid_byte);
+    }
+
+    #[test]
+    fn rejects_non_btf_blob() {
+        assert!(parse_task_offsets(&[0, 1, 2, 3, 4, 5, 6, 7]).is_none());
+        assert!(parse_task_offsets(&[]).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_task_struct_absent() {
+        // Header with an empty type section and a one-byte string section.
+        let hdr_len: u32 = 24;
+        let mut blob: Vec<u8> = Vec::new();
+        blob.extend_from_slice(&BTF_MAGIC.to_le_bytes());
+        blob.push(1);
+        blob.push(0);
+        blob.extend_from_slice(&hdr_len.to_le_bytes());
+        blob.extend_from_slice(&0u32.to_le_bytes()); // type_off
+        blob.extend_from_slice(&0u32.to_le_bytes()); // type_len
+        blob.extend_from_slice(&0u32.to_le_bytes()); // str_off
+        blob.extend_from_slice(&1u32.to_le_bytes()); // str_len
+        blob.push(0); // empty string
+        assert!(parse_task_offsets(&blob).is_none());
+    }
+}

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -44,6 +44,7 @@
 // Cross-platform modules (no aya dependency).
 pub mod agent_discover;
 pub mod alert;
+pub mod btf_offsets;
 pub mod control;
 pub mod error;
 pub mod events;

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -55,7 +55,13 @@ use crate::maps::PathPattern;
 /// with the file I/O kprobe subsystem. It is only functional on Linux; on
 /// other platforms it returns [`EbpfError::ProgramLoad`] immediately.
 pub struct FileIoLoader {
-    /// Target PID to monitor (and its descendants).
+    /// Target PID to monitor.
+    ///
+    /// NOTE (AAASM-3916): unlike the exec and syscall-guard loaders, the
+    /// file-I/O probe has **no** `sched_process_fork` propagation, so only this
+    /// exact tgid is monitored — descendants are NOT followed. Descendant
+    /// file-I/O telemetry is a follow-up (a fork tracepoint mirroring
+    /// `PID_FILTER` membership like the syscall guard does).
     #[allow(dead_code)]
     target_pid: u32,
     /// Loaded BPF object handle (Linux only).
@@ -64,7 +70,8 @@ pub struct FileIoLoader {
 }
 
 impl FileIoLoader {
-    /// Create a new loader targeting the given PID and its descendants.
+    /// Create a new loader targeting the given PID (this exact tgid only; see
+    /// the `target_pid` field note on the lack of descendant propagation).
     pub fn new(target_pid: u32) -> Self {
         Self {
             target_pid,

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -553,11 +553,16 @@ impl SyscallGuardLoader {
     }
 
     /// Attach the enforcement tracepoint (`aa_syscall_guard` at
-    /// `raw_syscalls/sys_enter`) and the descendant-confinement tracepoint
-    /// (`aa_syscall_guard_fork` at `sched/sched_process_fork`, AAASM-3916).
+    /// `raw_syscalls/sys_enter`), the descendant-confinement tracepoint
+    /// (`aa_syscall_guard_fork` at `sched/sched_process_fork`, AAASM-3916), and
+    /// the confinement-cleanup tracepoint (`aa_syscall_guard_exit` at
+    /// `sched/sched_process_exit`, AAASM-3921c).
     ///
     /// The fork tracepoint must be attached so that children of a confined
-    /// process inherit `PID_FILTER` membership and cannot run unconfined.
+    /// process inherit `PID_FILTER` membership and cannot run unconfined; the
+    /// exit tracepoint releases those entries so the map cannot exhaust (which
+    /// would make later descendants fail open) and reused pids cannot inherit
+    /// stale confinement.
     ///
     /// # Errors
     ///
@@ -582,6 +587,10 @@ impl SyscallGuardLoader {
             let tracepoints: &[(&str, &str, &str)] = &[
                 ("aa_syscall_guard", "raw_syscalls", "sys_enter"),
                 ("aa_syscall_guard_fork", "sched", "sched_process_fork"),
+                // Release PID_FILTER entries on exit so the map cannot exhaust
+                // (fail-open) and reused pids cannot inherit stale confinement
+                // (AAASM-3921c).
+                ("aa_syscall_guard_exit", "sched", "sched_process_exit"),
             ];
 
             for (prog_name, category, tp_name) in tracepoints {

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -545,11 +545,16 @@ impl SyscallGuardLoader {
         }
     }
 
-    /// Attach the `aa_syscall_guard` program at `raw_syscalls/sys_enter`.
+    /// Attach the enforcement tracepoint (`aa_syscall_guard` at
+    /// `raw_syscalls/sys_enter`) and the descendant-confinement tracepoint
+    /// (`aa_syscall_guard_fork` at `sched/sched_process_fork`, AAASM-3916).
+    ///
+    /// The fork tracepoint must be attached so that children of a confined
+    /// process inherit `PID_FILTER` membership and cannot run unconfined.
     ///
     /// # Errors
     ///
-    /// Returns [`EbpfError::ProbeAttach`] on non-Linux or if the tracepoint
+    /// Returns [`EbpfError::ProbeAttach`] on non-Linux or if either tracepoint
     /// fails to attach.
     pub fn attach(&mut self) -> Result<(), EbpfError> {
         #[cfg(not(target_os = "linux"))]
@@ -566,18 +571,27 @@ impl SyscallGuardLoader {
                 .as_mut()
                 .ok_or_else(|| EbpfError::ProbeAttach("BPF not loaded — call load() first".into()))?;
 
-            let program: &mut TracePoint = bpf
-                .program_mut("aa_syscall_guard")
-                .ok_or_else(|| EbpfError::ProbeAttach("aa_syscall_guard program not found".into()))?
-                .try_into()
-                .map_err(|e: aya::programs::ProgramError| EbpfError::ProbeAttach(e.to_string()))?;
+            // (program name, tracepoint category, tracepoint name)
+            let tracepoints: &[(&str, &str, &str)] = &[
+                ("aa_syscall_guard", "raw_syscalls", "sys_enter"),
+                ("aa_syscall_guard_fork", "sched", "sched_process_fork"),
+            ];
 
-            program.load().map_err(|e| EbpfError::ProbeAttach(e.to_string()))?;
-            program
-                .attach("raw_syscalls", "sys_enter")
-                .map_err(|e| EbpfError::ProbeAttach(e.to_string()))?;
+            for (prog_name, category, tp_name) in tracepoints {
+                let program: &mut TracePoint = bpf
+                    .program_mut(prog_name)
+                    .ok_or_else(|| EbpfError::ProbeAttach(format!("{prog_name} program not found")))?
+                    .try_into()
+                    .map_err(|e: aya::programs::ProgramError| EbpfError::ProbeAttach(e.to_string()))?;
 
-            tracing::info!("syscall-guard tracepoint attached at raw_syscalls/sys_enter");
+                program.load().map_err(|e| EbpfError::ProbeAttach(e.to_string()))?;
+                program
+                    .attach(category, tp_name)
+                    .map_err(|e| EbpfError::ProbeAttach(e.to_string()))?;
+
+                tracing::info!(program = prog_name, tracepoint = %format!("{category}/{tp_name}"), "syscall-guard tracepoint attached");
+            }
+
             Ok(())
         }
     }

--- a/aa-ebpf/src/maps.rs
+++ b/aa-ebpf/src/maps.rs
@@ -21,9 +21,18 @@ pub enum PathVerdict {
 /// Userspace writes these entries to configure which file paths the kprobes
 /// should flag. The map is updatable at runtime without reloading the eBPF
 /// programs.
+///
+/// **Match contract (AAASM-3921a/b).** In-kernel matching is **exact,
+/// NUL-padded full-path equality** only — it is NOT prefix matching despite the
+/// historical "prefix" wording. A directory rule like `/etc/` therefore never
+/// fires in-kernel; express directory/prefix and non-canonical rules through
+/// the userspace [`SensitivePathDetector`](crate::alert::SensitivePathDetector),
+/// which canonicalizes and does boundary-aware prefix matching. The file layer
+/// is OBSERVE-ONLY, so this split degrades alert coverage, not enforcement.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PathPattern {
-    /// The path prefix or exact path to match (e.g., `/etc/shadow`).
+    /// The **exact** path to match (e.g., `/etc/shadow`). Matched byte-for-byte
+    /// in-kernel; use the userspace detector for prefix/canonical rules.
     pub pattern: String,
     /// Whether matching this pattern should allow or deny the operation.
     pub verdict: PathVerdict,

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -45,6 +45,12 @@ impl TracepointManager {
     pub fn attach(bpf: &mut Ebpf) -> Result<Self, EbpfError> {
         use aya::programs::TracePoint;
 
+        // Publish the kernel's `task_struct` field offsets so the exec probe can
+        // read `current->real_parent->tgid` directly (AAASM-3921c). Best-effort:
+        // if BTF is unavailable or the map is missing the probe falls back to
+        // its fork-populated map path, so a failure here is not fatal.
+        Self::populate_task_offsets(bpf);
+
         let tracepoints: &[(&str, &str, &str)] = &[
             // Attach fork first so the child→parent map is populated before any
             // exec it enables can be observed (AAASM-3921c).
@@ -74,6 +80,47 @@ impl TracepointManager {
         }
 
         Ok(Self { _links: links })
+    }
+
+    /// Resolve `task_struct.real_parent` / `task_struct.tgid` byte-offsets from
+    /// the running kernel's BTF and write them into the exec probe's
+    /// `TASK_OFFSETS` array map (index 0 = `real_parent`, 1 = `tgid`).
+    ///
+    /// Best-effort and non-fatal: on any failure the map is left zeroed and the
+    /// probe falls back to its fork-populated `PARENT_TGID` map (AAASM-3921c).
+    #[cfg(target_os = "linux")]
+    fn populate_task_offsets(bpf: &mut Ebpf) {
+        let Some(offsets) = crate::btf_offsets::task_offsets_from_sys() else {
+            tracing::warn!("task_struct BTF offsets unavailable; exec ppid falls back to fork map");
+            return;
+        };
+
+        let Some(map) = bpf.map_mut("TASK_OFFSETS") else {
+            tracing::warn!("TASK_OFFSETS map not found; exec ppid falls back to fork map");
+            return;
+        };
+
+        let mut arr: aya::maps::Array<_, u32> = match aya::maps::Array::try_from(map) {
+            Ok(arr) => arr,
+            Err(e) => {
+                tracing::warn!(error = %e, "TASK_OFFSETS not an Array map; skipping offset publish");
+                return;
+            }
+        };
+
+        if let Err(e) = arr
+            .set(0, offsets.real_parent, 0)
+            .and_then(|()| arr.set(1, offsets.tgid, 0))
+        {
+            tracing::warn!(error = %e, "failed to write TASK_OFFSETS; exec ppid falls back to fork map");
+            return;
+        }
+
+        tracing::info!(
+            real_parent = offsets.real_parent,
+            tgid = offsets.tgid,
+            "published task_struct offsets for CO-RE exec ppid"
+        );
     }
 
     /// Explicitly detach all tracepoints.

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -1,7 +1,9 @@
 //! Tracepoint management for process exec monitoring (AAASM-39).
 //!
-//! Attaches the `sched/sched_process_exec` and `sched/sched_process_exit`
-//! tracepoints from the `aa-exec-probes` BPF binary.
+//! Attaches the `sched/sched_process_fork`, `sched/sched_process_exec`, and
+//! `sched/sched_process_exit` tracepoints from the `aa-exec-probes` BPF binary.
+//! The fork tracepoint supplies the real parent pid and descendant coverage
+//! (AAASM-3921c).
 
 #[cfg(target_os = "linux")]
 use aya::Ebpf;
@@ -24,12 +26,12 @@ pub struct TracepointManager {
 }
 
 impl TracepointManager {
-    /// Attach both `sched/sched_process_exec` and `sched/sched_process_exit`
-    /// tracepoint programs.
+    /// Attach the `sched/sched_process_fork`, `sched/sched_process_exec`, and
+    /// `sched/sched_process_exit` tracepoint programs.
     ///
-    /// These tracepoints fire for every `execve`/`execveat` and process exit
-    /// on the system. The BPF-side PID filter (`EXEC_PID_FILTER`) limits
-    /// which events are emitted to the ring buffer.
+    /// These tracepoints fire for every `fork`/`clone`, `execve`/`execveat`,
+    /// and process exit on the system. The BPF-side PID filter
+    /// (`EXEC_PID_FILTER`) limits which events are emitted to the ring buffer.
     ///
     /// # Errors
     ///
@@ -44,6 +46,9 @@ impl TracepointManager {
         use aya::programs::TracePoint;
 
         let tracepoints: &[(&str, &str, &str)] = &[
+            // Attach fork first so the child→parent map is populated before any
+            // exec it enables can be observed (AAASM-3921c).
+            ("handle_sched_process_fork", "sched", "sched_process_fork"),
             ("handle_sched_process_exec", "sched", "sched_process_exec"),
             ("handle_sched_process_exit", "sched", "sched_process_exit"),
         ];


### PR DESCRIPTION
## What changed

Fixes two related eBPF-probe correctness/security bugs in one PR (they share a `sched_process_fork` tracepoint and overlapping files in `aa-ebpf-probes` and `aa-ebpf`, so combining avoids a merge conflict).

### AAASM-3916 [High] — syscall_guard confined only the single target PID; descendants escaped
- `aa-ebpf-probes/src/syscall_guard.rs`: add an `aa_syscall_guard_fork` tracepoint at `sched/sched_process_fork`. When the parent tgid is in `PID_FILTER`, it mirrors that membership onto the forked child so the child is confined from its first syscall. `SYSCALL_ALLOWLIST` is global (keyed by syscall number, not per-PID), so only `PID_FILTER` membership needs propagation.
- `aa-ebpf/src/loader.rs`: `SyscallGuardLoader::attach` now also loads+attaches the new fork tracepoint.
- Documented fork-vs-thread and attach-time TOCTOU caveats; corrected the `FileIoLoader` doc that over-claimed descendant monitoring (the file-I/O probe has no fork propagation — noted as a follow-up).

### AAASM-3921 [Med] — path match non-canonical + prefix-no-op + exec ppid wrong
- **(a) non-canonical paths** — added `canonicalize_lexical()` (pure userspace helper) and applied it in `SensitivePathDetector` to both stored prefixes and incoming event paths, so the OBSERVE-ONLY alerting layer now catches `/etc//shadow`, `/etc/./shadow`, `/etc/../etc/shadow`, etc. Directory-prefix boundaries preserved (`/home/` ≠ `/homestead`). **Lexical only** — symlink/CWD/mount resolution still needs an in-kernel `d_path` walk (deferred; needs Linux). Done & host-tested.
- **(b) prefix-no-op** — chose the lower-risk option: corrected the in-kernel `PATH_BLOCKLIST`/`PATH_ALLOWLIST` and `PathPattern` docs from the false "hash of path prefix" / "prefix or exact" to the actual **exact NUL-padded full-path equality** contract, and reconciled directory/prefix/canonical rules onto the userspace detector. In-kernel bounded prefix matching deferred (needs Linux). Done (docs/contract) + reconciled.
- **(c) exec ppid wrong** — `sched_process_exec`'s `pid` field is the new process's own pid, so `ppid == pid` broke `ProcessLineageTracker::is_descendant_of` (self-cycle → always false). Added `handle_sched_process_fork` to `exec_probes.rs` recording child→parent tgid in `PARENT_TGID` (plus `EXEC_PID_FILTER` descendant propagation); the exec handler now resolves the real ppid from it, falling back to `0` (unknown root). Wired into `TracepointManager`. Exit handler cleans the maps. Done (latent path; kernel data now correct).

## Why
Descendants of a confined process ran fully UNCONFINED (High); sensitive-path alerting was defeated by trivial non-canonical paths and directory rules silently never fired; and process-lineage attribution was structurally broken. See AAASM-3916 / AAASM-3921.

## Validation

> ⚠️ **eBPF is Linux-only and was changed on macOS — kernel runtime behavior is NOT validated locally and MUST be validated on Linux CI before merge.** This is why the PR is a Draft.

**Validated locally (macOS):**
- `cargo check -p aa-ebpf` ✅ and `rustup run nightly cargo check --release` of the standalone `aa-ebpf-probes` workspace (bpfel target, build-std) ✅ — the BPF probe code type-checks/compiles, but the **verifier does not run** off-Linux.
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p aa-ebpf -p aa-ebpf-common --all-targets -- -D warnings` ✅ (no lint warnings)
- `cargo nextest run -p aa-ebpf -p aa-ebpf-common` ✅ 106 passed — includes the new `canonicalize_lexical` + detector tests and the existing lineage descendant tests.

**MUST be validated on Linux CI before merge (changed blind on macOS):**
- BPF **verifier acceptance** of the two new `sched_process_fork` tracepoint programs (map writes, `read_at` offsets).
- Correctness of the `sched_process_fork` field offset (`child_pid` @ 44) and that fork fires before exec at runtime.
- Runtime confinement of descendants by the syscall guard; real-ppid population for exec events (`aa-ebpf` integration tests `exec_tracepoint.rs` / `e2e_ebpf.rs`, run as root with `--features integration-test`).

Closes AAASM-3916
Closes AAASM-3921

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf