### PR TITLE
[AAASM-4104] ✅ (test): aa-api per-operation authz regression coverage

### DIFF
--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -617,3 +617,72 @@ async fn get_agent_subtree_burn_includes_self_and_child_spend() {
         .collect();
     assert!(names.contains(&"(self)"), "self row must be present; got {names:?}");
 }
+
+// ── AAASM-4104 — per-operation authz regression coverage ────────────────────
+//
+// The agent write endpoints gate mutation behind the compile-time `RequireWrite`
+// scope extractor. These tests lock in that a read-scoped caller is rejected
+// with 403 so a future refactor that drops the extractor is caught. The scope
+// extractor runs before the handler body, so an arbitrary agent id suffices.
+
+use aa_api::auth::scope::Scope;
+
+#[tokio::test]
+async fn delete_agent_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/api/v1/agents/{}", hex_id(0x01)))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn suspend_agent_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/agents/{}/suspend", hex_id(0x01)))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn resume_agent_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/agents/{}/resume", hex_id(0x01)))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/aa-api/tests/alerts.rs
+++ b/aa-api/tests/alerts.rs
@@ -555,3 +555,55 @@ async fn resolve_alert_returns_404_for_unknown_id() {
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
+
+// ── AAASM-4104 — per-operation authz regression coverage ────────────────────
+//
+// The alert write endpoints (resolve, silence) gate mutation behind the
+// compile-time `RequireWrite` scope extractor, which runs before the handler
+// body. These tests lock in that a read-scoped caller is rejected with 403 so a
+// future refactor that drops the extractor is caught.
+
+use aa_api::auth::scope::Scope;
+
+#[tokio::test]
+async fn resolve_alert_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/alerts/00000000000000000000000000/resolve")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn silence_alert_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/alerts/silence")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"fingerprint":"abc","duration_secs":3600,"reason":"ack"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/aa-api/tests/approvals.rs
+++ b/aa-api/tests/approvals.rs
@@ -607,3 +607,52 @@ async fn get_approval_includes_routing_status_when_recorded() {
     let history = json["routing_status"]["history"].as_array().unwrap();
     assert_eq!(history[0]["from_role"], "oncall");
 }
+
+// ── AAASM-4104 — per-operation authz regression coverage ────────────────────
+//
+// The approval decision endpoints (approve, reject) gate the mutation behind the
+// compile-time `RequireWrite` scope extractor, which runs before the handler
+// body. These tests lock in that a read-scoped caller is rejected with 403 so a
+// future refactor that drops the extractor is caught.
+
+use aa_api::auth::scope::Scope;
+
+#[tokio::test]
+async fn approve_action_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/approvals/00000000-0000-0000-0000-000000000000/approve")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn reject_action_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/approvals/00000000-0000-0000-0000-000000000000/reject")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/aa-api/tests/edges.rs
+++ b/aa-api/tests/edges.rs
@@ -649,3 +649,40 @@ async fn list_topology_edges_with_team_filter_keeps_only_team_edges() {
     assert_eq!(edges.len(), 1);
     assert_eq!(edges[0]["source_agent_id"], hex(0x01));
 }
+
+// ── AAASM-4104 — per-operation authz regression coverage ────────────────────
+//
+// `POST /topology/edges` gates edge creation behind the compile-time
+// `RequireWrite` scope extractor, which runs before the handler body. This test
+// locks in that a read-scoped caller is rejected with 403 so a future refactor
+// that drops the extractor is caught.
+
+use aa_api::auth::scope::Scope;
+
+#[tokio::test]
+async fn report_edge_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/topology/edges")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "from_agent_id": hex(0x01),
+                        "to_agent_id": hex(0x02),
+                        "edge_type": "delegation",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
## Description

Adds per-operation authorization regression tests to `aa-api`. Several write endpoints enforce authz via the compile-time `RequireWrite` scope extractor but had **no** integration test asserting that a read-scoped caller is actually rejected. Without such a test, a future refactor that drops an extractor would silently open the endpoint. This PR closes that gap for the agent, alert, edge, and approval write endpoints.

Each new test mints a read-only (`Scope::Read`) API key, drives the real HTTP route through the full auth-enabled app (`test_app_with_auth`), and asserts `403 Forbidden`. The `RequireWrite` extractor runs before the handler body, so an arbitrary resource id is sufficient — the tests verify the authz gate, not the resource semantics.

Endpoints covered:
- `DELETE /api/v1/agents/{id}`, `POST /api/v1/agents/{id}/suspend`, `POST /api/v1/agents/{id}/resume`
- `POST /api/v1/alerts/{id}/resolve`, `POST /api/v1/alerts/silence`
- `POST /api/v1/topology/edges`
- `POST /api/v1/approvals/{id}/approve`, `POST /api/v1/approvals/{id}/reject`

This is **test-only** — no production behavior changes.

Note: the requested "Write-scoped caller 403 on GLOBAL-scoped policy create" case is already integration-covered via the real route by `policy_rbac_integration::write_scope_denied_at_global_org_team_scopes[global]` (and the `None`/default case), so no redundant test was added there.

## Type of Change

- [x] ✅ Tests (regression coverage)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4104

## Testing

- [x] Integration tests added
- [x] `cargo nextest run -p aa-api <new tests>` — 8 new tests pass
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p aa-api --all-targets -- -D warnings` clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — test only)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
