### PR TITLE
[AAASM-4099] 🔒 (policy): Enforce or fail-loud on previously-unmapped capabilities

### DIFF
--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -39,6 +39,29 @@ pub struct CapabilitySet {
     pub deny: BTreeSet<Capability>,
 }
 
+impl Capability {
+    /// Whether declaring this capability in a policy actually governs anything.
+    ///
+    /// A capability is *enforceable* only if some [`crate::GovernanceAction`]
+    /// maps to it via [`action_to_capability`] — otherwise no action ever routes
+    /// to it, so a declared allow/deny is silently inert and gives the operator a
+    /// false sense of security (AAASM-4099).
+    ///
+    /// Currently inert (no corresponding action variant): [`Capability::Model`],
+    /// [`Capability::NetworkInbound`], and [`Capability::AgentSpawn`]. This
+    /// predicate is the single source of truth policy validation uses to warn
+    /// loudly when a policy references one of them; keep it in lock-step with
+    /// [`action_to_capability`] — when a new action lands that maps to one of
+    /// these, wire the mapping there and drop it from the inert arm below.
+    #[must_use]
+    pub fn is_enforceable(&self) -> bool {
+        !matches!(
+            self,
+            Capability::Model(_) | Capability::NetworkInbound | Capability::AgentSpawn
+        )
+    }
+}
+
 impl FromStr for Capability {
     type Err = String;
 
@@ -130,8 +153,11 @@ pub fn action_to_capability(action: &crate::GovernanceAction) -> Option<Capabili
     use crate::GovernanceAction;
 
     // NOTE: Capability::AgentSpawn, NetworkInbound, and Model variants have no
-    // corresponding GovernanceAction yet. When new action variants land, add
-    // mappings here to avoid silent policy bypasses.
+    // corresponding GovernanceAction yet — they are flagged by
+    // `Capability::is_enforceable` so policy load warns loudly instead of
+    // presenting a silently-inert control (AAASM-4099). When new action variants
+    // land, add mappings here AND drop the variant from `is_enforceable`'s inert
+    // arm to avoid silent policy bypasses.
     match action {
         GovernanceAction::ToolCall { name, .. } => Some(Capability::McpTool(name.clone())),
         GovernanceAction::ToolResult { tool_name, .. } => Some(Capability::McpTool(tool_name.clone())),
@@ -456,6 +482,63 @@ mod tests {
             method: "GET".to_string(),
         };
         assert_eq!(super::action_to_capability(&action), Some(Capability::NetworkOutbound));
+    }
+
+    // ------------------------------------------------------------------
+    // is_enforceable tests (AAASM-4099)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn is_enforceable_false_for_inert_capabilities() {
+        // These have no GovernanceAction mapping, so declaring them is silently
+        // inert — is_enforceable must flag them so policy load can warn loudly.
+        assert!(!Capability::NetworkInbound.is_enforceable());
+        assert!(!Capability::AgentSpawn.is_enforceable());
+        assert!(!Capability::Model("gpt-4o".to_string()).is_enforceable());
+    }
+
+    #[test]
+    fn is_enforceable_true_for_action_backed_capabilities() {
+        assert!(Capability::FileRead.is_enforceable());
+        assert!(Capability::FileWrite.is_enforceable());
+        assert!(Capability::NetworkOutbound.is_enforceable());
+        assert!(Capability::TerminalExec.is_enforceable());
+        assert!(Capability::McpTool("bash".to_string()).is_enforceable());
+    }
+
+    #[test]
+    fn action_to_capability_only_yields_enforceable_capabilities() {
+        // Invariant: every capability an action can produce must be enforceable,
+        // otherwise stage_capability could deny on a cap load warned was inert.
+        let actions = [
+            crate::GovernanceAction::ToolCall {
+                name: "bash".to_string(),
+                args: "{}".to_string(),
+            },
+            crate::GovernanceAction::FileAccess {
+                path: "/tmp/f".to_string(),
+                mode: crate::policy::FileMode::Read,
+            },
+            crate::GovernanceAction::FileAccess {
+                path: "/tmp/f".to_string(),
+                mode: crate::policy::FileMode::Write,
+            },
+            crate::GovernanceAction::NetworkRequest {
+                url: "https://example.com".to_string(),
+                method: "GET".to_string(),
+            },
+            crate::GovernanceAction::ProcessExec {
+                command: "ls".to_string(),
+            },
+        ];
+        for action in &actions {
+            if let Some(cap) = super::action_to_capability(action) {
+                assert!(
+                    cap.is_enforceable(),
+                    "action {action:?} mapped to inert capability {cap:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -108,6 +108,21 @@ impl ValidationWarning {
         let message = format!("Unknown key '{}' will be ignored", field);
         Self { field, message }
     }
+
+    /// Construct a warning that a referenced capability is declared but not yet
+    /// enforceable — no governance action routes to it, so the allow/deny is
+    /// silently inert (AAASM-4099). Fail loud so operators are not misled into
+    /// believing the control is active.
+    pub fn inert_capability(field: impl Into<String>, capability: impl std::fmt::Display) -> Self {
+        let field = field.into();
+        let message = format!(
+            "Capability '{}' is declared but NOT enforced — no governance action \
+             maps to it yet, so this allow/deny is currently inert and provides no \
+             protection",
+            capability
+        );
+        Self { field, message }
+    }
 }
 
 impl fmt::Display for ValidationWarning {
@@ -157,6 +172,15 @@ mod tests {
     fn validation_warning_unknown_key_nested_path() {
         let w = ValidationWarning::unknown_key("network.blocklist");
         assert_eq!(w.field, "network.blocklist");
+    }
+
+    #[test]
+    fn validation_warning_inert_capability_is_loud() {
+        let w = ValidationWarning::inert_capability("capabilities.deny[0]", "agent_spawn");
+        assert_eq!(w.field, "capabilities.deny[0]");
+        assert!(w.message.contains("agent_spawn"));
+        assert!(w.message.contains("NOT enforced"));
+        assert!(w.message.contains("inert"));
     }
 
     #[test]

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -397,6 +397,14 @@ impl PolicyValidator {
         for (i, s) in raw.allow.unwrap_or_default().iter().enumerate() {
             match s.parse::<aa_core::Capability>() {
                 Ok(cap) => {
+                    // AAASM-4099: warn loudly when a capability has no governance
+                    // action routing to it — the allow/deny would be silently inert.
+                    if !cap.is_enforceable() {
+                        warnings.push(ValidationWarning::inert_capability(
+                            format!("capabilities.allow[{}]", i),
+                            &cap,
+                        ));
+                    }
                     allow.insert(cap);
                 }
                 Err(msg) => errors.push(ValidationError::new(format!("capabilities.allow[{}]", i), msg)),
@@ -407,6 +415,15 @@ impl PolicyValidator {
         for (i, s) in raw.deny.unwrap_or_default().iter().enumerate() {
             match s.parse::<aa_core::Capability>() {
                 Ok(cap) => {
+                    // AAASM-4099: a declared deny on an unenforceable capability
+                    // is the dangerous case — the operator believes they blocked
+                    // it. Surface it loudly.
+                    if !cap.is_enforceable() {
+                        warnings.push(ValidationWarning::inert_capability(
+                            format!("capabilities.deny[{}]", i),
+                            &cap,
+                        ));
+                    }
                     deny.insert(cap);
                 }
                 Err(msg) => errors.push(ValidationError::new(format!("capabilities.deny[{}]", i), msg)),
@@ -931,6 +948,48 @@ mod tests {
         let yaml = "capabilities:\n  allow: []\n  extra_key: true\n";
         let out = PolicyValidator::from_yaml(yaml).unwrap();
         assert!(out.warnings.iter().any(|w| w.field == "capabilities.extra_key"));
+    }
+
+    #[test]
+    fn capabilities_inert_deny_parses_but_warns_loudly() {
+        // AAASM-4099: network_inbound / agent_spawn / model:* have no governance
+        // action, so a declared deny is silently inert. Loading must still
+        // succeed (shipped strict.yaml relies on it) but MUST warn loudly.
+        for cap in ["network_inbound", "agent_spawn", "model:gpt-4o"] {
+            let yaml = format!("capabilities:\n  deny:\n    - {cap}\n");
+            let out = PolicyValidator::from_yaml(&yaml)
+                .unwrap_or_else(|e| panic!("inert cap {cap} must not be a hard error: {e:?}"));
+            let warning = out
+                .warnings
+                .iter()
+                .find(|w| w.field == "capabilities.deny[0]")
+                .unwrap_or_else(|| panic!("expected inert-capability warning for {cap}"));
+            assert!(
+                warning.message.contains("NOT enforced") && warning.message.contains("inert"),
+                "warning for {cap} must be loud about non-enforcement: {}",
+                warning.message
+            );
+        }
+    }
+
+    #[test]
+    fn capabilities_inert_allow_warns_loudly() {
+        let yaml = "capabilities:\n  allow:\n    - agent_spawn\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(out
+            .warnings
+            .iter()
+            .any(|w| w.field == "capabilities.allow[0]" && w.message.contains("NOT enforced")));
+    }
+
+    #[test]
+    fn capabilities_enforceable_caps_produce_no_inert_warning() {
+        let yaml = "capabilities:\n  deny:\n    - terminal_exec\n    - file_write\n    - network_outbound\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(
+            !out.warnings.iter().any(|w| w.message.contains("NOT enforced")),
+            "action-backed capabilities must not emit an inert warning"
+        );
     }
 
     // ── Full-policy integration ─────────────────────────────────────────────


### PR DESCRIPTION
## Description

`Capability::NetworkInbound`, `Capability::Model`, and `Capability::AgentSpawn` had **no `GovernanceAction` mapping** in `action_to_capability`, and no action variant (nor any runtime/proxy/eBPF enforcement path) routes to them. Because `stage_capability` only denies a capability that some `GovernanceAction` produces, a policy declaring `allow`/`deny` on these three passed validation and hot-loaded **silently**, while the control was entirely inert — an operator who wrote `deny: [network_inbound]` (as the shipped `policy-examples/strict.yaml` does) or `deny: [agent_spawn]` believed they had restricted the agent when nothing was enforced.

Per-capability investigation outcome — **all three are currently unenforceable** (no wireable action exists; `AgentSpawn` exists only as an audit-side `ActionType`, never as a policy-evaluated `GovernanceAction`), so this is a **fail-loud** fix rather than a wiring fix:

- **`aa-core`** — added `Capability::is_enforceable()` as the single source of truth for "does any `GovernanceAction` route to this capability", kept in lock-step with `action_to_capability` (documented invariant). Returns `false` for `Model`, `NetworkInbound`, `AgentSpawn`.
- **`aa-gateway`** — `validate_capabilities` now emits a loud `ValidationWarning::inert_capability` for any declared allow/deny capability whose `is_enforceable()` is `false`. The policy still **loads** (a hard error would break the deliberately-shipped `strict.yaml` deny of `network_inbound` and the policy-examples corpus), but the inertness is now surfaced to the operator (dashboard ValidationPanel / CLI) instead of hidden.

A hard `ValidationError` was considered and rejected: the shipped corpus and two corpus-parsing test suites (`aa-security::policy_examples_parse`, `aa-gateway::cross_layer_policy_consistency_test`) intentionally use `network_inbound` as a capability floor, so a warning + doc is the principled fail-loud choice here.

## Type of Change

- [x] 🐛 Bug fix (security: silently-inert control)

## Breaking Changes

- [x] No — policies that previously loaded still load; they now additionally carry a validation warning.

## Related Issues

- Related Jira ticket: AAASM-4099
- Note: sibling PR **#1408** (AAASM-4103) also edits `aa-core/src/capability.rs` (adds a `FileDelete` variant + `Delete → FileDelete` mapping). This PR touches only the `is_enforceable`/`action_to_capability` NOTE and a new `impl Capability` block — different match arms, so the hunks are disjoint.

## Testing

- [x] Unit tests added / updated

Local validation (no full suite, per scope):
- `cargo fmt --all` — clean
- `cargo clippy -p aa-core -p aa-gateway --all-targets -- -D warnings` — clean (only pre-existing Cargo manifest `default-features` warnings)
- `cargo nextest run -p aa-core -p aa-gateway` (new + related): **10/10 pass** — `is_enforceable_*`, `action_to_capability_only_yields_enforceable_capabilities`, `capabilities_inert_deny_parses_but_warns_loudly`, `capabilities_inert_allow_warns_loudly`, `capabilities_enforceable_caps_produce_no_inert_warning`, `validation_warning_inert_capability_is_loud`
- Regression: `policy_examples_parse` + `cross_layer_policy_consistency_test` + `capability_integration_test`: **13/13 pass** (strict.yaml with `network_inbound` still loads).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
