### PR TITLE
[AAASM-3995] 🐛 (aa-gateway): Policy-plane authz & context fail-closed hardening

### DIFF
--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -10,7 +10,7 @@ use aa_gateway::policy::rbac::MutationKind;
 use aa_gateway::policy::scope::PolicyScope;
 
 use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
-use crate::auth::scope::RequireRead;
+use crate::auth::scope::{RequireRead, Scope};
 use crate::error::ProblemDetail;
 use crate::pagination::{PaginatedResponse, PaginationParams};
 use crate::state::AppState;
@@ -50,18 +50,29 @@ pub struct PolicyListFilter {
     path = "/api/v1/policies",
     params(PaginationParams, PolicyListFilter),
     responses(
-        (status = 200, description = "Paginated list of policy versions", body = Vec<PolicyResponse>)
+        (status = 200, description = "Paginated list of policy versions", body = Vec<PolicyResponse>),
+        (status = 403, description = "Caller lacks admin scope")
     ),
     tag = "policies"
 )]
 pub async fn list_policies(
     // AAASM-3865: governance policy YAML is sensitive; require read scope so an
     // unauthenticated caller cannot dump the full policy set.
-    RequireRead(_caller): RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     axum::extract::Query(params): axum::extract::Query<PaginationParams>,
     axum::extract::Query(filter): axum::extract::Query<PolicyListFilter>,
 ) -> Result<impl IntoResponse, ProblemDetail> {
+    // AAASM-3995(a): a policy version is a whole governance document spanning
+    // every tenant's cascade (global + org + team + agent rules), so it is not
+    // attributable to a single team/org that could be filtered per caller.
+    // Enumerating the full policy set therefore requires cross-tenant Admin
+    // scope; a plain Read caller must not be able to dump every tenant's rules.
+    if !caller.scopes.contains(&Scope::Admin) {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("listing policy versions requires admin scope".to_string()));
+    }
+
     let all = state
         .policy_history
         .list(usize::MAX)
@@ -216,15 +227,23 @@ impl IntoResponse for PolicyCreateError {
     path = "/api/v1/policies/active",
     responses(
         (status = 200, description = "Currently active policy", body = PolicyResponse),
+        (status = 403, description = "Caller lacks admin scope"),
         (status = 404, description = "No active policy loaded")
     ),
     tag = "policies"
 )]
 pub async fn get_active_policy(
     // AAASM-3865: the active policy YAML is sensitive; require read scope.
-    RequireRead(_caller): RequireRead,
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
 ) -> Result<(StatusCode, Json<PolicyResponse>), ProblemDetail> {
+    // AAASM-3995(a): the active policy is the full cross-tenant governance
+    // document; gate its raw YAML behind Admin scope, like the version list.
+    if !caller.scopes.contains(&Scope::Admin) {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("reading the active policy requires admin scope".to_string()));
+    }
+
     let info = state.policy_engine.active_policy_info();
 
     // No named policy is loaded — honour the 404 documented in the OpenAPI spec.

--- a/aa-api/tests/policies.rs
+++ b/aa-api/tests/policies.rs
@@ -2,6 +2,7 @@
 
 mod common;
 
+use aa_api::auth::scope::Scope;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
@@ -79,6 +80,67 @@ async fn create_policy_returns_400_for_invalid_yaml() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn list_policies_forbidden_for_read_only_caller() {
+    // AAASM-3995(a): policy versions are cross-tenant governance documents, so a
+    // plain Read caller must not be able to enumerate the full policy set.
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/policies")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn list_policies_allowed_for_admin_caller() {
+    let (token, entry) =
+        common::generate_test_api_key("admin-key", vec![Scope::Read, Scope::Write, Scope::Admin]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/policies")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn get_active_policy_forbidden_for_read_only_caller() {
+    // AAASM-3995(a): the active policy is the full cross-tenant document.
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/policies/active")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]

--- a/aa-api/tests/policies.rs
+++ b/aa-api/tests/policies.rs
@@ -105,8 +105,7 @@ async fn list_policies_forbidden_for_read_only_caller() {
 
 #[tokio::test]
 async fn list_policies_allowed_for_admin_caller() {
-    let (token, entry) =
-        common::generate_test_api_key("admin-key", vec![Scope::Read, Scope::Write, Scope::Admin]);
+    let (token, entry) = common::generate_test_api_key("admin-key", vec![Scope::Read, Scope::Write, Scope::Admin]);
     let app = common::test_app_with_auth(&[entry], 1000);
 
     let response = app

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -1103,9 +1103,11 @@ async fn get_active_policy_requires_authentication() {
     );
 }
 
-/// Positive control: an authenticated read caller may list policies.
+/// AAASM-3995(a): a policy version is a cross-tenant governance document, so a
+/// plain Read caller may no longer enumerate the full policy set — that now
+/// requires Admin scope.
 #[tokio::test]
-async fn list_policies_authenticated_read_caller_is_ok() {
+async fn list_policies_read_only_caller_is_403() {
     let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
     let app = aa_api::build_app(state);
 
@@ -1113,8 +1115,23 @@ async fn list_policies_authenticated_read_caller_is_ok() {
     let response = app.oneshot(bearer("/api/v1/policies", &token)).await.unwrap();
     assert_eq!(
         response.status(),
+        StatusCode::FORBIDDEN,
+        "a plain read caller must not enumerate cross-tenant policy versions"
+    );
+}
+
+/// Positive control: an Admin caller may list policies.
+#[tokio::test]
+async fn list_policies_admin_caller_is_ok() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("u", &[Scope::Read, Scope::Write, Scope::Admin]);
+    let response = app.oneshot(bearer("/api/v1/policies", &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
         StatusCode::OK,
-        "an authenticated read caller may list policies"
+        "an admin caller may list policy versions"
     );
 }
 

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1198,6 +1198,21 @@ impl PolicyEngine {
         None
     }
 
+    /// AAASM-3995(c) — whether any `requires_approval_if` in the cascade
+    /// references live runtime context (registry graph / budget state). Such
+    /// verdicts must not be served from the decision cache, whose key omits the
+    /// live context, or a context-dependent approval could be frozen for the
+    /// cache TTL.
+    fn cascade_has_live_context_approval(cascade: &[Arc<PolicyDocument>]) -> bool {
+        cascade.iter().any(|doc| {
+            doc.tools.values().any(|tp| {
+                tp.requires_approval_if
+                    .as_deref()
+                    .is_some_and(crate::policy::expr::references_live_context)
+            })
+        })
+    }
+
     /// Cascade evaluation path: runs `merge_decisions` across all scoped policies,
     /// then applies rate-limit (stage 4), budget (stage 7), and credential scan
     /// (stage 6) at the engine level.
@@ -1238,7 +1253,16 @@ impl PolicyEngine {
         });
         let pctx_dyn: Option<&dyn crate::policy::context::PolicyContext> = pctx.as_ref().map(|c| c as _);
 
-        let verdict = if let Some(cached) = self.decision_cache.get(&cache_key) {
+        // AAASM-3995(c): a `requires_approval_if` that references live runtime
+        // context (team.active_agents / team.budget_remaining / …) produces a
+        // verdict that changes as that context changes. The decision cache keys
+        // only on (agent, epoch, action), so caching such a verdict would freeze
+        // a context-dependent approval decision for the cache TTL. Evaluate those
+        // fresh — like the schedule stage above — instead of serving stale.
+        let context_dependent = Self::cascade_has_live_context_approval(&cascade);
+        let verdict = if context_dependent {
+            merge_decisions(&cascade, ctx, action, pctx_dyn)
+        } else if let Some(cached) = self.decision_cache.get(&cache_key) {
             cached
         } else {
             // Stages 1–3 and 5: stateless per-doc rules merged across cascade.
@@ -3719,5 +3743,64 @@ mod tests {
             },
             "unregistered agent falls back to ctx-supplied org lineage"
         );
+    }
+
+    #[test]
+    fn cascade_context_dependent_approval_is_not_frozen_by_decision_cache() {
+        // AAASM-3995(c): a `requires_approval_if` referencing live context
+        // (team.active_agents) must be re-evaluated as that context changes —
+        // not served stale from the decision cache, which keys only on
+        // (agent, epoch, action).
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("000-global.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: t-approval\n  version: \"0.1.0\"\n\
+             spec:\n  tools:\n    spawn:\n      allow: true\n      requires_approval_if: \"team.active_agents > 1\"\n",
+        )
+        .unwrap();
+        let budget = Arc::new(BudgetTracker::new(
+            crate::budget::PricingTable::default_table(),
+            None,
+            None,
+            chrono_tz::UTC,
+        ));
+        let registry = Arc::new(crate::registry::AgentRegistry::new());
+        registry
+            .register(registry_record([0x01; 16], "t", Some("o")))
+            .expect("register first member");
+        let engine = PolicyEngine::load_cascade_from_dir_with_budget(tmp.path(), budget)
+            .expect("cascade loads")
+            .with_registry(Arc::clone(&registry));
+
+        let mut ctx = make_ctx();
+        ctx.agent_id = AgentId::from_bytes([0x01; 16]);
+        ctx.team_id = Some("t".to_string());
+        let action = tool_call("spawn", "");
+
+        // One team member: `1 > 1` is false → Allow (evaluated fresh).
+        assert_eq!(
+            engine.evaluate(&ctx, &action).decision,
+            PolicyResult::Allow,
+            "one team member is under the approval threshold"
+        );
+
+        // A second team member joins; live context now crosses the threshold.
+        registry
+            .register(registry_record([0x02; 16], "t", Some("o")))
+            .expect("register second member");
+
+        // Two members: `2 > 1` is true → RequiresApproval. A cache that froze the
+        // earlier Allow (same agent/epoch/action) would wrongly still allow.
+        assert!(
+            matches!(
+                engine.evaluate(&ctx, &action).decision,
+                PolicyResult::RequiresApproval { .. }
+            ),
+            "context-dependent approval must reflect the updated team size, not a stale cached Allow"
+        );
+
+        drop(tmp);
     }
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1222,7 +1222,9 @@ pub(crate) fn references_live_context(expr: &str) -> bool {
     let Some(tokens) = tokenize(expr) else {
         return false;
     };
-    tokens.iter().any(|t| matches!(t, Token::Field(f) if is_live_context_field(f)))
+    tokens
+        .iter()
+        .any(|t| matches!(t, Token::Field(f) if is_live_context_field(f)))
 }
 
 /// Classify a [`FieldRef`] as backed by live runtime state (registry / budget)

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1206,6 +1206,47 @@ pub(crate) fn evaluate(
     eval_tokens(&tokens, action, agent_level, policy_ctx)
 }
 
+/// AAASM-3995(c) — whether `expr` references any field whose value is resolved
+/// from live, mutable runtime state (the agent registry graph or the budget
+/// tracker) rather than from the request's action.
+///
+/// The decision cache keys only on `(agent_id, policy_epoch, action)`, so a
+/// verdict that depends on live context (e.g. `team.active_agents`,
+/// `team.budget_remaining`) would be frozen for the cache TTL. Callers use this
+/// to evaluate such verdicts fresh instead of serving a stale cached one.
+///
+/// Action-derived fields (`tool`, `path`, `url`, `method`, `command`,
+/// `governance_level`, `args.*`, `tool_result*`, `source.*`, `target.*`) are
+/// already captured by the cache key and are NOT treated as live context.
+pub(crate) fn references_live_context(expr: &str) -> bool {
+    let Some(tokens) = tokenize(expr) else {
+        return false;
+    };
+    tokens.iter().any(|t| matches!(t, Token::Field(f) if is_live_context_field(f)))
+}
+
+/// Classify a [`FieldRef`] as backed by live runtime state (registry / budget)
+/// for [`references_live_context`].
+fn is_live_context_field(field: &FieldRef) -> bool {
+    matches!(
+        field,
+        FieldRef::AgentDepth
+            | FieldRef::TeamActiveAgents
+            | FieldRef::TeamParallelAgents
+            | FieldRef::TeamBudgetRemaining
+            | FieldRef::AgentAge
+            | FieldRef::AgentChildrenCount
+            | FieldRef::ChildTool
+            | FieldRef::ChildRiskTier
+            | FieldRef::AgentRiskTier
+            | FieldRef::ParentRiskTier
+            | FieldRef::AgentParentId
+            | FieldRef::AgentTeamId
+            | FieldRef::AgentIsRoot
+            | FieldRef::AgentIsLeaf
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1480,6 +1521,19 @@ mod tests {
         // not become an implicit Allow when that context is unresolved.
         assert!(evaluate("team.budget_remaining < 100", &tool("any"), None, None));
         assert!(evaluate("agent.children_count > 3", &tool("any"), None, None));
+    }
+
+    #[test]
+    fn references_live_context_flags_registry_and_budget_fields() {
+        // AAASM-3995(c): registry / budget-backed fields are live context.
+        assert!(references_live_context("team.active_agents > 1"));
+        assert!(references_live_context("team.budget_remaining < 100"));
+        assert!(references_live_context("agent.depth > 2 OR tool == \"x\""));
+        assert!(references_live_context("agent.children_count > 0"));
+        // Action-derived fields are captured by the cache key — not live context.
+        assert!(!references_live_context("tool == \"bash\""));
+        assert!(!references_live_context("path starts_with \"/etc\""));
+        assert!(!references_live_context("governance_level >= trusted"));
     }
 
     // ── risk tier tests ──────────────────────────────────────────────────

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -497,7 +497,14 @@ fn eval_numeric_ctx_field(
     };
     Some(match numeric_ctx_value {
         Some(lhs) => compare_numeric(lhs, op, literal),
-        None => false,
+        // AAASM-3995(b): this evaluator drives `requires_approval_if`, where a
+        // `false` result means "no approval required". When a context field
+        // (agent.depth / team.*) cannot be resolved, silently returning `false`
+        // lets a sole-clause approval guard never fire — the action runs
+        // unguarded (fail-open). An unresolvable guard condition must fail
+        // CLOSED: fire the predicate (require approval), mirroring the
+        // fail-closed handling of unparseable ordered comparisons (AAASM-3893).
+        None => true,
     })
 }
 
@@ -1452,16 +1459,27 @@ mod tests {
     }
 
     #[test]
-    fn null_safety_team_active_returns_false_when_no_team() {
-        // team_active = None means the agent has no team; condition must not fire.
+    fn unresolved_team_active_fires_approval_fail_closed() {
+        // AAASM-3995(b): team_active = None (unresolvable in this approval
+        // context) must FAIL CLOSED — the guard fires (require approval) rather
+        // than silently letting the action run unguarded.
         let ctx = crate::policy::context::FakePolicyContext::default();
-        assert!(!evaluate("team.active_agents > 0", &tool("any"), None, Some(&ctx)));
+        assert!(evaluate("team.active_agents > 0", &tool("any"), None, Some(&ctx)));
     }
 
     #[test]
-    fn null_safety_returns_false_when_no_context() {
-        // No context at all: graph-aware field must not fire (fail-closed → no-match).
-        assert!(!evaluate("agent.depth > 0", &tool("any"), None, None));
+    fn unresolved_context_fires_approval_fail_closed() {
+        // AAASM-3995(b): no context at all → the context-dependent guard cannot
+        // be evaluated, so it fails closed (require approval).
+        assert!(evaluate("agent.depth > 0", &tool("any"), None, None));
+    }
+
+    #[test]
+    fn sole_clause_context_approval_fails_closed_when_unresolved() {
+        // A `requires_approval_if` whose only clause references live context must
+        // not become an implicit Allow when that context is unresolved.
+        assert!(evaluate("team.budget_remaining < 100", &tool("any"), None, None));
+        assert!(evaluate("agent.children_count > 3", &tool("any"), None, None));
     }
 
     // ── risk tier tests ──────────────────────────────────────────────────
@@ -1632,8 +1650,9 @@ mod tests {
     }
 
     #[test]
-    fn null_safety_agent_age_returns_false_without_context() {
-        assert!(!evaluate("agent.age > 24h", &tool("any"), None, None));
+    fn agent_age_fails_closed_without_context() {
+        // AAASM-3995(b): unresolved agent.age in an approval clause fails closed.
+        assert!(evaluate("agent.age > 24h", &tool("any"), None, None));
     }
 
     // ── inter-team message condition tests ───────────────────────────────────
@@ -1889,8 +1908,9 @@ mod tests {
     }
 
     #[test]
-    fn agent_children_count_null_safe_without_context() {
-        assert!(!evaluate("agent.children_count > 0", &tool("any"), None, None));
+    fn agent_children_count_fails_closed_without_context() {
+        // AAASM-3995(b): unresolved agent.children_count in an approval clause fails closed.
+        assert!(evaluate("agent.children_count > 0", &tool("any"), None, None));
     }
 
     // ── agent.is_root, agent.is_leaf tests ───────────────────────────────────

--- a/aa-gateway/tests/graph_vars_fixture_test.rs
+++ b/aa-gateway/tests/graph_vars_fixture_test.rs
@@ -57,14 +57,15 @@ fn agent_depth_allow_fixture_loads_without_errors() {
 }
 
 #[test]
-fn agent_depth_allow_produces_allow_without_context() {
-    // Without a PolicyContext the graph-aware clause evaluates to false (null-safe),
-    // so no RequireApproval fires → Allow.
+fn agent_depth_allow_requires_approval_without_context() {
+    // AAASM-3995(b): without a PolicyContext the graph-aware approval clause is
+    // unresolvable, so it now FAILS CLOSED — RequireApproval fires rather than
+    // letting the action run unguarded.
     let doc = load_fixture("agent_depth_allow.yaml");
     let ctx = make_ctx();
     let action = tool_action("deploy");
     let result = merge_decisions(&[doc], &ctx, &action, None);
-    assert_eq!(result, PolicyDecision::Allow);
+    assert!(matches!(result, PolicyDecision::RequireApproval { .. }));
 }
 
 #[test]
@@ -84,12 +85,13 @@ fn team_active_agents_allow_fixture_loads_without_errors() {
 }
 
 #[test]
-fn team_active_agents_allow_produces_allow_without_context() {
+fn team_active_agents_allow_requires_approval_without_context() {
+    // AAASM-3995(b): unresolved team.active_agents in an approval clause fails closed.
     let doc = load_fixture("team_active_agents_allow.yaml");
     let ctx = make_ctx();
     let action = tool_action("spawn");
     let result = merge_decisions(&[doc], &ctx, &action, None);
-    assert_eq!(result, PolicyDecision::Allow);
+    assert!(matches!(result, PolicyDecision::RequireApproval { .. }));
 }
 
 // ── team.budget_remaining fixtures ───────────────────────────────────────────
@@ -100,12 +102,14 @@ fn team_budget_remaining_deny_fixture_loads_without_errors() {
 }
 
 #[test]
-fn team_budget_remaining_deny_produces_allow_without_context() {
+fn team_budget_remaining_deny_requires_approval_without_context() {
+    // AAASM-3995(b): a sole-clause requires_approval_if on team.budget_remaining
+    // must not become an implicit Allow when context is unresolved — fail closed.
     let doc = load_fixture("team_budget_remaining_deny.yaml");
     let ctx = make_ctx();
     let action = tool_action("expensive_op");
     let result = merge_decisions(&[doc], &ctx, &action, None);
-    assert_eq!(result, PolicyDecision::Allow);
+    assert!(matches!(result, PolicyDecision::RequireApproval { .. }));
 }
 
 // ── child.tool fixtures ───────────────────────────────────────────────────────
@@ -165,7 +169,7 @@ fn snapshot_unconditional_deny_unaffected_by_null_ctx() {
 }
 
 #[test]
-fn snapshot_null_ctx_team_active_agents_allow_fixture_yields_allow() {
+fn snapshot_null_ctx_team_active_agents_fixture_requires_approval() {
     let doc = load_fixture("team_active_agents_allow.yaml");
     let ctx = make_ctx();
     let action = tool_action("spawn");
@@ -174,7 +178,7 @@ fn snapshot_null_ctx_team_active_agents_allow_fixture_yields_allow() {
 }
 
 #[test]
-fn snapshot_null_ctx_team_budget_remaining_deny_fixture_yields_allow() {
+fn snapshot_null_ctx_team_budget_remaining_fixture_requires_approval() {
     let doc = load_fixture("team_budget_remaining_deny.yaml");
     let ctx = make_ctx();
     let action = tool_action("expensive_op");
@@ -192,7 +196,7 @@ fn snapshot_null_ctx_child_tool_deny_fixture_yields_allow() {
 }
 
 #[test]
-fn snapshot_null_ctx_agent_depth_allow_fixture_yields_allow() {
+fn snapshot_null_ctx_agent_depth_fixture_requires_approval() {
     let doc = load_fixture("agent_depth_allow.yaml");
     let ctx = make_ctx();
     let action = tool_action("deploy");

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_agent_depth_allow_fixture_yields_allow.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_agent_depth_allow_fixture_yields_allow.snap
@@ -1,6 +1,0 @@
----
-source: aa-gateway/tests/graph_vars_fixture_test.rs
-assertion_line: 197
-expression: result
----
-Allow

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_agent_depth_fixture_requires_approval.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_agent_depth_fixture_requires_approval.snap
@@ -1,0 +1,8 @@
+---
+source: aa-gateway/tests/graph_vars_fixture_test.rs
+expression: result
+---
+RequireApproval {
+    reason: "approval required for tool 'deploy'",
+    timeout_secs: 300,
+}

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_active_agents_allow_fixture_yields_allow.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_active_agents_allow_fixture_yields_allow.snap
@@ -1,6 +1,0 @@
----
-source: aa-gateway/tests/graph_vars_fixture_test.rs
-assertion_line: 170
-expression: result
----
-Allow

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_active_agents_fixture_requires_approval.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_active_agents_fixture_requires_approval.snap
@@ -1,0 +1,8 @@
+---
+source: aa-gateway/tests/graph_vars_fixture_test.rs
+expression: result
+---
+RequireApproval {
+    reason: "approval required for tool 'spawn'",
+    timeout_secs: 300,
+}

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_budget_remaining_deny_fixture_yields_allow.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_budget_remaining_deny_fixture_yields_allow.snap
@@ -1,6 +1,0 @@
----
-source: aa-gateway/tests/graph_vars_fixture_test.rs
-assertion_line: 179
-expression: result
----
-Allow

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_budget_remaining_fixture_requires_approval.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_budget_remaining_fixture_requires_approval.snap
@@ -1,0 +1,8 @@
+---
+source: aa-gateway/tests/graph_vars_fixture_test.rs
+expression: result
+---
+RequireApproval {
+    reason: "approval required for tool 'expensive_op'",
+    timeout_secs: 300,
+}

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -5684,6 +5684,13 @@ export interface operations {
                     "application/json": components["schemas"]["PolicyResponse"][];
                 };
             };
+            /** @description Caller lacks admin scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     create_policy: {
@@ -5741,6 +5748,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["PolicyResponse"];
                 };
+            };
+            /** @description Caller lacks admin scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description No active policy loaded */
             404: {

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -2027,6 +2027,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PolicyResponse'
+        '403':
+          description: Caller lacks admin scope
     post:
       tags:
       - policies
@@ -2067,6 +2069,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PolicyResponse'
+        '403':
+          description: Caller lacks admin scope
         '404':
           description: No active policy loaded
   /api/v1/tools:


### PR DESCRIPTION
## What
Batch of three related policy-plane authz / fail-closed fixes.

**(a) aa-api — cross-tenant policy disclosure.** `GET /api/v1/policies` and `GET /api/v1/policies/active` discarded the caller, so any Read caller could enumerate every tenant's policy documents. A policy version is a whole governance document spanning all tenants' cascade, so it cannot be filtered per team/org — both endpoints now require **Admin** scope.

**(b) aa-gateway — approval-condition context fields failed OPEN.** In the `requires_approval_if` evaluator, unresolved numeric context fields (`agent.depth`, `agent.age`, `agent.children_count`, `team.active_agents`, `team.parallel_agents`, `team.budget_remaining`) evaluated to `false`, so a sole-clause approval guard silently allowed the action. They now **fail closed** (fire the approval predicate), mirroring the existing fail-closed handling of unparseable ordered comparisons (AAASM-3893).

**(c) aa-gateway — decision cache froze context-dependent approvals.** The decision cache keys only on `(agent, epoch, action)`, so a `requires_approval_if` depending on live context (`team.active_agents`, `team.budget_remaining`, …) could be served stale for the cache TTL. Such verdicts are now detected (`expr::references_live_context`) and evaluated fresh, bypassing the cache — like the schedule stage.

**(d, info only)** `apply_yaml` has no evaluation effect in cascade mode (engine/mod.rs ~783) — noted, no fix; the cascade is fed from the scope index, and `apply_yaml` updates the primary policy which the cascade path does not consult. Left as-is per ticket (out of scope for this security batch).

## Why
Each is a fail-open / cross-tenant disclosure in the policy plane: (a) leaks every tenant's rules to any reader; (b) lets a context-dependent approval guard be bypassed whenever its context is unresolved; (c) lets a stale cached Allow override a now-required approval.

## How verified
- (a) `list_policies_forbidden_for_read_only_caller` / `_allowed_for_admin_caller`, `get_active_policy_forbidden_for_read_only_caller`; updated tenant-scope expectations.
- (b) updated null-safety unit tests + fixture assertions + null-context snapshots (AAASM-1035 sanctioned review) to fail-closed.
- (c) `references_live_context_flags_registry_and_budget_fields` + engine `cascade_context_dependent_approval_is_not_frozen_by_decision_cache`.
- Full `aa-gateway` (1342) and `aa-api` suites green; fmt + clippy clean.

Closes AAASM-3995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73