### PR TITLE
[AAASM-4123] 🐛 (gateway): Enforce capability stage on the single-file/primary policy path

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1108,6 +1108,19 @@ impl PolicyEngine {
             return result;
         }
 
+        // Stage 2b — Capability authorization (AAASM-4123). Mirrors the cascade
+        // path's `cascade_capability_guard` via the shared `capability_guard`
+        // helper so the single-file/primary surface (`aasm policy simulate`,
+        // aa-api, single-file gateway) enforces per-op read/write/delete instead
+        // of silently permitting every capability-denied action. Runs before the
+        // tool stages so a capability-denied action never consumes a rate-limit
+        // token. A doc with no `capabilities` block imposes no restriction.
+        if let Some(caps) = &policy.capabilities {
+            if let Some(result) = Self::capability_guard(caps, action) {
+                return result;
+            }
+        }
+
         // Stages 3-5b — Tool/message rules: allow/deny, rate limit, approval.
         if let Some(result) = self.eval_tool_stages(&policy, ctx, action) {
             return result;

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1166,11 +1166,29 @@ impl PolicyEngine {
         action: &aa_core::GovernanceAction,
     ) -> Option<EvaluationResult> {
         let merged_caps = Self::collect_merged_capabilities(cascade);
+        Self::capability_guard(&merged_caps, action)
+    }
+
+    /// Capability authorization gate shared by BOTH the primary
+    /// (`evaluate_primary`) and cascade (`cascade_capability_guard`) paths: deny
+    /// when `caps.deny` blocks the action's capability, or a non-empty
+    /// `caps.allow` omits it. `None` when the action maps to no capability or is
+    /// permitted.
+    ///
+    /// Extracted so the single-file and directory-cascade paths can never
+    /// diverge again (AAASM-4123): the primary path previously ran every stage
+    /// EXCEPT this one, silently permitting capability-denied actions on the
+    /// single-file surface (`aasm policy simulate`, aa-api, single-file
+    /// gateway). This is the same fail-open-by-omission class closed for the
+    /// network stage via a shared helper (AAASM-3728). `capability_is_denied`
+    /// carries the write-deny⇒delete-deny defense-in-depth rule, so both paths
+    /// inherit it identically.
+    fn capability_guard(caps: &aa_core::CapabilitySet, action: &aa_core::GovernanceAction) -> Option<EvaluationResult> {
         let cap = aa_core::action_to_capability(action)?;
-        if aa_core::capability_is_denied(&merged_caps.deny, &cap) {
+        if aa_core::capability_is_denied(&caps.deny, &cap) {
             return Some(EvaluationResult::deny("capability denied by policy"));
         }
-        if !merged_caps.allow.is_empty() && !merged_caps.allow.contains(&cap) {
+        if !caps.allow.is_empty() && !caps.allow.contains(&cap) {
             return Some(EvaluationResult::deny("capability not in allow list"));
         }
         None

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -3266,6 +3266,128 @@ mod tests {
         );
     }
 
+    // ── Primary-path capability stage regression (AAASM-4123) ─────────────────
+
+    /// Load a single-file policy via the same public loader `aasm policy
+    /// simulate` / aa-api use, so `evaluate` takes the primary path (empty
+    /// `scope_index`).
+    fn load_single_file_engine(yaml: &str) -> PolicyEngine {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(tmp, "{yaml}").unwrap();
+        tmp.flush().unwrap();
+        let (alert_tx, _) = tokio::sync::broadcast::channel::<crate::budget::BudgetAlert>(64);
+        PolicyEngine::load_from_file(tmp.path(), alert_tx).expect("policy should load")
+    }
+
+    #[test]
+    fn single_file_strict_policy_enforces_capability_stage() {
+        // AAASM-4123: before the fix the primary path skipped the capability
+        // stage entirely, so a single-file strict policy (deny terminal_exec +
+        // file_write) silently ALLOWED process-exec / file-write / file-delete
+        // even though the network stage correctly denied. Mirrors the shipped
+        // policy-examples/strict.yaml capability floor.
+        let engine = load_single_file_engine(
+            "version: \"1\"\n\
+             network:\n  allowlist:\n    - api.openai.com\n\
+             capabilities:\n  deny:\n    - terminal_exec\n    - file_write\n\
+             tools:\n  read_file:\n    allow: true\n",
+        );
+        let ctx = make_ctx();
+
+        // Proof the primary path actually runs: a non-allowlisted GET is denied
+        // by the network stage.
+        let net = aa_core::GovernanceAction::NetworkRequest {
+            url: "https://evil.example.com/".into(),
+            method: "GET".into(),
+        };
+        assert_eq!(
+            engine.evaluate(&ctx, &net).decision,
+            PolicyResult::Deny {
+                reason: "host not in network allowlist".into()
+            }
+        );
+
+        // terminal_exec deny ⇒ ProcessExec denied.
+        let exec = aa_core::GovernanceAction::ProcessExec { command: "id".into() };
+        assert_eq!(
+            engine.evaluate(&ctx, &exec).decision,
+            PolicyResult::Deny {
+                reason: "capability denied by policy".into()
+            }
+        );
+
+        // file_write deny ⇒ FileAccess::Write denied.
+        let write = aa_core::GovernanceAction::FileAccess {
+            path: "/etc/passwd".into(),
+            mode: aa_core::FileMode::Write,
+        };
+        assert_eq!(
+            engine.evaluate(&ctx, &write).decision,
+            PolicyResult::Deny {
+                reason: "capability denied by policy".into()
+            }
+        );
+
+        // file_write deny ⇒ FileAccess::Delete denied too (defense-in-depth:
+        // a pre-file_delete write-deny must keep blocking delete, AAASM-4103).
+        let delete = aa_core::GovernanceAction::FileAccess {
+            path: "/etc/passwd".into(),
+            mode: aa_core::FileMode::Delete,
+        };
+        assert_eq!(
+            engine.evaluate(&ctx, &delete).decision,
+            PolicyResult::Deny {
+                reason: "capability denied by policy".into()
+            }
+        );
+
+        // file_read is not denied and the allow list is empty ⇒ read is not
+        // blocked by the capability stage.
+        let read = aa_core::GovernanceAction::FileAccess {
+            path: "/tmp/ok".into(),
+            mode: aa_core::FileMode::Read,
+        };
+        assert_ne!(
+            engine.evaluate(&ctx, &read).decision,
+            PolicyResult::Deny {
+                reason: "capability denied by policy".into()
+            }
+        );
+    }
+
+    #[test]
+    fn single_file_file_delete_deny_blocks_delete_on_primary_path() {
+        // AAASM-4123 + AAASM-4103: delete is a first-class verb. A single-file
+        // policy that denies only file_delete must block delete on the primary
+        // path while still permitting writes (delete-deny ≠ write-deny).
+        let engine = load_single_file_engine("version: \"1\"\ncapabilities:\n  deny:\n    - file_delete\n");
+        let ctx = make_ctx();
+
+        let delete = aa_core::GovernanceAction::FileAccess {
+            path: "/tmp/x".into(),
+            mode: aa_core::FileMode::Delete,
+        };
+        assert_eq!(
+            engine.evaluate(&ctx, &delete).decision,
+            PolicyResult::Deny {
+                reason: "capability denied by policy".into()
+            }
+        );
+
+        // A write is NOT denied by a delete-only deny.
+        let write = aa_core::GovernanceAction::FileAccess {
+            path: "/tmp/x".into(),
+            mode: aa_core::FileMode::Write,
+        };
+        assert_ne!(
+            engine.evaluate(&ctx, &write).decision,
+            PolicyResult::Deny {
+                reason: "capability denied by policy".into()
+            }
+        );
+    }
+
     // ── Directory-cascade binary-loader regression (AAASM-3499) ───────────────
 
     /// Build a `ctx` for a distinct agent (`agent_byte`) whose lineage


### PR DESCRIPTION
## Description

`evaluate_primary` — the single-file / primary policy pipeline `evaluate` takes whenever the `scope_index` is empty — ran the schedule, network, tool, credential, and budget stages but **had no capability stage**. Capability enforcement lived only in `cascade_capability_guard`, called exclusively on the directory-cascade path. The single-file loaders (`load_from_file` / `load_from_file_with_budget`) build an empty `ScopeIndex`, so every single-file surface — `aasm policy simulate`, the aa-api `PolicyEngine`, and a gateway configured with a single-file `policy_path` — silently permitted every capability-denied action (per-op read / write / delete unenforced). Same fail-open-by-omission class as the network (AAASM-3728), tool-scope (AAASM-3981), and schedule (AAASM-3847) primary-path gaps.

This PR:
1. Extracts the deny/allow-list check out of `cascade_capability_guard` into a free-standing `capability_guard(caps, action)` helper, so both paths apply identical fail-closed logic and cannot diverge again (the pattern used to close AAASM-3728).
2. Wires a capability stage (Stage 2b) into `evaluate_primary`, evaluating the primary doc's `capabilities` via the shared helper. It runs before the tool stages so a capability-denied action never consumes a rate-limit token.
3. Adds regression tests loading a single-file strict policy through the public `load_from_file` loader.

The capability model itself was already correct (delete is its own verb; `capability_is_denied` carries write-deny⇒delete-deny defense-in-depth) — only the primary-path wiring was missing.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Policies with no `capabilities` block are unaffected (empty set imposes no restriction). Only policies that already declared capability denies/allows — previously ignored on the single-file path — now enforce them, as intended.

## Related Issues

- Related Jira ticket: AAASM-4123

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

New tests (`aa-gateway engine::tests`):
- `single_file_strict_policy_enforces_capability_stage` — a single-file strict floor (deny `terminal_exec` + `file_write`) denies `ProcessExec`, `FileAccess::Write`, and `FileAccess::Delete` (delete via write-deny⇒delete-deny), a non-allowlisted GET still denies (proving the primary path runs), and a read is permitted.
- `single_file_file_delete_deny_blocks_delete_on_primary_path` — a `file_delete`-only deny blocks delete yet permits writes on the primary path.

Behavioral verification with the shipped example, before vs. after:

```
$ aasm policy simulate --policy policy-examples/strict.yaml --against probe.jsonl

EVENT#   ACTION                              DECISION   REASON
0        net:GET:https://evil.example.com/   deny       host not in network allowlist
1        exec:id                             deny       capability denied by policy   # was ALLOW before
2        file:Write:/etc/passwd              deny       capability denied by policy   # was ALLOW before
3        file:Delete:/etc/passwd             deny       capability denied by policy   # was ALLOW before
(file:Read:/tmp/ok.txt -> allowed)
```

Full `cargo nextest run -p aa-gateway` green; `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
