### PR TITLE
[AAASM-4032] ✨ (aa-gateway): Wire TenancyMode from config + tenanted registration invariant

### DIFF
--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -15,7 +15,7 @@ use crate::registry::AgentRegistry;
 use crate::secrets::InMemorySecretsStore;
 use crate::service::{
     AgentLifecycleServiceImpl, ApprovalServiceImpl, AuditServiceImpl, PolicyServiceImpl, SecretsServiceImpl,
-    TopologyServiceImpl,
+    TenancyMode, TopologyServiceImpl,
 };
 use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
@@ -580,7 +580,11 @@ pub async fn serve_tcp(
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry))
         .with_initial_seq(initial_seq);
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
-    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo);
+    // AAASM-4032: resolve the deployment tenancy posture once at boot and thread
+    // it through the tenancy-aware services. Default is Untenanted so OSS/single-
+    // tenant behaviour (and existing tests) are unchanged.
+    let tenancy_mode = TenancyMode::from_env();
+    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo).with_tenancy_mode(tenancy_mode);
     // AAASM-3788 — build the agent-plane auth interceptors from the shared
     // registry before it is moved into the lifecycle service. `auth` is
     // fail-closed (applied to the previously-unauthenticated services); `enrich`
@@ -603,11 +607,14 @@ pub async fn serve_tcp(
         }
     };
     let lifecycle_svc = match challenge_store {
-        Some(store) => AgentLifecycleServiceImpl::new(registry).with_challenge_store(store),
-        None => AgentLifecycleServiceImpl::new(registry),
+        Some(store) => AgentLifecycleServiceImpl::new(registry)
+            .with_challenge_store(store)
+            .with_tenancy_mode(tenancy_mode),
+        None => AgentLifecycleServiceImpl::new(registry).with_tenancy_mode(tenancy_mode),
     };
-    let approval_svc =
-        ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler).with_db_scheduler(db_scheduler);
+    let approval_svc = ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler)
+        .with_db_scheduler(db_scheduler)
+        .with_tenancy_mode(tenancy_mode);
     let secrets_svc = SecretsServiceImpl::new(Arc::new(InMemorySecretsStore::new()));
 
     let addr = listen_addr.parse()?;
@@ -714,7 +721,11 @@ pub async fn serve_uds(
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry))
         .with_initial_seq(initial_seq);
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
-    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo);
+    // AAASM-4032: resolve the deployment tenancy posture once at boot and thread
+    // it through the tenancy-aware services. Default is Untenanted so OSS/single-
+    // tenant behaviour (and existing tests) are unchanged.
+    let tenancy_mode = TenancyMode::from_env();
+    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo).with_tenancy_mode(tenancy_mode);
     // AAASM-3788 — agent-plane auth interceptors (see serve_tcp for the
     // fail-closed vs enrich rationale). UDS is additionally protected by
     // filesystem permissions; the credential interceptor is enforced regardless.
@@ -734,11 +745,14 @@ pub async fn serve_uds(
         }
     };
     let lifecycle_svc = match challenge_store {
-        Some(store) => AgentLifecycleServiceImpl::new(registry).with_challenge_store(store),
-        None => AgentLifecycleServiceImpl::new(registry),
+        Some(store) => AgentLifecycleServiceImpl::new(registry)
+            .with_challenge_store(store)
+            .with_tenancy_mode(tenancy_mode),
+        None => AgentLifecycleServiceImpl::new(registry).with_tenancy_mode(tenancy_mode),
     };
-    let approval_svc =
-        ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler).with_db_scheduler(db_scheduler);
+    let approval_svc = ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler)
+        .with_db_scheduler(db_scheduler)
+        .with_tenancy_mode(tenancy_mode);
     let secrets_svc = SecretsServiceImpl::new(Arc::new(InMemorySecretsStore::new()));
 
     tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS (per-RPC credential auth enforced)");

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -26,6 +26,7 @@ use crate::registry::convert::{proto_agent_id_to_key, validate_proto_agent_id};
 use crate::registry::store::AgentRecord;
 use crate::registry::token::{generate_credential_token, validate_token};
 use crate::registry::{AgentRegistry, AgentStatus, LineageError, OrphanMode, RegistryError, SuspendReason};
+use crate::service::TenancyMode;
 
 /// Default heartbeat interval returned to agents at registration (seconds).
 const DEFAULT_HEARTBEAT_INTERVAL_SEC: i64 = 30;
@@ -217,6 +218,11 @@ pub struct AgentLifecycleServiceImpl {
     /// process-local [`InMemoryChallengeStore`]; a horizontally-scaled gateway
     /// injects a shared backend via [`Self::with_challenge_store`].
     challenges: Arc<dyn ChallengeStoreLike>,
+    /// Deployment tenancy posture (AAASM-4032). Defaults to
+    /// [`TenancyMode::Untenanted`] so OSS/single-tenant deployments register
+    /// team-less agents exactly as before; in [`TenancyMode::Tenanted`],
+    /// `Register` rejects an agent that carries no `team_id`.
+    tenancy_mode: TenancyMode,
 }
 
 impl AgentLifecycleServiceImpl {
@@ -229,6 +235,7 @@ impl AgentLifecycleServiceImpl {
             audit_seq: Arc::new(AtomicU64::new(0)),
             audit_last_hash: Arc::new(Mutex::new([0u8; 32])),
             challenges: Arc::new(InMemoryChallengeStore::default()),
+            tenancy_mode: TenancyMode::default(),
         }
     }
 
@@ -244,6 +251,7 @@ impl AgentLifecycleServiceImpl {
             audit_seq: Arc::new(AtomicU64::new(0)),
             audit_last_hash: Arc::new(Mutex::new([0u8; 32])),
             challenges: Arc::new(InMemoryChallengeStore::default()),
+            tenancy_mode: TenancyMode::default(),
         }
     }
 
@@ -265,6 +273,16 @@ impl AgentLifecycleServiceImpl {
     /// registration fails closed.
     pub fn with_challenge_store(mut self, challenges: Arc<dyn ChallengeStoreLike>) -> Self {
         self.challenges = challenges;
+        self
+    }
+
+    /// Set the deployment tenancy posture (AAASM-4032).
+    ///
+    /// In [`TenancyMode::Tenanted`], `Register` rejects a team-less agent
+    /// (empty/absent `team_id`) with `FailedPrecondition`. Under the default
+    /// [`TenancyMode::Untenanted`], registration is unchanged.
+    pub fn with_tenancy_mode(mut self, mode: TenancyMode) -> Self {
+        self.tenancy_mode = mode;
         self
     }
 }
@@ -323,6 +341,17 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             .as_ref()
             .ok_or_else(|| Status::invalid_argument("missing agent_id"))?;
         validate_proto_agent_id(proto_id).map_err(|e| Status::invalid_argument(e.to_string()))?;
+
+        // AAASM-4032: in a Tenanted deployment posture, every agent MUST belong
+        // to a team. Reject a team-less registration up front (before the
+        // possession-proof challenge is consumed) so a caller cannot register an
+        // agent that would then pass every tenant's cross-tenant fallback check.
+        // Under the default Untenanted posture this guard is inert.
+        if self.tenancy_mode == TenancyMode::Tenanted && proto_id.team_id.is_empty() {
+            return Err(Status::failed_precondition(
+                "tenanted gateway: registration requires a non-empty team_id (AAASM-4032)",
+            ));
+        }
 
         if req.public_key.is_empty() {
             return Err(Status::invalid_argument("missing public_key"));

--- a/aa-gateway/src/service/mod.rs
+++ b/aa-gateway/src/service/mod.rs
@@ -25,6 +25,58 @@ pub enum TenancyMode {
     Tenanted,
 }
 
+impl TenancyMode {
+    /// Environment variable that selects the deployment tenancy posture at
+    /// gateway boot (AAASM-4032).
+    pub const ENV_VAR: &'static str = "AA_GATEWAY_TENANCY_MODE";
+
+    /// Resolve the tenancy posture from [`Self::ENV_VAR`].
+    ///
+    /// Accepts `tenanted` / `untenanted` case-insensitively (surrounding
+    /// whitespace ignored). An unset, empty, or unrecognised value falls back to
+    /// the [`Untenanted`](Self::Untenanted) default, so OSS/single-tenant
+    /// deployments keep zero-config behaviour.
+    pub fn from_env() -> Self {
+        match std::env::var(Self::ENV_VAR) {
+            Ok(v) => Self::parse(&v),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Parse a posture string, defaulting to [`Untenanted`](Self::Untenanted)
+    /// for anything other than an explicit `tenanted`.
+    fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "tenanted" => Self::Tenanted,
+            _ => Self::Untenanted,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tenancy_mode_tests {
+    use super::TenancyMode;
+
+    #[test]
+    fn default_is_untenanted() {
+        assert_eq!(TenancyMode::default(), TenancyMode::Untenanted);
+    }
+
+    #[test]
+    fn parse_tenanted_variants() {
+        assert_eq!(TenancyMode::parse("tenanted"), TenancyMode::Tenanted);
+        assert_eq!(TenancyMode::parse("Tenanted"), TenancyMode::Tenanted);
+        assert_eq!(TenancyMode::parse("  TENANTED  "), TenancyMode::Tenanted);
+    }
+
+    #[test]
+    fn parse_untenanted_and_unknown_fall_back_to_untenanted() {
+        assert_eq!(TenancyMode::parse("untenanted"), TenancyMode::Untenanted);
+        assert_eq!(TenancyMode::parse(""), TenancyMode::Untenanted);
+        assert_eq!(TenancyMode::parse("nonsense"), TenancyMode::Untenanted);
+    }
+}
+
 pub mod approval_service;
 pub mod audit_service;
 pub mod convert;

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -119,6 +119,30 @@ async fn start_server_with_engine(
     (addr, registry, engine)
 }
 
+/// AAASM-4032: start a server whose lifecycle service runs under an explicit
+/// tenancy posture, so the registration invariant can be exercised.
+async fn start_server_with_tenancy(mode: aa_gateway::service::TenancyMode) -> (SocketAddr, Arc<AgentRegistry>) {
+    let registry = Arc::new(AgentRegistry::new());
+    let service = AgentLifecycleServiceImpl::new(Arc::clone(&registry)).with_tenancy_mode(mode);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let registry_clone = Arc::clone(&registry);
+    tokio::spawn(async move {
+        let _reg = registry_clone;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(AgentLifecycleServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, registry)
+}
+
 // ── Full lifecycle test ────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -1203,6 +1227,104 @@ async fn register_proof_over_a_different_value_than_the_issued_nonce_is_rejected
         .unwrap_err();
 
     assert_eq!(status.code(), tonic::Code::Unauthenticated);
+}
+
+// ── AAASM-4032: tenanted registration invariant ──────────────────────────────
+//
+// Under the default Untenanted posture, a team-less agent registers exactly as
+// before. Under Tenanted, registration requires a non-empty team_id — a team-
+// less agent is rejected with FailedPrecondition, while an agent that carries a
+// team registers normally.
+
+/// Build a well-formed RegisterRequest for `agent_id`, leaving the
+/// possession-proof fields for `register_with_challenge` to populate.
+fn register_req(agent_id: ProtoAgentId, name: &str) -> RegisterRequest {
+    RegisterRequest {
+        agent_id: Some(agent_id),
+        name: name.into(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: test_ed25519_public_key_hex(),
+        metadata: Default::default(),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn untenanted_default_accepts_team_less_registration() {
+    let (addr, _registry) = start_server_with_tenancy(aa_gateway::service::TenancyMode::Untenanted).await;
+    let mut client = connect(addr).await;
+
+    let resp = register_with_challenge(
+        &mut client,
+        register_req(
+            ProtoAgentId {
+                org_id: "org-untenanted".into(),
+                team_id: String::new(),
+                agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+            },
+            "team-less-untenanted",
+        ),
+    )
+    .await
+    .expect("untenanted posture must accept a team-less agent")
+    .into_inner();
+
+    assert!(!resp.credential_token.is_empty());
+    assert_eq!(resp.team_id, None, "team-less agent normalizes team_id to None");
+}
+
+#[tokio::test]
+async fn tenanted_rejects_team_less_registration() {
+    let (addr, _registry) = start_server_with_tenancy(aa_gateway::service::TenancyMode::Tenanted).await;
+    let mut client = connect(addr).await;
+
+    let status = register_with_challenge(
+        &mut client,
+        register_req(
+            ProtoAgentId {
+                org_id: "org-tenanted".into(),
+                team_id: String::new(),
+                agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+            },
+            "team-less-tenanted",
+        ),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        status.message().contains("team_id"),
+        "error must name the missing team_id: {}",
+        status.message()
+    );
+}
+
+#[tokio::test]
+async fn tenanted_accepts_registration_with_team() {
+    let (addr, _registry) = start_server_with_tenancy(aa_gateway::service::TenancyMode::Tenanted).await;
+    let mut client = connect(addr).await;
+
+    let resp = register_with_challenge(
+        &mut client,
+        register_req(
+            ProtoAgentId {
+                org_id: "org-tenanted".into(),
+                team_id: "team-alpha".into(),
+                agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+            },
+            "teamed-tenanted",
+        ),
+    )
+    .await
+    .expect("tenanted posture must accept an agent that carries a team")
+    .into_inner();
+
+    assert!(!resp.credential_token.is_empty());
+    assert_eq!(resp.team_id, Some("team-alpha".into()));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Makes the `TenancyMode` posture (added by AAASM-4021) reachable from deployment config and adds a registration invariant.

- **Config wiring** — `TenancyMode::from_env()` reads `AA_GATEWAY_TENANCY_MODE` (`tenanted` | `untenanted`, case-insensitive) at gateway boot in `server.rs` (`serve_tcp` + `serve_uds`), and threads the resolved posture into `ApprovalServiceImpl`, `TopologyServiceImpl`, and `AgentLifecycleServiceImpl` via `.with_tenancy_mode(...)`. These previously used `TenancyMode::default()` and so were never reachable from config.
- **Registration invariant** — in `Tenanted` posture, `AgentLifecycleService::Register` rejects a team-less agent (empty/absent `team_id`) with `FailedPrecondition`, before the possession-proof challenge is consumed. Under `Untenanted` the guard is inert.

## Why

AAASM-4021 shipped the cross-tenant `caller_may_*` guards but left the posture hardwired to the default. A registered but team-less agent otherwise passes every tenant's permissive fallback once tenancy is in use. This PR lets an operator opt into `Tenanted` and closes the team-less registration hole at the source.

**Default remains `Untenanted`** — unset/empty/unrecognised env values fall back to it, so OSS/single-tenant deployments and all existing tests are unchanged.

## How verified

- New unit tests (`service::tenancy_mode_tests`): default is `Untenanted`; `from_env` parsing of tenanted variants + fallback.
- New integration tests (`lifecycle_service_test`): untenanted default accepts a team-less agent; tenanted rejects a team-less agent with `FailedPrecondition`; tenanted accepts an agent with a team.
- Gates on `aa-gateway`: `cargo fmt --all`, `cargo build`, `cargo nextest run` (1361 passed), `cargo clippy --all-targets -- -D warnings` (clean).

Closes AAASM-4032

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73