### PR TITLE
🐛 (aa-gateway): Add version to aa-auth path-dep for crates.io publish

### DIFF
--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -10,8 +10,11 @@ description = "Control plane — policy enforcement engine and agent registry fo
 aa-core      = { path = "../aa-core", version = "0.0.1-rc.3", features = ["serde"] }
 # AAASM-3907: the shared HTTP auth framework (AuthConfig / ApiKeyStore /
 # JwtVerifier / RateLimiter / RequireAdmin) extracted to a leaf crate by
-# AAASM-3899. Path-only like aa-api — the gateway never publishes against it.
-aa-auth      = { path = "../aa-auth" }
+# AAASM-3899. aa-gateway IS in the crates.io publish set, so this path-dep MUST
+# carry a version — crates.io rejects a version-less path-dep on a published
+# crate (broke the v0.0.1-rc.3 publish). Keep this pin realigned to the workspace
+# version on every release cut, like the other internal deps below.
+aa-auth      = { path = "../aa-auth", version = "0.0.1-rc.3" }
 aa-security  = { path = "../aa-security", version = "0.0.1-rc.3", features = ["serde"] }
 aa-proto     = { path = "../aa-proto", version = "0.0.1-rc.3" }
 aa-runtime   = { path = "../aa-runtime", version = "0.0.1-rc.3" }


### PR DESCRIPTION
## What changed

`aa-gateway/Cargo.toml` — the `aa-auth` path-dependency now carries `version = "0.0.1-rc.3"` (was version-less path-only).

## Why

The `v0.0.1-rc.3` tag's `release.yml` **Publish workspace to crates.io** job failed:

```
error: failed to verify manifest at aa-gateway/Cargo.toml
  dependency `aa-auth` does not specify a version
  unable to publish package `aa-gateway`
```

`aa-gateway` **is** in the crates.io publish set. crates.io rejects a version-less path-dep on a published crate. `aa-auth` was extracted as a leaf crate in AAASM-3898/3899 and wired into the gateway (AAASM-3907) as `{ path = "../aa-auth" }` with no `version` — the only such internal dep on the gateway. Every other internal path-dep (`aa-core`, `aa-security`, `aa-proto`, `aa-runtime`) already carries a version pin; this one was the gap that broke the publish.

The comment claimed "the gateway never publishes against it" — factually wrong (aa-gateway has no `publish = false`). Rewritten to state the real invariant and the release-cut realignment requirement.

## Scope / side-effects

- **No code change** — one manifest line + comment. Behavior identical; `version` on a path-dep only takes effect when publishing to a registry (path wins for local/workspace builds).
- The two remaining version-less internal deps in `aa-gateway/Cargo.toml` are **intentionally** version-less and do not block publish: line 85 `aa-storage-postgres` (optional) sits inside a `strip-for-publish:begin/end audit-consumer` block that `.ci/strip-for-publish.sh` removes before publish; lines 92/96 (`aa-storage-postgres`, `aa-sdk-client`) are `[dev-dependencies]`, excluded from packaging. Verified against the CI publish log — aa-auth was the sole failure.
- Pin realigns to the workspace version on each release cut going forward (matches the sibling internal deps).

## How to verify

`cargo package -p aa-gateway --no-verify` after `.ci/strip-for-publish.sh` packages cleanly. Recovers the stalled rc.3 crates.io publish (aa-gateway + aa-cli; the 14 already-published crates are immutable and unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73