### PR TITLE
[AAASM-4031] ✨ (aa-runtime): Propagate eBPF is_sensitive into file-io audit event

### DIFF
--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -793,6 +793,7 @@ mod tests {
                 bytes: 1024,
                 source: "sdk_hook".into(),
                 latency_ms: 0,
+                sensitive: false,
             })),
         );
         let fields = unwrap_audit_fields(build_violation_payload(&ev));
@@ -871,6 +872,7 @@ mod tests {
                 bytes: 1024,
                 source: "ebpf".into(),
                 latency_ms: 42,
+                sensitive: false,
             })),
         );
         let fields = unwrap_audit_fields(build_violation_payload(&ev));

--- a/aa-runtime/src/ebpf_bridge.rs
+++ b/aa-runtime/src/ebpf_bridge.rs
@@ -238,6 +238,30 @@ mod tests {
     }
 
     #[test]
+    fn file_io_to_audit_propagates_sensitive_true() {
+        let mut event = make_file_io(SyscallKind::Read, "/etc/passwd");
+        event.is_sensitive = true;
+        let audit = file_io_to_audit(&event);
+        let detail = audit.detail.expect("detail should be set");
+        match detail {
+            Detail::FileOp(ref fop) => assert!(fop.sensitive),
+            _ => panic!("expected FileOp detail"),
+        }
+    }
+
+    #[test]
+    fn file_io_to_audit_propagates_sensitive_false() {
+        let event = make_file_io(SyscallKind::Read, "/tmp/ordinary.txt");
+        assert!(!event.is_sensitive);
+        let audit = file_io_to_audit(&event);
+        let detail = audit.detail.expect("detail should be set");
+        match detail {
+            Detail::FileOp(ref fop) => assert!(!fop.sensitive),
+            _ => panic!("expected FileOp detail"),
+        }
+    }
+
+    #[test]
     fn file_io_to_audit_maps_all_syscall_kinds() {
         let cases = [
             (SyscallKind::Openat, "create"),

--- a/aa-runtime/src/ebpf_bridge.rs
+++ b/aa-runtime/src/ebpf_bridge.rs
@@ -40,6 +40,9 @@ pub fn file_io_to_audit(event: &FileIoEvent) -> AuditEvent {
             // the syscall has only an entry hook (read / write / unlink /
             // rename — follow-up under AAASM-1425).
             latency_ms: (event.duration_ns / 1_000_000) as i64,
+            // Carry the kernel-side sensitive-path classification
+            // (AAASM-4012) through to the audit event (AAASM-4031).
+            sensitive: event.is_sensitive,
         })),
         ..AuditEvent::default()
     }

--- a/proto/audit.proto
+++ b/proto/audit.proto
@@ -175,6 +175,11 @@ message FileOpDetail {
   // tracked under AAASM-1425. Schema lives here so the wire path is
   // ready when the kernel-side instrumentation lands.
   int64  latency_ms = 5;
+  // Whether the accessed path matched the eBPF sensitive-path classifier
+  // (AAASM-4012). `false` for SDK-hook sourced events and for paths the
+  // kernel probe did not flag. Additive field (default `false`) so events
+  // serialized before this field existed still decode.
+  bool   sensitive  = 6;
 }
 
 // NetworkCallDetail records the outcome of an outbound network request.


### PR DESCRIPTION
## What
Adds a `sensitive` boolean to the `FileOpDetail` audit proto message and threads the eBPF `FileIoEvent.is_sensitive` flag through `file_io_to_audit` into it. The kernel-side sensitive-path classification (added by AAASM-4012) is now preserved on the emitted audit event instead of being dropped at the bridge.

## Why
`file_io_to_audit` mapped a `FileIoEvent` into an `AuditEvent` but never read `is_sensitive`, so downstream consumers lost the sensitive-path signal. AAASM-4031 propagates it end-to-end.

## How
- `proto/audit.proto`: new additive field `bool sensitive = 6;` on `FileOpDetail` (field number 6, default `false`) — existing serialized events still decode, SDK-hook sourced events report `false`.
- `aa-runtime/src/ebpf_bridge.rs`: `file_io_to_audit` now sets `sensitive: event.is_sensitive`.
- `aa-api/src/ws/handler.rs`: updated the two `FileOpDetail` test literals for the new field (compile fix only; the WS payload does not expose `sensitive`).

## How verified
- `cargo fmt --all --check` — clean.
- `cargo build -p aa-runtime -p aa-api` — 0 errors.
- `cargo nextest run -p aa-runtime -p aa-api -p aa-proto` — 1209 passed, 2 skipped, incl. two new tests covering `is_sensitive` true→`sensitive=true` and false→false.
- `cargo clippy -p aa-runtime -p aa-api -p aa-proto --all-targets -- -D warnings` — clean.
- OpenAPI: regenerated `openapi/v1.yaml` and diffed — **no drift** (field is internal-only; not surfaced in the WS payload/OpenAPI), so no dashboard codegen needed.

Refs AAASM-4031