### PR TITLE
[AAASM-4134] 📝 (cli): Fix strict.yaml allowlist comment and config help wording

### DIFF
--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -57,7 +57,7 @@ pub enum Commands {
     Policy(policy::PolicyArgs),
     /// Manage named API contexts (connection profiles).
     Context(context::ContextArgs),
-    /// Validate an `agent-assembly.toml` runtime configuration file.
+    /// Work with `agent-assembly.toml` runtime config (see `validate` and `boot` subcommands).
     Config(config::ConfigArgs),
     /// Generate shell completion scripts.
     Completion(completion::CompletionArgs),

--- a/policy-examples/strict.yaml
+++ b/policy-examples/strict.yaml
@@ -11,8 +11,8 @@ spec:
   scope: global
 
   network:
-    # Empty-but-present allowlist still allows any host (an empty list means
-    # "no restriction"). To actually restrict egress, list the exact hosts.
+    # An empty-but-present allowlist denies all egress (fail-closed): every host
+    # is blocked until you list it. List the exact hosts you want to permit.
     allowlist:
       - api.openai.com
       - api.anthropic.com


### PR DESCRIPTION
## What changed

Two docs/UX correctness fixes surfaced by the AAASM-4120 QA sweep (AAASM-4134, LOW):

1. **`policy-examples/strict.yaml`** — the network-allowlist comment claimed an empty-but-present allowlist "allows any host / no restriction". That contradicts the actual hardened behavior: an empty allowlist is **deny-all** (fail-closed). Corrected the comment so a copy-paste operator isn't misled into a wide-open egress config.
2. **`aasm` top-level help** — the `config` command summary read "Validate an `agent-assembly.toml` runtime configuration file", implying `aasm config <file>` takes a file argument. It doesn't — the real forms are `aasm config validate <file>` and `aasm config boot`. Reworded the summary to point at the subcommands.

## Why

Both are operator-facing correctness issues: one could cause a security misconfiguration (trusting the wrong allowlist semantics), the other sends operators down an invalid `unrecognized subcommand` path.

## How to verify

- `aasm --help` / `aasm config --help` now describe `config` as a subcommand group referencing `validate` and `boot`.
- `aasm policy validate policy-examples/strict.yaml` still passes (exit 0).
- Comment/help-only change: `cargo build -p aa-cli`, `cargo fmt -p aa-cli --check`, and `cargo clippy -p aa-cli --all-targets -- -D warnings` all clean.

Closes AAASM-4134