### PR TITLE
[AAASM-3911] 🔒 (aa-api): Tenant-scope AlertRule/Destination + revert admin-gate to Write

### DIFF
--- a/aa-api/src/alerts/rules/evaluator.rs
+++ b/aa-api/src/alerts/rules/evaluator.rs
@@ -216,6 +216,8 @@ mod tests {
             enabled: true,
             created_at: String::new(),
             updated_at: String::new(),
+            team_id: None,
+            org_id: None,
         }
     }
 

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -194,6 +194,8 @@ mod tests {
             enabled: true,
             created_at: String::new(),
             updated_at: String::new(),
+            team_id: None,
+            org_id: None,
         }
     }
 

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -109,6 +109,19 @@ pub struct AlertRule {
     pub created_at: String,
     /// RFC 3339 timestamp of the last mutation.
     pub updated_at: String,
+    /// AAASM-3911: owning team, stamped from the creating caller's tenant.
+    ///
+    /// Internal-only: `#[serde(skip)]` keeps it off the wire and out of the
+    /// OpenAPI schema, so the public alert-rule DTO is unchanged. It confines
+    /// list/get/update/delete to the rule's tenant (an admin sees every
+    /// tenant). `None` for rules created by an admin / bypass caller with no
+    /// tenant scope — such rules are untagged and admin-only.
+    #[serde(skip)]
+    pub team_id: Option<String>,
+    /// AAASM-3911: owning org, stamped from the creating caller's tenant.
+    /// Internal-only — see [`Self::team_id`].
+    #[serde(skip)]
+    pub org_id: Option<String>,
 }
 
 /// Validation failure surfaced from [`AlertRule::validate`].
@@ -323,6 +336,8 @@ mod tests {
             enabled: true,
             created_at: "2026-05-13T09:00:00Z".to_string(),
             updated_at: "2026-05-13T09:00:00Z".to_string(),
+            team_id: None,
+            org_id: None,
         }
     }
 

--- a/aa-api/src/destinations/store.rs
+++ b/aa-api/src/destinations/store.rs
@@ -47,7 +47,18 @@ pub trait DestinationStore: Send + Sync {
     /// Fetch a single destination by id.
     fn get(&self, id: &str) -> Option<Destination>;
     /// Insert a new destination and return the persisted record.
-    fn create(&self, name: String, config: DestinationConfig, enabled: bool) -> Destination;
+    ///
+    /// `team_id` / `org_id` are the owning tenant, taken from the creating
+    /// caller (AAASM-3911). Pass `None` for an admin / bypass caller with no
+    /// tenant scope — the destination is then untagged (admin-only).
+    fn create(
+        &self,
+        name: String,
+        config: DestinationConfig,
+        enabled: bool,
+        team_id: Option<String>,
+        org_id: Option<String>,
+    ) -> Destination;
     /// Mutate any subset of `name`/`config`/`enabled` and bump `updated_at`.
     fn update(
         &self,
@@ -99,7 +110,14 @@ impl DestinationStore for InMemoryDestinationStore {
         self.items.get(id).map(|e| e.value().clone())
     }
 
-    fn create(&self, name: String, config: DestinationConfig, enabled: bool) -> Destination {
+    fn create(
+        &self,
+        name: String,
+        config: DestinationConfig,
+        enabled: bool,
+        team_id: Option<String>,
+        org_id: Option<String>,
+    ) -> Destination {
         let now = Utc::now().to_rfc3339();
         let d = Destination {
             id: Self::generate_id(),
@@ -108,6 +126,8 @@ impl DestinationStore for InMemoryDestinationStore {
             enabled,
             created_at: now.clone(),
             updated_at: now,
+            team_id,
+            org_id,
         };
         self.items.insert(d.id.clone(), d.clone());
         d
@@ -171,7 +191,7 @@ mod tests {
     #[test]
     fn create_then_get() {
         let s = store();
-        let d = s.create("hook".into(), webhook("https://example.com/hook"), true);
+        let d = s.create("hook".into(), webhook("https://example.com/hook"), true, None, None);
         assert!(d.id.starts_with("dst_"));
         assert_eq!(d.id.len(), 4 + 32);
         let fetched = s.get(&d.id).unwrap();
@@ -182,9 +202,9 @@ mod tests {
     #[test]
     fn list_filters_by_kind() {
         let s = store();
-        s.create("h1".into(), webhook("https://example.com/h1"), true);
-        s.create("s1".into(), slack("https://hooks.slack.com/x"), true);
-        s.create("h2".into(), webhook("https://example.com/h2"), false);
+        s.create("h1".into(), webhook("https://example.com/h1"), true, None, None);
+        s.create("s1".into(), slack("https://hooks.slack.com/x"), true, None, None);
+        s.create("h2".into(), webhook("https://example.com/h2"), false, None, None);
 
         assert_eq!(s.list(None).len(), 3);
         assert_eq!(s.list(Some(DestinationKind::Webhook)).len(), 2);
@@ -196,7 +216,7 @@ mod tests {
     #[test]
     fn update_preserves_created_at_and_bumps_updated_at() {
         let s = store();
-        let d = s.create("hook".into(), webhook("https://example.com/hook"), true);
+        let d = s.create("hook".into(), webhook("https://example.com/hook"), true, None, None);
         let orig_created = d.created_at.clone();
         let orig_updated = d.updated_at.clone();
         std::thread::sleep(std::time::Duration::from_millis(15));
@@ -233,7 +253,7 @@ mod tests {
     #[test]
     fn delete_returns_in_use_when_checker_says_yes() {
         let s = InMemoryDestinationStore::new(Arc::new(AlwaysReferenced));
-        let d = s.create("hook".into(), webhook("https://example.com/hook"), true);
+        let d = s.create("hook".into(), webhook("https://example.com/hook"), true, None, None);
         assert_eq!(s.delete(&d.id), Err(StoreError::InUse));
         // still present after the failed delete
         assert!(s.get(&d.id).is_some());

--- a/aa-api/src/destinations/types.rs
+++ b/aa-api/src/destinations/types.rs
@@ -124,6 +124,19 @@ pub struct Destination {
     pub created_at: String,
     /// RFC 3339 last-mutation timestamp.
     pub updated_at: String,
+    /// AAASM-3911: owning team, stamped from the creating caller's tenant.
+    ///
+    /// Internal-only: `#[serde(skip)]` keeps it off the wire (the public
+    /// `DestinationResponse` DTO does not carry it) and out of the OpenAPI
+    /// schema. It confines list/get/update/delete/test to the destination's
+    /// tenant (an admin sees every tenant). `None` for destinations created by
+    /// an admin / bypass caller with no tenant scope — untagged, admin-only.
+    #[serde(skip)]
+    pub team_id: Option<String>,
+    /// AAASM-3911: owning org, stamped from the creating caller's tenant.
+    /// Internal-only — see [`Self::team_id`].
+    #[serde(skip)]
+    pub org_id: Option<String>,
 }
 
 #[cfg(test)]
@@ -199,6 +212,8 @@ mod tests {
             enabled: true,
             created_at: "2026-05-20T00:00:00Z".to_string(),
             updated_at: "2026-05-20T00:00:00Z".to_string(),
+            team_id: None,
+            org_id: None,
         };
         let json = serde_json::to_value(&dst).unwrap();
         assert_eq!(json["id"], "dst_1");

--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -317,6 +317,8 @@ mod tests {
             enabled: true,
             created_at: "now".into(),
             updated_at: "now".into(),
+            team_id: None,
+            org_id: None,
         };
         assert_eq!(
             validate_destination(&dst),
@@ -407,6 +409,8 @@ mod tests_extra {
             enabled: true,
             created_at: "2026-06-25T00:00:00Z".to_string(),
             updated_at: "2026-06-25T00:00:00Z".to_string(),
+            team_id: None,
+            org_id: None,
         }
     }
 

--- a/aa-api/src/routes/alert_rules.rs
+++ b/aa-api/src/routes/alert_rules.rs
@@ -24,7 +24,8 @@ use utoipa::ToSchema;
 
 use crate::alerts::rules::store::AlertRuleStoreError;
 use crate::alerts::rules::types::{AlertRule, AlertRuleValidationError, RuleMetric, RuleOperator, RuleSeverity};
-use crate::auth::scope::{RequireAdmin, RequireRead};
+use crate::auth::scope::{RequireRead, RequireWrite, Scope};
+use crate::auth::AuthenticatedCaller;
 use crate::error::ProblemDetail;
 use crate::state::AppState;
 
@@ -159,6 +160,42 @@ fn parse_severity(s: &str) -> Result<RuleSeverity, ProblemDetail> {
     }
 }
 
+/// Enforce tenant ownership of an alert rule for a caller that already cleared
+/// the scope gate (AAASM-3911).
+///
+/// Mirrors `alerts::authorize_alert_owner` / `agents::authorize_agent_access`:
+/// an admin may act on any rule; a tenant-scoped caller may act only on rules
+/// its own tenant owns; a caller with neither admin scope nor any tenant scope
+/// is denied up front (fail-closed) so it cannot enumerate rules. Rules with no
+/// tenant tag (created by an admin / bypass caller) are admin-only.
+///
+/// A rule is matched on its finer-grained tag first: a `team_id` requires team
+/// access, otherwise an `org_id` requires org access, otherwise (untagged) admin
+/// is required.
+fn authorize_rule_owner(caller: &AuthenticatedCaller, rule: &AlertRule) -> Result<(), ProblemDetail> {
+    let is_admin = caller.scopes.contains(&Scope::Admin);
+    if !is_admin && caller.tenant.team_id.is_none() && caller.tenant.org_id.is_none() {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("This operation requires admin scope or a tenant scope".to_string()));
+    }
+    let authorized = match (rule.team_id.as_deref(), rule.org_id.as_deref()) {
+        (Some(team), _) => caller.can_access_team(team),
+        (None, Some(org)) => caller.can_access_org(org),
+        (None, None) => is_admin,
+    };
+    if !authorized {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("This operation requires admin scope or membership in the rule's tenant".to_string()));
+    }
+    Ok(())
+}
+
+/// Whether `caller` may see `rule` — the boolean form of
+/// [`authorize_rule_owner`], used to filter the list response.
+fn rule_visible_to(caller: &AuthenticatedCaller, rule: &AlertRule) -> bool {
+    authorize_rule_owner(caller, rule).is_ok()
+}
+
 /// List alert rules.
 ///
 /// Returns every persisted [`AlertRule`] as a bare JSON array ordered
@@ -176,11 +213,16 @@ fn parse_severity(s: &str) -> Result<RuleSeverity, ProblemDetail> {
     tag = "alert-rules"
 )]
 pub async fn list_rules(
-    _auth: RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     Query(params): Query<ListRulesParams>,
 ) -> impl IntoResponse {
     let mut rules = state.alert_rule_store.list(params.enabled);
+    // AAASM-3911: confine the listing to rules the caller's tenant owns. An
+    // admin sees every rule; a tenant-scoped caller sees only its own tenant's
+    // rules; a caller with no tenant scope (and no admin) sees none. Untagged
+    // rules are admin-only.
+    rules.retain(|r| rule_visible_to(&caller, r));
     // Deterministic order so the dashboard table doesn't reshuffle
     // between fetches.
     rules.sort_by(|a, b| a.created_at.cmp(&b.created_at).then(a.id.cmp(&b.id)));
@@ -206,17 +248,22 @@ pub async fn list_rules(
     tag = "alert-rules"
 )]
 pub async fn create_rule(
-    // AAASM-3894: alert rules carry no team_id/org_id, so a Write-scope key in
-    // any tenant could otherwise mutate every tenant's alerting. Alerting is
-    // admin-managed infrastructure, so gate all mutations on admin scope.
-    // (Deeper per-object tenant tagging is tracked as a follow-up.)
-    _auth: RequireAdmin,
+    // AAASM-3911: reverts the AAASM-3894 admin-gate stopgap back to Write scope.
+    // This is now safe because the rule is stamped with (and later confined to)
+    // the creating caller's tenant, so a Write key can only manage its own
+    // tenant's alerting.
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     Json(body): Json<AlertRuleRequest>,
 ) -> Result<(StatusCode, Json<AlertRuleResponse>), ProblemDetail> {
-    let rule = body.into_alert_rule()?;
+    let mut rule = body.into_alert_rule()?;
     rule.validate(state.destination_registry.as_ref())
         .map_err(validation_error_to_problem)?;
+    // AAASM-3911: stamp the owning tenant from the authenticated caller. An
+    // admin / bypass caller has no tenant → the rule is untagged (admin-only).
+    // The tenant is never taken from the request body.
+    rule.team_id = caller.tenant.team_id.clone();
+    rule.org_id = caller.tenant.org_id.clone();
     let created = state.alert_rule_store.create(rule).map_err(store_error_to_problem)?;
     Ok((StatusCode::CREATED, Json(created)))
 }
@@ -245,11 +292,13 @@ fn not_found(id: &str) -> ProblemDetail {
     tag = "alert-rules"
 )]
 pub async fn get_rule(
-    _auth: RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<(StatusCode, Json<AlertRuleResponse>), ProblemDetail> {
     let rule = state.alert_rule_store.get(&id).ok_or_else(|| not_found(&id))?;
+    // AAASM-3911: tenant ownership before exposing the rule.
+    authorize_rule_owner(&caller, &rule)?;
     Ok((StatusCode::OK, Json(rule)))
 }
 
@@ -272,15 +321,24 @@ pub async fn get_rule(
     tag = "alert-rules"
 )]
 pub async fn update_rule(
-    // AAASM-3894: admin-gated — see `create_rule`.
-    _auth: RequireAdmin,
+    // AAASM-3911: Write scope — see `create_rule`.
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
     Json(body): Json<AlertRuleRequest>,
 ) -> Result<(StatusCode, Json<AlertRuleResponse>), ProblemDetail> {
-    let rule = body.into_alert_rule()?;
+    // AAASM-3911: tenant ownership on the existing rule before mutating it.
+    let existing = state.alert_rule_store.get(&id).ok_or_else(|| not_found(&id))?;
+    authorize_rule_owner(&caller, &existing)?;
+
+    let mut rule = body.into_alert_rule()?;
     rule.validate(state.destination_registry.as_ref())
         .map_err(validation_error_to_problem)?;
+    // Preserve the rule's original owning tenant — an update must not re-tenant
+    // it (the request body carries no tenant and the caller must not be able to
+    // move a rule between tenants).
+    rule.team_id = existing.team_id.clone();
+    rule.org_id = existing.org_id.clone();
     let updated = state
         .alert_rule_store
         .update(&id, rule)
@@ -304,11 +362,15 @@ pub async fn update_rule(
     tag = "alert-rules"
 )]
 pub async fn delete_rule(
-    // AAASM-3894: admin-gated — see `create_rule`.
-    _auth: RequireAdmin,
+    // AAASM-3911: Write scope — see `create_rule`.
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ProblemDetail> {
+    // AAASM-3911: tenant ownership on the existing rule before deleting it.
+    let existing = state.alert_rule_store.get(&id).ok_or_else(|| not_found(&id))?;
+    authorize_rule_owner(&caller, &existing)?;
+
     if state.alert_rule_store.delete(&id) {
         Ok(StatusCode::NO_CONTENT)
     } else {

--- a/aa-api/src/routes/alert_rules.rs
+++ b/aa-api/src/routes/alert_rules.rs
@@ -90,6 +90,10 @@ impl AlertRuleRequest {
             enabled: self.enabled,
             created_at: String::new(),
             updated_at: String::new(),
+            // AAASM-3911: tenant is stamped from the authenticated caller in
+            // `create_rule`, not taken from the request body.
+            team_id: None,
+            org_id: None,
         })
     }
 }

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -12,7 +12,8 @@ use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
-use crate::auth::scope::{RequireAdmin, RequireRead};
+use crate::auth::scope::{RequireRead, RequireWrite, Scope};
+use crate::auth::AuthenticatedCaller;
 use crate::destinations::connectors::slack::SlackConnector;
 use crate::destinations::connectors::webhook::WebhookConnector;
 use crate::destinations::connectors::{ConnectorError, DispatchRequest, NotificationConnector};
@@ -260,6 +261,40 @@ fn in_use_problem() -> ProblemDetail {
     ProblemDetail::from_status(StatusCode::CONFLICT).with_detail("destination_in_use")
 }
 
+/// Enforce tenant ownership of a destination for a caller that already cleared
+/// the scope gate (AAASM-3911).
+///
+/// Mirrors `alert_rules::authorize_rule_owner`: an admin may act on any
+/// destination; a tenant-scoped caller may act only on destinations its own
+/// tenant owns; a caller with neither admin scope nor any tenant scope is
+/// denied up front (fail-closed). Untagged destinations (created by an admin /
+/// bypass caller) are admin-only. A destination is matched on its finer-grained
+/// tag first: a `team_id` requires team access, otherwise an `org_id` requires
+/// org access, otherwise (untagged) admin is required.
+fn authorize_destination_owner(caller: &AuthenticatedCaller, dest: &Destination) -> Result<(), ProblemDetail> {
+    let is_admin = caller.scopes.contains(&Scope::Admin);
+    if !is_admin && caller.tenant.team_id.is_none() && caller.tenant.org_id.is_none() {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("This operation requires admin scope or a tenant scope"));
+    }
+    let authorized = match (dest.team_id.as_deref(), dest.org_id.as_deref()) {
+        (Some(team), _) => caller.can_access_team(team),
+        (None, Some(org)) => caller.can_access_org(org),
+        (None, None) => is_admin,
+    };
+    if !authorized {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("This operation requires admin scope or membership in the destination's tenant"));
+    }
+    Ok(())
+}
+
+/// Whether `caller` may see `dest` — the boolean form of
+/// [`authorize_destination_owner`], used to filter the list response.
+fn destination_visible_to(caller: &AuthenticatedCaller, dest: &Destination) -> bool {
+    authorize_destination_owner(caller, dest).is_ok()
+}
+
 /// Pick the connector implementation matching a destination kind.
 fn connector_for(kind: DestinationKind) -> Box<dyn NotificationConnector> {
     match kind {
@@ -348,14 +383,19 @@ impl IntoResponse for TestDestinationFailure {
     tag = "alert-destinations"
 )]
 pub async fn list_destinations(
-    _auth: RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     Query(filter): Query<DestinationListFilter>,
 ) -> Json<Vec<DestinationResponse>> {
+    // AAASM-3911: confine the listing to destinations the caller's tenant owns.
+    // An admin sees every destination; a tenant-scoped caller sees only its own
+    // tenant's; a caller with no tenant scope (and no admin) sees none. Untagged
+    // destinations are admin-only.
     let items = state
         .destination_store
         .list(filter.kind)
         .into_iter()
+        .filter(|d| destination_visible_to(&caller, d))
         .map(DestinationResponse::from)
         .collect();
     Json(items)
@@ -377,12 +417,11 @@ pub async fn list_destinations(
     tag = "alert-destinations"
 )]
 pub async fn create_destination(
-    // AAASM-3894: destinations carry no team_id/org_id, so a Write-scope key in
-    // any tenant could otherwise create/modify/delete/test-fire every tenant's
-    // notification targets. Destinations are admin-managed infrastructure, so
-    // gate all mutations (incl. the egressing test-fire) on admin scope.
-    // (Deeper per-object tenant tagging is tracked as a follow-up.)
-    _auth: RequireAdmin,
+    // AAASM-3911: reverts the AAASM-3894 admin-gate stopgap back to Write scope.
+    // Safe now because the destination is stamped with (and later confined to)
+    // the creating caller's tenant, so a Write key can only manage its own
+    // tenant's notification targets (incl. the egressing test-fire).
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     body: Bytes,
 ) -> Result<(StatusCode, Json<DestinationResponse>), ProblemDetail> {
@@ -394,9 +433,16 @@ pub async fn create_destination(
     }
     validate_config(&req.config).map_err(validation_error_to_problem)?;
 
-    let d = state
-        .destination_store
-        .create(req.name, req.config, req.enabled, None, None);
+    // AAASM-3911: stamp the owning tenant from the authenticated caller. An
+    // admin / bypass caller has no tenant → the destination is untagged
+    // (admin-only). The tenant is never taken from the request body.
+    let d = state.destination_store.create(
+        req.name,
+        req.config,
+        req.enabled,
+        caller.tenant.team_id.clone(),
+        caller.tenant.org_id.clone(),
+    );
     Ok((StatusCode::CREATED, Json(d.into())))
 }
 
@@ -415,11 +461,13 @@ pub async fn create_destination(
     tag = "alert-destinations"
 )]
 pub async fn get_destination(
-    _auth: RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<DestinationResponse>, ProblemDetail> {
     let d = state.destination_store.get(&id).ok_or_else(not_found_problem)?;
+    // AAASM-3911: tenant ownership before exposing the destination.
+    authorize_destination_owner(&caller, &d)?;
     Ok(Json(d.into()))
 }
 
@@ -441,12 +489,16 @@ pub async fn get_destination(
     tag = "alert-destinations"
 )]
 pub async fn update_destination(
-    // AAASM-3894: admin-gated — see `create_destination`.
-    _auth: RequireAdmin,
+    // AAASM-3911: Write scope — see `create_destination`.
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
     body: Bytes,
 ) -> Result<Json<DestinationResponse>, ProblemDetail> {
+    // AAASM-3911: tenant ownership on the existing destination before mutating.
+    let existing = state.destination_store.get(&id).ok_or_else(not_found_problem)?;
+    authorize_destination_owner(&caller, &existing)?;
+
     let mut req = parse_update_body(&body)?;
     if let Some(name) = &req.name {
         if name.trim().is_empty() {
@@ -461,8 +513,7 @@ pub async fn update_destination(
     // would otherwise fail URL validation, and a masked value of any kind must
     // never overwrite the real stored secret on a GET → edit → PUT round-trip.
     if let Some(cfg) = &mut req.config {
-        let stored = state.destination_store.get(&id).map(|d| d.config);
-        restore_masked_secrets(cfg, stored);
+        restore_masked_secrets(cfg, Some(existing.config.clone()));
     }
 
     if let Some(cfg) = &req.config {
@@ -496,11 +547,15 @@ pub async fn update_destination(
     tag = "alert-destinations"
 )]
 pub async fn delete_destination(
-    // AAASM-3894: admin-gated — see `create_destination`.
-    _auth: RequireAdmin,
+    // AAASM-3911: Write scope — see `create_destination`.
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ProblemDetail> {
+    // AAASM-3911: tenant ownership on the existing destination before deleting.
+    let existing = state.destination_store.get(&id).ok_or_else(not_found_problem)?;
+    authorize_destination_owner(&caller, &existing)?;
+
     state.destination_store.delete(&id).map_err(|e| match e {
         StoreError::NotFound => not_found_problem(),
         StoreError::InUse => in_use_problem(),
@@ -527,8 +582,9 @@ pub async fn delete_destination(
     tag = "alert-destinations"
 )]
 pub async fn test_destination(
-    // AAASM-3894: admin-gated — see `create_destination`.
-    _auth: RequireAdmin,
+    // AAASM-3911: Write scope — see `create_destination`. The test-fire egresses,
+    // so tenant ownership is enforced below before any network dispatch.
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
     body: Option<Json<TestDestinationRequest>>,
@@ -537,6 +593,10 @@ pub async fn test_destination(
         .destination_store
         .get(&id)
         .ok_or_else(|| TestDestinationFailure::NotFound(not_found_problem()))?;
+
+    // AAASM-3911: tenant ownership before firing (a 403 is surfaced as a
+    // rejection, mapped to its ProblemDetail status).
+    authorize_destination_owner(&caller, &destination).map_err(TestDestinationFailure::Rejected)?;
 
     // AAASM-3789 / AAASM-3868: SSRF egress guard. Before dispatching a test-fire,
     // reject targets that resolve to an internal address (loopback / RFC1918 /
@@ -611,8 +671,12 @@ mod tests {
     use crate::auth::scope::Scope;
     use crate::auth::{AuthenticatedCaller, Tenant};
 
-    fn admin() -> RequireAdmin {
-        RequireAdmin(AuthenticatedCaller {
+    // AAASM-3911: the mutation handlers now gate on Write scope + tenant
+    // ownership (reverting the AAASM-3894 admin-gate). This admin caller (Admin
+    // satisfies Write) with no tenant scope owns untagged destinations, so the
+    // existing SSRF / masking tests still exercise the handlers unchanged.
+    fn admin() -> RequireWrite {
+        RequireWrite(AuthenticatedCaller {
             key_id: "k".to_string(),
             scopes: vec![Scope::Admin],
             tenant: Tenant::default(),

--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -394,7 +394,9 @@ pub async fn create_destination(
     }
     validate_config(&req.config).map_err(validation_error_to_problem)?;
 
-    let d = state.destination_store.create(req.name, req.config, req.enabled);
+    let d = state
+        .destination_store
+        .create(req.name, req.config, req.enabled, None, None);
     Ok((StatusCode::CREATED, Json(d.into())))
 }
 
@@ -639,6 +641,8 @@ mod tests {
             enabled: true,
             created_at: String::new(),
             updated_at: String::new(),
+            team_id: None,
+            org_id: None,
         };
         let req = DispatchRequest {
             severity: "LOW".to_string(),
@@ -657,6 +661,8 @@ mod tests {
                 secret_header: None,
             },
             true,
+            None,
+            None,
         );
         // SSRF egress guard (AAASM-3789): a loopback target is refused before dispatch.
         let failure = test_destination(admin(), Extension(state), Path(dest.id), None)
@@ -682,6 +688,8 @@ mod tests {
                     channel_override: None,
                 },
                 true,
+                None,
+                None,
             );
             let failure = test_destination(admin(), Extension(state), Path(dest.id), None)
                 .await
@@ -704,6 +712,8 @@ mod tests {
                 secret_header: Some("real-secret".to_string()),
             },
             true,
+            None,
+            None,
         );
         // A GET → edit → PUT round-trip ships back the masked sentinel; it must not
         // clobber the real stored secret.
@@ -775,6 +785,8 @@ mod tests {
                 enabled: true,
                 created_at: String::new(),
                 updated_at: String::new(),
+                team_id: None,
+                org_id: None,
             };
             match DestinationResponse::from(dest).config {
                 DestinationConfig::Webhook { secret_header, .. } => {

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -317,6 +317,172 @@ async fn delete_rule_preserves_snapshot_on_already_recorded_alerts() {
     assert_eq!(body["ruleSnapshot"]["metric"], "budget_spent_pct");
 }
 
+// ── AAASM-3911: tenant isolation ────────────────────────────────────────────
+
+/// Attach a Bearer JWT to a request builder body-less GET.
+fn get_as(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn post_as(uri: &str, token: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn put_as(uri: &str, token: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("PUT")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn delete_as(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method("DELETE")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn named_rule_body(name: &str) -> serde_json::Value {
+    let mut body = valid_rule_body();
+    body["name"] = json!(name);
+    body
+}
+
+/// A tenant-confined Write key manages ONLY its own tenant's alert rules: it
+/// cannot list, read, update, or delete another tenant's rules, while an admin
+/// key retains cross-tenant access. Reverts the AAASM-3894 admin-gate stopgap.
+#[tokio::test]
+async fn write_key_is_confined_to_its_own_tenant_alert_rules() {
+    let app = common::test_app_with_auth(&[], 1000);
+
+    let write = &[Scope::Read, Scope::Write];
+    let token_a = common::generate_test_jwt_for_team("key-a", write, "team-a");
+    let token_b = common::generate_test_jwt_for_team("key-b", write, "team-b");
+    let token_admin = common::generate_test_jwt("key-admin", &[Scope::Admin]);
+
+    // Team A (Write) creates a rule → 201.
+    let response = app
+        .clone()
+        .oneshot(post_as("/api/v1/alerts/rules", &token_a, named_rule_body("rule-a")))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED, "team-A Write key can create");
+    let rule_a_id = read_json(response).await["id"].as_str().unwrap().to_string();
+
+    // Team B (Write) creates its own rule → 201.
+    let response = app
+        .clone()
+        .oneshot(post_as("/api/v1/alerts/rules", &token_b, named_rule_body("rule-b")))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let rule_b_id = read_json(response).await["id"].as_str().unwrap().to_string();
+
+    // Team B's list must contain only its own rule — never team-A's.
+    let response = app
+        .clone()
+        .oneshot(get_as("/api/v1/alerts/rules", &token_b))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let arr = read_json(response).await;
+    let arr = arr.as_array().unwrap();
+    assert_eq!(arr.len(), 1, "team-B sees only its own rule");
+    assert_eq!(arr[0]["id"], rule_b_id);
+
+    // Team B cannot read team-A's rule.
+    let response = app
+        .clone()
+        .oneshot(get_as(&format!("/api/v1/alerts/rules/{rule_a_id}"), &token_b))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "team-B cannot read team-A's rule"
+    );
+
+    // Team B cannot update team-A's rule.
+    let response = app
+        .clone()
+        .oneshot(put_as(
+            &format!("/api/v1/alerts/rules/{rule_a_id}"),
+            &token_b,
+            named_rule_body("rule-a-hijack"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "team-B cannot update team-A's rule"
+    );
+
+    // Team B cannot delete team-A's rule.
+    let response = app
+        .clone()
+        .oneshot(delete_as(&format!("/api/v1/alerts/rules/{rule_a_id}"), &token_b))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "team-B cannot delete team-A's rule"
+    );
+
+    // Team A still sees and can read its own rule (untouched by B's attempts).
+    let response = app
+        .clone()
+        .oneshot(get_as("/api/v1/alerts/rules", &token_a))
+        .await
+        .unwrap();
+    let arr = read_json(response).await;
+    let arr = arr.as_array().unwrap();
+    assert_eq!(arr.len(), 1, "team-A sees only its own rule");
+    assert_eq!(arr[0]["id"], rule_a_id);
+
+    // Admin sees every tenant's rules and can act cross-tenant.
+    let response = app
+        .clone()
+        .oneshot(get_as("/api/v1/alerts/rules", &token_admin))
+        .await
+        .unwrap();
+    let arr = read_json(response).await;
+    assert_eq!(arr.as_array().unwrap().len(), 2, "admin sees both tenants' rules");
+
+    let response = app
+        .clone()
+        .oneshot(get_as(&format!("/api/v1/alerts/rules/{rule_a_id}"), &token_admin))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "admin reads any tenant's rule");
+
+    let response = app
+        .oneshot(delete_as(&format!("/api/v1/alerts/rules/{rule_a_id}"), &token_admin))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "admin deletes any tenant's rule"
+    );
+}
+
 #[tokio::test]
 async fn create_accepts_every_operator_variant() {
     let app = common::test_app();
@@ -364,11 +530,13 @@ async fn create_with_unknown_severity_returns_invalid_severity() {
     assert_eq!(json["error_code"], "invalid_severity");
 }
 
-// ── AAASM-3894 — alert-rule mutations require admin scope ─────────────────────
+// ── AAASM-3911 — alert-rule mutations are tenant-scoped Write ─────────────────
 //
-// Alert rules carry no team_id/org_id, so before this fix any Write-scope key —
-// in any tenant — could create/update/delete every tenant's alerting. Gate the
-// mutations on admin scope; a non-admin (write-only) caller must be rejected.
+// AAASM-3894 gated alert-rule mutations on admin scope as a stopgap because
+// rules carried no tenant. Now each rule is stamped with (and confined to) its
+// creating tenant, so mutations revert to Write scope — see
+// `write_key_is_confined_to_its_own_tenant_alert_rules` above for the full
+// isolation contract. An admin caller still creates rules cross-tenant.
 
 use aa_api::auth::config::AuthMode;
 use aa_api::auth::scope::Scope;
@@ -387,32 +555,39 @@ fn bearer(method: &str, uri: &str, token: &str, body: Option<serde_json::Value>)
     }
 }
 
+/// A tenant-confined Write key cannot mutate another tenant's rule: PUT / DELETE
+/// against a rule the caller's tenant does not own is refused. (Creation and the
+/// full isolation contract are covered by
+/// `write_key_is_confined_to_its_own_tenant_alert_rules`.)
 #[tokio::test]
-async fn create_rule_write_only_token_is_403() {
+async fn write_key_cannot_mutate_another_tenants_rule() {
     let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
     let app = aa_api::build_app(state);
-    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    let write = &[Scope::Read, Scope::Write];
+    let token_a = common::generate_test_jwt_for_team("key-a", write, "team-a");
+    let token_b = common::generate_test_jwt_for_team("key-b", write, "team-b");
+
+    // Team A creates a rule.
     let resp = app
-        .oneshot(bearer("POST", "/api/v1/alerts/rules", &token, Some(valid_rule_body())))
+        .clone()
+        .oneshot(bearer(
+            "POST",
+            "/api/v1/alerts/rules",
+            &token_a,
+            Some(valid_rule_body()),
+        ))
         .await
         .unwrap();
-    assert_eq!(
-        resp.status(),
-        StatusCode::FORBIDDEN,
-        "a non-admin write caller must not create an alert rule"
-    );
-}
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let id = read_json(resp).await["id"].as_str().unwrap().to_string();
 
-#[tokio::test]
-async fn update_rule_write_only_token_is_403() {
-    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
-    let app = aa_api::build_app(state);
-    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    // Team B cannot update or delete it.
     let resp = app
+        .clone()
         .oneshot(bearer(
             "PUT",
-            "/api/v1/alerts/rules/any-id",
-            &token,
+            &format!("/api/v1/alerts/rules/{id}"),
+            &token_b,
             Some(valid_rule_body()),
         ))
         .await
@@ -420,23 +595,17 @@ async fn update_rule_write_only_token_is_403() {
     assert_eq!(
         resp.status(),
         StatusCode::FORBIDDEN,
-        "a non-admin write caller must not update an alert rule"
+        "team-B cannot update team-A's rule"
     );
-}
 
-#[tokio::test]
-async fn delete_rule_write_only_token_is_403() {
-    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
-    let app = aa_api::build_app(state);
-    let token = common::generate_test_jwt("u", &[Scope::Write]);
     let resp = app
-        .oneshot(bearer("DELETE", "/api/v1/alerts/rules/any-id", &token, None))
+        .oneshot(bearer("DELETE", &format!("/api/v1/alerts/rules/{id}"), &token_b, None))
         .await
         .unwrap();
     assert_eq!(
         resp.status(),
         StatusCode::FORBIDDEN,
-        "a non-admin write caller must not delete an alert rule"
+        "team-B cannot delete team-A's rule"
     );
 }
 

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -261,6 +261,8 @@ async fn delete_rule_preserves_snapshot_on_already_recorded_alerts() {
         enabled: true,
         created_at: "2026-05-13T09:00:00Z".to_string(),
         updated_at: "2026-05-13T09:00:00Z".to_string(),
+        team_id: None,
+        org_id: None,
     };
     let alert_id = alert_store.record_rule_alert(&RuleAlertSeed {
         agent_id: None,

--- a/aa-api/tests/alerts.rs
+++ b/aa-api/tests/alerts.rs
@@ -399,6 +399,8 @@ fn sample_alert_rule() -> AlertRule {
         enabled: true,
         created_at: "2026-05-13T09:00:00Z".to_string(),
         updated_at: "2026-05-13T09:00:00Z".to_string(),
+        team_id: None,
+        org_id: None,
     }
 }
 

--- a/aa-api/tests/connectors.rs
+++ b/aa-api/tests/connectors.rs
@@ -26,6 +26,8 @@ fn destination(config: DestinationConfig) -> Destination {
         enabled: true,
         created_at: "2026-06-18T00:00:00Z".to_string(),
         updated_at: "2026-06-18T00:00:00Z".to_string(),
+        team_id: None,
+        org_id: None,
     }
 }
 

--- a/aa-api/tests/destinations.rs
+++ b/aa-api/tests/destinations.rs
@@ -524,9 +524,10 @@ async fn webhook_secret_header_is_not_returned_in_cleartext() {
     let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
     let app = aa_api::build_app(state);
 
-    // An admin caller creates a webhook destination with a secret.
-    // AAASM-3894: destination mutations now require admin scope.
-    let write_token = common::generate_test_jwt("w", &[Scope::Admin]);
+    // A tenant-scoped Write caller creates a webhook destination with a secret.
+    // AAASM-3911: destination mutations are Write scope, confined to the
+    // caller's tenant; a same-tenant reader (below) can then fetch it.
+    let write_token = common::generate_test_jwt_for_team("w", &[Scope::Read, Scope::Write], "team-x");
     let payload = json!({
         "name": "hook",
         "kind": "webhook",
@@ -552,8 +553,9 @@ async fn webhook_secret_header_is_not_returned_in_cleartext() {
     );
     let id = created["id"].as_str().unwrap().to_string();
 
-    // A read caller fetching the destination must not receive the raw secret.
-    let read_token = common::generate_test_jwt("r", &[Scope::Read]);
+    // A same-tenant read caller fetching the destination must not receive the
+    // raw secret.
+    let read_token = common::generate_test_jwt_for_team("r", &[Scope::Read], "team-x");
     let resp = app
         .oneshot(bearer_empty(
             "GET",
@@ -839,44 +841,90 @@ async fn update_destination_with_malformed_json_returns_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
-// ── AAASM-3894 — destination mutations require admin scope ────────────────────
+// ── AAASM-3911 — destination mutations are tenant-scoped Write ────────────────
 //
-// Destinations carry no team_id/org_id, so before this fix any Write-scope key —
-// in any tenant — could create/update/delete/test-fire every tenant's
-// notification targets. Gate the mutations on admin scope; a non-admin
-// (write-only) caller must be rejected, while an admin caller is allowed.
+// AAASM-3894 gated destination mutations on admin scope as a stopgap because
+// destinations carried no tenant. Now each destination is stamped with (and
+// confined to) its creating tenant, so mutations revert to Write scope: a
+// tenant-confined Write key manages ONLY its own tenant's destinations, while
+// an admin key retains cross-tenant access.
 
+/// A tenant-confined Write key manages ONLY its own tenant's destinations: it
+/// cannot list, read, update, delete, or test-fire another tenant's, while an
+/// admin key retains cross-tenant access.
 #[tokio::test]
-async fn create_destination_write_only_token_is_403() {
+async fn write_key_is_confined_to_its_own_tenant_destinations() {
     let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
     let app = aa_api::build_app(state);
-    let token = common::generate_test_jwt("u", &[Scope::Write]);
+
+    let write = &[Scope::Read, Scope::Write];
+    let token_a = common::generate_test_jwt_for_team("key-a", write, "team-a");
+    let token_b = common::generate_test_jwt_for_team("key-b", write, "team-b");
+    let token_admin = common::generate_test_jwt("key-admin", &[Scope::Admin]);
+
+    // Team A (Write) creates a destination → 201 (reverted from the 3894 stopgap
+    // that required admin).
     let resp = app
+        .clone()
         .oneshot(bearer_json(
             "POST",
             "/api/v1/alerts/destinations",
-            &token,
-            webhook_payload("hook", "https://example.com/hook"),
+            &token_a,
+            webhook_payload("hook-a", "https://example.com/hook-a"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED, "team-A Write key can create");
+    let dst_a = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+    // Team B (Write) creates its own destination → 201.
+    let resp = app
+        .clone()
+        .oneshot(bearer_json(
+            "POST",
+            "/api/v1/alerts/destinations",
+            &token_b,
+            webhook_payload("hook-b", "https://example.com/hook-b"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let dst_b = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+    // Team B's list must contain only its own destination — never team-A's.
+    let resp = app
+        .clone()
+        .oneshot(bearer_empty("GET", "/api/v1/alerts/destinations", &token_b))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let items = body_json(resp).await;
+    let items = items.as_array().unwrap();
+    assert_eq!(items.len(), 1, "team-B sees only its own destination");
+    assert_eq!(items[0]["id"], dst_b);
+
+    // Team B cannot read / update / delete / test-fire team-A's destination.
+    let resp = app
+        .clone()
+        .oneshot(bearer_empty(
+            "GET",
+            &format!("/api/v1/alerts/destinations/{dst_a}"),
+            &token_b,
         ))
         .await
         .unwrap();
     assert_eq!(
         resp.status(),
         StatusCode::FORBIDDEN,
-        "a non-admin write caller must not create a destination"
+        "team-B cannot read team-A's destination"
     );
-}
 
-#[tokio::test]
-async fn update_destination_write_only_token_is_403() {
-    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
-    let app = aa_api::build_app(state);
-    let token = common::generate_test_jwt("u", &[Scope::Write]);
     let resp = app
+        .clone()
         .oneshot(bearer_json(
             "PUT",
-            "/api/v1/alerts/destinations/dst_x",
-            &token,
+            &format!("/api/v1/alerts/destinations/{dst_a}"),
+            &token_b,
             json!({ "enabled": false }),
         ))
         .await
@@ -884,36 +932,32 @@ async fn update_destination_write_only_token_is_403() {
     assert_eq!(
         resp.status(),
         StatusCode::FORBIDDEN,
-        "a non-admin write caller must not update a destination"
+        "team-B cannot update team-A's destination"
     );
-}
 
-#[tokio::test]
-async fn delete_destination_write_only_token_is_403() {
-    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
-    let app = aa_api::build_app(state);
-    let token = common::generate_test_jwt("u", &[Scope::Write]);
     let resp = app
-        .oneshot(bearer_empty("DELETE", "/api/v1/alerts/destinations/dst_x", &token))
+        .clone()
+        .oneshot(bearer_empty(
+            "DELETE",
+            &format!("/api/v1/alerts/destinations/{dst_a}"),
+            &token_b,
+        ))
         .await
         .unwrap();
     assert_eq!(
         resp.status(),
         StatusCode::FORBIDDEN,
-        "a non-admin write caller must not delete a destination"
+        "team-B cannot delete team-A's destination"
     );
-}
 
-#[tokio::test]
-async fn test_destination_write_only_token_is_403() {
-    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
-    let app = aa_api::build_app(state);
-    let token = common::generate_test_jwt("u", &[Scope::Write]);
+    // Test-fire ownership is enforced before any egress, so a wrong-tenant
+    // caller is rejected with 403 without a network round-trip.
     let resp = app
+        .clone()
         .oneshot(bearer_json(
             "POST",
-            "/api/v1/alerts/destinations/dst_x/test",
-            &token,
+            &format!("/api/v1/alerts/destinations/{dst_a}/test"),
+            &token_b,
             json!({ "severity": "LOW" }),
         ))
         .await
@@ -921,7 +965,56 @@ async fn test_destination_write_only_token_is_403() {
     assert_eq!(
         resp.status(),
         StatusCode::FORBIDDEN,
-        "a non-admin write caller must not test-fire a destination"
+        "team-B cannot test-fire team-A's destination"
+    );
+
+    // Team A still sees and can read its own destination (untouched by B).
+    let resp = app
+        .clone()
+        .oneshot(bearer_empty("GET", "/api/v1/alerts/destinations", &token_a))
+        .await
+        .unwrap();
+    let items = body_json(resp).await;
+    let items = items.as_array().unwrap();
+    assert_eq!(items.len(), 1, "team-A sees only its own destination");
+    assert_eq!(items[0]["id"], dst_a);
+
+    // Admin sees every tenant's destinations and can act cross-tenant.
+    let resp = app
+        .clone()
+        .oneshot(bearer_empty("GET", "/api/v1/alerts/destinations", &token_admin))
+        .await
+        .unwrap();
+    let items = body_json(resp).await;
+    assert_eq!(
+        items.as_array().unwrap().len(),
+        2,
+        "admin sees both tenants' destinations"
+    );
+
+    let resp = app
+        .clone()
+        .oneshot(bearer_empty(
+            "GET",
+            &format!("/api/v1/alerts/destinations/{dst_a}"),
+            &token_admin,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "admin reads any tenant's destination");
+
+    let resp = app
+        .oneshot(bearer_empty(
+            "DELETE",
+            &format!("/api/v1/alerts/destinations/{dst_a}"),
+            &token_admin,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "admin deletes any tenant's destination"
     );
 }
 


### PR DESCRIPTION
## Description

Follow-up to **AAASM-3894**. That ticket gated all `AlertRule` and `Destination` mutations on `RequireAdmin` as a **stopgap**, because those objects carried no tenant, so a `Write`-scope key in any tenant could otherwise mutate every tenant's alerting/notification infrastructure.

This PR adds a tenant dimension to both objects and reverts the admin-gate back to `RequireWrite` — now safe because writes are tenant-scoped.

- Added internal `team_id` / `org_id` to the stored `AlertRule` and `Destination`. Both are `#[serde(skip)]` (internal only): they never appear on the wire, and are kept out of the OpenAPI schema, so the public DTOs are unchanged.
- On **create**, the tenant is stamped from the authenticated caller (`AuthenticatedCaller.tenant`) — never from the request body. An admin/bypass caller has no tenant, so the object is untagged (admin-only).
- **list** filters to the objects the caller's tenant owns; **get/update/delete** (and destination **test**-fire) authorize tenant ownership on the stored object. Ownership mirrors the sibling `alerts.rs` / `agents.rs` pattern via `can_access_team` / `can_access_org`. Update preserves the object's original tenant (cannot be re-tenanted).
- **Fail-closed**: a non-admin caller with no tenant scope resolved sees an empty list and is denied every get/mutate (never cross-tenant). An admin retains cross-tenant access.
- Reverted the create/update/delete guards (and destination `test`) from `RequireAdmin` (the 3894 stopgap) back to `RequireWrite`.

## Type of Change

- [x] 🐛 Bug fix (security hardening / stopgap removal)

## Breaking Changes

- [x] No

The tenant fields are internal (`#[serde(skip)]`); OpenAPI regeneration shows **no drift**, so the dashboard contract is unchanged. Behaviour change: `Write`-scope keys can again manage alert rules / destinations, but only within their own tenant.

## Related Issues

- Related Jira ticket: AAASM-3911
- Un-does the AAASM-3894 `RequireAdmin` stopgap (now safe: writes are tenant-scoped)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

New tenant-isolation integration tests prove a tenant-A `Write` key cannot list/read/update/delete/test-fire tenant-B's alert rules + destinations (403 / filtered out), while an admin key retains cross-tenant access. Full `aa-api` suite: 808 passed. `cargo fmt --check`, `cargo clippy -p aa-api --all-targets -D warnings`, and OpenAPI regen+diff all clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3911

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73
