### PR TITLE
[AAASM-3989] 🔒 (aa-sdk-client): Cap IPC frame + fail-closed on unknown decision

### DIFF
--- a/aa-sdk-client/src/codec.rs
+++ b/aa-sdk-client/src/codec.rs
@@ -40,12 +40,31 @@ pub const TAG_VIOLATION_ALERT: u8 = 4;
 /// runtime → SDK per-session nonce challenge (AAASM-3587).
 pub const TAG_HANDSHAKE_CHALLENGE: u8 = 5;
 
+/// Maximum accepted length-delimited payload size, in bytes (8 MiB).
+///
+/// The wire length prefix is attacker-controlled: anything that can connect to
+/// the runtime socket (including a `/tmp` socket-squatter when the real runtime
+/// is down) can send a varint claiming a multi-gigabyte payload, and
+/// `vec![0u8; len]` would attempt to allocate it *before* a single payload byte
+/// is read — a trivial local DoS that OOM-aborts the agent (AAASM-3989). We
+/// reject any frame larger than this bound before allocating. 8 MiB matches
+/// `aa-runtime`'s `MAX_FRAME_LEN`, comfortably exceeding any legitimate
+/// `CheckActionResponse` / `PolicyViolation` while keeping a single hostile
+/// frame from exhausting memory.
+pub const MAX_FRAME_LEN: usize = 8 * 1024 * 1024;
+
 /// Errors that can occur during codec operations.
 #[derive(Debug)]
 pub enum CodecError {
     Io(std::io::Error),
     UnknownTag(u8),
     DecodeError(prost::DecodeError),
+    /// The wire length prefix exceeded [`MAX_FRAME_LEN`]. Rejected before any
+    /// allocation so a hostile peer cannot force a large buffer alloc.
+    FrameTooLarge {
+        len: usize,
+        max: usize,
+    },
 }
 
 impl std::fmt::Display for CodecError {
@@ -54,6 +73,9 @@ impl std::fmt::Display for CodecError {
             CodecError::Io(e) => write!(f, "IO error: {e}"),
             CodecError::UnknownTag(t) => write!(f, "unknown response tag: {t}"),
             CodecError::DecodeError(e) => write!(f, "prost decode error: {e}"),
+            CodecError::FrameTooLarge { len, max } => {
+                write!(f, "frame length {len} exceeds maximum {max}")
+            }
         }
     }
 }
@@ -190,6 +212,16 @@ where
     R: AsyncReadExt + Unpin,
 {
     let len = read_varint(reader).await? as usize;
+    // AAASM-3989: bound the claimed length BEFORE allocating. The prefix comes
+    // off the wire from an untrusted peer (e.g. a socket-squatter on the runtime
+    // path), so allocating `len` bytes first would let a single hostile frame
+    // exhaust memory and abort the host agent.
+    if len > MAX_FRAME_LEN {
+        return Err(CodecError::FrameTooLarge {
+            len,
+            max: MAX_FRAME_LEN,
+        });
+    }
     let mut buf = vec![0u8; len];
     reader.read_exact(&mut buf).await?;
     Ok(buf)

--- a/aa-sdk-client/src/codec.rs
+++ b/aa-sdk-client/src/codec.rs
@@ -326,4 +326,42 @@ mod tests {
         let result = read_response(&mut cursor).await;
         assert!(matches!(result, Err(CodecError::UnknownTag(99))));
     }
+
+    /// AAASM-3989: a frame whose length prefix exceeds `MAX_FRAME_LEN` must be
+    /// rejected *before* the body is allocated. We build the wire by hand with a
+    /// tag and an oversized varint length but no body — if the codec allocated
+    /// first it would attempt a `usize::MAX`-scale `vec![0u8; len]`; instead it
+    /// returns `FrameTooLarge` after reading only the varint.
+    #[tokio::test]
+    async fn oversized_frame_length_rejected_before_alloc() {
+        // Encode a policy-response frame claiming u64::MAX bytes of payload.
+        let mut wire = vec![TAG_POLICY_RESPONSE];
+        write_varint(&mut wire, u64::MAX).await.unwrap();
+        // Deliberately provide no payload bytes: the guard must fire first.
+        let mut cursor = Cursor::new(wire);
+        let result = read_response(&mut cursor).await;
+        match result {
+            Err(CodecError::FrameTooLarge { len, max }) => {
+                assert_eq!(max, MAX_FRAME_LEN);
+                assert!(len > MAX_FRAME_LEN, "claimed len {len} must exceed the cap");
+            }
+            other => panic!("expected FrameTooLarge, got {other:?}"),
+        }
+    }
+
+    /// A frame at exactly `MAX_FRAME_LEN` is not rejected by the bound (the guard
+    /// is `len > MAX_FRAME_LEN`); it proceeds to read the body. Here the body is
+    /// absent, so it fails with an IO error, proving the length check itself did
+    /// not reject it.
+    #[tokio::test]
+    async fn frame_at_max_len_passes_the_bound() {
+        let mut wire = vec![TAG_POLICY_RESPONSE];
+        write_varint(&mut wire, MAX_FRAME_LEN as u64).await.unwrap();
+        let mut cursor = Cursor::new(wire);
+        let result = read_response(&mut cursor).await;
+        assert!(
+            matches!(result, Err(CodecError::Io(_))),
+            "MAX_FRAME_LEN must pass the bound and fail only reading the absent body"
+        );
+    }
 }

--- a/aa-sdk-client/src/decision.rs
+++ b/aa-sdk-client/src/decision.rs
@@ -17,13 +17,17 @@
 //! # Contract
 //!
 //! Under **fail-closed** (enforce) the SDK pre-exec gate must never downgrade to
-//! allow-on-failure: a stalled or killed sidecar (unreachable runtime) and a
-//! held-for-approval (`PENDING`) action both resolve to [`Decision::Deny`]. Only
-//! when fail-closed is explicitly disabled (observe mode) is the historical
-//! fail-open preserved. A runtime `DENY`/`REDACT` is honoured verbatim in both
-//! modes, and an `UNSPECIFIED`/unknown code is never treated as a block (it
-//! folds to [`Decision::Allow`]) so the SDK cannot silently wedge on a decision
-//! it cannot interpret.
+//! allow-on-failure: a stalled or killed sidecar (unreachable runtime), a
+//! held-for-approval (`PENDING`) action, and an `UNSPECIFIED`/unknown code all
+//! resolve to [`Decision::Deny`]. Only when fail-closed is explicitly disabled
+//! (observe mode) is the historical fail-open preserved. A runtime `DENY`/
+//! `REDACT` is honoured verbatim in both modes.
+//!
+//! Denying the uninterpretable case under enforce closes a forward-compatibility
+//! downgrade (AAASM-3996): a future, more-restrictive `Decision` variant that an
+//! older SDK sees as an unknown code must not silently fold to `Allow` while the
+//! operator believes enforce is active. In observe mode the code still folds to
+//! `Allow` so the SDK cannot wedge on a decision it cannot interpret.
 //!
 //! The SDK remains advisory: `aa-runtime` / proxy / eBPF are the authoritative
 //! enforcement points. This is a defense-in-depth posture, not the primary gate.
@@ -50,7 +54,7 @@ use crate::error::SdkClientError;
 /// | `Ok(PENDING)` | `Deny` | `Pending` |
 /// | `Ok(REDACT)` | `Redact` | `Redact` |
 /// | `Ok(ALLOW)` | `Allow` | `Allow` |
-/// | `Ok(UNSPECIFIED)` / unknown code | `Allow` | `Allow` |
+/// | `Ok(UNSPECIFIED)` / unknown code | `Deny` | `Allow` |
 pub fn resolve_decision(result: &Result<CheckActionResponse, SdkClientError>, fail_closed: bool) -> Decision {
     match result {
         Ok(resp) => match Decision::try_from(resp.decision) {
@@ -66,9 +70,17 @@ pub fn resolve_decision(result: &Result<CheckActionResponse, SdkClientError>, fa
             }
             Ok(Decision::Redact) => Decision::Redact,
             Ok(Decision::Allow) => Decision::Allow,
-            // Unspecified or an unknown/garbled code is not a deny signal; never
-            // silently block on a decision the SDK cannot interpret.
-            Ok(Decision::Unspecified) | Err(_) => Decision::Allow,
+            // Unspecified or an unknown/garbled code is uninterpretable. Under
+            // enforce we deny it so a future restrictive Decision variant an old
+            // SDK cannot decode is not silently downgraded to Allow (AAASM-3996);
+            // in observe mode we preserve the historical fail-open.
+            Ok(Decision::Unspecified) | Err(_) => {
+                if fail_closed {
+                    Decision::Deny
+                } else {
+                    Decision::Allow
+                }
+            }
         },
         // Runtime unreachable / slow / closed session: fail closed under enforce
         // so a stalled or killed sidecar cannot turn deny-on-failure into
@@ -176,19 +188,32 @@ mod tests {
         assert_eq!(resolve_decision(&answered(Decision::Redact), false), Decision::Redact);
     }
 
-    // --- an uninterpretable decision never silently blocks ---
+    // --- an uninterpretable decision denies under enforce (AAASM-3996) ---
 
     #[test]
-    fn unspecified_allows_even_when_fail_closed() {
+    fn unspecified_denies_when_fail_closed() {
+        // Under enforce, a decision the SDK cannot interpret must not proceed:
+        // this closes the fwd-compat downgrade of a future restrictive variant.
+        assert_eq!(resolve_decision(&answered(Decision::Unspecified), true), Decision::Deny);
+    }
+
+    #[test]
+    fn unspecified_allows_when_fail_open() {
         assert_eq!(
-            resolve_decision(&answered(Decision::Unspecified), true),
+            resolve_decision(&answered(Decision::Unspecified), false),
             Decision::Allow
         );
     }
 
     #[test]
-    fn unknown_code_allows_even_when_fail_closed() {
-        // A garbled/out-of-range code is not a deny signal.
-        assert_eq!(resolve_decision(&answered_raw(9999), true), Decision::Allow);
+    fn unknown_code_denies_when_fail_closed() {
+        // A garbled/out-of-range code (e.g. a variant added after this SDK was
+        // built) denies under enforce rather than downgrading to Allow.
+        assert_eq!(resolve_decision(&answered_raw(9999), true), Decision::Deny);
+    }
+
+    #[test]
+    fn unknown_code_allows_when_fail_open() {
+        assert_eq!(resolve_decision(&answered_raw(9999), false), Decision::Allow);
     }
 }

--- a/aa-sdk-client/src/gateway.rs
+++ b/aa-sdk-client/src/gateway.rs
@@ -27,12 +27,23 @@ pub struct GatewayRegistrationClient {
     client: AgentLifecycleServiceClient<Channel>,
 }
 
+/// Maximum accepted gRPC decode size for gateway responses, in bytes (4 MiB).
+///
+/// tonic's implicit default is already 4 MiB, but the gateway endpoint is
+/// attacker-influenceable and a future codegen/tonic bump could change that
+/// implicit default; pin it explicitly so a hostile or misconfigured gateway
+/// cannot force an unbounded response buffer (AAASM-3996). A `RegisterResponse`
+/// / `ChallengeResponse` is a few hundred bytes, so 4 MiB is comfortably
+/// generous.
+const MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+
 impl GatewayRegistrationClient {
     /// Connect to the gateway gRPC endpoint (e.g. `"http://127.0.0.1:50051"`).
     pub async fn connect(endpoint: String) -> Result<Self, SdkClientError> {
         let client = AgentLifecycleServiceClient::connect(endpoint)
             .await
-            .map_err(|_| SdkClientError::GatewayUnreachable)?;
+            .map_err(|_| SdkClientError::GatewayUnreachable)?
+            .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
         Ok(Self { client })
     }
 

--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -58,6 +58,15 @@ impl std::fmt::Debug for IpcCommand {
 /// The command loop pushes one when it writes a `PolicyQuery`; the reader pops
 /// the oldest when a `PolicyResponse` arrives. The wire carries no correlation
 /// id, so responses match queries by order over the single connection.
+///
+// TODO(AAASM-3996): make query↔response correlation id-based rather than
+// positional. Today a single dropped/reordered `PolicyResponse` would misalign
+// every subsequent query with the wrong waiter. A proper fix adds a request-id
+// to the frame or the `CheckActionRequest`/`Response` protos and keys `pending`
+// by id — but that is a wire-protocol change that also touches `aa-runtime`'s
+// codec and `aa-proto`, which is out of scope for this hardening batch. Deferred
+// to its own ticket; the current single-connection FIFO invariant holds because
+// the runtime answers queries strictly in receive order over one stream.
 type PendingQueries = Arc<Mutex<VecDeque<blocking_mpsc::Sender<CheckActionResponse>>>>;
 
 /// Handle to the background IPC thread.


### PR DESCRIPTION
## Description

Hardens `aa-sdk-client` against untrusted IPC/gateway input and closes a
forward-compatibility fail-open in the enforcement fold.

- **AAASM-3989 (IPC frame allocation):** `read_length_delimited` allocated
  `vec![0u8; len]` from an attacker-controlled varint capped only at 64 bits, so
  a peer on the runtime socket (e.g. a `/tmp` socket-squatter when the runtime is
  down) could claim a near-`u64::MAX` payload and OOM-abort the host agent before
  a single body byte was read. Frames over `MAX_FRAME_LEN` (8 MiB, matching
  `aa-runtime`) are now rejected with `CodecError::FrameTooLarge` **before**
  allocating.
- **AAASM-3996 (Rust part):**
  - `decision.rs`: `resolve_decision` folded `UNSPECIFIED`/unknown decision codes
    to `Allow` even under `fail_closed`. Under enforce these now map to `Deny`,
    so a future restrictive `Decision` variant an older SDK cannot decode is not
    silently downgraded to `Allow`. Observe mode keeps the historical fail-open.
  - `gateway.rs`: pin an explicit 4 MiB `max_decoding_message_size` on the
    gateway gRPC client instead of relying on tonic's implicit default.
  - `ipc.rs`: documented (TODO) why query↔response correlation stays positional;
    id-based correlation needs a wire-protocol change touching `aa-runtime` +
    `aa-proto`, out of scope for this batch — deferred to its own ticket.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] Yes (describe below)

Behavioral: under `fail_closed == true`, an `UNSPECIFIED`/unknown runtime
decision now resolves to `Deny` (previously `Allow`). This only affects the
enforce posture and is the intended fail-closed hardening; observe mode is
unchanged. The AAASM-3958 tests that locked `unknown → Allow` were updated
accordingly.

## Related Issues

- Related Jira ticket: Closes AAASM-3989 · Refs AAASM-3996 (Rust part; the
  node-sdk parity change is in a separate PR)

## Testing

- [x] Unit tests added / updated

- `cargo build -p aa-sdk-client` — clean
- `cargo nextest run -p aa-sdk-client` — 75 passed (new oversized-frame tests +
  updated fail-closed decision tests)
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p aa-sdk-client --all-targets -- -D warnings` — clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73
