### PR TITLE
[AAASM-4133] 🔒 (gateway): Defense-in-depth hardening batch (agent_id, CA, tenancy, edge authz, gRPC size)

### DIFF
--- a/aa-api/src/routes/edges.rs
+++ b/aa-api/src/routes/edges.rs
@@ -59,6 +59,28 @@ fn authorize_agent_team_access(
     Ok(())
 }
 
+/// Reject an edge whose **target** is another team's agent (AAASM-4133).
+///
+/// `report_edge` already authorizes ownership of the *source* (reporting) agent
+/// (AAASM-3790). Without this check a caller could still insert an edge whose
+/// target is an agent owned by a different team, polluting that team's
+/// inbound-topology view. An admin may target any agent; a team-scoped caller
+/// may target only agents in a team it can access. A **team-less** target is
+/// not "another team's agent", so it stays allowed — SDK emitters legitimately
+/// record edges to as-yet-unregistered or shared/team-less peers.
+fn authorize_edge_target(caller: &AuthenticatedCaller, state: &AppState, target: AgentId) -> Result<(), ProblemDetail> {
+    if caller.scopes.contains(&Scope::Admin) {
+        return Ok(());
+    }
+    if let Some(team) = agent_team_id(state, target) {
+        if !caller.can_access_team(&team) {
+            return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+                .with_detail("Edge target agent belongs to another team".to_string()));
+        }
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -213,6 +235,9 @@ pub async fn report_edge(
     // AAASM-3790: write-scope + ownership of the source (reporting) agent so a
     // caller cannot poison another team's topology with fabricated edges.
     authorize_agent_team_access(&caller, &state, source)?;
+    // AAASM-4133: also authorize the target so a caller cannot pollute another
+    // team's inbound topology with an edge pointing at that team's agent.
+    authorize_edge_target(&caller, &state, target)?;
 
     let metadata = if let Some(json_str) = body.metadata_json {
         if json_str.is_empty() {

--- a/aa-api/tests/edges.rs
+++ b/aa-api/tests/edges.rs
@@ -686,3 +686,103 @@ async fn report_edge_with_read_only_scope_is_forbidden() {
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
+
+// ── AAASM-4133 — report_edge authorizes the edge TARGET, not just the source ──
+//
+// A write-scoped, team-scoped caller may own the source (reporting) agent yet
+// still try to point the edge at another team's agent, polluting that team's
+// inbound-topology view. The target must be authorized too.
+
+use aa_api::auth::config::AuthMode;
+
+async fn post_edge_auth(app: axum::Router, token: &str, body: Value) -> StatusCode {
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/api/v1/topology/edges")
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+    .status()
+}
+
+#[tokio::test]
+async fn report_edge_rejects_target_in_another_team() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    // Source belongs to the caller's team (alpha); target belongs to beta.
+    state.agent_registry.register(team_agent(0x01, "alpha")).unwrap();
+    state.agent_registry.register(team_agent(0x02, "beta")).unwrap();
+    let app = build_app(state);
+
+    let token = common::generate_test_jwt_for_team("alpha-writer", &[Scope::Read, Scope::Write], "alpha");
+    let status = post_edge_auth(
+        app,
+        &token,
+        json!({
+            "source_agent_id": hex(0x01),
+            "target_agent_id": hex(0x02),
+            "edge_type": "messages",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "an edge whose target is another team's agent must be rejected",
+    );
+}
+
+#[tokio::test]
+async fn report_edge_allows_target_in_callers_own_team() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    // Both source and target belong to the caller's team (alpha).
+    state.agent_registry.register(team_agent(0x01, "alpha")).unwrap();
+    state.agent_registry.register(team_agent(0x02, "alpha")).unwrap();
+    let app = build_app(state);
+
+    let token = common::generate_test_jwt_for_team("alpha-writer", &[Scope::Read, Scope::Write], "alpha");
+    let status = post_edge_auth(
+        app,
+        &token,
+        json!({
+            "source_agent_id": hex(0x01),
+            "target_agent_id": hex(0x02),
+            "edge_type": "messages",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "a same-team target must still be accepted (no regression on the legitimate path)",
+    );
+}
+
+#[tokio::test]
+async fn report_edge_allows_team_less_target() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    // Source in the caller's team; target is unregistered / team-less, which is
+    // not "another team's agent" — SDK emitters legitimately record such edges.
+    state.agent_registry.register(team_agent(0x01, "alpha")).unwrap();
+    let app = build_app(state);
+
+    let token = common::generate_test_jwt_for_team("alpha-writer", &[Scope::Read, Scope::Write], "alpha");
+    let status = post_edge_auth(
+        app,
+        &token,
+        json!({
+            "source_agent_id": hex(0x01),
+            "target_agent_id": hex(0x09),
+            "edge_type": "messages",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CREATED, "a team-less target must stay allowed");
+}

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
+use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Server;
 
 use crate::anomaly::{AnomalyConfig, AnomalyDetector, AnomalyEvent};
@@ -38,6 +39,15 @@ use crate::budget::persistence::{
 };
 use crate::budget::{BudgetAlert, BudgetTracker, BudgetWindow};
 use tokio_util::sync::CancellationToken;
+
+/// Explicit inbound gRPC message-size cap for every gateway service (AAASM-4133).
+///
+/// tonic defaults `max_decoding_message_size` to 4 MiB; pin it explicitly on
+/// each service so the ceiling is intentional and centrally tunable rather than
+/// an implicit library default an agent-supplied payload could quietly rely on.
+/// The value matches the current default, so existing traffic is unaffected —
+/// only the bound is now owned in-tree.
+const MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 
 /// Default audit directory.
 ///
@@ -639,17 +649,33 @@ pub async fn serve_tcp(
     tracing::info!(%addr, "starting gRPC server on TCP (per-RPC credential auth enforced)");
 
     Server::builder()
-        .add_service(PolicyServiceServer::with_interceptor(policy_svc, enrich.clone()))
-        .add_service(AuditServiceServer::with_interceptor(audit_svc, auth.clone()))
-        .add_service(AgentLifecycleServiceServer::with_interceptor(
-            lifecycle_svc,
+        .add_service(InterceptedService::new(
+            PolicyServiceServer::new(policy_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
             enrich.clone(),
         ))
-        .add_service(ApprovalServiceServer::with_interceptor(approval_svc, auth.clone()))
-        .add_service(TopologyServiceServer::with_interceptor(topology_svc, auth.clone()))
-        .add_service(SecretsServiceServer::with_interceptor(secrets_svc, auth.clone()))
-        .add_service(InvalidationServiceServer::with_interceptor(
-            InvalidationServiceImpl::new(Arc::clone(&invalidation_hub)),
+        .add_service(InterceptedService::new(
+            AuditServiceServer::new(audit_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            auth.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            AgentLifecycleServiceServer::new(lifecycle_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            enrich.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            ApprovalServiceServer::new(approval_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            auth.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            TopologyServiceServer::new(topology_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            auth.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            SecretsServiceServer::new(secrets_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            auth.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            InvalidationServiceServer::new(InvalidationServiceImpl::new(Arc::clone(&invalidation_hub)))
+                .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
             auth.clone(),
         ))
         .serve_with_shutdown(addr, async move {
@@ -765,17 +791,33 @@ pub async fn serve_uds(
     let incoming = tokio_stream::wrappers::UnixListenerStream::new(uds);
 
     Server::builder()
-        .add_service(PolicyServiceServer::with_interceptor(policy_svc, enrich.clone()))
-        .add_service(AuditServiceServer::with_interceptor(audit_svc, auth.clone()))
-        .add_service(AgentLifecycleServiceServer::with_interceptor(
-            lifecycle_svc,
+        .add_service(InterceptedService::new(
+            PolicyServiceServer::new(policy_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
             enrich.clone(),
         ))
-        .add_service(ApprovalServiceServer::with_interceptor(approval_svc, auth.clone()))
-        .add_service(TopologyServiceServer::with_interceptor(topology_svc, auth.clone()))
-        .add_service(SecretsServiceServer::with_interceptor(secrets_svc, auth.clone()))
-        .add_service(InvalidationServiceServer::with_interceptor(
-            InvalidationServiceImpl::new(Arc::clone(&invalidation_hub)),
+        .add_service(InterceptedService::new(
+            AuditServiceServer::new(audit_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            auth.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            AgentLifecycleServiceServer::new(lifecycle_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            enrich.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            ApprovalServiceServer::new(approval_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            auth.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            TopologyServiceServer::new(topology_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            auth.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            SecretsServiceServer::new(secrets_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            auth.clone(),
+        ))
+        .add_service(InterceptedService::new(
+            InvalidationServiceServer::new(InvalidationServiceImpl::new(Arc::clone(&invalidation_hub)))
+                .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
             auth.clone(),
         ))
         .serve_with_incoming_shutdown(incoming, async move {

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -317,18 +317,41 @@ impl PolicyServiceImpl {
         self
     }
 
-    /// Look up the per-agent `enforcement_mode` override for the request's agent.
+    /// Resolve the authoritative agent key for agent-scoped controls.
     ///
-    /// Returns `Some(_)` when the request's agent is registered AND its record
-    /// carries an explicit override; `None` in every other case (no registry
-    /// attached, agent unregistered, agent registered with no override). The
-    /// resolver in [`crate::engine::resolve_enforcement_mode`] treats `None` as
-    /// "inherit from policy default", so an unknown / unregistered agent
-    /// transparently falls back to live enforcement.
+    /// AAASM-4133 — `req.agent_id` is client-supplied and forgeable (the
+    /// `PolicyService` runs under the non-rejecting `enrich` interceptor). When
+    /// the credential token resolves to a registered owner, that owner's key is
+    /// the trust anchor, so agent-scoped controls bind to it: a credentialed
+    /// caller can neither dodge its own agent-scoped enforcement override by
+    /// presenting a different `agent_id`, nor trip a budget-suspend against a
+    /// victim's claimed id. Falls back to the client-supplied `agent_id` only
+    /// when no token owner resolves — the unregistered OSS runtime→gateway flow
+    /// that forwards checks without a per-agent token — mirroring
+    /// [`Self::apply_authoritative_tenancy`].
+    fn authoritative_agent_key(&self, req: &CheckActionRequest) -> Option<[u8; 16]> {
+        if let Some(registry) = &self.registry {
+            if !req.credential_token.is_empty() {
+                if let Some(owner_key) = registry.find_by_credential_token(&req.credential_token) {
+                    return Some(owner_key);
+                }
+            }
+        }
+        req.agent_id.as_ref().map(proto_agent_id_to_key)
+    }
+
+    /// Look up the per-agent `enforcement_mode` override for the request's
+    /// authoritative agent (see [`Self::authoritative_agent_key`]).
+    ///
+    /// Returns `Some(_)` when that agent is registered AND its record carries an
+    /// explicit override; `None` in every other case (no registry attached,
+    /// agent unregistered, agent registered with no override). The resolver in
+    /// [`crate::engine::resolve_enforcement_mode`] treats `None` as "inherit
+    /// from policy default", so an unknown / unregistered agent transparently
+    /// falls back to live enforcement.
     fn lookup_agent_enforcement_override(&self, req: &CheckActionRequest) -> Option<aa_core::EnforcementMode> {
         let registry = self.registry.as_ref()?;
-        let proto_agent = req.agent_id.as_ref()?;
-        let agent_key = proto_agent_id_to_key(proto_agent);
+        let agent_key = self.authoritative_agent_key(req)?;
         registry.get(&agent_key)?.enforcement_mode
     }
 
@@ -451,11 +474,13 @@ impl PolicyServiceImpl {
             Some(r) => r,
             None => return,
         };
-        let proto_agent = match req.agent_id.as_ref() {
-            Some(a) => a,
+        // AAASM-4133 — suspend the token-derived owner, never a client-claimed
+        // `agent_id`, so a credentialed caller cannot trip budget-suspend on a
+        // victim's id.
+        let agent_key = match self.authoritative_agent_key(req) {
+            Some(k) => k,
             None => return,
         };
-        let agent_key = proto_agent_id_to_key(proto_agent);
         let reason_text = "budget limit exceeded";
         if let Err(e) = registry
             .suspend_and_notify(&agent_key, SuspendReason::BudgetExceeded, reason_text)
@@ -463,7 +488,7 @@ impl PolicyServiceImpl {
         {
             tracing::warn!(error = %e, "failed to suspend agent on budget exceeded");
         } else {
-            tracing::info!(agent_id = ?proto_agent.agent_id, "agent suspended: {reason_text}");
+            tracing::info!(agent_key = ?agent_key, "agent suspended: {reason_text}");
         }
     }
 

--- a/aa-gateway/tests/agent_id_bound_to_token_test.rs
+++ b/aa-gateway/tests/agent_id_bound_to_token_test.rs
@@ -1,0 +1,202 @@
+//! AAASM-4133 — agent-scoped controls bind to the token-derived owner, not a
+//! client-supplied `agent_id`.
+//!
+//! `req.agent_id` is client-supplied and forgeable (PolicyService runs under
+//! the non-rejecting `enrich` interceptor). A credentialed caller must not be
+//! able to dodge its own agent-scoped enforcement override by presenting a
+//! different agent's id. These tests drive the gRPC `check_action` path and
+//! assert the enforcement mode resolves from the *token owner*, not the claimed
+//! id.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_core::{AuditEntry, GovernanceLevel};
+use aa_gateway::registry::convert::proto_agent_id_to_key;
+use aa_gateway::registry::store::AgentRecord;
+use aa_gateway::registry::{AgentRegistry, AgentStatus};
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{action_context::Action, ActionContext, CheckActionRequest, ToolCallContext};
+use chrono::Utc;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tonic::transport::Server;
+
+const DENY_BASH_POLICY: &str = r#"
+version: "1"
+tools:
+  bash:
+    allow: false
+"#;
+
+async fn start_server(policy_yaml: &str) -> (SocketAddr, Arc<AgentRegistry>) {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", policy_yaml).unwrap();
+    tmp.flush().unwrap();
+
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap());
+    let registry = Arc::new(AgentRegistry::new());
+    let (audit_tx, _audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::with_registry(
+        Arc::clone(&engine),
+        Arc::clone(&registry),
+        audit_tx,
+        audit_drops,
+        [0u8; 32],
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, registry)
+}
+
+/// Register an agent carrying an explicit credential token and enforcement mode.
+fn register(
+    registry: &AgentRegistry,
+    proto_id: &ProtoAgentId,
+    credential_token: &str,
+    mode: Option<aa_core::EnforcementMode>,
+) {
+    let record = AgentRecord {
+        agent_id: proto_agent_id_to_key(proto_id),
+        name: proto_id.agent_id.clone(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "pk".into(),
+        credential_token: credential_token.into(),
+        metadata: BTreeMap::new(),
+        registered_at: Utc::now(),
+        last_heartbeat: Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: vec![],
+        recent_events: VecDeque::new(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+        children: vec![],
+        parent_key: None,
+        enforcement_mode: mode,
+        org_id: None,
+    };
+    registry.register(record).unwrap();
+}
+
+fn bash_request(agent: &ProtoAgentId, credential_token: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(agent.clone()),
+        credential_token: credential_token.into(),
+        trace_id: format!("trace-{credential_token}"),
+        span_id: "span-1".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "bash".into(),
+                tool_source: "test".into(),
+                args_json: b"{}".to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+        caller_agent_id: None,
+    }
+}
+
+fn proto(agent_id: &str) -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: agent_id.into(),
+    }
+}
+
+#[tokio::test]
+async fn spoofed_agent_id_cannot_borrow_another_agents_observe_mode() {
+    // Owner is enforced (no override → live). Decoy is in Observe mode. A caller
+    // authenticated as owner claims the decoy's agent_id to try to inherit the
+    // decoy's monitor-only posture and dodge the deny. The enforcement override
+    // must resolve from the *token owner*, so the deny is still enforced.
+    let (addr, registry) = start_server(DENY_BASH_POLICY).await;
+    let owner = proto("owner-agent");
+    let decoy = proto("decoy-agent");
+    register(&registry, &owner, "token-owner", None);
+    register(
+        &registry,
+        &decoy,
+        "token-decoy",
+        Some(aa_core::EnforcementMode::Observe),
+    );
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let resp = client
+        // owner's token, but decoy's agent_id.
+        .check_action(bash_request(&decoy, "token-owner"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.decision,
+        Decision::Deny as i32,
+        "spoofing the decoy's agent_id must NOT inherit its observe mode — deny must still fire, got {:?}",
+        resp.reason
+    );
+}
+
+#[tokio::test]
+async fn honest_observe_mode_agent_is_still_monitored_not_blocked() {
+    // Control: the decoy, presenting its OWN token, keeps its observe mode and
+    // the deny is rewritten to Allow. This proves the observe posture is real,
+    // so the spoof test above is decisive rather than vacuous.
+    let (addr, registry) = start_server(DENY_BASH_POLICY).await;
+    let decoy = proto("decoy-agent");
+    register(
+        &registry,
+        &decoy,
+        "token-decoy",
+        Some(aa_core::EnforcementMode::Observe),
+    );
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let resp = client
+        .check_action(bash_request(&decoy, "token-decoy"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.decision,
+        Decision::Allow as i32,
+        "an agent presenting its own token keeps its observe mode (deny → allow)",
+    );
+}

--- a/aa-gateway/tests/observe_mode_test.rs
+++ b/aa-gateway/tests/observe_mode_test.rs
@@ -71,10 +71,15 @@ async fn start_server_with_audit_rx(policy_yaml: &str) -> (SocketAddr, Arc<Agent
 }
 
 /// Construct an `AgentRecord` carrying `enforcement_mode` and register it.
+///
+/// AAASM-4133 — agent-scoped controls (enforcement override) now resolve from
+/// the token-derived owner, so each agent must carry its OWN credential token
+/// for per-agent isolation to hold. `credential_token` is therefore explicit.
 fn register_agent_with_mode(
     registry: &AgentRegistry,
     agent_name: &str,
     proto_id: &ProtoAgentId,
+    credential_token: &str,
     mode: Option<aa_core::EnforcementMode>,
 ) {
     let key = proto_agent_id_to_key(proto_id);
@@ -86,7 +91,7 @@ fn register_agent_with_mode(
         risk_tier: 0,
         tool_names: vec![],
         public_key: "pk".into(),
-        credential_token: "tok".into(),
+        credential_token: credential_token.into(),
         metadata: BTreeMap::new(),
         registered_at: Utc::now(),
         last_heartbeat: Utc::now(),
@@ -114,10 +119,10 @@ fn register_agent_with_mode(
     registry.register(record).unwrap();
 }
 
-fn tool_call_request_for(proto_id: &ProtoAgentId, tool_name: &str) -> CheckActionRequest {
+fn tool_call_request_for(proto_id: &ProtoAgentId, credential_token: &str, tool_name: &str) -> CheckActionRequest {
     CheckActionRequest {
         agent_id: Some(proto_id.clone()),
-        credential_token: "tok".into(),
+        credential_token: credential_token.into(),
         trace_id: format!("trace-{tool_name}"),
         span_id: "span-1".into(),
         action_type: ActionType::ToolCall as i32,
@@ -171,12 +176,13 @@ async fn st_sandbox_1_observe_mode_with_deny_rule_returns_allow_and_dry_run_audi
         &registry,
         "observe-agent",
         &proto_id,
+        "tok",
         Some(aa_core::EnforcementMode::Observe),
     );
 
     let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
     let resp = client
-        .check_action(tool_call_request_for(&proto_id, "bash"))
+        .check_action(tool_call_request_for(&proto_id, "tok", "bash"))
         .await
         .unwrap()
         .into_inner();
@@ -224,12 +230,13 @@ tools:
         &registry,
         "observe-clean-agent",
         &proto_id,
+        "tok",
         Some(aa_core::EnforcementMode::Observe),
     );
 
     let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
     let resp = client
-        .check_action(tool_call_request_for(&proto_id, "web_search"))
+        .check_action(tool_call_request_for(&proto_id, "tok", "web_search"))
         .await
         .unwrap()
         .into_inner();
@@ -257,11 +264,11 @@ async fn st_sandbox_3_enforce_mode_with_deny_rule_still_blocks_agent() {
         team_id: "team".into(),
         agent_id: "enforce-agent".into(),
     };
-    register_agent_with_mode(&registry, "enforce-agent", &proto_id, None);
+    register_agent_with_mode(&registry, "enforce-agent", &proto_id, "tok", None);
 
     let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
     let resp = client
-        .check_action(tool_call_request_for(&proto_id, "bash"))
+        .check_action(tool_call_request_for(&proto_id, "tok", "bash"))
         .await
         .unwrap()
         .into_inner();
@@ -304,18 +311,19 @@ async fn st_sandbox_4_per_agent_override_isolates_two_agents_under_one_policy() 
         &registry,
         "experimental-agent",
         &experimental_id,
+        "tok-experimental",
         Some(aa_core::EnforcementMode::Observe),
     );
-    register_agent_with_mode(&registry, "trusted-agent", &trusted_id, None);
+    register_agent_with_mode(&registry, "trusted-agent", &trusted_id, "tok-trusted", None);
 
     let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
     let experimental_resp = client
-        .check_action(tool_call_request_for(&experimental_id, "bash"))
+        .check_action(tool_call_request_for(&experimental_id, "tok-experimental", "bash"))
         .await
         .unwrap()
         .into_inner();
     let trusted_resp = client
-        .check_action(tool_call_request_for(&trusted_id, "bash"))
+        .check_action(tool_call_request_for(&trusted_id, "tok-trusted", "bash"))
         .await
         .unwrap()
         .into_inner();

--- a/aa-integration-tests/tests/observe_mode_e2e.rs
+++ b/aa-integration-tests/tests/observe_mode_e2e.rs
@@ -108,10 +108,15 @@ async fn start_gateway_with_policy_fixture(
 /// Build and register an `AgentRecord` carrying an optional per-agent
 /// `enforcement_mode` override. `None` leaves the agent on the policy
 /// default (which today is hardcoded `Enforce`).
+///
+/// AAASM-4133 — agent-scoped controls (enforcement override) now resolve from
+/// the token-derived owner, so each agent must carry its OWN credential token
+/// for per-agent isolation to hold. `credential_token` is therefore explicit.
 fn register_agent_with_mode(
     registry: &AgentRegistry,
     agent_name: &str,
     proto_id: &ProtoAgentId,
+    credential_token: &str,
     mode: Option<aa_core::EnforcementMode>,
 ) {
     let key = proto_agent_id_to_key(proto_id);
@@ -123,7 +128,7 @@ fn register_agent_with_mode(
         risk_tier: 0,
         tool_names: vec![],
         public_key: "pk".into(),
-        credential_token: "tok".into(),
+        credential_token: credential_token.into(),
         metadata: BTreeMap::new(),
         registered_at: Utc::now(),
         last_heartbeat: Utc::now(),
@@ -152,10 +157,10 @@ fn register_agent_with_mode(
 }
 
 /// Build a `CheckActionRequest` for the given agent invoking `tool_name`.
-fn tool_call_request_for(proto_id: &ProtoAgentId, tool_name: &str) -> CheckActionRequest {
+fn tool_call_request_for(proto_id: &ProtoAgentId, credential_token: &str, tool_name: &str) -> CheckActionRequest {
     CheckActionRequest {
         agent_id: Some(proto_id.clone()),
-        credential_token: "tok".into(),
+        credential_token: credential_token.into(),
         trace_id: format!("trace-{tool_name}"),
         span_id: "span-1".into(),
         action_type: ActionType::ToolCall as i32,
@@ -205,6 +210,7 @@ async fn st_r_1_observe_mode_deny_rule_returns_allow_and_dry_run_audit() {
         &registry,
         "observe-agent",
         &proto_id,
+        "tok",
         Some(aa_core::EnforcementMode::Observe),
     );
 
@@ -212,7 +218,7 @@ async fn st_r_1_observe_mode_deny_rule_returns_allow_and_dry_run_audit() {
         .await
         .expect("connect to PolicyService");
     let resp = client
-        .check_action(tool_call_request_for(&proto_id, "bash"))
+        .check_action(tool_call_request_for(&proto_id, "tok", "bash"))
         .await
         .expect("check_action RPC")
         .into_inner();
@@ -268,6 +274,7 @@ async fn st_r_2_observe_mode_allow_decision_emits_no_shadow_metadata() {
         &registry,
         "observe-clean-agent",
         &proto_id,
+        "tok",
         Some(aa_core::EnforcementMode::Observe),
     );
 
@@ -275,7 +282,7 @@ async fn st_r_2_observe_mode_allow_decision_emits_no_shadow_metadata() {
         .await
         .expect("connect to PolicyService");
     let resp = client
-        .check_action(tool_call_request_for(&proto_id, "read_file"))
+        .check_action(tool_call_request_for(&proto_id, "tok", "read_file"))
         .await
         .expect("check_action RPC")
         .into_inner();
@@ -375,13 +382,13 @@ async fn st_r_4_enforce_mode_deny_still_blocks_and_emits_no_shadow_event() {
         team_id: "team-st-r-4".into(),
         agent_id: "enforce-agent".into(),
     };
-    register_agent_with_mode(&registry, "enforce-agent", &proto_id, None);
+    register_agent_with_mode(&registry, "enforce-agent", &proto_id, "tok", None);
 
     let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
         .await
         .expect("connect to PolicyService");
     let resp = client
-        .check_action(tool_call_request_for(&proto_id, "bash"))
+        .check_action(tool_call_request_for(&proto_id, "tok", "bash"))
         .await
         .expect("check_action RPC")
         .into_inner();
@@ -438,21 +445,22 @@ async fn st_r_5_per_agent_override_isolates_observe_from_enforce_under_one_polic
         &registry,
         "experimental-agent",
         &experimental_id,
+        "tok-experimental",
         Some(aa_core::EnforcementMode::Observe),
     );
-    register_agent_with_mode(&registry, "trusted-agent", &trusted_id, None);
+    register_agent_with_mode(&registry, "trusted-agent", &trusted_id, "tok-trusted", None);
 
     let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
         .await
         .expect("connect to PolicyService");
 
     let experimental_resp = client
-        .check_action(tool_call_request_for(&experimental_id, "bash"))
+        .check_action(tool_call_request_for(&experimental_id, "tok-experimental", "bash"))
         .await
         .expect("check_action RPC (experimental)")
         .into_inner();
     let trusted_resp = client
-        .check_action(tool_call_request_for(&trusted_id, "bash"))
+        .check_action(tool_call_request_for(&trusted_id, "tok-trusted", "bash"))
         .await
         .expect("check_action RPC (trusted)")
         .into_inner();

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -6,10 +6,66 @@
 use std::path::{Path, PathBuf};
 
 use rcgen::PKCS_ECDSA_P256_SHA256;
-use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose};
+use rcgen::{
+    BasicConstraints, CertificateParams, CidrSubnet, DnType, GeneralSubtree, IsCa, Issuer, KeyPair, KeyUsagePurpose,
+    NameConstraints,
+};
 use time::{Duration, OffsetDateTime};
 
 use crate::error::ProxyError;
+
+/// Build the [`CertificateParams`] for the MitM root CA.
+///
+/// AAASM-4133 — the CA is installed as a system trust root with 10-year
+/// validity, so a leak of `~/.aa/ca/ca-key.pem` is high-impact. The proxy only
+/// ever signs leaf certs for *outbound public egress* endpoints, so the CA is
+/// name-constrained to **exclude** the internal / private namespaces it never
+/// legitimately intercepts: loopback, mDNS (`.local`), `.internal`,
+/// `home.arpa`, and the RFC 1918 / loopback / link-local / IPv6 ULA IP ranges.
+/// A leaked key then cannot mint trusted certs impersonating those internal
+/// services. Only excluded subtrees are set (no permitted list), so
+/// interception of arbitrary *public* domains is unchanged.
+fn build_ca_params() -> Result<CertificateParams, ProxyError> {
+    let mut ca_params = CertificateParams::new(vec![]).map_err(|e| ProxyError::CertGen(e.to_string()))?;
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    ca_params
+        .distinguished_name
+        .push(DnType::CommonName, "Agent Assembly CA");
+    ca_params.name_constraints = Some(NameConstraints {
+        permitted_subtrees: vec![],
+        excluded_subtrees: vec![
+            GeneralSubtree::DnsName("localhost".into()),
+            GeneralSubtree::DnsName("local".into()),
+            GeneralSubtree::DnsName("internal".into()),
+            GeneralSubtree::DnsName("home.arpa".into()),
+            GeneralSubtree::IpAddress(CidrSubnet::from_v4_prefix([10, 0, 0, 0], 8)),
+            GeneralSubtree::IpAddress(CidrSubnet::from_v4_prefix([172, 16, 0, 0], 12)),
+            GeneralSubtree::IpAddress(CidrSubnet::from_v4_prefix([192, 168, 0, 0], 16)),
+            GeneralSubtree::IpAddress(CidrSubnet::from_v4_prefix([127, 0, 0, 0], 8)),
+            GeneralSubtree::IpAddress(CidrSubnet::from_v4_prefix([169, 254, 0, 0], 16)),
+            // ::1/128 loopback, fc00::/7 unique-local, fe80::/10 link-local.
+            GeneralSubtree::IpAddress(CidrSubnet::from_v6_prefix(
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+                128,
+            )),
+            GeneralSubtree::IpAddress(CidrSubnet::from_v6_prefix(
+                [0xfc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                7,
+            )),
+            GeneralSubtree::IpAddress(CidrSubnet::from_v6_prefix(
+                [0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                10,
+            )),
+        ],
+    });
+    let now = OffsetDateTime::now_utc();
+    ca_params.not_before = now;
+    ca_params.not_after = now
+        .checked_add(Duration::days(365 * 10))
+        .expect("date arithmetic cannot overflow for 10-year span");
+    Ok(ca_params)
+}
 
 /// A signed TLS certificate and its corresponding private key in DER encoding.
 ///
@@ -65,17 +121,7 @@ impl CaStore {
         // Generate a new EC P-256 CA key pair.
         let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).map_err(|e| ProxyError::CertGen(e.to_string()))?;
 
-        let mut ca_params = CertificateParams::new(vec![]).map_err(|e| ProxyError::CertGen(e.to_string()))?;
-        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
-        ca_params
-            .distinguished_name
-            .push(DnType::CommonName, "Agent Assembly CA");
-        let now = OffsetDateTime::now_utc();
-        ca_params.not_before = now;
-        ca_params.not_after = now
-            .checked_add(Duration::days(365 * 10))
-            .expect("date arithmetic cannot overflow for 10-year span");
+        let ca_params = build_ca_params()?;
 
         let ca_cert = ca_params
             .self_signed(&ca_key)
@@ -177,6 +223,22 @@ impl CaStore {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn ca_cert_carries_name_constraints_extension() {
+        // AAASM-4133: the root CA must be name-constrained. The X.509
+        // NameConstraints extension is OID 2.5.29.30, which DER-encodes to the
+        // byte sequence `06 03 55 1D 1E`; assert it appears in the cert DER.
+        let params = build_ca_params().unwrap();
+        let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        let der = cert.der();
+        let needle = [0x06u8, 0x03, 0x55, 0x1d, 0x1e];
+        assert!(
+            der.as_ref().windows(needle.len()).any(|w| w == needle),
+            "CA cert must carry the X.509 NameConstraints extension (OID 2.5.29.30)"
+        );
+    }
 
     #[tokio::test]
     async fn load_or_create_generates_pem_files() {


### PR DESCRIPTION
## What changed

Defense-in-depth hardening batch for **AAASM-4133** (sweep AAASM-4120). Each finding is LOW severity — none independently exploitable given the token-as-trust-anchor + runtime-as-authoritative model — but each narrows blast radius. Implemented as independent granular commits.

| # | Finding | Fix | Commit |
|---|---------|-----|--------|
| 1 | Client-supplied `agent_id` drove agent-scoped matching + suspend targeting (`policy_service.rs`) | New `authoritative_agent_key()` binds the enforcement-override lookup and budget-suspend target to the credential-token owner, falling back to the client id only for the tokenless unregistered OSS flow | `🔒 Bind agent-scoped controls to token-derived id` + `✅` test |
| 2 | MitM root CA `BasicConstraints::Unconstrained`, 10-yr system trust root (`aa-proxy/tls/ca.rs`) | Extracted `build_ca_params()` and added X.509 `NameConstraints` **excluding** the internal/private namespaces the egress proxy never intercepts (loopback, `.local`, `.internal`, `home.arpa`, RFC 1918 / loopback / link-local / IPv6 ULA). Excluded-only ⇒ interception of arbitrary public domains is unchanged | `🔒 Constrain MitM root CA with X.509 NameConstraints` (+ unit test) |
| 3 | Multi-tenant guard defaults to `TenancyMode::Untenanted` | **No code change — already addressed at HEAD.** AAASM-4032 already made this explicit config via `AA_GATEWAY_TENANCY_MODE` with a documented default. See "Deferred" below | — |
| 4 | `report_edge` authorized source but not target (`aa-api/edges.rs`) | Added `authorize_edge_target()`: rejects an edge whose target is another team's agent (admin bypass; team-less target stays allowed as it is not "another team's agent") | `🔒 Authorize edge target team in report_edge` + `✅` test |
| 5 | No explicit gRPC `max_decoding_message_size` (relied on tonic 4 MiB default) | Pinned the ceiling explicitly on every gRPC service in both serve paths (TCP + UDS) via a shared `MAX_DECODING_MESSAGE_SIZE` const; value matches the current default so traffic is unaffected | `🔒 Set explicit gRPC max_decoding_message_size` |

## Why

Hardening sweep — bound the blast radius of a leaked credential/CA key and close permissive fallbacks, without changing any legitimate flow.

## Item #3 — deferred (safe minimal)

Finding #3 offered two options: flip the fail-safe default to `tenanted`, **or** make it explicit config with a clear default. The latter is **already done at HEAD** (AAASM-4032: `AA_GATEWAY_TENANCY_MODE`, `TenancyMode::from_env`). Flipping the *global* default to `tenanted` is **not** minimal here: the `lifecycle_service` registration guard rejects team-less agents in `Tenanted` mode, so a default flip would break zero-config OSS agent registration. Per the ticket's own guidance (implement the safe minimal version, note the follow-up), #3 is left as explicit-config; a deployment-posture default flip is an ops/design decision tracked separately.

## How to verify

- `cargo nextest run -p aa-gateway -p aa-api` — 2216 passed
- `cargo nextest run -p aa-proxy` — 201 passed (incl. new `ca_cert_carries_name_constraints_extension`)
- `cargo fmt --all -- --check`, `cargo clippy -p aa-gateway -p aa-api -p aa-proxy --all-targets -- -D warnings` — clean
- New tests: `agent_id_bound_to_token_test` (spoof cannot dodge enforcement override), `report_edge_rejects_target_in_another_team` (+ same-team / team-less positives), CA name-constraints extension present.

## Notes

- Sibling **AAASM-4125** also edits `policy_service.rs` but in the LLM-metering region (~line 1257); this PR edits the agent_id region (~328/454) + other files. Whichever of the two merges second may need a trivial rebase.
- `observe_mode_test::st_sandbox_4` shared one credential token across two agents — unrealistic under 1:1 token→owner binding; each agent now carries its own token. Assertions unchanged.

Closes AAASM-4133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
