### PR TITLE
[AAASM-3983] 🔒 (aa-proxy): Canonicalize host + DLP-scan plaintext egress

### DIFF
--- a/aa-proxy/src/intercept/detect.rs
+++ b/aa-proxy/src/intercept/detect.rs
@@ -19,9 +19,14 @@ pub enum LlmApiPattern {
 /// Classify `host` (the CONNECT tunnel target hostname) as an [`LlmApiPattern`].
 ///
 /// Comparison is case-insensitive. A host like `api.openai.com:443` is
-/// normalised by stripping the port before matching.
+/// normalised by stripping the port before matching. A single trailing dot is
+/// also stripped (AAASM-3983): `api.openai.com.` is a valid, equivalent FQDN
+/// for `api.openai.com`, so without this it would classify as `Unknown` and —
+/// under `llm_only` — take the transparent raw-tunnel path, reaching the
+/// provider with no scan/redact/audit.
 pub fn detect_api(host: &str) -> LlmApiPattern {
     let hostname = host.split(':').next().unwrap_or(host);
+    let hostname = hostname.strip_suffix('.').unwrap_or(hostname);
     match hostname.to_ascii_lowercase().as_str() {
         "api.openai.com" => LlmApiPattern::OpenAi,
         "api.anthropic.com" => LlmApiPattern::Anthropic,

--- a/aa-proxy/src/intercept/detect.rs
+++ b/aa-proxy/src/intercept/detect.rs
@@ -74,4 +74,20 @@ mod tests {
     fn subdomain_does_not_match() {
         assert_eq!(detect_api("cdn.api.openai.com"), LlmApiPattern::Unknown);
     }
+
+    #[test]
+    fn trailing_dot_fqdn_is_normalized() {
+        // AAASM-3983: a trailing-dot FQDN is equivalent to the dotless host and
+        // must classify identically — otherwise it slips through as Unknown and
+        // takes the transparent raw-tunnel path under llm_only.
+        assert_eq!(detect_api("api.openai.com."), LlmApiPattern::OpenAi);
+        assert_eq!(detect_api("api.anthropic.com."), LlmApiPattern::Anthropic);
+        assert_eq!(detect_api("api.cohere.com."), LlmApiPattern::Cohere);
+    }
+
+    #[test]
+    fn trailing_dot_with_port_and_mixed_case_is_normalized() {
+        // Port strip + trailing-dot strip + case-fold all compose.
+        assert_eq!(detect_api("API.OpenAI.CoM.:443"), LlmApiPattern::OpenAi);
+    }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -1303,4 +1303,71 @@ mod tests {
             "plain-HTTP request to a blocked IP must be refused with 403, got: {buf:?}"
         );
     }
+
+    #[tokio::test]
+    async fn plain_http_to_llm_host_is_refused() {
+        // AAASM-3984: a cleartext `http://` request to a known LLM provider must
+        // be refused (403) before any upstream dial. The plain-HTTP path does no
+        // credential scanning, so allowing a downgrade to reach an LLM host would
+        // let a steered agent exfiltrate the secret in this body with zero DLP.
+        // The empty allowlist permits the public host past the egress gate, so
+        // the 403 here proves the LLM-downgrade refusal (not the egress check).
+        use tokio::io::AsyncReadExt;
+        let server = server_with(vec![], vec![]).await;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        let (server_stream, _) = listener.accept().await.unwrap();
+
+        let body = "{\"api_key\":\"sk-secretvalue1234567890\"}";
+        let req = format!(
+            "POST http://api.openai.com/v1/chat HTTP/1.1\r\nHost: api.openai.com\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body,
+        );
+        client.write_all(req.as_bytes()).await.unwrap();
+
+        server
+            .handle_connection(server_stream)
+            .await
+            .expect("refused request returns Ok after writing 403");
+
+        let mut buf = String::new();
+        client.read_to_string(&mut buf).await.unwrap();
+        assert!(
+            buf.contains("403"),
+            "cleartext plain-HTTP request to an LLM host must be refused with 403, got: {buf:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn plain_http_to_llm_host_trailing_dot_is_refused() {
+        // AAASM-3983 + AAASM-3984: the trailing-dot / mixed-case downgrade
+        // variant must also be refused — detect_api canonicalizes the host.
+        use tokio::io::AsyncReadExt;
+        let server = server_with(vec![], vec![]).await;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        let (server_stream, _) = listener.accept().await.unwrap();
+
+        client
+            .write_all(b"POST http://API.OpenAI.CoM./v1/chat HTTP/1.1\r\nHost: API.OpenAI.CoM.\r\n\r\n")
+            .await
+            .unwrap();
+
+        server
+            .handle_connection(server_stream)
+            .await
+            .expect("refused request returns Ok after writing 403");
+
+        let mut buf = String::new();
+        client.read_to_string(&mut buf).await.unwrap();
+        assert!(
+            buf.contains("403"),
+            "trailing-dot cleartext request to an LLM host must be refused with 403, got: {buf:?}"
+        );
+    }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -570,7 +570,20 @@ impl ProxyServer {
                 return Some("ssrf: blocked address range");
             }
         }
-        if self.config.denied_hosts.iter().any(|denied| denied == host) {
+        // AAASM-3983: canonicalise the host ONCE (lowercase + strip a single
+        // trailing dot) before the denied_hosts and allowlist comparisons. The
+        // byte-exact `denied == host` check let `EVIL.COM` or `evil.com.` evade
+        // a lowercase `evil.com` denylist entry, and the allowlist matcher —
+        // though it lowercases — never stripped a trailing dot, so `evil.com.`
+        // slipped past it too. Compare canonical-to-canonical on both sides.
+        let host = canonical_host(host);
+        let host = host.as_str();
+        if self
+            .config
+            .denied_hosts
+            .iter()
+            .any(|denied| canonical_host(denied) == host)
+        {
             return Some("host policy");
         }
         if !aa_core::policy::is_host_allowed_by_egress_allowlist(host, &self.config.network_allowlist) {
@@ -803,8 +816,15 @@ impl ProxyServer {
             }
         }
 
-        // Extract hostname (strip port) for deny check and certificate generation.
-        let host = target.split(':').next().unwrap_or(target);
+        // Extract hostname (strip port) and canonicalise it (AAASM-3983:
+        // lowercase + strip a single trailing dot) so the deny check, cert
+        // generation, LLM-pattern detection, SNI, and upstream dial all consume
+        // one canonical form. Without this an `api.openai.com.` CONNECT would be
+        // classified Unknown and raw-tunnelled under llm_only, and case/dot
+        // variants would evade the denylist. `target` (with port) is retained
+        // for the DNS/connect calls, which tolerate the trailing dot.
+        let host = canonical_host(target);
+        let host = host.as_str();
 
         // Egress policy: deny-list, then AAASM-1943 network allowlist.
         // Both return 403 + emit a deny decision and end the connection.
@@ -1008,6 +1028,23 @@ impl ProxyServer {
 
         Ok(())
     }
+}
+
+/// Canonicalise a host for policy comparison and LLM-pattern detection
+/// (AAASM-3983).
+///
+/// DNS names are case-insensitive (RFC 4343) and a single trailing dot denotes
+/// the (equivalent) fully-qualified form — `API.OPENAI.COM` and
+/// `api.openai.com.` both address the same host as `api.openai.com`. Comparing
+/// hosts byte-exact (as the `denied_hosts` check did) or lowercasing without
+/// stripping the trailing dot (as the allowlist matcher did) let a caller evade
+/// a `denied_hosts` entry or the LLM-only MitM path by varying only case or a
+/// trailing dot. Canonicalising once — strip the port, strip a single trailing
+/// dot, lowercase — closes that bypass. The result carries no port.
+fn canonical_host(host: &str) -> String {
+    let no_port = host.split(':').next().unwrap_or(host);
+    let no_dot = no_port.strip_suffix('.').unwrap_or(no_port);
+    no_dot.to_ascii_lowercase()
 }
 
 /// Parse the upstream host for a plain (non-CONNECT) HTTP request from the

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -989,6 +989,31 @@ impl ProxyServer {
             return Ok(());
         }
 
+        // AAASM-3984: refuse plaintext (`http://`) egress to a known LLM
+        // provider. The credential-scanning DLP (scan → block/redact) only runs
+        // on the HTTPS MitM path (`handle_llm_mitm`); the plain-HTTP path below
+        // is a raw bidirectional copy with no `intercept_request` scan. LLM
+        // provider APIs are HTTPS-only, so a cleartext request to an LLM host is
+        // always a protocol-downgrade bypass — a steered agent could exfiltrate
+        // secrets in cleartext with zero inspection. Refuse it here (fail-closed,
+        // 403) rather than raw-copying it upstream un-inspected. `detect_api`
+        // canonicalizes case/port/trailing-dot, so downgrade variants like
+        // `http://API.OpenAI.CoM.` are caught too. Legitimate LLM traffic is
+        // HTTPS and continues to be inspected by `handle_llm_mitm`.
+        if detect_api(deny_host) != LlmApiPattern::Unknown {
+            tracing::info!(
+                host = %deny_host,
+                "plain-HTTP egress to LLM host refused: cleartext downgrade bypasses DLP",
+            );
+            self.interceptor.emit_policy_decision(deny_host, true).await;
+            let mut stream = reader.into_inner();
+            stream
+                .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
+                .await?;
+            let _ = stream.shutdown().await;
+            return Ok(());
+        }
+
         // Connect to upstream via plain TCP.
         let upstream_addr = if host.contains(':') {
             host.to_string()

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -1167,6 +1167,38 @@ mod tests {
         assert_eq!(server.connect_deny_reason("1.1.1.1"), None);
     }
 
+    #[test]
+    fn canonical_host_strips_port_trailing_dot_and_case() {
+        // AAASM-3983: port, single trailing dot, and case are all normalised.
+        assert_eq!(canonical_host("EVIL.COM"), "evil.com");
+        assert_eq!(canonical_host("evil.com."), "evil.com");
+        assert_eq!(canonical_host("Evil.Com.:443"), "evil.com");
+        assert_eq!(canonical_host("evil.com"), "evil.com");
+    }
+
+    #[tokio::test]
+    async fn connect_deny_reason_denylist_defeats_case_and_trailing_dot_evasion() {
+        // AAASM-3983: a lowercase `evil.com` denylist entry must catch the
+        // uppercase and trailing-dot variants, which previously slipped past
+        // the byte-exact comparison.
+        let server = server_with(vec!["evil.com".to_string()], vec![]).await;
+        assert_eq!(server.connect_deny_reason("evil.com"), Some("host policy"));
+        assert_eq!(server.connect_deny_reason("EVIL.COM"), Some("host policy"));
+        assert_eq!(server.connect_deny_reason("evil.com."), Some("host policy"));
+        assert_eq!(server.connect_deny_reason("Evil.Com.:443"), Some("host policy"));
+    }
+
+    #[tokio::test]
+    async fn connect_deny_reason_allowlist_rejects_trailing_dot_non_member() {
+        // With api.openai.com allowlisted, a trailing-dot form of a *different*
+        // host must still be rejected (it is not a member), and the trailing-dot
+        // form of the allowlisted host must be permitted.
+        let server = server_with(vec![], vec!["api.openai.com".to_string()]).await;
+        assert_eq!(server.connect_deny_reason("evil.com."), Some("network allowlist"));
+        assert_eq!(server.connect_deny_reason("api.openai.com."), None);
+        assert_eq!(server.connect_deny_reason("API.OPENAI.COM"), None);
+    }
+
     fn req_with(headers: Vec<(&str, &str)>, target: &str) -> HttpRequest {
         HttpRequest {
             method: "POST".into(),


### PR DESCRIPTION
## What changed

Two related aa-proxy host/DLP hardening fixes that share `proxy/mod.rs`.

### AAASM-3983 — host normalization bypass
- `detect_api` (`intercept/detect.rs`) now strips a single trailing dot in addition to the port + lowercase, so a valid FQDN like `api.openai.com.` classifies as the LLM provider instead of `Unknown` (which under `llm_only` took the transparent raw-tunnel path — no scan/redact/audit — yet still reached the provider).
- Added a `canonical_host` helper (strip port + single trailing dot + lowercase) in `proxy/mod.rs`. `connect_deny_reason` now compares canonical-to-canonical for the `denied_hosts` check (previously byte-exact) and passes the canonical host to the egress allowlist matcher. This closes the `EVIL.COM` / `evil.com.` evasion of a lowercase `evil.com` denylist entry, and the trailing-dot evasion of the allowlist.
- The CONNECT path canonicalizes the host once, so detect_api, cert generation, SNI, and the upstream dial all consume one canonical form. The plain-HTTP and in-tunnel paths route through `connect_deny_reason`, so they get canonical policy checks too.

### AAASM-3984 — plaintext http:// downgrade skips DLP
- The plain-HTTP path enforced egress allow/deny + SSRF revalidation but then raw-copied bytes with no credential scan/redaction, so an agent downgrading to `http://` could exfiltrate secrets with zero DLP.
- **Approach chosen: refuse plaintext egress to LLM-pattern hosts** (fail-closed 403). Rationale: the scan→block/redact DLP only runs on the HTTPS MitM path (`handle_llm_mitm`); the existing architecture only inspects LLM-pattern hosts. LLM provider APIs are HTTPS-only, so a cleartext request to a known LLM host is *always* a protocol-downgrade bypass whose only purpose is to evade that inspection — refusing it is stronger than redaction and avoids duplicating the MitM read/scan machinery on a path that would only ever see malicious traffic. Legitimate LLM traffic stays HTTPS and continues to be inspected by `handle_llm_mitm`. `detect_api`'s canonicalization means downgrade variants (`http://API.OpenAI.CoM.`) are caught too.

## Why
Both are MED-severity DLP/egress-policy bypasses reachable by a prompt-injected / steered agent.

## How to verify
- `cargo nextest run -p aa-proxy` — 188 pass (3 skipped).
- New tests: `detect_api` trailing-dot normalization; `canonical_host` + `connect_deny_reason` case/trailing-dot denylist evasion; plaintext egress to an LLM host (incl. trailing-dot/mixed-case variant) refused with 403.
- `cargo fmt --all -- --check`, `cargo clippy -p aa-proxy --all-targets -- -D warnings` — clean.

`ssrf.rs` intentionally untouched.

Closes AAASM-3983
Closes AAASM-3984

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73