### PR TITLE
[AAASM-4008] 🔧 (ci): Exclude aa-ebpf/src from Codecov to match SonarCloud scope

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -34,9 +34,15 @@ coverage:
 # Paths excluded from all coverage reports (including PR patch coverage).
 # Listed binaries are run manually (not by `cargo test`), so coverage tooling
 # never observes them and they would otherwise drag patch coverage to 0%.
+#
+# aa-ebpf/src: the userspace eBPF loader has no testable logic; the coverage
+# job already `--exclude aa-ebpf` and SonarCloud drops it via sonar.exclusions
+# (aa-ebpf/src/**). Mirroring it here keeps Codecov's denominator aligned with
+# SonarCloud's — otherwise its ~2% coverage drags only the Codecov number down.
 ignore:
   - "conformance/src/bin/"
   - "aa-proxy/src/main.rs"
+  - "aa-ebpf/src/"
 
 comment:
   layout: "reach,diff,flags,tree"


### PR DESCRIPTION
## What
Add `aa-ebpf/src/` to `codecov.yml` `ignore` so Codecov measures the same set as SonarCloud.

## Why
Root-caused the agent-assembly Codecov (91.8%) vs SonarCloud (93.2%) gap (AAASM-4008, Epic AAASM-3999): it is dominated by one crate, `aa-ebpf` (~1096 lines @ 2.2%). That userspace eBPF loader has no testable logic — the coverage job already `--exclude aa-ebpf` and SonarCloud drops it via `sonar.exclusions=aa-ebpf/src/**`, but `codecov.yml ignore` did not, so its low coverage dragged only the Codecov number down. The other non-Sonar crates are well-tested (~92.5%) and are intentionally kept visible on Codecov.

## How to verify
- `codecov.yml` `ignore` now lists `aa-ebpf/src/`; YAML validated.
- After the next master `coverage` run, Codecov ≈ 93%, converging with SonarCloud 93.2% (residual is Sonar's line-engine only).
- Config-only; no Sonar/QG change, no source touched.

Closes AAASM-4008
