### PR TITLE
[AAASM-4021] 🐛 (aa-gateway): Confine team-less caller under tenanted posture

### DIFF
--- a/aa-gateway/src/service/approval_service.rs
+++ b/aa-gateway/src/service/approval_service.rs
@@ -16,18 +16,30 @@ use crate::approval::db_escalation_scheduler::DbEscalationScheduler;
 use crate::approval::escalation::EscalationScheduler;
 use crate::iam::VerifiedCaller;
 use crate::service::convert;
+use crate::service::TenancyMode;
 
-/// Tenant-authorization rule for an approval action (AAASM-3788).
+/// Tenant-authorization rule for an approval action (AAASM-3788, AAASM-4021).
 ///
 /// A credentialed caller may act on an approval only when the caller and the
 /// approval are not in *different* tenants. When both the caller and the
-/// approval carry a `team_id`, they must match; if either side is untenanted
-/// the action is allowed (the untenanted/single-tenant deployment fallback,
-/// mirroring the policy-service tenancy residual under AAASM-3416). The
-/// interceptor has already guaranteed the caller is authenticated.
-fn caller_may_act_on(caller: &VerifiedCaller, approval_team: Option<&str>) -> bool {
+/// approval carry a `team_id`, they must match. If either side is untenanted
+/// the action is allowed — the untenanted/single-tenant deployment fallback,
+/// mirroring the policy-service tenancy residual under AAASM-3416.
+///
+/// AAASM-4021: that fallback is safe in an [`Untenanted`](TenancyMode::Untenanted)
+/// deployment, but in a [`Tenanted`](TenancyMode::Tenanted) one it would let a
+/// registered but *team-less* caller act on any tenant's approval. So when
+/// tenancy is enforced, a team-less caller acting on a *tenanted* approval is
+/// denied; the permissive fallback is preserved for every untenanted case
+/// (untenanted resource, or untenanted deployment). The interceptor has already
+/// guaranteed the caller is authenticated.
+fn caller_may_act_on(caller: &VerifiedCaller, approval_team: Option<&str>, mode: TenancyMode) -> bool {
     match (caller.team_id.as_deref(), approval_team) {
         (Some(caller_team), Some(approval_team)) => caller_team == approval_team,
+        // Team-less caller vs a tenanted approval: permissive only when tenancy
+        // is not being enforced (AAASM-4021).
+        (None, Some(_)) => mode == TenancyMode::Untenanted,
+        // Untenanted approval (shared/global) — unchanged fallback.
         _ => true,
     }
 }
@@ -37,6 +49,10 @@ pub struct ApprovalServiceImpl {
     queue: Arc<ApprovalQueue>,
     escalation_scheduler: Option<Arc<EscalationScheduler>>,
     db_escalation_scheduler: Option<Arc<DbEscalationScheduler>>,
+    /// Deployment tenancy posture for the cross-tenant guard (AAASM-4021).
+    /// Defaults to [`TenancyMode::Untenanted`] so OSS/single-tenant deployments
+    /// keep the permissive fallback.
+    tenancy_mode: TenancyMode,
 }
 
 impl ApprovalServiceImpl {
@@ -46,6 +62,7 @@ impl ApprovalServiceImpl {
             queue,
             escalation_scheduler: None,
             db_escalation_scheduler: None,
+            tenancy_mode: TenancyMode::default(),
         }
     }
 
@@ -60,6 +77,7 @@ impl ApprovalServiceImpl {
             queue,
             escalation_scheduler,
             db_escalation_scheduler: None,
+            tenancy_mode: TenancyMode::default(),
         }
     }
 
@@ -68,6 +86,15 @@ impl ApprovalServiceImpl {
     /// When present, `decide()` also cancels the DB-backed escalation row.
     pub fn with_db_scheduler(mut self, scheduler: Option<Arc<DbEscalationScheduler>>) -> Self {
         self.db_escalation_scheduler = scheduler;
+        self
+    }
+
+    /// Set the deployment tenancy posture (AAASM-4021).
+    ///
+    /// In [`TenancyMode::Tenanted`] a team-less caller can no longer act on a
+    /// tenanted approval via the untenanted fallback.
+    pub fn with_tenancy_mode(mut self, mode: TenancyMode) -> Self {
+        self.tenancy_mode = mode;
         self
     }
 
@@ -80,7 +107,7 @@ impl ApprovalServiceImpl {
     fn enforce_decide_tenancy(&self, caller: &VerifiedCaller, request_id: &str) -> Result<(), Status> {
         if let Ok(id) = request_id.parse::<ApprovalRequestId>() {
             if let Some(ApprovalLookup::Pending(pending)) = self.queue.get_by_id(id) {
-                if !caller_may_act_on(caller, pending.team_id.as_deref()) {
+                if !caller_may_act_on(caller, pending.team_id.as_deref(), self.tenancy_mode) {
                     return Err(Status::permission_denied("approval belongs to a different tenant"));
                 }
             }
@@ -129,7 +156,7 @@ impl ApprovalService for ApprovalServiceImpl {
         let requests = pending
             .iter()
             .filter(|p| match &caller {
-                Some(c) => caller_may_act_on(c, p.team_id.as_deref()),
+                Some(c) => caller_may_act_on(c, p.team_id.as_deref(), self.tenancy_mode),
                 None => true,
             })
             .map(convert::pending_to_proto)
@@ -357,6 +384,60 @@ mod tests {
 
         let resp = service.decide(req).await.unwrap().into_inner();
         assert!(resp.success);
+    }
+
+    // AAASM-4021 — the untenanted fallback must not let a registered but
+    // team-less caller act on a tenanted approval once tenancy is enforced.
+    #[tokio::test]
+    async fn decide_tenanted_mode_teamless_caller_denied_on_tenanted_approval() {
+        let queue = Arc::new(ApprovalQueue::new());
+        let service = ApprovalServiceImpl::new(Arc::clone(&queue)).with_tenancy_mode(TenancyMode::Tenanted);
+        let id = Uuid::new_v4();
+        queue.submit(make_approval_request_with_team(id, Some("team-b")));
+
+        let mut req = tonic::Request::new(DecideRequest {
+            request_id: id.to_string(),
+            decision: ApprovalDecisionType::Approved.into(),
+            decided_by: "teamless".to_string(),
+            reason: String::new(),
+        });
+        req.extensions_mut().insert(verified_caller(None));
+
+        let err = service.decide(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[test]
+    fn caller_may_act_on_tenancy_matrix() {
+        // Same-tenant match / mismatch is mode-independent.
+        assert!(caller_may_act_on(
+            &verified_caller(Some("t")),
+            Some("t"),
+            TenancyMode::Tenanted
+        ));
+        assert!(!caller_may_act_on(
+            &verified_caller(Some("t")),
+            Some("u"),
+            TenancyMode::Untenanted
+        ));
+        // Team-less caller vs tenanted approval: permissive only when untenanted.
+        assert!(caller_may_act_on(
+            &verified_caller(None),
+            Some("t"),
+            TenancyMode::Untenanted
+        ));
+        assert!(!caller_may_act_on(
+            &verified_caller(None),
+            Some("t"),
+            TenancyMode::Tenanted
+        ));
+        // Untenanted approval stays permissive in either mode.
+        assert!(caller_may_act_on(
+            &verified_caller(Some("t")),
+            None,
+            TenancyMode::Tenanted
+        ));
+        assert!(caller_may_act_on(&verified_caller(None), None, TenancyMode::Tenanted));
     }
 
     #[tokio::test]

--- a/aa-gateway/src/service/mod.rs
+++ b/aa-gateway/src/service/mod.rs
@@ -1,5 +1,30 @@
 //! gRPC service layer — wires tonic-generated services to business logic.
 
+/// Deployment tenancy posture governing the cross-tenant `caller_may_*` checks
+/// (AAASM-4021).
+///
+/// The cross-tenant guards fall back to *allow* whenever either the caller or
+/// the resource is untenanted, so a single-tenant / OSS deployment (where
+/// nothing carries a `team_id`) works with zero configuration. That same
+/// fallback, however, lets a **registered but team-less caller** pass every
+/// tenant's check — reading or acting on another tenant's resource — once
+/// tenancy is actually in use. This posture makes the distinction explicit:
+///
+/// * [`Untenanted`](TenancyMode::Untenanted) — the legacy permissive fallback;
+///   a team-less caller is unconfined. This is the default so OSS/single-tenant
+///   deployments are unaffected.
+/// * [`Tenanted`](TenancyMode::Tenanted) — tenancy is enforced; a team-less
+///   caller may **not** be treated as cross-tenant-allowed against a tenanted
+///   resource.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TenancyMode {
+    /// Single-tenant / OSS: a team-less caller is unconfined (legacy fallback).
+    #[default]
+    Untenanted,
+    /// Multi-tenant: a team-less caller cannot act on a tenanted resource.
+    Tenanted,
+}
+
 pub mod approval_service;
 pub mod audit_service;
 pub mod convert;

--- a/aa-gateway/src/service/topology_service.rs
+++ b/aa-gateway/src/service/topology_service.rs
@@ -15,16 +15,34 @@ use aa_proto::assembly::topology::v1::{
 use crate::edges::InMemoryEdgeRepo;
 use crate::iam::VerifiedCaller;
 use crate::registry::{AgentRecord, AgentRegistry, AgentStatus};
+use crate::service::TenancyMode;
 
 /// gRPC service implementation for topology queries.
 pub struct TopologyServiceImpl {
     registry: Arc<AgentRegistry>,
     edge_repo: InMemoryEdgeRepo,
+    /// Deployment tenancy posture for the cross-tenant guard (AAASM-4021).
+    /// Defaults to [`TenancyMode::Untenanted`] so OSS/single-tenant deployments
+    /// keep the permissive fallback.
+    tenancy_mode: TenancyMode,
 }
 
 impl TopologyServiceImpl {
     pub fn new(registry: Arc<AgentRegistry>, edge_repo: InMemoryEdgeRepo) -> Self {
-        Self { registry, edge_repo }
+        Self {
+            registry,
+            edge_repo,
+            tenancy_mode: TenancyMode::default(),
+        }
+    }
+
+    /// Set the deployment tenancy posture (AAASM-4021).
+    ///
+    /// In [`TenancyMode::Tenanted`] a team-less caller can no longer read or
+    /// enumerate a tenanted resource via the untenanted fallback.
+    pub fn with_tenancy_mode(mut self, mode: TenancyMode) -> Self {
+        self.tenancy_mode = mode;
+        self
     }
 }
 
@@ -52,13 +70,25 @@ fn format_id(id: &[u8; 16]) -> String {
 /// only act on a resource in the same team and org; when either side is
 /// untenanted access is allowed (the untenanted/single-tenant deployment
 /// fallback).
-fn caller_may_read(caller: &VerifiedCaller, resource_team: Option<&str>, resource_org: Option<&str>) -> bool {
+///
+/// AAASM-4021: in [`TenancyMode::Tenanted`] the fallback is tightened so a
+/// registered but team-less (resp. org-less) caller can no longer read a
+/// *tenanted* resource — that permissive path is kept only for the untenanted
+/// posture. Untenanted resources stay readable in either mode.
+fn caller_may_read(
+    caller: &VerifiedCaller,
+    resource_team: Option<&str>,
+    resource_org: Option<&str>,
+    mode: TenancyMode,
+) -> bool {
     let team_ok = match (caller.team_id.as_deref(), resource_team) {
         (Some(caller_team), Some(resource_team)) => caller_team == resource_team,
+        (None, Some(_)) => mode == TenancyMode::Untenanted,
         _ => true,
     };
     let org_ok = match (caller.org_id.as_deref(), resource_org) {
         (Some(caller_org), Some(resource_org)) => caller_org == resource_org,
+        (None, Some(_)) => mode == TenancyMode::Untenanted,
         _ => true,
     };
     team_ok && org_ok
@@ -129,7 +159,12 @@ impl TopologyService for TopologyServiceImpl {
         // AAASM-3846 — confine a tenanted caller to its own team/org so one team
         // cannot read another team's delegation tree.
         if let Some(caller) = &caller {
-            if !caller_may_read(caller, record.team_id.as_deref(), record.org_id.as_deref()) {
+            if !caller_may_read(
+                caller,
+                record.team_id.as_deref(),
+                record.org_id.as_deref(),
+                self.tenancy_mode,
+            ) {
                 return Err(Status::permission_denied("agent belongs to a different tenant"));
             }
         }
@@ -162,7 +197,12 @@ impl TopologyService for TopologyServiceImpl {
         // AAASM-3846 — a tenanted caller may only trace lineage for an agent in
         // its own team/org.
         if let Some(caller) = &caller {
-            if !caller_may_read(caller, record.team_id.as_deref(), record.org_id.as_deref()) {
+            if !caller_may_read(
+                caller,
+                record.team_id.as_deref(),
+                record.org_id.as_deref(),
+                self.tenancy_mode,
+            ) {
                 return Err(Status::permission_denied("agent belongs to a different tenant"));
             }
         }
@@ -193,10 +233,17 @@ impl TopologyService for TopologyServiceImpl {
         // AAASM-3846 — a tenanted caller may only enumerate its own team's
         // members, never another team's roster.
         if let Some(caller) = &caller {
-            if let Some(caller_team) = caller.team_id.as_deref() {
-                if caller_team != req.team_id {
+            match caller.team_id.as_deref() {
+                Some(caller_team) if caller_team != req.team_id => {
                     return Err(Status::permission_denied("team belongs to a different tenant"));
                 }
+                // AAASM-4021: a team-less caller may enumerate an arbitrary
+                // team's roster only in the untenanted posture; when tenancy is
+                // enforced it is confined out of another team's roster.
+                None if self.tenancy_mode == TenancyMode::Tenanted => {
+                    return Err(Status::permission_denied("team belongs to a different tenant"));
+                }
+                _ => {}
             }
         }
 
@@ -260,6 +307,7 @@ impl TopologyService for TopologyServiceImpl {
             &caller,
             source_record.team_id.as_deref(),
             source_record.org_id.as_deref(),
+            self.tenancy_mode,
         ) {
             return Err(Status::permission_denied("source agent belongs to a different tenant"));
         }
@@ -271,6 +319,7 @@ impl TopologyService for TopologyServiceImpl {
             &caller,
             target_record.team_id.as_deref(),
             target_record.org_id.as_deref(),
+            self.tenancy_mode,
         ) {
             return Err(Status::permission_denied("target agent belongs to a different tenant"));
         }
@@ -431,6 +480,72 @@ mod tests {
 
         let resp = svc.get_agent_tree(req).await.unwrap().into_inner();
         assert_eq!(resp.root.unwrap().agent.unwrap().id, format_id(&root));
+    }
+
+    fn service_tenanted(records: Vec<AgentRecord>) -> TopologyServiceImpl {
+        service_with(records).with_tenancy_mode(TenancyMode::Tenanted)
+    }
+
+    // AAASM-4021 — the untenanted fallback must not let a registered but
+    // team-less caller read a tenanted agent once tenancy is enforced.
+    #[tokio::test]
+    async fn tenanted_mode_teamless_caller_denied_reading_tenanted_agent() {
+        let root: [u8; 16] = [0xf0; 16];
+        let svc = service_tenanted(vec![make_record(root, "root", None, Some("team-b"), Some("org-b"))]);
+
+        let mut req = Request::new(GetAgentTreeRequest {
+            agent_id: format_id(&root),
+            max_depth: 0,
+        });
+        req.extensions_mut().insert(caller(None, None));
+
+        let err = svc.get_agent_tree(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn tenanted_mode_teamless_caller_denied_enumerating_team() {
+        let agent: [u8; 16] = [0xf1; 16];
+        let svc = service_tenanted(vec![make_record(agent, "a", None, Some("team-b"), None)]);
+
+        let mut req = Request::new(GetTeamMembersRequest {
+            team_id: "team-b".into(),
+        });
+        req.extensions_mut().insert(caller(None, None));
+
+        let err = svc.get_team_members(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[test]
+    fn caller_may_read_tenancy_matrix() {
+        // Team-less caller vs tenanted resource: permissive only when untenanted.
+        assert!(caller_may_read(
+            &caller(None, None),
+            Some("t"),
+            None,
+            TenancyMode::Untenanted
+        ));
+        assert!(!caller_may_read(
+            &caller(None, None),
+            Some("t"),
+            None,
+            TenancyMode::Tenanted
+        ));
+        // Untenanted resource stays readable in either mode.
+        assert!(caller_may_read(
+            &caller(Some("t"), None),
+            None,
+            None,
+            TenancyMode::Tenanted
+        ));
+        // Same-tenant match is mode-independent.
+        assert!(caller_may_read(
+            &caller(Some("t"), Some("o")),
+            Some("t"),
+            Some("o"),
+            TenancyMode::Tenanted
+        ));
     }
 
     // ── report_edge tenant authz (AAASM-3855) ──────────────────────────────


### PR DESCRIPTION
## What
The gRPC cross-tenant guards `approval_service::caller_may_act_on` and `topology_service::caller_may_read` (plus `get_team_members`) fall back to **allow** whenever *either* the caller or the resource is untenanted. That fallback keeps OSS/single-tenant deployments zero-config, but it also means a **registered but team-less caller** passes every tenant's check — it can decide another team's approval, read another team's delegation tree/lineage, or enumerate another team's roster once tenancy is in use.

This adds an explicit `TenancyMode` posture (`service::mod`):
- `Untenanted` (default) — legacy permissive fallback; **behavior unchanged**, so OSS/single-tenant deployments and all existing tests are unaffected (`server.rs` constructs both services with the default).
- `Tenanted` — a team-less caller is **not** treated as cross-tenant-allowed against a *tenanted* resource (`(None, Some) ⇒ deny`). Untenanted resources stay readable in either mode.

The `_may_*` checks are gated on this posture rather than breaking the untenanted fallback, matching the finding's guidance.

## Why
LOW-severity cross-tenant authz gap (AAASM-4021): the documented untenanted fallback is safe for OSS but must not silently authorize a team-less caller once tenancy is enforced.

## How to verify
- `cargo nextest run -p aa-gateway` — 1355 passed. New tests: tenanted-mode team-less caller denied on decide / get_agent_tree / get_team_members, plus `caller_may_*` truth-table units; existing untenanted-fallback tests still pass.
- `cargo clippy -p aa-gateway --all-targets -- -D warnings` — clean.

Closes AAASM-4021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73