### PR TITLE
[AAASM-4125] 🐛 (budget): Meter LLM calls even when client declares prompt_tokens=0

### DIFF
--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1219,6 +1219,20 @@ impl PolicyServiceImpl {
         }
     }
 
+    /// AAASM-4125 — conservative server-side floor for a *client-declared* prompt
+    /// token count that is non-positive (`0`, negative, or an omitted proto field
+    /// which deserializes to `0`). A real LLM call always consumes some prompt
+    /// tokens; a declared `0` is therefore either an omission or a deliberate
+    /// under-report and must NOT be trusted as a genuinely empty call. Pricing it
+    /// at `$0` trips the `cost <= 0.0` accrual short-circuit and skips the budget
+    /// reservation entirely, giving an agent that always sends `prompt_tokens: 0`
+    /// unmetered LLM spend indefinitely. Flooring to a minimum estimate keeps the
+    /// call priced non-zero so the daily / monthly cap engages (fail-closed,
+    /// mirroring the unknown-model handling in AAASM-4069). Legitimate calls that
+    /// report a real positive count are priced on that count and are unaffected,
+    /// so no legitimate call is double-charged.
+    const MIN_ESTIMATED_PROMPT_TOKENS: u64 = 1_000;
+
     /// AAASM-3353 / AAASM-3986 — atomically reserve the cost of a non-denied LLM
     /// call against the agent's budget so daily / monthly limits actually fire,
     /// with no check→record TOCTOU.
@@ -1238,10 +1252,14 @@ impl PolicyServiceImpl {
     /// response is returned unchanged when:
     /// * the action is not an `LLM_CALL`;
     /// * the decision was already a hard `Deny` (a denied call did not run);
-    /// * the priced cost is `0.0` — a genuinely empty call (0 tokens). An
-    ///   unrecognised model name is NO LONGER treated as zero cost (AAASM-4069):
-    ///   it fails closed at the conservative fallback rate so the budget cap
-    ///   still engages instead of being bypassed.
+    /// * the priced cost is `0.0`. Two client-controlled inputs that used to
+    ///   force a `0.0` price — and so bypass metering — now fail closed instead:
+    ///   an unrecognised model name is priced at the conservative fallback rate
+    ///   (AAASM-4069), and a client-declared prompt-token count of `0` (or a
+    ///   negative / omitted value, which the proto deserializes to `0`) is
+    ///   floored to [`Self::MIN_ESTIMATED_PROMPT_TOKENS`] rather than trusted as
+    ///   a genuinely empty call (AAASM-4125). A `0.0` price is therefore only
+    ///   reached for a truly unpriceable call, not a client-declared empty one.
     fn maybe_accrue_llm_spend(&self, req: &CheckActionRequest, response: CheckActionResponse) -> CheckActionResponse {
         use aa_proto::assembly::policy::v1::action_context::Action;
 
@@ -1254,7 +1272,14 @@ impl PolicyServiceImpl {
             return response;
         };
 
-        let input_tokens = lc.prompt_tokens.max(0) as u64;
+        // AAASM-4125 — `prompt_tokens` is client-supplied (see `convert.rs`). A
+        // non-positive declared count must not price to `$0` and bypass metering,
+        // so floor it to a conservative server-side minimum; a real positive count
+        // is used as-is.
+        let input_tokens = match u64::try_from(lc.prompt_tokens) {
+            Ok(t) if t > 0 => t,
+            _ => Self::MIN_ESTIMATED_PROMPT_TOKENS,
+        };
         // The pre-execution check has no completion yet, so output tokens are 0.
         let cost = self.engine.llm_call_cost_usd(&lc.model, input_tokens, 0);
         if cost <= 0.0 {

--- a/aa-gateway/tests/budget_accrual_test.rs
+++ b/aa-gateway/tests/budget_accrual_test.rs
@@ -29,9 +29,23 @@ budget:
   action_on_exceed: deny
 "#;
 
+/// A daily limit small enough that the server-side prompt-token floor priced for
+/// a *single* `prompt_tokens: 0` call (AAASM-4125) already exceeds it on the next
+/// check — proving the floored call accrued spend rather than pricing to $0.
+const TINY_BUDGET_YAML: &str = r#"
+version: "1"
+budget:
+  daily_limit_usd: 0.001
+  action_on_exceed: deny
+"#;
+
 fn make_service(audit_tx: mpsc::Sender<AuditEntry>) -> PolicyServiceImpl {
+    make_service_with_budget(BUDGET_YAML, audit_tx)
+}
+
+fn make_service_with_budget(budget_yaml: &str, audit_tx: mpsc::Sender<AuditEntry>) -> PolicyServiceImpl {
     let mut tmp = tempfile::NamedTempFile::new().unwrap();
-    write!(tmp, "{}", BUDGET_YAML).unwrap();
+    write!(tmp, "{}", budget_yaml).unwrap();
     tmp.flush().unwrap();
     let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
     let engine = PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap();
@@ -90,6 +104,52 @@ async fn llm_spend_accrues_and_later_call_is_denied_once_limit_exceeded() {
         second.decision,
         Decision::Deny as i32,
         "second call must be denied once accrued spend exceeds the daily limit"
+    );
+    assert!(
+        second.reason.contains("budget"),
+        "deny reason must reference the budget, got: {}",
+        second.reason
+    );
+}
+
+#[tokio::test]
+async fn zero_prompt_tokens_still_accrues_spend_and_engages_cap() {
+    // AAASM-4125 fail-closed: `prompt_tokens` is client-supplied. A declared `0`
+    // (or a negative / omitted value) used to price the pre-execution call to
+    // $0.00, tripping the `cost <= 0.0` accrual short-circuit so NO spend accrued
+    // — an agent that always sent `prompt_tokens: 0` had unmetered LLM spend
+    // indefinitely, even for a known priced model. A non-positive count must now
+    // be floored to a conservative server-side minimum so the call still accrues
+    // and the daily/monthly cap engages.
+    let (audit_tx, _audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let service = make_service_with_budget(TINY_BUDGET_YAML, audit_tx);
+
+    // First call: spend is $0 at evaluation, so it is allowed. Despite the
+    // client declaring `prompt_tokens: 0` for a known priced model (gpt-4o), it
+    // must accrue the floored cost against the tiny daily budget.
+    let first = service
+        .check_action(Request::new(llm_call_request("gpt-4o", 0)))
+        .await
+        .expect("first check_action ok")
+        .into_inner();
+    assert_eq!(
+        first.decision,
+        Decision::Allow as i32,
+        "first zero-token call must be allowed (no spend recorded yet)"
+    );
+
+    // Second call: the floored spend from the first call now exceeds the tiny
+    // daily limit, so Stage 7 denies it. Before the fix this stayed allowed
+    // forever because a client-declared 0 priced to $0 and never accrued.
+    let second = service
+        .check_action(Request::new(llm_call_request("gpt-4o", 0)))
+        .await
+        .expect("second check_action ok")
+        .into_inner();
+    assert_eq!(
+        second.decision,
+        Decision::Deny as i32,
+        "zero-token spend must accrue and eventually hit the daily cap"
     );
     assert!(
         second.reason.contains("budget"),


### PR DESCRIPTION
## Description

The pre-execution LLM budget accrual in the gateway (`maybe_accrue_llm_spend`) priced a call from the **client-supplied** `prompt_tokens` count. A declared `0` (or a negative / omitted value, which the proto deserializes to `0`) made `llm_call_cost_usd` return `$0.00`, which tripped the `cost <= 0.0` early-return so `check_and_accrue_llm_spend` was never called. An agent that always sent `LlmCall{ prompt_tokens: 0 }` therefore incurred **unmetered LLM spend indefinitely**, even for a known priced model — the daily/monthly cap never engaged.

This floors a non-positive client-declared prompt-token count to a conservative server-side minimum (`MIN_ESTIMATED_PROMPT_TOKENS = 1_000`) before pricing, so the call always prices non-zero and the budget reservation runs. Same fail-closed posture as the AAASM-4069 unknown-*model* fix (which the AAASM-4120 sweep flagged as distinct from this token-count trust gap). Legitimate calls that report a real positive count are priced on that count and are unaffected, so no legitimate call is double-charged.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Behaviour change is confined to calls that declared a non-positive prompt-token count — those previously bypassed metering entirely and now accrue a conservative floored cost.

## Related Issues

- Related Jira ticket: AAASM-4125
- Related GitHub issues: N/A

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Added `zero_prompt_tokens_still_accrues_spend_and_engages_cap` in `aa-gateway/tests/budget_accrual_test.rs`: two `check_action` calls for a known priced model (gpt-4o) with `prompt_tokens: 0` against a tiny daily budget — the first accrues the floored cost, the second is denied once accrued spend exceeds the cap. Fails against the pre-fix code (both calls stayed allowed).

Validation (local, aa-gateway scoped):
- `cargo nextest run -p aa-gateway` — green
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p aa-gateway --all-targets -- -D warnings` — clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

---

Note: sibling ticket AAASM-4133 also edits `aa-gateway/src/service/policy_service.rs` but in a different region (client `agent_id`, ~lines 328/454); this change is confined to the LLM-metering region (~line 1257). Whichever of the two PRs merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
