### PR TITLE
[AAASM-3982] 🔒 (aa-ebpf): Reap thread-tid keys on exit (fix confinement bypass)

### DIFF
--- a/aa-ebpf-probes/src/exec_probes.rs
+++ b/aa-ebpf-probes/src/exec_probes.rs
@@ -282,10 +282,13 @@ fn try_sched_process_exec(ctx: &TracePointContext) -> Result<u32, i64> {
 
 /// Tracepoint on `sched/sched_process_exit`: fires on every *thread* exit.
 ///
-/// Only whole-process exits (the thread-group leader, `pid == tgid`) trigger
-/// cleanup + a [`ProcessExitEvent`] so the userspace `ProcessLineageTracker`
-/// removes the PID from the lineage map. Non-leader thread exits are ignored so
-/// a live multithreaded process is not torn down mid-flight (AAASM-3921c).
+/// Map cleanup removes the EXITING THREAD'S OWN tid key from `PARENT_TGID` and
+/// `EXEC_PID_FILTER` on every thread exit (AAASM-3982) — reaping the inert tid
+/// keys the fork handler inserts for CLONE_THREAD children, which the old
+/// leader-only cleanup leaked. A [`ProcessExitEvent`] is still emitted only on
+/// whole-process exit (the thread-group leader, `pid == tgid`) so the userspace
+/// `ProcessLineageTracker` does not drop a live multithreaded process mid-flight
+/// (AAASM-3921c).
 #[tracepoint]
 pub fn handle_sched_process_exit(ctx: TracePointContext) -> u32 {
     try_sched_process_exit(&ctx).unwrap_or_default()
@@ -296,30 +299,33 @@ fn try_sched_process_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
     let tgid = (pid_tgid >> 32) as u32;
     let pid = pid_tgid as u32;
 
-    // `sched_process_exit` fires PER-THREAD. Only act on whole-process exit —
-    // the thread-group leader, where `pid == tgid`. A non-leader thread of a
-    // multithreaded monitored process (Go/Node/Python agents are all
-    // multithreaded) exiting must NOT tear down the still-live process's
-    // tgid-keyed map entries: removing `EXEC_PID_FILTER[tgid]` would stop the
-    // process's own future execs and fork-propagation from being observed, and
-    // emitting a process-exit event would make the lineage tracker drop a live
-    // process (AAASM-3921c). Bare thread exits are ignored entirely.
+    // Capture monitoring status BEFORE cleanup (the reap below removes this
+    // thread's own key, which on a leader exit is the tgid key `pid_allowed`
+    // consults). The wildcard key (0) is never an exiting tid.
+    let allowed = pid_allowed(tgid);
+
+    // `sched_process_exit` fires PER-THREAD. Reap the EXITING THREAD'S OWN tid
+    // key from both maps unconditionally (AAASM-3982). The fork handler inserts
+    // each new fork/thread's `child_pid` into `PARENT_TGID` and
+    // `EXEC_PID_FILTER`; for a CLONE_THREAD child that key is a tid whose tgid
+    // is already the monitored parent's, so it is inert but was NEVER reclaimed
+    // under the old leader-only (pid == tgid) cleanup — `EXEC_PID_FILTER`
+    // (cap 256) / `PARENT_TGID` (cap 1024) leaked toward exhaustion, after which
+    // fork propagation fails open and reused pids inherit stale entries.
+    // Removing by the exiting thread's own tid frees leaked tid keys on thread
+    // exit while leaving a still-live multithreaded process's tgid entry intact
+    // (a non-leader exit removes only its own inert key); the tgid entry is
+    // released when the leader exits (`pid == tgid`).
+    let _ = PARENT_TGID.remove(&pid);
+    let _ = EXEC_PID_FILTER.remove(&pid);
+
+    // Only whole-process exit (thread-group leader, `pid == tgid`) emits a
+    // `ProcessExitEvent`. A non-leader thread of a multithreaded monitored
+    // process (Go/Node/Python agents are all multithreaded) exiting must NOT
+    // make the lineage tracker drop the still-live process (AAASM-3921c).
     if pid != tgid {
         return Ok(0);
     }
-
-    // Capture monitoring status BEFORE cleanup (cleanup may remove this tgid's
-    // own filter entry, which `pid_allowed` would otherwise consult).
-    let allowed = pid_allowed(tgid);
-
-    // Release this tgid's parent-cache and propagated-filter entries on whole-
-    // process exit (AAASM-3921c). The fork handler records `PARENT_TGID` for
-    // *every* fork (so the exec handler can always resolve the real ppid), so
-    // the leader-exit cleanup runs unconditionally for the leader — otherwise
-    // the map would grow without bound and reused pids could inherit a stale
-    // parent / filter membership. The wildcard key (0) is never an exiting tgid.
-    let _ = PARENT_TGID.remove(&tgid);
-    let _ = EXEC_PID_FILTER.remove(&tgid);
 
     // Only emit the exit event for monitored processes (lineage cleanup).
     if !allowed {
@@ -362,7 +368,8 @@ fn try_sched_process_fork(ctx: &TracePointContext) -> Result<u32, i64> {
 
     // For a real new process `child_pid == child_tgid` (the key used by the
     // exec handler and the filter); for a thread the tgid is already the
-    // monitored parent's, so the extra key is inert.
+    // monitored parent's, so the extra tid key is inert — and is reaped by
+    // [`try_sched_process_exit`] when that thread exits (AAASM-3982).
     let child_pid: u32 = unsafe { ctx.read_at(SCHED_FORK_CHILD_PID_OFFSET) }.map_err(|_| -1i64)?;
 
     // Record the real parent for the exec handler, and confine the child to the

--- a/aa-ebpf-probes/src/syscall_guard.rs
+++ b/aa-ebpf-probes/src/syscall_guard.rs
@@ -32,13 +32,16 @@
 //! post-escape guarantee. The [`aa_syscall_guard_fork`] tracepoint closes this
 //! by copying `PID_FILTER` membership from a monitored parent to each newly
 //! forked child at `sched/sched_process_fork`, so the child is confined from
-//! its first syscall. The paired [`aa_syscall_guard_exit`] tracepoint releases
-//! a tgid's `PID_FILTER` entry at `sched/sched_process_exit` — but only on
-//! whole-process (thread-group-leader) exit, since that tracepoint fires
-//! per-thread and tearing the entry down on a non-leader thread exit would
-//! unconfine a still-live multithreaded process. Leader-gated cleanup keeps the
-//! map (cap 1024) from exhausting — which would make later descendants fail
-//! open — and stops a reused pid inheriting stale confinement (AAASM-3921c).
+//! its first syscall. The paired [`aa_syscall_guard_exit`] tracepoint reaps a
+//! key from `PID_FILTER` at `sched/sched_process_exit` — that tracepoint fires
+//! per-thread, so it removes the *exiting thread's own tid* on every thread
+//! exit (AAASM-3982). On leader exit (`pid == tgid`) this releases the live
+//! process's tgid entry; on a non-leader thread exit it reaps that thread's
+//! inert tid key (inserted by fork propagation) while leaving the still-live
+//! process's tgid entry intact. Reaping every thread's own key keeps the map
+//! (cap 1024) from leaking toward exhaustion — which would make later
+//! descendants fail open — and stops a reused pid inheriting stale confinement
+//! (AAASM-3921c / AAASM-3982).
 //!
 //! Note the `SYSCALL_ALLOWLIST` is a single global map keyed by syscall number
 //! (not per-PID), so it already applies to every monitored tgid — there is no
@@ -65,8 +68,10 @@
 //!   `child_pid == child_tgid`, so the child tgid is confined. For a new
 //!   *thread* (`CLONE_THREAD`) `child_pid` is a new tid while the thread's tgid
 //!   equals the already-confined parent tgid — so threads are covered by the
-//!   parent's existing membership; the extra tid key is inert (lookups are by
-//!   tgid). A child that forks *before* the guard observes the parent (TOCTOU
+//!   parent's existing membership; the extra tid key is functionally inert
+//!   (lookups are by tgid) and is reaped when that thread exits (AAASM-3982), so
+//!   it no longer leaks the map. A child that forks *before* the guard observes
+//!   the parent (TOCTOU
 //!   at attach time) is not covered — attach the guard before launching the
 //!   confined process.
 
@@ -195,7 +200,8 @@ fn try_fork_propagate(ctx: &TracePointContext) -> Result<(), i64> {
 
     // Read the child's pid. For a real new process `child_pid == child_tgid`,
     // which is the key the enforcement tracepoint looks up; for a thread the
-    // tgid is already the (confined) parent's, so the extra key is inert.
+    // tgid is already the (confined) parent's, so the extra tid key is inert —
+    // and is reaped by [`try_exit_cleanup`] when that thread exits (AAASM-3982).
     let child_pid = unsafe { ctx.read_at::<u32>(SCHED_FORK_CHILD_PID_OFFSET) }?;
 
     // Confine the child by mirroring the parent's PID_FILTER membership.
@@ -203,30 +209,30 @@ fn try_fork_propagate(ctx: &TracePointContext) -> Result<(), i64> {
     Ok(())
 }
 
-/// Descendant-confinement cleanup tracepoint (AAASM-3921c): at
-/// `sched_process_exit`, remove the exiting tgid from `PID_FILTER` — but ONLY on
-/// whole-process exit (the thread-group leader, `pid == tgid`).
+/// Descendant-confinement cleanup tracepoint (AAASM-3921c / AAASM-3982): at
+/// `sched_process_exit`, remove the EXITING THREAD'S OWN tid key from
+/// `PID_FILTER` on **every** thread exit.
 ///
 /// `sched_process_exit` fires per-thread. A monitored process is confined by
-/// tgid, so removing `PID_FILTER[tgid]` when a non-leader thread of a
-/// multithreaded confined process (Go/Node/Python agents are all multithreaded)
-/// exits would unconfine the still-live process — it would run its remaining
-/// syscalls **unconfined** and its forks would no longer be propagated (the
-/// fork handler's parent check would see the tgid absent). The `pid == tgid`
-/// guard keeps confinement live for the whole process lifetime and cleans up
-/// only when the process itself exits.
+/// tgid, and the fork handler also inserts each new thread's tid as a
+/// (functionally inert) extra key. Removing by the exiting thread's own tid is
+/// what makes this safe for multithreaded confined processes (Go/Node/Python
+/// agents are all multithreaded): a non-leader thread exit reaps only its own
+/// inert tid key, leaving the live process's tgid entry — and thus its
+/// confinement and fork propagation — fully intact; the tgid entry is released
+/// only when the leader itself exits (`pid == tgid`).
 ///
-/// Without any cleanup the fork-propagated `PID_FILTER` entries (cap 1024) are
-/// never released, so the map exhausts under a forking workload — after which
-/// [`try_fork_propagate`]'s `insert` fails and further descendants run
-/// **unconfined** (fail-open), defeating the post-escape guarantee. Worse, a
-/// stale entry whose tgid is later reused by an unrelated process would cause
-/// the enforcement tracepoint to `SIGKILL` that innocent process. Releasing the
-/// entry on leader exit bounds the map and closes the pid-reuse hole; this
-/// mirrors the exec probe's own leader-gated exit-side cleanup.
+/// This unconditional per-thread reap fixes AAASM-3982: the previous
+/// leader-only (`pid == tgid`) gate removed by tgid, so non-leader tid keys were
+/// **never** reclaimed. Under a multithreaded/forking workload PID_FILTER (cap
+/// 1024) leaked toward exhaustion — after which [`try_fork_propagate`]'s
+/// `insert` fails and further descendants run **unconfined** (fail-open,
+/// reopening AAASM-3916), plus a leaked tid later reused as a live tgid would
+/// make the enforcement tracepoint `SIGKILL` an innocent process. Reaping each
+/// thread's own key on exit bounds the map and closes the pid-reuse hole.
 ///
-/// Returns `0` always; the removal is best-effort and a miss (the tgid was
-/// never confined) is a harmless no-op.
+/// Returns `0` always; the removal is best-effort and a miss (the tid was never
+/// a key) is a harmless no-op.
 #[tracepoint]
 pub fn aa_syscall_guard_exit(ctx: TracePointContext) -> u32 {
     let _ = try_exit_cleanup(&ctx);
@@ -234,15 +240,22 @@ pub fn aa_syscall_guard_exit(ctx: TracePointContext) -> u32 {
 }
 
 fn try_exit_cleanup(_ctx: &TracePointContext) -> Result<(), i64> {
-    // sched_process_exit is per-thread; only clean up on whole-process exit so a
-    // non-leader thread exit does not unconfine a live multithreaded process.
-    let pid_tgid = bpf_get_current_pid_tgid();
-    let tgid = (pid_tgid >> 32) as u32;
-    let pid = pid_tgid as u32;
-    if pid != tgid {
-        return Ok(());
-    }
-    let _ = PID_FILTER.remove(&tgid);
+    // sched_process_exit fires PER-THREAD. Remove the EXITING THREAD'S OWN tid
+    // key unconditionally (AAASM-3982):
+    //
+    // - On whole-process (thread-group-leader) exit `pid == tgid`, so this frees
+    //   the live process's confinement entry — exactly the old leader-gated
+    //   behavior.
+    // - On a non-leader thread exit `pid` is the thread's tid, which the fork
+    //   handler inserted as a (functionally inert) extra key; removing it here
+    //   reaps that key so PID_FILTER (cap 1024) cannot leak toward exhaustion.
+    //
+    // Removing only the exiting thread's own key never touches a still-live
+    // multithreaded process's tgid entry, so confinement stays intact until the
+    // leader itself exits. Do NOT gate this on `pid == tgid`: that gate was the
+    // AAASM-3982 leak — non-leader tid keys were never reclaimed.
+    let pid = bpf_get_current_pid_tgid() as u32;
+    let _ = PID_FILTER.remove(&pid);
     Ok(())
 }
 


### PR DESCRIPTION
## What changed

Fixes a thread-tid key leak in the two eBPF `sched_process_exit` handlers that
reopened descendant-confinement bypass (AAASM-3916) and could cause false SIGKILLs.

`sched_process_fork` fires for `CLONE_THREAD` too, so the fork handlers insert the
new thread's **tid** as a key into `PID_FILTER` (cap 1024), `EXEC_PID_FILTER`
(cap 256) and `PARENT_TGID` (cap 1024). The old exit handlers were leader-gated
(`pid == tgid`) and removed by **tgid**, so those tid keys were **never** reclaimed.
Under any normal multithreaded agent (Go/Node/Python) the maps leaked toward
exhaustion → a later fork's tgid insert fails → the syscall guard early-returns for
the child → the child runs **unconfined** (fail-open). A leaked tid later reused as a
live tgid could also make the enforcement tracepoint `SIGKILL` an innocent process.

The fix, in both exit handlers:
- Remove the entry by the **exiting thread's own tid** (`remove(&pid)` where
  `pid = bpf_get_current_pid_tgid() as u32`) **unconditionally** on every thread exit,
  for `PID_FILTER` / `EXEC_PID_FILTER` / `PARENT_TGID`.
- Keep the `pid == tgid` (leader) gate **only** for emitting `ProcessExitEvent` /
  computing `allowed` — not for the map removals.

On leader exit `pid == tgid`, so the live process's tgid entry is freed exactly as
before; a non-leader thread exit reaps only its own inert tid key, leaving the live
process's confinement intact. Doc comments that called tid keys "inert" now note
they are reaped on thread exit.

## Why

MED severity: descendant-confinement bypass (reopens AAASM-3916) + map exhaustion +
false SIGKILL on tgid==leaked-tid reuse.

## How to verify

- Local (macOS): `cargo +nightly check` in `aa-ebpf-probes` (bpfel-unknown-none target)
  passes; changed files are rustfmt-clean; `aa-ebpf` / `aa-ebpf-common` host-side check green.
- The kernel path (map reaping across real thread/fork/exit) cannot run on macOS —
  **Linux CI is the gate**: `e2e — Layer 3 eBPF (Linux)` and `eBPF probes build (Linux nightly)`.
- No host-side unit tests added: these are `#![no_std]` `#![no_main]` BPF binaries whose
  changed logic is entirely `bpf_get_current_pid_tgid` + map ops with no extractable host logic.

Closes AAASM-3982

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73
