### PR TITLE
[AAASM-4127] 🐛 (proxy): Wire CLI/runtime gateway endpoint into aa-proxy for MCP enforcement

### DIFF
--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -69,6 +69,26 @@ pub fn resolve_binary() -> Option<PathBuf> {
     None
 }
 
+/// Build the environment overrides applied to the spawned `aa-proxy` child.
+///
+/// AAASM-4127: the proxy reads its gateway endpoint from
+/// `AA_PROXY_GATEWAY_ENDPOINT` — **not** `AA_GATEWAY_URL`, which it ignores — and
+/// only performs MCP `tools/call` enforcement when that endpoint is set. A prior
+/// version exported `AA_GATEWAY_URL`, so `aasm proxy start --gateway <url>` left
+/// `gateway_endpoint = None` → raw passthrough with MCP enforcement silently OFF.
+///
+/// When a gateway is configured we also force `AA_PROXY_LLM_ONLY=false` so
+/// non-LLM MCP hosts are intercepted and routed to the gateway's PolicyService
+/// rather than transparently tunnelled before enforcement can run.
+fn proxy_child_env(listen: &str, gateway: Option<&str>) -> Vec<(&'static str, String)> {
+    let mut env = vec![("AA_PROXY_ADDR", listen.to_string())];
+    if let Some(gw) = gateway {
+        env.push(("AA_PROXY_GATEWAY_ENDPOINT", gw.to_string()));
+        env.push(("AA_PROXY_LLM_ONLY", "false".to_string()));
+    }
+    env
+}
+
 /// Poll TCP connect on `addr` until the socket accepts or `timeout` elapses.
 fn wait_for_port(addr: &str, timeout: Duration) -> bool {
     let Ok(sock_addr) = addr.parse::<SocketAddr>() else {
@@ -105,9 +125,8 @@ pub fn dispatch(args: StartArgs) -> ExitCode {
     };
 
     let mut cmd = std::process::Command::new(&binary);
-    cmd.env("AA_PROXY_ADDR", &args.listen);
-    if let Some(ref gw) = args.gateway {
-        cmd.env("AA_GATEWAY_URL", gw);
+    for (key, value) in proxy_child_env(&args.listen, args.gateway.as_deref()) {
+        cmd.env(key, value);
     }
     if let Some(ref ca_dir) = args.ca_dir {
         cmd.env("AA_CA_DIR", ca_dir);

--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -251,6 +251,36 @@ mod tests {
     }
 
     #[test]
+    fn proxy_child_env_gateway_uses_proxy_endpoint_var() {
+        // AAASM-4127 regression guard: aa-proxy reads AA_PROXY_GATEWAY_ENDPOINT,
+        // so `--gateway <url>` must export that exact name. A prior bug exported
+        // AA_GATEWAY_URL (which aa-proxy ignores), leaving gateway_endpoint None
+        // → raw passthrough with MCP enforcement silently OFF.
+        let env = proxy_child_env("127.0.0.1:8899", Some("http://127.0.0.1:50051"));
+        assert!(
+            env.contains(&("AA_PROXY_GATEWAY_ENDPOINT", "http://127.0.0.1:50051".to_string())),
+            "gateway must be exported as AA_PROXY_GATEWAY_ENDPOINT, got: {env:?}"
+        );
+        // llm_only disabled so non-LLM MCP hosts reach the gateway routing
+        // instead of being transparently tunnelled before enforcement.
+        assert!(env.contains(&("AA_PROXY_LLM_ONLY", "false".to_string())));
+        // The old, ignored variable name must never be exported to the child.
+        assert!(
+            !env.iter().any(|(k, _)| *k == "AA_GATEWAY_URL"),
+            "AA_GATEWAY_URL must not be exported (aa-proxy ignores it)"
+        );
+    }
+
+    #[test]
+    fn proxy_child_env_omits_gateway_vars_when_absent() {
+        let env = proxy_child_env("127.0.0.1:8899", None);
+        assert!(!env.iter().any(|(k, _)| *k == "AA_PROXY_GATEWAY_ENDPOINT"));
+        assert!(!env.iter().any(|(k, _)| *k == "AA_PROXY_LLM_ONLY"));
+        // The listen address is always exported.
+        assert!(env.contains(&("AA_PROXY_ADDR", "127.0.0.1:8899".to_string())));
+    }
+
+    #[test]
     fn wait_for_port_returns_false_on_unbound_addr() {
         // Port 1 is privileged and never listening in test environments.
         assert!(!wait_for_port("127.0.0.1:1", Duration::from_millis(200)));

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -46,6 +46,7 @@ fn spawn_proxy(
     tracker: &TaskTracker,
     broadcast_tx: &tokio::sync::broadcast::Sender<crate::pipeline::PipelineEvent>,
     active_layers: crate::layer::LayerSet,
+    gateway_endpoint: Option<&str>,
     degraded_layers: &mut Vec<String>,
 ) {
     let proxy_bin = match which::which("aa-proxy") {
@@ -60,11 +61,21 @@ fn spawn_proxy(
 
     let proxy_broadcast_tx = broadcast_tx.clone();
     let proxy_bin_display = proxy_bin.display().to_string();
+    // AAASM-4127: forward the runtime's gateway endpoint to the child proxy so
+    // its MCP `tools/call` enforcement activates. The proxy reads
+    // `AA_PROXY_GATEWAY_ENDPOINT`; without it the spawned proxy runs in
+    // raw-passthrough with MCP enforcement silently OFF. When an endpoint is
+    // configured we also disable `llm_only` so non-LLM MCP hosts are intercepted
+    // and routed to the gateway rather than transparently tunnelled.
+    let proxy_gateway_endpoint = gateway_endpoint.map(str::to_owned);
     tracker.spawn(async move {
-        let result = tokio::process::Command::new(&proxy_bin)
-            .kill_on_drop(true)
-            .status()
-            .await;
+        let mut command = tokio::process::Command::new(&proxy_bin);
+        command.kill_on_drop(true);
+        if let Some(endpoint) = &proxy_gateway_endpoint {
+            command.env("AA_PROXY_GATEWAY_ENDPOINT", endpoint);
+            command.env("AA_PROXY_LLM_ONLY", "false");
+        }
+        let result = command.status().await;
         match result {
             Ok(status) if status.success() => {
                 tracing::info!("proxy subsystem exited normally");
@@ -644,7 +655,13 @@ pub async fn run(config: RuntimeConfig) {
 
     // Spawn the proxy subsystem if the PROXY layer is active.
     if active_layers.contains(crate::layer::LayerSet::PROXY) {
-        spawn_proxy(&tracker, &broadcast_tx, active_layers, &mut degraded_layers);
+        spawn_proxy(
+            &tracker,
+            &broadcast_tx,
+            active_layers,
+            config.gateway_endpoint.as_deref(),
+            &mut degraded_layers,
+        );
     }
 
     // Shared metrics — future health/metrics endpoints will receive an Arc clone.
@@ -1122,7 +1139,7 @@ mod tests {
         let active_layers = crate::layer::LayerSet::PROXY | crate::layer::LayerSet::SDK;
         let mut degraded = Vec::new();
 
-        super::spawn_proxy(&tracker, &tx, active_layers, &mut degraded);
+        super::spawn_proxy(&tracker, &tx, active_layers, None, &mut degraded);
 
         std::env::set_var("PATH", &orig_path);
 
@@ -1165,7 +1182,7 @@ mod tests {
         let active_layers = crate::layer::LayerSet::PROXY | crate::layer::LayerSet::SDK;
         let mut degraded = Vec::new();
 
-        super::spawn_proxy(&tracker, &tx, active_layers, &mut degraded);
+        super::spawn_proxy(&tracker, &tx, active_layers, None, &mut degraded);
 
         // Binary found, so no immediate degradation.
         assert!(!degraded.contains(&"proxy".to_string()));

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1837,6 +1837,7 @@ mod layer_integration {
             &tracker,
             &tx,
             crate::layer::LayerSet::EBPF | crate::layer::LayerSet::PROXY,
+            None,
             &mut degraded,
         );
 
@@ -1918,6 +1919,7 @@ mod layer_integration {
             &tracker,
             &tx,
             crate::layer::LayerSet::EBPF | crate::layer::LayerSet::PROXY,
+            None,
             &mut degraded,
         );
 


### PR DESCRIPTION
## What changed

`aasm proxy start --gateway <url>` exported `AA_GATEWAY_URL` to the spawned `aa-proxy` child, but aa-proxy reads its gateway endpoint from `AA_PROXY_GATEWAY_ENDPOINT` (it does not reference `AA_GATEWAY_URL` anywhere). The child therefore always saw `gateway_endpoint = None` and ran in raw passthrough with MCP `tools/call` enforcement silently **OFF**, even though the operator had configured a gateway (and startup even fail-closes when the gateway is unreachable — giving false assurance).

Two producer-side call sites are fixed:

- **`aa-cli` (`proxy/start.rs`)** — export `AA_PROXY_GATEWAY_ENDPOINT` (the name aa-proxy reads) instead of `AA_GATEWAY_URL`, plus `AA_PROXY_LLM_ONLY=false`. The env mapping is factored into a pure `proxy_child_env()` helper.
- **`aa-runtime` (`runtime.rs`)** — `spawn_proxy` previously launched aa-proxy with no environment; now it forwards the runtime's `gateway_endpoint` as `AA_PROXY_GATEWAY_ENDPOINT` (and `AA_PROXY_LLM_ONLY=false`) when configured.

Setting `AA_PROXY_LLM_ONLY=false` is required alongside the endpoint: with the default `llm_only=true`, non-LLM MCP hosts (`LlmApiPattern::Unknown`) are transparently tunnelled in `proxy/mod.rs` *before* `handle_non_llm_with_gateway` runs, so the gateway routing is never reached. Disabling `llm_only` when a gateway is configured makes those MCP flows get intercepted and enforced.

## Why

Silent fail-open on a governance path (MED). An operator who configures a gateway reasonably expects MCP enforcement, but the env-var name mismatch left it entirely off; only the advisory in-process SDK fast-path remained, which a non-SDK or compromised agent evades.

## How to verify

- `cargo nextest run -p aa-cli` — includes new regression tests `proxy_child_env_gateway_uses_proxy_endpoint_var` and `proxy_child_env_omits_gateway_vars_when_absent`, which assert `--gateway` maps to `AA_PROXY_GATEWAY_ENDPOINT` (+ `AA_PROXY_LLM_ONLY=false`) and never the ignored `AA_GATEWAY_URL`.
- Manual: `aasm proxy start --gateway http://127.0.0.1:50051` now yields a non-None `gateway_endpoint` in the proxy config.

## Validation run locally

- `aa-cli`: `cargo nextest run -p aa-cli` — 800 passed (incl. new tests), 0 failed.
- `aa-runtime`: validated by `cargo build -p aa-runtime` + `cargo clippy -p aa-runtime --all-targets -- -D warnings` (its integration tests require Docker/testcontainers and were not run here; the change is pure child-process env forwarding).
- `cargo clippy -p aa-cli -p aa-runtime --all-targets -- -D warnings`: clean.
- `cargo fmt -p aa-cli -p aa-runtime --check`: clean.

Scope is limited to `aa-cli/src/commands/proxy/start.rs` and `aa-runtime/src/runtime.rs` (no changes to `aa-proxy` source — its `config.rs` already reads `AA_PROXY_GATEWAY_ENDPOINT` correctly).

Closes AAASM-4127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz