### PR TITLE
[AAASM-3957] 🧹 (installer): Safe uninstall + full local cleanup for curl installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,38 @@ pre-releases — see [Project Status](#project-status).
 > (repo `homebrew-agent-assembly`) still works via a GitHub redirect but is
 > deprecated — use `ai-agent-assembly/tap/aasm`.
 
+## Uninstall
+
+For **curl** installs, the default uninstall removes the tools and **keeps your
+local data** (config, policies, state, logs):
+
+```sh
+aasm uninstall                          # remove tools; preserve data
+aasm uninstall --components cli,runtime # remove only these components
+```
+
+To also remove Agent Assembly-owned local data, opt in explicitly (prompts for
+confirmation; preview with `--dry-run`):
+
+```sh
+aasm uninstall --all --purge            # remove tools + config + state
+aasm uninstall --all --purge --dry-run  # show what would be removed
+```
+
+If `aasm` is missing or broken, the installer provides the same uninstall engine
+as a fallback:
+
+```sh
+curl -fsSL https://agent-assembly.com/install.sh | sh -s -- --uninstall
+```
+
+**Homebrew** installs are detected and left untouched by the above — remove them
+with Homebrew instead:
+
+```sh
+brew uninstall aasm            # plus aasm-runtime / aasm-proxy if installed
+```
+
 ## Overview
 
 `agent-assembly` brings governance to AI agents at scale. It intercepts what an

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -37,6 +37,7 @@ pub mod tools;
 // strip-for-publish:end devtool
 pub mod topology;
 pub mod trace;
+pub mod uninstall;
 pub mod version;
 
 /// Top-level subcommands for the `aasm` CLI.
@@ -92,6 +93,9 @@ pub enum Commands {
     Start(start::StartArgs),
     /// Stop the locally-managed Agent Assembly gateway process.
     Stop(stop::StopArgs),
+    /// Uninstall Agent Assembly tools installed via the curl installer (safe by
+    /// default; `--purge` also removes local data; Homebrew installs redirected).
+    Uninstall(uninstall::UninstallArgs),
 }
 
 /// Dispatch the parsed CLI command to the appropriate handler.
@@ -124,5 +128,6 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Proxy(args) => proxy::dispatch(args),
         Commands::Start(args) => start::run(args),
         Commands::Stop(args) => stop::run(args),
+        Commands::Uninstall(args) => uninstall::dispatch(args),
     }
 }

--- a/aa-cli/src/commands/uninstall.rs
+++ b/aa-cli/src/commands/uninstall.rs
@@ -1,0 +1,114 @@
+//! `aasm uninstall` — thin wrapper over the installer's uninstall engine.
+//!
+//! The curl installer (`scripts/install-cli.sh`) is the single source of truth
+//! for the manifest-driven removal + `--purge` logic (AAASM-3957, shell-primary
+//! by design). On install it persists a runnable copy at
+//! `${AASM_STATE_DIR:-~/.aasm}/aasm-uninstall`; this command forwards to it so
+//! the CLI, the curl installer, and the offline fallback all share one engine
+//! (no divergent rm/purge logic to keep in sync). Homebrew-managed installs are
+//! detected *by the engine* and redirected to `brew uninstall`.
+
+use std::path::PathBuf;
+use std::process::{Command, ExitCode};
+
+/// `aasm uninstall` command-line arguments (forwarded verbatim to the engine).
+#[derive(Debug, clap::Args)]
+pub struct UninstallArgs {
+    /// Remove only these components (comma-separated: cli,runtime,proxy,ebpf).
+    #[arg(long)]
+    pub components: Option<String>,
+
+    /// Remove a single component; repeat the flag for several.
+    #[arg(long)]
+    pub component: Vec<String>,
+
+    /// Also remove Agent Assembly-owned local data (config + state).
+    #[arg(long)]
+    pub purge: bool,
+
+    /// Uninstall all components (the default scope; accepted for explicitness).
+    #[arg(long)]
+    pub all: bool,
+
+    /// Show what would be removed without changing anything.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Skip the `--purge` confirmation prompt (non-interactive).
+    #[arg(short = 'y', long)]
+    pub yes: bool,
+}
+
+/// Resolve the persisted uninstaller path (`${AASM_STATE_DIR:-~/.aasm}/aasm-uninstall`).
+///
+/// Returns `None` only when no home directory can be resolved and
+/// `AASM_STATE_DIR` is unset (rare; sandboxed environments).
+fn uninstaller_path() -> Option<PathBuf> {
+    let base = match std::env::var_os("AASM_STATE_DIR") {
+        Some(v) => PathBuf::from(v),
+        None => dirs::home_dir()?.join(".aasm"),
+    };
+    Some(base.join("aasm-uninstall"))
+}
+
+/// Entry point for `aasm uninstall`. Forwards flags to the persisted engine.
+pub fn dispatch(args: UninstallArgs) -> ExitCode {
+    let helper = match uninstaller_path() {
+        Some(p) if p.exists() => p,
+        _ => {
+            eprintln!(
+                "aasm uninstall: no local uninstaller found.\n\
+                 If you installed via Homebrew, run:  brew uninstall aasm\n\
+                 Otherwise use the fallback:\n  \
+                 curl -fsSL https://agent-assembly.com/install.sh | sh -s -- --uninstall"
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(&helper).arg("--uninstall");
+    if let Some(c) = &args.components {
+        cmd.arg("--components").arg(c);
+    }
+    for c in &args.component {
+        cmd.arg("--component").arg(c);
+    }
+    if args.all {
+        cmd.arg("--all");
+    }
+    if args.purge {
+        cmd.arg("--purge");
+    }
+    if args.dry_run {
+        cmd.arg("--dry-run");
+    }
+    if args.yes {
+        cmd.arg("--yes");
+    }
+
+    match cmd.status() {
+        Ok(s) if s.success() => ExitCode::SUCCESS,
+        Ok(_) => ExitCode::FAILURE,
+        Err(e) => {
+            eprintln!("aasm uninstall: failed to run {}: {e}", helper.display());
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `AASM_STATE_DIR` overrides `~/.aasm` so custom layouts (and tests) resolve
+    /// the engine deterministically. nextest runs each test in its own process,
+    /// so the env mutation is isolated.
+    #[test]
+    fn uninstaller_path_honors_state_dir_override() {
+        std::env::set_var("AASM_STATE_DIR", "/tmp/aa-state-xyz");
+        let p = uninstaller_path().expect("path resolves when AASM_STATE_DIR is set");
+        std::env::remove_var("AASM_STATE_DIR");
+        assert_eq!(p, PathBuf::from("/tmp/aa-state-xyz/aasm-uninstall"));
+    }
+}

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -79,6 +79,20 @@ PROFILES:
   full      cli,runtime,proxy   (ebpf only where explicitly supported)
 
 Note: installing `runtime` does NOT start it. Start it yourself afterwards.
+
+UNINSTALL:
+  --uninstall                Remove installed Agent Assembly tools (preserves
+                             your config/state/data by default).
+  --uninstall --components <a,b>   Uninstall only the listed components.
+  --uninstall --all --purge  Remove tools AND Agent Assembly-owned local data
+                             (config + state). Prompts for confirmation.
+  --uninstall --purge --dry-run    Show what a full cleanup would remove; change
+                             nothing.
+  -y, --yes                  Skip the purge confirmation prompt (non-interactive).
+
+  Homebrew-managed installs are detected and left untouched — use
+  `brew uninstall aasm` instead. Fallback (no `aasm` on PATH):
+    curl -fsSL https://agent-assembly.com/install.sh | sh -s -- --uninstall
 EOF
 }
 
@@ -318,9 +332,165 @@ install_component() {
   esac
 }
 
+# ── install manifest + uninstall (AAASM-3957) ─────────────────────────────────
+
+# AA-owned local data locations (only touched by an explicit --purge).
+aa_config_dir()    { echo "${AASM_CONFIG_DIR:-$HOME/.aa}"; }
+aa_state_dir()     { echo "${AASM_STATE_DIR:-$HOME/.aasm}"; }
+manifest_path()    { echo "$(aa_state_dir)/install-manifest"; }
+uninstaller_path() { echo "$(aa_state_dir)/aasm-uninstall"; }
+
+# Canonical installer URL, used to persist an offline uninstaller when the script
+# was piped (curl | sh) and thus has no readable $0 to copy.
+INSTALLER_URL="${AASM_INSTALLER_URL:-https://agent-assembly.com/install.sh}"
+
+now_utc() { date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown"; }
+
+write_manifest() {
+  # Record what was installed so uninstall never guesses. KEY=VALUE lines with
+  # repeatable keys (component=/binary=). Merges with any existing manifest so a
+  # later component install augments the record rather than replacing it.
+  # Args: <install-dir> <version> <space-separated components>
+  _dir="$1" _ver="$2" _comps="$3"
+  _mf="$(manifest_path)"
+  mkdir -p "$(dirname "$_mf")"
+
+  _old_comps="" _created=""
+  if [ -f "$_mf" ]; then
+    _old_comps="$(grep '^component=' "$_mf" 2>/dev/null | cut -d= -f2- | tr '\n' ' ')"
+    _created="$(grep '^created=' "$_mf" 2>/dev/null | head -1 | cut -d= -f2-)"
+  fi
+  [ -n "$_created" ] || _created="$(now_utc)"
+  _all_comps="$(dedupe_words "$_old_comps $_comps")"
+  case "$_dir" in "$HOME"/*) _mode="user" ;; *) _mode="system" ;; esac
+
+  {
+    echo "# agent-assembly install manifest v1 — managed by install.sh (AAASM-3957); do not hand-edit"
+    echo "installer_source=curl"
+    echo "version=${_ver}"
+    echo "install_mode=${_mode}"
+    echo "install_root=${_dir}"
+    echo "created=${_created}"
+    echo "updated=$(now_utc)"
+    for _c in $_all_comps; do
+      echo "component=${_c}"
+      echo "binary=$(component_binary "$_c")"
+    done
+    echo "config_location=$(aa_config_dir)"
+    echo "state_location=$(aa_state_dir)"
+  } > "$_mf"
+  chmod 600 "$_mf" 2>/dev/null || true
+}
+
+persist_uninstaller() {
+  # Persist a runnable copy of this installer so `aasm uninstall` and offline
+  # cleanup work without re-fetching. Copies $0 when it is a real file (review-
+  # first `sh install.sh`), else downloads the canonical installer (piped run).
+  # Best-effort: a failure here must never fail the install.
+  _u="$(uninstaller_path)"
+  mkdir -p "$(dirname "$_u")"
+  if [ -f "$0" ] && [ -r "$0" ]; then
+    cp "$0" "$_u" 2>/dev/null || { warn "could not persist uninstaller to $_u"; return 0; }
+  else
+    curl -fsSL "$INSTALLER_URL" -o "$_u" 2>/dev/null \
+      || { warn "could not persist offline uninstaller; use: curl -fsSL $INSTALLER_URL | sh -s -- --uninstall"; return 0; }
+  fi
+  chmod 755 "$_u" 2>/dev/null || true
+}
+
+detect_homebrew_managed() {
+  # Return 0 if <path> lives under a Homebrew prefix — then we must NOT rm it;
+  # the user should `brew uninstall` instead.
+  case "$1" in
+    */Cellar/*|*/homebrew/*|*/Homebrew/*) return 0 ;;
+  esac
+  if command -v brew >/dev/null 2>&1; then
+    _bp="$(brew --prefix 2>/dev/null)"
+    [ -n "$_bp" ] && case "$1" in "${_bp}"/*) return 0 ;; esac
+  fi
+  return 1
+}
+
+remove_path() {
+  # Remove <path> honoring DRY_RUN; warn (never fail) when already gone. Only
+  # ever called with a manifest-recorded / AA-owned path — never a computed glob.
+  _p="$1"
+  if [ ! -e "$_p" ] && [ ! -L "$_p" ]; then warn "already absent: $_p"; return 0; fi
+  if [ "${DRY_RUN:-0}" = "1" ]; then say "  would remove: $_p"; return 0; fi
+  rm -rf "$_p" && say "  removed: $_p"
+}
+
+do_uninstall() {
+  # Manifest-driven uninstall. Removes tool binaries by default; with PURGE also
+  # removes AA-owned config/state. Homebrew-managed installs are redirected.
+  # Globals: COMPONENTS (scope; empty = all recorded), PURGE, DRY_RUN, ASSUME_YES.
+  _mf="$(manifest_path)"
+  if [ ! -f "$_mf" ]; then
+    warn "no install manifest at $_mf — nothing recorded to uninstall."
+    warn "If you installed via Homebrew, run: brew uninstall aasm"
+    return 0
+  fi
+
+  _root="$(grep '^install_root=' "$_mf" | head -1 | cut -d= -f2-)"
+  _all_comps="$(grep '^component=' "$_mf" | cut -d= -f2- | tr '\n' ' ')"
+  _scope="$(dedupe_words "${COMPONENTS:-$_all_comps}")"
+
+  # Homebrew guard: never delete brew-managed files.
+  if detect_homebrew_managed "${_root}/aasm"; then
+    warn "aasm appears Homebrew-managed (${_root}). Not removing any files."
+    warn "Use: brew uninstall aasm   (plus aasm-runtime / aasm-proxy as needed)"
+    return 0
+  fi
+
+  say "Uninstalling [${_scope}] from ${_root}$( [ "${DRY_RUN:-0}" = 1 ] && printf ' (dry-run)' )..."
+  for _c in $_scope; do
+    remove_path "${_root}/$(component_binary "$_c")"
+    # aa-gateway ships inside the cli component tarball; remove it with cli.
+    [ "$_c" = "cli" ] && remove_path "${_root}/aa-gateway"
+  done
+
+  if [ "${PURGE:-0}" = "1" ]; then
+    _cfg="$(grep '^config_location=' "$_mf" | head -1 | cut -d= -f2-)"
+    _st="$(grep '^state_location=' "$_mf"  | head -1 | cut -d= -f2-)"
+    warn "PURGE also removes Agent Assembly local data:"
+    say  "  config: ${_cfg}"
+    say  "  state:  ${_st}  (includes the manifest + persisted uninstaller)"
+    if [ "${DRY_RUN:-0}" != "1" ] && [ "${ASSUME_YES:-0}" != "1" ]; then
+      printf 'Proceed with full cleanup? [y/N] '
+      read -r _ans </dev/tty 2>/dev/null || _ans=""
+      case "$_ans" in y|Y|yes|YES) ;; *) err "aborted; no data removed." ;; esac
+    fi
+    remove_path "$_cfg"
+    remove_path "$_st"
+  else
+    say "Preserved local data (config/state). Full cleanup: --uninstall --purge"
+  fi
+
+  # Scoped, non-purge uninstall: rewrite the manifest with the remaining
+  # components, or drop it entirely when nothing is left.
+  if [ "${DRY_RUN:-0}" != "1" ] && [ "${PURGE:-0}" != "1" ] && [ -n "$COMPONENTS" ]; then
+    _remaining=""
+    for _c in $_all_comps; do
+      case " $_scope " in *" $_c "*) ;; *) _remaining="$_remaining $_c" ;; esac
+    done
+    _remaining="$(dedupe_words "$_remaining")"
+    if [ -n "$_remaining" ]; then
+      # Rewrite fresh (not merge): write_manifest unions with the existing file,
+      # which would re-add the just-removed component — so drop it first.
+      _ver="$(grep '^version=' "$_mf" | head -1 | cut -d= -f2-)"
+      rm -f "$_mf"
+      write_manifest "$_root" "$_ver" "$_remaining"
+    else
+      remove_path "$_mf"; remove_path "$(uninstaller_path)"
+    fi
+  fi
+  say "Uninstall complete."
+}
+
 # ── argument parsing ──────────────────────────────────────────────────────────
 
 COMPONENTS=""   # space-separated selection; empty means the default (cli)
+UNINSTALL=0 PURGE=0 DRY_RUN=0 ASSUME_YES=0
 
 add_components() {
   # Append the components in $1 (comma- or space-separated) to COMPONENTS,
@@ -353,12 +523,18 @@ parse_args() {
       --version=*)     VERSION="${1#*=}"; shift ;;
       --install-dir)   [ $# -ge 2 ] || err "--install-dir needs a value"; AASM_INSTALL_DIR="$2"; shift 2 ;;
       --install-dir=*) AASM_INSTALL_DIR="${1#*=}"; shift ;;
+      --uninstall)     UNINSTALL=1; shift ;;
+      --purge)         PURGE=1; shift ;;
+      --all)           shift ;;   # uninstall all components (the default scope) — accepted for explicitness
+      --dry-run)       DRY_RUN=1; shift ;;
+      -y|--yes)        ASSUME_YES=1; shift ;;
       -h|--help)       usage; exit 0 ;;
       *)               err "unknown option: $1 (try --help)" ;;
     esac
   done
-  # Default to CLI-only when nothing is selected; then dedupe.
-  [ -n "$COMPONENTS" ] || COMPONENTS="cli"
+  # Install: default to CLI-only when nothing is selected. Uninstall: an empty
+  # selection means "all recorded components", so don't inject the cli default.
+  if [ "$UNINSTALL" != "1" ] && [ -z "$COMPONENTS" ]; then COMPONENTS="cli"; fi
   COMPONENTS="$(dedupe_words "$COMPONENTS")"
 }
 
@@ -366,6 +542,15 @@ parse_args() {
 
 main() {
   parse_args "$@"
+
+  # Uninstall mode (AAASM-3957) needs no downloads — dispatch before requiring
+  # curl/tar. The served installer thus doubles as the fallback uninstaller:
+  #   curl -fsSL https://agent-assembly.com/install.sh | sh -s -- --uninstall
+  if [ "$UNINSTALL" = "1" ]; then
+    do_uninstall
+    return
+  fi
+
   need curl
   need tar
 
@@ -405,6 +590,11 @@ main() {
   for comp in $COMPONENTS; do
     install_component "$comp" "$VERSION" "$TMP" "${TMP}/SHA256SUMS" "$INSTALL_DIR"
   done
+
+  # Record the install so `aasm uninstall` never guesses which files are ours,
+  # and persist an offline uninstaller (AAASM-3957). Both are best-effort.
+  write_manifest "$INSTALL_DIR" "$VERSION" "$COMPONENTS"
+  persist_uninstaller
 
   # PATH hint (shown once).
   case ":${PATH}:" in

--- a/tests/install_uninstall.bats
+++ b/tests/install_uninstall.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# bats tests for scripts/install-cli.sh uninstall + manifest (AAASM-3957).
+# Run with: bats tests/install_uninstall.bats
+# Sources the installer with AASM_LIB=1 to load functions without running main.
+
+INSTALL_CLI="$BATS_TEST_DIRNAME/../scripts/install-cli.sh"
+
+setup() {
+  TMP="$(mktemp -d)"
+  export HOME="$TMP/home"
+  export AASM_CONFIG_DIR="$HOME/.aa"
+  export AASM_STATE_DIR="$HOME/.aasm"
+  mkdir -p "$AASM_CONFIG_DIR" "$AASM_STATE_DIR"
+  : > "$AASM_CONFIG_DIR/config.yaml"
+  ROOT="$TMP/bin"
+  mkdir -p "$ROOT"
+  : > "$ROOT/aasm"; : > "$ROOT/aa-gateway"; : > "$ROOT/aa-runtime"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "write_manifest records install root, components, and data locations" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  write_manifest "$ROOT" "v0.0.1-rc.2" "cli runtime"
+  run cat "$(manifest_path)"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"install_root=$ROOT"* ]]
+  [[ "$output" == *"component=cli"* ]]
+  [[ "$output" == *"component=runtime"* ]]
+  [[ "$output" == *"config_location=$AASM_CONFIG_DIR"* ]]
+}
+
+@test "default uninstall removes tool binaries and preserves user data" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  write_manifest "$ROOT" "v0.0.1-rc.2" "cli runtime"
+  do_uninstall
+  [ ! -e "$ROOT/aasm" ]
+  [ ! -e "$ROOT/aa-gateway" ]
+  [ ! -e "$ROOT/aa-runtime" ]
+  [ -e "$AASM_CONFIG_DIR/config.yaml" ]   # data preserved by default
+}
+
+@test "scoped uninstall removes only the requested component and rewrites the manifest" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  write_manifest "$ROOT" "v0.0.1-rc.2" "cli runtime"
+  COMPONENTS="runtime" do_uninstall
+  [ ! -e "$ROOT/aa-runtime" ]   # runtime removed
+  [ -e "$ROOT/aasm" ]           # cli kept
+  run grep -c '^component=' "$(manifest_path)"
+  [ "$output" -eq 1 ]           # only cli remains
+  run grep '^component=' "$(manifest_path)"
+  [[ "$output" == "component=cli" ]]
+}
+
+@test "purge --dry-run changes nothing" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  write_manifest "$ROOT" "v0.0.1-rc.2" "cli"
+  PURGE=1 DRY_RUN=1 do_uninstall
+  [ -e "$ROOT/aasm" ]                       # dry-run touched nothing
+  [ -e "$AASM_CONFIG_DIR/config.yaml" ]
+  [ -e "$(manifest_path)" ]
+}
+
+@test "purge --yes removes tools and AA-owned data" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  write_manifest "$ROOT" "v0.0.1-rc.2" "cli"
+  PURGE=1 ASSUME_YES=1 do_uninstall
+  [ ! -e "$ROOT/aasm" ]
+  [ ! -d "$AASM_CONFIG_DIR" ]   # config purged
+  [ ! -d "$AASM_STATE_DIR" ]    # state purged
+}
+
+@test "uninstall with no manifest is a safe no-op" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  rm -f "$(manifest_path)"
+  run do_uninstall
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing recorded to uninstall"* ]]
+  [ -e "$ROOT/aasm" ]           # untouched
+}
+
+@test "Homebrew-managed install is detected and redirected, not deleted" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  run detect_homebrew_managed "/opt/homebrew/bin/aasm"
+  [ "$status" -eq 0 ]
+  run detect_homebrew_managed "$ROOT/aasm"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Description

Adds the **safe uninstall lifecycle** for curl-based installs (AAASM-3957),
shell-primary by design so the CLI, the curl installer, and the offline fallback
share one manifest-driven engine.

- **Install manifest** (`${AASM_STATE_DIR:-~/.aasm}/install-manifest`): written by
  `install-cli.sh` on every install/component change — records installer source,
  version, install mode (user/system), install root, components, binaries, and the
  config/state locations. Uninstall uses it as the source of truth (never guesses
  paths / globs).
- **`install-cli.sh --uninstall`** engine: default removes tool binaries and
  **preserves user data**; `--components a,b` scopes it (and rewrites the manifest);
  `--all --purge` also removes AA-owned config+state **with a confirmation prompt**;
  `--dry-run` previews; `-y/--yes` for non-interactive. Homebrew-managed installs
  are detected and redirected to `brew uninstall` (never rm'd). The served
  installer doubles as the **fallback**: `curl … install.sh | sh -s -- --uninstall`.
- **`aasm uninstall`** (Rust): thin wrapper forwarding flags to the persisted
  `~/.aasm/aasm-uninstall` engine; prints Homebrew/fallback guidance if absent.
- Installer persists an offline copy of itself as the uninstaller (copies `$0`, or
  re-downloads the canonical installer when piped).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — install flow unchanged except it now also writes a manifest + persists
  an uninstaller (both best-effort; failures never fail the install). New
  `aasm uninstall` subcommand + new `--uninstall/--purge/--dry-run/--yes/--all`
  installer flags are additive.

## Related Issues

- Jira: AAASM-3957 · Epic AAASM-3948 · ADR-014

## Testing / Verification

- **Shell engine (the core):** `tests/install_uninstall.bats` — 7 tests, all pass
  (manifest write; default uninstall preserves data; scoped uninstall rewrites the
  manifest; purge `--dry-run` no-op; purge `--yes` removes data; no-manifest safe
  no-op; Homebrew detection). Existing installer bats still pass. `shellcheck`
  clean apart from the 2 pre-existing `local` warnings.
- **Rust wrapper:** `cargo check -p aa-cli` ✅, `cargo nextest -p aa-cli uninstall`
  ✅, `cargo clippy -p aa-cli -- -D warnings` → 0 errors (6 warnings are
  pre-existing Cargo.toml `default-features` notices, not from this change),
  `cargo fmt` applied.

## Safety notes

- Uninstall only touches manifest-recorded / AA-owned paths — no broad filesystem
  guessing. `--purge` requires explicit opt-in + interactive confirmation (or
  `--yes`), and supports `--dry-run`. Homebrew-owned files are never removed.

## Notes / follow-up

- Repo-level install/uninstall integration coverage is tracked under **AAASM-3955**
  (this PR ships the unit/bats coverage in-repo).
- Pushed via the GitHub Git Data API (this branch touches Rust, so the local
  `pre-push` `cargo doc` gate — macOS/eBPF-incompatible — can't run); no
  `--no-verify` used. CI will run the full doc/build/test suite.

## Checklist

- [x] Commits small + Gitmoji, bisectable (module added before it's registered)
- [x] Self-review completed
- [x] Docs updated (README + `--help`)
