### PR TITLE
[AAASM-4022] 🔒 (ci): Supply-chain CI hardening batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,12 +637,20 @@ jobs:
         working-directory: proto
       - name: Create local base branch for buf breaking check
         if: github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+        # AAASM-4022: route github.base_ref through a quoted env var instead of
+        # expanding it directly into the shell command (workflow-injection
+        # hardening — the ${{ }} expansion is otherwise pasted verbatim into the
+        # run script).
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$BASE_REF:$BASE_REF"
       - name: Check breaking changes against base branch
         if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           buf breaking \
-            --against "../.git#branch=${{ github.base_ref }},subdir=proto"
+            --against "../.git#branch=$BASE_REF,subdir=proto"
         working-directory: proto
 
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,8 +26,39 @@ on:
     tags: ["v*"]
 
 jobs:
+  # AAASM-4022: PR-validation build only — no `packages: write`. A PR-triggered
+  # run must never hold registry write scope (it never pushes), so this job runs
+  # with `contents: read` and `push: false`. The tag-only `publish-*` jobs below
+  # carry `packages: write` and are the only paths that push to GHCR.
   build-and-push:
     name: Build (and publish on tag)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Build aa-runtime image (PR validation, no push)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: aa-runtime/Dockerfile
+          platforms: linux/amd64
+          push: false
+          tags: ghcr.io/ai-agent-assembly/aa-runtime:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish-runtime:
+    # AAASM-4022: tag-only publish path. `packages: write` lives here (never on
+    # the PR build path) so registry write scope is only granted on a v* tag.
+    name: Publish aa-runtime image (tag)
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,29 +68,27 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4
 
       - name: Set up QEMU (ARM emulation for multi-arch)
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build multi-arch image (build only on PR, push on tag)
+      - name: Build + push multi-arch image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: aa-runtime/Dockerfile
-          platforms: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+          platforms: linux/amd64,linux/arm64
+          push: true
           tags: |
-            ghcr.io/ai-agent-assembly/aa-runtime:${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha }}
+            ghcr.io/ai-agent-assembly/aa-runtime:${{ github.ref_name }}
             ghcr.io/ai-agent-assembly/aa-runtime:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -94,12 +123,15 @@ jobs:
           printf 'lang_matrix={"include":%s}\n' "$sel" >> "$GITHUB_OUTPUT"
 
   build-and-push-language-images:
+    # AAASM-4022: PR-validation build only — no `packages: write`. Builds each
+    # image, loads it locally, and runs the language smoke test. Never pushes;
+    # the tag-only `publish-language-images` job below holds `packages: write`.
     name: Build language image — ${{ matrix.lang }} (and publish on tag)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: prep
     permissions:
       contents: read
-      packages: write
 
     # Matrix covers AAASM-1204 (F114, Phase 1: latest per language) + AAASM-1441
     # (F114b, Phase 2: extended-version variants). Each entry feeds a single
@@ -113,20 +145,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4
 
-      - name: Set up QEMU (ARM emulation for multi-arch)
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
-
-      - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Resolve the pinned SDK version for this language from the single source
       # of truth (docker/sdk-versions.json) and pass it into the build as
@@ -137,46 +157,26 @@ jobs:
         run: echo "version=$(jq -r --arg l "${{ matrix.lang }}" '.sdk[$l]' docker/sdk-versions.json)" >> "$GITHUB_OUTPUT"
 
       # PR build: linux/amd64 only + load into local Docker daemon so the
-      # follow-up smoke step can `docker run` the image. Tag-push build:
-      # multi-arch + push to GHCR. `load` and multi-arch are mutually exclusive,
-      # so the two modes are gated on the event type.
-      - name: "Build ${{ matrix.lang }} image — PR loads for smoke, tag pushes to GHCR"
+      # follow-up smoke step can `docker run` the image.
+      - name: "Build ${{ matrix.lang }} image — loads locally for smoke"
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          platforms: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-          load: ${{ github.event_name == 'pull_request' }}
+          platforms: linux/amd64
+          push: false
+          load: true
           build-args: |
             SDK_VERSION=${{ steps.sdkver.outputs.version }}
-          # Tags:
-          #   <lang>:<version>                    — moving tag, always.
-          #   <lang>:<version>-<ref_name>         — immutable product-version tag.
-          #     Emitted ONLY on a v* tag push, where ref_name is the release tag
-          #     (e.g. v0.0.1-beta.4). On a PR, ref_name is the merge ref
-          #     (e.g. `1257/merge`) whose `/` is an illegal Docker tag character
-          #     and would fail the build, so the immutable tag is omitted on PRs
-          #     (the image is loaded locally for smoke under the moving tag anyway).
-          #   <lang>:latest                       — only for is_latest entries.
-          # The `:latest` tag is only pushed by matrix entries flagged with
-          # `is_latest: true` (the F114 pin per language). Without this gate,
-          # every F114b leg would race to overwrite `:latest`, defeating the
-          # parent Story's "`:latest` per language still routes to the F114
-          # variant" AC bullet. See AAASM-1446.
-          tags: |
-            ghcr.io/ai-agent-assembly/${{ matrix.lang }}:${{ matrix.version }}
-            ${{ startsWith(github.ref, 'refs/tags/v') && format('ghcr.io/ai-agent-assembly/{0}:{1}-{2}', matrix.lang, matrix.version, github.ref_name) || '' }}
-            ${{ matrix.is_latest && format('ghcr.io/ai-agent-assembly/{0}:latest', matrix.lang) || '' }}
+          tags: ghcr.io/ai-agent-assembly/${{ matrix.lang }}:${{ matrix.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Smoke run on PR builds only — the image is locally loaded, so we can
-      # exercise `aasm --version` and the language-specific entrypoint before
-      # the PR can merge. Tag-push smoke is covered by AAASM-1226 via
-      # `docker pull` against the freshly-published GHCR tag.
+      # Smoke run on PR builds — the image is locally loaded, so we can exercise
+      # `aasm --version` and the language-specific entrypoint before the PR can
+      # merge. Tag-push smoke is covered by AAASM-1226 via `docker pull` against
+      # the freshly-published GHCR tag.
       - name: Smoke run (PR only)
-        if: github.event_name == 'pull_request'
         env:
           IMAGE: ghcr.io/ai-agent-assembly/${{ matrix.lang }}:${{ matrix.version }}
           SMOKE_RUN: ${{ matrix.smoke_run }}
@@ -212,6 +212,64 @@ jobs:
             exit 1
           fi
           echo "SDK version OK for $LANG_KEY: $installed == $SDK_VERSION"
+
+  publish-language-images:
+    # AAASM-4022: tag-only publish path for the language images. `packages: write`
+    # lives here (never on the PR build path) so registry write scope is only
+    # granted on a v* tag.
+    name: Publish language image — ${{ matrix.lang }} (tag)
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: prep
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prep.outputs.lang_matrix) }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4
+
+      - name: Set up QEMU (ARM emulation for multi-arch)
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve pinned SDK version for ${{ matrix.lang }}
+        id: sdkver
+        run: echo "version=$(jq -r --arg l "${{ matrix.lang }}" '.sdk[$l]' docker/sdk-versions.json)" >> "$GITHUB_OUTPUT"
+
+      # Tag-push build: multi-arch + push to GHCR.
+      #   <lang>:<version>                    — moving tag, always.
+      #   <lang>:<version>-<ref_name>         — immutable product-version tag
+      #     (ref_name is the release tag, e.g. v0.0.1-beta.4).
+      #   <lang>:latest                       — only for is_latest entries (the
+      #     F114 pin per language). See AAASM-1446.
+      - name: "Push ${{ matrix.lang }} image to GHCR"
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            SDK_VERSION=${{ steps.sdkver.outputs.version }}
+          tags: |
+            ghcr.io/ai-agent-assembly/${{ matrix.lang }}:${{ matrix.version }}
+            ghcr.io/ai-agent-assembly/${{ matrix.lang }}:${{ matrix.version }}-${{ github.ref_name }}
+            ${{ matrix.is_latest && format('ghcr.io/ai-agent-assembly/{0}:latest', matrix.lang) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,10 @@ jobs:
         # the dist binary is Developer-ID-signed with a hardened runtime and
         # notarized so macOS Gatekeeper accepts it. (Bare CLI Mach-O binaries can't
         # be stapled; Gatekeeper verifies the notarization online on first run.)
-        if: ${{ runner.os == 'macOS' && vars.MACOS_SIGNING_ENABLED == 'true' }}
+        # AAASM-4022: also gate on a tag push so PR dry-runs never touch the
+        # Apple signing keychain / notary credentials even if MACOS_SIGNING_ENABLED
+        # is set — codesigning + notarization only run when publishing a release.
+        if: ${{ github.event_name == 'push' && runner.os == 'macOS' && vars.MACOS_SIGNING_ENABLED == 'true' }}
         env:
           APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
           APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}

--- a/deny.toml
+++ b/deny.toml
@@ -12,8 +12,12 @@
 # below make the remaining knobs explicit and non-silent.
 [advisories]
 # Scope selectors: "all", "workspace", "transitive", "none".
-# "workspace" = flag unmaintained advisories for crates we directly depend on.
-unmaintained = "workspace"
+# AAASM-4022: "all" = flag unmaintained advisories across the ENTIRE dependency
+# graph (direct + transitive), not just workspace-direct crates. An unmaintained
+# transitive dep is the more likely supply-chain risk (no upstream to patch a
+# future advisory), so it must surface in the gate rather than hide behind a
+# direct dep.
+unmaintained = "all"
 # Yanked crates are denied (was "warn"): a yanked version is a supply-chain
 # signal — it must fail the gate, not merely warn.
 yanked = "deny"


### PR DESCRIPTION
## What changed

Supply-chain / CI hardening batch (AAASM-4022):

- **`deny.toml`** — `[advisories] unmaintained` `"workspace"` → `"all"` so an unmaintained crate anywhere in the transitive graph fails the gate, not only workspace-direct deps.
- **`.github/workflows/docker.yml`** — `build-and-push` and `build-and-push-language-images` each declared `packages: write` and ran on PR *and* tag, so PR runs held unused GHCR write scope. Kept those two as PR-validation-only (`contents: read`, `push: false` / load+smoke) and moved publishing into new tag-only jobs `publish-runtime` / `publish-language-images` that carry `packages: write`. Registry write scope is now granted only on a `v*` tag. (Existing PR job IDs/names preserved so any required status checks keep matching.)
- **`.github/workflows/release.yml`** — added `github.event_name == 'push'` to the macOS codesign+notarize step's `if:` so a PR dry-run never unlocks the Apple keychain / notary creds even when `MACOS_SIGNING_ENABLED` is set.
- **`.github/workflows/ci.yml`** — buf-lint expanded `${{ github.base_ref }}` directly into its `git fetch` and `buf --against` run scripts; routed it through a quoted `BASE_REF` env var (workflow-injection hardening). (Actual location is the `buf-lint` job ~line 640, not ~1244.)

## Decisions / notes for reviewers

- **`multiple-versions` left as `"warn"`** (not flipped to `"deny"`): flipping it can't be verified safe without a full `cargo deny check bans` CI dry-run against the resolved graph, and a large Rust workspace routinely carries duplicate transitive versions. Recommend enabling `deny` in a follow-up once a dry-run confirms a clean (or curated `skip`-listed) graph.
- The `publish` (GitHub Release) job was **not** changed — it already uses least-privilege + keyless cosign OIDC.

## Stacked on #1375 (AAASM-4016)

This branch is **stacked on `v0.0.1/AAASM-4016/config/release_env_protection` (PR #1375)** because both edit `release.yml` (non-overlapping regions). Base is `master`; if #1375 merges first this diff is clean. If reviewing before #1375 merges, the environment-gating hunks belong to #1375.

## How to verify

- All four changed files: YAML/TOML parse; `actionlint` clean on `docker.yml`, `release.yml` (only a pre-existing unrelated SC2046 in the codesign shell body), and the buf-lint region of `ci.yml`.
- Config-only; no build impact.

Closes AAASM-4022

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73