### PR TITLE
[AAASM-4070] 🐛 (proxy): Fail closed on JSON-RPC batch to close MCP tools/call bypass

### DIFF
--- a/aa-proxy/src/intercept/mcp.rs
+++ b/aa-proxy/src/intercept/mcp.rs
@@ -217,4 +217,76 @@ mod tests {
         assert_eq!(call.tool_name, "ping");
         assert_eq!(call.arguments, serde_json::Value::Null);
     }
+
+    #[test]
+    fn one_element_batch_tools_call_is_flagged_unenforceable() {
+        // AAASM-4070 regression: the bypass vector. `parse_mcp_request` only
+        // deserialises a single object, so this one-element batch returned
+        // `None` and the caller's pre-fix `else` branch forwarded it upstream
+        // with NO gateway CheckAction and NO credential/DLP scan. The detector
+        // must flag it so the caller fails closed instead of forwarding.
+        let body = br#"[
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": { "name": "execute_bash", "arguments": { "cmd": "rm -rf /" } }
+            }
+        ]"#;
+        assert!(
+            parse_mcp_request(body).is_none(),
+            "batch must not parse as a single call"
+        );
+        assert!(
+            is_unenforceable_tool_call(body),
+            "a one-element batch tools/call must be flagged so it is fail-closed, not forwarded"
+        );
+    }
+
+    #[test]
+    fn multi_element_batch_with_a_tools_call_is_flagged() {
+        // A tool call hidden among benign requests in a batch must still be
+        // flagged — any element carrying `method == "tools/call"` taints the
+        // whole batch, since the strict parser can enforce none of them.
+        let body = br#"[
+            {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}},
+            {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_file"}}
+        ]"#;
+        assert!(is_unenforceable_tool_call(body));
+    }
+
+    #[test]
+    fn object_tools_call_that_fails_strict_extraction_is_flagged() {
+        // `method == "tools/call"` but the envelope fails strict extraction
+        // (wrong jsonrpc version, missing `params.name`). `parse_mcp_request`
+        // returns `None` for these by contract; the detector must still flag
+        // them as tool-call attempts so a malformed envelope cannot slip a call
+        // past enforcement via the blind-forward path.
+        let wrong_version = br#"{"jsonrpc":"1.0","id":1,"method":"tools/call","params":{"name":"x"}}"#;
+        assert!(parse_mcp_request(wrong_version).is_none());
+        assert!(is_unenforceable_tool_call(wrong_version));
+
+        let missing_name = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{}}"#;
+        assert!(parse_mcp_request(missing_name).is_none());
+        assert!(is_unenforceable_tool_call(missing_name));
+    }
+
+    #[test]
+    fn non_tool_call_traffic_is_not_flagged() {
+        // The detector must NOT fire on ordinary non-MCP HTTPS traffic that
+        // happens to flow through this route, or it would break every non-tool
+        // request. A single non-tools/call object, a batch of non-tool
+        // requests, non-JSON bodies, an empty body, and a plain JSON array of
+        // scalars must all pass through untouched (return `false`).
+        assert!(!is_unenforceable_tool_call(
+            br#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#
+        ));
+        assert!(!is_unenforceable_tool_call(
+            br#"[{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}]"#
+        ));
+        assert!(!is_unenforceable_tool_call(br#"{"hello":"world"}"#));
+        assert!(!is_unenforceable_tool_call(b"not json at all"));
+        assert!(!is_unenforceable_tool_call(b""));
+        assert!(!is_unenforceable_tool_call(b"[1, 2, 3]"));
+    }
 }

--- a/aa-proxy/src/intercept/mcp.rs
+++ b/aa-proxy/src/intercept/mcp.rs
@@ -93,6 +93,42 @@ pub fn parse_mcp_request(body: &[u8]) -> Option<McpToolCall> {
     })
 }
 
+/// Classify a body that [`parse_mcp_request`] could **not** turn into a single
+/// [`McpToolCall`], to decide whether it is nonetheless an attempt to invoke
+/// `tools/call` that must be fail-closed rather than blindly forwarded upstream.
+///
+/// Returns `true` when the body is JSON-RPC framing that references a
+/// `tools/call` the strict single-object parser cannot fully evaluate:
+///
+/// * a top-level JSON-RPC **batch** array with any element carrying
+///   `method == "tools/call"` — `parse_mcp_request` only deserialises a single
+///   object, so a one-element batch `[{…tools/call…}]` returned `None` and was
+///   forwarded upstream with no gateway decision (AAASM-4070); or
+/// * a top-level object whose `method == "tools/call"` but whose envelope fails
+///   strict extraction (wrong/missing `jsonrpc`, missing `params.name`) — a
+///   steered agent could malform these to slip a tool call past enforcement.
+///
+/// Non-JSON bodies, and JSON carrying no `tools/call` method, return `false` so
+/// ordinary non-MCP HTTPS traffic on this route still flows through untouched.
+/// This is deliberately a *detector*, not a parser: it does not change the
+/// `None`-on-false-positive contract [`parse_mcp_request`] relies on.
+pub fn is_unenforceable_tool_call(body: &[u8]) -> bool {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return false;
+    };
+    match &value {
+        serde_json::Value::Array(elements) => elements.iter().any(mentions_tools_call),
+        serde_json::Value::Object(_) => mentions_tools_call(&value),
+        _ => false,
+    }
+}
+
+/// True when `value` is a JSON object whose `method` field is exactly
+/// `"tools/call"` — the marker that a JSON-RPC request intends to invoke a tool.
+fn mentions_tools_call(value: &serde_json::Value) -> bool {
+    value.get("method").and_then(serde_json::Value::as_str) == Some(MCP_TOOLS_CALL_METHOD)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -25,7 +25,7 @@ use crate::credentials::CredentialStore;
 use crate::error::ProxyError;
 use crate::intercept::detect::{detect_api, LlmApiPattern};
 use crate::intercept::event::ProxyEvent;
-use crate::intercept::mcp::parse_mcp_request;
+use crate::intercept::mcp::{is_unenforceable_tool_call, parse_mcp_request};
 use crate::intercept::{InterceptVerdict, Interceptor, VerdictDecision};
 use crate::mcp_enforce::{evaluate_mcp_call, McpDecision};
 use crate::proxy::http::{
@@ -505,6 +505,37 @@ impl ProxyServer {
                     return Ok(());
                 }
             }
+        } else if is_unenforceable_tool_call(&req.body) {
+            // AAASM-4070: `parse_mcp_request` only deserialises a single
+            // JSON-RPC object, so a `tools/call` wrapped in a batch array
+            // (`[{…tools/call…}]`) or malformed just enough to fail strict
+            // extraction returned `None` above — and the pre-fix `else` branch
+            // forwarded that body upstream with NO gateway CheckAction and NO
+            // credential/DLP scan. A steered agent used a one-element batch to
+            // slip a denied tool call past enforcement. Fail closed: this body
+            // is a tool-call attempt the enforcement path cannot evaluate, so
+            // deny it with a JSON-RPC error envelope instead of forwarding,
+            // mirroring an explicit gateway Deny. Non-MCP traffic is unaffected
+            // (the detector only fires on `method == "tools/call"`).
+            let reason = "MCP tools/call in unsupported JSON-RPC framing (batch array or malformed envelope) cannot be enforced and was rejected (fail-closed)";
+            tracing::warn!(
+                %host,
+                "MCP tools/call bypass attempt via batch/malformed framing; denying (fail-closed). \
+                 The gateway CheckAction and credential scan cannot evaluate this envelope.",
+            );
+            self.interceptor.emit_mcp_decision("unknown", &[], true, reason).await;
+            // -32600 = JSON-RPC "Invalid Request": the proxy does not accept
+            // this framing for an enforceable tool call.
+            let body = build_jsonrpc_error_response(-32600, reason);
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body,
+            );
+            let mut client_tls = client_reader.into_inner();
+            client_tls.write_all(resp.as_bytes()).await?;
+            let _ = client_tls.shutdown().await;
+            return Ok(());
         } else {
             None
         };


### PR DESCRIPTION
## What changed

`aa-proxy`'s MCP interception (`handle_non_llm_with_gateway`) enforced `tools/call`
policy and ran the credential/DLP scan only when `parse_mcp_request` produced a
single `McpToolCall`. That parser deserialises a **single** JSON-RPC object, so a
`tools/call` wrapped in a JSON-RPC 2.0 **batch array**
(`[{"jsonrpc":"2.0","method":"tools/call","params":{"name":"execute_bash",...}}]`)
— or an object malformed just enough that strict extraction fails — returned
`None`. The `else { None }` branch then forwarded the body upstream with **no
gateway CheckAction and no credential/DLP scan**. A steered agent could wrap a
denied tool call in a one-element batch to bypass Layer-2 policy entirely.

This PR adds a fail-closed detector, `intercept::mcp::is_unenforceable_tool_call`,
and wires it into the forward gate:

- A top-level JSON-RPC batch array with any `method == "tools/call"` element, or an
  object whose `method == "tools/call"` but whose envelope fails strict extraction,
  is now **rejected with a JSON-RPC `-32600` (Invalid Request) error envelope**
  instead of being forwarded upstream — mirroring an explicit gateway Deny, and
  emitting a denied `emit_mcp_decision` for audit.
- The detector is deliberately a *detector*, not a parser: it does not change
  `parse_mcp_request`'s existing `None`-on-false-positive contract.
- Ordinary non-MCP HTTPS traffic on this route is unaffected — the detector only
  fires on `method == "tools/call"`, so `tools/list`, non-JSON bodies, and every
  other request still flow through untouched.

## Why

Closes the MCP `tools/call` enforcement + DLP bypass via JSON-RPC batch framing
(AAASM-4070). The batch/malformed-framing path can no longer reach upstream
without a gateway decision and credential/DLP scan.

## How to verify

- `cargo nextest run -p aa-proxy intercept::mcp::tests` — 10 tests pass, including
  the new regression cases:
  - `one_element_batch_tools_call_is_flagged_unenforceable` (the exact bypass vector)
  - `multi_element_batch_with_a_tools_call_is_flagged`
  - `object_tools_call_that_fails_strict_extraction_is_flagged`
  - `non_tool_call_traffic_is_not_flagged` (tools/list object + batch, non-JSON,
    empty body, scalar array — all pass through)
- `cargo clippy -p aa-proxy --all-targets -- -D warnings` — clean.
- No new panic on malformed JSON: the detector treats any non-JSON body as `false`.

## Related Jira

AAASM-4070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
