### PR TITLE
[AAASM-4128] 🔒 (security): Detect gho_/ghu_/ghr_/github_pat_/xapp- token prefixes

### DIFF
--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1124,6 +1124,17 @@ mod tests {
         assert!(redacted.contains("[REDACTED:GitHubRefreshToken]"));
     }
 
+    #[test]
+    fn detects_and_redacts_github_fine_grained_pat() {
+        let scanner = CredentialScanner::new();
+        let text = "token: github_pat_11ABCDE0000abcdefghij_1234567890abcdefghijklmnopqrstuvwxyzABCDEF";
+        let result = scanner.scan(text);
+        assert!(result.findings.iter().any(|f| f.kind == CredentialKind::GitHubPat));
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("github_pat_"));
+        assert!(redacted.contains("[REDACTED:GitHubPat]"));
+    }
+
     // --- Cloud credential patterns ---
 
     #[test]

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1096,6 +1096,20 @@ mod tests {
         assert!(redacted.contains("[REDACTED:GitHubOAuthToken]"));
     }
 
+    #[test]
+    fn detects_and_redacts_github_user_token() {
+        let scanner = CredentialScanner::new();
+        let text = "token: ghu_1234567890abcdefghijklmnopqrstuvwxyz";
+        let result = scanner.scan(text);
+        assert!(result
+            .findings
+            .iter()
+            .any(|f| f.kind == CredentialKind::GitHubUserToken));
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("ghu_"));
+        assert!(redacted.contains("[REDACTED:GitHubUserToken]"));
+    }
+
     // --- Cloud credential patterns ---
 
     #[test]

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1080,6 +1080,22 @@ mod tests {
             .any(|f| f.kind == CredentialKind::SlackOAuthToken));
     }
 
+    // --- AAASM-4128: sibling token prefixes the entropy backstop misses ---
+
+    #[test]
+    fn detects_and_redacts_github_oauth_token() {
+        let scanner = CredentialScanner::new();
+        let text = "token: gho_1234567890abcdefghijklmnopqrstuvwxyz";
+        let result = scanner.scan(text);
+        assert!(result
+            .findings
+            .iter()
+            .any(|f| f.kind == CredentialKind::GitHubOAuthToken));
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("gho_"));
+        assert!(redacted.contains("[REDACTED:GitHubOAuthToken]"));
+    }
+
     // --- Cloud credential patterns ---
 
     #[test]

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -37,6 +37,20 @@ const AC_PATTERNS: &[&str] = &[
     "\"type\":\"service_account\"",   // 18 GcpServiceAccount (compact, no space)
     "\"type\" :\"service_account\"",  // 19 GcpServiceAccount (space before colon)
     "\"type\" : \"service_account\"", // 20 GcpServiceAccount (spaces around colon)
+    // AAASM-4128: near-parity token prefixes that share a brand stem with the
+    // detectors above. The brand prefix dilutes each token's run entropy below
+    // the 4.5 gate (and `xapp-` tokens exceed the 20–64 whitespace-token window),
+    // so the entropy backstop never catches them — literal-prefix detection is
+    // the only reliable path. `github_pat_` (fine-grained PAT) and `ASIA` (STS
+    // temporary access key ID) are the same credential kind as their siblings,
+    // mirroring the GCP multi-pattern → single-kind mapping above.
+    "gho_",        // 21 GitHubOAuthToken
+    "ghu_",        // 22 GitHubUserToken
+    "ghr_",        // 23 GitHubRefreshToken
+    "github_pat_", // 24 GitHubPat (fine-grained PAT)
+    "xapp-",       // 25 SlackAppToken
+    "xoxr-",       // 26 SlackRefreshToken
+    "ASIA",        // 27 AwsAccessKey (STS temporary access key ID)
 ];
 
 /// Maps AC pattern index → [`CredentialKind`].
@@ -62,6 +76,13 @@ const AC_KINDS: &[CredentialKind] = &[
     CredentialKind::GcpServiceAccount,     // 18 (compact JSON)
     CredentialKind::GcpServiceAccount,     // 19 (space before colon)
     CredentialKind::GcpServiceAccount,     // 20 (spaces around colon)
+    CredentialKind::GitHubOAuthToken,      // 21
+    CredentialKind::GitHubUserToken,       // 22
+    CredentialKind::GitHubRefreshToken,    // 23
+    CredentialKind::GitHubPat,             // 24 (fine-grained PAT)
+    CredentialKind::SlackAppToken,         // 25
+    CredentialKind::SlackRefreshToken,     // 26
+    CredentialKind::AwsAccessKey,          // 27 (STS temporary access key ID)
 ];
 
 // ---------------------------------------------------------------------------
@@ -75,7 +96,7 @@ pub enum CredentialKind {
     // API keys
     /// Anthropic API key (prefix `sk-ant-`).
     AnthropicKey,
-    /// AWS access key ID (prefix `AKIA`).
+    /// AWS access key ID (long-term prefix `AKIA`, STS temporary prefix `ASIA`).
     AwsAccessKey,
     /// GCP service account JSON credential (contains `"type": "service_account"`).
     GcpServiceAccount,
@@ -87,12 +108,22 @@ pub enum CredentialKind {
     // Auth tokens
     /// GitHub App installation token (prefix `ghs_`).
     GitHubAppToken,
-    /// GitHub personal access token (prefix `ghp_`).
+    /// GitHub OAuth access token (prefix `gho_`).
+    GitHubOAuthToken,
+    /// GitHub personal access token (classic prefix `ghp_`, fine-grained prefix `github_pat_`).
     GitHubPat,
+    /// GitHub refresh token (prefix `ghr_`).
+    GitHubRefreshToken,
+    /// GitHub user-to-server token (prefix `ghu_`).
+    GitHubUserToken,
+    /// Slack app-level token (prefix `xapp-`).
+    SlackAppToken,
     /// Slack bot token (prefix `xoxb-`).
     SlackBotToken,
     /// Slack OAuth token (prefix `xoxa-`).
     SlackOAuthToken,
+    /// Slack refresh token (prefix `xoxr-`).
+    SlackRefreshToken,
     /// Slack user token (prefix `xoxp-`).
     SlackUserToken,
     // Database URLs
@@ -143,7 +174,10 @@ impl CredentialKind {
             Self::GcpServiceAccount => "GcpServiceAccount",
             Self::GenericHighEntropy => "GenericHighEntropy",
             Self::GitHubAppToken => "GitHubAppToken",
+            Self::GitHubOAuthToken => "GitHubOAuthToken",
             Self::GitHubPat => "GitHubPat",
+            Self::GitHubRefreshToken => "GitHubRefreshToken",
+            Self::GitHubUserToken => "GitHubUserToken",
             Self::MongodbUrl => "MongodbUrl",
             Self::MysqlUrl => "MysqlUrl",
             Self::OpenAiKey => "OpenAiKey",
@@ -152,8 +186,10 @@ impl CredentialKind {
             Self::PostgresUrl => "PostgresUrl",
             Self::PrivateKey => "PrivateKey",
             Self::RsaPrivateKey => "RsaPrivateKey",
+            Self::SlackAppToken => "SlackAppToken",
             Self::SlackBotToken => "SlackBotToken",
             Self::SlackOAuthToken => "SlackOAuthToken",
+            Self::SlackRefreshToken => "SlackRefreshToken",
             Self::SlackUserToken => "SlackUserToken",
             Self::SsnPattern => "SsnPattern",
             Self::Custom => "Custom",
@@ -184,7 +220,10 @@ impl CredentialKind {
             | Self::EcPrivateKey
             | Self::GcpServiceAccount
             | Self::GitHubAppToken
+            | Self::GitHubOAuthToken
             | Self::GitHubPat
+            | Self::GitHubRefreshToken
+            | Self::GitHubUserToken
             | Self::MongodbUrl
             | Self::MysqlUrl
             | Self::OpenAiKey
@@ -193,8 +232,10 @@ impl CredentialKind {
             | Self::PostgresUrl
             | Self::PrivateKey
             | Self::RsaPrivateKey
+            | Self::SlackAppToken
             | Self::SlackBotToken
             | Self::SlackOAuthToken
+            | Self::SlackRefreshToken
             | Self::SlackUserToken
             | Self::SsnPattern
             | Self::Custom => 2,

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1110,6 +1110,20 @@ mod tests {
         assert!(redacted.contains("[REDACTED:GitHubUserToken]"));
     }
 
+    #[test]
+    fn detects_and_redacts_github_refresh_token() {
+        let scanner = CredentialScanner::new();
+        let text = "token: ghr_1234567890abcdefghijklmnopqrstuvwxyz";
+        let result = scanner.scan(text);
+        assert!(result
+            .findings
+            .iter()
+            .any(|f| f.kind == CredentialKind::GitHubRefreshToken));
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("ghr_"));
+        assert!(redacted.contains("[REDACTED:GitHubRefreshToken]"));
+    }
+
     // --- Cloud credential patterns ---
 
     #[test]

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1135,6 +1135,17 @@ mod tests {
         assert!(redacted.contains("[REDACTED:GitHubPat]"));
     }
 
+    #[test]
+    fn detects_and_redacts_slack_app_token() {
+        let scanner = CredentialScanner::new();
+        let text = "SLACK_APP_TOKEN=xapp-1-A012345678-1234567890123-abcdef0123456789abcdef0123456789abcdef";
+        let result = scanner.scan(text);
+        assert!(result.findings.iter().any(|f| f.kind == CredentialKind::SlackAppToken));
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("xapp-"));
+        assert!(redacted.contains("[REDACTED:SlackAppToken]"));
+    }
+
     // --- Cloud credential patterns ---
 
     #[test]

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1160,6 +1160,17 @@ mod tests {
         assert!(redacted.contains("[REDACTED:SlackRefreshToken]"));
     }
 
+    #[test]
+    fn detects_and_redacts_aws_sts_temporary_key() {
+        let scanner = CredentialScanner::new();
+        let text = "AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE";
+        let result = scanner.scan(text);
+        assert!(result.findings.iter().any(|f| f.kind == CredentialKind::AwsAccessKey));
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("ASIA"));
+        assert!(redacted.contains("[REDACTED:AwsAccessKey]"));
+    }
+
     // --- Cloud credential patterns ---
 
     #[test]

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1146,6 +1146,20 @@ mod tests {
         assert!(redacted.contains("[REDACTED:SlackAppToken]"));
     }
 
+    #[test]
+    fn detects_and_redacts_slack_refresh_token() {
+        let scanner = CredentialScanner::new();
+        let text = "token=xoxr-123456789012-123456789012-XXXXXXXXXXXX";
+        let result = scanner.scan(text);
+        assert!(result
+            .findings
+            .iter()
+            .any(|f| f.kind == CredentialKind::SlackRefreshToken));
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("xoxr-"));
+        assert!(redacted.contains("[REDACTED:SlackRefreshToken]"));
+    }
+
     // --- Cloud credential patterns ---
 
     #[test]


### PR DESCRIPTION
## What changed

Adds the missing sibling credential prefixes to the `aa-security` scanner's `AC_PATTERNS` (literal Aho-Corasick prefixes, entropy-independent):

- `gho_` → `GitHubOAuthToken` (new kind)
- `ghu_` → `GitHubUserToken` (new kind)
- `ghr_` → `GitHubRefreshToken` (new kind)
- `github_pat_` → `GitHubPat` (fine-grained PAT; existing kind)
- `xapp-` → `SlackAppToken` (new kind)
- `xoxr-` → `SlackRefreshToken` (new kind)
- `ASIA` → `AwsAccessKey` (STS temporary access-key ID; existing kind)

`github_pat_` and `ASIA` map to the existing `GitHubPat` / `AwsAccessKey` kinds, mirroring the established GCP multi-pattern → single-kind approach. The four new `CredentialKind` variants are wired through `as_str()` and `priority()` (high-signal tier, so they win over the generic backstops on overlap).

## Why

The scanner listed `ghp_`/`ghs_` and `xoxb-`/`xoxp-`/`xoxa-` but not these near-parity prefixes. Their brand stem dilutes each token's run entropy below the 4.5 gate (e.g. `gho_` run ≈ 4.14), and `xapp-` tokens exceed the 20–64 whitespace-token window at `scanner.rs:715`, so the entropy backstop never caught them either. A live `gho_` / `ghu_` / `github_pat_` / `xapp-` / `ASIA` token was scanned, matched nothing, and the unredacted secret was forwarded/stored. Literal-prefix detection is the only reliable path.

## How to verify

7 new detection + redaction tests, one per prefix, mirroring the existing `ghp_`/`xoxb-` tests:

```
cargo nextest run -p aa-security
```

All 123 aa-security tests pass. `cargo fmt --check` and `cargo clippy -p aa-security --all-targets -- -D warnings` are clean.

Closes AAASM-4128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz