### PR TITLE
[AAASM-3997] 🔒 (hardening): storage/proxy/scanner/cache defense-in-depth batch

### DIFF
--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -2,7 +2,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use aa_core::storage::Result;
 use dashmap::mapref::entry::Entry;
@@ -29,17 +29,37 @@ pub struct L1Cache<S: CacheSource> {
     /// in-flight load is never silently lost (see AAASM-3985).
     epoch: AtomicU64,
     ttl: Duration,
+    /// Upper bound on the number of live entries. Once an insert pushes the map
+    /// past this, [`enforce_capacity`](Self::enforce_capacity) drops expired
+    /// entries first, then the oldest-by-insertion entries, so the cache can
+    /// never grow without bound (AAASM-3997).
+    max_entries: usize,
 }
 
+/// Default entry ceiling for [`L1Cache::new`]. Large enough to be a no-op for
+/// realistic agent populations, small enough to bound memory if a caller never
+/// invalidates and the key space is effectively unbounded.
+const DEFAULT_MAX_ENTRIES: usize = 100_000;
+
 impl<S: CacheSource> L1Cache<S> {
-    /// Wrap `inner`, expiring cached entries `ttl` after insertion.
+    /// Wrap `inner`, expiring cached entries `ttl` after insertion, with the
+    /// default entry ceiling ([`DEFAULT_MAX_ENTRIES`]).
     pub fn new(inner: S, ttl: Duration) -> Self {
+        Self::with_max_entries(inner, ttl, DEFAULT_MAX_ENTRIES)
+    }
+
+    /// Like [`new`](Self::new) but with an explicit maximum live-entry count.
+    ///
+    /// `max_entries` is clamped to at least 1 so the cache always retains the
+    /// entry it just loaded.
+    pub fn with_max_entries(inner: S, ttl: Duration, max_entries: usize) -> Self {
         Self {
             inner,
             entries: Arc::new(DashMap::new()),
             inflight: Arc::new(DashMap::new()),
             epoch: AtomicU64::new(0),
             ttl,
+            max_entries: max_entries.max(1),
         }
     }
 
@@ -80,6 +100,38 @@ impl<S: CacheSource> L1Cache<S> {
         // lost to a racing insert (AAASM-3985).
         self.epoch.fetch_add(1, Ordering::AcqRel);
         self.entries.remove(key).is_some()
+    }
+
+    /// Bound the live-entry count at [`max_entries`](Self::max_entries),
+    /// evicting when an insert pushes the map over the ceiling (AAASM-3997).
+    ///
+    /// Eviction is a pure size-management concern, independent of the
+    /// invalidation epoch: removing a cached entry is always safe (the worst
+    /// case is a subsequent miss that reloads from the source of truth), so this
+    /// never races the epoch/guarded-insert logic. It must be called *without*
+    /// holding any `entries` shard guard to avoid a DashMap self-deadlock.
+    fn enforce_capacity(&self) {
+        if self.entries.len() <= self.max_entries {
+            return;
+        }
+        // Cheap first pass: drop entries already past their TTL (they are misses
+        // anyway) before resorting to age-based eviction of live entries.
+        self.entries.retain(|_, value| !value.is_expired(self.ttl));
+        let len = self.entries.len();
+        if len <= self.max_entries {
+            return;
+        }
+        // Still over budget: evict the oldest-by-insertion entries. Snapshot the
+        // (inserted_at, key) pairs, sort ascending, and remove the excess.
+        let mut stamped: Vec<(Instant, S::Key)> = self
+            .entries
+            .iter()
+            .map(|entry| (entry.value().inserted_at, entry.key().clone()))
+            .collect();
+        stamped.sort_by_key(|(inserted_at, _)| *inserted_at);
+        for (_, key) in stamped.into_iter().take(len - self.max_entries) {
+            self.entries.remove(&key);
+        }
     }
 
     /// Return a fresh (non-expired) cached value for `key`, if present.
@@ -124,6 +176,7 @@ impl<S: CacheSource> L1Cache<S> {
                     // `invalidate` that lands mid-load is detected below.
                     let epoch_before = self.epoch.load(Ordering::Acquire);
                     let result = self.inner.load(&key).await;
+                    let mut inserted = false;
                     if let Ok(ref value) = result {
                         // Commit under the key's shard lock, and only if no
                         // invalidation raced the load. Holding the entry guard
@@ -131,17 +184,27 @@ impl<S: CacheSource> L1Cache<S> {
                         // `remove`, so a concurrent eviction is never lost: either
                         // we observe the bumped epoch and skip the insert, or the
                         // remove runs after us and drops the entry we just wrote.
-                        let entry = self.entries.entry(key.clone());
-                        if self.epoch.load(Ordering::Acquire) == epoch_before {
-                            match entry {
-                                Entry::Occupied(mut occupied) => {
-                                    occupied.insert(CachedValue::new(value.clone()));
+                        // The guard is confined to this inner block so it is
+                        // dropped before `enforce_capacity` touches the map.
+                        {
+                            let entry = self.entries.entry(key.clone());
+                            if self.epoch.load(Ordering::Acquire) == epoch_before {
+                                match entry {
+                                    Entry::Occupied(mut occupied) => {
+                                        occupied.insert(CachedValue::new(value.clone()));
+                                    }
+                                    Entry::Vacant(vacant) => {
+                                        vacant.insert(CachedValue::new(value.clone()));
+                                    }
                                 }
-                                Entry::Vacant(vacant) => {
-                                    vacant.insert(CachedValue::new(value.clone()));
-                                }
+                                inserted = true;
                             }
                         }
+                    }
+                    // Bound the cache size once the shard guard is released
+                    // (AAASM-3997). Only meaningful after a real insert.
+                    if inserted {
+                        self.enforce_capacity();
                     }
                     if let Some((_, notify)) = self.inflight.remove(&key) {
                         notify.notify_waiters();
@@ -271,6 +334,34 @@ mod tests {
         cache.get(id).await.expect("policy present");
         assert_eq!(cache.inner().call_count(), 2);
         assert_eq!(cache.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_is_bounded_by_max_entries() {
+        // AAASM-3997: without a bound the L1 map grew once per distinct key and
+        // never shrank. With a ceiling of 2, loading 5 distinct keys must leave
+        // at most 2 resident, and the most-recently loaded key stays cached.
+        let mut store = MemoryPolicyStore::new();
+        for seed in 0..5u8 {
+            store.insert(agent(seed), sample_policy(u32::from(seed)));
+        }
+        let cache = L1Cache::with_max_entries(store, Duration::from_secs(60), 2);
+
+        for seed in 0..5u8 {
+            cache.get(agent(seed)).await.expect("policy present");
+        }
+
+        assert!(cache.len() <= 2, "cache grew past its ceiling: {} entries", cache.len());
+
+        // The newest key was loaded last, so it survived eviction: serving it is
+        // a hit that does not touch the store again.
+        let calls_before = cache.inner().call_count();
+        cache.get(agent(4)).await.expect("policy present");
+        assert_eq!(
+            cache.inner().call_count(),
+            calls_before,
+            "the most-recently loaded key should still be cached"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/aa-gateway/src/invalidation/hub.rs
+++ b/aa-gateway/src/invalidation/hub.rs
@@ -1,7 +1,9 @@
 //! [`InvalidationHub`] — the gateway-side fan-out for L1 push-invalidation.
 //!
-//! One [`Subscriber`] is tracked per connected Assembly (keyed by `assembly_id`).
-//! Each subscriber owns a monotonic sequence counter and a bounded replay ring
+//! One [`Subscriber`] is tracked per connected Assembly, keyed by
+//! `(tenant, assembly_id)` so two different tenants that happen to choose the
+//! same `assembly_id` get independent slots (AAASM-3997). Each subscriber owns a
+//! monotonic sequence counter and a bounded replay ring
 //! so a reconnecting Assembly can request everything it missed via
 //! `SubscribeInitial.last_seq_seen`. A policy mutation calls
 //! [`InvalidationHub::broadcast_policy_invalidated`], which fans the event out to
@@ -19,6 +21,11 @@ use aa_runtime::approval::{ApprovalDecision, ApprovalResolvedNotifier};
 
 /// Stable identifier of a subscribing Assembly instance.
 pub type AssemblyId = String;
+
+/// Key under which a [`Subscriber`] is tracked: the owning tenant paired with the
+/// Assembly id. Including the tenant makes the namespace per-tenant, so one
+/// tenant cannot squat another tenant's `assembly_id` (AAASM-3997).
+type SubscriberKey = (Option<String>, AssemblyId);
 
 /// Number of recent events retained per subscriber for replay-on-reconnect.
 const REPLAY_RING_CAPACITY: usize = 1024;
@@ -47,13 +54,16 @@ struct Subscriber {
 }
 
 /// Why [`InvalidationHub::subscribe`] refused to register a subscription.
+///
+/// Retained for API stability. As of AAASM-3997 the subscriber map is keyed by
+/// `(tenant, assembly_id)`, so a cross-tenant `assembly_id` clash no longer
+/// collides onto one slot — the two callers get independent subscribers — and
+/// this error is never returned in practice.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubscribeError {
     /// The `assembly_id` is already registered under a different tenant than the
-    /// authenticated caller. Reusing the slot would attach this caller's
-    /// receiver to the existing tenant's broadcast channel (leaking its events)
-    /// and let this caller's acks trim that tenant's replay ring. Fail-closed:
-    /// the subscription is refused (AAASM-3914).
+    /// authenticated caller. Superseded by per-tenant keying (AAASM-3997); kept
+    /// so the `subscribe` signature and its callers stay source-compatible.
     TenantMismatch,
 }
 
@@ -71,7 +81,7 @@ pub struct SubscriptionHandle {
 /// Assembly and buffers them for replay across reconnects.
 #[derive(Default)]
 pub struct InvalidationHub {
-    subscribers: RwLock<HashMap<AssemblyId, Arc<Subscriber>>>,
+    subscribers: RwLock<HashMap<SubscriberKey, Arc<Subscriber>>>,
 }
 
 /// Decide whether a subscriber is entitled to an event, given the subscriber's
@@ -106,13 +116,16 @@ impl InvalidationHub {
     /// scope tenant-bound events to their owning tenant. On reconnect the
     /// originally-registered tenant is retained.
     ///
-    /// Returns [`SubscribeError::TenantMismatch`] when `assembly_id` is already
-    /// registered under a tenant other than `tenant` (AAASM-3914). The match is
-    /// exact: an untenanted slot (`None`) may not be claimed by a tenant, nor a
-    /// tenanted slot by an untenanted caller — any mismatch is fail-closed, so a
-    /// caller can never attach to another tenant's channel or trim its ring. A
-    /// reconnect by the same tenant (the common `None == None` cold-start case
-    /// included) is permitted and resumes from `last_seq_seen`.
+    /// Subscribers are keyed by `(tenant, assembly_id)` (AAASM-3997), so two
+    /// different tenants that pick the same `assembly_id` get independent slots:
+    /// neither can attach to the other's channel or trim its ring, and — unlike
+    /// the earlier reject-on-clash approach (AAASM-3914) — a tenant can no longer
+    /// deny another tenant service by squatting its `assembly_id`. A reconnect by
+    /// the same tenant with the same id reuses the existing slot and resumes from
+    /// `last_seq_seen`.
+    ///
+    /// The `Result` return is retained for API compatibility;
+    /// [`SubscribeError::TenantMismatch`] is no longer produced.
     pub fn subscribe(
         &self,
         assembly_id: impl Into<AssemblyId>,
@@ -120,20 +133,13 @@ impl InvalidationHub {
         last_seq_seen: u64,
     ) -> Result<SubscriptionHandle, SubscribeError> {
         let assembly_id = assembly_id.into();
+        let key: SubscriberKey = (tenant.clone(), assembly_id);
         let mut subscribers = self
             .subscribers
             .write()
             .expect("invalidation subscribers lock poisoned");
-        // Fail-closed: an existing subscriber bound to a different tenant must
-        // not be re-bound to this caller, or its events would leak to — and its
-        // replay ring be trimmed by — the wrong tenant (AAASM-3914).
-        if let Some(existing) = subscribers.get(&assembly_id) {
-            if existing.tenant != tenant {
-                return Err(SubscribeError::TenantMismatch);
-            }
-        }
         let subscriber = subscribers
-            .entry(assembly_id)
+            .entry(key)
             .or_insert_with(|| {
                 let (tx, _rx) = broadcast::channel(SUBSCRIBER_CHANNEL_CAPACITY);
                 Arc::new(Subscriber {
@@ -244,10 +250,15 @@ impl InvalidationHub {
 
     /// Trim a subscriber's replay ring up to and including `seq`, in response to
     /// a `SubscribeAck`. Advances the low-water mark so acknowledged events are
-    /// not replayed again. Unknown `assembly_id`s are ignored.
-    pub fn ack(&self, assembly_id: &str, seq: u64) {
+    /// not replayed again. Unknown `(tenant, assembly_id)` keys are ignored.
+    ///
+    /// `tenant` must match the tenant the subscription was registered under
+    /// (AAASM-3997): a caller can only trim its own `(tenant, assembly_id)` ring,
+    /// never another tenant's slot sharing the same `assembly_id`.
+    pub fn ack(&self, tenant: Option<&str>, assembly_id: &str, seq: u64) {
         let subscribers = self.subscribers.read().expect("invalidation subscribers lock poisoned");
-        if let Some(subscriber) = subscribers.get(assembly_id) {
+        let key: SubscriberKey = (tenant.map(str::to_string), assembly_id.to_string());
+        if let Some(subscriber) = subscribers.get(&key) {
             let mut ring = subscriber.ring.lock().expect("replay ring lock poisoned");
             while ring.front().is_some_and(|event| event.seq <= seq) {
                 ring.pop_front();
@@ -340,7 +351,7 @@ mod tests {
         hub.broadcast_policy_invalidated("agent-a", 1);
         hub.broadcast_policy_invalidated("agent-b", 2);
 
-        hub.ack("asm-1", 1);
+        hub.ack(None, "asm-1", 1);
 
         // After acking seq 1, a cold reconnect only replays seq 2.
         let reconnect = hub.subscribe("asm-1", None, 0).expect("subscribe succeeds");
@@ -427,26 +438,27 @@ mod tests {
         );
     }
 
-    /// AAASM-3914 regression: a Subscribe whose `assembly_id` already belongs to
-    /// another tenant is refused, so the caller can neither attach to the
-    /// victim's broadcast channel nor trim its replay ring.
+    /// AAASM-3997 regression: two tenants sharing the same `assembly_id` get
+    /// independent slots. The attacker who subscribes first cannot deny the
+    /// victim service (availability), and neither can read the other's events
+    /// (confidentiality). Supersedes the earlier reject-on-clash behaviour.
     #[tokio::test]
-    async fn subscribe_rejects_cross_tenant_assembly_id_reuse() {
+    async fn subscribe_isolates_cross_tenant_same_assembly_id() {
         let hub = InvalidationHub::new();
+
+        // Attacker in team-b squats the shared assembly_id first.
+        let mut attacker = hub
+            .subscribe("asm-shared", Some("team-b".to_string()), 0)
+            .expect("attacker subscribe succeeds");
+
+        // The victim in team-a with the SAME assembly_id is NOT denied service:
+        // it gets its own independent subscriber slot (availability preserved).
         let mut victim = hub
             .subscribe("asm-shared", Some("team-a".to_string()), 0)
-            .expect("victim subscribe succeeds");
+            .expect("victim subscribe is not blocked by the squatter");
+        assert_eq!(hub.subscriber_count(), 2, "each tenant holds its own slot");
 
-        // Attacker in team-b knows team-a's assembly_id; binding is refused.
-        let attacker = hub.subscribe("asm-shared", Some("team-b".to_string()), 0);
-        assert!(matches!(attacker, Err(SubscribeError::TenantMismatch)));
-
-        // An untenanted caller likewise may not claim a tenanted slot.
-        let untenanted = hub.subscribe("asm-shared", None, 0);
-        assert!(matches!(untenanted, Err(SubscribeError::TenantMismatch)));
-
-        // The victim's own event still flows to the victim only; the rejected
-        // attacker never received a handle, so nothing leaked.
+        // team-a's event reaches only the victim, never the attacker's channel.
         hub.broadcast_approval_resolved("req-a", Decision::Approved, Some("team-a"));
         let event = tokio::time::timeout(Duration::from_millis(100), victim.receiver.recv())
             .await
@@ -454,8 +466,19 @@ mod tests {
             .expect("channel open");
         assert_eq!(event.seq, 1);
 
-        // The attacker's rejection left no extra subscriber registered.
-        assert_eq!(hub.subscriber_count(), 1);
+        // The attacker (team-b) must NOT receive team-a's event.
+        let leaked = tokio::time::timeout(Duration::from_millis(50), attacker.receiver.recv()).await;
+        assert!(leaked.is_err(), "attacker must not receive the victim's event");
+
+        // The victim's ack trims only the victim's ring, not the attacker's.
+        hub.ack(Some("team-a"), "asm-shared", 1);
+        let attacker_reconnect = hub
+            .subscribe("asm-shared", Some("team-b".to_string()), 0)
+            .expect("attacker reconnect succeeds");
+        assert!(
+            attacker_reconnect.replay.is_empty(),
+            "attacker's ring is independent and was never populated with team-a's event"
+        );
     }
 
     /// AAASM-3914 regression: the legitimate reconnect path — same tenant, same

--- a/aa-gateway/src/invalidation/service.rs
+++ b/aa-gateway/src/invalidation/service.rs
@@ -76,9 +76,11 @@ impl InvalidationService for InvalidationServiceImpl {
             _ => 0,
         };
 
-        // Fail-closed (AAASM-3914): the hub refuses to bind this stream to an
-        // `assembly_id` already registered under a different tenant, so a caller
-        // cannot hijack another tenant's events or trim its replay ring.
+        // AAASM-3997: the hub keys subscribers by `(tenant, assembly_id)`, so a
+        // cross-tenant `assembly_id` clash yields an independent slot rather than
+        // hijacking (or being denied service by) another tenant's subscription.
+        // The `tenant` is also needed to trim the correct ring on Ack below.
+        let tenant_for_ack = tenant.clone();
         let handle = self.hub.subscribe(assembly_id.clone(), tenant, last_seq_seen).map_err(
             |super::SubscribeError::TenantMismatch| {
                 Status::permission_denied("assembly_id is registered to a different tenant")
@@ -90,7 +92,7 @@ impl InvalidationService for InvalidationServiceImpl {
         tokio::spawn(async move {
             while let Ok(Some(message)) = inbound.message().await {
                 if let Some(Kind::Ack(ack)) = message.kind {
-                    hub.ack(&assembly_id, ack.seq);
+                    hub.ack(tenant_for_ack.as_deref(), &assembly_id, ack.seq);
                 }
             }
         });

--- a/aa-gateway/src/ops/nats.rs
+++ b/aa-gateway/src/ops/nats.rs
@@ -152,18 +152,32 @@ fn subject_authorizes_envelope(subject: &str, envelope: &OpControlWireEnvelope) 
     subject_for(envelope) == subject
 }
 
-/// Replace every character outside `[A-Za-z0-9_-]` with `_` so the result is a
-/// single valid NATS subject token (NATS reserves `.`, `*`, `>` and whitespace).
+/// Encode `raw` into a single valid NATS subject token
+/// (NATS reserves `.`, `*`, `>` and whitespace) **injectively** (AAASM-3997).
+///
+/// The previous implementation replaced every character outside `[A-Za-z0-9_-]`
+/// with `_`, which is lossy: `acme.corp`, `acme corp` and the literal
+/// `acme_corp` all collapsed to `acme_corp` and therefore to the *same* subject.
+/// For the op-control kill switch that is a cross-tenant hazard — a halt for one
+/// tenant would be delivered on a subject a colliding tenant name also maps to.
+///
+/// This encoding is collision-free: ASCII alphanumerics and `-` pass through
+/// unchanged, and every other byte (including `_` itself) is escaped as
+/// `_HH` (uppercase hex of the byte). Because a literal `_` is always escaped,
+/// `_` in the output unambiguously starts a 2-hex escape, so distinct inputs
+/// always produce distinct tokens. The output alphabet is `[A-Za-z0-9_-]`, a
+/// valid single NATS subject token.
 fn sanitize_token(raw: &str) -> String {
-    raw.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
+    let mut out = String::with_capacity(raw.len());
+    for b in raw.bytes() {
+        if b.is_ascii_alphanumeric() || b == b'-' {
+            out.push(b as char);
+        } else {
+            out.push('_');
+            out.push_str(&format!("{b:02X}"));
+        }
+    }
+    out
 }
 
 /// Errors raised by the op-control NATS publisher and bridge.
@@ -849,6 +863,8 @@ mod tests {
 
     #[test]
     fn subject_sanitizes_unsafe_tokens_and_falls_back_for_empty_agent() {
+        // Unsafe bytes are hex-escaped (`_HH`) rather than flattened to `_`, so
+        // the encoding is injective. ' ' -> _20, '.' -> _2E.
         let dotted = env(
             false,
             "acme corp.eu",
@@ -857,10 +873,48 @@ mod tests {
             "agent:bot.7",
             OpControlSignal::Terminate,
         );
-        assert_eq!(subject_for(&dotted), "assembly.opcontrol.acme_corp_eu.bot_7");
+        assert_eq!(subject_for(&dotted), "assembly.opcontrol.acme_20corp_2Eeu.bot_2E7");
 
         let no_agent = env(false, "acme", "", "", "*", OpControlSignal::Terminate);
         assert_eq!(subject_for(&no_agent), "assembly.opcontrol.acme.unknown");
+    }
+
+    #[test]
+    fn distinct_tenant_ids_never_collide_onto_one_subject() {
+        // AAASM-3997: the old lossy `_`-substitution mapped all of these tenant
+        // ids to the same subject, so a halt for one could be delivered on a
+        // subject a colliding tenant also mapped to. The injective encoding must
+        // give each a distinct subject.
+        let make = |org: &str| subject_for(&env(false, org, "", "bot-7", "agent:bot-7", OpControlSignal::Terminate));
+        let dotted = make("acme.corp");
+        let spaced = make("acme corp");
+        let underscored = make("acme_corp");
+        let plain = make("acmecorp");
+
+        // All four are pairwise distinct.
+        let all = [&dotted, &spaced, &underscored, &plain];
+        for i in 0..all.len() {
+            for j in (i + 1)..all.len() {
+                assert_ne!(all[i], all[j], "tenant subjects collided: {} == {}", all[i], all[j]);
+            }
+        }
+
+        // And each remains a single, safe NATS subject token (no `.`/`*`/`>`/space
+        // inside the tenant position).
+        for s in all {
+            let tenant = s
+                .strip_prefix("assembly.opcontrol.")
+                .unwrap()
+                .split('.')
+                .next()
+                .unwrap();
+            assert!(
+                tenant
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_'),
+                "tenant token is not subject-safe: {tenant}"
+            );
+        }
     }
 
     #[test]

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -89,6 +89,29 @@ fn build_jsonrpc_error_response(code: i32, message: &str) -> String {
     format!(r#"{{"jsonrpc":"2.0","id":null,"error":{{"code":{code},"message":{msg_json}}}}}"#)
 }
 
+/// Fail-closed client response for an MCP upstream response the proxy could not
+/// parse (chunked / malformed) and therefore could not scan for secrets
+/// (AAASM-3997).
+///
+/// The pre-3997 behaviour relayed the un-parsed upstream bytes verbatim, which
+/// leaked an *unredacted* upstream body straight to the agent — defeating
+/// response-side credential redaction on any response the parser chokes on.
+/// Rather than forward bytes we never inspected, return a JSON-RPC error
+/// envelope so the agent gets a clean, secret-free failure. The returned bytes
+/// never contain any upstream content.
+fn mcp_unparseable_response_bytes() -> Vec<u8> {
+    let body = build_jsonrpc_error_response(
+        -32000,
+        "MCP response could not be inspected for secrets and was withheld (fail-closed)",
+    );
+    format!(
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body,
+    )
+    .into_bytes()
+}
+
 /// The running proxy server.
 ///
 /// Create via [`ProxyServer::new`], then drive the accept loop with
@@ -527,18 +550,28 @@ impl ProxyServer {
                     // Upstream closed without writing a response — nothing to forward.
                 }
                 Err(e) => {
-                    // Could not parse the response (e.g. chunked, malformed) —
-                    // relay the remaining upstream bytes to the client. AAASM-3864
-                    // (a): we relay only upstream→client, never copying further
-                    // client bytes upstream, so no follow-up request can reach
-                    // upstream un-inspected.
+                    // AAASM-3997: an MCP response we cannot parse cannot be
+                    // scanned or redacted. Relaying the un-parsed upstream bytes
+                    // (the pre-3997 behaviour) would leak an *unredacted* body —
+                    // potentially carrying credentials the response-side scanner
+                    // would have stripped — straight to the agent. Fail closed:
+                    // withhold the upstream body and return a JSON-RPC error
+                    // envelope instead. (We still never copy client→upstream, so
+                    // AAASM-3864's no-uninspected-request property holds.)
                     tracing::warn!(
                         tool_name = %call.tool_name,
                         error = %e,
-                        "MCP response parse failed, relaying remaining upstream bytes",
+                        "MCP response parse failed; withholding unredacted upstream body (fail-closed)",
                     );
-                    let mut upstream_read = upstream_reader.into_inner();
-                    tokio::io::copy(&mut upstream_read, &mut client_tls).await?;
+                    self.interceptor
+                        .emit_mcp_decision(
+                            &call.tool_name,
+                            &args_bytes,
+                            true,
+                            "response unparseable, withheld (fail-closed)",
+                        )
+                        .await;
+                    client_tls.write_all(&mcp_unparseable_response_bytes()).await?;
                 }
             }
         } else {
@@ -1099,6 +1132,30 @@ fn parse_plain_http_host(target: &str, headers: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unparseable_mcp_response_is_fail_closed_and_carries_no_upstream_bytes() {
+        // AAASM-3997: the fail-closed response for an unparseable MCP upstream
+        // response must be a clean JSON-RPC error envelope, never a passthrough
+        // of upstream bytes (which could carry credentials the scanner never saw).
+        let bytes = mcp_unparseable_response_bytes();
+        let text = String::from_utf8(bytes).expect("valid UTF-8 HTTP response");
+
+        // A well-formed HTTP error response, not a relayed 200 upstream body.
+        assert!(text.starts_with("HTTP/1.1 502"), "expected a 502 status line: {text}");
+        assert!(
+            text.contains("\"jsonrpc\":\"2.0\""),
+            "expected a JSON-RPC error body: {text}"
+        );
+        assert!(text.contains("fail-closed"), "expected the fail-closed reason: {text}");
+
+        // The envelope is synthesized from constants only: a would-be leaked
+        // upstream secret can never appear in it.
+        assert!(
+            !text.contains("sk-LEAKED-UPSTREAM-SECRET"),
+            "fail-closed response must not echo upstream content"
+        );
+    }
 
     async fn server_with(denied_hosts: Vec<String>, allowlist: Vec<String>) -> Arc<ProxyServer> {
         let dir = tempfile::tempdir().unwrap();

--- a/aa-proxy/src/ssrf.rs
+++ b/aa-proxy/src/ssrf.rs
@@ -47,15 +47,31 @@ fn is_blocked_ipv4(v4: Ipv4Addr) -> bool {
         || v4.is_unspecified()
         // Carrier-grade NAT (100.64.0.0/10) — not globally routable.
         || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 0x40)
+        // "This network" (0.0.0.0/8) — non-routable source space; on many
+        // stacks 0.x.x.x is treated as loopback/local. `is_unspecified` only
+        // covers the single 0.0.0.0, so block the whole /8 (AAASM-3997).
+        || v4.octets()[0] == 0
 }
 
 fn is_blocked_ipv6(v6: Ipv6Addr) -> bool {
+    let seg = v6.segments();
     v6.is_loopback()
         || v6.is_unspecified()
         // Unique-local (fc00::/7).
-        || (v6.segments()[0] & 0xfe00) == 0xfc00
+        || (seg[0] & 0xfe00) == 0xfc00
         // Link-local (fe80::/10).
-        || (v6.segments()[0] & 0xffc0) == 0xfe80
+        || (seg[0] & 0xffc0) == 0xfe80
+        // NAT64 well-known prefix (64:ff9b::/96): embeds an IPv4 in the low 32
+        // bits that a translator forwards to — an attacker can embed an
+        // internal IPv4 here, so reject the whole prefix (AAASM-3997).
+        || (seg[0] == 0x0064 && seg[1] == 0xff9b && seg[2] == 0 && seg[3] == 0 && seg[4] == 0 && seg[5] == 0)
+        // 6to4 (2002::/16): embeds an IPv4 in seg[1..3] that could be internal;
+        // reject the whole range rather than trust the embedded address.
+        || seg[0] == 0x2002
+        // IPv4-compatible IPv6 (::/96, deprecated): the low 32 bits are an IPv4
+        // literal, so `::a.b.c.d` could smuggle an internal v4. `::`/`::1` are
+        // already covered above; this catches the rest of ::/96.
+        || (seg[0] == 0 && seg[1] == 0 && seg[2] == 0 && seg[3] == 0 && seg[4] == 0 && seg[5] == 0)
 }
 
 /// When `host` is an IP literal, returns whether it is blocked. Returns `None`
@@ -102,10 +118,43 @@ mod tests {
     }
 
     #[test]
+    fn this_network_0_0_0_0_8_is_blocked() {
+        // 0.0.0.0/8 — "this network"; not just the single unspecified address.
+        assert!(is_blocked_ip("0.0.0.0".parse().unwrap()));
+        assert!(is_blocked_ip("0.1.2.3".parse().unwrap()));
+        assert!(is_blocked_ip("0.255.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn nat64_well_known_prefix_is_blocked() {
+        // 64:ff9b::/96 embedding 10.0.0.1 and 169.254.169.254.
+        assert!(is_blocked_ip("64:ff9b::a00:1".parse().unwrap()));
+        assert!(is_blocked_ip("64:ff9b::a9fe:a9fe".parse().unwrap()));
+        assert!(is_blocked_ip("64:ff9b::".parse().unwrap()));
+    }
+
+    #[test]
+    fn six_to_four_2002_16_is_blocked() {
+        // 2002::/16 (6to4) embedding a private and a metadata v4.
+        assert!(is_blocked_ip("2002:0a00:0001::1".parse().unwrap()));
+        assert!(is_blocked_ip("2002:a9fe:a9fe::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ipv4_compatible_ipv6_is_blocked() {
+        // ::/96 (deprecated IPv4-compatible) — low 32 bits are an IPv4 literal.
+        assert!(is_blocked_ip("::a00:1".parse().unwrap())); // ::10.0.0.1
+        assert!(is_blocked_ip("::a9fe:a9fe".parse().unwrap())); // ::169.254.169.254
+        assert!(is_blocked_ip("::808:808".parse().unwrap())); // ::8.8.8.8 — still deprecated space
+    }
+
+    #[test]
     fn public_ips_are_allowed() {
         assert!(!is_blocked_ip("1.1.1.1".parse().unwrap()));
         assert!(!is_blocked_ip("8.8.8.8".parse().unwrap()));
         assert!(!is_blocked_ip("2606:4700:4700::1111".parse().unwrap()));
+        // A global IPv6 that merely starts with 0x20 (but is not 6to4/2002) stays allowed.
+        assert!(!is_blocked_ip("2001:4860:4860::8888".parse().unwrap()));
     }
 
     #[test]

--- a/aa-security/src/policy/error.rs
+++ b/aa-security/src/policy/error.rs
@@ -34,6 +34,13 @@ pub enum PolicyParseError {
         /// The unrecognised key.
         key: String,
     },
+    /// The document was empty or null.
+    ///
+    /// An empty / null / `{}` policy deserializes to an all-`None` document,
+    /// which is fully permissive (no capability denials, no allowlist, no tool
+    /// gating). A policy must positively declare its posture, so a blank
+    /// document is rejected rather than silently defaulting open (AAASM-3997).
+    EmptyDocument,
 }
 
 impl fmt::Display for PolicyParseError {
@@ -48,6 +55,12 @@ impl fmt::Display for PolicyParseError {
             }
             Self::UnknownKey { path, key } => {
                 write!(f, "unknown policy key {key:?} under {path}")
+            }
+            Self::EmptyDocument => {
+                write!(
+                    f,
+                    "empty or null policy document is not permitted (would be fully permissive)"
+                )
             }
         }
     }

--- a/aa-security/src/policy/parse.rs
+++ b/aa-security/src/policy/parse.rs
@@ -83,6 +83,15 @@ impl PolicyDocument {
         // successfully (AAASM-3874).
         let value: serde_yaml::Value =
             serde_yaml::from_str(yaml_str).map_err(|e| PolicyParseError::Yaml(e.to_string()))?;
+        // AAASM-3997: an empty / null / `{}` document deserializes to an
+        // all-`None` (fully-permissive) policy. Reject it here — the gateway load
+        // path has no live caller that guards against this, so parsing must be
+        // the fail-closed floor: a policy must positively declare its posture.
+        match &value {
+            serde_yaml::Value::Null => return Err(PolicyParseError::EmptyDocument),
+            serde_yaml::Value::Mapping(map) if map.is_empty() => return Err(PolicyParseError::EmptyDocument),
+            _ => {}
+        }
         validate_schema(&value)?;
         let env: raw::Envelope = serde_yaml::from_value(value).map_err(|e| PolicyParseError::Yaml(e.to_string()))?;
 
@@ -339,6 +348,19 @@ spec:
     fn rejects_malformed_yaml() {
         let err = PolicyDocument::from_yaml("spec: [unclosed").unwrap_err();
         assert!(matches!(err, PolicyParseError::Yaml(_)));
+    }
+
+    #[test]
+    fn rejects_empty_or_null_document() {
+        // AAASM-3997: a blank document parsed to a fully-permissive policy. It
+        // must now fail closed instead of defaulting open.
+        for blank in ["", "   \n  ", "null", "~", "{}"] {
+            let err = PolicyDocument::from_yaml(blank).unwrap_err();
+            assert!(
+                matches!(err, PolicyParseError::EmptyDocument),
+                "blank input {blank:?} should be rejected as empty, got {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -396,6 +396,10 @@ impl CredentialScanner {
         // Phase 4: High-entropy / long-hex tokens (encoding & length evasions, AAASM-3870)
         scan_high_entropy(text, &mut findings);
 
+        // Phase 5: Azure `AccountKey=` values wherever they appear in a
+        //          connection string (AAASM-3997).
+        scan_azure_account_key(text, &mut findings);
+
         findings.sort_by_key(|f| f.offset);
         ScanResult { findings }
     }
@@ -452,6 +456,38 @@ fn coalesce_findings(findings: &[CredentialFinding]) -> Vec<MergedSpan> {
         }
     }
     merged
+}
+
+/// Redact the secret value of every Azure `AccountKey=<value>` in `text`,
+/// regardless of its position in a connection string (AAASM-3997).
+///
+/// The `DefaultEndpointsProtocol=` prefix detector coalesces its span only up to
+/// the first `;` (see [`token_end`]), so in a canonical
+/// `DefaultEndpointsProtocol=...;AccountName=...;AccountKey=<secret>` string the
+/// `AccountKey` — which sits after two `;` separators — was left in the clear.
+/// This pass targets the key's value directly: it spans from the `AccountKey=`
+/// marker to the next `;`, token terminator, or end of input, so the secret is
+/// redacted wherever it falls in the string.
+fn scan_azure_account_key(text: &str, findings: &mut Vec<CredentialFinding>) {
+    const MARKER: &str = "AccountKey=";
+    let mut search_from = 0;
+    while let Some(rel) = text[search_from..].find(MARKER) {
+        let offset = search_from + rel;
+        let value_start = offset + MARKER.len();
+        // The value ends at the next connection-string delimiter (`;`), a
+        // whitespace/quote/bracket token terminator, or the end of the input.
+        let end = text[value_start..]
+            .find(|c: char| c.is_whitespace() || matches!(c, ';' | '"' | '\'' | ',' | ')' | ']' | '}'))
+            .map(|i| value_start + i)
+            .unwrap_or(text.len());
+        findings.push(CredentialFinding::new(
+            CredentialKind::AzureConnectionString,
+            offset,
+            end,
+        ));
+        // Advance past this marker (at least) so overlapping/repeated keys still progress.
+        search_from = end.max(value_start);
+    }
 }
 
 /// Returns the byte index of the first token-terminating character at or after
@@ -899,6 +935,30 @@ mod tests {
             .findings
             .iter()
             .any(|f| f.kind == CredentialKind::AzureConnectionString));
+    }
+
+    #[test]
+    fn redacts_azure_account_key_value_after_semicolons() {
+        // AAASM-3997: the `DefaultEndpointsProtocol=` prefix detector stops at the
+        // first `;`, so the AccountKey — which appears two segments later — used to
+        // survive redaction in the clear. The dedicated AccountKey pass must redact
+        // the secret wherever it falls in the connection string.
+        let scanner = CredentialScanner::new();
+        let secret = "abc123DEF456ghi789JKL012mno345PQR678stu901VWX234yz==";
+        let input = format!(
+            "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey={secret};EndpointSuffix=core.windows.net"
+        );
+        let redacted = scanner.scan(&input).redact(&input);
+        assert!(
+            !redacted.contains(secret),
+            "Azure AccountKey secret leaked past redaction: {redacted}"
+        );
+        assert!(
+            redacted.contains("[REDACTED:AzureConnectionString]"),
+            "expected an AzureConnectionString redaction label: {redacted}"
+        );
+        // The trailing segment after the key is preserved (only the value is redacted).
+        assert!(redacted.contains("EndpointSuffix=core.windows.net"));
     }
 
     // --- Database URL patterns ---

--- a/aa-storage/src/config.rs
+++ b/aa-storage/src/config.rs
@@ -1,6 +1,7 @@
 //! [`StorageConfig`] — the `[storage]` section of `agent-assembly.toml`.
 
 use std::collections::HashMap;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
@@ -30,7 +31,15 @@ use crate::DriverName;
 /// and handed verbatim to that driver's factory.
 ///
 /// [`drivers`]: StorageConfig::drivers
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `Debug` is implemented by hand rather than derived: the per-driver
+/// [`drivers`](StorageConfig::drivers) sections hold raw `toml::Value` tables that
+/// typically carry a driver's connection string (e.g. `url =
+/// "postgresql://user:password@host/db"`). A derived `Debug` would render those
+/// DSNs verbatim into any log line that formats a `StorageConfig`, leaking the
+/// embedded credentials. The manual impl below redacts every driver section's
+/// value, printing only its name (AAASM-3997).
+#[derive(Clone, Serialize, Deserialize)]
 pub struct StorageConfig {
     /// Driver backing the [`PolicyStore`](crate::PolicyStore).
     pub policy_store: DriverName,
@@ -56,5 +65,86 @@ impl StorageConfig {
     /// Return the `[storage.<name>]` subsection for `name`, if present.
     pub fn driver_section(&self, name: &DriverName) -> Option<&toml::Value> {
         self.drivers.get(name)
+    }
+}
+
+impl fmt::Debug for StorageConfig {
+    /// Redacting `Debug`: renders the driver-kind selections but replaces every
+    /// `[storage.<name>]` section's raw value with `<redacted>` so a connection
+    /// string (and any credentials embedded in it) can never reach a log line
+    /// (AAASM-3997).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageConfig")
+            .field("policy_store", &self.policy_store)
+            .field("audit_sink", &self.audit_sink)
+            .field("session_store", &self.session_store)
+            .field("credential_store", &self.credential_store)
+            .field("rate_limit_counter", &self.rate_limit_counter)
+            .field("lifecycle_store", &self.lifecycle_store)
+            .field("drivers", &RedactedDrivers(&self.drivers))
+            .finish()
+    }
+}
+
+/// `Debug` adapter that prints the driver-section names but redacts their raw
+/// `toml::Value` contents (which carry DSNs / credentials).
+struct RedactedDrivers<'a>(&'a HashMap<DriverName, toml::Value>);
+
+impl fmt::Debug for RedactedDrivers<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut map = f.debug_map();
+        for name in self.0.keys() {
+            map.key(name).value(&"<redacted>");
+        }
+        map.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_config(drivers: HashMap<DriverName, toml::Value>) -> StorageConfig {
+        StorageConfig {
+            policy_store: DriverName::new("redis"),
+            audit_sink: DriverName::new("postgres"),
+            session_store: DriverName::new("redis"),
+            credential_store: DriverName::new("postgres"),
+            rate_limit_counter: DriverName::new("redis"),
+            lifecycle_store: DriverName::new("postgres"),
+            drivers,
+        }
+    }
+
+    #[test]
+    fn debug_redacts_driver_connection_strings() {
+        let mut drivers = HashMap::new();
+        let mut section = toml::value::Table::new();
+        section.insert(
+            "url".to_string(),
+            toml::Value::String("postgresql://admin:s3cr3t-pw@db.internal:5432/assembly".to_string()),
+        );
+        drivers.insert(DriverName::new("postgres"), toml::Value::Table(section));
+        let config = base_config(drivers);
+
+        let rendered = format!("{config:?}");
+        // The DSN and the password embedded in it must never render.
+        assert!(
+            !rendered.contains("s3cr3t-pw"),
+            "connection-string password leaked into Debug output: {rendered}"
+        );
+        assert!(
+            !rendered.contains("postgresql://"),
+            "connection string leaked into Debug output: {rendered}"
+        );
+        // The driver name and a redaction marker are still shown for diagnostics.
+        assert!(
+            rendered.contains("<redacted>"),
+            "expected a redaction marker: {rendered}"
+        );
+        assert!(
+            rendered.contains("postgres"),
+            "driver name should still render: {rendered}"
+        );
     }
 }

--- a/conformance/vectors/credential_detection/api_keys_azure.json
+++ b/conformance/vectors/credential_detection/api_keys_azure.json
@@ -1,8 +1,9 @@
 {
-  "description": "Azure storage connection string — identified by DefaultEndpointsProtocol= prefix",
+  "description": "Azure storage connection string — DefaultEndpointsProtocol= prefix and the AccountKey= secret value are both redacted (AAASM-3997)",
   "input_text": "AZURE_CONN=DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=XXXX",
   "expected_findings": [
-    { "kind": "AzureConnectionString", "offset": 11 }
+    { "kind": "AzureConnectionString", "offset": 11 },
+    { "kind": "AzureConnectionString", "offset": 64 }
   ],
-  "expected_redacted": "AZURE_CONN=[REDACTED:AzureConnectionString];AccountName=myaccount;AccountKey=XXXX"
+  "expected_redacted": "AZURE_CONN=[REDACTED:AzureConnectionString];AccountName=myaccount;[REDACTED:AzureConnectionString]"
 }


### PR DESCRIPTION
## What

A batch of small, independent defense-in-depth hardening fixes across storage, proxy, scanner, cache, and gateway. One commit per item; all are LOW-severity, none has a live-exploit call site under current code paths.

| Item | Area | What / Why | How verified |
|---|---|---|---|
| (a) | `aa-storage` config | Aggregate `StorageConfig` derived `Debug` over raw `toml::Value` driver sections → latent plaintext-DSN leak if logged. Hand-written redacting `Debug` renders `<redacted>` for every `[storage.<name>]` value. | `config::tests::debug_redacts_driver_connection_strings` |
| (b) | `aa-proxy` SSRF | Blocklist missed `0.0.0.0/8`, NAT64 `64:ff9b::/96`, 6to4 `2002::/16`, IPv4-compatible `::/96` — each can encode an internal IPv4. Added all ranges. | 4 new range tests + public-IP allow test in `ssrf::tests` |
| (c) | `aa-security` scanner | Azure connection-string redaction stopped at the first `;`, leaving `AccountKey=` in the clear. Added a dedicated pass that redacts the `AccountKey` value wherever it appears. | `scanner::tests::redacts_azure_account_key_value_after_semicolons` |
| (d) | `aa-proxy` MCP response | Response-side redaction was bypassed on an unparseable/chunked upstream response (relayed verbatim). Now fails closed: withholds the body, returns a JSON-RPC error envelope. | `proxy::tests::unparseable_mcp_response_is_fail_closed_and_carries_no_upstream_bytes` |
| (e) | `aa-cache` L1 | Unbounded L1 cache (no eviction). Added a `max_entries` ceiling with expired-then-oldest eviction, layered without disturbing the AAASM-3985 invalidation-epoch/guarded-insert logic (eviction is epoch-independent, runs off the shard guard). | `l1::tests::cache_is_bounded_by_max_entries` + all AAASM-3985 epoch tests still green |
| (f) | `aa-security` policy parse | Empty/null/`{}` policy document parsed to a fully-permissive `PolicyDocument`. Confirmed no live gateway caller of `PolicyDocument::from_yaml` guards this, so parse now fails closed with `PolicyParseError::EmptyDocument`. | `parse::tests::rejects_empty_or_null_document` |
| (g) | `aa-gateway` ops/nats | `sanitize_token` was lossy (`.`/space/`_` all → `_`), so distinct tenant ids collided onto one op-control subject → cross-tenant halt. Replaced with injective `_HH` hex-escaping. | `nats::tests::distinct_tenant_ids_never_collide_onto_one_subject` (+ updated existing subject tests) |
| (h) | `aa-gateway` invalidation/hub | Subscribers keyed by bare `assembly_id` (global namespace) → cross-tenant squat blocked victim push-invalidation (availability). Now keyed by `(tenant, assembly_id)`: clashing ids get independent, isolated slots. `ack` threads tenant. | `hub::tests::subscribe_isolates_cross_tenant_same_assembly_id` |

No item was skipped as a false positive — all eight reproduced on real master `63e04150`.

## How to verify

```
cargo nextest run -p aa-storage -p aa-proxy -p aa-security -p aa-cache -p aa-gateway
cargo clippy -p aa-storage -p aa-proxy -p aa-security -p aa-cache -p aa-gateway --all-targets -- -D warnings
```

1676 tests pass (3 skipped); clippy clean; `cargo fmt --all` applied.

Closes AAASM-3997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73