### PR TITLE
[AAASM-3988] 🔒 (aa-security): Linear-time email scan (fix O(n²) DoS)

### DIFF
--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -679,37 +679,71 @@ fn scan_long_base64_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
     }
 }
 
-/// Scans `text` for email addresses by locating `@` signs and expanding outward.
+/// RFC 5321 caps the local-part of an address at 64 octets. A run longer than
+/// this cannot be a legitimate email, so it is skipped — this also bounds the
+/// per-`@` work on delimiter-free input (AAASM-3988).
+const MAX_EMAIL_LOCAL_LEN: usize = 64;
+
+/// RFC 5321 caps the domain of an address at 255 octets. Capping the forward
+/// domain scan at this length keeps [`scan_emails`] linear on pathological
+/// input (e.g. `a@a@a@…`) without affecting any real address (AAASM-3988).
+const MAX_EMAIL_DOMAIN_LEN: usize = 255;
+
+/// Like [`token_end`] but scans at most `max_len` bytes forward, returning a
+/// valid char boundary. Bounding the scan prevents a single `@` from costing
+/// O(n) on delimiter-free input, keeping [`scan_emails`] linear overall.
+fn bounded_token_end(text: &str, from: usize, max_len: usize) -> usize {
+    let mut end = from;
+    for (i, c) in text[from..].char_indices() {
+        if i >= max_len {
+            return from + i;
+        }
+        if c.is_whitespace() || matches!(c, '"' | '\'' | ',' | ';' | ')' | ']' | '}') {
+            return from + i;
+        }
+        end = from + i + c.len_utf8();
+    }
+    end
+}
+
+/// Scans `text` for email addresses in a single forward pass.
+///
+/// The local-part start is tracked as the byte offset just past the most recent
+/// token-delimiting character, so it is known in O(1) per `@` rather than an
+/// O(n) backward rescan. Combined with the local/domain length caps this keeps
+/// the scan linear even on adversarial input such as ~1 MB of consecutive `@`
+/// with no delimiters (AAASM-3988 — quadratic-time DoS).
 fn scan_emails(text: &str, findings: &mut Vec<CredentialFinding>) {
-    let mut search = text;
-    let mut base = 0usize;
+    // Byte offset just past the most recent delimiter — i.e. the local-part
+    // start for the next `@` encountered. Equivalent to the old backward
+    // `rfind`, computed incrementally.
+    let mut local_start = 0usize;
 
-    while let Some(at) = search.find('@') {
-        let abs_at = base + at;
+    for (idx, c) in text.char_indices() {
+        if c == '@' {
+            // Skip an empty or over-long local-part. The length cap also gates
+            // the domain scan below so delimiter-free runs stay linear.
+            if idx == local_start || idx - local_start > MAX_EMAIL_LOCAL_LEN {
+                continue;
+            }
 
-        let local_start = text[..abs_at]
-            .rfind(|c: char| c.is_whitespace() || matches!(c, '<' | ',' | ';' | '"' | '\''))
-            .map(|i| i + 1)
-            .unwrap_or(0);
+            let domain_start = idx + 1;
+            let domain_end = bounded_token_end(text, domain_start, MAX_EMAIL_DOMAIN_LEN);
+            let domain = &text[domain_start..domain_end];
 
-        let domain_end = token_end(text, abs_at + 1);
-        let local = &text[local_start..abs_at];
-        let domain = &text[abs_at + 1..domain_end];
-
-        if !local.is_empty() && domain.contains('.') && domain.len() >= 3 {
-            findings.push(CredentialFinding::new(
-                CredentialKind::EmailAddress,
-                local_start,
-                domain_end,
-            ));
+            if domain.contains('.') && domain.len() >= 3 {
+                findings.push(CredentialFinding::new(
+                    CredentialKind::EmailAddress,
+                    local_start,
+                    domain_end,
+                ));
+            }
+            continue;
         }
 
-        let next = abs_at + 1;
-        if next >= text.len() {
-            break;
+        if c.is_whitespace() || matches!(c, '<' | ',' | ';' | '"' | '\'') {
+            local_start = idx + c.len_utf8();
         }
-        search = &text[next..];
-        base = next;
     }
 }
 

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1004,6 +1004,60 @@ mod tests {
         assert!(result.findings.iter().any(|f| f.kind == CredentialKind::EmailAddress));
     }
 
+    #[test]
+    fn detects_email_after_delimiter() {
+        // The forward-pass local-part tracking must start after the delimiter,
+        // matching the previous backward-rfind behaviour.
+        let input = "mail to: <alice@example.org>";
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan(input);
+        // The local-part must begin at 'alice' (just past '<'), not at '<'.
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|f| f.kind == CredentialKind::EmailAddress
+                    && input[f.offset..f.end].starts_with("alice@example.org"))
+        );
+    }
+
+    #[test]
+    fn email_scan_is_linear_on_pathological_at_run() {
+        // Regression for AAASM-3988: ~1 MB of consecutive '@' with no
+        // delimiters previously drove scan_emails to O(n²) (~1e12 ops),
+        // hanging the enforcement/redaction path. It must now complete
+        // near-instantly and flag nothing.
+        let scanner = CredentialScanner::new();
+        let payload = "@".repeat(1_000_000);
+
+        let start = std::time::Instant::now();
+        let result = scanner.scan(&payload);
+        let elapsed = start.elapsed();
+
+        assert!(
+            !result.findings.iter().any(|f| f.kind == CredentialKind::EmailAddress),
+            "delimiter-free '@' run must not be flagged as an email",
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(1),
+            "email scan took {elapsed:?}; expected well under a second",
+        );
+    }
+
+    #[test]
+    fn email_scan_is_linear_on_alternating_at_run() {
+        // A delimiter-free `a@a@a@…` run keeps the domain token scan bounded.
+        let scanner = CredentialScanner::new();
+        let payload = "a@".repeat(500_000);
+
+        let start = std::time::Instant::now();
+        let _ = scanner.scan(&payload);
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "alternating '@' run must scan in linear time",
+        );
+    }
+
     // --- High-entropy ---
 
     #[test]


### PR DESCRIPTION
## What changed
`scan_emails` in `aa-security/src/scanner.rs` is now linear-time.

Previously, for every `@` in the payload it (1) ran a backward `rfind` to the previous delimiter to locate the local-part start and (2) ran an unbounded forward `token_end` scan for the domain. On delimiter-free input — e.g. ~1 MB of consecutive `@` — both were O(n) per `@`, making the whole scan O(n²) (~1e12 ops), hanging the scanner which sits on the enforcement/redaction path.

The rewrite makes a single forward pass, tracking the local-part start incrementally (byte offset just past the most recent delimiter) instead of re-scanning backward, and caps the local-part (RFC 5321: 64 octets) and domain (255 octets) scans via a new `bounded_token_end` helper. These caps gate the per-`@` work so pathological input stays linear.

## Why
[AAASM-3988] [MED] — quadratic-time DoS in the email credential scanner on the enforcement/redaction hot path.

## How to verify
- `cargo nextest run -p aa-security` — 110 pass, including new regression tests:
  - `email_scan_is_linear_on_pathological_at_run` — ~1 MB all-`@` completes in <1s, flags nothing
  - `email_scan_is_linear_on_alternating_at_run` — `a@a@…` (1 MB) completes in <1s
  - `detects_email_after_delimiter` — guards forward local-part tracking
- Detection unchanged for legitimate addresses (existing tests green).
- `cargo fmt --all -- --check`, `cargo clippy -p aa-security --all-targets -- -D warnings` — clean.

Closes AAASM-3988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73

[AAASM-3988]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ