### PR TITLE
[AAASM-4107] ✨ (dashboard): Reflect caller permissions in the UI (client-side RBAC)

### DIFF
--- a/dashboard/src/auth/AuthContext.ts
+++ b/dashboard/src/auth/AuthContext.ts
@@ -1,7 +1,24 @@
 import { createContext } from 'react'
+import type { components } from '../api/generated/schema'
+
+/**
+ * Authorization scope level, mirroring the server `Scope` enum. Privilege is
+ * ordered `read < write < admin` (see `aa-auth::scope::Scope`).
+ */
+export type Scope = components['schemas']['Scope']
 
 export interface AuthContextValue {
   token: string | null
+  /**
+   * Scopes granted to the current caller, taken from the token-issue response
+   * or parsed from the JWT `scope` claim. Empty when unauthenticated or when
+   * the claim cannot be read.
+   *
+   * Advisory only: this exists so the UI can hide/disable controls the caller
+   * can't use. The gateway re-checks scope on every mutation and remains the
+   * sole authority — never treat this as a security boundary.
+   */
+  scopes: Scope[]
   login: (apiKey: string) => Promise<void>
   logout: () => void
 }

--- a/dashboard/src/auth/AuthProvider.tsx
+++ b/dashboard/src/auth/AuthProvider.tsx
@@ -1,9 +1,15 @@
 import { useCallback, useMemo, useState } from 'react'
-import { AuthContext } from './AuthContext'
+import { AuthContext, type Scope } from './AuthContext'
+import { parseScopesFromJwt } from './jwtScopes'
 
 export function AuthProvider({ children }: Readonly<{ children: React.ReactNode }>) {
   const [token, setToken] = useState<string | null>(
     () => localStorage.getItem('aa_token'),
+  )
+  // Seed from the persisted token's JWT claim so a reload keeps reflecting the
+  // caller's permission level without re-issuing a token.
+  const [scopes, setScopes] = useState<Scope[]>(
+    () => parseScopesFromJwt(localStorage.getItem('aa_token')),
   )
 
   const login = useCallback(async (apiKey: string): Promise<void> => {
@@ -19,17 +25,23 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
     if (!res.ok) {
       throw new Error(`Authentication failed (${res.status})`)
     }
-    const data = (await res.json()) as { token: string }
+    const data = (await res.json()) as { token: string; scopes?: Scope[] }
     localStorage.setItem('aa_token', data.token)
     setToken(data.token)
+    // Prefer the response's explicit scopes; fall back to the JWT claim.
+    setScopes(data.scopes ?? parseScopesFromJwt(data.token))
   }, [])
 
   const logout = useCallback(() => {
     localStorage.removeItem('aa_token')
     setToken(null)
+    setScopes([])
   }, [])
 
-  const value = useMemo(() => ({ token, login, logout }), [token, login, logout])
+  const value = useMemo(
+    () => ({ token, scopes, login, logout }),
+    [token, scopes, login, logout],
+  )
 
   return (
     <AuthContext.Provider value={value}>

--- a/dashboard/src/auth/jwtScopes.ts
+++ b/dashboard/src/auth/jwtScopes.ts
@@ -1,0 +1,33 @@
+import type { Scope } from './AuthContext'
+
+const VALID_SCOPES: readonly Scope[] = ['read', 'write', 'admin']
+
+/**
+ * Extract the `scope` claim from an unverified JWT payload.
+ *
+ * The dashboard only persists the token string in localStorage, so after a
+ * reload the token-issue response (which carries `scopes`) is gone — this
+ * recovers the caller's scopes from the token itself so the UI can reflect
+ * them. The signature is deliberately NOT verified here: the gateway validates
+ * the token on every request and is the sole authority. A missing, malformed,
+ * or scope-less token yields `[]`, which reflects as "no mutating controls".
+ */
+export function parseScopesFromJwt(token: string | null): Scope[] {
+  if (!token) return []
+  const parts = token.split('.')
+  if (parts.length !== 3) return []
+  try {
+    const payload = JSON.parse(base64UrlDecode(parts[1])) as { scope?: unknown }
+    if (!Array.isArray(payload.scope)) return []
+    return payload.scope.filter((s): s is Scope => VALID_SCOPES.includes(s as Scope))
+  } catch {
+    return []
+  }
+}
+
+/** Decode a base64url segment (JWT parts are unpadded base64url). */
+function base64UrlDecode(segment: string): string {
+  const base64 = segment.replace(/-/g, '+').replace(/_/g, '/')
+  const pad = base64.length % 4 === 0 ? '' : '='.repeat(4 - (base64.length % 4))
+  return atob(base64 + pad)
+}

--- a/dashboard/src/auth/usePermissions.test.tsx
+++ b/dashboard/src/auth/usePermissions.test.tsx
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { AuthContext, type AuthContextValue, type Scope } from './AuthContext'
+import { scopesSatisfy, useCan, usePermissions } from './usePermissions'
+import { parseScopesFromJwt } from './jwtScopes'
+
+function providerWith(scopes: Scope[]) {
+  const value: AuthContextValue = {
+    token: 'tok',
+    scopes,
+    login: async () => {},
+    logout: () => {},
+  }
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  }
+}
+
+/** Build an unsigned JWT with the given `scope` claim payload. */
+function jwtWithScope(scope: unknown): string {
+  const b64 = (obj: unknown) =>
+    btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  return `${b64({ alg: 'HS256' })}.${b64({ sub: 'k', scope })}.sig`
+}
+
+describe('scopesSatisfy', () => {
+  it('honors the read < write < admin ordering', () => {
+    // read grant satisfies only read
+    expect(scopesSatisfy(['read'], 'read')).toBe(true)
+    expect(scopesSatisfy(['read'], 'write')).toBe(false)
+    expect(scopesSatisfy(['read'], 'admin')).toBe(false)
+
+    // write grant satisfies read and write, not admin
+    expect(scopesSatisfy(['write'], 'read')).toBe(true)
+    expect(scopesSatisfy(['write'], 'write')).toBe(true)
+    expect(scopesSatisfy(['write'], 'admin')).toBe(false)
+
+    // admin satisfies everything
+    expect(scopesSatisfy(['admin'], 'read')).toBe(true)
+    expect(scopesSatisfy(['admin'], 'write')).toBe(true)
+    expect(scopesSatisfy(['admin'], 'admin')).toBe(true)
+  })
+
+  it('treats an empty grant as no permission', () => {
+    expect(scopesSatisfy([], 'read')).toBe(false)
+    expect(scopesSatisfy([], 'write')).toBe(false)
+  })
+})
+
+describe('usePermissions', () => {
+  it('reports a read-only caller cannot write or admin', () => {
+    const { result } = renderHook(() => usePermissions(), { wrapper: providerWith(['read']) })
+    expect(result.current.canWrite).toBe(false)
+    expect(result.current.canAdmin).toBe(false)
+    expect(result.current.can('read')).toBe(true)
+  })
+
+  it('reports a write caller can write but not admin', () => {
+    const { result } = renderHook(() => usePermissions(), { wrapper: providerWith(['write']) })
+    expect(result.current.canWrite).toBe(true)
+    expect(result.current.canAdmin).toBe(false)
+  })
+
+  it('useCan resolves a single required level', () => {
+    const write = renderHook(() => useCan('write'), { wrapper: providerWith(['read']) })
+    expect(write.result.current).toBe(false)
+    const admin = renderHook(() => useCan('write'), { wrapper: providerWith(['admin']) })
+    expect(admin.result.current).toBe(true)
+  })
+
+  it('falls back to permissive when no AuthProvider is mounted', () => {
+    const { result } = renderHook(() => usePermissions())
+    expect(result.current.canWrite).toBe(true)
+    expect(result.current.canAdmin).toBe(true)
+  })
+})
+
+describe('parseScopesFromJwt', () => {
+  it('extracts the scope claim from a JWT payload', () => {
+    expect(parseScopesFromJwt(jwtWithScope(['read', 'write']))).toEqual(['read', 'write'])
+  })
+
+  it('drops unknown scope values', () => {
+    expect(parseScopesFromJwt(jwtWithScope(['read', 'superuser']))).toEqual(['read'])
+  })
+
+  it('returns [] for null, malformed, or scope-less tokens', () => {
+    expect(parseScopesFromJwt(null)).toEqual([])
+    expect(parseScopesFromJwt('not-a-jwt')).toEqual([])
+    expect(parseScopesFromJwt(jwtWithScope('read'))).toEqual([])
+    expect(parseScopesFromJwt(jwtWithScope(undefined))).toEqual([])
+  })
+})

--- a/dashboard/src/auth/usePermissions.ts
+++ b/dashboard/src/auth/usePermissions.ts
@@ -1,12 +1,18 @@
-import { useMemo } from 'react'
-import { useAuth } from './useAuth'
-import type { Scope } from './AuthContext'
+import { useContext, useMemo } from 'react'
+import { AuthContext, type Scope } from './AuthContext'
 
 /**
  * Privilege ranking, mirroring the server ordering `read < write < admin`
  * (`aa-auth::scope::Scope`). A higher scope satisfies a lower requirement.
  */
 const SCOPE_RANK: Record<Scope, number> = { read: 0, write: 1, admin: 2 }
+
+/** Tooltip/title copy shown on controls disabled for a read-only caller. */
+export const WRITE_REQUIRED_HINT =
+  'You have read-only access — write permission is required for this action.'
+
+/** Every scope — the permissive fallback when no AuthProvider is mounted. */
+const ALL_SCOPES: readonly Scope[] = ['read', 'write', 'admin']
 
 /**
  * Does any granted scope satisfy the required level? Mirrors the server's
@@ -16,6 +22,18 @@ const SCOPE_RANK: Record<Scope, number> = { read: 0, write: 1, admin: 2 }
 export function scopesSatisfy(granted: readonly Scope[], required: Scope): boolean {
   const needed = SCOPE_RANK[required]
   return granted.some((s) => SCOPE_RANK[s] >= needed)
+}
+
+/**
+ * Resolve the caller's scopes from context. When no AuthProvider is mounted we
+ * can't know them, so — because this gate is advisory (the gateway re-checks
+ * every mutation) — we fall back to all scopes rather than hide controls we
+ * have no basis to hide. In the real app the provider is always present, so a
+ * read-only token yields `['read']` and correctly disables write controls.
+ */
+function useScopes(): readonly Scope[] {
+  const ctx = useContext(AuthContext)
+  return ctx ? ctx.scopes : ALL_SCOPES
 }
 
 export interface Permissions {
@@ -36,7 +54,7 @@ export interface Permissions {
  * hides/disables controls the caller can't use.
  */
 export function usePermissions(): Permissions {
-  const { scopes } = useAuth()
+  const scopes = useScopes()
   return useMemo(
     () => ({
       scopes,
@@ -50,6 +68,6 @@ export function usePermissions(): Permissions {
 
 /** Convenience hook for a single check, e.g. `useCan('write')`. */
 export function useCan(required: Scope): boolean {
-  const { scopes } = useAuth()
+  const scopes = useScopes()
   return useMemo(() => scopesSatisfy(scopes, required), [scopes, required])
 }

--- a/dashboard/src/auth/usePermissions.ts
+++ b/dashboard/src/auth/usePermissions.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react'
+import { useAuth } from './useAuth'
+import type { Scope } from './AuthContext'
+
+/**
+ * Privilege ranking, mirroring the server ordering `read < write < admin`
+ * (`aa-auth::scope::Scope`). A higher scope satisfies a lower requirement.
+ */
+const SCOPE_RANK: Record<Scope, number> = { read: 0, write: 1, admin: 2 }
+
+/**
+ * Does any granted scope satisfy the required level? Mirrors the server's
+ * `Scope::is_satisfied_by` — e.g. `admin` satisfies a `write` requirement.
+ * Pure and exported so it can be unit-tested without a React tree.
+ */
+export function scopesSatisfy(granted: readonly Scope[], required: Scope): boolean {
+  const needed = SCOPE_RANK[required]
+  return granted.some((s) => SCOPE_RANK[s] >= needed)
+}
+
+export interface Permissions {
+  scopes: readonly Scope[]
+  /** Whether the caller's scopes satisfy the given required level. */
+  can: (required: Scope) => boolean
+  /** Shorthand: caller can perform write-level mutations. */
+  canWrite: boolean
+  /** Shorthand: caller has admin-level access. */
+  canAdmin: boolean
+}
+
+/**
+ * Reflect the current caller's permission level for gating UI controls.
+ *
+ * Advisory only: the gateway re-checks scope on every request, so this must
+ * never be the only thing standing between a caller and a mutation — it just
+ * hides/disables controls the caller can't use.
+ */
+export function usePermissions(): Permissions {
+  const { scopes } = useAuth()
+  return useMemo(
+    () => ({
+      scopes,
+      can: (required: Scope) => scopesSatisfy(scopes, required),
+      canWrite: scopesSatisfy(scopes, 'write'),
+      canAdmin: scopesSatisfy(scopes, 'admin'),
+    }),
+    [scopes],
+  )
+}
+
+/** Convenience hook for a single check, e.g. `useCan('write')`. */
+export function useCan(required: Scope): boolean {
+  const { scopes } = useAuth()
+  return useMemo(() => scopesSatisfy(scopes, required), [scopes, required])
+}

--- a/dashboard/src/components/Tooltip.tsx
+++ b/dashboard/src/components/Tooltip.tsx
@@ -10,7 +10,9 @@ interface TooltipProps {
 
 export function Tooltip({ content, children, open = false }: Readonly<TooltipProps>) {
   const [hovered, setHovered] = useState(false)
-  const visible = open || hovered
+  // Empty content means "no tooltip" — lets callers conditionally attach a hint
+  // (e.g. only when a control is disabled) without wrapping markup twice.
+  const visible = (open || hovered) && content.length > 0
 
   return (
     <span

--- a/dashboard/src/features/iam/ApiKeyList.tsx
+++ b/dashboard/src/features/iam/ApiKeyList.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { ignorePromise } from '../../lib/ignorePromise'
 import { useApiKeysQuery, useRevokeApiKeyMutation, useRotateApiKeyMutation } from './apiKeys'
 import { useToast } from '../../components/Toast'
+import { Tooltip } from '../../components/Tooltip'
+import { usePermissions, WRITE_REQUIRED_HINT } from '../../auth/usePermissions'
 import type { ApiKey, GeneratedApiKey } from './types'
 import './ApiKeyList.css'
 
@@ -103,6 +105,7 @@ export function ApiKeyList({ selectedKeyId = null, onSelect, onRotated }: ApiKey
   const { data, isLoading, isError, refetch } = useApiKeysQuery()
   const revoke = useRevokeApiKeyMutation()
   const rotate = useRotateApiKeyMutation()
+  const { canWrite } = usePermissions()
   const { toast } = useToast()
   const [pendingRevoke, setPendingRevoke] = useState<ApiKey | null>(null)
   const [pendingRotate, setPendingRotate] = useState<ApiKey | null>(null)
@@ -233,33 +236,37 @@ export function ApiKeyList({ selectedKeyId = null, onSelect, onRotated }: ApiKey
                 </td>
                 <td>
                   {!revoked && (
-                    <div className="iam-api-key-list__row-actions">
-                      <button
-                        type="button"
-                        className="iam-api-key-list__rotate-btn"
-                        data-testid={`api-key-rotate-${k.id}`}
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setPendingRotate(k)
-                        }}
-                        disabled={rotate.isPending}
-                      >
-                        Rotate
-                      </button>
-                      <button
-                        type="button"
-                        className="iam-api-key-list__revoke-btn"
-                        data-testid={`api-key-revoke-${k.id}`}
-                        onClick={(e) => {
-                          // Don't bubble to the row's onClick selection handler.
-                          e.stopPropagation()
-                          setPendingRevoke(k)
-                        }}
-                        disabled={revoke.isPending}
-                      >
-                        Revoke
-                      </button>
-                    </div>
+                    <Tooltip content={canWrite ? '' : WRITE_REQUIRED_HINT}>
+                      <div className="iam-api-key-list__row-actions">
+                        <button
+                          type="button"
+                          className="iam-api-key-list__rotate-btn"
+                          data-testid={`api-key-rotate-${k.id}`}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setPendingRotate(k)
+                          }}
+                          disabled={rotate.isPending || !canWrite}
+                          title={canWrite ? undefined : WRITE_REQUIRED_HINT}
+                        >
+                          Rotate
+                        </button>
+                        <button
+                          type="button"
+                          className="iam-api-key-list__revoke-btn"
+                          data-testid={`api-key-revoke-${k.id}`}
+                          onClick={(e) => {
+                            // Don't bubble to the row's onClick selection handler.
+                            e.stopPropagation()
+                            setPendingRevoke(k)
+                          }}
+                          disabled={revoke.isPending || !canWrite}
+                          title={canWrite ? undefined : WRITE_REQUIRED_HINT}
+                        >
+                          Revoke
+                        </button>
+                      </div>
+                    </Tooltip>
                   )}
                 </td>
               </tr>

--- a/dashboard/src/pages/AlertsPage.rbac.test.tsx
+++ b/dashboard/src/pages/AlertsPage.rbac.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AlertsPage } from './AlertsPage'
+import { ToastProvider } from '../components/ToastProvider'
+import { AuthContext, type AuthContextValue, type Scope } from '../auth/AuthContext'
+import * as alertsApi from '../features/alerts/api'
+import * as stream from '../features/alerts/useAlertsStream'
+import type { Alert, AlertRule } from '../features/alerts/types'
+
+function q<T>(partial: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, Error> {
+  return partial as unknown as UseQueryResult<T, Error>
+}
+
+const RULE: AlertRule = {
+  id: 'r-1',
+  name: 'Budget burn',
+  description: '',
+  metric: 'budget_spent_pct',
+  operator: '>',
+  threshold: 80,
+  evaluationWindowSeconds: 300,
+  severity: 'HIGH',
+  destinationIds: [],
+  dedupWindowSeconds: 600,
+  suppressionLabels: {},
+  enabled: true,
+  createdAt: '',
+  updatedAt: '',
+}
+
+function renderWithScopes(scopes: Scope[]) {
+  vi.spyOn(alertsApi, 'useAlertsQuery').mockReturnValue(
+    q<readonly Alert[]>({ data: [], isLoading: false, isError: false }),
+  )
+  vi.spyOn(alertsApi, 'useAlertRulesQuery').mockReturnValue(
+    q<readonly AlertRule[]>({ data: [RULE], isLoading: false, isError: false }),
+  )
+  vi.spyOn(stream, 'useAlertsStream').mockReturnValue('open')
+  const auth: AuthContextValue = {
+    token: 'tok',
+    scopes,
+    login: async () => {},
+    logout: () => {},
+  }
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <AuthContext.Provider value={auth}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/alerts']}>
+            <AlertsPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </AuthContext.Provider>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('AlertsPage RBAC reflection', () => {
+  it('disables the "New rule" control for a read-only caller', () => {
+    renderWithScopes(['read'])
+    expect(screen.getByTestId('alerts-open-rule-form')).toBeDisabled()
+  })
+
+  it('enables the "New rule" control for a write caller', () => {
+    renderWithScopes(['write'])
+    expect(screen.getByTestId('alerts-open-rule-form')).toBeEnabled()
+  })
+})

--- a/dashboard/src/pages/AlertsPage.tsx
+++ b/dashboard/src/pages/AlertsPage.tsx
@@ -21,6 +21,8 @@ import {
   filtersToSearchParams,
 } from '../features/alerts/urlFilters'
 import type { Alert, AlertFilters, AlertRule } from '../features/alerts/types'
+import { Tooltip } from '../components/Tooltip'
+import { usePermissions, WRITE_REQUIRED_HINT } from '../auth/usePermissions'
 
 function partitionByTab(rows: readonly Alert[], tab: AlertsTab): readonly Alert[] {
   if (tab === 'incidents') return rows.filter((r) => r.status === 'RESOLVED')
@@ -72,6 +74,7 @@ export function AlertsPage() {
   /** When editing an existing rule, holds it so AlertRuleForm pre-fills (AAASM-1393). */
   const [editingRule, setEditingRule] = useState<AlertRule | null>(null)
   const [destinationsOpen, setDestinationsOpen] = useState(false)
+  const { canWrite } = usePermissions()
 
   const queryClient = useQueryClient()
   const streamStatus = useAlertsStream({
@@ -130,22 +133,26 @@ export function AlertsPage() {
           >
             Destinations
           </button>
-          <button
-            type="button"
-            data-testid="alerts-open-rule-form"
-            onClick={() => setRuleFormOpen(true)}
-            style={{
-              padding: '6px 12px',
-              background: 'var(--button-primary-bg)',
-              color: 'var(--button-primary-text)',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-            }}
-          >
-            New rule
-          </button>
+          <Tooltip content={canWrite ? '' : WRITE_REQUIRED_HINT}>
+            <button
+              type="button"
+              data-testid="alerts-open-rule-form"
+              onClick={() => setRuleFormOpen(true)}
+              disabled={!canWrite}
+              title={canWrite ? undefined : WRITE_REQUIRED_HINT}
+              style={{
+                padding: '6px 12px',
+                background: 'var(--button-primary-bg)',
+                color: 'var(--button-primary-text)',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: canWrite ? 'pointer' : 'not-allowed',
+                fontSize: '0.875rem',
+              }}
+            >
+              New rule
+            </button>
+          </Tooltip>
         </div>
       </header>
 

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -24,7 +24,9 @@ import { ModeChip } from '../components/fleet/ModeChip'
 import { TrustBar } from '../components/fleet/TrustBar'
 import { useToast } from '../components/Toast'
 import { SuspendReasonDialog } from '../components/SuspendReasonDialog'
+import { Tooltip } from '../components/Tooltip'
 import { useSuspendAgent, useResumeAgent } from '../features/agents/mutations'
+import { usePermissions, WRITE_REQUIRED_HINT } from '../auth/usePermissions'
 import { FleetFilterBar } from './FleetFilterBar'
 import './FleetPage.css'
 
@@ -292,6 +294,7 @@ export function FleetPage() {
 
   const suspend = useSuspendAgent()
   const resume = useResumeAgent()
+  const { canWrite } = usePermissions()
 
   const reportBulkResult = useCallback(
     (verb: 'suspended' | 'resumed', ids: string[], results: PromiseSettledResult<unknown>[]) => {
@@ -410,32 +413,38 @@ export function FleetPage() {
           <span className="fleet-bulkbar__count" data-testid="fleet-bulkbar-count">
             {selected.size} selected
           </span>
-          <button
-            type="button"
-            className="fleet-bulkbar__btn"
-            onClick={() => toast(`Switched ${selected.size} agents to shadow mode (mock)`, 'info')}
-            data-testid="fleet-bulkbar-shadow"
-          >
-            → shadow mode
-          </button>
-          <button
-            type="button"
-            className="fleet-bulkbar__btn fleet-bulkbar__btn--danger"
-            onClick={() => setShowBulkSuspendDialog(true)}
-            disabled={bulkSuspendPending || bulkResumePending}
-            data-testid="fleet-bulkbar-suspend"
-          >
-            ■ suspend
-          </button>
-          <button
-            type="button"
-            className="fleet-bulkbar__btn"
-            onClick={() => ignorePromise(onClickBulkResume())}
-            disabled={bulkSuspendPending || bulkResumePending}
-            data-testid="fleet-bulkbar-resume"
-          >
-            {bulkResumePending ? 'Resuming…' : '▶ resume'}
-          </button>
+          <Tooltip content={canWrite ? '' : WRITE_REQUIRED_HINT}>
+            <button
+              type="button"
+              className="fleet-bulkbar__btn"
+              onClick={() => toast(`Switched ${selected.size} agents to shadow mode (mock)`, 'info')}
+              disabled={!canWrite}
+              title={canWrite ? undefined : WRITE_REQUIRED_HINT}
+              data-testid="fleet-bulkbar-shadow"
+            >
+              → shadow mode
+            </button>
+            <button
+              type="button"
+              className="fleet-bulkbar__btn fleet-bulkbar__btn--danger"
+              onClick={() => setShowBulkSuspendDialog(true)}
+              disabled={bulkSuspendPending || bulkResumePending || !canWrite}
+              title={canWrite ? undefined : WRITE_REQUIRED_HINT}
+              data-testid="fleet-bulkbar-suspend"
+            >
+              ■ suspend
+            </button>
+            <button
+              type="button"
+              className="fleet-bulkbar__btn"
+              onClick={() => ignorePromise(onClickBulkResume())}
+              disabled={bulkSuspendPending || bulkResumePending || !canWrite}
+              title={canWrite ? undefined : WRITE_REQUIRED_HINT}
+              data-testid="fleet-bulkbar-resume"
+            >
+              {bulkResumePending ? 'Resuming…' : '▶ resume'}
+            </button>
+          </Tooltip>
           <button
             type="button"
             className="fleet-bulkbar__btn fleet-bulkbar__btn--ghost"

--- a/dashboard/src/pages/LoginPage.test.tsx
+++ b/dashboard/src/pages/LoginPage.test.tsx
@@ -7,6 +7,7 @@ import * as useAuthModule from '../auth/useAuth'
 function renderLogin(login: (apiKey: string) => Promise<void>) {
   vi.spyOn(useAuthModule, 'useAuth').mockReturnValue({
     token: null,
+    scopes: [],
     login,
     logout: vi.fn(),
   })

--- a/dashboard/src/pages/PoliciesPage.tsx
+++ b/dashboard/src/pages/PoliciesPage.tsx
@@ -10,6 +10,8 @@ import { OverlayHost } from '../components/OverlayHost'
 import { useOverlay } from '../components/useOverlay'
 import { useToast } from '../components/Toast'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import { Tooltip } from '../components/Tooltip'
+import { usePermissions, WRITE_REQUIRED_HINT } from '../auth/usePermissions'
 import { PolicyEditorOverlay } from '../features/policies/editor/PolicyEditorOverlay'
 import { emptyDraft, stubDraftFromIdentity } from '../features/policies/editor/constants'
 import { serializeDraft } from '../features/policies/editor/serializeDraft'
@@ -232,6 +234,7 @@ interface PoliciesContentProps {
   readonly onRetry: () => void
   readonly onNew: () => void
   readonly onEdit: (policy: Policy) => void
+  readonly canWrite: boolean
 }
 
 /**
@@ -247,6 +250,7 @@ function PoliciesContent({
   onRetry,
   onNew,
   onEdit,
+  canWrite,
 }: PoliciesContentProps) {
   if (isError) {
     return (
@@ -273,14 +277,18 @@ function PoliciesContent({
         description={emptyStateDescription(filter)}
         action={
           filter === 'all' ? (
-            <button
-              type="button"
-              className="policies-page__new-btn"
-              data-testid="new-policy-empty-btn"
-              onClick={onNew}
-            >
-              + new policy
-            </button>
+            <Tooltip content={canWrite ? '' : WRITE_REQUIRED_HINT}>
+              <button
+                type="button"
+                className="policies-page__new-btn"
+                data-testid="new-policy-empty-btn"
+                onClick={onNew}
+                disabled={!canWrite}
+                title={canWrite ? undefined : WRITE_REQUIRED_HINT}
+              >
+                + new policy
+              </button>
+            </Tooltip>
           ) : undefined
         }
       />
@@ -307,6 +315,7 @@ export function PoliciesPage() {
   const { toast } = useToast()
   const { mutateAsync: createPolicy, isPending: enablingLive } = useCreatePolicy()
   const [enableLiveOpen, setEnableLiveOpen] = useState(false)
+  const { canWrite } = usePermissions()
 
   // Observe-mode policies detected by parsing each policy_yaml client-side.
   // The aa-api `PolicyResponse` doesn't expose `enforcement_mode` as a
@@ -389,14 +398,18 @@ export function PoliciesPage() {
             Visual builder for narrowing rules — open one to edit.
           </p>
         </div>
-        <button
-          type="button"
-          className="policies-page__new-btn"
-          data-testid="new-policy-btn"
-          onClick={handleNew}
-        >
-          + new policy
-        </button>
+        <Tooltip content={canWrite ? '' : WRITE_REQUIRED_HINT}>
+          <button
+            type="button"
+            className="policies-page__new-btn"
+            data-testid="new-policy-btn"
+            onClick={handleNew}
+            disabled={!canWrite}
+            title={canWrite ? undefined : WRITE_REQUIRED_HINT}
+          >
+            + new policy
+          </button>
+        </Tooltip>
       </header>
 
       {showSandboxBanner ? (
@@ -416,6 +429,7 @@ export function PoliciesPage() {
         onRetry={() => ignorePromise(refetch())}
         onNew={handleNew}
         onEdit={handleEdit}
+        canWrite={canWrite}
       />
 
       <OverlayHost name="policy-editor" onRequestClose={attemptCloseEditor}>


### PR DESCRIPTION
## Description

Reflect the caller's permission level in the dashboard UI (client-side RBAC). Previously the auth context carried only the token, so a read-only viewer saw the same edit/suspend/rotate/revoke controls as an owner. This adds the caller's granted scopes to the auth context and disables the clear write-level controls (with a tooltip hint) when the caller lacks write scope.

This is **UX reflection only** — the gateway re-checks scope on every request and remains the sole authority. No server-side check is weakened; the client gate is advisory.

**What changed**
- `AuthContext` now exposes `scopes`, sourced from the `/api/v1/auth/token` response `scopes` and, on reload, parsed from the persisted JWT `scope` claim (`jwtScopes.ts`).
- New `usePermissions()` / `useCan()` hook mapping the `read < write < admin` ordering (mirrors `aa-auth::scope::Scope::is_satisfied_by`).
- Gated controls (all require `Write` server-side): Fleet bulk shadow/suspend/resume, Policy "new policy" (header + empty state), IAM key rotate/revoke, Alerts "new rule". Disabled + tooltip, consistent with existing patterns.
- `usePermissions` falls back to permissive when no `AuthProvider` is mounted (advisory gate; keeps isolated component tests working — the real app always wraps the provider).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4107

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed (type-check, lint, targeted vitest)

Verification:
- `corepack pnpm type-check` — clean
- `corepack pnpm lint` — clean
- `corepack pnpm test run` new specs — `usePermissions.test.tsx` + `AlertsPage.rbac.test.tsx` = 11 passed (scope mapping, JWT parse, read-only disabled vs write enabled)
- Existing specs for touched surfaces (Fleet/Policies/Alerts/ApiKeyList/Tooltip/AuthProvider/LoginPage) = 85 passed

Server-side authorization remains authoritative — this PR only hides/disables controls a caller cannot use.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
