### PR TITLE
[AAASM-3980] 🔒 (aa-api): Tenant-isolate WebSocket event & alert streams

### DIFF
--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -56,6 +56,8 @@ url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
+# AAASM-3980: WS tenant-isolation tests construct AuditEvent to set team_id.
+aa-proto = { path = "../aa-proto" }
 axum-test = "21"
 futures = { workspace = true }
 hmac = { workspace = true }

--- a/aa-api/src/models/event.rs
+++ b/aa-api/src/models/event.rs
@@ -34,4 +34,17 @@ pub struct GovernanceEvent {
     /// Timestamp when the event was received by the API layer (ISO 8601).
     #[schema(value_type = String)]
     pub timestamp: DateTime<Utc>,
+    /// Owning team of the event, resolved from the source event's tenant
+    /// context (AAASM-3980). Server-side only: `#[serde(skip)]` keeps it
+    /// off the wire (no OpenAPI change) so it is never disclosed to
+    /// clients — it exists solely so the WebSocket dispatch loop can gate
+    /// both live and replayed events by tenant. `None` means the event
+    /// carries no resolvable owning team.
+    #[serde(skip)]
+    pub team_id: Option<String>,
+    /// Owning org of the event, resolved from the agent-registry lineage
+    /// (AAASM-3980). Server-side only for the same reason as
+    /// [`Self::team_id`]; `None` when no org could be resolved.
+    #[serde(skip)]
+    pub org_id: Option<String>,
 }

--- a/aa-api/src/replay.rs
+++ b/aa-api/src/replay.rs
@@ -63,6 +63,8 @@ mod tests {
             agent_id: "agent-a".to_string(),
             payload: serde_json::json!({}),
             timestamp: chrono::Utc::now(),
+            team_id: None,
+            org_id: None,
         }
     }
 

--- a/aa-api/src/ws/alerts_handler.rs
+++ b/aa-api/src/ws/alerts_handler.rs
@@ -28,13 +28,16 @@ use axum::Extension;
 use futures::{SinkExt, StreamExt};
 use tokio::sync::broadcast;
 
-use crate::alerts::{AlertEvent, AlertStore};
+use aa_gateway::registry::AgentRegistry;
+
+use crate::alerts::{AlertEvent, AlertStore, StoredAlert};
 use crate::auth::AuthenticatedCaller;
 use crate::error::ProblemDetail;
 use crate::models::alert_ws_payloads::AlertWsFrame;
 use crate::routes::alerts::alert_response_from_stored;
 use crate::state::AppState;
 use crate::ws::alerts_params::{AlertsFilter, AlertsWsQueryParams};
+use crate::ws::tenant::{agent_id_to_bytes, caller_can_view, resolve_event_tenant};
 
 /// Required client-offered WebSocket subprotocol.
 pub const SUBPROTOCOL: &str = "aaasm-alerts-v1";
@@ -67,7 +70,7 @@ static NEXT_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
     tag = "alerts-stream"
 )]
 pub async fn ws_alerts_handler(
-    _caller: AuthenticatedCaller,
+    caller: AuthenticatedCaller,
     headers: HeaderMap,
     ws: WebSocketUpgrade,
     Query(params): Query<AlertsWsQueryParams>,
@@ -88,8 +91,11 @@ pub async fn ws_alerts_handler(
 
     let conn_id = NEXT_CONNECTION_ID.fetch_add(1, Ordering::Relaxed);
     let alert_store = state.alert_store.clone();
+    // AAASM-3980: the caller's tenant + the registry (for org lineage) travel
+    // into the socket so each alert is tenant-gated before it is forwarded.
+    let registry = state.agent_registry.clone();
     ws.protocols([SUBPROTOCOL])
-        .on_upgrade(move |socket| run_alerts_socket(socket, filter, alert_store, conn_id))
+        .on_upgrade(move |socket| run_alerts_socket(socket, filter, alert_store, registry, caller, conn_id))
         .into_response()
 }
 
@@ -107,7 +113,14 @@ fn client_offered_subprotocol(headers: &HeaderMap, wanted: &str) -> bool {
 /// Drive a single WebSocket connection: subscribe to the alert bus,
 /// forward filtered events, send periodic heartbeats, and close on
 /// client disconnect or unexpected client frame.
-async fn run_alerts_socket(socket: WebSocket, filter: AlertsFilter, alert_store: Arc<dyn AlertStore>, conn_id: u64) {
+async fn run_alerts_socket(
+    socket: WebSocket,
+    filter: AlertsFilter,
+    alert_store: Arc<dyn AlertStore>,
+    registry: Arc<AgentRegistry>,
+    caller: AuthenticatedCaller,
+    conn_id: u64,
+) {
     let (mut sender, mut receiver) = socket.split();
     let mut rx = alert_store.subscribe();
 
@@ -146,6 +159,18 @@ async fn run_alerts_socket(socket: WebSocket, filter: AlertsFilter, alert_store:
             event_result = rx.recv() => {
                 match event_result {
                     Ok(event) => {
+                        // AAASM-3980: fail-closed tenant gate before the
+                        // client's own filter — an alert stream must not leak
+                        // another tenant's budget / secret / rule alerts.
+                        let stored = alert_stored(&event);
+                        let (team_id, org_id) = resolve_event_tenant(
+                            &registry,
+                            stored.team_id.clone(),
+                            agent_id_to_bytes(&stored.agent_id),
+                        );
+                        if !caller_can_view(&caller, team_id.as_deref(), org_id.as_deref()) {
+                            continue;
+                        }
                         if !filter.matches(&event) {
                             continue;
                         }
@@ -182,6 +207,14 @@ async fn run_alerts_socket(socket: WebSocket, filter: AlertsFilter, alert_store:
                 }
             }
         }
+    }
+}
+
+/// Borrow the [`StoredAlert`] carried by any [`AlertEvent`] variant, so the
+/// tenant gate (AAASM-3980) can read its `team_id` / `agent_id` uniformly.
+fn alert_stored(event: &AlertEvent) -> &StoredAlert {
+    match event {
+        AlertEvent::Fire(stored) | AlertEvent::Resolve(stored) | AlertEvent::Silence(stored) => stored,
     }
 }
 

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -287,6 +287,10 @@ fn build_governance_event(
         agent_id,
         payload: serde_json::to_value(payload).unwrap_or_default(),
         timestamp: chrono::Utc::now(),
+        // Populated by the caller via the tenant-resolution path (AAASM-3980);
+        // `None` here keeps this constructor tenant-agnostic.
+        team_id: None,
+        org_id: None,
     }
 }
 

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -9,6 +9,7 @@ use crate::models::{EventType, GovernanceEvent};
 // shipped in PR-B (AAASM-1651).
 use crate::state::AppState;
 use crate::ws::params::WsQueryParams;
+use crate::ws::tenant::{agent_id_to_bytes, caller_can_view, resolve_event_tenant};
 use axum::body::Bytes;
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::{Query, WebSocketUpgrade};
@@ -58,16 +59,19 @@ const PING_INTERVAL: Duration = Duration::from_secs(30);
     tag = "events"
 )]
 pub async fn ws_events_handler(
-    _caller: AuthenticatedCaller,
+    caller: AuthenticatedCaller,
     ws: WebSocketUpgrade,
     Query(params): Query<WsQueryParams>,
     Extension(state): Extension<AppState>,
 ) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_socket(socket, params, state))
+    // AAASM-3980: the authenticated caller's tenant travels into the dispatch
+    // loop so every live and replayed event is gated against it — the shared
+    // broadcast channels are cross-tenant and must not leak to a scoped caller.
+    ws.on_upgrade(move |socket| handle_socket(socket, params, state, caller))
 }
 
 /// Drive a single WebSocket connection: replay, then stream live events.
-async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState) {
+async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState, caller: AuthenticatedCaller) {
     let (sender, receiver) = socket.split();
     let sender = std::sync::Arc::new(tokio::sync::Mutex::new(sender));
 
@@ -77,9 +81,16 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
     // Replay buffered events if `since` was provided. A send failure during
     // replay means the client is gone — abandon the connection.
     if let Some(since_id) = params.since {
-        if replay_buffered_events(&state, &sender, since_id, &allowed_types, agent_filter.as_deref())
-            .await
-            .is_err()
+        if replay_buffered_events(
+            &state,
+            &caller,
+            &sender,
+            since_id,
+            &allowed_types,
+            agent_filter.as_deref(),
+        )
+        .await
+        .is_err()
         {
             return;
         }
@@ -107,6 +118,7 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
     // or the client goes away; the keep-alive/reader tasks run alongside.
     dispatch_live_events(DispatchCtx {
         state: &state,
+        caller: &caller,
         sender: &live_sender,
         next_id: &next_id,
         allowed_types: &allowed_types,
@@ -166,6 +178,8 @@ async fn reader_loop(
 /// state and the five live receivers so the dispatch loop has a flat signature.
 struct DispatchCtx<'a> {
     state: &'a AppState,
+    /// The connecting caller — its tenant gates every forwarded event (AAASM-3980).
+    caller: &'a AuthenticatedCaller,
     sender: &'a SharedSender,
     next_id: &'a std::sync::atomic::AtomicU64,
     allowed_types: &'a [EventType],
@@ -183,6 +197,7 @@ struct DispatchCtx<'a> {
 async fn dispatch_live_events(ctx: DispatchCtx<'_>) {
     loop {
         let Some(event) = next_governance_event(
+            ctx.state.agent_registry.as_ref(),
             ctx.next_id,
             ctx.pipeline_rx,
             ctx.approval_rx,
@@ -195,8 +210,16 @@ async fn dispatch_live_events(ctx: DispatchCtx<'_>) {
             break;
         };
 
-        // Store in replay buffer before filtering.
+        // Store in replay buffer before filtering. The buffered copy keeps its
+        // resolved tenant so a later reconnect from a *different* caller is
+        // re-gated against that caller's tenant on replay.
         ctx.state.replay_buffer.push(event.clone());
+
+        // AAASM-3980: tenant gate first (fail-closed) — never forward an event
+        // the caller isn't entitled to — then the client's type/agent filters.
+        if !caller_can_view(ctx.caller, event.team_id.as_deref(), event.org_id.as_deref()) {
+            continue;
+        }
 
         if !matches_filter(&event, ctx.allowed_types, ctx.agent_filter) {
             continue;
@@ -213,6 +236,7 @@ async fn dispatch_live_events(ctx: DispatchCtx<'_>) {
 /// (the `else` arm), which signals the dispatch loop to terminate.
 #[allow(clippy::too_many_arguments)]
 async fn next_governance_event(
+    registry: &aa_gateway::registry::AgentRegistry,
     next_id: &std::sync::atomic::AtomicU64,
     pipeline_rx: &mut tokio::sync::broadcast::Receiver<aa_runtime::pipeline::event::PipelineEvent>,
     approval_rx: &mut tokio::sync::broadcast::Receiver<aa_runtime::approval::ApprovalRequest>,
@@ -222,19 +246,34 @@ async fn next_governance_event(
 ) -> Option<GovernanceEvent> {
     tokio::select! {
         Ok(pipeline_ev) = pipeline_rx.recv() => {
+            let agent_id = extract_pipeline_agent_id(&pipeline_ev);
+            let (team_id, org_id) = resolve_event_tenant(
+                registry,
+                pipeline_explicit_team(&pipeline_ev),
+                agent_id_to_bytes(&agent_id),
+            );
             Some(build_governance_event(
                 next_id,
                 EventType::Violation,
-                extract_pipeline_agent_id(&pipeline_ev),
+                agent_id,
                 EventPayload::Violation(build_violation_payload(&pipeline_ev)),
+                team_id,
+                org_id,
             ))
         }
         Ok(approval_ev) = approval_rx.recv() => {
+            let (team_id, org_id) = resolve_event_tenant(
+                registry,
+                approval_ev.team_id.clone(),
+                agent_id_to_bytes(&approval_ev.agent_id),
+            );
             Some(build_governance_event(
                 next_id,
                 EventType::Approval,
                 approval_ev.agent_id.clone(),
                 EventPayload::Approval(build_approval_payload(&approval_ev)),
+                team_id,
+                org_id,
             ))
         }
         Ok(expired_ev) = approval_expiry_rx.recv() => {
@@ -242,44 +281,85 @@ async fn next_governance_event(
             // elapsed without a human decision. Propagate as an
             // `approval` event with `status: "expired"` so the
             // dashboard can move the row to the Expired section.
+            let (team_id, org_id) = resolve_event_tenant(
+                registry,
+                expired_ev.team_id.clone(),
+                agent_id_to_bytes(&expired_ev.agent_id),
+            );
             Some(build_governance_event(
                 next_id,
                 EventType::Approval,
                 expired_ev.agent_id.clone(),
                 EventPayload::Approval(build_expired_approval_payload(&expired_ev)),
+                team_id,
+                org_id,
             ))
         }
         Ok(budget_ev) = budget_rx.recv() => {
+            let (team_id, org_id) = resolve_event_tenant(
+                registry,
+                budget_ev.team_id.clone(),
+                Some(*budget_ev.agent_id.as_bytes()),
+            );
             Some(build_governance_event(
                 next_id,
                 EventType::Budget,
                 format!("{:02x?}", budget_ev.agent_id.as_bytes()),
                 EventPayload::Budget(build_budget_alert_payload(&budget_ev)),
+                team_id,
+                org_id,
             ))
         }
         Ok(ops_ev) = ops_change_rx.recv() => {
             // AAASM-1657 PR-H: forward operator-driven ops registry
             // transitions to the dashboard so it can clear optimistic
             // overrides and update the row in place by op_id.
+            // The ops-change envelope carries no tenant tag, so resolve it
+            // from the agent-registry lineage keyed by the agent id.
+            let (team_id, org_id) = resolve_event_tenant(
+                registry,
+                None,
+                agent_id_to_bytes(&ops_ev.agent_id),
+            );
             Some(build_governance_event(
                 next_id,
                 EventType::OpsChange,
                 ops_ev.agent_id,
                 EventPayload::OpsChange(ops_ev.payload),
+                team_id,
+                org_id,
             ))
         }
         else => None,
     }
 }
 
+/// The explicit owning team carried by a pipeline event, if any. Audit events
+/// carry it on `inner.team_id` (empty string when unset → `None`); layer
+/// degradation is a deployment-wide system notice with no owning team.
+fn pipeline_explicit_team(ev: &aa_runtime::pipeline::event::PipelineEvent) -> Option<String> {
+    use aa_runtime::pipeline::event::PipelineEvent;
+    match ev {
+        PipelineEvent::Audit(enriched) if !enriched.inner.team_id.is_empty() => Some(enriched.inner.team_id.clone()),
+        _ => None,
+    }
+}
+
 /// Assemble a [`GovernanceEvent`] with the next monotonic id and current
 /// timestamp. A failed payload serialization falls back to `Value::Null`
 /// (`unwrap_or_default`), preserving the prior per-arm behaviour.
+///
+/// `team_id` / `org_id` are the event's resolved owning tenant (AAASM-3980),
+/// carried server-side only so the dispatch loop can gate live and replayed
+/// events; they are never serialized onto the wire.
+#[allow(clippy::too_many_arguments)]
 fn build_governance_event(
     next_id: &std::sync::atomic::AtomicU64,
     event_type: EventType,
     agent_id: String,
     payload: EventPayload,
+    team_id: Option<String>,
+    org_id: Option<String>,
 ) -> GovernanceEvent {
     GovernanceEvent {
         id: next_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
@@ -287,10 +367,8 @@ fn build_governance_event(
         agent_id,
         payload: serde_json::to_value(payload).unwrap_or_default(),
         timestamp: chrono::Utc::now(),
-        // Populated by the caller via the tenant-resolution path (AAASM-3980);
-        // `None` here keeps this constructor tenant-agnostic.
-        team_id: None,
-        org_id: None,
+        team_id,
+        org_id,
     }
 }
 
@@ -524,12 +602,18 @@ fn detail_op_fields(
 /// caller can abandon the connection; `Ok(())` when all matching events are sent.
 async fn replay_buffered_events(
     state: &AppState,
+    caller: &AuthenticatedCaller,
     sender: &std::sync::Arc<tokio::sync::Mutex<SplitSink<WebSocket, Message>>>,
     since_id: u64,
     allowed_types: &[EventType],
     agent_filter: Option<&str>,
 ) -> Result<(), ()> {
     for event in state.replay_buffer.events_since(since_id) {
+        // AAASM-3980: apply the same fail-closed tenant gate as the live path —
+        // a reconnecting caller must not replay another tenant's buffered events.
+        if !caller_can_view(caller, event.team_id.as_deref(), event.org_id.as_deref()) {
+            continue;
+        }
         if !matches_filter(&event, allowed_types, agent_filter) {
             continue;
         }

--- a/aa-api/src/ws/mod.rs
+++ b/aa-api/src/ws/mod.rs
@@ -4,6 +4,7 @@ pub mod alerts_handler;
 pub mod alerts_params;
 pub mod handler;
 pub mod params;
+pub mod tenant;
 
 pub use alerts_handler::ws_alerts_handler;
 pub use alerts_params::{AlertEventKind, AlertsFilter, AlertsWsQueryParams, FilterError, WireSeverity};

--- a/aa-api/src/ws/tenant.rs
+++ b/aa-api/src/ws/tenant.rs
@@ -1,0 +1,76 @@
+//! Tenant authorization for the WebSocket event and alert streams (AAASM-3980).
+//!
+//! The live event / alert channels are shared across all tenants, so the
+//! dispatch loops must gate every frame — live *and* replayed — against the
+//! connecting caller's tenant before forwarding it. This mirrors the
+//! per-tenant REST surface (`routes::agents` / `routes::alerts`), which
+//! authorizes each row via [`AuthenticatedCaller::can_access_team`] /
+//! [`AuthenticatedCaller::can_access_org`].
+//!
+//! The gate is **fail-closed**: an event whose owning tenant cannot be
+//! resolved is visible only to admins. A non-admin caller therefore never
+//! receives cross-tenant data, even for events that carry no tenant tag.
+
+use aa_gateway::registry::AgentRegistry;
+
+use crate::auth::scope::Scope;
+use crate::auth::AuthenticatedCaller;
+
+/// Whether `caller` is entitled to see an event owned by the given tenant.
+///
+/// Admins (including the bypass-mode synthetic caller) see every tenant's
+/// events. Any other caller must be entitled to the event's owning `team_id`
+/// or `org_id`. Fail-closed: when the event carries neither a resolvable team
+/// nor org, only admins pass — a tenant-scoped caller sees nothing rather than
+/// risk cross-tenant disclosure.
+pub(crate) fn caller_can_view(caller: &AuthenticatedCaller, team_id: Option<&str>, org_id: Option<&str>) -> bool {
+    if caller.scopes.contains(&Scope::Admin) {
+        return true;
+    }
+    if let Some(team) = team_id {
+        if caller.can_access_team(team) {
+            return true;
+        }
+    }
+    if let Some(org) = org_id {
+        if caller.can_access_org(org) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Resolve the owning `(team_id, org_id)` for an event.
+///
+/// Prefers the tenant carried on the event itself (`explicit_team`); falls
+/// back to the agent-registry lineage when a resolvable agent id is available.
+/// The org tier is only ever known via lineage, since the live event payloads
+/// don't carry it. Returns `(None, None)` when nothing can be resolved — the
+/// [`caller_can_view`] gate then treats the event as admin-only.
+pub(crate) fn resolve_event_tenant(
+    registry: &AgentRegistry,
+    explicit_team: Option<String>,
+    agent_id: Option<[u8; 16]>,
+) -> (Option<String>, Option<String>) {
+    let lineage = agent_id.and_then(|bytes| registry.lineage(&bytes));
+    let team = explicit_team
+        .filter(|t| !t.is_empty())
+        .or_else(|| lineage.as_ref().and_then(|l| l.team_id.clone()));
+    let org = lineage.and_then(|l| l.org_id);
+    (team, org)
+}
+
+/// Parse a 32-char hex agent id into its 16 raw bytes, or `None` when the
+/// string isn't a well-formed hex agent id (e.g. `"system:ebpf"`, a human
+/// label, or an empty string). Used to key the registry lineage lookup for
+/// events whose agent id travels as a display string.
+pub(crate) fn agent_id_to_bytes(id: &str) -> Option<[u8; 16]> {
+    if id.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    for (i, slot) in out.iter_mut().enumerate() {
+        *slot = u8::from_str_radix(id.get(i * 2..i * 2 + 2)?, 16).ok()?;
+    }
+    Some(out)
+}

--- a/aa-api/src/ws/tenant.rs
+++ b/aa-api/src/ws/tenant.rs
@@ -74,3 +74,177 @@ pub(crate) fn agent_id_to_bytes(id: &str) -> Option<[u8; 16]> {
     }
     Some(out)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::Tenant;
+    use aa_gateway::registry::{AgentRecord, AgentStatus};
+
+    fn caller(scopes: &[Scope], team: Option<&str>, org: Option<&str>) -> AuthenticatedCaller {
+        AuthenticatedCaller {
+            key_id: "k".into(),
+            scopes: scopes.to_vec(),
+            tenant: Tenant {
+                team_id: team.map(str::to_string),
+                org_id: org.map(str::to_string),
+            },
+        }
+    }
+
+    // ── caller_can_view ──────────────────────────────────────────────────────
+
+    #[test]
+    fn admin_sees_every_tenant_including_untagged_events() {
+        let admin = caller(&[Scope::Read, Scope::Admin], None, None);
+        assert!(caller_can_view(&admin, Some("team-a"), None));
+        assert!(caller_can_view(&admin, Some("team-b"), Some("org-z")));
+        // Fail-open only for admins: an event with no owning tenant is still visible.
+        assert!(caller_can_view(&admin, None, None));
+    }
+
+    #[test]
+    fn team_scoped_caller_sees_only_its_own_team() {
+        let a = caller(&[Scope::Read], Some("team-a"), None);
+        assert!(caller_can_view(&a, Some("team-a"), None), "same team is visible");
+        assert!(
+            !caller_can_view(&a, Some("team-b"), None),
+            "cross-tenant team must be blocked"
+        );
+    }
+
+    #[test]
+    fn team_scoped_caller_never_sees_untagged_events() {
+        // Fail-closed: an event with no resolvable owning tenant is admin-only.
+        let a = caller(&[Scope::Read], Some("team-a"), None);
+        assert!(!caller_can_view(&a, None, None));
+    }
+
+    #[test]
+    fn org_scoped_caller_sees_its_own_org() {
+        let o = caller(&[Scope::Read], None, Some("org-z"));
+        assert!(
+            caller_can_view(&o, Some("team-a"), Some("org-z")),
+            "same org is visible"
+        );
+        assert!(
+            !caller_can_view(&o, Some("team-a"), Some("org-y")),
+            "cross-tenant org must be blocked"
+        );
+    }
+
+    #[test]
+    fn caller_with_no_tenant_and_no_admin_sees_nothing() {
+        let none = caller(&[Scope::Read], None, None);
+        assert!(!caller_can_view(&none, Some("team-a"), None));
+        assert!(!caller_can_view(&none, None, Some("org-z")));
+        assert!(!caller_can_view(&none, None, None));
+    }
+
+    // ── agent_id_to_bytes ────────────────────────────────────────────────────
+
+    #[test]
+    fn agent_id_to_bytes_parses_valid_hex() {
+        let hex = "000102030405060708090a0b0c0d0e0f";
+        assert_eq!(
+            agent_id_to_bytes(hex),
+            Some([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        );
+    }
+
+    #[test]
+    fn agent_id_to_bytes_rejects_non_hex_ids() {
+        assert_eq!(agent_id_to_bytes("system:ebpf"), None);
+        assert_eq!(agent_id_to_bytes(""), None);
+        assert_eq!(agent_id_to_bytes("support-agent"), None);
+        // Right length, but not hex.
+        assert_eq!(agent_id_to_bytes(&"z".repeat(32)), None);
+    }
+
+    // ── resolve_event_tenant ─────────────────────────────────────────────────
+
+    fn record_with_tenant(id: [u8; 16], team: Option<&str>, org: Option<&str>) -> AgentRecord {
+        AgentRecord {
+            agent_id: id,
+            name: "test".into(),
+            framework: "test".into(),
+            version: "0.0.1".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: "deadbeef".into(),
+            credential_token: "tok".into(),
+            metadata: Default::default(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: vec![],
+            recent_events: Default::default(),
+            recent_traces: vec![],
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: team.map(str::to_string),
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: None,
+            children: vec![],
+            parent_key: None,
+            enforcement_mode: None,
+            org_id: org.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn explicit_team_is_used_verbatim_when_present() {
+        let reg = AgentRegistry::new();
+        let (team, org) = resolve_event_tenant(&reg, Some("team-a".into()), None);
+        assert_eq!(team.as_deref(), Some("team-a"));
+        assert_eq!(org, None, "org is only known via lineage");
+    }
+
+    #[test]
+    fn unresolvable_event_yields_no_tenant() {
+        // Empty explicit team + an agent id absent from the registry → nothing
+        // resolves, so the gate treats the event as admin-only.
+        let reg = AgentRegistry::new();
+        let (team, org) = resolve_event_tenant(&reg, None, Some([9u8; 16]));
+        assert_eq!(team, None);
+        assert_eq!(org, None);
+        // An empty explicit team string is also treated as absent.
+        let (team, _) = resolve_event_tenant(&reg, Some(String::new()), None);
+        assert_eq!(team, None);
+    }
+
+    #[test]
+    fn lineage_fills_team_and_org_for_tagless_events() {
+        // Mirrors the ops-change path: the event carries only an agent id, and
+        // the owning team + org are recovered from the agent-registry lineage.
+        let reg = AgentRegistry::new();
+        let id = [7u8; 16];
+        reg.register(record_with_tenant(id, Some("team-a"), Some("org-z")))
+            .unwrap();
+
+        let (team, org) = resolve_event_tenant(&reg, None, Some(id));
+        assert_eq!(team.as_deref(), Some("team-a"));
+        assert_eq!(org.as_deref(), Some("org-z"));
+    }
+
+    #[test]
+    fn explicit_team_wins_but_org_still_from_lineage() {
+        let reg = AgentRegistry::new();
+        let id = [7u8; 16];
+        reg.register(record_with_tenant(id, Some("team-a"), Some("org-z")))
+            .unwrap();
+
+        // The event tags team-a explicitly; org is not on the event, so it is
+        // still pulled from lineage.
+        let (team, org) = resolve_event_tenant(&reg, Some("team-a".into()), Some(id));
+        assert_eq!(team.as_deref(), Some("team-a"));
+        assert_eq!(org.as_deref(), Some("org-z"));
+    }
+}

--- a/aa-api/tests/replay_buffer.rs
+++ b/aa-api/tests/replay_buffer.rs
@@ -11,6 +11,8 @@ fn make_event(id: u64, event_type: EventType) -> GovernanceEvent {
         agent_id: "test-agent".to_string(),
         payload: serde_json::json!({"test": true}),
         timestamp: Utc::now(),
+        team_id: None,
+        org_id: None,
     }
 }
 

--- a/aa-api/tests/ws_alerts.rs
+++ b/aa-api/tests/ws_alerts.rs
@@ -213,6 +213,88 @@ async fn ws_alerts_unexpected_client_frame_triggers_1008_close() {
     assert!(saw_close, "server must answer an unexpected frame with a 1008 close");
 }
 
+// ── AAASM-3980: tenant isolation of the alert stream ─────────────────────────
+
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
+
+async fn start_auth_server() -> (String, TestHandle) {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::server::build_app(state.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let url = format!("ws://127.0.0.1:{}", addr.port());
+    (url, TestHandle { state, _server: handle })
+}
+
+/// Alerts WS handshake request with subprotocol *and* a bearer token.
+fn alerts_ws_request_auth(url: &str, token: &str) -> ClientRequestBuilder {
+    let full = format!("{url}/api/v1/alerts/ws");
+    let uri: Uri = full.parse().expect("parse ws uri");
+    ClientRequestBuilder::new(uri)
+        .with_sub_protocol(SUBPROTOCOL)
+        .with_header("Authorization", format!("Bearer {token}"))
+}
+
+fn budget_alert_for_team(team: &str, agent_byte: u8) -> BudgetAlert {
+    BudgetAlert {
+        agent_id: aa_core::AgentId::from_bytes([agent_byte; 16]),
+        team_id: Some(team.to_string()),
+        threshold_pct: 95,
+        spent_usd: 9.0,
+        limit_usd: 10.0,
+    }
+}
+
+#[tokio::test]
+async fn ws_alerts_blocks_cross_tenant_and_allows_own_team() {
+    let (url, handle) = start_auth_server().await;
+    let token = common::generate_test_jwt_for_team("key-a", &[Scope::Read], "team-a");
+    let (mut ws, _) = tokio_tungstenite::connect_async(alerts_ws_request_auth(&url, &token))
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // A team-b alert must never reach the team-a caller.
+    handle.state.alert_store.record(&budget_alert_for_team("team-b", 0xBB));
+    let blocked = tokio::time::timeout(std::time::Duration::from_millis(250), ws.next()).await;
+    assert!(blocked.is_err(), "team-a caller must not receive a team-b alert");
+
+    // The caller's own team-a alert is delivered.
+    handle.state.alert_store.record(&budget_alert_for_team("team-a", 0xAA));
+    let msg = tokio::time::timeout(std::time::Duration::from_millis(200), ws.next())
+        .await
+        .expect("own-team alert must arrive")
+        .expect("stream not ended")
+        .expect("ws error");
+    let frame: serde_json::Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+    assert_eq!(frame["type"], "alert.fire");
+    assert_eq!(frame["alert"]["team_id"], "team-a");
+}
+
+#[tokio::test]
+async fn ws_alerts_admin_receives_every_tenant() {
+    let (url, handle) = start_auth_server().await;
+    let token = common::generate_test_jwt("admin", &[Scope::Read, Scope::Admin]);
+    let (mut ws, _) = tokio_tungstenite::connect_async(alerts_ws_request_auth(&url, &token))
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    handle.state.alert_store.record(&budget_alert_for_team("team-b", 0xBB));
+    let msg = tokio::time::timeout(std::time::Duration::from_millis(200), ws.next())
+        .await
+        .expect("admin must receive every tenant's alert")
+        .expect("stream not ended")
+        .expect("ws error");
+    let frame: serde_json::Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+    assert_eq!(frame["type"], "alert.fire");
+    assert_eq!(frame["alert"]["team_id"], "team-b");
+}
+
 /// Client Ping/Pong frames are ignored (the loop `continue`s) and a
 /// subsequent Close terminates the connection cleanly.
 #[tokio::test]

--- a/aa-api/tests/ws_streaming.rs
+++ b/aa-api/tests/ws_streaming.rs
@@ -114,6 +114,8 @@ async fn ws_replay_sends_buffered_events() {
             agent_id: "agent-1".to_string(),
             payload: serde_json::json!({"seq": i}),
             timestamp: Utc::now(),
+            team_id: None,
+            org_id: None,
         });
     }
     // Set next_event_id past the buffered events.

--- a/aa-api/tests/ws_streaming.rs
+++ b/aa-api/tests/ws_streaming.rs
@@ -452,6 +452,230 @@ async fn ws_receives_ops_change_event() {
     assert_eq!(ev.payload["op_id"], "trace-1:span-1");
 }
 
+// ── AAASM-3980: tenant isolation of the event stream ─────────────────────────
+
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+/// Start a server with auth enabled (JWT via the shared test secret) so tenant
+/// isolation can be exercised with real team/admin bearer tokens.
+async fn start_auth_server() -> (String, TestHandle) {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::server::build_app(state.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let url = format!("ws://127.0.0.1:{}", addr.port());
+    (url, TestHandle { state, _server: handle })
+}
+
+/// Build a WebSocket handshake request carrying `Authorization: Bearer <token>`.
+fn ws_request(url: &str, token: &str) -> tokio_tungstenite::tungstenite::handshake::client::Request {
+    let mut req = url.into_client_request().expect("valid ws url");
+    req.headers_mut().insert(
+        tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
+        format!("Bearer {token}").parse().unwrap(),
+    );
+    req
+}
+
+/// Assert the socket yields no frame within a short idle window.
+async fn assert_no_event(
+    ws: &mut (impl futures::StreamExt<
+        Item = Result<tokio_tungstenite::tungstenite::Message, tokio_tungstenite::tungstenite::Error>,
+    > + Unpin),
+) {
+    // `next()` comes from the `StreamExt` bound on the parameter.
+    let res = tokio::time::timeout(std::time::Duration::from_millis(250), ws.next()).await;
+    assert!(res.is_err(), "expected no cross-tenant frame, got one");
+}
+
+fn budget_alert(team: &str, agent_byte: u8) -> aa_gateway::budget::types::BudgetAlert {
+    aa_gateway::budget::types::BudgetAlert {
+        agent_id: aa_core::identity::AgentId::from_bytes([agent_byte; 16]),
+        team_id: Some(team.to_string()),
+        threshold_pct: 95,
+        spent_usd: 95.0,
+        limit_usd: 100.0,
+    }
+}
+
+fn pipeline_for_team(team: &str, agent_id: &str) -> PipelineEvent {
+    PipelineEvent::Audit(Box::new(EnrichedEvent {
+        inner: aa_proto::assembly::audit::v1::AuditEvent {
+            team_id: team.to_string(),
+            ..Default::default()
+        },
+        received_at_ms: 0,
+        source: EventSource::Sdk,
+        agent_id: agent_id.to_string(),
+        connection_id: 0,
+        sequence_number: 0,
+        observed_sdk_identity: Default::default(),
+        tamper: None,
+    }))
+}
+
+#[tokio::test]
+async fn ws_budget_stream_blocks_cross_tenant_and_allows_own_team() {
+    let (url, handle) = start_auth_server().await;
+    let token = common::generate_test_jwt_for_team("key-a", &[Scope::Read], "team-a");
+    let ws_url = format!("{url}/api/v1/ws/events?types=budget");
+    let (mut ws, _) = tokio_tungstenite::connect_async(ws_request(&ws_url, &token))
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let tx = handle.state.events.budget_sender();
+    // A team-b alert must never reach the team-a caller.
+    tx.send(budget_alert("team-b", 0xBB)).unwrap();
+    assert_no_event(&mut ws).await;
+
+    // The caller's own team-a alert is delivered.
+    tx.send(budget_alert("team-a", 0xAA)).unwrap();
+    let ev = read_gov_event(&mut ws).await;
+    assert_eq!(ev.event_type, EventType::Budget);
+}
+
+#[tokio::test]
+async fn ws_admin_receives_every_tenant_budget() {
+    let (url, handle) = start_auth_server().await;
+    // Admin scope, no team tenant — must see all tenants.
+    let token = common::generate_test_jwt("admin", &[Scope::Read, Scope::Admin]);
+    let ws_url = format!("{url}/api/v1/ws/events?types=budget");
+    let (mut ws, _) = tokio_tungstenite::connect_async(ws_request(&ws_url, &token))
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    handle
+        .state
+        .events
+        .budget_sender()
+        .send(budget_alert("team-b", 0xBB))
+        .unwrap();
+    let ev = read_gov_event(&mut ws).await;
+    assert_eq!(ev.event_type, EventType::Budget);
+}
+
+#[tokio::test]
+async fn ws_pipeline_stream_blocks_cross_tenant_and_allows_own_team() {
+    let (url, handle) = start_auth_server().await;
+    let token = common::generate_test_jwt_for_team("key-a", &[Scope::Read], "team-a");
+    let ws_url = format!("{url}/api/v1/ws/events?types=violation");
+    let (mut ws, _) = tokio_tungstenite::connect_async(ws_request(&ws_url, &token))
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let tx = handle.state.events.pipeline_sender();
+    tx.send(pipeline_for_team("team-b", "agent-b")).unwrap();
+    assert_no_event(&mut ws).await;
+
+    tx.send(pipeline_for_team("team-a", "agent-a")).unwrap();
+    let ev = read_gov_event(&mut ws).await;
+    assert_eq!(ev.event_type, EventType::Violation);
+}
+
+#[tokio::test]
+async fn ws_approval_stream_blocks_cross_tenant() {
+    let (url, handle) = start_auth_server().await;
+    let token = common::generate_test_jwt_for_team("key-a", &[Scope::Read], "team-a");
+    let ws_url = format!("{url}/api/v1/ws/events?types=approval");
+    let (mut ws, _) = tokio_tungstenite::connect_async(ws_request(&ws_url, &token))
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let mut req = make_approval_request();
+    req.team_id = Some("team-b".to_string());
+    handle.state.events.approval_sender().send(req).unwrap();
+    assert_no_event(&mut ws).await;
+
+    let mut own = make_approval_request();
+    own.team_id = Some("team-a".to_string());
+    handle.state.events.approval_sender().send(own).unwrap();
+    let ev = read_gov_event(&mut ws).await;
+    assert_eq!(ev.event_type, EventType::Approval);
+}
+
+#[tokio::test]
+async fn ws_ops_change_is_admin_only_when_tenant_unresolvable() {
+    // The ops-change envelope carries no tenant and its agent is not in the
+    // registry, so it is fail-closed to admins. A team-scoped caller sees
+    // nothing; an admin sees it.
+    let (url, handle) = start_auth_server().await;
+    let ops = || aa_api::events::OpsChangeBroadcast {
+        agent_id: "ops-agent".to_string(),
+        payload: aa_api::models::ws_payloads::OpsChangePayload {
+            op_id: "trace-1:span-1".to_string(),
+            state: aa_api::ops::OpState::Running,
+            updated_at: "2026-06-25T00:00:00Z".to_string(),
+        },
+    };
+
+    let team_token = common::generate_test_jwt_for_team("key-a", &[Scope::Read], "team-a");
+    let ws_url = format!("{url}/api/v1/ws/events?types=ops_change");
+    let (mut team_ws, _) = tokio_tungstenite::connect_async(ws_request(&ws_url, &team_token))
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    handle.state.events.ops_change_sender().send(ops()).unwrap();
+    assert_no_event(&mut team_ws).await;
+
+    let admin_token = common::generate_test_jwt("admin", &[Scope::Read, Scope::Admin]);
+    let (mut admin_ws, _) = tokio_tungstenite::connect_async(ws_request(&ws_url, &admin_token))
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    handle.state.events.ops_change_sender().send(ops()).unwrap();
+    let ev = read_gov_event(&mut admin_ws).await;
+    assert_eq!(ev.event_type, EventType::OpsChange);
+}
+
+#[tokio::test]
+async fn ws_replay_is_tenant_isolated() {
+    use chrono::Utc;
+    let (url, handle) = start_auth_server().await;
+
+    // Buffer one team-b and one team-a event. The tenant tags live on the
+    // server-only fields, mirroring what the live dispatch path stamps.
+    handle.state.replay_buffer.push(GovernanceEvent {
+        id: 1,
+        event_type: EventType::Violation,
+        agent_id: "agent-b".to_string(),
+        payload: serde_json::json!({"seq": 1}),
+        timestamp: Utc::now(),
+        team_id: Some("team-b".to_string()),
+        org_id: None,
+    });
+    handle.state.replay_buffer.push(GovernanceEvent {
+        id: 2,
+        event_type: EventType::Violation,
+        agent_id: "agent-a".to_string(),
+        payload: serde_json::json!({"seq": 2}),
+        timestamp: Utc::now(),
+        team_id: Some("team-a".to_string()),
+        org_id: None,
+    });
+    handle.state.next_event_id.store(3, Ordering::Relaxed);
+
+    // team-a caller replays from the start: only its own event 2 comes through;
+    // team-b's event 1 is dropped by the replay-path tenant gate.
+    let token = common::generate_test_jwt_for_team("key-a", &[Scope::Read], "team-a");
+    let ws_url = format!("{url}/api/v1/ws/events?since=0");
+    let (mut ws, _) = tokio_tungstenite::connect_async(ws_request(&ws_url, &token))
+        .await
+        .unwrap();
+
+    let ev = read_gov_event(&mut ws).await;
+    assert_eq!(ev.id, 2, "team-a caller must only replay its own team's event");
+    assert_no_event(&mut ws).await;
+}
+
 #[tokio::test]
 async fn ws_handles_client_pong_then_close_frame() {
     use futures::SinkExt;

--- a/aa-integration-tests/tests/api_ws.rs
+++ b/aa-integration-tests/tests/api_ws.rs
@@ -96,6 +96,8 @@ fn make_governance_event(id: u64) -> GovernanceEvent {
         agent_id: "test-agent".to_string(),
         payload: serde_json::json!({}),
         timestamp: Utc::now(),
+        team_id: None,
+        org_id: None,
     }
 }
 


### PR DESCRIPTION
## Description

Fixes a HIGH-severity cross-tenant disclosure on the two WebSocket streams.
`ws_events_handler` and `ws_alerts_handler` authenticated the upgrade but then
**discarded** the caller: the shared pipeline / approval / approval-expiry /
budget / ops-change channels (and the alert bus) were filtered only by the
client-chosen `types` / `agent_id`. Any authenticated Read token for one tenant
therefore received **every** tenant's live governance events and alerts over
`/api/v1/ws/events` and `/api/v1/alerts/ws`.

The caller's tenant is now threaded into both dispatch loops and every frame —
**live and replayed** — is gated fail-closed, mirroring the tenant-scoped REST
surface (`can_access_team` / `can_access_org`).

### How it works
- `GovernanceEvent` gains server-only `team_id` / `org_id` fields (`#[serde(skip)]`
  — never on the wire, no OpenAPI change) so the replay buffer can be re-gated per
  reconnecting caller.
- New `ws::tenant` module: `caller_can_view` (admin sees all; else the event's
  owning team/org must match; **no resolvable tenant → admin-only**) and
  `resolve_event_tenant`, which derives each event's owning team/org from its own
  tenant fields and the agent-registry lineage (covers tag-less events like
  ops-change).
- The alert stream reuses the same gate, resolving each alert's tenant from
  `StoredAlert.team_id` + registry lineage.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] No — the WS wire schema is unchanged (verified: no `openapi/v1.yaml` diff).

## Related Issues

- Related Jira ticket: AAASM-3980

## Testing

- [x] Unit tests added (`ws::tenant`: gate matrix, hex parsing, lineage resolution)
- [x] Integration tests added (auth-on, real team/admin JWTs): budget & pipeline
  streams block cross-tenant and deliver own-team; approval blocks cross-tenant;
  admin receives all; ops-change fail-closed to admins; `since=` replay is
  tenant-isolated; alert stream blocks cross-tenant + admin sees all.
- Full `cargo nextest run -p aa-api` — 827 passed. `cargo fmt --all --check`,
  `cargo clippy -p aa-api --all-targets -D warnings`, and the OpenAPI drift check
  all clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3980

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73
