### PR TITLE
[AAASM-3958] 🔒 (sdk): Fail-closed on runtime-unreachable in monorepo aa-ffi-*/aa-sdk-client

### DIFF
--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -20,7 +20,9 @@ use crate::ipc::{IpcCommand, IpcHandle};
 use crate::preflight::Preflight;
 
 /// How long [`AssemblyClient::query_policy`] blocks for a runtime decision
-/// before failing open with [`SdkClientError::QueryFailed`].
+/// before returning the non-OK [`SdkClientError::QueryFailed`] sentinel (which
+/// [`resolve_decision`](crate::decision::resolve_decision) fails closed under
+/// enforce, AAASM-3958).
 const QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Handle to an active Agent Assembly session.
@@ -230,9 +232,12 @@ impl AssemblyClient {
     ///
     /// Sends a `CheckActionRequest` to `aa-runtime` over the IPC connection and
     /// blocks (up to [`QUERY_TIMEOUT`]) for the `CheckActionResponse`. Returns
-    /// [`SdkClientError::QueryFailed`] when the runtime does not answer in time
-    /// or the connection closes — callers must treat that as *fail-open* (the
-    /// SDK is advisory; the runtime/proxy/eBPF layers are authoritative).
+    /// the non-OK sentinel [`SdkClientError::QueryFailed`] when the runtime does
+    /// not answer in time or the connection closes; it never fabricates a
+    /// decision. Callers must map the outcome to a final decision through
+    /// [`resolve_decision`](crate::decision::resolve_decision), which fails
+    /// *closed* under enforce (AAASM-3958) and preserves the advisory fail-open
+    /// only when fail-closed is disabled — never treat a raw `Err` as Allow.
     ///
     /// FFI shims that hold a language-runtime lock (e.g. Python's GIL) should
     /// release it around this call, since it blocks the calling thread.

--- a/aa-sdk-client/src/decision.rs
+++ b/aa-sdk-client/src/decision.rs
@@ -1,0 +1,85 @@
+//! Fail-closed resolution of a runtime policy-query outcome (AAASM-3958).
+//!
+//! [`AssemblyClient::query_policy`](crate::client::AssemblyClient::query_policy)
+//! is intentionally low-level: it returns the runtime's [`CheckActionResponse`]
+//! on success and a non-OK [`SdkClientError`] sentinel
+//! (`QueryFailed`/`ChannelClosed`/`Shutdown`) when the runtime is unreachable,
+//! slow, or the session is gone. It never fabricates a decision.
+//!
+//! Turning that outcome into a final [`Decision`] a pre-exec gate can act on is
+//! an *enforcement-mode* choice, and it must be identical across every language
+//! FFI shim (`aa-ffi-go`, `aa-ffi-python`, `aa-ffi-node`) — otherwise each shim
+//! re-derives the fold and they drift. [`resolve_decision`] is that single,
+//! FFI-agnostic mapping, so the shims (which pin this crate by git-SHA) share
+//! one tested source of truth instead of each re-implementing it (AAASM-3920
+//! fixed the shims; this makes the fix durable at the source, AAASM-3958).
+//!
+//! # Contract
+//!
+//! Under **fail-closed** (enforce) the SDK pre-exec gate must never downgrade to
+//! allow-on-failure: a stalled or killed sidecar (unreachable runtime) and a
+//! held-for-approval (`PENDING`) action both resolve to [`Decision::Deny`]. Only
+//! when fail-closed is explicitly disabled (observe mode) is the historical
+//! fail-open preserved. A runtime `DENY`/`REDACT` is honoured verbatim in both
+//! modes, and an `UNSPECIFIED`/unknown code is never treated as a block (it
+//! folds to [`Decision::Allow`]) so the SDK cannot silently wedge on a decision
+//! it cannot interpret.
+//!
+//! The SDK remains advisory: `aa-runtime` / proxy / eBPF are the authoritative
+//! enforcement points. This is a defense-in-depth posture, not the primary gate.
+
+use aa_proto::assembly::common::v1::Decision;
+use aa_proto::assembly::policy::v1::CheckActionResponse;
+
+use crate::error::SdkClientError;
+
+/// Resolve a runtime policy-query outcome into the [`Decision`] an FFI shim
+/// should enforce, applying the fail-closed contract described in the
+/// [module docs](self).
+///
+/// `result` is exactly what
+/// [`query_policy`](crate::client::AssemblyClient::query_policy) returned.
+/// `fail_closed` mirrors the go SDK's `WithFailClosed` (and the Python
+/// enforce-mode guard): `true` denies on runtime-unreachable and on `PENDING`;
+/// `false` preserves the advisory fail-open.
+///
+/// | outcome | `fail_closed == true` | `fail_closed == false` |
+/// |---|---|---|
+/// | `Err(_)` (unreachable / closed / shutdown) | `Deny` | `Allow` |
+/// | `Ok(DENY)` | `Deny` | `Deny` |
+/// | `Ok(PENDING)` | `Deny` | `Pending` |
+/// | `Ok(REDACT)` | `Redact` | `Redact` |
+/// | `Ok(ALLOW)` | `Allow` | `Allow` |
+/// | `Ok(UNSPECIFIED)` / unknown code | `Allow` | `Allow` |
+pub fn resolve_decision(result: &Result<CheckActionResponse, SdkClientError>, fail_closed: bool) -> Decision {
+    match result {
+        Ok(resp) => match Decision::try_from(resp.decision) {
+            Ok(Decision::Deny) => Decision::Deny,
+            // A held-for-approval action is not an allow: under enforce the gate
+            // must block rather than proceed (go WaitForApproval equivalent).
+            Ok(Decision::Pending) => {
+                if fail_closed {
+                    Decision::Deny
+                } else {
+                    Decision::Pending
+                }
+            }
+            Ok(Decision::Redact) => Decision::Redact,
+            Ok(Decision::Allow) => Decision::Allow,
+            // Unspecified or an unknown/garbled code is not a deny signal; never
+            // silently block on a decision the SDK cannot interpret.
+            Ok(Decision::Unspecified) | Err(_) => Decision::Allow,
+        },
+        // Runtime unreachable / slow / closed session: fail closed under enforce
+        // so a stalled or killed sidecar cannot turn deny-on-failure into
+        // allow-on-failure. Preserve the advisory fail-open only when explicitly
+        // disabled (observe mode).
+        Err(_) => {
+            if fail_closed {
+                Decision::Deny
+            } else {
+                Decision::Allow
+            }
+        }
+    }
+}

--- a/aa-sdk-client/src/decision.rs
+++ b/aa-sdk-client/src/decision.rs
@@ -83,3 +83,112 @@ pub fn resolve_decision(result: &Result<CheckActionResponse, SdkClientError>, fa
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A runtime response carrying `decision`.
+    fn answered(decision: Decision) -> Result<CheckActionResponse, SdkClientError> {
+        Ok(CheckActionResponse {
+            decision: decision as i32,
+            ..Default::default()
+        })
+    }
+
+    /// A response with a raw (possibly out-of-range) decision code.
+    fn answered_raw(decision: i32) -> Result<CheckActionResponse, SdkClientError> {
+        Ok(CheckActionResponse {
+            decision,
+            ..Default::default()
+        })
+    }
+
+    // --- runtime unreachable: the core AAASM-3920 regression ---
+    // Mirrors go-sdk `query_policy_fails_closed_with_no_server`: with no
+    // reachable runtime the query yields a non-OK sentinel, and under
+    // fail-closed the SDK must deny rather than synthesize Allow.
+
+    #[test]
+    fn query_failed_denies_when_fail_closed() {
+        assert_eq!(
+            resolve_decision(&Err(SdkClientError::QueryFailed), true),
+            Decision::Deny
+        );
+    }
+
+    #[test]
+    fn channel_closed_denies_when_fail_closed() {
+        assert_eq!(
+            resolve_decision(&Err(SdkClientError::ChannelClosed), true),
+            Decision::Deny
+        );
+    }
+
+    #[test]
+    fn shutdown_denies_when_fail_closed() {
+        assert_eq!(resolve_decision(&Err(SdkClientError::Shutdown), true), Decision::Deny);
+    }
+
+    #[test]
+    fn unreachable_allows_when_fail_open() {
+        // Fail-open is preserved only when fail-closed is explicitly disabled.
+        assert_eq!(
+            resolve_decision(&Err(SdkClientError::QueryFailed), false),
+            Decision::Allow
+        );
+        assert_eq!(
+            resolve_decision(&Err(SdkClientError::ChannelClosed), false),
+            Decision::Allow
+        );
+        assert_eq!(resolve_decision(&Err(SdkClientError::Shutdown), false), Decision::Allow);
+    }
+
+    // --- PENDING -> deny under enforce (go WaitForApproval equivalent) ---
+
+    #[test]
+    fn pending_denies_when_fail_closed() {
+        assert_eq!(resolve_decision(&answered(Decision::Pending), true), Decision::Deny);
+    }
+
+    #[test]
+    fn pending_preserved_when_fail_open() {
+        assert_eq!(resolve_decision(&answered(Decision::Pending), false), Decision::Pending);
+    }
+
+    // --- reachable-runtime path is behavior-preserving in both modes ---
+
+    #[test]
+    fn deny_preserved_in_both_modes() {
+        assert_eq!(resolve_decision(&answered(Decision::Deny), true), Decision::Deny);
+        assert_eq!(resolve_decision(&answered(Decision::Deny), false), Decision::Deny);
+    }
+
+    #[test]
+    fn allow_preserved_in_both_modes() {
+        assert_eq!(resolve_decision(&answered(Decision::Allow), true), Decision::Allow);
+        assert_eq!(resolve_decision(&answered(Decision::Allow), false), Decision::Allow);
+    }
+
+    #[test]
+    fn redact_preserved_in_both_modes() {
+        assert_eq!(resolve_decision(&answered(Decision::Redact), true), Decision::Redact);
+        assert_eq!(resolve_decision(&answered(Decision::Redact), false), Decision::Redact);
+    }
+
+    // --- an uninterpretable decision never silently blocks ---
+
+    #[test]
+    fn unspecified_allows_even_when_fail_closed() {
+        assert_eq!(
+            resolve_decision(&answered(Decision::Unspecified), true),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn unknown_code_allows_even_when_fail_closed() {
+        // A garbled/out-of-range code is not a deny signal.
+        assert_eq!(resolve_decision(&answered_raw(9999), true), Decision::Allow);
+    }
+}

--- a/aa-sdk-client/src/error.rs
+++ b/aa-sdk-client/src/error.rs
@@ -17,7 +17,10 @@ pub enum SdkClientError {
     ChannelClosed,
     /// A synchronous policy query did not complete: the runtime did not answer
     /// within the timeout, or the IPC connection closed before a response
-    /// arrived. Callers should treat this as *fail-open* (the SDK is advisory).
+    /// arrived. This is a non-OK sentinel, not an implicit allow: callers resolve
+    /// it through [`resolve_decision`](crate::decision::resolve_decision), which
+    /// fails *closed* under enforce and preserves fail-open only when fail-closed
+    /// is disabled (AAASM-3958).
     QueryFailed,
     /// The gateway gRPC endpoint could not be reached for registration.
     GatewayUnreachable,

--- a/aa-sdk-client/src/lib.rs
+++ b/aa-sdk-client/src/lib.rs
@@ -28,6 +28,7 @@
 pub mod client;
 pub mod codec;
 pub mod config;
+pub mod decision;
 pub mod error;
 pub mod gateway;
 pub mod identity;
@@ -38,6 +39,7 @@ pub mod preflight;
 
 pub use client::AssemblyClient;
 pub use config::AssemblyConfig;
+pub use decision::resolve_decision;
 pub use error::SdkClientError;
 pub use identity::agent_id_to_did_key;
 pub use keypair::AgentKeypair;


### PR DESCRIPTION
## Description

Durability follow-up to **AAASM-3920** (fixed in the SDK repos: go-sdk #115, python-sdk #198). Those fixes were applied to the SDK repos' native shims, which pin the monorepo `aa-*` crates by git-SHA — so they regress on the next re-sync unless the durable fix lands in the monorepo source.

**Verification of current monorepo state first (the fold differed from the vendored copies):**

- `aa-ffi-go` / `aa-ffi-python` do **not** exist as crates in this monorepo — they live only in the SDK repos (`go-sdk/native/aa-ffi-go`, `python-sdk/native/aa-ffi-python`). Nothing to fix here for them directly; they consume `aa-sdk-client`.
- `aa-sdk-client::query_policy` **already** returns the non-OK sentinel (`QueryFailed`/`ChannelClosed`/`Shutdown`) on runtime-unreachable and preserves `Deny`/`Pending` verbatim — it never folded to Allow. The Allow fold lived only in the per-language shims.
- What was genuinely missing in the vendored monorepo source was a **centralized fail-closed resolver**. Each shim re-implemented the (unreachable, PENDING) → decision fold, which is exactly what regresses.

**Fix (durable source):** add an FFI-agnostic `resolve_decision(result, fail_closed)` to `aa-sdk-client` encoding the AAASM-3920 contract:

| outcome | `fail_closed` (enforce) | fail-closed disabled (observe) |
|---|---|---|
| `Err(_)` unreachable/closed/shutdown | `Deny` | `Allow` |
| `Ok(PENDING)` (go `WaitForApproval` equiv) | `Deny` | `Pending` |
| `Ok(DENY)` / `Ok(REDACT)` | verbatim | verbatim |
| `Ok(ALLOW)` / `Ok(UNSPECIFIED)` / unknown | `Allow` | `Allow` |

The SHA-pinned FFI shims (`aa-ffi-go`/`-python`/`-node`) call this on their next SHA bump instead of re-deriving the fold, so the AAASM-3920 fixes become durable at the source. Also redirected the `query_policy`/`QueryFailed` doc-comments (which prescribed unconditional fail-open — the guidance that produced the regression) at the new resolver.

SDKs remain advisory; `aa-runtime`/proxy/eBPF are authoritative — this is defense-in-depth.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No (additive `pub` API + doc updates; reachable-runtime path is behavior-preserving)

## Related Issues

- Related Jira ticket: AAASM-3958
- Follow-up to: AAASM-3920 (go-sdk #115, python-sdk #198)

Closes AAASM-3958

## Testing

- [x] Unit tests added / updated

11 unit tests in `decision.rs` mirroring go-sdk's `query_policy_fails_closed_with_no_server`: unreachable → Deny under fail-closed / Allow when disabled; PENDING → Deny under enforce / preserved otherwise; DENY/ALLOW/REDACT preserved in both modes; UNSPECIFIED and unknown codes never block.

Validation (worktree, `-p aa-sdk-client`): `cargo build` clean · `cargo nextest run` 71/71 pass · `cargo fmt --all -- --check` clean · `cargo clippy --all-targets -- -D warnings` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73
