### PR TITLE
[AAASM-4018] 🐛 (aa-api): Fix parse_agent_id panic-DoS on malformed ids

### DIFF
--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -38,7 +38,7 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tower = { workspace = true }
-tower-http = { workspace = true, features = ["trace", "cors", "compression-gzip", "request-id", "util", "set-header"] }
+tower-http = { workspace = true, features = ["trace", "cors", "compression-gzip", "request-id", "util", "set-header", "catch-panic"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 utoipa = { workspace = true }

--- a/aa-api/src/middleware/mod.rs
+++ b/aa-api/src/middleware/mod.rs
@@ -1,10 +1,12 @@
 //! Tower middleware stack for the API server.
 //!
 //! Middleware is applied in this order (outermost first):
-//! 1. Request ID injection (`x-request-id`)
-//! 2. Structured tracing (logs method, path, status, duration, request_id)
-//! 3. CORS (allow dashboard origin)
-//! 4. Response compression (gzip)
+//! 1. Panic capture (`catch_panic`) — outermost, so a panic anywhere in the
+//!    stack or a handler becomes a `500` instead of aborting the connection
+//! 2. Request ID injection (`x-request-id`)
+//! 3. Structured tracing (logs method, path, status, duration, request_id)
+//! 4. CORS (allow dashboard origin)
+//! 5. Response compression (gzip)
 //!
 //! Authentication is handled by FromRequestParts extractors (see auth module),
 //! not middleware layers.
@@ -15,6 +17,7 @@ pub mod request_id;
 pub mod tracing;
 
 use axum::Router;
+use tower_http::catch_panic::CatchPanicLayer;
 use tower_http::request_id::{PropagateRequestIdLayer, SetRequestIdLayer};
 
 use self::request_id::UuidRequestId;
@@ -27,4 +30,10 @@ pub fn apply_middleware(router: Router) -> Router {
         .layer(self::tracing::trace_layer())
         .layer(PropagateRequestIdLayer::x_request_id())
         .layer(SetRequestIdLayer::x_request_id(UuidRequestId))
+        // AAASM-4018: defense-in-depth. A panic in any handler (e.g. an
+        // unchecked slice on a malformed path parameter) would otherwise unwind
+        // the request task and drop the connection; the outermost catch_panic
+        // turns it into a `500 Internal Server Error` so one bad request cannot
+        // take down the worker.
+        .layer(CatchPanicLayer::new())
 }

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -57,14 +57,17 @@ fn authorize_agent_access(
 }
 
 /// Parse a hex-encoded agent ID string into a 16-byte array.
+///
+/// Decodes via [`hex::decode`] rather than slicing the input by byte index: the
+/// previous `&id[i..i + 2]` implementation panicked on an odd-length id (index
+/// past the end) or a multibyte path segment (a non-char-boundary slice),
+/// turning a malformed `{id}` path parameter into a request-thread panic
+/// (AAASM-4018). `hex::decode` rejects odd-length and non-hex input with a
+/// clean `Err`, so every malformed id now surfaces as a `400` instead.
 fn parse_agent_id(id: &str) -> Result<[u8; 16], ProblemDetail> {
-    let bytes: Vec<u8> = (0..id.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&id[i..i + 2], 16))
-        .collect::<Result<Vec<u8>, _>>()
-        .map_err(|_| {
-            ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid agent ID format: {id}"))
-        })?;
+    let bytes = hex::decode(id).map_err(|_| {
+        ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid agent ID format: {id}"))
+    })?;
 
     let arr: [u8; 16] = bytes.try_into().map_err(|_| {
         ProblemDetail::from_status(StatusCode::BAD_REQUEST)
@@ -871,5 +874,37 @@ mod tests {
         assert_eq!(json["agent_id"], "aabbccdd00112233");
         assert_eq!(json["previous_status"], "Suspended(Manual)");
         assert_eq!(json["new_status"], "Active");
+    }
+
+    #[test]
+    fn parse_agent_id_accepts_valid_32_hex() {
+        let id = "aabbccdd00112233445566778899aabb";
+        assert_eq!(
+            parse_agent_id(id).unwrap(),
+            [0xaa, 0xbb, 0xcc, 0xdd, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,]
+        );
+    }
+
+    #[test]
+    fn parse_agent_id_odd_length_is_bad_request_not_panic() {
+        // AAASM-4018: an odd-length id previously sliced past the end and
+        // panicked. It must now surface as a clean 400.
+        let err = parse_agent_id("abc").unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST.as_u16());
+    }
+
+    #[test]
+    fn parse_agent_id_multibyte_is_bad_request_not_panic() {
+        // AAASM-4018: a multibyte path segment previously sliced on a non-char
+        // boundary and panicked. It must now surface as a clean 400.
+        let err = parse_agent_id("éééééééééééééééé").unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST.as_u16());
+    }
+
+    #[test]
+    fn parse_agent_id_wrong_length_is_bad_request() {
+        // Valid hex but not 16 bytes → 400 rather than a truncated id.
+        let err = parse_agent_id("aabb").unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST.as_u16());
     }
 }


### PR DESCRIPTION
## What
`parse_agent_id` in `aa-api/src/routes/agents.rs` sliced the id with `&id[i..i+2]`, which panics on an **odd-length** id (index past the end) or a **multibyte** path segment (non-char-boundary slice). Every agent-scoped endpoint that parses `{id}` was affected: get/delete/suspend/resume_agent plus get_agent_capabilities/budget/subtree_burn.

This replaces the manual slice with `hex::decode` (the same safe pattern used by the sibling parsers `audit.rs::parse_agent_id` / `ops.rs::parse_hex_agent_id`), so malformed ids now return a clean `400`. As defense-in-depth it also adds a `tower_http::catch_panic` layer (outermost) to the API middleware stack so any unexpected handler panic becomes a `500` instead of aborting the worker connection.

## Why
LOW-severity panic-DoS (AAASM-4018): a single malformed path parameter could panic a request thread.

## How to verify
- `cargo nextest run -p aa-api` — 835 passed. New regression tests exercise odd-length and multibyte ids returning `400` (not panic).
- `cargo clippy -p aa-api --all-targets -- -D warnings` — clean.

Closes AAASM-4018

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73