### PR TITLE
[AAASM-3987] 🔒 (aa-runtime): Deadline on gateway policy RPC (fix hang HoL DoS)

### DIFF
--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -4,6 +4,13 @@ use std::path::PathBuf;
 
 use crate::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES;
 
+/// Default per-RPC deadline for a gateway policy query, in milliseconds.
+///
+/// A few seconds is generous for a healthy in-cluster gateway hop yet short
+/// enough that a hung gateway cannot stall the runtime's policy checks for long
+/// (AAASM-3987).
+pub const DEFAULT_GATEWAY_TIMEOUT_MS: u64 = 5_000;
+
 /// Configuration for the `aa-runtime` sidecar process.
 ///
 /// All fields are populated by [`RuntimeConfig::from_env`].
@@ -142,6 +149,19 @@ pub struct RuntimeConfig {
     /// allow on no match. Accepts `false`/`0`/`no`/`off` (case-insensitive) to
     /// disable; any other value (or unset) keeps fail-closed.
     pub gateway_fail_closed: bool,
+
+    /// Per-RPC deadline, in milliseconds, applied to each gateway policy query
+    /// (`check_action`).
+    ///
+    /// Read from `AA_GATEWAY_TIMEOUT_MS`; defaults to [`DEFAULT_GATEWAY_TIMEOUT_MS`].
+    /// A gateway that accepts a connection but then stops responding would
+    /// otherwise block the policy check forever, stalling every agent's checks
+    /// behind the shared client — a runtime-wide head-of-line DoS (AAASM-3987).
+    /// The deadline bounds that: on elapse the query is treated as a failure and
+    /// routed into the same fail-closed path as a transport error. Zero falls
+    /// back to the default so the deadline can never be disabled (that would
+    /// reintroduce the hang).
+    pub gateway_timeout_ms: u64,
 }
 
 impl RuntimeConfig {
@@ -172,6 +192,7 @@ impl RuntimeConfig {
     /// | `AA_AUDIT_BUFFER_PATH` | `PathBuf` | `<temp>/aa-audit-buffer-<agent_id>.db` |
     /// | `AA_ENFORCEMENT_MAX_FIELD_BYTES` | `usize` | `65536` (64 KiB) |
     /// | `AA_GATEWAY_FAIL_CLOSED` | `bool` | `true` (deny on gateway unreachable) |
+    /// | `AA_GATEWAY_TIMEOUT_MS` | `u64` | `5000` (per-RPC gateway deadline) |
     /// | `AA_AGENT_TEAM_ID` | `String` | `""` (op-control subscription identity) |
     /// | `AA_AGENT_ORG_ID` | `String` | `""` (op-control subscription identity) |
     pub fn from_env() -> Result<Self, String> {
@@ -276,6 +297,14 @@ impl RuntimeConfig {
             .map(|v| !matches!(v.trim().to_ascii_lowercase().as_str(), "false" | "0" | "no" | "off"))
             .unwrap_or(true);
 
+        // Zero (or unparseable) falls back to the default: the deadline must not
+        // be disable-able, or the head-of-line DoS it guards against returns.
+        let gateway_timeout_ms = std::env::var("AA_GATEWAY_TIMEOUT_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(DEFAULT_GATEWAY_TIMEOUT_MS);
+
         Ok(Self {
             agent_id,
             agent_team_id,
@@ -296,6 +325,7 @@ impl RuntimeConfig {
             audit_buffer_path,
             enforcement_max_field_bytes,
             gateway_fail_closed,
+            gateway_timeout_ms,
         })
     }
 }
@@ -844,5 +874,33 @@ mod tests {
 
         std::env::remove_var("AA_AGENT_ID");
         std::env::remove_var("AA_GATEWAY_FAIL_CLOSED");
+    }
+
+    #[test]
+    fn gateway_timeout_defaults_and_rejects_zero() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-to");
+
+        // Unset → the default deadline.
+        std::env::remove_var("AA_GATEWAY_TIMEOUT_MS");
+        assert_eq!(
+            RuntimeConfig::from_env().unwrap().gateway_timeout_ms,
+            DEFAULT_GATEWAY_TIMEOUT_MS
+        );
+
+        // A positive value is honoured verbatim.
+        std::env::set_var("AA_GATEWAY_TIMEOUT_MS", "1500");
+        assert_eq!(RuntimeConfig::from_env().unwrap().gateway_timeout_ms, 1_500);
+
+        // Zero must NOT disable the deadline — fall back to the default so the
+        // head-of-line DoS guard (AAASM-3987) cannot be turned off.
+        std::env::set_var("AA_GATEWAY_TIMEOUT_MS", "0");
+        assert_eq!(
+            RuntimeConfig::from_env().unwrap().gateway_timeout_ms,
+            DEFAULT_GATEWAY_TIMEOUT_MS
+        );
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_GATEWAY_TIMEOUT_MS");
     }
 }

--- a/aa-runtime/src/correlation/config.rs
+++ b/aa-runtime/src/correlation/config.rs
@@ -83,6 +83,7 @@ mod tests {
             audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
             enforcement_max_field_bytes: crate::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES,
             gateway_fail_closed: true,
+            gateway_timeout_ms: crate::config::DEFAULT_GATEWAY_TIMEOUT_MS,
         };
 
         let config = CorrelationConfig::from_runtime_config(&rc);

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -1132,6 +1132,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            gateway_timeout: std::time::Duration::from_secs(5),
             min_sdk_version: None,
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
@@ -1230,6 +1231,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            gateway_timeout: std::time::Duration::from_secs(5),
             min_sdk_version: None,
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
@@ -1335,6 +1337,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            gateway_timeout: std::time::Duration::from_secs(5),
             min_sdk_version: None,
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -588,6 +588,7 @@ mod tests {
             audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
             enforcement_max_field_bytes: 4096,
             gateway_fail_closed: true,
+            gateway_timeout_ms: crate::config::DEFAULT_GATEWAY_TIMEOUT_MS,
         };
 
         let config = EnforcementConfig::from_runtime_config(&rc);

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -2328,6 +2328,121 @@ mod tests {
         token.cancel();
     }
 
+    /// AAASM-3987: a gateway that *accepts* the connection but never answers
+    /// `check_action` (a wedged/hung gateway) must not block the policy check
+    /// forever. The per-RPC deadline turns the hang into a failure, so in the
+    /// fail-closed (enforce) posture the check is DENIED — and, critically, it
+    /// resolves within roughly the deadline rather than never. Without the
+    /// deadline this test would hang: the shared client lock and single pipeline
+    /// loop would be pinned on the stuck RPC, stalling every agent (head-of-line
+    /// DoS).
+    #[tokio::test]
+    async fn gateway_hang_fail_closed_denies_within_deadline() {
+        use aa_proto::assembly::common::v1::{ActionType, Decision};
+        use aa_proto::assembly::policy::v1::policy_service_server::{PolicyService, PolicyServiceServer};
+        use aa_proto::assembly::policy::v1::{
+            BatchCheckRequest, BatchCheckResponse, CheckActionRequest as ProtoReq, CheckActionResponse as ProtoResp,
+            OpControlMessage, OpControlSubscribeRequest,
+        };
+        use tonic::{Request, Response, Status};
+
+        // Stub gateway: accepts the RPC but parks the handler far beyond the
+        // test's lifetime — models a gateway that stopped responding.
+        struct HangingGateway;
+
+        #[tonic::async_trait]
+        impl PolicyService for HangingGateway {
+            async fn check_action(&self, _request: Request<ProtoReq>) -> Result<Response<ProtoResp>, Status> {
+                tokio::time::sleep(Duration::from_secs(3_600)).await;
+                Ok(Response::new(ProtoResp::default()))
+            }
+
+            async fn batch_check(
+                &self,
+                _request: Request<BatchCheckRequest>,
+            ) -> Result<Response<BatchCheckResponse>, Status> {
+                Err(Status::unimplemented("not exercised by this test"))
+            }
+
+            type OpControlStreamStream =
+                std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<OpControlMessage, Status>> + Send + 'static>>;
+
+            async fn op_control_stream(
+                &self,
+                _request: Request<OpControlSubscribeRequest>,
+            ) -> Result<Response<Self::OpControlStreamStream>, Status> {
+                Err(Status::unimplemented("not exercised by this test"))
+            }
+        }
+
+        // Bind first (socket is listening), then serve on a background task.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_token = CancellationToken::new();
+        let server_shutdown = server_token.clone();
+        tokio::spawn(async move {
+            let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+            let _ = tonic::transport::Server::builder()
+                .add_service(PolicyServiceServer::new(HangingGateway))
+                .serve_with_incoming_shutdown(incoming, server_shutdown.cancelled())
+                .await;
+        });
+        // Give the serve loop a moment to start handling the h2 handshake.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let client = crate::gateway_client::GatewayClient::connect(&format!("http://{addr}"))
+            .await
+            .expect("client should connect to the listening (but hanging) stub");
+        let gateway = Arc::new(Mutex::new(client));
+
+        // Short deadline so the test resolves quickly; fail-closed posture.
+        let mut config = test_config(100, 10_000);
+        config.gateway_timeout = Duration::from_millis(300);
+
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, _rx) = broadcast::channel::<PipelineEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+        let (router, mut resp_rx) = make_router_with_receiver();
+        let approval_queue = crate::approval::ApprovalQueue::new();
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics,
+            token.clone(),
+            Arc::new(PolicyRules::default()),
+            router,
+            approval_queue,
+            Some(gateway),
+            crate::op_control::OpControlStore::new(),
+            Arc::new(AtomicU64::new(0)),
+            crate::ipc::new_verified_identity_store(),
+        ));
+
+        tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
+
+        // The 300ms deadline must yield a Deny well inside 2s — proving the check
+        // does not wait on the hung gateway forever.
+        let resp = tokio::time::timeout(Duration::from_secs(2), resp_rx.recv())
+            .await
+            .expect("hung gateway must not block the policy check past the deadline")
+            .expect("channel closed");
+
+        if let IpcResponse::PolicyResponse(r) = resp {
+            assert_eq!(
+                r.decision,
+                Decision::Deny as i32,
+                "hung gateway in fail-closed posture must deny via the RPC deadline"
+            );
+        } else {
+            panic!("expected PolicyResponse, got {resp:?}");
+        }
+        token.cancel();
+        server_token.cancel();
+    }
+
     /// AAASM-3110: in the observe/disabled posture (`gateway_fail_closed = false`)
     /// a gateway-unreachable check falls back to permissive local evaluation,
     /// which allows when no local rule matches.

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -44,6 +44,11 @@ pub struct PipelineConfig {
     /// instead of falling back to permissive local evaluation (AAASM-3110).
     /// Copied from [`RuntimeConfig::gateway_fail_closed`]; defaults to `true`.
     pub gateway_fail_closed: bool,
+    /// Per-RPC deadline for each gateway policy query. Bounds how long a hung
+    /// gateway can block the runtime's policy checks before the query is treated
+    /// as a failure and routed into the fail-closed path (AAASM-3987). Derived
+    /// from [`RuntimeConfig::gateway_timeout_ms`].
+    pub gateway_timeout: Duration,
     /// Minimum supported SDK version. When set, an observed SDK version below it
     /// is classified as a downgrade (AAASM-3640). `None` imposes no floor.
     pub min_sdk_version: Option<String>,
@@ -60,6 +65,7 @@ impl PipelineConfig {
             agent_id: c.agent_id.clone(),
             enforcement: enforcement::EnforcementConfig::from_runtime_config(c),
             gateway_fail_closed: c.gateway_fail_closed,
+            gateway_timeout: Duration::from_millis(c.gateway_timeout_ms),
             // No operator-configurable SDK version floor yet; downgrade
             // detection activates once a minimum is wired into RuntimeConfig.
             min_sdk_version: None,
@@ -161,6 +167,7 @@ pub async fn run(
                             &op_control,
                             &config.agent_id,
                             config.gateway_fail_closed,
+                            config.gateway_timeout,
                             &broadcast_tx,
                             &seq,
                         )
@@ -407,6 +414,7 @@ async fn handle_policy_query(
     op_control: &crate::op_control::OpControlStore,
     agent_id: &str,
     fail_closed: bool,
+    gateway_timeout: Duration,
     broadcast_tx: &broadcast::Sender<PipelineEvent>,
     sequence_counter: &AtomicU64,
 ) {
@@ -445,6 +453,7 @@ async fn handle_policy_query(
         connection_id,
         &req,
         gateway_client,
+        gateway_timeout,
         response_router,
         broadcast_tx,
         sequence_counter,
@@ -627,10 +636,20 @@ enum GatewayOutcome {
 
 /// Forward the request to the governance gateway over gRPC when a client is
 /// configured. See [`GatewayOutcome`] for how the caller interprets the result.
+///
+/// The RPC is bounded by `gateway_timeout` (AAASM-3987): a gateway that accepts
+/// the connection but then stops responding would otherwise hold the shared
+/// client lock — and the single pipeline loop — forever, stalling *every*
+/// agent's policy checks (a runtime-wide head-of-line DoS). On elapse the query
+/// is treated as a failure ([`GatewayOutcome::Failed`]), the same as a transport
+/// error, so the caller's fail-closed path applies. Dropping the timed-out
+/// future also releases the client lock, so a subsequent stuck query cannot
+/// wedge for longer than one deadline.
 async fn try_gateway_forward(
     connection_id: u64,
     req: &aa_proto::assembly::policy::v1::CheckActionRequest,
     gateway_client: &Option<Arc<Mutex<GatewayClient>>>,
+    gateway_timeout: Duration,
     response_router: &ResponseRouter,
     broadcast_tx: &broadcast::Sender<PipelineEvent>,
     sequence_counter: &AtomicU64,
@@ -639,8 +658,9 @@ async fn try_gateway_forward(
         return GatewayOutcome::NoClient;
     };
     let mut guard = client.lock().await;
-    match guard.check_action(req.clone()).await {
-        Ok(resp) => {
+    let call = tokio::time::timeout(gateway_timeout, guard.check_action(req.clone())).await;
+    match call {
+        Ok(Ok(resp)) => {
             tracing::debug!(connection_id, decision = resp.decision, "gateway responded");
             // On Deny: surface a structured PolicyViolation event into
             // the broadcast pipeline so the Live Ops dashboard sees the
@@ -652,11 +672,23 @@ async fn try_gateway_forward(
             send_ipc_response(connection_id, IpcResponse::PolicyResponse(resp), response_router).await;
             GatewayOutcome::Handled
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             tracing::warn!(
                 connection_id,
                 error = %e,
                 "gateway call failed"
+            );
+            GatewayOutcome::Failed
+        }
+        Err(_elapsed) => {
+            // The gateway accepted but did not answer within the deadline —
+            // treat identically to a transport failure so the fail-closed path
+            // denies (in enforce posture) instead of hanging (AAASM-3987).
+            ::metrics::counter!("aa_gateway_policy_query_timeouts_total").increment(1);
+            tracing::warn!(
+                connection_id,
+                timeout_ms = gateway_timeout.as_millis() as u64,
+                "gateway policy query timed out — treating as failure"
             );
             GatewayOutcome::Failed
         }
@@ -1085,6 +1117,10 @@ mod tests {
             runtime_config.pipeline_broadcast_capacity
         );
         assert_eq!(pipeline_config.agent_id, runtime_config.agent_id);
+        assert_eq!(
+            pipeline_config.gateway_timeout,
+            Duration::from_millis(runtime_config.gateway_timeout_ms)
+        );
     }
 
     #[test]
@@ -1097,6 +1133,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            gateway_timeout: Duration::from_secs(5),
             min_sdk_version: None,
         };
 
@@ -1118,6 +1155,9 @@ mod tests {
             agent_id: "test-agent".to_string(),
             enforcement: enforcement::EnforcementConfig::default(),
             gateway_fail_closed: true,
+            // Generous default for tests that don't exercise the deadline; the
+            // hanging-gateway regression test overrides this with a short value.
+            gateway_timeout: Duration::from_secs(5),
             min_sdk_version: None,
         }
     }

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -1069,6 +1069,7 @@ mod tests {
             audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
             enforcement_max_field_bytes: enforcement::DEFAULT_MAX_FIELD_BYTES,
             gateway_fail_closed: true,
+            gateway_timeout_ms: crate::config::DEFAULT_GATEWAY_TIMEOUT_MS,
         };
 
         let pipeline_config = PipelineConfig::from_runtime_config(&runtime_config);

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1318,6 +1318,7 @@ mod tests {
             audit_buffer_path: std::env::temp_dir().join("aa-audit-buffer-audit-test.db"),
             enforcement_max_field_bytes: crate::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES,
             gateway_fail_closed: true,
+            gateway_timeout_ms: crate::config::DEFAULT_GATEWAY_TIMEOUT_MS,
         }
     }
 

--- a/aa-runtime/tests/aaasm_2568_gate_verification.rs
+++ b/aa-runtime/tests/aaasm_2568_gate_verification.rs
@@ -33,6 +33,7 @@ fn verify_config(batch_size: usize) -> PipelineConfig {
         agent_id: "verify-agent".to_string(),
         enforcement: aa_runtime::pipeline::enforcement::EnforcementConfig::default(),
         gateway_fail_closed: true,
+        gateway_timeout: Duration::from_secs(5),
         min_sdk_version: None,
     }
 }

--- a/aa-runtime/tests/aaasm_3571_tamper_observability.rs
+++ b/aa-runtime/tests/aaasm_3571_tamper_observability.rs
@@ -44,6 +44,7 @@ fn verify_config() -> PipelineConfig {
         agent_id: "verify-agent".to_string(),
         enforcement: aa_runtime::pipeline::enforcement::EnforcementConfig::default(),
         gateway_fail_closed: true,
+        gateway_timeout: Duration::from_secs(5),
         min_sdk_version: None,
     }
 }

--- a/aa-runtime/tests/runtime_lifecycle.rs
+++ b/aa-runtime/tests/runtime_lifecycle.rs
@@ -50,6 +50,7 @@ fn lifecycle_config(agent_id: &str) -> RuntimeConfig {
         audit_buffer_path: std::env::temp_dir().join(format!("aa-audit-buffer-{agent_id}.db")),
         enforcement_max_field_bytes: DEFAULT_MAX_FIELD_BYTES,
         gateway_fail_closed: true,
+        gateway_timeout_ms: aa_runtime::config::DEFAULT_GATEWAY_TIMEOUT_MS,
     }
 }
 


### PR DESCRIPTION
## Description

`aa-runtime` forwarded policy checks to the gateway (`GatewayClient::check_action`) with **no deadline**. A gateway that accepts a connection but then stops responding (wedged, not down) would block `check_action` forever. Because the call is awaited inline in the single pipeline `run()` loop and holds the shared `GatewayClient` mutex, one hung RPC stalls **every** agent's policy checks, plus audit/redaction — a runtime-wide head-of-line DoS. The existing fail-closed logic (AAASM-3110) covers gateway *errors* but not *hangs*.

This adds a bounded per-RPC deadline: `try_gateway_forward` now wraps `check_action` in `tokio::time::timeout(gateway_timeout)`. On elapse the query is treated as a failure and routed into the **existing** fail-closed path (Deny under enforce / `gateway_fail_closed` default `true`), identical to a transport error. Reachable-gateway behavior is unchanged. Dropping the timed-out future also releases the client lock, so a subsequent stuck query cannot wedge longer than one deadline.

The deadline is operator-tunable via `AA_GATEWAY_TIMEOUT_MS` (default 5000ms); zero falls back to the default so the guard can never be disabled. A `aa_gateway_policy_query_timeouts_total` counter is emitted on each timeout.

**Follow-up (not in scope):** the policy query is still awaited inline in the single accept loop, so the deadline bounds — but does not eliminate — head-of-line serialization. Dispatching the query off the loop is a separate improvement; the deadline is the core fix.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3987

## Testing

- [x] Unit tests added / updated
  - `config::tests::gateway_timeout_defaults_and_rejects_zero` — env parse + zero-rejects-to-default
  - `pipeline::tests::from_runtime_config_copies_all_fields` — timeout mapping
  - `pipeline::tests::gateway_hang_fail_closed_denies_within_deadline` — gRPC stub whose `check_action` parks forever; the check returns fail-closed Deny within the (shortened) deadline instead of blocking. Without the fix this test hangs.
- Validated locally: `cargo build -p aa-runtime`, `cargo nextest run -p aa-runtime` (363 pass + new tests; the only red was `enforce_scan_p99_within_budget`, a load-sensitive perf benchmark unrelated to this change — passes in isolation), `cargo fmt --all -- --check`, `cargo clippy -p aa-runtime --all-targets -- -D warnings` (clean).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3987

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73