### PR TITLE
[AAASM-4103] ✨ (policy): Split file delete into a distinct FileDelete capability

### DIFF
--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -15,6 +15,11 @@ pub enum Capability {
     FileRead,
     /// Write access to the filesystem.
     FileWrite,
+    /// Delete/unlink access to the filesystem.
+    ///
+    /// A distinct verb from [`Capability::FileWrite`] so a policy can allow
+    /// writes while denying deletes (and vice versa). See AAASM-4103.
+    FileDelete,
     /// Outbound network connections.
     NetworkOutbound,
     /// Inbound network connections.
@@ -46,6 +51,7 @@ impl FromStr for Capability {
         match s {
             "file_read" => Ok(Capability::FileRead),
             "file_write" => Ok(Capability::FileWrite),
+            "file_delete" => Ok(Capability::FileDelete),
             "network_outbound" => Ok(Capability::NetworkOutbound),
             "network_inbound" => Ok(Capability::NetworkInbound),
             "terminal_exec" => Ok(Capability::TerminalExec),
@@ -74,6 +80,7 @@ impl core::fmt::Display for Capability {
         match self {
             Capability::FileRead => f.write_str("file_read"),
             Capability::FileWrite => f.write_str("file_write"),
+            Capability::FileDelete => f.write_str("file_delete"),
             Capability::NetworkOutbound => f.write_str("network_outbound"),
             Capability::NetworkInbound => f.write_str("network_inbound"),
             Capability::TerminalExec => f.write_str("terminal_exec"),

--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -273,6 +273,23 @@ mod tests {
     }
 
     #[test]
+    fn capability_from_str_file_delete() {
+        assert_eq!("file_delete".parse::<Capability>().unwrap(), Capability::FileDelete);
+    }
+
+    #[test]
+    fn capability_file_delete_display_round_trips() {
+        let cap = Capability::FileDelete;
+        assert_eq!(cap.to_string(), "file_delete");
+        assert_eq!(cap.to_string().parse::<Capability>().unwrap(), cap);
+    }
+
+    #[test]
+    fn capability_file_delete_distinct_from_file_write() {
+        assert_ne!(Capability::FileDelete, Capability::FileWrite);
+    }
+
+    #[test]
     fn capability_from_str_network_outbound() {
         assert_eq!(
             "network_outbound".parse::<Capability>().unwrap(),
@@ -500,5 +517,45 @@ mod tests {
             command: "ls".to_string(),
         };
         assert_eq!(super::action_to_capability(&action), Some(Capability::TerminalExec));
+    }
+
+    // ------------------------------------------------------------------
+    // capability_is_denied tests (AAASM-4103 fail-closed migration)
+    // ------------------------------------------------------------------
+
+    fn deny_set(caps: &[Capability]) -> BTreeSet<Capability> {
+        caps.iter().cloned().collect()
+    }
+
+    #[test]
+    fn capability_is_denied_direct_match() {
+        let deny = deny_set(&[Capability::FileDelete]);
+        assert!(super::capability_is_denied(&deny, &Capability::FileDelete));
+    }
+
+    #[test]
+    fn capability_is_denied_empty_set_is_false() {
+        let deny = deny_set(&[]);
+        assert!(!super::capability_is_denied(&deny, &Capability::FileDelete));
+    }
+
+    #[test]
+    fn capability_is_denied_file_write_deny_also_denies_delete() {
+        // Defense in depth: a pre-4103 `file_write` deny keeps blocking delete.
+        let deny = deny_set(&[Capability::FileWrite]);
+        assert!(super::capability_is_denied(&deny, &Capability::FileDelete));
+    }
+
+    #[test]
+    fn capability_is_denied_file_delete_deny_does_not_deny_write() {
+        // Asymmetric: delete-deny must NOT block writes.
+        let deny = deny_set(&[Capability::FileDelete]);
+        assert!(!super::capability_is_denied(&deny, &Capability::FileWrite));
+    }
+
+    #[test]
+    fn capability_is_denied_unrelated_deny_is_false() {
+        let deny = deny_set(&[Capability::NetworkOutbound]);
+        assert!(!super::capability_is_denied(&deny, &Capability::FileDelete));
     }
 }

--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -163,6 +163,26 @@ pub fn action_to_capability(action: &crate::GovernanceAction) -> Option<Capabili
     }
 }
 
+/// Whether a policy `deny` set blocks `cap`, honoring superset denies.
+///
+/// A `FileWrite` deny also blocks `FileDelete`: policies authored before
+/// `FileDelete` existed (AAASM-4103) expressed "no mutation" as a single
+/// `file_write` deny, and that intent must keep blocking delete — a stale
+/// write-deny must never leak delete (fail-closed migration). The converse is
+/// deliberately absent: a `FileWrite` *allow* never grants `FileDelete`;
+/// delete requires an explicit `file_delete` allow. Net effect: the new verb
+/// can only ever make delete *more* restricted than before, never less.
+///
+/// Requires the `alloc` feature.
+#[cfg(feature = "alloc")]
+pub fn capability_is_denied(deny: &BTreeSet<Capability>, cap: &Capability) -> bool {
+    if deny.contains(cap) {
+        return true;
+    }
+    // Defense in depth: deny(file_write) ⇒ deny(file_delete).
+    matches!(cap, Capability::FileDelete) && deny.contains(&Capability::FileWrite)
+}
+
 /// Per-scope contribution to an effective permission set.
 ///
 /// Carries the `allow` and `deny` capabilities a single policy document declares

--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -146,9 +146,17 @@ pub fn action_to_capability(action: &crate::GovernanceAction) -> Option<Capabili
             mode: FileMode::Read, ..
         } => Some(Capability::FileRead),
         GovernanceAction::FileAccess {
-            mode: FileMode::Write | FileMode::Append | FileMode::Delete,
+            mode: FileMode::Write | FileMode::Append,
             ..
         } => Some(Capability::FileWrite),
+        // Delete is a first-class verb (AAASM-4103): it maps to FileDelete, not
+        // FileWrite, so a policy can allow writes yet deny deletes. A pre-4103
+        // `file_write` allow no longer implies delete — delete needs an explicit
+        // `file_delete` grant (fail-closed). See `capability_is_denied` for the
+        // reverse defense-in-depth rule on the deny side.
+        GovernanceAction::FileAccess {
+            mode: FileMode::Delete, ..
+        } => Some(Capability::FileDelete),
         GovernanceAction::NetworkRequest { .. } => Some(Capability::NetworkOutbound),
         GovernanceAction::ProcessExec { .. } => Some(Capability::TerminalExec),
         GovernanceAction::SendMessage { .. } => None,
@@ -448,12 +456,13 @@ mod tests {
     }
 
     #[test]
-    fn action_to_capability_file_delete_is_file_write() {
+    fn action_to_capability_file_delete_is_file_delete() {
+        // AAASM-4103: Delete is its own capability, not FileWrite.
         let action = crate::GovernanceAction::FileAccess {
             path: "/tmp/f".to_string(),
             mode: crate::policy::FileMode::Delete,
         };
-        assert_eq!(super::action_to_capability(&action), Some(Capability::FileWrite));
+        assert_eq!(super::action_to_capability(&action), Some(Capability::FileDelete));
     }
 
     #[test]

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -75,7 +75,8 @@ pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError, Lineage};
 
 #[cfg(feature = "alloc")]
 pub use capability::{
-    action_to_capability, merge_capabilities, Capability, CapabilitySet, EffectivePermissions, PermissionSource,
+    action_to_capability, capability_is_denied, merge_capabilities, Capability, CapabilitySet, EffectivePermissions,
+    PermissionSource,
 };
 
 #[cfg(feature = "std")]

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -194,7 +194,7 @@ fn stage_tool_allow(doc: &PolicyDocument, action: &aa_core::GovernanceAction) ->
 fn stage_capability(doc: &PolicyDocument, action: &aa_core::GovernanceAction) -> Option<PolicyDecision> {
     let caps = doc.capabilities.as_ref()?;
     let cap = aa_core::action_to_capability(action)?;
-    if caps.deny.contains(&cap) {
+    if aa_core::capability_is_denied(&caps.deny, &cap) {
         return Some(PolicyDecision::Deny {
             reason: "capability denied by policy".into(),
             source_scope: doc.scope.clone(),

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1167,7 +1167,7 @@ impl PolicyEngine {
     ) -> Option<EvaluationResult> {
         let merged_caps = Self::collect_merged_capabilities(cascade);
         let cap = aa_core::action_to_capability(action)?;
-        if merged_caps.deny.contains(&cap) {
+        if aa_core::capability_is_denied(&merged_caps.deny, &cap) {
             return Some(EvaluationResult::deny("capability denied by policy"));
         }
         if !merged_caps.allow.is_empty() && !merged_caps.allow.contains(&cap) {

--- a/aa-gateway/src/policy/canonical.rs
+++ b/aa-gateway/src/policy/canonical.rs
@@ -28,6 +28,7 @@ fn to_canon_capability(cap: &aa_core::Capability) -> CanonCapability {
     match cap {
         aa_core::Capability::FileRead => CanonCapability::FileRead,
         aa_core::Capability::FileWrite => CanonCapability::FileWrite,
+        aa_core::Capability::FileDelete => CanonCapability::FileDelete,
         aa_core::Capability::NetworkOutbound => CanonCapability::NetworkOutbound,
         aa_core::Capability::NetworkInbound => CanonCapability::NetworkInbound,
         aa_core::Capability::TerminalExec => CanonCapability::TerminalExec,

--- a/aa-gateway/tests/capability_integration_test.rs
+++ b/aa-gateway/tests/capability_integration_test.rs
@@ -340,3 +340,117 @@ fn mcp_tool_capability_allowlist_permits_only_listed_tools() {
         git_result
     );
 }
+
+// ── FileDelete governance (AAASM-4103) ──────────────────────────────────────────
+
+/// A policy that allows `file_write` (but not `file_delete`) must deny a delete:
+/// a write grant no longer implies delete (fail-closed).
+#[test]
+fn delete_denied_when_only_file_write_is_granted() {
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(
+        PolicyScope::Global,
+        &[Capability::FileRead, Capability::FileWrite],
+        &[],
+    ));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::FileAccess {
+        path: "/tmp/data.txt".into(),
+        mode: aa_core::FileMode::Delete,
+    };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert!(
+        matches!(result, PolicyResult::Deny { .. }),
+        "expected Deny: a file_write grant must not imply delete, got {:?}",
+        result
+    );
+}
+
+/// A policy that explicitly allows `file_delete` must allow a delete action.
+#[test]
+fn delete_allowed_when_file_delete_is_granted() {
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(
+        PolicyScope::Global,
+        &[Capability::FileRead, Capability::FileWrite, Capability::FileDelete],
+        &[],
+    ));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::FileAccess {
+        path: "/tmp/data.txt".into(),
+        mode: aa_core::FileMode::Delete,
+    };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert_eq!(
+        result,
+        PolicyResult::Allow,
+        "expected Allow: file_delete explicitly granted, got {:?}",
+        result
+    );
+}
+
+/// The headline allow-write-deny-delete shape: with `allow=[file_write]` and
+/// `deny=[file_delete]`, a write is allowed but a delete is denied.
+#[test]
+fn allow_write_deny_delete_governs_verbs_independently() {
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(
+        PolicyScope::Global,
+        &[Capability::FileWrite],
+        &[Capability::FileDelete],
+    ));
+
+    let ctx = make_ctx();
+
+    let write = engine
+        .evaluate(
+            &ctx,
+            &GovernanceAction::FileAccess {
+                path: "/tmp/report.txt".into(),
+                mode: aa_core::FileMode::Write,
+            },
+        )
+        .decision;
+    assert_eq!(write, PolicyResult::Allow, "write must be allowed, got {:?}", write);
+
+    let delete = engine
+        .evaluate(
+            &ctx,
+            &GovernanceAction::FileAccess {
+                path: "/tmp/report.txt".into(),
+                mode: aa_core::FileMode::Delete,
+            },
+        )
+        .decision;
+    assert!(
+        matches!(delete, PolicyResult::Deny { .. }),
+        "delete must be denied, got {:?}",
+        delete
+    );
+}
+
+/// Defense-in-depth: a pre-4103 policy that only denies `file_write` (to lock
+/// down all mutation) must keep blocking delete even though it never names
+/// `file_delete`.
+#[test]
+fn legacy_file_write_deny_still_blocks_delete() {
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(PolicyScope::Global, &[], &[Capability::FileWrite]));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::FileAccess {
+        path: "/tmp/data.txt".into(),
+        mode: aa_core::FileMode::Delete,
+    };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert!(
+        matches!(result, PolicyResult::Deny { .. }),
+        "expected Deny: a stale file_write deny must keep blocking delete, got {:?}",
+        result
+    );
+}

--- a/aa-security/src/policy/capability.rs
+++ b/aa-security/src/policy/capability.rs
@@ -28,6 +28,12 @@ pub enum Capability {
     FileRead,
     /// Write access to the filesystem.
     FileWrite,
+    /// Delete/unlink access to the filesystem.
+    ///
+    /// A distinct verb from [`Capability::FileWrite`] so a policy can allow
+    /// writes while denying deletes. Mirrors `aa_core::Capability::FileDelete`
+    /// so the gateway→canonical projection stays lossless. See AAASM-4103.
+    FileDelete,
     /// Outbound network connections.
     NetworkOutbound,
     /// Inbound network connections.
@@ -59,6 +65,7 @@ impl FromStr for Capability {
         match s {
             "file_read" => Ok(Capability::FileRead),
             "file_write" => Ok(Capability::FileWrite),
+            "file_delete" => Ok(Capability::FileDelete),
             "network_outbound" => Ok(Capability::NetworkOutbound),
             "network_inbound" => Ok(Capability::NetworkInbound),
             "terminal_exec" => Ok(Capability::TerminalExec),
@@ -87,6 +94,7 @@ impl fmt::Display for Capability {
         match self {
             Capability::FileRead => f.write_str("file_read"),
             Capability::FileWrite => f.write_str("file_write"),
+            Capability::FileDelete => f.write_str("file_delete"),
             Capability::NetworkOutbound => f.write_str("network_outbound"),
             Capability::NetworkInbound => f.write_str("network_inbound"),
             Capability::TerminalExec => f.write_str("terminal_exec"),

--- a/aa-security/src/policy/ebpf.rs
+++ b/aa-security/src/policy/ebpf.rs
@@ -14,8 +14,9 @@
 //!
 //! - **Filesystem path rules** derived from `tools.*.requires_approval_if`
 //!   predicates of the form `path starts_with "<prefix>"` (each becomes a
-//!   [`PathVerdict::Deny`] [`PathRule`]) and from a capability `file_write`
-//!   deny (which seeds the well-known sensitive-path deny defaults).
+//!   [`PathVerdict::Deny`] [`PathRule`]) and from a capability `file_write` or
+//!   `file_delete` deny (which seeds the well-known sensitive-path deny
+//!   defaults — the kernel path probe cannot tell write from delete).
 //! - **Egress allowlist** copied verbatim from `network.allowlist`.
 //!
 //! Everything else is explicitly **L7-only** and documented in
@@ -106,10 +107,11 @@ impl EbpfRuleSet {
 }
 
 /// Well-known sensitive paths denied in-kernel whenever the policy denies the
-/// `file_write` capability. These mirror the kernel probe's sensitive-path
-/// defaults so a "deny file_write" floor is reflected at the kernel boundary,
-/// not just at L7.
-const SENSITIVE_WRITE_DENY_DEFAULTS: &[&str] = &["/etc", "/root/.ssh", "/var/run/secrets"];
+/// `file_write` or `file_delete` capability. These mirror the kernel probe's
+/// sensitive-path defaults so a "deny mutation" floor is reflected at the
+/// kernel boundary, not just at L7. Delete is included because the path probe
+/// matches on paths, not the mutation verb (AAASM-4103).
+const SENSITIVE_MUTATION_DENY_DEFAULTS: &[&str] = &["/etc", "/root/.ssh", "/var/run/secrets"];
 
 /// Lower a canonical [`PolicyDocument`] to its [`EbpfRuleSet`].
 ///
@@ -118,14 +120,16 @@ const SENSITIVE_WRITE_DENY_DEFAULTS: &[&str] = &["/etc", "/root/.ssh", "/var/run
 pub fn lower_to_ebpf(doc: &PolicyDocument) -> EbpfRuleSet {
     let mut path_rules: Vec<PathRule> = Vec::new();
 
-    // 1. Capability `file_write` deny → seed the sensitive-path deny defaults.
-    let denies_file_write = doc
+    // 1. Capability `file_write` OR `file_delete` deny → seed the sensitive-path
+    //    deny defaults. The kernel path probe matches paths, not the mutation
+    //    verb, so a deny of either mutation capability projects the same floor.
+    let denies_file_mutation = doc
         .capabilities
         .as_ref()
-        .map(|c| c.deny.contains(&Capability::FileWrite))
+        .map(|c| c.deny.contains(&Capability::FileWrite) || c.deny.contains(&Capability::FileDelete))
         .unwrap_or(false);
-    if denies_file_write {
-        for prefix in SENSITIVE_WRITE_DENY_DEFAULTS {
+    if denies_file_mutation {
+        for prefix in SENSITIVE_MUTATION_DENY_DEFAULTS {
             push_unique(
                 &mut path_rules,
                 PathRule {
@@ -226,6 +230,18 @@ mod tests {
     fn file_write_deny_seeds_sensitive_path_denies() {
         let mut caps = CapabilitySet::default();
         caps.deny.insert(Capability::FileWrite);
+        let rules = lower_to_ebpf(&doc_with(Some(caps), vec![], vec![]));
+        let deny: Vec<&str> = rules.deny_paths().collect();
+        assert!(deny.contains(&"/etc"));
+        assert!(deny.contains(&"/root/.ssh"));
+    }
+
+    #[test]
+    fn file_delete_deny_seeds_sensitive_path_denies() {
+        // AAASM-4103: a file_delete deny projects the same kernel path floor as
+        // file_write, since the path probe cannot distinguish the two verbs.
+        let mut caps = CapabilitySet::default();
+        caps.deny.insert(Capability::FileDelete);
         let rules = lower_to_ebpf(&doc_with(Some(caps), vec![], vec![]));
         let deny: Vec<&str> = rules.deny_paths().collect();
         assert!(deny.contains(&"/etc"));

--- a/docs/src/policy-reference.md
+++ b/docs/src/policy-reference.md
@@ -490,7 +490,8 @@ Recognised capability strings:
 | String | Capability |
 |---|---|
 | `file_read` | read the filesystem |
-| `file_write` | write the filesystem |
+| `file_write` | write (create / truncate / append) the filesystem |
+| `file_delete` | delete / unlink files from the filesystem |
 | `network_outbound` | outbound network |
 | `network_inbound` | inbound network |
 | `terminal_exec` | execute shell commands |
@@ -500,6 +501,26 @@ Recognised capability strings:
 
 An unknown capability string, or an `mcp_tool:` / `model:` with an empty name,
 is a validation error.
+
+`file_delete` is a distinct verb from `file_write`, so a policy can allow writes
+while denying deletes (or the reverse). Two fail-closed rules apply:
+
+- A `file_write` **allow** does **not** grant delete — a delete action is denied
+  unless the policy explicitly allows `file_delete`.
+- A `file_write` **deny** still blocks delete (defense in depth), so a policy
+  that denies `file_write` to lock down all mutations keeps blocking deletes
+  even if it never names `file_delete`.
+
+To allow writes but forbid deletion:
+
+```yaml
+capabilities:
+  allow:
+    - file_read
+    - file_write
+  deny:
+    - file_delete
+```
 
 ## `approval`
 

--- a/policy-examples/capability-policy.yaml
+++ b/policy-examples/capability-policy.yaml
@@ -14,3 +14,4 @@ spec:
     deny:
       - terminal_exec
       - file_write
+      - file_delete

--- a/policy-examples/file-delete-policy.yaml
+++ b/policy-examples/file-delete-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: file-delete-example
+  version: "1.0.0"
+  description: >
+    Let an agent read and write files but never delete them. `file_delete`
+    is a distinct capability from `file_write` (AAASM-4103): allowing writes
+    does not grant deletion, so it must be denied (or simply omitted from the
+    allow list) explicitly. This is the canonical "allow-write, deny-delete"
+    shape — e.g. a report-generating agent that may edit its outputs but must
+    not remove existing files.
+spec:
+  scope: global
+  capabilities:
+    allow:
+      - file_read
+      - file_write
+    deny:
+      - file_delete


### PR DESCRIPTION
## Description

Splits file **delete** into its own capability verb. Today `FileMode::Delete`
maps to `Capability::FileWrite`, so a policy cannot allow writes while denying
deletes. This PR introduces a distinct `Capability::FileDelete` so file deletion
is independently governable.

What changed:
- New `Capability::FileDelete` variant with the `file_delete` wire string
  (FromStr/Display) in both `aa-core` and the `aa-security` canonical policy AST,
  plus the lossless gateway→canonical bridge arm.
- `action_to_capability(FileMode::Delete)` now returns `FileDelete` (was
  `FileWrite`).
- `capability_is_denied` helper wires both gateway capability-evaluation sites
  (per-doc stage + cascade guard) so delete is a first-class deny/allow verb.
- eBPF lowering seeds the kernel sensitive-path deny defaults on a `file_delete`
  deny as well as `file_write` (the path probe can't distinguish the verbs).
- Docs + a new `policy-examples/file-delete-policy.yaml` demonstrating
  allow-write / deny-delete.

The capability evaluation, cascade merge, and validator are all generic over the
`Capability` enum, so once the vocabulary and the delete→FileDelete mapping are
in place, deny/allow/cascade all treat `FileDelete` as first-class with no other
changes.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] Yes (describe below)

**Behavioral change (policy semantics), fail-closed in both directions:**

1. A `file_write` **allow** no longer implies delete. A delete action is denied
   unless the policy explicitly grants `file_delete`. Policies that previously
   relied on a `file_write` allow to permit deletes must add `file_delete` to
   their allow list.
2. A `file_write` **deny** still blocks delete (defense in depth, via
   `capability_is_denied`). Policies that denied `file_write` to lock down all
   mutations keep blocking deletes even if they never name `file_delete`.

Net effect: the new verb can only ever make delete **more** restricted than
before, never less — a stale write grant can never silently allow a delete.

No public Rust API is removed; `Capability` gains a variant (exhaustive matches
over it are updated in-tree).

## Related Issues

- Related Jira ticket: AAASM-4103
- Note: sibling ticket AAASM-4099 will wire the remaining unmapped capabilities
  in `action_to_capability`; this PR is scoped to delete only.

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required

- `aa-core`: `file_delete` FromStr/Display round-trip, distinctness from
  `file_write`, `action_to_capability(Delete) == FileDelete`, and
  `capability_is_denied` (direct deny, empty set, write-deny⇒delete-deny, the
  asymmetric delete-deny⇏write-deny, unrelated deny).
- `aa-gateway`: end-to-end through `PolicyEngine::evaluate` — delete denied when
  only `file_write` granted, delete allowed with explicit `file_delete`, the
  allow-write-deny-delete shape, and a legacy `file_write`-deny still blocking
  delete.
- `aa-security`: `file_delete` deny seeds the kernel sensitive-path denies.
- Existing cross-layer consistency test passes against the new example.
- Validated locally: `cargo fmt --all --check`, workspace
  `cargo clippy --all-targets --all-features -D warnings` (via lefthook on every
  commit), and `cargo nextest run` for the capability / canonical / cross-layer
  suites (67 passed).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
