### PR TITLE
[AAASM-3985] 🔒 (aa-cache): Fix lost-invalidation race (revoked policy served full TTL)

### DIFF
--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -234,6 +234,45 @@ mod tests {
         assert_eq!(cache.inner().call_count(), 2);
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn invalidate_during_load_is_not_lost() {
+        use std::sync::Arc;
+
+        let id = agent(5);
+        // A 50ms inner delay holds the leader inside `load` long enough for the
+        // racing `invalidate` below to land in the middle of the load window.
+        let store = MemoryPolicyStore::with_policy(id, sample_policy(1)).with_delay(Duration::from_millis(50));
+        let cache = Arc::new(L1Cache::new(store, Duration::from_secs(60)));
+
+        // Leader begins a miss and is now sleeping inside `load`.
+        let leader = {
+            let cache = Arc::clone(&cache);
+            tokio::spawn(async move { cache.get(id).await })
+        };
+
+        // Let the leader enter `load`, then invalidate while it is in flight.
+        // `entries` is still empty, so the old code's `remove` was a silent
+        // no-op and the leader would go on to cache the value it is loading.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!cache.invalidate(&id));
+
+        // The leader still returns the value it loaded, but must NOT have cached
+        // it: the invalidation raced its load and takes precedence.
+        leader.await.expect("task joined").expect("policy present");
+        assert_eq!(
+            cache.len(),
+            0,
+            "stale value must not be cached after a racing invalidate"
+        );
+        assert_eq!(cache.inner().call_count(), 1);
+
+        // Because nothing was cached, the next get is a fresh miss that reloads
+        // from the source of truth rather than serving the stale entry.
+        cache.get(id).await.expect("policy present");
+        assert_eq!(cache.inner().call_count(), 2);
+        assert_eq!(cache.len(), 1);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_misses_collapse_to_one_load() {
         use std::sync::Arc;

--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -1,5 +1,6 @@
 //! [`L1Cache`] — a `DashMap`-backed, TTL'd, cache-aside wrapper over a store.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -22,6 +23,11 @@ pub struct L1Cache<S: CacheSource> {
     inner: S,
     entries: Arc<DashMap<S::Key, CachedValue<S::Value>>>,
     inflight: Arc<DashMap<S::Key, Arc<Notify>>>,
+    /// Monotonic invalidation counter, bumped by every [`invalidate`](Self::invalidate).
+    /// A leader snapshots it before loading and refuses to cache its result if the
+    /// counter moved during the load window, so a push-invalidation that races an
+    /// in-flight load is never silently lost (see AAASM-3985).
+    epoch: AtomicU64,
     ttl: Duration,
 }
 
@@ -32,6 +38,7 @@ impl<S: CacheSource> L1Cache<S> {
             inner,
             entries: Arc::new(DashMap::new()),
             inflight: Arc::new(DashMap::new()),
+            epoch: AtomicU64::new(0),
             ttl,
         }
     }
@@ -65,6 +72,13 @@ impl<S: CacheSource> L1Cache<S> {
     /// Gateway reports that an agent's policy changed: the next `get` reloads
     /// from the source of truth rather than serving a stale entry.
     pub fn invalidate(&self, key: &S::Key) -> bool {
+        // Bump the epoch *before* removing. A concurrent leader load that
+        // snapshotted the old epoch will fail its post-load check and discard
+        // its now-stale value; and because the leader commits its insert under
+        // the same shard lock that `remove` takes, the bump-then-remove here is
+        // ordered against the check-then-insert there — the eviction can't be
+        // lost to a racing insert (AAASM-3985).
+        self.epoch.fetch_add(1, Ordering::AcqRel);
         self.entries.remove(key).is_some()
     }
 
@@ -106,9 +120,28 @@ impl<S: CacheSource> L1Cache<S> {
             match follower {
                 // Leader: load once, populate, then wake every waiter.
                 None => {
+                    // Snapshot the invalidation epoch before the load so a push
+                    // `invalidate` that lands mid-load is detected below.
+                    let epoch_before = self.epoch.load(Ordering::Acquire);
                     let result = self.inner.load(&key).await;
                     if let Ok(ref value) = result {
-                        self.entries.insert(key.clone(), CachedValue::new(value.clone()));
+                        // Commit under the key's shard lock, and only if no
+                        // invalidation raced the load. Holding the entry guard
+                        // serializes this check-and-insert against `invalidate`'s
+                        // `remove`, so a concurrent eviction is never lost: either
+                        // we observe the bumped epoch and skip the insert, or the
+                        // remove runs after us and drops the entry we just wrote.
+                        let entry = self.entries.entry(key.clone());
+                        if self.epoch.load(Ordering::Acquire) == epoch_before {
+                            match entry {
+                                Entry::Occupied(mut occupied) => {
+                                    occupied.insert(CachedValue::new(value.clone()));
+                                }
+                                Entry::Vacant(vacant) => {
+                                    vacant.insert(CachedValue::new(value.clone()));
+                                }
+                            }
+                        }
                     }
                     if let Some((_, notify)) = self.inflight.remove(&key) {
                         notify.notify_waiters();


### PR DESCRIPTION
## What changed

Fixes a TOCTOU lost-invalidation race in `aa-cache/src/l1.rs`. On a cache miss the leader reads a value from the store; if a concurrent push `invalidate(key)` lands during that load window it finds no entry (`entries.remove` is a no-op) and is silently lost — the leader then unconditionally caches the just-loaded (now-stale) value, so a **revoked policy is served for a full TTL**.

The fix adds a monotonic invalidation epoch (`AtomicU64`):
- `invalidate()` bumps the epoch **before** removing the entry.
- The leader snapshots the epoch **before** `load`, then commits its insert under the key's `DashMap` shard `entry` guard **only if** the epoch is unchanged.

Because `invalidate`'s `remove` contends for the same shard lock as the leader's guarded insert, the bump-then-remove is ordered against the check-then-insert: either the leader observes the bumped epoch and skips the insert, or the remove runs after the insert and drops it. The eviction can no longer be lost, and single-flight/stampede behavior is unchanged.

## Why

Severity Medium — silent loss of a policy revocation lets a denied agent keep operating under a stale ALLOW until the TTL elapses.

## How to verify

- New regression test `l1::tests::invalidate_during_load_is_not_lost` holds a leader inside `load` via an inner delay, fires `invalidate()` mid-load, and asserts the value is **not** cached (`len == 0`) so a subsequent get reloads. Fails against pre-fix code.
- `cargo nextest run -p aa-cache` — 5/5 pass.
- `cargo fmt --all -- --check`, `cargo clippy -p aa-cache --all-targets --all-features -- -D warnings`, `cargo doc -p aa-cache --no-deps` all clean.

Closes AAASM-3985

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73