### PR TITLE
[AAASM-4012] 🐛 (aa-ebpf): Attach full file-I/O kprobe return-probe set

### DIFF
--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -59,21 +59,15 @@ impl KprobeManager {
                 .map_err(|e| EbpfError::ProbeAttach(e.to_string()))?;
         }
 
-        // Attach all file I/O kprobe programs to their kernel functions.
-        // `aa_sys_unlink_legacy` / `aa_sys_rename_legacy` cover the legacy
-        // syscall entry points that glibc on x86_64 invokes for libc
-        // `unlink()` / `rename()` — bypassing the at-variant probes
-        // above. See AAASM-1574.
-        let probes: &[(&str, &str)] = &[
-            ("aa_sys_openat", "__x64_sys_openat"),
-            ("aa_sys_openat_ret", "__x64_sys_openat"),
-            ("aa_sys_read", "__x64_sys_read"),
-            ("aa_sys_write", "__x64_sys_write"),
-            ("aa_sys_unlink", "__x64_sys_unlinkat"),
-            ("aa_sys_unlink_legacy", "__x64_sys_unlink"),
-            ("aa_sys_rename", "__x64_sys_renameat2"),
-            ("aa_sys_rename_legacy", "__x64_sys_rename"),
-        ];
+        // Attach all file I/O kprobe programs to their kernel functions from the
+        // single authoritative target list ([`KprobeManager::KPROBE_TARGETS`]).
+        // Every observed syscall has BOTH an entry kprobe and a return
+        // kretprobe — emission happens in the kretprobe, so attaching entry
+        // probes alone yields no events (AAASM-4012). The `*_legacy` pairs cover
+        // the legacy syscall entry points that glibc on x86_64 invokes for libc
+        // `unlink()` / `rename()`, bypassing the at-variant probes. See
+        // AAASM-1574.
+        let probes = Self::KPROBE_TARGETS;
 
         let mut links: Vec<Box<dyn std::any::Any>> = Vec::with_capacity(probes.len());
 
@@ -137,17 +131,32 @@ impl KprobeManager {
         false
     }
 
-    /// The complete list of (BPF program name, kernel function) pairs that
-    /// `attach()` will load. Exposed for testing and introspection.
+    /// The complete, authoritative list of (BPF program name, kernel function)
+    /// pairs that `attach()` loads — the single source of truth shared with
+    /// [`crate::loader::FileIoLoader::attach_kprobes`] so both entry points
+    /// attach an identical probe set (AAASM-4012). Exposed for testing and
+    /// introspection.
+    ///
+    /// Each observed syscall contributes an entry kprobe **and** a return
+    /// kretprobe (`*_ret`); the event is emitted from the kretprobe, so a
+    /// missing `*_ret` silently drops all events for that syscall. The
+    /// `*_legacy` / `*_legacy_ret` pairs cover glibc's legacy `unlink(2)` /
+    /// `rename(2)` entry points on x86_64 (AAASM-1574).
     pub const KPROBE_TARGETS: &[(&str, &str)] = &[
         ("aa_sys_openat", "__x64_sys_openat"),
         ("aa_sys_openat_ret", "__x64_sys_openat"),
         ("aa_sys_read", "__x64_sys_read"),
+        ("aa_sys_read_ret", "__x64_sys_read"),
         ("aa_sys_write", "__x64_sys_write"),
+        ("aa_sys_write_ret", "__x64_sys_write"),
         ("aa_sys_unlink", "__x64_sys_unlinkat"),
+        ("aa_sys_unlink_ret", "__x64_sys_unlinkat"),
         ("aa_sys_unlink_legacy", "__x64_sys_unlink"),
+        ("aa_sys_unlink_legacy_ret", "__x64_sys_unlink"),
         ("aa_sys_rename", "__x64_sys_renameat2"),
+        ("aa_sys_rename_ret", "__x64_sys_renameat2"),
         ("aa_sys_rename_legacy", "__x64_sys_rename"),
+        ("aa_sys_rename_legacy_ret", "__x64_sys_rename"),
     ];
 }
 
@@ -173,17 +182,48 @@ mod tests {
     #[test]
     fn kprobe_targets_covers_all_file_io_syscalls() {
         let targets = KprobeManager::KPROBE_TARGETS;
-        assert_eq!(targets.len(), 8);
+        // openat/read/write/unlink(at)/rename(at2) + the two legacy syscalls,
+        // each with an entry kprobe AND a return kretprobe = 14 programs.
+        assert_eq!(targets.len(), 14);
 
         let prog_names: Vec<&str> = targets.iter().map(|(p, _)| *p).collect();
-        assert!(prog_names.contains(&"aa_sys_openat"));
-        assert!(prog_names.contains(&"aa_sys_openat_ret"));
-        assert!(prog_names.contains(&"aa_sys_read"));
-        assert!(prog_names.contains(&"aa_sys_write"));
-        assert!(prog_names.contains(&"aa_sys_unlink"));
-        assert!(prog_names.contains(&"aa_sys_unlink_legacy"));
-        assert!(prog_names.contains(&"aa_sys_rename"));
-        assert!(prog_names.contains(&"aa_sys_rename_legacy"));
+        for name in [
+            "aa_sys_openat",
+            "aa_sys_openat_ret",
+            "aa_sys_read",
+            "aa_sys_read_ret",
+            "aa_sys_write",
+            "aa_sys_write_ret",
+            "aa_sys_unlink",
+            "aa_sys_unlink_ret",
+            "aa_sys_unlink_legacy",
+            "aa_sys_unlink_legacy_ret",
+            "aa_sys_rename",
+            "aa_sys_rename_ret",
+            "aa_sys_rename_legacy",
+            "aa_sys_rename_legacy_ret",
+        ] {
+            assert!(prog_names.contains(&name), "missing probe program {name}");
+        }
+    }
+
+    #[test]
+    fn kprobe_targets_pair_every_entry_with_a_return_probe() {
+        // Every non-`_ret` entry program must have a matching `_ret` kretprobe
+        // on the same kernel function — the event is emitted from the
+        // kretprobe, so a missing pair silently drops that syscall's events
+        // (AAASM-4012).
+        let targets = KprobeManager::KPROBE_TARGETS;
+        let names: Vec<&str> = targets.iter().map(|(p, _)| *p).collect();
+        for (prog, _) in targets {
+            if !prog.ends_with("_ret") {
+                let ret = format!("{prog}_ret");
+                assert!(
+                    names.contains(&ret.as_str()),
+                    "entry probe {prog} has no paired return probe {ret}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -139,14 +139,14 @@ impl FileIoLoader {
                 .as_mut()
                 .ok_or_else(|| EbpfError::ProbeAttach("BPF not loaded — call load() first".into()))?;
 
-            let probes: &[(&str, &str)] = &[
-                ("aa_sys_openat", "__x64_sys_openat"),
-                ("aa_sys_openat_ret", "__x64_sys_openat"),
-                ("aa_sys_read", "__x64_sys_read"),
-                ("aa_sys_write", "__x64_sys_write"),
-                ("aa_sys_unlink", "__x64_sys_unlinkat"),
-                ("aa_sys_rename", "__x64_sys_renameat2"),
-            ];
+            // Attach the single authoritative probe set shared with
+            // [`crate::kprobe::KprobeManager`] (AAASM-4012). This list pairs an
+            // entry kprobe with a return kretprobe (`*_ret`) for every observed
+            // syscall — read/write/unlink/rename all emit their events from the
+            // kretprobe, so attaching only the entry probes (the prior bug) left
+            // openat as the sole syscall producing events. It also includes the
+            // legacy `unlink(2)` / `rename(2)` glibc entry points (AAASM-1574).
+            let probes = crate::kprobe::KprobeManager::KPROBE_TARGETS;
 
             for (prog_name, fn_name) in probes {
                 let program: &mut KProbe = bpf

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -244,7 +244,31 @@ fn spawn_ebpf_file_io(
         return;
     }
 
-    let mut rx = match loader.start_event_reader() {
+    // AAASM-4012: seed the in-kernel PATH_BLOCKLIST from the detector's
+    // exact-file rules so the kretprobe sets the sensitive-path flag (bit 0)
+    // in-kernel, and drive event reading through the userspace detector so
+    // `is_sensitive` is also set for the prefix/canonical rules the kernel's
+    // exact-match map cannot express (see `aa_ebpf::maps::PathPattern`). Without
+    // this the events carried no sensitivity signal at all.
+    let detector = aa_ebpf::SensitivePathDetector::with_defaults();
+    let blocklist: Vec<aa_ebpf::PathPattern> = detector
+        .prefixes()
+        .iter()
+        .filter(|p| !p.ends_with('/'))
+        .map(|p| aa_ebpf::PathPattern {
+            pattern: p.clone(),
+            verdict: aa_ebpf::PathVerdict::Deny,
+        })
+        .collect();
+    if let Err(e) = loader.update_path_filter(&blocklist) {
+        let reason = format!("file I/O path blocklist update failed: {e}");
+        tracing::warn!(%reason, "degrading ebpf/file_io sub-layer");
+        emit_ebpf_degradation(broadcast_tx, "ebpf/file_io", reason);
+        degraded_layers.push("ebpf/file_io".to_string());
+        return;
+    }
+
+    let mut rx = match loader.start_event_reader_with_alerts(detector) {
         Ok(r) => r,
         Err(e) => {
             let reason = format!("file I/O event reader failed: {e}");


### PR DESCRIPTION
## What
`FileIoLoader::attach_kprobes` attached the `openat` entry+return probes but only the **entry** kprobes for `read`/`write`/`unlink`/`rename`. Those syscalls emit their `FileIoEventRaw` from the **kretprobe** (`aa_sys_*_ret`), which was never attached — so in practice only `openat` produced events. The legacy glibc `unlink(2)`/`rename(2)` entry+return pairs (AAASM-1574) were also missing from the loader.

This PR:
- Promotes `KprobeManager::KPROBE_TARGETS` to the **single authoritative** list of all 14 (entry + return) programs, including the four missing `*_ret` retprobes and the two legacy `*_legacy_ret` retprobes.
- Makes **both** `KprobeManager::attach` and `FileIoLoader::attach_kprobes` iterate that one list, so the two entry points can no longer drift.
- `spawn_ebpf_file_io` now seeds `PATH_BLOCKLIST` (exact-file sensitive rules) via `update_path_filter` and reads events through `start_event_reader_with_alerts(SensitivePathDetector)`, so events actually carry an `is_sensitive` signal (in-kernel exact-match + userspace prefix/canonical).

## Why
Without the return probes attached, the file-I/O eBPF sub-layer silently observed only `open` — read/write/delete/rename went unmonitored, and no event was ever flagged sensitive.

## How verified
- `cargo fmt --all`, `cargo check -p aa-ebpf`, `cargo clippy -p aa-ebpf --all-targets -- -D warnings` — clean.
- `cargo test -p aa-ebpf --lib` — 104 pass, including a new regression test asserting every entry kprobe has a paired return probe and the list has all 14 targets.
- `cargo check -p aa-runtime` (macOS) — clean.

## ⚠️ Linux CI is the authoritative gate
eBPF is Linux-only. The `attach_kprobes` / `spawn_ebpf_file_io` bodies are `#[cfg(target_os = "linux")]` and cannot be compiled on the macOS dev host (the BPF bytecode objects are not built there). The changed logic mirrors the already-working `KprobeManager::attach` loop and established loader APIs; the **`e2e — Layer 3 eBPF (Linux)`** and **`eBPF probes build (Linux nightly)`** jobs are the real validation.

Refs AAASM-4012

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73