### PR TITLE
[AAASM-4075] 🔒 (auth,scanner): Bound pre-auth argon2 + catch separator-delimited secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
  "utoipa",

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -434,6 +434,9 @@ impl AppState {
                     label: Some("local single-process admin key".to_string()),
                     team_id: None,
                     org_id: None,
+                    // AAASM-4075 — index this key so credential validation runs
+                    // argon2 only on the matching candidate, not per-key.
+                    key_lookup: Some(parsed.lookup()),
                 };
                 state.auth_config = Arc::new(AuthConfig {
                     mode: AuthMode::On,

--- a/aa-api/tests/auth_jwt.rs
+++ b/aa-api/tests/auth_jwt.rs
@@ -156,6 +156,7 @@ async fn issued_jwt_retains_caller_tenant() {
         label: Some("tenant key".to_string()),
         team_id: Some("alpha".to_string()),
         org_id: Some("org-1".to_string()),
+        key_lookup: Some(key.lookup()),
     };
     let app = common::test_app_with_auth(&[entry], 1000);
 

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -246,6 +246,7 @@ pub fn generate_test_api_key(id: &str, scopes: Vec<Scope>) -> (String, ApiKeyEnt
         label: Some(format!("test key {id}")),
         team_id: None,
         org_id: None,
+        key_lookup: Some(key.lookup()),
     };
     (key.as_str().to_string(), entry)
 }

--- a/aa-auth/Cargo.toml
+++ b/aa-auth/Cargo.toml
@@ -16,6 +16,11 @@ rand = "0.10"
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+# Fast lookup-hash for the API-key prefix index (AAASM-4075): a truncated SHA-256
+# of the raw key selects the single candidate entry so `validate_detailed` runs
+# argon2 once, not once per stored key, on unauthenticated input. sha2 is a
+# workspace dependency already pulled in transitively by argon2.
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 utoipa = { workspace = true }

--- a/aa-auth/src/api_key.rs
+++ b/aa-auth/src/api_key.rs
@@ -457,4 +457,63 @@ mod tests {
         assert!(store.is_empty());
         assert_eq!(store.len(), 0);
     }
+
+    /// AAASM-4075 (anti-fan-out DoS): `validate_detailed` must argon2-verify only
+    /// the entries selected by the incoming key's lookup bucket, never every
+    /// stored key. We prove the fan-out is gone by filing an entry whose argon2
+    /// hash *would* match the probe token but under a *different* lookup bucket: a
+    /// naive fan-out scan would verify and match it, whereas the indexed scan must
+    /// not even reach it — so the probe is `NotFound`.
+    #[test]
+    fn invalid_token_is_not_verified_against_mismatched_lookup_bucket() {
+        let probe = ApiKey::generate();
+        let probe_hash = probe.hash().expect("hash");
+
+        // Entry whose hash matches `probe`, deliberately filed under a bucket that
+        // does not match `probe.lookup()`.
+        let wrong_bucket = "deadbeefdeadbeef".to_string();
+        assert_ne!(
+            wrong_bucket,
+            probe.lookup(),
+            "fixture bucket must differ from the probe's real lookup"
+        );
+        let trap = ApiKeyEntry {
+            id: "trap".to_string(),
+            key_hash: probe_hash,
+            scopes: vec![Scope::Admin],
+            created_at: 0,
+            label: None,
+            team_id: None,
+            org_id: None,
+            key_lookup: Some(wrong_bucket),
+        };
+        let store = ApiKeyStore::from_entries(vec![trap]);
+
+        // The probe's own hash is present, but the index never selects it (and so
+        // argon2 never runs on it), proving there is no per-key fan-out.
+        assert!(matches!(
+            store.validate_detailed(probe.as_str()),
+            Err(KeyNotValid::NotFound)
+        ));
+    }
+
+    /// AAASM-4075 backward-compat: an entry with no `key_lookup` (e.g. loaded from
+    /// a key file written before the index existed) still authenticates via the
+    /// legacy argon2 fallback scan.
+    #[test]
+    fn legacy_entry_without_lookup_still_validates() {
+        let key = ApiKey::generate();
+        let entry = ApiKeyEntry {
+            id: "legacy".to_string(),
+            key_hash: key.hash().expect("hash"),
+            scopes: vec![Scope::Read],
+            created_at: 0,
+            label: None,
+            team_id: None,
+            org_id: None,
+            key_lookup: None,
+        };
+        let store = ApiKeyStore::from_entries(vec![entry]);
+        assert_eq!(store.validate(key.as_str()).map(|e| e.id.as_str()), Some("legacy"));
+    }
 }

--- a/aa-auth/src/api_key.rs
+++ b/aa-auth/src/api_key.rs
@@ -1,5 +1,6 @@
 //! API key generation, validation, and storage.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use argon2::password_hash::SaltString;
@@ -8,6 +9,7 @@ use dashmap::DashMap;
 use rand::RngExt as _;
 use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use super::scope::Scope;
@@ -17,6 +19,14 @@ const API_KEY_PREFIX: &str = "aa_";
 
 /// Expected length of the hex portion of an API key.
 const API_KEY_HEX_LEN: usize = 32;
+
+/// Hex length of the per-key lookup index derived by [`ApiKey::lookup`].
+///
+/// 16 hex chars = 64 bits of SHA-256 output — enough that unrelated keys almost
+/// never share a bucket (so a bogus token normally selects zero candidates and
+/// runs argon2 zero times), while a collision only ever adds one extra argon2
+/// verification, never restoring the O(N) fan-out.
+const KEY_LOOKUP_HEX_LEN: usize = 16;
 
 /// An Agent Assembly API key in `aa_<32-hex-chars>` format.
 #[derive(Debug, Clone)]
@@ -76,6 +86,23 @@ impl ApiKey {
         };
         Argon2::default().verify_password(self.0.as_bytes(), &parsed).is_ok()
     }
+
+    /// Derive the fast, non-secret lookup index for this key (AAASM-4075).
+    ///
+    /// A truncated SHA-256 of the raw key. Because SHA-256 is preimage-resistant,
+    /// persisting this alongside the argon2 hash leaks nothing about the key even
+    /// if the key store is exfiltrated, yet it lets [`ApiKeyStore::validate_detailed`]
+    /// select the single candidate entry in O(1) and run the expensive argon2
+    /// verification only on that candidate — never once per stored key. argon2
+    /// remains the sole authority for the final match.
+    pub fn lookup(&self) -> String {
+        let digest = Sha256::digest(self.0.as_bytes());
+        let mut out = String::with_capacity(KEY_LOOKUP_HEX_LEN);
+        for b in &digest[..KEY_LOOKUP_HEX_LEN / 2] {
+            out.push_str(&format!("{b:02x}"));
+        }
+        out
+    }
 }
 
 /// A stored API key entry with metadata.
@@ -100,11 +127,27 @@ pub struct ApiKeyEntry {
     /// AAASM-3139 — the org this key is scoped to. See [`ApiKeyEntry::team_id`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub org_id: Option<String>,
+    /// AAASM-4075 — the fast lookup index ([`ApiKey::lookup`]) for this key.
+    ///
+    /// Populated when the entry is created from a known raw key so the store can
+    /// select it in O(1) and run argon2 only on this candidate. `None` marks a
+    /// legacy entry (e.g. loaded from a key file written before this field
+    /// existed); such entries fall back to the pre-index argon2 scan, so they do
+    /// not benefit from the anti-fan-out guarantee but remain fully valid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_lookup: Option<String>,
 }
 
 /// In-memory store of API key entries loaded from a JSON file.
 pub struct ApiKeyStore {
     entries: Vec<ApiKeyEntry>,
+    /// AAASM-4075 — maps a key's [`ApiKey::lookup`] index to the entry indices
+    /// sharing it, so `validate_detailed` selects candidates in O(1) instead of
+    /// running argon2 against every entry. Built once at construction.
+    lookup_index: HashMap<String, Vec<usize>>,
+    /// AAASM-4075 — indices of entries with no `key_lookup` (legacy). These are
+    /// unavoidably argon2-scanned on every call; the set is normally empty.
+    unindexed: Vec<usize>,
     /// Runtime-revoked key IDs; checked during every `validate_detailed` call.
     revoked_ids: DashMap<String, ()>,
 }
@@ -116,10 +159,28 @@ impl ApiKeyStore {
     /// single admin key from the environment (or a generated one) without a
     /// keys-on-disk file.
     pub fn from_entries(entries: Vec<ApiKeyEntry>) -> Self {
+        let (lookup_index, unindexed) = Self::build_index(&entries);
         Self {
             entries,
+            lookup_index,
+            unindexed,
             revoked_ids: DashMap::new(),
         }
+    }
+
+    /// Partition entries into the [`ApiKey::lookup`] index and the legacy
+    /// (no-`key_lookup`) fallback set. Shared by every constructor so the two
+    /// stay in sync (AAASM-4075).
+    fn build_index(entries: &[ApiKeyEntry]) -> (HashMap<String, Vec<usize>>, Vec<usize>) {
+        let mut lookup_index: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut unindexed = Vec::new();
+        for (idx, entry) in entries.iter().enumerate() {
+            match &entry.key_lookup {
+                Some(lookup) => lookup_index.entry(lookup.clone()).or_default().push(idx),
+                None => unindexed.push(idx),
+            }
+        }
+        (lookup_index, unindexed)
     }
 
     /// Load API key entries from a JSON file.
@@ -127,19 +188,13 @@ impl ApiKeyStore {
     /// Returns an empty store if the file does not exist.
     pub fn load(path: &Path) -> Result<Self, ApiKeyError> {
         if !path.exists() {
-            return Ok(Self {
-                entries: Vec::new(),
-                revoked_ids: DashMap::new(),
-            });
+            return Ok(Self::from_entries(Vec::new()));
         }
 
         let content = std::fs::read_to_string(path).map_err(|e| ApiKeyError::Io(e.to_string()))?;
         let entries: Vec<ApiKeyEntry> =
             serde_json::from_str(&content).map_err(|e| ApiKeyError::ParseError(e.to_string()))?;
-        Ok(Self {
-            entries,
-            revoked_ids: DashMap::new(),
-        })
+        Ok(Self::from_entries(entries))
     }
 
     /// Mark a key ID as revoked; subsequent `validate_detailed` calls for that
@@ -155,7 +210,23 @@ impl ApiKeyStore {
     /// other failure (parse error, wrong hash, unknown key).
     pub fn validate_detailed(&self, raw_key: &str) -> Result<&ApiKeyEntry, KeyNotValid> {
         let key = ApiKey::parse(raw_key).map_err(|_| KeyNotValid::NotFound)?;
-        match self.entries.iter().find(|entry| key.verify(&entry.key_hash)) {
+
+        // AAASM-4075 — select candidates by the cheap SHA-256 lookup index so an
+        // unauthenticated attacker bursting well-formed-but-invalid tokens cannot
+        // force one argon2 verification per stored key (a CPU/memory DoS). Only
+        // entries whose lookup matches, plus any legacy entries lacking the index,
+        // are argon2-verified; a bogus token normally selects zero indexed
+        // candidates. argon2 stays the sole authority for the final match.
+        let lookup = key.lookup();
+        let candidates = self
+            .lookup_index
+            .get(&lookup)
+            .into_iter()
+            .flatten()
+            .chain(self.unindexed.iter())
+            .filter_map(|&idx| self.entries.get(idx));
+
+        match candidates.into_iter().find(|entry| key.verify(&entry.key_hash)) {
             None => Err(KeyNotValid::NotFound),
             Some(entry) => {
                 if self.revoked_ids.contains_key(&entry.id) {
@@ -301,11 +372,9 @@ mod tests {
             label: Some("test key".to_string()),
             team_id: None,
             org_id: None,
+            key_lookup: Some(key.lookup()),
         };
-        let store = ApiKeyStore {
-            entries: vec![entry],
-            revoked_ids: DashMap::new(),
-        };
+        let store = ApiKeyStore::from_entries(vec![entry]);
 
         let result = store.validate(key.as_str());
         assert!(result.is_some());
@@ -325,11 +394,9 @@ mod tests {
             label: None,
             team_id: None,
             org_id: None,
+            key_lookup: Some(key1.lookup()),
         };
-        let store = ApiKeyStore {
-            entries: vec![entry],
-            revoked_ids: DashMap::new(),
-        };
+        let store = ApiKeyStore::from_entries(vec![entry]);
 
         let result = store.validate(key2.as_str());
         assert!(result.is_none());
@@ -360,6 +427,7 @@ mod tests {
             label: None,
             team_id: None,
             org_id: None,
+            key_lookup: Some(key.lookup()),
         };
         let store = ApiKeyStore::from_entries(vec![entry]);
         assert_eq!(store.len(), 1);

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -1374,6 +1374,7 @@ pub fn make_api_key(id: &str, scopes: Vec<aa_api::auth::scope::Scope>) -> (Strin
         label: Some(format!("test key {id}")),
         team_id: None,
         org_id: None,
+        key_lookup: Some(key.lookup()),
     };
     (key.as_str().to_string(), entry)
 }

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1244,6 +1244,59 @@ mod tests {
         );
     }
 
+    /// AAASM-4075: a 64-hex secret reformatted with `:` (or `-`) separators
+    /// splits into 2-char groups that clear neither the contiguous-hex length bar
+    /// nor the base64 entropy gate, evading passes 1-3. The separator-grouped pass
+    /// must still flag it once the total hex-digit count reaches 64.
+    #[test]
+    fn detects_separator_delimited_hex_secret() {
+        let scanner = CredentialScanner::new();
+        // The 64-hex secret from `detects_64_char_lowercase_hex_secret`, regrouped
+        // into colon-separated byte pairs (32 groups × 2 hex = 64 hex digits).
+        let raw = "deadbeefcafebabe0123456789abcdef0123456789abcdeffedcba9876543210";
+        let colon = raw
+            .as_bytes()
+            .chunks(2)
+            .map(|c| std::str::from_utf8(c).unwrap())
+            .collect::<Vec<_>>()
+            .join(":");
+        let dash = colon.replace(':', "-");
+        for secret in [&colon, &dash] {
+            let result = scanner.scan(&format!("token={secret}"));
+            assert!(
+                result
+                    .findings
+                    .iter()
+                    .any(|f| f.kind == CredentialKind::GenericHighEntropy),
+                "separator-delimited hex secret must be flagged: {secret:?} -> {:?}",
+                result.findings
+            );
+            // And end-to-end the raw secret must not survive redaction.
+            let text = format!(r#"{{"api_token":"{secret}"}}"#);
+            let redacted = scanner.scan(&text).redact(&text);
+            assert!(!redacted.contains(secret.as_str()), "raw secret survived: {redacted}");
+        }
+    }
+
+    /// A MAC address (12 hex digits) and a dash-delimited UUID (32 hex digits)
+    /// carry separators but stay well under the 64-digit bar, so the AAASM-4075
+    /// pass must leave them clean — no new false positives.
+    #[test]
+    fn does_not_flag_short_separated_hex() {
+        let scanner = CredentialScanner::new();
+        for text in ["mac de:ad:be:ef:00:01 up", "id 550e8400-e29b-41d4-a716-446655440000 ok"] {
+            let result = scanner.scan(text);
+            assert!(
+                !result
+                    .findings
+                    .iter()
+                    .any(|f| f.kind == CredentialKind::GenericHighEntropy),
+                "short separated hex wrongly flagged: {text:?} -> {:?}",
+                result.findings
+            );
+        }
+    }
+
     /// Branded literal prefixes must remain detected after the rewrite — the
     /// long-token rules must not displace the high-signal AC matchers.
     #[test]

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -647,6 +647,12 @@ fn is_base64_char(b: u8) -> bool {
 /// 3. **Long base64 run** (AAASM-3870) — a contiguous base64/base64url run
 ///    longer than [`BASE64_RUN_MIN_LEN`] whose entropy exceeds the gate, closing
 ///    the > 64-char length evasion that the pass-1 upper bound skipped.
+/// 4. **Separator-grouped hex run** (AAASM-4075) — a hex run broken into groups
+///    by `:` / `-` separators (e.g. `de:ad:be:ef:…`) whose total hex-digit count
+///    reaches [`HEX_RUN_MIN_LEN`]. Such reformatting splits the contiguous run
+///    into 2-char groups that clear neither the pass-2 length bar nor (with `-`
+///    kept inside the base64 alphabet) the pass-3 entropy gate, so it evades
+///    passes 1-3 entirely; this pass closes that gap.
 fn scan_high_entropy(text: &str, findings: &mut Vec<CredentialFinding>) {
     // Pass 1: whitespace-delimited high-entropy tokens, length 20–64.
     let mut offset = 0usize;
@@ -673,6 +679,8 @@ fn scan_high_entropy(text: &str, findings: &mut Vec<CredentialFinding>) {
     // Passes 2 & 3: contiguous encoded-blob runs that the token pass misses.
     scan_long_hex_runs(text, findings);
     scan_long_base64_runs(text, findings);
+    // Pass 4: separator-grouped hex runs the contiguous passes miss (AAASM-4075).
+    scan_separated_hex_runs(text, findings);
 }
 
 /// Pass 2 — flag every contiguous hex run of length ≥ [`HEX_RUN_MIN_LEN`].
@@ -711,6 +719,60 @@ fn scan_long_base64_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
         let run = &text[start..i];
         if run.len() > BASE64_RUN_MIN_LEN && shannon_entropy(run) > ENTROPY_BITS_GATE {
             findings.push(CredentialFinding::new(CredentialKind::GenericHighEntropy, start, i));
+        }
+    }
+}
+
+/// Returns `true` for the intra-token separators that a secret can be rewritten
+/// around to split it into small groups (`de:ad:be:ef…`, `de-ad-be-ef…`). Note
+/// `-` is also a base64url character, so dash-grouping additionally dilutes the
+/// per-run entropy below [`ENTROPY_BITS_GATE`] — both reasons the contiguous
+/// passes miss these tokens.
+fn is_hex_group_separator(b: u8) -> bool {
+    matches!(b, b':' | b'-')
+}
+
+/// Pass 4 — flag a hex run split into groups by `:` / `-` separators whose total
+/// hex-digit count reaches [`HEX_RUN_MIN_LEN`] (AAASM-4075).
+///
+/// Scans each maximal run of `[0-9a-fA-F:-]`, counts only the hex digits (the
+/// separators are the evasion and are not part of the secret's entropy), and
+/// flags the run — trimmed to its first/last hex digit — when it both contains a
+/// separator (a contiguous run is already handled by [`scan_long_hex_runs`]) and
+/// carries at least [`HEX_RUN_MIN_LEN`] hex digits. Keying the bar on the same
+/// 64-digit threshold as the contiguous rule keeps benign grouped hex — MAC
+/// addresses (12 digits) and dash-delimited UUIDs (32 digits) — below the bar.
+fn scan_separated_hex_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if !bytes[i].is_ascii_hexdigit() && !is_hex_group_separator(bytes[i]) {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut hex_count = 0usize;
+        let mut has_separator = false;
+        let mut first_hex: Option<usize> = None;
+        let mut last_hex = start;
+        while i < bytes.len() && (bytes[i].is_ascii_hexdigit() || is_hex_group_separator(bytes[i])) {
+            if bytes[i].is_ascii_hexdigit() {
+                hex_count += 1;
+                first_hex.get_or_insert(i);
+                last_hex = i;
+            } else {
+                has_separator = true;
+            }
+            i += 1;
+        }
+        if has_separator && hex_count >= HEX_RUN_MIN_LEN {
+            if let Some(span_start) = first_hex {
+                findings.push(CredentialFinding::new(
+                    CredentialKind::GenericHighEntropy,
+                    span_start,
+                    last_hex + 1,
+                ));
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Two defense-in-depth security hardening fixes (AAASM-4075):

**(a) Pre-auth argon2 grinding DoS — `aa-auth`.** `ApiKeyStore::validate_detailed` ran argon2id (~19 MiB, t=2) against *every* stored entry for a non-matching key, and the `RateLimiter` is keyed on `caller.key_id` — which only exists *after* successful validation. So an unauthenticated attacker bursting well-formed-but-invalid `Authorization: Bearer aa_<32-hex>` tokens forced N (= key count) argon2 verifications per request with no throttle → CPU/memory DoS. Fix: derive a fast, non-secret lookup index (truncated SHA-256) per key, persist it on `ApiKeyEntry`, and select candidates through an O(1) map so argon2 runs only on the single matching entry — a bogus token normally selects zero candidates and runs argon2 zero times. argon2 remains the sole authority for the final match; a lookup collision only ever adds one extra verification, never restoring the O(N) fan-out. Legacy entries without the index fall back to the prior scan, preserving backward compatibility.

**(b) Separator-delimited secret scanner evasion — `aa-security`.** A secret reformatted `de:ad:be:ef:…` splits the contiguous run at `:`/`-` separators: colons break both the hex and base64 runs, while `-` (a base64url char) keeps one run but dilutes its entropy below the gate — so such tokens evaded all three existing passes. Fix: an additive pass 4 scans each maximal `[0-9a-fA-F:-]` run, counts only the hex digits, and flags a separator-bearing run once its hex-digit count reaches the same 64-digit bar as the contiguous-hex rule.

## Type of Change

- [x] 🐛 Bug fix (security hardening)

## Breaking Changes

- [x] No

`ApiKeyEntry` gains an optional `key_lookup` field (`#[serde(default, skip_serializing_if)]`); existing key files without it load and authenticate unchanged via the fallback scan.

## Related Issues

- Related Jira ticket: AAASM-4075
- Sibling PR **AAASM-4071** also edits `aa-security/src/scanner.rs` (it changes the base64-run floor constant + comparison operator). This PR's scanner change is a **disjoint** additive hunk — a new `scan_separated_hex_runs` pass that does not touch the base64-floor lines. Both branch off `remote/master`; a small rebase at merge is expected.

## Testing

- [x] Unit tests added / updated

- `aa-auth`: `invalid_token_is_not_verified_against_mismatched_lookup_bucket` deterministically proves the O(N) fan-out is gone (an entry whose argon2 hash matches the probe but is filed under a mismatched bucket is never selected → `NotFound`); `legacy_entry_without_lookup_still_validates` guards backward compat. Full suite: 43/43 pass.
- `aa-security`: `detects_separator_delimited_hex_secret` (colon- and dash-grouped 64-hex secret flagged + redacted) and `does_not_flag_short_separated_hex` (MAC address + dash-UUID stay clean — no new false positives). Full scanner suite green; `aa-security` 156/156 pass.
- `cargo fmt --all` clean; `cargo clippy -p aa-auth -p aa-security --all-targets -- -D warnings` clean; `aa-api` auth tests 29/29 pass.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
