### PR TITLE
[AAASM-4080] 🐛 (dashboard): Fix hardcoded agent-assembly.io links to canonical .com

### DIFF
--- a/dashboard/docs/verification/aaasm-4080-domain-tld-fe-validation.md
+++ b/dashboard/docs/verification/aaasm-4080-domain-tld-fe-validation.md
@@ -1,0 +1,45 @@
+# AAASM-4080 — Dashboard domain TLD fix, Front-End validation
+
+**Bug**: [AAASM-4080](https://lightning-dust-mite.atlassian.net/browse/AAASM-4080) — dashboard hardcoded dead `agent-assembly.io` links; canonical is `.com` per ADR-0007.
+**Epic**: [AAASM-4068](https://lightning-dust-mite.atlassian.net/browse/AAASM-4068) (2026-07-04 security + QA sweep fix wave)
+**PR**: ai-agent-assembly/agent-assembly#1401
+**Validated**: 2026-07-04, branch `v0.0.1/AAASM-4080/fix/dashboard_domain_tld`
+**Method**: live Playwright drive of the built dashboard (vite dev + Prism OpenAPI mock backend on `127.0.0.1:8080`), logged in through the real API-key form.
+
+## Change under test
+
+Four user-facing hardcoded URLs retargeted `agent-assembly.io` → `agent-assembly.com`:
+
+| File | Link |
+|---|---|
+| `src/features/alerts/EmptyStateNoAlerts.tsx` | `https://docs.agent-assembly.com/dashboard/alerts` |
+| `src/pages/FleetPage.tsx` | `https://docs.agent-assembly.com/quickstart` |
+| `src/features/onboarding/steps/Step2InstallSdk.tsx` | `https://api.agent-assembly.com` |
+| `src/components/ErrorState.tsx` | `status.agent-assembly.com` |
+
+## Evidence
+
+| Check | Result |
+|---|---|
+| `pnpm type-check` (CI) | ✅ pass (0 errors) |
+| `pnpm lint` (CI) | ✅ pass (0 warnings) |
+| `grep -rn "agent-assembly\.io" dashboard/src` | ✅ empty (0 occurrences) |
+| Live render — `/alerts` empty-state "Read the alerts docs →" anchor `href` | ✅ `https://docs.agent-assembly.com/dashboard/alerts` |
+| Live render — any `agent-assembly.io` anchor on the alerts page | ✅ none (`anyDotIoLeft: false`) |
+| Dashboard shell / routing / login | ✅ renders + navigates without crash (full 12-route walk done in the originating session) |
+
+Live DOM assertion (Playwright `page.evaluate`):
+
+```json
+{
+  "alertsDocsHref": "https://docs.agent-assembly.com/dashboard/alerts",
+  "allAgentAssemblyLinksOnPage": ["https://docs.agent-assembly.com/dashboard/alerts"],
+  "anyDotIoLeft": false
+}
+```
+
+Screenshot captured during the session: `AAASM-4080-alerts-docs-link-dotcom.png` (alerts empty-state rendering the corrected `.com` docs link).
+
+## Verdict
+
+✅ Front-End behaves correctly. The link-target change is purely a URL string fix with no visual or behavioral delta; the alerts empty-state renders and its docs link now resolves to the canonical `docs.agent-assembly.com` host. No regression to dashboard rendering, routing, or the alerts view.

--- a/dashboard/src/components/ErrorState.tsx
+++ b/dashboard/src/components/ErrorState.tsx
@@ -20,7 +20,7 @@ const COPY: Record<ErrorStateKind, CopyEntry> = {
     msg: (
       <>
         Backend returned <code>503 service_unavailable</code>. This is usually transient — retry in a few seconds.
-        If it persists, check <code>status.agent-assembly.io</code>.
+        If it persists, check <code>status.agent-assembly.com</code>.
       </>
     ),
     cta: 'Retry',

--- a/dashboard/src/features/alerts/EmptyStateNoAlerts.tsx
+++ b/dashboard/src/features/alerts/EmptyStateNoAlerts.tsx
@@ -22,7 +22,7 @@ export function EmptyStateNoAlerts() {
         above, or read the docs for tips on tuning rule thresholds.
       </p>
       <a
-        href="https://docs.agent-assembly.io/dashboard/alerts"
+        href="https://docs.agent-assembly.com/dashboard/alerts"
         target="_blank"
         rel="noreferrer"
         data-testid="alerts-empty-docs-link"

--- a/dashboard/src/features/onboarding/steps/Step2InstallSdk.tsx
+++ b/dashboard/src/features/onboarding/steps/Step2InstallSdk.tsx
@@ -26,7 +26,7 @@ const VERIFIED_LINES: Line[] = [
   { kind: 'cmd', text: 'aa-cli verify' },
   { kind: 'out', text: 'connecting to runtime…  done.' },
   { kind: 'out', text: 'sdk version    1.4.2 (latest)' },
-  { kind: 'out', text: 'control-plane  https://api.agent-assembly.io' },
+  { kind: 'out', text: 'control-plane  https://api.agent-assembly.com' },
   { kind: 'ok', text: '✓ verified · ready to enroll' },
 ]
 

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -457,7 +457,7 @@ export function FleetPage() {
       {view === 'agents' && !isLoading && !isError && agents?.length === 0 && (
         <p className="fleet-empty fleet-empty--inline" data-testid="agents-empty">
           No agents registered yet.{' '}
-          <a href="https://docs.agent-assembly.io/quickstart" target="_blank" rel="noreferrer">
+          <a href="https://docs.agent-assembly.com/quickstart" target="_blank" rel="noreferrer">
             Read the quickstart guide →
           </a>
         </p>


### PR DESCRIPTION
## Description

The dashboard hardcoded the dead TLD `agent-assembly.io` in four user-facing spots. Per ADR-0007 the canonical TLD is `.com` (docs=`docs.agent-assembly.com`, marketing=`agent-assembly.com`, SaaS=`app.agent-assembly.com`). This PR points all four references at the canonical `.com`:

- `dashboard/src/features/alerts/EmptyStateNoAlerts.tsx` — docs alerts link
- `dashboard/src/pages/FleetPage.tsx` — quickstart docs link
- `dashboard/src/features/onboarding/steps/Step2InstallSdk.tsx` — sample CLI `control-plane` host (`api.` → `.com`)
- `dashboard/src/components/ErrorState.tsx` — status page host (`status.` → `.com`)

String-only fix; no behavior or layout change.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4080

## Testing

Describe the testing performed for this PR:

- [x] Manual testing performed
- [x] No tests required (explain why)

`corepack pnpm type-check` and `corepack pnpm lint` both clean. `grep -rn "agent-assembly\.io" dashboard/src` returns no matches. The live UI was already verified in the originating session; this is a link-target-only change with no visual difference, so no new screenshot is warranted.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
