### PR TITLE
[AAASM-4020] 🐛 (aa-runtime/security/cli): Robustness fail-closed batch

### DIFF
--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -40,7 +40,12 @@ fn default_log_path() -> PathBuf {
 /// Resolve the aa-proxy binary by trying, in order:
 /// 1. `which aa-proxy` (checks PATH)
 /// 2. `~/.cargo/bin/aa-proxy`
-/// 3. `./target/release/aa-proxy`
+///
+/// The former `./target/release/aa-proxy` cwd-relative fallback was dropped
+/// (AAASM-4020): resolving a binary relative to the current working directory
+/// lets whoever controls where `aasm` is invoked substitute an attacker-planted
+/// `aa-proxy`. Only trusted, absolute locations (PATH, the cargo bin dir) are
+/// honored.
 pub fn resolve_binary() -> Option<PathBuf> {
     #[cfg(unix)]
     {
@@ -59,11 +64,6 @@ pub fn resolve_binary() -> Option<PathBuf> {
         if cargo_bin.exists() {
             return Some(cargo_bin);
         }
-    }
-
-    let local = PathBuf::from("./target/release/aa-proxy");
-    if local.exists() {
-        return Some(local);
     }
 
     None
@@ -98,8 +98,8 @@ pub fn dispatch(args: StartArgs) -> ExitCode {
     let Some(binary) = resolve_binary() else {
         eprintln!(
             "error: aa-proxy binary not found.\n\
-             Install with `cargo install aa-proxy` or ensure it is on PATH, \
-             in ~/.cargo/bin, or at ./target/release/aa-proxy."
+             Install with `cargo install aa-proxy` or ensure it is on PATH \
+             or in ~/.cargo/bin."
         );
         return ExitCode::FAILURE;
     };

--- a/aa-runtime/src/l1_cache.rs
+++ b/aa-runtime/src/l1_cache.rs
@@ -10,29 +10,68 @@ use dashmap::DashMap;
 
 use crate::invalidation_client::InvalidationSink;
 
+/// Default upper bound on the number of cached entries (AAASM-4020).
+///
+/// The cache is keyed by attacker-influenceable `agent_id`, so it must be
+/// bounded before any insert path is wired — an unbounded [`DashMap`] would grow
+/// with every distinct id and become a memory-exhaustion vector.
+pub const DEFAULT_CAPACITY: usize = 10_000;
+
 /// A `DashMap`-backed L1 cache of per-agent values (e.g. policy decisions),
 /// invalidated on demand by the push-invalidation subscriber.
+///
+/// The map is bounded to [`DEFAULT_CAPACITY`] (override via
+/// [`PolicyL1Cache::with_capacity`]). When full, inserting a *new* key evicts an
+/// arbitrary existing entry: a policy-cache eviction is safe because a miss just
+/// triggers a re-fetch, so approximate (non-LRU) eviction trades exactness for a
+/// hard memory ceiling.
 pub struct PolicyL1Cache<V> {
     entries: DashMap<String, V>,
+    capacity: usize,
 }
 
 impl<V> Default for PolicyL1Cache<V> {
     fn default() -> Self {
         Self {
             entries: DashMap::new(),
+            capacity: DEFAULT_CAPACITY,
         }
     }
 }
 
 impl<V> PolicyL1Cache<V> {
-    /// Create an empty cache.
+    /// Create an empty cache bounded to [`DEFAULT_CAPACITY`].
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Create an empty cache bounded to `capacity` entries.
+    ///
+    /// A `capacity` of `0` is treated as `1` so the cache can always hold the
+    /// entry just inserted.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: DashMap::new(),
+            capacity: capacity.max(1),
+        }
+    }
+
     /// Insert or replace the cached value for `agent_id`.
+    ///
+    /// Enforces the capacity bound (AAASM-4020): when the cache is full and the
+    /// key is new, one arbitrary entry is evicted first so the map never exceeds
+    /// its configured ceiling.
     pub fn insert(&self, agent_id: impl Into<String>, value: V) {
-        self.entries.insert(agent_id.into(), value);
+        let key = agent_id.into();
+        if self.entries.len() >= self.capacity && !self.entries.contains_key(&key) {
+            // Clone the victim key so the read guard is dropped before `remove`
+            // takes a write lock (a held ref + same-shard write would deadlock).
+            let victim = self.entries.iter().next().map(|e| e.key().clone());
+            if let Some(victim) = victim {
+                self.entries.remove(&victim);
+            }
+        }
+        self.entries.insert(key, value);
     }
 
     /// Drop the cached value for `agent_id`, if present.
@@ -114,6 +153,29 @@ mod tests {
 
         assert!(!cache.contains("agent-a"));
         assert!(cache.contains("agent-b"));
+    }
+
+    #[test]
+    fn insert_enforces_capacity_bound() {
+        // AAASM-4020: the map must never exceed its configured ceiling, however
+        // many distinct keys are inserted.
+        let cache: PolicyL1Cache<u32> = PolicyL1Cache::with_capacity(4);
+        for i in 0..100u32 {
+            cache.insert(format!("agent-{i}"), i);
+        }
+        assert!(cache.len() <= 4, "len {} exceeded capacity", cache.len());
+    }
+
+    #[test]
+    fn insert_existing_key_does_not_evict() {
+        // Replacing an existing key must not trip the eviction path.
+        let cache: PolicyL1Cache<u32> = PolicyL1Cache::with_capacity(2);
+        cache.insert("a", 1);
+        cache.insert("b", 2);
+        cache.insert("a", 9);
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get("a"), Some(9));
+        assert_eq!(cache.get("b"), Some(2));
     }
 
     #[test]

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -645,6 +645,24 @@ enum GatewayOutcome {
 /// error, so the caller's fail-closed path applies. Dropping the timed-out
 /// future also releases the client lock, so a subsequent stuck query cannot
 /// wedge for longer than one deadline.
+/// Collapse a gateway decision code that the SDK path does not understand to a
+/// fail-closed `Deny` (AAASM-4020).
+///
+/// The SDK/runtime enforcement path only acts on `Allow`, `Deny`, and
+/// `Pending`. Any other code — `Unspecified`, a `Redact` verdict the runtime
+/// cannot apply on this path, or an out-of-range value from a newer gateway —
+/// is rewritten to `Deny` so an unknown verdict never relays through as an
+/// implicit allow. Mirrors `aa-proxy::mcp_enforce::decision_from_response`.
+fn normalize_gateway_decision(resp: &mut CheckActionResponse) {
+    let recognized = matches!(
+        Decision::try_from(resp.decision),
+        Ok(Decision::Allow | Decision::Deny | Decision::Pending)
+    );
+    if !recognized {
+        resp.decision = Decision::Deny as i32;
+    }
+}
+
 async fn try_gateway_forward(
     connection_id: u64,
     req: &aa_proto::assembly::policy::v1::CheckActionRequest,
@@ -660,7 +678,13 @@ async fn try_gateway_forward(
     let mut guard = client.lock().await;
     let call = tokio::time::timeout(gateway_timeout, guard.check_action(req.clone())).await;
     match call {
-        Ok(Ok(resp)) => {
+        Ok(Ok(mut resp)) => {
+            // AAASM-4020: normalize the decision before relaying it to the SDK.
+            // Only Allow/Deny/Pending are valid verdicts on this path; an
+            // Unspecified, out-of-range, or otherwise unrecognized code
+            // collapses to a fail-closed Deny rather than being forwarded
+            // verbatim (mirrors aa-proxy::mcp_enforce::decision_from_response).
+            normalize_gateway_decision(&mut resp);
             tracing::debug!(connection_id, decision = resp.decision, "gateway responded");
             // On Deny: surface a structured PolicyViolation event into
             // the broadcast pipeline so the Live Ops dashboard sees the
@@ -844,6 +868,32 @@ mod tests {
     use crate::policy::PolicyRules;
     use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, PolicyViolation};
     use aa_proto::assembly::policy::v1::OpControlSignal;
+
+    #[test]
+    fn normalize_gateway_decision_collapses_unknown_to_deny() {
+        // AAASM-4020: only Allow/Deny/Pending survive; everything else (an
+        // Unspecified, a Redact verdict, or an out-of-range code) becomes Deny.
+        for kept in [Decision::Allow, Decision::Deny, Decision::Pending] {
+            let mut resp = CheckActionResponse {
+                decision: kept as i32,
+                ..Default::default()
+            };
+            normalize_gateway_decision(&mut resp);
+            assert_eq!(resp.decision, kept as i32);
+        }
+        for code in [Decision::Unspecified as i32, Decision::Redact as i32, 9999] {
+            let mut resp = CheckActionResponse {
+                decision: code,
+                ..Default::default()
+            };
+            normalize_gateway_decision(&mut resp);
+            assert_eq!(
+                resp.decision,
+                Decision::Deny as i32,
+                "code {code} should collapse to Deny"
+            );
+        }
+    }
 
     /// Unwrap a `PipelineEvent::Audit` variant, panicking if it is a different variant.
     fn unwrap_audit(event: PipelineEvent) -> EnrichedEvent {

--- a/aa-security/src/policy/error.rs
+++ b/aa-security/src/policy/error.rs
@@ -41,6 +41,14 @@ pub enum PolicyParseError {
     /// gating). A policy must positively declare its posture, so a blank
     /// document is rejected rather than silently defaulting open (AAASM-3997).
     EmptyDocument,
+    /// The document parsed but declared no enforcement dimension.
+    ///
+    /// A metadata-only document (e.g. just `apiVersion`/`kind`/`metadata`, with
+    /// no `network`, `capabilities`, `tools`, or `syscalls`) deserializes to a
+    /// fully-permissive policy exactly like an empty one. It is rejected so a
+    /// policy cannot become open by omission rather than by declaration
+    /// (AAASM-4020, extending the AAASM-3997 empty/null floor).
+    NoEnforcementSection,
 }
 
 impl fmt::Display for PolicyParseError {
@@ -60,6 +68,13 @@ impl fmt::Display for PolicyParseError {
                 write!(
                     f,
                     "empty or null policy document is not permitted (would be fully permissive)"
+                )
+            }
+            Self::NoEnforcementSection => {
+                write!(
+                    f,
+                    "policy declares no enforcement section (network/capabilities/tools/syscalls); \
+                     it would be fully permissive"
                 )
             }
         }

--- a/aa-security/src/policy/parse.rs
+++ b/aa-security/src/policy/parse.rs
@@ -146,13 +146,27 @@ impl PolicyDocument {
             None => None,
         };
 
-        Ok(PolicyDocument {
+        let doc = PolicyDocument {
             name,
             network,
             capabilities,
             tools,
             syscall_allowlist,
-        })
+        };
+
+        // AAASM-4020: a document that parses but declares no enforcement
+        // dimension (e.g. metadata-only) is fully permissive, just like the
+        // empty/null case rejected above. Require at least one enforcement
+        // section so a policy cannot become open by omission.
+        if doc.network.is_none()
+            && doc.capabilities.is_none()
+            && doc.tools.is_empty()
+            && doc.syscall_allowlist.is_none()
+        {
+            return Err(PolicyParseError::NoEnforcementSection);
+        }
+
+        Ok(doc)
     }
 }
 
@@ -361,6 +375,39 @@ spec:
                 "blank input {blank:?} should be rejected as empty, got {err:?}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_metadata_only_document() {
+        // AAASM-4020: a document with only envelope metadata declares no
+        // enforcement dimension and would be fully permissive — reject it.
+        let yaml = r#"
+apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: does-nothing
+"#;
+        let err = PolicyDocument::from_yaml(yaml).unwrap_err();
+        assert!(
+            matches!(err, PolicyParseError::NoEnforcementSection),
+            "metadata-only doc should be rejected, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_l7_only_document_with_no_cross_layer_section() {
+        // A doc carrying only L7-only sections (budget/schedule/data) declares
+        // nothing this crate can enforce → fully permissive here → rejected.
+        let yaml = r#"
+spec:
+  budget:
+    daily_limit_usd: 5.0
+"#;
+        let err = PolicyDocument::from_yaml(yaml).unwrap_err();
+        assert!(
+            matches!(err, PolicyParseError::NoEnforcementSection),
+            "L7-only doc should be rejected, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What
Four independent fail-closed / robustness fixes (LOW severity, AAASM-4020):

- **(a) aa-runtime `pipeline/mod.rs`** — the SDK pipeline relayed the gateway's decision code verbatim, so an `Unspecified`/out-of-range verdict could pass through as an implicit allow. `normalize_gateway_decision` now collapses anything outside `Allow`/`Deny`/`Pending` to `Deny` before the response is sent, mirroring `aa-proxy::mcp_enforce::decision_from_response`.
- **(b) aa-runtime `l1_cache.rs`** — `PolicyL1Cache` was an unbounded `DashMap` keyed by `agent_id` (currently dormant/unwired). Added a capacity ceiling (default 10k, `with_capacity` override, evict-an-entry on full) so it can never become a memory-exhaustion vector once an insert path is wired.
- **(c) aa-security `policy/parse.rs`** — a metadata-only (or L7-only) document parsed to a fully-permissive policy, exactly like the empty/null case already rejected under AAASM-3997. It now requires at least one enforcement section (network/capabilities/tools/syscalls) via a new `PolicyParseError::NoEnforcementSection`; the existing empty/null rejection is unchanged.
- **(d) aa-cli `commands/proxy/start.rs`** — `resolve_binary` dropped the cwd-relative `./target/release/aa-proxy` fallback, which let whoever controls the launch directory substitute an attacker-planted binary. Only trusted PATH and `~/.cargo/bin` locations remain.

## Why
LOW-severity robustness/fail-closed hardening.

## How to verify
- `cargo nextest run -p aa-runtime -p aa-security -p aa-cli` — 1295 passed. New tests: decision-normalization matrix, L1 capacity bound + no-evict-on-replace, metadata-only + L7-only policy rejection. (No feasible deterministic/isolated unit test for `resolve_binary`, which depends on live PATH/HOME/`which`; the change is a pure removal of the insecure fallback.)
- `cargo clippy -p aa-runtime -p aa-security -p aa-cli --all-targets -- -D warnings` — clean.

Note: the aa-sandbox instantiate-OOM-telemetry sub-item of AAASM-4020 is handled in the AAASM-4015 PR to avoid a file conflict.

Closes AAASM-4020

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73