### PR TITLE
[AAASM-3956] 🔧 (release): Point release automation + skill at the renamed homebrew-tap

### DIFF
--- a/.claude/skills/homebrew-tap-merge/EXAMPLES.md
+++ b/.claude/skills/homebrew-tap-merge/EXAMPLES.md
@@ -15,8 +15,8 @@ AAASM-2871 stale-master rebase path. The lean plan lives in
 
 ## Worked example — alpha-9 (2026-06-14)
 
-PR [#16](https://github.com/ai-agent-assembly/homebrew-agent-assembly/pull/16)
-on `ai-agent-assembly/homebrew-agent-assembly`, titled `🤖 (formula): aasm
+PR [#16](https://github.com/ai-agent-assembly/homebrew-tap/pull/16)
+on `ai-agent-assembly/homebrew-tap`, titled `🤖 (formula): aasm
 0.0.1-alpha.9`, opened by the release-bot at 2026-06-13 18:09 UTC after the
 upstream `v0.0.1-alpha.9` tag push triggered `release.yml`'s
 `update-homebrew-tap` job.
@@ -28,7 +28,7 @@ pre-`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` master tip).
 ### Step 1 — Scope check
 
 ```bash
-gh pr view 16 --repo ai-agent-assembly/homebrew-agent-assembly \
+gh pr view 16 --repo ai-agent-assembly/homebrew-tap \
   --json files,additions,deletions
 # → single file Formula/aasm.rb, ~5 additions, ~5 deletions  ✓
 ```
@@ -53,12 +53,12 @@ The four sha256 values pinned in the PR diff (also present in upstream
 ### Step 3 — Detect stale-master + server-side rebase
 
 ```bash
-gh pr view 16 --repo ai-agent-assembly/homebrew-agent-assembly \
+gh pr view 16 --repo ai-agent-assembly/homebrew-tap \
   --json mergeStateStatus
 # → "BEHIND"
 
 gh api -X PUT \
-  /repos/ai-agent-assembly/homebrew-agent-assembly/pulls/16/update-branch \
+  /repos/ai-agent-assembly/homebrew-tap/pulls/16/update-branch \
   -f update_method=rebase
 ```
 
@@ -72,7 +72,7 @@ the AAASM-2871 sandbox quirk.
 # brew install + test (macOS) goes green; the success log contains:
 #   Pouring … Cellar/aasm/0.0.1-alpha.9: 3 files, 21.5MB, built in 1 second
 
-gh pr merge 16 --repo ai-agent-assembly/homebrew-agent-assembly --squash
+gh pr merge 16 --repo ai-agent-assembly/homebrew-tap --squash
 ```
 
 Verifies the AAASM-2871 workaround is active in workflow env, then squashes

--- a/.claude/skills/homebrew-tap-merge/SKILL.md
+++ b/.claude/skills/homebrew-tap-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: homebrew-tap-merge
-description: Verify and merge the bot PR that release.yml auto-opens on homebrew-agent-assembly for a new agent-assembly release. Use when a bot/aasm-<version> PR is open on the Homebrew tap and needs sha256 cross-verification against the upstream SHA256SUMS, a stale-master server-side rebase, or the AAASM-2871 macOS-CI tap-trust workaround before it can be merged.
+description: Verify and merge the bot PR that release.yml auto-opens on homebrew-tap for a new agent-assembly release. Use when a bot/aasm-<version> PR is open on the Homebrew tap and needs sha256 cross-verification against the upstream SHA256SUMS, a stale-master server-side rebase, or the AAASM-2871 macOS-CI tap-trust workaround before it can be merged.
 ---
 
 # SKILL.md — homebrew-tap-merge
@@ -8,7 +8,7 @@ description: Verify and merge the bot PR that release.yml auto-opens on homebrew
 ## Purpose
 
 After each `agent-assembly` release, `release.yml`'s `update-homebrew-tap` job
-opens a `bot/aasm-<version>` PR on `ai-agent-assembly/homebrew-agent-assembly`
+opens a `bot/aasm-<version>` PR on `ai-agent-assembly/homebrew-tap`
 that bumps `Formula/aasm.rb` (version line + 4 SHA256 sums). This skill owns the
 verify-and-merge flow for that PR so `brew install aasm` picks up the release.
 
@@ -18,7 +18,7 @@ it is logically owned by the upstream that publishes to it.
 ## When to use
 
 Invoke when `release.yml`'s `update-homebrew-tap` job has finished and a
-`bot/aasm-<version>` PR is open on `ai-agent-assembly/homebrew-agent-assembly`,
+`bot/aasm-<version>` PR is open on `ai-agent-assembly/homebrew-tap`,
 and the operator (or `release-watch`) wants to verify the bot diff and merge it.
 
 ## When NOT to use
@@ -38,7 +38,7 @@ and the operator (or `release-watch`) wants to verify the bot diff and merge it.
 ```
 
 Example: `/homebrew-tap-merge 16`. Resolve the PR number with
-`gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open`. The
+`gh pr list --repo ai-agent-assembly/homebrew-tap --state open`. The
 matching upstream `agent-assembly` release must already be published with its
 `SHA256SUMS` asset attached.
 
@@ -47,7 +47,7 @@ matching upstream `agent-assembly` release must already be published with its
 ### 1. Verify PR scope
 
 ```bash
-gh pr view <n> --repo ai-agent-assembly/homebrew-agent-assembly \
+gh pr view <n> --repo ai-agent-assembly/homebrew-tap \
   --json files,additions,deletions
 ```
 
@@ -69,7 +69,7 @@ mismatch table — **escalate; do not merge**.
 ### 3. Handle red `brew install + test (macOS)` check
 
 ```bash
-gh pr view <n> --repo ai-agent-assembly/homebrew-agent-assembly \
+gh pr view <n> --repo ai-agent-assembly/homebrew-tap \
   --json baseRefOid,mergeable,mergeStateStatus
 ```
 
@@ -78,21 +78,21 @@ gh pr view <n> --repo ai-agent-assembly/homebrew-agent-assembly \
 
   ```bash
   gh api -X PUT \
-    /repos/ai-agent-assembly/homebrew-agent-assembly/pulls/<n>/update-branch \
+    /repos/ai-agent-assembly/homebrew-tap/pulls/<n>/update-branch \
     -f update_method=rebase
   ```
 
   Wait for CI to re-run, then re-evaluate. See the AAASM-2871 note below.
 
 - If the PR is up to date, surface the failure log with
-  `gh run view --repo ai-agent-assembly/homebrew-agent-assembly --job <id> --log-failed`.
+  `gh run view --repo ai-agent-assembly/homebrew-tap --job <id> --log-failed`.
 
 ### 4. Merge
 
 Once CI is green and sha256s are verified:
 
 ```bash
-gh pr merge <n> --repo ai-agent-assembly/homebrew-agent-assembly --squash
+gh pr merge <n> --repo ai-agent-assembly/homebrew-tap --squash
 ```
 
 ## AAASM-2871 quirk (live until Homebrew/brew#22719 ships)

--- a/.claude/skills/homebrew-tap-merge/scripts/verify-tap-sha256.sh
+++ b/.claude/skills/homebrew-tap-merge/scripts/verify-tap-sha256.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Cross-verify the 4 sha256 lines in homebrew-agent-assembly's Formula/aasm.rb
+# Cross-verify the 4 sha256 lines in homebrew-tap's Formula/aasm.rb
 # against the upstream agent-assembly release's SHA256SUMS asset.
 #
 # AAASM-2888 — extracted from .claude/skills/homebrew-tap-merge/SKILL.md step 2.
@@ -17,7 +17,7 @@
 set -uo pipefail
 
 UPSTREAM_REPO="ai-agent-assembly/agent-assembly"
-TAP_REPO="ai-agent-assembly/homebrew-agent-assembly"
+TAP_REPO="ai-agent-assembly/homebrew-tap"
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
   echo "Usage: $0 <tag> [<pr>]" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -556,10 +556,13 @@ jobs:
           # github.ref_name is the tag (e.g. v0.0.1); strip the leading "v".
           echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout homebrew-agent-assembly tap
+      - name: Checkout homebrew-tap tap
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: ai-agent-assembly/homebrew-agent-assembly
+          # Renamed from homebrew-agent-assembly → homebrew-tap (AAASM-3950) so
+          # Homebrew resolves the tap as ai-agent-assembly/tap. The old name still
+          # redirects, but target the canonical repo directly.
+          repository: ai-agent-assembly/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
 


### PR DESCRIPTION
## Description

Release-side tap-name cleanup for the componentized installer work (AAASM-3956),
completing the `homebrew-agent-assembly → homebrew-tap` rename (AAASM-3950) on the
release automation:

- `release.yml` `update-homebrew-tap` job now checks out
  `ai-agent-assembly/homebrew-tap` (old name still redirects; target the canonical
  repo directly).
- `homebrew-tap-merge` skill (SKILL.md, EXAMPLES.md, `verify-tap-sha256.sh`)
  updated to the renamed tap repo.

The operator-facing release checklist for the component artifacts + install
verification lives in the `inner-document` runbook PR (AAASM-3956, sibling PR).

## Type of Change

- [x] 🔧 Configuration / CI change (+ skill docs)

## Breaking Changes

- [x] No — the tap repo redirect means the job worked before and after; this just
  points at the canonical name. No behavioral change to the release flow.

## Related Issues

- Related Jira ticket: AAASM-3956
- Epic: AAASM-3948 · Tap rename: AAASM-3950

## Testing

- [x] No tests required (workflow `repository:` value + skill-doc string updates) —
  `release.yml` only runs on tag push; the change is a static repo-name swap.

## Notes

- Follow-up (documented in the runbook): the `update-homebrew-tap` job still syncs
  only `Formula/aasm.rb` SHAs — extend it to the component formulae
  (`aasm-runtime/-proxy/-ebpf`) once the first component artifacts ship.

## Checklist

- [x] Self-review completed
- [x] Commits small + Gitmoji
- [x] No untrusted input in the workflow change (static `repository:` value)
