### PR TITLE
[release] 🔧 (release): Complete v0.0.1-rc.3 bump — path-dep pins + aa-auth README

### DIFF
--- a/aa-auth/README.md
+++ b/aa-auth/README.md
@@ -1,0 +1,21 @@
+# aa-auth
+
+Authentication primitives for Agent Assembly — API-key and JWT verification,
+credential-token checks, and the fail-closed auth posture the gateway enforces.
+
+[![crates.io](https://img.shields.io/crates/v/aa-auth?logo=rust&label=crates.io)](https://crates.io/crates/aa-auth)
+[![docs.rs](https://img.shields.io/docsrs/aa-auth?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-auth)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+
+Owns the shared authentication types and verification logic so the gateway can
+guard privileged surfaces (e.g. `/admin/status`) without pulling the full
+gateway into its dependency graph. Deliberately a **leaf** crate: it holds the
+auth mode (`AuthMode`), the API-key/JWT verifiers, and the request-extractor
+contracts, and its bypass-default (`AuthMode::Off` unless auth is explicitly
+configured) preserves the zero-config developer experience while failing closed
+the moment auth is turned on.
+
+Extracted from `aa-gateway` (AAASM-3898) so authentication is independently
+testable and reusable across the HTTP (`aa-api`) and gRPC surfaces.
+
+Part of [Agent Assembly](https://github.com/ai-agent-assembly/agent-assembly) — [documentation](https://docs.agent-assembly.com/) · [monorepo](https://github.com/ai-agent-assembly/agent-assembly).

--- a/aa-cache/Cargo.toml
+++ b/aa-cache/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "In-process L1 cache wrapper (DashMap + TTL + stampede protection) for the Agent Assembly storage traits"
 
 [dependencies]
-aa-core = { path = "../aa-core", version = "0.0.1-rc.2" }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.3" }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -11,8 +11,8 @@ name = "aasm"
 path = "src/main.rs"
 
 [dependencies]
-aa-core              = { path = "../aa-core", version = "0.0.1-rc.2" }
-aa-security          = { path = "../aa-security", version = "0.0.1-rc.2", features = ["serde"] }
+aa-core              = { path = "../aa-core", version = "0.0.1-rc.3" }
+aa-security          = { path = "../aa-security", version = "0.0.1-rc.3", features = ["serde"] }
 # strip-for-publish:begin devtool
 # AAASM-2340: these three deps wire `aasm run` + `aasm tools` to the
 # `aa-devtool*` adapter crates. The dev-tool subsystem isn't ready to
@@ -20,16 +20,16 @@ aa-security          = { path = "../aa-security", version = "0.0.1-rc.2", featur
 # (and the source files that consume it) before `cargo workspaces publish`
 # runs. Source builds keep the full surface — no edits required to
 # develop on `aasm run` / `aasm tools` locally.
-aa-devtool           = { path = "../aa-devtool", version = "0.0.1-rc.2" }
-aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-rc.2" }
-aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-rc.2" }
+aa-devtool           = { path = "../aa-devtool", version = "0.0.1-rc.3" }
+aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-rc.3" }
+aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-rc.3" }
 # strip-for-publish:end devtool
-aa-gateway           = { path = "../aa-gateway", version = "0.0.1-rc.2" }
-aa-proxy             = { path = "../aa-proxy", version = "0.0.1-rc.2" }
-aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-rc.2" }
-aa-storage           = { path = "../aa-storage", version = "0.0.1-rc.2" }
-aa-storage-memory    = { path = "../aa-storage-memory", version = "0.0.1-rc.2" }
-aa-storage-redis     = { path = "../aa-storage-redis", version = "0.0.1-rc.2" }
+aa-gateway           = { path = "../aa-gateway", version = "0.0.1-rc.3" }
+aa-proxy             = { path = "../aa-proxy", version = "0.0.1-rc.3" }
+aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-rc.3" }
+aa-storage           = { path = "../aa-storage", version = "0.0.1-rc.3" }
+aa-storage-memory    = { path = "../aa-storage-memory", version = "0.0.1-rc.3" }
+aa-storage-redis     = { path = "../aa-storage-redis", version = "0.0.1-rc.3" }
 anyhow         = { workspace = true }
 async-trait    = { workspace = true }
 axum           = { workspace = true }

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Pure domain logic for Agent Assembly — no_std compatible"
 
 [dependencies]
-aa-security  = { path = "../aa-security", version = "0.0.1-rc.2", optional = true }
+aa-security  = { path = "../aa-security", version = "0.0.1-rc.3", optional = true }
 async-trait  = { workspace = true, optional = true }
 cfg-if       = "1"
 chrono       = { workspace = true, default-features = false, features = ["clock"], optional = true }

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -30,8 +30,8 @@ default = []
 integration-test = []
 
 [dependencies]
-aa-core        = { path = "../aa-core", version = "0.0.1-rc.2" }
-aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.2", features = ["std"] }
+aa-core        = { path = "../aa-core", version = "0.0.1-rc.3" }
+aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.3", features = ["std"] }
 anyhow         = { workspace = true }
 # AAASM-3918: umask tightening + geteuid for the loaderd control-socket hardening
 # (umask-tightened bind, peer-credential UID check). Cross-platform crate.

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -7,14 +7,14 @@ repository.workspace = true
 description = "Control plane — policy enforcement engine and agent registry for Agent Assembly"
 
 [dependencies]
-aa-core      = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
+aa-core      = { path = "../aa-core", version = "0.0.1-rc.3", features = ["serde"] }
 # AAASM-3907: the shared HTTP auth framework (AuthConfig / ApiKeyStore /
 # JwtVerifier / RateLimiter / RequireAdmin) extracted to a leaf crate by
 # AAASM-3899. Path-only like aa-api — the gateway never publishes against it.
 aa-auth      = { path = "../aa-auth" }
-aa-security  = { path = "../aa-security", version = "0.0.1-rc.2", features = ["serde"] }
-aa-proto     = { path = "../aa-proto", version = "0.0.1-rc.2" }
-aa-runtime   = { path = "../aa-runtime", version = "0.0.1-rc.2" }
+aa-security  = { path = "../aa-security", version = "0.0.1-rc.3", features = ["serde"] }
+aa-proto     = { path = "../aa-proto", version = "0.0.1-rc.3" }
+aa-runtime   = { path = "../aa-runtime", version = "0.0.1-rc.3" }
 tokio        = { workspace = true, features = ["full"] }
 regex        = "1"
 serde        = { workspace = true }

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -14,10 +14,10 @@ name = "aa-proxy"
 path = "src/main.rs"
 
 [dependencies]
-aa-core    = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
-aa-security = { path = "../aa-security", version = "0.0.1-rc.2", features = ["serde"] }
-aa-proto   = { path = "../aa-proto", version = "0.0.1-rc.2" }
-aa-runtime = { path = "../aa-runtime", version = "0.0.1-rc.2" }
+aa-core    = { path = "../aa-core", version = "0.0.1-rc.3", features = ["serde"] }
+aa-security = { path = "../aa-security", version = "0.0.1-rc.3", features = ["serde"] }
+aa-proto   = { path = "../aa-proto", version = "0.0.1-rc.3" }
+aa-runtime = { path = "../aa-runtime", version = "0.0.1-rc.3" }
 clap       = { workspace = true, features = ["derive"] }
 tokio      = { workspace = true, features = ["full"] }
 hyper      = { workspace = true, features = ["server", "http1"] }

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -14,10 +14,10 @@ default = []
 integration-test = []
 
 [dependencies]
-aa-core                     = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
-aa-security                 = { path = "../aa-security", version = "0.0.1-rc.2", features = ["serde"] }
-aa-proto                    = { path = "../aa-proto", version = "0.0.1-rc.2" }
-aa-storage-sqlite-buffer    = { path = "../aa-storage-sqlite-buffer", version = "0.0.1-rc.2" }
+aa-core                     = { path = "../aa-core", version = "0.0.1-rc.3", features = ["serde"] }
+aa-security                 = { path = "../aa-security", version = "0.0.1-rc.3", features = ["serde"] }
+aa-proto                    = { path = "../aa-proto", version = "0.0.1-rc.3" }
+aa-storage-sqlite-buffer    = { path = "../aa-storage-sqlite-buffer", version = "0.0.1-rc.3" }
 async-nats                  = { workspace = true }
 async-trait                 = { workspace = true }
 axum                        = { workspace = true }
@@ -48,7 +48,7 @@ tracing-subscriber          = { workspace = true, features = ["json", "env-filte
 which                       = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-aa-ebpf = { path = "../aa-ebpf", version = "0.0.1-rc.2" }
+aa-ebpf = { path = "../aa-ebpf", version = "0.0.1-rc.3" }
 
 # Peer-credential (geteuid) check on the IPC socket — all Unix targets
 # (AAASM-3579). Backed by getpeereid/SO_PEERCRED via tokio's peer_cred.
@@ -58,7 +58,7 @@ libc = { workspace = true }
 # Linux-only dev dep: the AAASM-3128 regression test constructs a
 # `TlsCaptureEvent` to prove the DEBUG log never emits its plaintext payload.
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.2", features = ["std"] }
+aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-rc.3", features = ["std"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/aa-sandbox/Cargo.toml
+++ b/aa-sandbox/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "WebAssembly/WASI sandbox runtime for Agent Assembly tool execution"
 
 [dependencies]
-aa-core       = { path = "../aa-core", version = "0.0.1-rc.2" }
+aa-core       = { path = "../aa-core", version = "0.0.1-rc.3" }
 thiserror     = { workspace = true }
 wasmtime      = "46"
 wasmtime-wasi = "46"

--- a/aa-storage-memory/Cargo.toml
+++ b/aa-storage-memory/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 description = "In-memory aa-storage driver (DashMap-backed) for tests and local development"
 
 [dependencies]
-aa-core = { path = "../aa-core", version = "0.0.1-rc.2" }
-aa-storage = { path = "../aa-storage", version = "0.0.1-rc.2" }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.3" }
+aa-storage = { path = "../aa-storage", version = "0.0.1-rc.3" }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }

--- a/aa-storage-postgres/Cargo.toml
+++ b/aa-storage-postgres/Cargo.toml
@@ -10,8 +10,8 @@ description = "PostgreSQL storage driver (L3 primary) for the Agent Assembly per
 publish = false
 
 [dependencies]
-aa-core    = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
-aa-storage = { path = "../aa-storage", version = "0.0.1-rc.2" }
+aa-core    = { path = "../aa-core", version = "0.0.1-rc.3", features = ["serde"] }
+aa-storage = { path = "../aa-storage", version = "0.0.1-rc.3" }
 async-trait = { workspace = true }
 sqlx       = { workspace = true, default-features = false, features = ["runtime-tokio-rustls", "postgres", "macros", "migrate", "uuid", "chrono", "json"] }
 serde      = { workspace = true }

--- a/aa-storage-redis/Cargo.toml
+++ b/aa-storage-redis/Cargo.toml
@@ -9,11 +9,11 @@ description = "Redis L2 shared-cache storage driver (SessionStore, RateLimitCoun
 [dependencies]
 # Trait contract — the storage traits live in `aa-core::storage` and are
 # re-exported verbatim by the `aa-storage` facade.
-aa-storage = { path = "../aa-storage", version = "0.0.1-rc.2" }
+aa-storage = { path = "../aa-storage", version = "0.0.1-rc.3" }
 # Pulled in only to enable `aa-core`'s `serde` feature so `PolicyDocument`
 # (re-exported through `aa-storage`) gains `Serialize`/`Deserialize`, which the
 # JSON-backed `RedisPolicyStore` needs. No `aa-core` items are named directly.
-aa-core = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.3", features = ["serde"] }
 
 async-trait = { workspace = true }
 # `redis = 1.2` matches the workspace pin. `tokio-rustls-comp` backs the
@@ -35,7 +35,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 testcontainers-modules = { workspace = true, features = ["redis"] }
 # Second driver for the mixed-config registry-integration test (redis backs the
 # L2 kinds; memory backs the durable kinds).
-aa-storage-memory = { path = "../aa-storage-memory", version = "0.0.1-rc.2" }
+aa-storage-memory = { path = "../aa-storage-memory", version = "0.0.1-rc.3" }
 
 [lints]
 workspace = true

--- a/aa-storage-sqlite-buffer/Cargo.toml
+++ b/aa-storage-sqlite-buffer/Cargo.toml
@@ -10,7 +10,7 @@ description = "Local in-process SQLite event buffer that survives brief gateway/
 # The buffer serializes and replays the storage contract's `AuditEntry` through
 # the `AuditSink` trait, both reached from `aa-core`. `serde` is enabled so
 # `AuditEntry` can be encoded into the on-disk BLOB.
-aa-core = { path = "../aa-core", version = "0.0.1-rc.2", features = ["serde"] }
+aa-core = { path = "../aa-core", version = "0.0.1-rc.3", features = ["serde"] }
 # Pinned to the rusqlite line that depends on `libsqlite3-sys 0.30`, matching
 # the `sqlx-sqlite 0.8.6` already resolved for `aa-gateway`. Only one crate in
 # the workspace may link the native `sqlite3` library, so both must resolve to

--- a/aa-storage/Cargo.toml
+++ b/aa-storage/Cargo.toml
@@ -11,7 +11,7 @@ description = "Storage trait abstraction (pure interface) for the Agent Assembly
 # here. `serde`/`toml` back the `[storage]` config schema + driver registry; the
 # crate stays a pure interface (no `sqlx`/`redis`/`tonic` backend dependency).
 # `async-trait` is a dev-dep used by the conformance test's example implementation.
-aa-core   = { path = "../aa-core", version = "0.0.1-rc.2" }
+aa-core   = { path = "../aa-core", version = "0.0.1-rc.3" }
 serde     = { workspace = true }
 thiserror = { workspace = true }
 toml      = { workspace = true }


### PR DESCRIPTION
## What
Completes the **v0.0.1-rc.3** version bump that #1394 left half-done (caught by `scripts/release-readiness.sh`):

- **Bump 39 inter-crate path-dependency version pins** `0.0.1-rc.2` → `0.0.1-rc.3` across ~12 crate `Cargo.toml` files (e.g. `aa-core = { path = "../aa-core", version = "0.0.1-rc.2" }`). The `release-tag-cut` helper only rewrites the crate's own `version =` field (now root-only via `version.workspace = true`); it does **not** touch path-dep pins — those must be realigned to the release version or `cargo publish` fails (rc.3 crates would depend on non-existent rc.2 siblings).
- **Add `aa-auth/README.md`** — new crate since rc.2 (Epic AAASM-3898); release-readiness requires a README on every published crate (AAASM-3774).
- Regenerate `Cargo.lock` (0 packages changed — path-dep pins resolve locally).

## Why
`release-readiness.sh` **BLOCKED** the rc.3 tag on these two gaps. Without them the release publish would ship inconsistent/broken crate metadata.

## Side-effects
None — version-pin literals + one README + lockfile only. No code. No transitive dep drift (`cargo update --workspace` locked 0 packages). Path-dep pins now match each crate's actual `0.0.1-rc.3` version.

## Verify
`bash scripts/release-readiness.sh 0.0.1-rc.3` — the path-dep + aa-auth-README failures are cleared (only the on-branch / clean-tree local checks remain, which pass once merged on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)