### PR TITLE
[AAASM-4065] 🐛 (agent-assembly): Repoint homebrew refs to homebrew-tap

### DIFF
--- a/.claude/skills/release-validate-channels/EXAMPLES.md
+++ b/.claude/skills/release-validate-channels/EXAMPLES.md
@@ -81,7 +81,7 @@ triple.
 
 ### 5. Homebrew tap
 
-`ai-agent-assembly/homebrew-agent-assembly` `master` carries
+`ai-agent-assembly/homebrew-tap` `master` carries
 `Formula/aasm.rb` with `version "0.0.1-alpha.9"` and 4 `sha256` literals
 that match the sums in the release's `SHA256SUMS` asset.
 

--- a/.claude/skills/release-validate-channels/REFERENCE.md
+++ b/.claude/skills/release-validate-channels/REFERENCE.md
@@ -187,7 +187,7 @@ do not block.
 ### 5. Homebrew tap — formula version + matching SHA256SUMS
 
 ```bash
-FORMULA="$(gh api repos/ai-agent-assembly/homebrew-agent-assembly/contents/Formula/aasm.rb \
+FORMULA="$(gh api repos/ai-agent-assembly/homebrew-tap/contents/Formula/aasm.rb \
   --jq '.content' | base64 -d)"
 printf '%s\n' "$FORMULA" | grep -E '^[[:space:]]*version '
 printf '%s\n' "$FORMULA" | grep -E 'sha256 '

--- a/.claude/skills/release-validate-channels/SKILL.md
+++ b/.claude/skills/release-validate-channels/SKILL.md
@@ -209,4 +209,4 @@ confirm.
   fresh tag, not a republish).
 - Validate go-sdk channels (decoupled, RUNBOOK section 7).
 - Touch repos other than `ai-agent-assembly/{agent-assembly,python-sdk,
-  node-sdk,homebrew-agent-assembly}`.
+  node-sdk,homebrew-tap}`.

--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -6,7 +6,7 @@
 
 This runbook assumes the operator has push rights to
 `ai-agent-assembly/agent-assembly` and merge rights on the
-`ai-agent-assembly/homebrew-agent-assembly` tap.
+`ai-agent-assembly/homebrew-tap` tap.
 
 ---
 
@@ -110,7 +110,7 @@ per the "Post-release verification" section of `RELEASING.md`.
 ## 4. Manual gate — merge the Homebrew tap PR (within ~5 minutes)
 
 `release.yml`'s `update-homebrew-tap` job opens a PR against
-`ai-agent-assembly/homebrew-agent-assembly` with branch `bot/aasm-<version>`
+`ai-agent-assembly/homebrew-tap` with branch `bot/aasm-<version>`
 and title `🤖 (formula): aasm <version>`.
 
 **Until that PR is merged, `brew install aasm` will still resolve to the
@@ -118,8 +118,8 @@ previous version.** The formula file on the tap's master branch is what
 Homebrew reads; the bot-created branch is invisible to `brew install`.
 
 ```bash
-gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open
-gh pr merge <pr-number> --repo ai-agent-assembly/homebrew-agent-assembly --squash
+gh pr list --repo ai-agent-assembly/homebrew-tap --state open
+gh pr merge <pr-number> --repo ai-agent-assembly/homebrew-tap --squash
 ```
 
 ## 5. Verification

--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -83,10 +83,10 @@ AASM_REQUIRE_SIGNATURE=1 curl -sSf https://agent-assembly.com/install.sh | sh
 ## Homebrew (macOS / Linux)
 
 Install the latest tagged `aasm` release from the
-[Homebrew tap](https://github.com/ai-agent-assembly/homebrew-agent-assembly):
+[Homebrew tap](https://github.com/ai-agent-assembly/homebrew-tap):
 
 ```sh
-brew install ai-agent-assembly/homebrew-agent-assembly/aasm
+brew install ai-agent-assembly/tap/aasm
 ```
 
 ## Pre-built binaries (manual)

--- a/docs/src/releases.md
+++ b/docs/src/releases.md
@@ -26,7 +26,7 @@ A single coordinated tag push fans out to every channel:
 |---|---|
 | GitHub Releases | `aasm-*.tar.gz` binaries + `SHA256SUMS` |
 | crates.io | Workspace crates at the tag version |
-| Homebrew tap | `aasm` formula ([`homebrew-agent-assembly`](https://github.com/ai-agent-assembly/homebrew-agent-assembly)) |
+| Homebrew tap | `aasm` formula ([`homebrew-tap`](https://github.com/ai-agent-assembly/homebrew-tap)) |
 | PyPI / npm | SDK packages |
 | GHCR | Container image |
 

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -62,16 +62,16 @@ else
 fi
 
 # ─── 2. Homebrew tap ──────────────────────────────────────────────────────
-FORMULA_CONTENT="$(gh api repos/ai-agent-assembly/homebrew-agent-assembly/contents/Formula/aasm.rb \
+FORMULA_CONTENT="$(gh api repos/ai-agent-assembly/homebrew-tap/contents/Formula/aasm.rb \
   --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)"
 if [ -z "$FORMULA_CONTENT" ]; then
   bad "Homebrew tap  " "Formula/aasm.rb not readable" \
       "gh workflow run release.yml --repo ai-agent-assembly/agent-assembly -f release_tag=$TAG"
 elif printf '%s\n' "$FORMULA_CONTENT" | grep -qE "^[[:space:]]*version \"${VERSION//./\\.}\""; then
-  TAP_PR_STATE="$(gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state all \
+  TAP_PR_STATE="$(gh pr list --repo ai-agent-assembly/homebrew-tap --state all \
     --json state,number,headRefName \
     --jq ".[] | select(.headRefName == \"bot/aasm-${VERSION}\") | .state" 2>/dev/null | head -1)"
-  TAP_PR_NUM="$(gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state all \
+  TAP_PR_NUM="$(gh pr list --repo ai-agent-assembly/homebrew-tap --state all \
     --json state,number,headRefName \
     --jq ".[] | select(.headRefName == \"bot/aasm-${VERSION}\") | .number" 2>/dev/null | head -1)"
   if [ "$TAP_PR_STATE" = "MERGED" ]; then
@@ -82,12 +82,12 @@ elif printf '%s\n' "$FORMULA_CONTENT" | grep -qE "^[[:space:]]*version \"${VERSI
     ok "Homebrew tap  " "formula at $VERSION on master (no matching bot PR found)"
   fi
 else
-  TAP_PR_NUM="$(gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open \
+  TAP_PR_NUM="$(gh pr list --repo ai-agent-assembly/homebrew-tap --state open \
     --json number,headRefName \
     --jq ".[] | select(.headRefName == \"bot/aasm-${VERSION}\") | .number" 2>/dev/null | head -1)"
   if [ -n "$TAP_PR_NUM" ]; then
     bad "Homebrew tap  " "formula on master NOT at $VERSION; PR #${TAP_PR_NUM} open" \
-        "gh pr merge ${TAP_PR_NUM} --repo ai-agent-assembly/homebrew-agent-assembly --squash"
+        "gh pr merge ${TAP_PR_NUM} --repo ai-agent-assembly/homebrew-tap --squash"
   else
     bad "Homebrew tap  " "formula on master NOT at $VERSION; no open bot PR" \
         "gh workflow run release.yml --repo ai-agent-assembly/agent-assembly -f release_tag=$TAG"

--- a/scripts/release-readiness.sh
+++ b/scripts/release-readiness.sh
@@ -105,8 +105,8 @@ for SECRET in CRATES_IO_TOKEN CROSS_REPO_DISPATCH_PAT HOMEBREW_TAP_TOKEN \
   fi
 done
 
-# 9. No open bot PRs on homebrew-agent-assembly for OTHER versions
-STALE_TAP_PRS="$(gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open \
+# 9. No open bot PRs on homebrew-tap for OTHER versions
+STALE_TAP_PRS="$(gh pr list --repo ai-agent-assembly/homebrew-tap --state open \
   --json number,headRefName,title \
   --jq ".[] | select(.headRefName | startswith(\"bot/aasm-\")) | select(.headRefName != \"bot/aasm-${VERSION}\") | \"#\(.number) \(.headRefName)\"" \
   2>/dev/null || true)"


### PR DESCRIPTION
## Jira Ticket
- [AAASM-4065](https://lightning-dust-mite.atlassian.net/browse/AAASM-4065) (subtask of [AAASM-4060](https://lightning-dust-mite.atlassian.net/browse/AAASM-4060))

## Summary
Repoint `agent-assembly`'s Homebrew references from the old repo name `homebrew-agent-assembly` (renamed to `homebrew-tap` in AAASM-3950) to the canonical name. GitHub redirects the rename today, but the references are non-canonical and fragile; the live install doc also promoted the long, repo-name-based command instead of the canonical tap command.

## Changes
**User-facing docs (commit 1)**
- `docs/src/quick-start/installation.md`: install command → `brew install ai-agent-assembly/tap/aasm` (was `.../homebrew-agent-assembly/aasm`); tap link → `homebrew-tap`.
- `docs/src/releases.md`: tap link/label → `homebrew-tap`.

**Release tooling (commit 2)**
- `scripts/check-release.sh` (5×), `scripts/release-readiness.sh` (2×), `.claude/skills/release-validate-channels/{SKILL,REFERENCE,EXAMPLES}.md`, `docs/release/RUNBOOK.md`: `gh api` / `gh pr` targets → `ai-agent-assembly/homebrew-tap`.

**Intentionally NOT changed**
- `README.md:88-89` deprecation note (documents the old command AS deprecated — AAASM-3950 AC).
- `.github/workflows/release.yml` (its `update-homebrew-tap` job already targets `homebrew-tap`; the only match is an explanatory rename comment).
- Frozen history: `docs/release/v0.0.1-*.md`, `CHANGELOG.md`, `verification-reports/*`.

## Validation
- [x] `bash -n scripts/check-release.sh` + `scripts/release-readiness.sh` → syntax OK.
- [x] Grep: 0 residual `homebrew-agent-assembly` in changed files; install command now canonical; README deprecation note untouched.
- [x] No unintended scope changes (8 files, all Homebrew references).

## Checklist
- [x] PR title follows convention
- [x] PR body follows template

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-4065]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-4060]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ