### PR TITLE
[AAASM-4016] 🔒 (ci): Gate release publish jobs behind protected Environments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,6 +412,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish
     if: github.event_name == 'push'
+    # AAASM-4016: gate this publish behind a protected GitHub Environment so a
+    # required-reviewer approval is needed before CRATES_IO_TOKEN is exposed and
+    # the workspace is pushed to crates.io. The environment (required reviewers +
+    # ref restriction to v* tags) must be created in repo Settings by an admin.
+    environment: release-crates
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -524,6 +529,10 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: read
+    # AAASM-4016: gate behind a protected GitHub Environment so a required
+    # reviewer approves before HOMEBREW_TAP_TOKEN is exposed and a formula PR is
+    # opened on the tap repo. Create the environment in repo Settings (admin).
+    environment: release-homebrew
 
     steps:
       - name: Download release artifacts
@@ -619,6 +628,10 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: read
+    # AAASM-4016: gate behind a protected GitHub Environment so a required
+    # reviewer approves before NODE_SDK_BOT_TOKEN is exposed and a pin-bump PR is
+    # opened on node-sdk. Create the environment in repo Settings (admin).
+    environment: release-node-sdk
 
     steps:
       - name: Checkout node-sdk
@@ -722,6 +735,10 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: read
+    # AAASM-4016: gate behind a protected GitHub Environment so a required
+    # reviewer approves before PYTHON_SDK_BOT_TOKEN is exposed and a pin-bump PR
+    # is opened on python-sdk. Create the environment in repo Settings (admin).
+    environment: release-python-sdk
 
     steps:
       - name: Checkout python-sdk
@@ -819,6 +836,10 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: read
+    # AAASM-4016: gate behind a protected GitHub Environment so a required
+    # reviewer approves before GO_SDK_BOT_TOKEN is exposed and a pin-bump PR is
+    # opened on go-sdk. Create the environment in repo Settings (admin).
+    environment: release-go-sdk
 
     steps:
       - name: Checkout go-sdk
@@ -928,6 +949,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # AAASM-4016: gate behind a protected GitHub Environment so a required
+    # reviewer approves before CROSS_REPO_DISPATCH_PAT is exposed and
+    # repository_dispatch events are fired at the downstream SDK repos. Create
+    # the environment in repo Settings (admin).
+    environment: release-notify
     steps:
       - name: Dispatch to node-sdk
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1


### PR DESCRIPTION
## What changed

`.github/workflows/release.yml`: added a protected `environment:` to every release-time publish job that previously auto-fired on any `v*` tag push with **no approval gate**:

| Job | Secret it exposes | Environment added |
|---|---|---|
| `publish-crates` | `CRATES_IO_TOKEN` | `release-crates` |
| `update-homebrew-tap` | `HOMEBREW_TAP_TOKEN` | `release-homebrew` |
| `update-node-sdk-ffi-pin` | `NODE_SDK_BOT_TOKEN` | `release-node-sdk` |
| `update-python-sdk-ffi-pin` | `PYTHON_SDK_BOT_TOKEN` | `release-python-sdk` |
| `update-go-sdk-ffi-pin` | `GO_SDK_BOT_TOKEN` | `release-go-sdk` |
| `notify-downstream` | `CROSS_REPO_DISPATCH_PAT` | `release-notify` |

Per-target environment names (not a single shared `release`) so each downstream token can be **scoped to its own environment** as an environment secret, and each downstream fan-out can be independently approved/restricted.

The `publish` (GitHub Release) job is intentionally left unchanged — it already runs with least-privilege + keyless **cosign OIDC** signing and publishes only to this same repo's Releases; no long-lived cross-repo/registry token to gate.

## Why

AAASM-4016 [MED]: these jobs hold long-lived cross-repo / registry credentials and fired with no required-reviewer gate, so a single `v*` tag push (or a compromised tag) published to crates.io, opened bot PRs on three SDK repos + the Homebrew tap, and dispatched cross-repo events — all with no human in the loop.

## ⚠️ Manual repo-settings steps required (admin)

The workflow now *references* these Environments; they must be created in **Settings → Environments** for them to actually gate. Until created, GitHub treats an unknown environment as auto-approved (no protection), so create them:

Create these 6 environments, each with **Required reviewers** (≥1 Pioneer) and a **Deployment branch/tag rule restricting to `v*` tags**:
- `release-crates` — add `CRATES_IO_TOKEN` as an environment secret
- `release-homebrew` — add `HOMEBREW_TAP_TOKEN`
- `release-node-sdk` — add `NODE_SDK_BOT_TOKEN`
- `release-python-sdk` — add `PYTHON_SDK_BOT_TOKEN`
- `release-go-sdk` — add `GO_SDK_BOT_TOKEN`
- `release-notify` — add `CROSS_REPO_DISPATCH_PAT`

(Moving each token from a repo secret to its environment secret is what enforces per-target scoping; optional but recommended.)

## How to verify

- YAML parses; `actionlint` clean (only a pre-existing unrelated SC2046 shellcheck warning in the macOS codesign step remains).
- Config-only change; no build impact.

Closes AAASM-4016

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73