### PR TITLE
[AAASM-4121] 🔒 (gateway): Ignore client-supplied weaker enforcement_mode on self-registration

### DIFF
--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -183,6 +183,39 @@ impl ChallengeStoreLike for InMemoryChallengeStore {
 /// `Status::unauthenticated` when the proof is missing, malformed, or does not
 /// verify — so no `credential_token` is minted for a caller that merely presents
 /// a public key it does not hold.
+/// Resolve the authoritative per-agent `enforcement_mode` override to store for
+/// a *self-registering* agent, dropping any client-supplied claim that would
+/// *weaken* enforcement (AAASM-4121).
+///
+/// `enforcement_mode` is a downgrade lever: on the `CheckAction` hot path a
+/// stored `Observe`/`Disabled` mode rewrites a `Deny`/`RequiresApproval` into an
+/// audited `Allow` (`engine::transform_for_observe_mode`). `Register` is the
+/// unauthenticated bootstrap path — its only gate is an Ed25519 possession-proof
+/// over a server nonce, which proves *key ownership*, NOT authorization. So a
+/// self-registering agent must not be able to neutralize its own governance by
+/// claiming `enforcement_mode = Observe/Disabled`.
+///
+/// Only a claim that *strengthens* enforcement (`Enforce`) is honored; a weaker
+/// claim is dropped to `None` so the server-side default (`Enforce`, resolved in
+/// `resolve_enforcement_mode`) governs. Operator-driven observe→enforce rollout
+/// belongs in server-side policy/config, never a client registration claim.
+/// Mirrors the trust-boundary treatment of forged tenancy in
+/// `PolicyServiceImpl::apply_authoritative_tenancy` (AAASM-3992).
+fn authoritative_enforcement_mode(proto_value: i32) -> Option<aa_core::EnforcementMode> {
+    match aa_core::EnforcementMode::from_proto_i32(proto_value) {
+        Some(aa_core::EnforcementMode::Enforce) => Some(aa_core::EnforcementMode::Enforce),
+        Some(weaker) => {
+            tracing::warn!(
+                ?weaker,
+                "ignoring client-supplied weaker enforcement_mode on self-registration; \
+                 defaulting to Enforce (AAASM-4121)"
+            );
+            None
+        }
+        None => None,
+    }
+}
+
 fn verify_possession_proof(
     verifying_key: &ed25519_dalek::VerifyingKey,
     challenge: &[u8],
@@ -458,7 +491,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             root_agent_id,
             children: Vec::new(),
             parent_key: resolved_parent_key,
-            enforcement_mode: aa_core::EnforcementMode::from_proto_i32(req.enforcement_mode),
+            enforcement_mode: authoritative_enforcement_mode(req.enforcement_mode),
             org_id: echo_org_id,
         };
 

--- a/aa-gateway/tests/enforcement_mode_self_registration_test.rs
+++ b/aa-gateway/tests/enforcement_mode_self_registration_test.rs
@@ -1,0 +1,167 @@
+//! AAASM-4121 — a self-registering agent must not be able to weaken its own
+//! enforcement posture.
+//!
+//! `enforcement_mode` is a downgrade lever: a stored `Observe`/`Disabled` mode
+//! rewrites a policy `Deny` into an audited `Allow` on the `CheckAction` hot
+//! path. `Register` is the unauthenticated bootstrap path (gated only by an
+//! Ed25519 possession-proof, which proves key ownership — not authorization), so
+//! a client-supplied `enforcement_mode = Observe` on that path must be ignored
+//! and default to `Enforce`.
+//!
+//! Regression guard: self-register with `enforcement_mode = OBSERVE`, then a
+//! `CheckAction` on a denied tool must still return `Deny`.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_gateway::registry::AgentRegistry;
+use aa_gateway::service::{AgentLifecycleServiceImpl, PolicyServiceImpl};
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::agent::v1::agent_lifecycle_service_client::AgentLifecycleServiceClient;
+use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
+use aa_proto::assembly::agent::v1::{ChallengeRequest, RegisterRequest};
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{action_context::Action, ActionContext, CheckActionRequest, ToolCallContext};
+use ed25519_dalek::Signer;
+use tokio::net::TcpListener;
+use tonic::transport::{Channel, Server};
+
+/// Deterministic Ed25519 test key; its public half is used as the agent's
+/// `public_key` and the challenge is signed with the private half.
+fn test_signing_key() -> ed25519_dalek::SigningKey {
+    ed25519_dalek::SigningKey::from_bytes(&[42u8; 32])
+}
+
+fn test_public_key_hex() -> String {
+    hex::encode(test_signing_key().verifying_key().as_bytes())
+}
+
+fn test_agent_id() -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "org-test".into(),
+        team_id: "team-test".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+    }
+}
+
+const DENY_BASH_POLICY: &str = r#"
+version: "1"
+tools:
+  bash:
+    allow: false
+"#;
+
+/// Start one gRPC server exposing both the `AgentLifecycleService` (Register) and
+/// the `PolicyService` (CheckAction) against a single shared registry + a
+/// deny-bash policy engine, so a self-registration on one path is observed by the
+/// enforcement decision on the other.
+async fn start_combined_server() -> SocketAddr {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", DENY_BASH_POLICY).unwrap();
+    tmp.flush().unwrap();
+
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap());
+    let registry = Arc::new(AgentRegistry::new());
+
+    let lifecycle = AgentLifecycleServiceImpl::new(Arc::clone(&registry));
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let policy = PolicyServiceImpl::with_registry(
+        Arc::clone(&engine),
+        Arc::clone(&registry),
+        audit_tx,
+        Arc::new(AtomicU64::new(0)),
+        [0u8; 32],
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(AgentLifecycleServiceServer::new(lifecycle))
+            .add_service(PolicyServiceServer::new(policy))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    addr
+}
+
+/// Drive the two-step registration handshake and submit Register with `req`,
+/// signing the server-issued nonce with the test key.
+async fn register_with_challenge(
+    client: &mut AgentLifecycleServiceClient<Channel>,
+    mut req: RegisterRequest,
+) -> String {
+    let challenge = client
+        .request_challenge(ChallengeRequest {
+            agent_id: req.agent_id.clone(),
+            public_key: req.public_key.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    req.possession_proof = test_signing_key().sign(&challenge.nonce).to_bytes().to_vec();
+    req.registration_nonce = challenge.nonce;
+    client.register(req).await.unwrap().into_inner().credential_token
+}
+
+#[tokio::test]
+async fn self_registration_with_observe_mode_is_ignored_deny_still_enforced() {
+    let addr = start_combined_server().await;
+    let proto_id = test_agent_id();
+
+    // Self-register claiming enforcement_mode = OBSERVE (proto value 2), which —
+    // if honored — would downgrade this agent's denies to audited allows.
+    let mut lifecycle_client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+    let register_req = RegisterRequest {
+        agent_id: Some(proto_id.clone()),
+        public_key: test_public_key_hex(),
+        enforcement_mode: 2, // EnforcementMode::Observe
+        ..Default::default()
+    };
+    let credential_token = register_with_challenge(&mut lifecycle_client, register_req).await;
+
+    // CheckAction on a denied tool must still return Deny — the client-supplied
+    // Observe mode must have been dropped in favor of the server default Enforce.
+    let mut policy_client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let resp = policy_client
+        .check_action(CheckActionRequest {
+            agent_id: Some(proto_id),
+            credential_token,
+            trace_id: "trace-4121".into(),
+            span_id: "span-1".into(),
+            action_type: ActionType::ToolCall as i32,
+            context: Some(ActionContext {
+                action: Some(Action::ToolCall(ToolCallContext {
+                    tool_name: "bash".into(),
+                    tool_source: "test".into(),
+                    args_json: b"{}".to_vec(),
+                    target_url: String::new(),
+                })),
+            }),
+            caller_agent_id: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.decision,
+        Decision::Deny as i32,
+        "self-registered Observe mode must be ignored; deny rule must still enforce (got reason {:?})",
+        resp.reason,
+    );
+}

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -1058,11 +1058,13 @@ async fn root_agent_id_when_parent_unknown_returns_invalid_argument() {
 }
 
 #[tokio::test]
-async fn register_persists_enforcement_mode_observe_override_on_agent_record() {
-    // AAASM-1557 contract: RegisterRequest.enforcement_mode = OBSERVE (proto
-    // value 2) is parsed via EnforcementMode::from_proto_i32 and stored as
-    // Some(Observe) on the AgentRecord. Resolution layer (separate test)
-    // takes care of using it; this test asserts the storage side only.
+async fn register_drops_client_supplied_weaker_enforcement_mode() {
+    // AAASM-4121 trust boundary: Register is the unauthenticated bootstrap path,
+    // so a client-supplied enforcement_mode = OBSERVE (proto value 2) — which
+    // would downgrade the agent's own Deny verdicts to audited Allow — must NOT
+    // be persisted. It is dropped to None so the server-side default (Enforce)
+    // governs. Supersedes the earlier AAASM-1557 storage contract that trusted
+    // the client claim. A strengthening Enforce claim is still honored.
     use aa_proto::assembly::common::v1::EnforcementMode as ProtoMode;
 
     let (addr, registry) = start_server().await;
@@ -1094,13 +1096,17 @@ async fn register_persists_enforcement_mode_observe_override_on_agent_record() {
     .await
     .unwrap();
 
-    // Reach into the registry and confirm the override landed on the record.
+    // The client-supplied Observe downgrade must have been dropped: the record
+    // carries no per-agent override, so resolution falls back to Enforce.
     let stored = registry
         .list()
         .into_iter()
         .find(|r| r.name == "experimental-agent")
         .expect("registered agent must be present in registry");
-    assert_eq!(stored.enforcement_mode, Some(aa_core::EnforcementMode::Observe));
+    assert_eq!(
+        stored.enforcement_mode, None,
+        "client-supplied Observe on self-registration must be dropped (AAASM-4121)"
+    );
 }
 
 // ── AAASM-3866: server-nonce possession proof ────────────────────────────────


### PR DESCRIPTION
## Description

Register is the unauthenticated bootstrap RPC — its only gate is an Ed25519 possession-proof, which proves *key ownership*, not *authorization*. It stored the client-supplied `enforcement_mode` verbatim on the `AgentRecord` (`lifecycle_service.rs`). Because a stored `Observe`/`Disabled` mode rewrites `Deny`/`RequiresApproval` → audited `Allow` on the `CheckAction` hot path (`engine::transform_for_observe_mode`), a self-registering agent could neutralize its own governance: generate a keypair → `RequestChallenge` → `Register{enforcement_mode=Observe}` → `CheckAction{denied action}` returns `Allow`. This bypassed the gateway-consultation enforcement path, not just audit.

This PR gates `enforcement_mode` at the trust boundary: a new `authoritative_enforcement_mode()` helper drops any client claim that *weakens* enforcement (`Observe`/`Disabled`) to `None`, so the server-side default (`Enforce`, via `resolve_enforcement_mode`) governs. Only a *strengthening* `Enforce` claim is honored. The legitimate zero-config bootstrap Register is unaffected (default is already Enforce). Mirrors the forged-tenancy treatment in `apply_authoritative_tenancy` (AAASM-3992).

Operator-driven observe→enforce rollout, if/when wired, belongs in server-side policy/config — never a client registration claim.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No

A self-registering client can no longer set `Observe`/`Disabled` for itself. This removes a security downgrade vector, not a supported capability; a strengthening `Enforce` claim and all default-Enforce behavior are unchanged.

## Related Issues

- Related Jira ticket: AAASM-4121

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

- New end-to-end regression test (`enforcement_mode_self_registration_test.rs`): self-register via the real Register RPC with `enforcement_mode=Observe`, then a `CheckAction` on a denied tool still returns `Deny`.
- Updated the AAASM-1557 storage test to assert the weaker client claim is dropped to `None` (previously asserted it persisted verbatim — the exact downgrade vector).
- Full `cargo nextest run -p aa-gateway` green (1372/1372; one `policy_latency_test` p99 flake under full-parallel contention, passes in isolation — documented local macOS timing flake, unrelated to this change).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean (lefthook pre-commit); `cargo doc --workspace --no-deps` clean (pre-push).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
