### PR TITLE
[AAASM-4033] ✅ (aa-integration-tests): Add runtime→loaderd orchestration e2e (Linux)

### DIFF
--- a/aa-integration-tests/tests/e2e_ebpf.rs
+++ b/aa-integration-tests/tests/e2e_ebpf.rs
@@ -33,6 +33,8 @@
 //! | 4 | `ebpf_catches_traffic_without_sdk_init` | enabled (root + libssl) |
 //! | 5 | `ebpf_event_includes_pid_and_cgroup` | enabled (root) |
 //! | 6 | `ebpf_load_and_unload_clean` | enabled (root) |
+//! | 7 | `ebpf_runtime_orchestration_drives_loaderd` | enabled (root + loaderd) |
+//! | 8 | `ebpf_loaderd_boot_liveness_degrades_without_hanging` | enabled (no BPF) |
 //!
 //! ## Why direct ring-buffer reads instead of HTTP gateway lookup
 //!
@@ -49,45 +51,60 @@
 //! complete, the gateway-side assertion can be added in a follow-up
 //! without changing the probe-fired half of the check.
 //!
-//! ## GAP — runtime → loaderd orchestration is NOT exercised here (AAASM-4011)
+//! ## runtime → loaderd orchestration — covered by AAASM-4033 (tests 7 & 8)
 //!
-//! Every test below loads and attaches probes **directly in-process** via
-//! `EbpfLoader` / `UprobeManager` / `TracepointManager` under `sudo`. That
-//! validates the probes themselves, but it deliberately bypasses the
-//! production control path AAASM-4011 wired up: the **unprivileged** runtime
-//! driving the **privileged** `aa-ebpf-loaderd` daemon over its control socket
-//! (`aa_runtime::ebpf_control::drive_ebpf_layer` →
-//! `aa_ebpf::control::client::LoaderControlClient` →
-//! `aa_ebpf::control::server`). None of that orchestration is covered by any
-//! test yet, so a Linux e2e must be added that verifies, end to end:
+//! Tests 1–6 load and attach probes **directly in-process** via `EbpfLoader` /
+//! `UprobeManager` / `TracepointManager` under `sudo`. That validates the probes
+//! themselves, but it bypasses the production control path AAASM-4011 wired up:
+//! the **unprivileged** runtime driving the **privileged** `aa-ebpf-loaderd`
+//! daemon over its control socket (`aa_runtime::ebpf_control::drive_ebpf_layer` →
+//! `aa_ebpf::control::client::LoaderControlClient` → `aa_ebpf::control::server`).
+//! AAASM-4033 adds the missing coverage:
 //!
-//! 1. **Unprivileged runtime, privileged daemon.** Start `aa-ebpf-loaderd`
-//!    with `CAP_BPF`/`CAP_PERFMON` and the runtime with **none** (the
-//!    `enforce_least_privilege` posture). With `AA_EBPF_INPROCESS_LOAD` unset,
-//!    `drive_ebpf_layer` must connect to the socket and `LoadProbeSet` the TLS,
-//!    file-I/O, and exec sets — no `ebpf/*` sub-layer degrades.
-//! 2. **Path map push.** With `AA_EBPF_POLICY_PATH` pointing at a policy that
-//!    denies a sensitive path, `UpdatePathMap` reaches the daemon and the
-//!    file-I/O probe flags an access to that path (`flags` bit 0 set).
-//! 3. **Syscall guard (enforce).** With `AA_EBPF_CONFINE_PID=<sandbox pid>` and
-//!    a policy that lowers to a non-empty syscall allowlist, the guard loads and
-//!    `UpdateSyscallAllowlist` lands; a confined process issuing a
-//!    non-allowlisted syscall is SIGKILLed, while the runtime's own syscalls are
-//!    never confined (guard scoped to the sandbox PID, not the runtime).
-//! 4. **Load→allowlist ordering hazard.** The current protocol couples
-//!    load+attach+PID-filter insertion in one `LoadProbeSet`, so there is a
-//!    window where the confined PID runs with an empty allowlist (default-deny).
-//!    The e2e must confirm the confined process is not spuriously killed before
-//!    `UpdateSyscallAllowlist` is applied — and, if it can be, that confirms the
-//!    protocol needs a `load-without-filter → set allowlist → add PID` sequence
-//!    (a follow-up on `aa_ebpf::control`).
-//! 5. **Observe-only telemetry gap.** `LoadProbeSet`'s doc promises the daemon
-//!    "begins streaming events back", but `aa_ebpf::control::server::dispatch`
-//!    does not yet stream — it only loads/attaches. So TLS/file-I/O/exec events
-//!    captured by the daemon-owned readers do **not** reach the runtime pipeline
-//!    over the control channel. Enforcement (syscall-guard SIGKILL, in-kernel
-//!    path-blocklist flagging) is autonomous and unaffected, but observe-only
-//!    audit telemetry via the daemon path is still unwired (follow-up).
+//! - **Test 7 — orchestration loads probes via the control protocol.** Spawns
+//!   the real `aa-ebpf-loaderd` binary on a private control socket and drives the
+//!   exact plan `drive_ebpf_layer` executes (`plan_control_ops`): `LoadProbeSet`
+//!   for the TLS / file-I/O / exec observe-only sets, `UpdatePathMap` with a
+//!   sensitive-path deny lowered through the canonical `lower_to_ebpf`, then
+//!   `LoadProbeSet` for the syscall guard scoped to a throwaway sandbox PID
+//!   followed by `UpdateSyscallAllowlist`. Every op returning `Ok` is
+//!   ground-truth that the probe actually loaded/attached and the map updated in
+//!   the kernel *through the daemon over the socket* — the half of the AAASM-4011
+//!   path no test previously touched. The guard is deliberately scoped to the
+//!   sandbox PID, never the runtime's own PID (the observe sets), so the
+//!   default-deny SIGKILL probe can never confine the test process.
+//! - **Test 8 — boot-liveness / degrade-not-hang.** `drive_ebpf_layer` wraps
+//!   every round-trip in `await_loaderd` under `loaderd_deadline`
+//!   (`AA_EBPF_LOADERD_TIMEOUT_MS`) so a wedged daemon degrades the layer instead
+//!   of hanging runtime boot. Test 8 exercises that discipline at the client
+//!   layer: an **absent** daemon makes `connect` fail fast, and a **hung** daemon
+//!   (accepts, never replies) makes a control op block indefinitely on its own —
+//!   completing only because the runtime-style deadline wrapper elapses it.
+//!
+//! ### Still deferred (out of scope for AAASM-4033)
+//!
+//! Test 7 asserts the control ops *land*; it does not assert the in-kernel
+//! *observation/enforcement side effects*, because the daemon does not surface
+//! them to the client:
+//!
+//! 1. **Observe-only telemetry over the control channel.** `LoadProbeSet`'s doc
+//!    promises the daemon "begins streaming events back", but
+//!    `aa_ebpf::control::server::dispatch` only loads/attaches — it does not
+//!    stream. So TLS/file-I/O/exec events captured by the daemon-owned readers do
+//!    not reach the runtime over the control channel, and the client cannot
+//!    observe them. Asserting the file-I/O path-deny *flag bit* and the exec/TLS
+//!    captures *via the daemon path* waits on that streaming follow-up.
+//! 2. **Syscall-guard SIGKILL assertion.** Enforcement (the guard SIGKILLing a
+//!    confined process on a non-allowlisted syscall) is autonomous in-kernel, but
+//!    asserting it end-to-end needs a confined helper that issues a controlled
+//!    forbidden syscall at a deterministic instant — fragile without a
+//!    purpose-built sandbox binary. Test 7 asserts the guard *loads and is
+//!    configured* via the protocol; observing the kill is deferred.
+//! 3. **Load→allowlist ordering hazard.** The protocol couples
+//!    load+attach+PID-filter insertion in one `LoadProbeSet`, leaving a window
+//!    where the confined PID runs with an empty (default-deny) allowlist before
+//!    `UpdateSyscallAllowlist`. A race-free fix (`load-without-filter → set
+//!    allowlist → add PID`) is a follow-up on `aa_ebpf::control`.
 
 // NOTE: The whole file is cfg-gated. There is intentionally nothing else at
 // the top level — without the feature/OS combo, the test binary is empty.

--- a/aa-integration-tests/tests/e2e_ebpf.rs
+++ b/aa-integration-tests/tests/e2e_ebpf.rs
@@ -98,6 +98,8 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
+use aa_ebpf::control::client::LoaderControlClient;
+use aa_ebpf::control::{PathRuleWire, ProbeSet};
 use aa_ebpf::loader::EbpfLoader;
 use aa_ebpf::ringbuf::{EbpfEvent, RingBufReader};
 use aa_ebpf::tracepoint::TracepointManager;
@@ -105,7 +107,9 @@ use aa_ebpf::uprobe::UprobeManager;
 use aa_ebpf::AA_EXEC_BPF;
 use aa_ebpf_common::exec::ExecEvent;
 use aa_ebpf_common::tls::TlsCaptureEvent;
+use aa_security::policy::{lower_to_ebpf, EbpfRuleSet, PathVerdict, PolicyDocument, SyscallAllowlist, ToolRule};
 use aya::Ebpf;
+use tokio::net::UnixListener;
 use tokio::time::timeout;
 
 // =============================================================================
@@ -511,4 +515,287 @@ async fn ebpf_load_and_unload_clean() {
             UprobeManager::attach(&mut bpf, None).expect("cycle 2: re-attach after first cycle dropped — clean unload");
         let _reader = RingBufReader::new(bpf).expect("cycle 2: ring-buffer reader after re-load");
     }
+}
+
+// =============================================================================
+// AAASM-4033 — runtime → loaderd orchestration helpers (tests 7 & 8)
+// =============================================================================
+
+/// Resolve the `aa-ebpf-loaderd` binary: an explicit override, the sibling build
+/// artifact next to the test executable, or a one-shot `cargo build`.
+///
+/// `cargo +nightly test -p aa-integration-tests` (the CI invocation) does not
+/// build sibling-crate binaries, so the daemon may not exist yet. The build
+/// fallback reuses the already-compiled `aa-ebpf` lib artifacts, so it is
+/// incremental.
+fn loaderd_bin_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("AA_EBPF_LOADERD_BIN") {
+        return PathBuf::from(p);
+    }
+    // current_exe() is `<target>/<profile>/deps/e2e_ebpf-<hash>`; the daemon
+    // binary lands at `<target>/<profile>/aa-ebpf-loaderd`.
+    let exe = std::env::current_exe().expect("current_exe");
+    let profile_dir = exe
+        .parent()
+        .and_then(|deps| deps.parent())
+        .expect("target profile dir")
+        .to_path_buf();
+    let candidate = profile_dir.join("aa-ebpf-loaderd");
+    if candidate.exists() {
+        return candidate;
+    }
+    let cargo = option_env!("CARGO").unwrap_or("cargo");
+    let status = Command::new(cargo)
+        .args(["build", "-p", "aa-ebpf", "--bin", "aa-ebpf-loaderd"])
+        .status()
+        .expect("failed to invoke cargo to build aa-ebpf-loaderd");
+    assert!(
+        status.success(),
+        "`cargo build -p aa-ebpf --bin aa-ebpf-loaderd` failed"
+    );
+    assert!(
+        candidate.exists(),
+        "aa-ebpf-loaderd missing at {} after build",
+        candidate.display()
+    );
+    candidate
+}
+
+/// A spawned `aa-ebpf-loaderd` daemon bound to a private control socket, killed
+/// on drop. Mirrors the production topology: a privileged daemon process the
+/// runtime drives over the control socket (here client and daemon share the same
+/// root UID, which the daemon's peer-credential gate admits).
+struct LoaderDaemon {
+    child: std::process::Child,
+    sock: PathBuf,
+}
+
+impl LoaderDaemon {
+    /// Spawn the daemon with `AA_EBPF_LOADERD_SOCK` pointed at a private path.
+    fn spawn() -> Self {
+        let sock = std::env::temp_dir().join(format!("aa-loaderd-e2e-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&sock);
+        let child = Command::new(loaderd_bin_path())
+            .env("AA_EBPF_LOADERD_SOCK", &sock)
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("failed to spawn aa-ebpf-loaderd (needs root: CAP_BPF + CAP_PERFMON)");
+        Self { child, sock }
+    }
+
+    /// Poll the control socket until the daemon answers a `Ping`, or panic after
+    /// `deadline`.
+    async fn wait_ready(&self, deadline: Duration) {
+        let start = Instant::now();
+        loop {
+            if start.elapsed() >= deadline {
+                panic!("aa-ebpf-loaderd did not become ready within {deadline:?}");
+            }
+            if let Ok(mut client) = LoaderControlClient::connect(&self.sock).await {
+                if client.ping().await.is_ok() {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Open a fresh control client to the daemon.
+    async fn client(&self) -> LoaderControlClient {
+        LoaderControlClient::connect(&self.sock)
+            .await
+            .expect("connect to loaderd control socket")
+    }
+}
+
+impl Drop for LoaderDaemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_file(&self.sock);
+    }
+}
+
+/// Build the same lowered rule set the runtime feeds the daemon: a sensitive
+/// path deny plus a non-empty syscall allowlist, produced through the canonical
+/// `lower_to_ebpf` pipeline `aa_runtime::ebpf_control::load_ebpf_ruleset` uses.
+fn orchestration_ruleset() -> EbpfRuleSet {
+    let doc = PolicyDocument {
+        name: Some("aaasm-4033-e2e".to_string()),
+        network: None,
+        capabilities: None,
+        tools: vec![ToolRule {
+            name: "write_file".to_string(),
+            allow: true,
+            requires_approval_if: Some("path starts_with \"/etc/shadow\"".to_string()),
+        }],
+        syscall_allowlist: Some(
+            SyscallAllowlist::from_names(["read", "write", "close", "exit"]).expect("known syscall names"),
+        ),
+    };
+    lower_to_ebpf(&doc)
+}
+
+// =============================================================================
+// Test 7 — runtime → loaderd orchestration loads probes via the control protocol
+// =============================================================================
+
+/// AAASM-4033 test 7 — `ebpf_runtime_orchestration_drives_loaderd`.
+///
+/// Closes the AAASM-4011 NOTE's core gap: the production control path (an
+/// unprivileged runtime driving the privileged `aa-ebpf-loaderd` over its socket)
+/// was validated by no test. This spawns the real daemon binary and drives the
+/// exact plan `aa_runtime::ebpf_control::drive_ebpf_layer` executes
+/// (`plan_control_ops`): `LoadProbeSet` for the three observe-only sets,
+/// `UpdatePathMap` with a lowered sensitive-path deny, then `LoadProbeSet` for
+/// the syscall guard (scoped to a throwaway sandbox PID) and
+/// `UpdateSyscallAllowlist`. Each op returning `Ok` is ground truth that the
+/// probe actually loaded/attached and the map updated in the kernel *through the
+/// daemon over the socket*.
+///
+/// Observation/enforcement side effects (path-flag bit, guard SIGKILL) are NOT
+/// asserted here — the daemon does not stream events back over the control
+/// channel, so the client cannot observe them; see the file-level "Still
+/// deferred" note.
+#[tokio::test(flavor = "multi_thread")]
+async fn ebpf_runtime_orchestration_drives_loaderd() {
+    let daemon = LoaderDaemon::spawn();
+    daemon.wait_ready(Duration::from_secs(10)).await;
+    let mut client = daemon.client().await;
+
+    let ruleset = orchestration_ruleset();
+    assert!(!ruleset.path_rules.is_empty(), "fixture must lower to a path rule");
+    assert!(
+        !ruleset.syscall_allowlist.is_empty(),
+        "fixture must lower to a non-empty syscall allowlist"
+    );
+
+    // Observe-only sets are scoped to this process, exactly as
+    // `drive_ebpf_layer` scopes them to the runtime's own PID.
+    let observe_pid = std::process::id();
+
+    // A quiescent sandbox child is the syscall-guard confine target. The guard is
+    // a default-deny SIGKILL probe, so it must NEVER be scoped to the test
+    // process — only to this throwaway PID.
+    let mut sandbox = Command::new("sleep")
+        .arg("300")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn sandbox sleep");
+    let confine_pid = sandbox.id();
+    assert_ne!(
+        observe_pid, confine_pid,
+        "guard confine target must be the sandbox, never the runtime process"
+    );
+
+    // 1. LoadProbeSet for the three observe-only sets — probes load + attach
+    //    through the real daemon over the control socket.
+    for set in [ProbeSet::Tls, ProbeSet::FileIo, ProbeSet::Exec] {
+        client
+            .load_probe_set(set, observe_pid)
+            .await
+            .unwrap_or_else(|e| panic!("LoadProbeSet({set:?}) must succeed via loaderd: {e}"));
+    }
+
+    // 2. UpdatePathMap lands the lowered sensitive-path deny into the file-I/O
+    //    BPF map (requires the FileIo set loaded above).
+    let path_wire: Vec<PathRuleWire> = ruleset
+        .path_rules
+        .iter()
+        .map(|r| PathRuleWire {
+            pattern: r.pattern.clone(),
+            deny: r.verdict == PathVerdict::Deny,
+        })
+        .collect();
+    client
+        .update_path_map(path_wire)
+        .await
+        .unwrap_or_else(|e| panic!("UpdatePathMap must succeed via loaderd: {e}"));
+
+    // 3. SyscallGuard load (scoped to the sandbox PID) then UpdateSyscallAllowlist
+    //    — the enforcing half of the plan.
+    client
+        .load_probe_set(ProbeSet::SyscallGuard, confine_pid)
+        .await
+        .unwrap_or_else(|e| panic!("LoadProbeSet(SyscallGuard) must succeed via loaderd: {e}"));
+    client
+        .update_syscall_allowlist(ruleset.syscall_allowlist.clone())
+        .await
+        .unwrap_or_else(|e| panic!("UpdateSyscallAllowlist must succeed via loaderd: {e}"));
+
+    // Tear down the confined probes so nothing survives the test.
+    let _ = client.detach(ProbeSet::SyscallGuard).await;
+
+    let _ = sandbox.kill();
+    let _ = sandbox.wait();
+}
+
+// =============================================================================
+// Test 8 — boot-liveness: the layer degrades (does not hang) on a bad daemon
+// =============================================================================
+
+/// AAASM-4033 test 8 — `ebpf_loaderd_boot_liveness_degrades_without_hanging`.
+///
+/// `drive_ebpf_layer` wraps every control round-trip in `await_loaderd` under
+/// `loaderd_deadline` (`AA_EBPF_LOADERD_TIMEOUT_MS`) so a wedged daemon degrades
+/// the eBPF layer instead of hanging runtime boot. `drive_ebpf_layer` itself is
+/// `pub(crate)` in `aa-runtime`, so this asserts that liveness property at the
+/// exact client layer the runtime relies on:
+///
+/// - **Absent daemon** — `LoaderControlClient::connect` fails fast (no hang).
+/// - **Hung daemon** — accepts the connection but never replies; the client's
+///   `read_frame` has no timeout of its own, so a control op blocks indefinitely
+///   and only elapses because a runtime-style deadline wraps it. That elapse is
+///   what `drive_ebpf_layer` turns into a sub-layer degradation.
+#[tokio::test(flavor = "multi_thread")]
+async fn ebpf_loaderd_boot_liveness_degrades_without_hanging() {
+    // Mirrors a small `AA_EBPF_LOADERD_TIMEOUT_MS` — the runtime's per-op bound.
+    const RUNTIME_STYLE_DEADLINE: Duration = Duration::from_millis(300);
+
+    // --- Absent daemon: connect must fail fast, not hang. ---
+    let absent = std::env::temp_dir().join(format!("aa-loaderd-absent-{}.sock", std::process::id()));
+    let _ = std::fs::remove_file(&absent);
+    let connect = timeout(Duration::from_secs(2), LoaderControlClient::connect(&absent)).await;
+    assert!(
+        connect.is_ok(),
+        "connecting to an absent daemon must fail fast, not hang"
+    );
+    assert!(
+        connect.unwrap().is_err(),
+        "connecting to an absent control socket must return an error"
+    );
+
+    // --- Hung daemon: accepts but never replies. ---
+    let hung = std::env::temp_dir().join(format!("aa-loaderd-hung-{}.sock", std::process::id()));
+    let _ = std::fs::remove_file(&hung);
+    let listener = UnixListener::bind(&hung).expect("bind hung listener");
+    let server = tokio::spawn(async move {
+        // Accept the connection and hold it open forever without ever writing a
+        // response. Keeping `_stream` alive across the never-resolving future is
+        // load-bearing: dropping it would close the socket and hand the client an
+        // EOF (a completed op), defeating the point — a truly wedged daemon keeps
+        // the connection up but silent.
+        if let Ok((_stream, _addr)) = listener.accept().await {
+            std::future::pending::<()>().await;
+        }
+    });
+
+    let mut client = LoaderControlClient::connect(&hung)
+        .await
+        .expect("a hung daemon still accepts the connection");
+    let op = timeout(
+        RUNTIME_STYLE_DEADLINE,
+        client.load_probe_set(ProbeSet::Tls, std::process::id()),
+    )
+    .await;
+    assert!(
+        op.is_err(),
+        "a control op against a hung daemon must not complete on its own — the runtime's \
+         deadline wrapper is what prevents a boot hang"
+    );
+
+    server.abort();
+    let _ = std::fs::remove_file(&hung);
 }


### PR DESCRIPTION
## What

Adds two Linux-only e2e tests to `aa-integration-tests/tests/e2e_ebpf.rs`, closing the code NOTE that AAASM-4011 left behind ("runtime → loaderd orchestration is NOT exercised here"):

- **Test 7 — `ebpf_runtime_orchestration_drives_loaderd`**: spawns the real `aa-ebpf-loaderd` privileged daemon on a private control socket and drives the exact plan `aa_runtime::ebpf_control::drive_ebpf_layer` executes (`plan_control_ops`) via the public `LoaderControlClient`: `LoadProbeSet` for the TLS / file-I/O / exec observe-only sets, `UpdatePathMap` (a sensitive-path deny lowered through the canonical `aa_security::policy::lower_to_ebpf`), then `LoadProbeSet` for the syscall guard — scoped to a throwaway sandbox PID, never the test process — followed by `UpdateSyscallAllowlist`. Each op returning `Ok` is ground truth that the probe actually loaded/attached and the map updated in the kernel *through the daemon over the socket*.
- **Test 8 — `ebpf_loaderd_boot_liveness_degrades_without_hanging`**: asserts the boot-liveness property `drive_ebpf_layer` relies on (`await_loaderd`/`loaderd_deadline`, `AA_EBPF_LOADERD_TIMEOUT_MS`). An **absent** daemon makes `connect` fail fast; a **hung** daemon (accepts, never replies) makes a control op block indefinitely on its own and complete only because a runtime-style deadline wrapper elapses it — i.e. the layer degrades rather than hangs.

The 5-point NOTE is rewritten to describe what is now covered vs. what stays deferred.

## Why

AAASM-4011 moved BPF privilege into the standalone `aa-ebpf-loaderd` daemon and had the unprivileged runtime drive it over a control socket, but **no test exercised that orchestration** — only in-process probe loads were covered. This PR adds that end-to-end coverage.

## How to verify

- **Linux CI is the gate.** eBPF is Linux-only and requires root (CAP_BPF + CAP_PERFMON), so these tests only run in the `e2e — Layer 3 eBPF (Linux)` job. The whole file is `#[cfg(all(target_os = "linux", feature = "integration-test"))]`; macOS builds see an empty file (no failures, no `#[ignore]`).
- The PR path-filter (`changes.ebpf`) does **not** trigger the eBPF job for a test-only change under `aa-integration-tests/`, so a **manual `workflow_dispatch`** is needed to run Test 7/8 on Linux: `gh workflow run ci.yml --ref v0.0.1/AAASM-4033/test/loaderd_orchestration_e2e`.
- Locally (macOS): `cargo fmt --all` and `cargo check -p aa-integration-tests --features integration-test` pass; the Linux test body cannot be compiled or run on macOS (aya is Linux-only).

## Deferred (documented in-file)

- Observe-only telemetry over the control channel (the daemon does not yet stream captured events back, so the client can't observe the file-I/O path-deny flag bit or TLS/exec captures via the daemon path).
- The syscall-guard SIGKILL enforcement assertion (needs a purpose-built confined helper issuing a controlled forbidden syscall).
- The load→allowlist race-free protocol fix (`load-without-filter → set allowlist → add PID`).

## Scope

Touches only `aa-integration-tests/tests/e2e_ebpf.rs`. No `aa-runtime` / `aa-ebpf` / `aa-gateway` source changed.

Closes AAASM-4033

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73