### PR TITLE
[AAASM-4115] 📝 (readme): Bump advertised version to v0.0.1-rc.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The alternate host `https://tool.agent-assembly.dev` serves the same script.
 
 ```sh
 # Pin a specific version
-AASM_VERSION=v0.0.1-beta.4 curl -sSf https://agent-assembly.com/install.sh | sh
+AASM_VERSION=v0.0.1-rc.3 curl -sSf https://agent-assembly.com/install.sh | sh
 
 # Custom install directory
 AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://agent-assembly.com/install.sh | sh
@@ -195,7 +195,7 @@ These two are built by `aa-ebpf/build.rs` (via `aya-build`) for the BPF target â
 public API and wire protocol are **not** stable; do not use in production.
 
 Releases are published as GitHub pre-releases â€” latest
-[`v0.0.1-beta.4`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.4)
+[`v0.0.1-rc.3`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-rc.3)
 (2026-06-20). The coordinated release tag also publishes the CLI, crates, SDK
 packages, and container image:
 


### PR DESCRIPTION
## Description

The top-level `README.md` still advertised the stale `v0.0.1-beta.4` release in two places. This PR bumps both to the current release channel `v0.0.1-rc.3`:

- **L30** — the pinned-install quick-start example: `AASM_VERSION=v0.0.1-beta.4` → `v0.0.1-rc.3`
- **L198** — the Project Status "latest" release link/tag: `v0.0.1-beta.4` → `v0.0.1-rc.3`

A full `grep -n 'beta'` of the README confirms no other stale release-version references remain. The historical span reference (`v0.0.1-alpha.1 … alpha.9`) on the GitHub Releases row is a factual statement about published pre-releases, not a current-release literal, and is left unchanged.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-4115

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Docs-only change. Verified with `grep -n 'beta' README.md` (no matches remain) and `grep -nE 'v0\.0\.1-(alpha|beta|rc)' README.md` (only the intended rc.3 refs plus the historical alpha-span row).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)