### PR TITLE
[AAASM-4069] 🐛 (budget): Fail closed on unrecognized LLM model in spend accrual

### DIFF
--- a/aa-core/src/llm.rs
+++ b/aa-core/src/llm.rs
@@ -54,8 +54,9 @@ impl Model {
     /// `gpt-4o-2024-08-06` maps to `Gpt4o` (not `Gpt4`) and
     /// `command-r-plus` maps to `CommandRPlus` (not `CommandR`).
     ///
-    /// Returns `None` for an unrecognised model name — the caller treats an
-    /// unknown model as zero cost (no spend accrued) rather than guessing.
+    /// Returns `None` for an unrecognised model name. Callers must decide how
+    /// to price an unknown model — the gateway budget stage fails closed at a
+    /// conservative fallback rate (AAASM-4069) rather than treating it as free.
     pub fn infer_from_name(name: &str) -> Option<(Provider, Self)> {
         let n = name.to_ascii_lowercase();
         // Most-specific patterns first; substrings of others must come earlier.

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -214,6 +214,29 @@ mod tests {
     }
 
     #[test]
+    fn fallback_cost_usd_is_nonzero_and_uses_costliest_rate() {
+        // AAASM-4069: an unknown model must price at the costliest known rate
+        // (Claude 3 Opus) so it can never be cheaper than a metered call.
+        fn d(s: &str) -> rust_decimal::Decimal {
+            s.parse().unwrap()
+        }
+        let table = PricingTable::default_table();
+        // 10,000 input tokens × $0.015/1k = $0.15 (Opus input rate).
+        assert_eq!(table.fallback_cost_usd(10_000, 0), d("0.15"));
+        // 1,000 input + 1,000 output = $0.015 + $0.075 = $0.09.
+        assert_eq!(table.fallback_cost_usd(1_000, 1_000), d("0.09"));
+        // The fallback rate matches the most expensive default entry.
+        let opus = table
+            .entry(
+                crate::budget::types::Provider::Anthropic,
+                crate::budget::types::Model::Claude3Opus,
+            )
+            .unwrap();
+        assert_eq!(table.fallback_entry().input_per_1k_usd, opus.input_per_1k_usd);
+        assert_eq!(table.fallback_entry().output_per_1k_usd, opus.output_per_1k_usd);
+    }
+
+    #[test]
     fn load_from_file_falls_back_to_defaults_on_missing_file() {
         let path = std::path::Path::new("/nonexistent/path/pricing.json");
         let table = PricingTable::load_from_file(path);

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -28,6 +28,11 @@ struct PricingJsonRow {
 #[derive(Debug, Clone)]
 pub struct PricingTable {
     entries: std::collections::HashMap<(crate::budget::types::Provider, crate::budget::types::Model), PricingEntry>,
+    /// Conservative price applied to a call whose model name does not resolve
+    /// to a known `(Provider, Model)` pair (AAASM-4069). Set to the most
+    /// expensive known rate so an unrecognized model can never be cheaper than
+    /// a metered one — the budget cap fails closed instead of open.
+    fallback: PricingEntry,
 }
 
 impl PricingTable {
@@ -62,7 +67,18 @@ impl PricingTable {
             })
             .collect();
 
-        Self { entries }
+        Self {
+            entries,
+            // AAASM-4069 fail-closed fallback: mirror the costliest default
+            // entry (Claude 3 Opus, "0.015"/"0.075") so a model outside the
+            // table is priced at least as high as any known model. Priced
+            // through `fallback_cost_usd`, this keeps unknown-model spend
+            // metered and the budget reservation reachable.
+            fallback: PricingEntry {
+                input_per_1k_usd: d("0.015"),
+                output_per_1k_usd: d("0.075"),
+            },
+        }
     }
 
     /// Load pricing overrides from a JSON string, merging on top of the defaults.
@@ -108,6 +124,27 @@ impl PricingTable {
             }
             None => Decimal::ZERO,
         }
+    }
+
+    /// Price a call whose model did not resolve to a known `(Provider, Model)`
+    /// pair, using the conservative fallback rate (AAASM-4069).
+    ///
+    /// Fail-closed: an unrecognized model name must NOT price to `$0`, or the
+    /// `cost <= 0.0` accrual short-circuit in the gateway skips the budget
+    /// reservation entirely and the daily/monthly cap is bypassed. Charging the
+    /// costliest-known rate keeps spend accruing so the cap still engages for
+    /// any current model outside the built-in table (o1/o3, gemini-*, llama-*,
+    /// "gpt-5", …). Cost is token-proportional, so a genuinely empty call
+    /// (0 tokens) still prices to zero — the token count is trusted separately.
+    pub fn fallback_cost_usd(&self, input_tokens: u64, output_tokens: u64) -> Decimal {
+        let input_cost = self.fallback.input_per_1k_usd * Decimal::from(input_tokens) / Decimal::from(1_000u64);
+        let output_cost = self.fallback.output_per_1k_usd * Decimal::from(output_tokens) / Decimal::from(1_000u64);
+        input_cost + output_cost
+    }
+
+    /// The conservative fallback pricing entry applied to unrecognized models.
+    pub fn fallback_entry(&self) -> &PricingEntry {
+        &self.fallback
     }
 
     /// Look up pricing for a `(provider, model)` pair.

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2419,6 +2419,45 @@ mod tests {
     }
 
     #[test]
+    fn unknown_model_accrues_fallback_spend_and_engages_budget_cap() {
+        // AAASM-4069 regression: a model outside the built-in pricing table
+        // (here "o3-mini") must NOT price to $0. Previously it did, and the
+        // `cost <= 0.0` accrual short-circuit skipped the budget reservation
+        // entirely — an agent could pick any current model for unlimited
+        // unmetered spend. It must now fail closed: cost > 0, spend accrues,
+        // and the daily cap engages just like a known model.
+        let mut doc = empty_doc();
+        doc.budget = Some(BudgetPolicy {
+            daily_limit_usd: Some(1.0),
+            monthly_limit_usd: None,
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
+            timezone: None,
+            action_on_exceed: ActionOnExceed::default(),
+            window: None,
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+
+        // An unrecognized model with a non-empty prompt is priced at the
+        // conservative fallback rate, never $0.
+        let cost = engine.llm_call_cost_usd("o3-mini", 10_000, 0);
+        assert!(cost > 0.0, "unknown model must not price to zero (was {cost})");
+
+        // The priced spend actually reserves against the budget, so repeated
+        // unknown-model calls exhaust the $1 daily cap and are then denied —
+        // proving the reservation is reachable, not bypassed.
+        let mut denied = false;
+        for _ in 0..1_000 {
+            if engine.check_and_accrue_llm_spend(&ctx, cost).is_some() {
+                denied = true;
+                break;
+            }
+        }
+        assert!(denied, "unknown-model spend must eventually hit the daily cap");
+    }
+
+    #[test]
     fn check_and_accrue_llm_spend_no_overspend_under_parallel_checks() {
         // AAASM-3986: the atomic check+commit must never let concurrent
         // reservations for one tenant overspend the daily limit. With a $10

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1460,18 +1460,21 @@ impl PolicyEngine {
     /// [`crate::budget::types::Model::infer_from_name`]; output tokens are
     /// treated as `0` because the pre-execution check has no completion yet.
     ///
-    /// Returns `0.0` for an unrecognised model (no spend accrued) so an
-    /// unknown name never silently charges against a wrong price.
+    /// AAASM-4069 — an unrecognised model name is priced at the conservative
+    /// fallback rate (the costliest known model), NOT `0.0`. Returning `0.0`
+    /// previously made the `cost <= 0.0` accrual short-circuit skip the budget
+    /// reservation, so an agent could pick any model outside the built-in table
+    /// (o1/o3, gemini-*, llama-*, "gpt-5", …) for unlimited unmetered spend.
+    /// Fail closed instead: unknown-model spend still accrues and the cap
+    /// engages. The model name is attacker-controlled — this must not panic.
     pub fn llm_call_cost_usd(&self, model_name: &str, input_tokens: u64, output_tokens: u64) -> f64 {
-        let Some((provider, model)) = crate::budget::types::Model::infer_from_name(model_name) else {
-            return 0.0;
-        };
         use rust_decimal::prelude::ToPrimitive;
-        self.budget
-            .pricing()
-            .cost_usd(provider, model, input_tokens, output_tokens)
-            .to_f64()
-            .unwrap_or(0.0)
+        let pricing = self.budget.pricing();
+        let cost = match crate::budget::types::Model::infer_from_name(model_name) {
+            Some((provider, model)) => pricing.cost_usd(provider, model, input_tokens, output_tokens),
+            None => pricing.fallback_cost_usd(input_tokens, output_tokens),
+        };
+        cost.to_f64().unwrap_or(0.0)
     }
 
     /// Resolve the budget tenancy (`team_id`, `org_id`) for `ctx` from the

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1238,7 +1238,10 @@ impl PolicyServiceImpl {
     /// response is returned unchanged when:
     /// * the action is not an `LLM_CALL`;
     /// * the decision was already a hard `Deny` (a denied call did not run);
-    /// * the model name is unrecognised (cost resolves to `0.0`).
+    /// * the priced cost is `0.0` — a genuinely empty call (0 tokens). An
+    ///   unrecognised model name is NO LONGER treated as zero cost (AAASM-4069):
+    ///   it fails closed at the conservative fallback rate so the budget cap
+    ///   still engages instead of being bypassed.
     fn maybe_accrue_llm_spend(&self, req: &CheckActionRequest, response: CheckActionResponse) -> CheckActionResponse {
         use aa_proto::assembly::policy::v1::action_context::Action;
 

--- a/aa-gateway/tests/budget_accrual_test.rs
+++ b/aa-gateway/tests/budget_accrual_test.rs
@@ -99,22 +99,45 @@ async fn llm_spend_accrues_and_later_call_is_denied_once_limit_exceeded() {
 }
 
 #[tokio::test]
-async fn unknown_model_accrues_no_spend() {
+async fn unknown_model_accrues_fallback_spend_and_engages_cap() {
+    // AAASM-4069 fail-closed: an unrecognised model name must NOT price to
+    // $0.00. Previously it did, so no spend accrued and the daily/monthly cap
+    // was bypassed entirely — an agent could pick any model outside the
+    // built-in pricing table for unlimited unmetered spend. It must now be
+    // priced at the conservative fallback rate so spend accrues and the cap
+    // engages just like a known model.
     let (audit_tx, _audit_rx) = mpsc::channel::<AuditEntry>(4096);
     let service = make_service(audit_tx);
 
-    // An unrecognised model name prices to $0.00, so no spend accrues and a
-    // large number of calls all stay allowed.
-    for _ in 0..5 {
-        let resp = service
-            .check_action(Request::new(llm_call_request("some-unknown-model", 1_000_000)))
-            .await
-            .expect("check_action ok")
-            .into_inner();
-        assert_eq!(
-            resp.decision,
-            Decision::Allow as i32,
-            "unknown model must accrue no spend and stay allowed"
-        );
-    }
+    // First call: spend is $0 at evaluation, so it is allowed. It then accrues
+    // the fallback-priced cost (1M prompt tokens at the costliest-known rate,
+    // ~$15) against the agent's $0.50 daily budget.
+    let first = service
+        .check_action(Request::new(llm_call_request("some-unknown-model", 1_000_000)))
+        .await
+        .expect("first check_action ok")
+        .into_inner();
+    assert_eq!(
+        first.decision,
+        Decision::Allow as i32,
+        "first unknown-model call must be allowed (no spend recorded yet)"
+    );
+
+    // Second call: accrued fallback spend now exceeds the $0.50 daily limit, so
+    // Stage 7 denies it. Before the fix this stayed allowed forever.
+    let second = service
+        .check_action(Request::new(llm_call_request("some-unknown-model", 1_000_000)))
+        .await
+        .expect("second check_action ok")
+        .into_inner();
+    assert_eq!(
+        second.decision,
+        Decision::Deny as i32,
+        "unknown-model spend must accrue and eventually hit the daily cap"
+    );
+    assert!(
+        second.reason.contains("budget"),
+        "deny reason must reference the budget, got: {}",
+        second.reason
+    );
 }


### PR DESCRIPTION
## Description

The per-team / agent / org budget cap failed **open** for any LLM model outside
the hardcoded 8-entry pricing table. `aa_core::llm::Model::infer_from_name`
substring-matches only gpt-4o / gpt-3.5 / gpt-4 / opus / sonnet / haiku /
command-r(+); any other model — o1/o3/o4-mini, gemini-*, llama-*, mistral-*,
deepseek-*, grok-*, "gpt-5", or garbage — resolved to `None`, so
`PolicyEngine::llm_call_cost_usd` returned `0.0`. In `maybe_accrue_llm_spend`
the `if cost <= 0.0 { return response }` short-circuit then **skipped the budget
reservation entirely**. Because the agent controls the `model` string in the
live gRPC `CheckAction(LlmCall)`, it could pick any unrecognized model for
**unlimited, unmetered spend** — budget control was inoperative for most
current models.

**Fix (fail-closed):** an unrecognized model name is now priced at a
conservative fallback rate — the costliest known model (Claude 3 Opus) — instead
of `$0`. Spend still accrues and the daily/monthly cap engages, so an unknown
model can never yield a zero-accrual budget bypass. The legitimate known-model
pricing path is unchanged, and a genuinely empty call (0 tokens) still prices to
zero. The attacker-controlled `model` string is handled without panicking.

Commits:
- `✨ (budget): Add conservative fallback price for unknown LLM models`
- `🐛 (budget): Fail closed on unrecognized LLM model in spend accrual`
- `✅ (budget): Test unknown model accrues fallback spend under cap`

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Behavioural change only: unknown-model LLM calls now accrue budget (previously
free). No public API signatures change.

## Related Issues

- Related Jira ticket: AAASM-4069

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

New regression tests:
- `budget::pricing::tests::fallback_cost_usd_is_nonzero_and_uses_costliest_rate`
  — the fallback rate is non-zero and equals the costliest known entry.
- `engine::tests::unknown_model_accrues_fallback_spend_and_engages_budget_cap`
  — an unknown model ("o3-mini") prices to `> 0` and repeated calls exhaust the
  daily cap and are denied, proving the reservation is reachable, not bypassed.

Both targeted tests pass; `cargo clippy -p aa-gateway -p aa-core --all-targets
-- -D warnings` is clean (only pre-existing Cargo manifest `default-features`
warnings remain). The full suite is owned by CI.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
