### PR TITLE
[AAASM-4140] 🔒 (gateway): Fail-safe tenancy fallback for team-less caller on tenanted resource

### DIFF
--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -590,11 +590,13 @@ pub async fn serve_tcp(
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry))
         .with_initial_seq(initial_seq);
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
-    // AAASM-4032: resolve the deployment tenancy posture once at boot and thread
-    // it through the tenancy-aware services. Default is Untenanted so OSS/single-
-    // tenant behaviour (and existing tests) are unchanged.
+    // AAASM-4032: resolve the deployment tenancy posture once at boot. It now
+    // gates only team-less agent *registration* (see `AgentLifecycleServiceImpl`);
+    // cross-tenant access is fail-safe unconditionally (AAASM-4140). Default is
+    // Untenanted so OSS/single-tenant registration (and existing tests) are
+    // unchanged.
     let tenancy_mode = TenancyMode::from_env();
-    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo).with_tenancy_mode(tenancy_mode);
+    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo);
     // AAASM-3788 — build the agent-plane auth interceptors from the shared
     // registry before it is moved into the lifecycle service. `auth` is
     // fail-closed (applied to the previously-unauthenticated services); `enrich`
@@ -622,9 +624,8 @@ pub async fn serve_tcp(
             .with_tenancy_mode(tenancy_mode),
         None => AgentLifecycleServiceImpl::new(registry).with_tenancy_mode(tenancy_mode),
     };
-    let approval_svc = ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler)
-        .with_db_scheduler(db_scheduler)
-        .with_tenancy_mode(tenancy_mode);
+    let approval_svc =
+        ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler).with_db_scheduler(db_scheduler);
     let secrets_svc = SecretsServiceImpl::new(Arc::new(InMemorySecretsStore::new()));
 
     let addr = listen_addr.parse()?;
@@ -747,11 +748,13 @@ pub async fn serve_uds(
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry))
         .with_initial_seq(initial_seq);
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
-    // AAASM-4032: resolve the deployment tenancy posture once at boot and thread
-    // it through the tenancy-aware services. Default is Untenanted so OSS/single-
-    // tenant behaviour (and existing tests) are unchanged.
+    // AAASM-4032: resolve the deployment tenancy posture once at boot. It now
+    // gates only team-less agent *registration* (see `AgentLifecycleServiceImpl`);
+    // cross-tenant access is fail-safe unconditionally (AAASM-4140). Default is
+    // Untenanted so OSS/single-tenant registration (and existing tests) are
+    // unchanged.
     let tenancy_mode = TenancyMode::from_env();
-    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo).with_tenancy_mode(tenancy_mode);
+    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo);
     // AAASM-3788 — agent-plane auth interceptors (see serve_tcp for the
     // fail-closed vs enrich rationale). UDS is additionally protected by
     // filesystem permissions; the credential interceptor is enforced regardless.
@@ -776,9 +779,8 @@ pub async fn serve_uds(
             .with_tenancy_mode(tenancy_mode),
         None => AgentLifecycleServiceImpl::new(registry).with_tenancy_mode(tenancy_mode),
     };
-    let approval_svc = ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler)
-        .with_db_scheduler(db_scheduler)
-        .with_tenancy_mode(tenancy_mode);
+    let approval_svc =
+        ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler).with_db_scheduler(db_scheduler);
     let secrets_svc = SecretsServiceImpl::new(Arc::new(InMemorySecretsStore::new()));
 
     tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS (per-RPC credential auth enforced)");

--- a/aa-gateway/src/service/approval_service.rs
+++ b/aa-gateway/src/service/approval_service.rs
@@ -16,30 +16,27 @@ use crate::approval::db_escalation_scheduler::DbEscalationScheduler;
 use crate::approval::escalation::EscalationScheduler;
 use crate::iam::VerifiedCaller;
 use crate::service::convert;
-use crate::service::TenancyMode;
 
-/// Tenant-authorization rule for an approval action (AAASM-3788, AAASM-4021).
+/// Tenant-authorization rule for an approval action (AAASM-3788, AAASM-4021,
+/// AAASM-4140).
 ///
 /// A credentialed caller may act on an approval only when the caller and the
-/// approval are not in *different* tenants. When both the caller and the
-/// approval carry a `team_id`, they must match. If either side is untenanted
-/// the action is allowed — the untenanted/single-tenant deployment fallback,
-/// mirroring the policy-service tenancy residual under AAASM-3416.
+/// approval are not in *different* tenants. When both carry a `team_id`, they
+/// must match. An untenanted approval (no `team_id`) stays shared/global — the
+/// single-tenant / OSS fallback, so zero-config deployments are unaffected.
 ///
-/// AAASM-4021: that fallback is safe in an [`Untenanted`](TenancyMode::Untenanted)
-/// deployment, but in a [`Tenanted`](TenancyMode::Tenanted) one it would let a
-/// registered but *team-less* caller act on any tenant's approval. So when
-/// tenancy is enforced, a team-less caller acting on a *tenanted* approval is
-/// denied; the permissive fallback is preserved for every untenanted case
-/// (untenanted resource, or untenanted deployment). The interceptor has already
-/// guaranteed the caller is authenticated.
-fn caller_may_act_on(caller: &VerifiedCaller, approval_team: Option<&str>, mode: TenancyMode) -> bool {
+/// AAASM-4140 — the fallback is fail-safe: a *team-less* caller acting on a
+/// *tenanted* approval is **always denied**, in every deployment posture. The
+/// permissive path survives only where the approval itself is untenanted; it no
+/// longer leaks a tenanted approval to an unconfined team-less caller (the
+/// AAASM-4133 item-5 residual). The interceptor has already guaranteed the
+/// caller is authenticated.
+fn caller_may_act_on(caller: &VerifiedCaller, approval_team: Option<&str>) -> bool {
     match (caller.team_id.as_deref(), approval_team) {
         (Some(caller_team), Some(approval_team)) => caller_team == approval_team,
-        // Team-less caller vs a tenanted approval: permissive only when tenancy
-        // is not being enforced (AAASM-4021).
-        (None, Some(_)) => mode == TenancyMode::Untenanted,
-        // Untenanted approval (shared/global) — unchanged fallback.
+        // Team-less caller vs a tenanted approval: fail safe — deny (AAASM-4140).
+        (None, Some(_)) => false,
+        // Untenanted approval (shared/global) — unchanged permissive fallback.
         _ => true,
     }
 }
@@ -49,10 +46,6 @@ pub struct ApprovalServiceImpl {
     queue: Arc<ApprovalQueue>,
     escalation_scheduler: Option<Arc<EscalationScheduler>>,
     db_escalation_scheduler: Option<Arc<DbEscalationScheduler>>,
-    /// Deployment tenancy posture for the cross-tenant guard (AAASM-4021).
-    /// Defaults to [`TenancyMode::Untenanted`] so OSS/single-tenant deployments
-    /// keep the permissive fallback.
-    tenancy_mode: TenancyMode,
 }
 
 impl ApprovalServiceImpl {
@@ -62,7 +55,6 @@ impl ApprovalServiceImpl {
             queue,
             escalation_scheduler: None,
             db_escalation_scheduler: None,
-            tenancy_mode: TenancyMode::default(),
         }
     }
 
@@ -77,7 +69,6 @@ impl ApprovalServiceImpl {
             queue,
             escalation_scheduler,
             db_escalation_scheduler: None,
-            tenancy_mode: TenancyMode::default(),
         }
     }
 
@@ -86,15 +77,6 @@ impl ApprovalServiceImpl {
     /// When present, `decide()` also cancels the DB-backed escalation row.
     pub fn with_db_scheduler(mut self, scheduler: Option<Arc<DbEscalationScheduler>>) -> Self {
         self.db_escalation_scheduler = scheduler;
-        self
-    }
-
-    /// Set the deployment tenancy posture (AAASM-4021).
-    ///
-    /// In [`TenancyMode::Tenanted`] a team-less caller can no longer act on a
-    /// tenanted approval via the untenanted fallback.
-    pub fn with_tenancy_mode(mut self, mode: TenancyMode) -> Self {
-        self.tenancy_mode = mode;
         self
     }
 
@@ -107,7 +89,7 @@ impl ApprovalServiceImpl {
     fn enforce_decide_tenancy(&self, caller: &VerifiedCaller, request_id: &str) -> Result<(), Status> {
         if let Ok(id) = request_id.parse::<ApprovalRequestId>() {
             if let Some(ApprovalLookup::Pending(pending)) = self.queue.get_by_id(id) {
-                if !caller_may_act_on(caller, pending.team_id.as_deref(), self.tenancy_mode) {
+                if !caller_may_act_on(caller, pending.team_id.as_deref()) {
                     return Err(Status::permission_denied("approval belongs to a different tenant"));
                 }
             }
@@ -156,7 +138,7 @@ impl ApprovalService for ApprovalServiceImpl {
         let requests = pending
             .iter()
             .filter(|p| match &caller {
-                Some(c) => caller_may_act_on(c, p.team_id.as_deref(), self.tenancy_mode),
+                Some(c) => caller_may_act_on(c, p.team_id.as_deref()),
                 None => true,
             })
             .map(convert::pending_to_proto)
@@ -366,13 +348,14 @@ mod tests {
         assert!(resp.success);
     }
 
+    // AAASM-4140 — zero-config preserved: a team-less caller may still act on an
+    // *untenanted* approval (single-tenant deployment fallback).
     #[tokio::test]
-    async fn decide_untenanted_caller_allowed_cross_team() {
-        // Untenanted caller falls back to allow (single-tenant deployment).
+    async fn decide_teamless_caller_allowed_on_untenanted_approval() {
         let queue = Arc::new(ApprovalQueue::new());
         let service = ApprovalServiceImpl::new(Arc::clone(&queue));
         let id = Uuid::new_v4();
-        queue.submit(make_approval_request_with_team(id, Some("team-b")));
+        queue.submit(make_approval_request_with_team(id, None));
 
         let mut req = tonic::Request::new(DecideRequest {
             request_id: id.to_string(),
@@ -386,12 +369,12 @@ mod tests {
         assert!(resp.success);
     }
 
-    // AAASM-4021 — the untenanted fallback must not let a registered but
-    // team-less caller act on a tenanted approval once tenancy is enforced.
+    // AAASM-4140 — fail-safe fallback: a registered but team-less caller may not
+    // act on a tenanted approval, in the default (Untenanted) posture too.
     #[tokio::test]
-    async fn decide_tenanted_mode_teamless_caller_denied_on_tenanted_approval() {
+    async fn decide_teamless_caller_denied_on_tenanted_approval() {
         let queue = Arc::new(ApprovalQueue::new());
-        let service = ApprovalServiceImpl::new(Arc::clone(&queue)).with_tenancy_mode(TenancyMode::Tenanted);
+        let service = ApprovalServiceImpl::new(Arc::clone(&queue));
         let id = Uuid::new_v4();
         queue.submit(make_approval_request_with_team(id, Some("team-b")));
 
@@ -408,36 +391,15 @@ mod tests {
     }
 
     #[test]
-    fn caller_may_act_on_tenancy_matrix() {
-        // Same-tenant match / mismatch is mode-independent.
-        assert!(caller_may_act_on(
-            &verified_caller(Some("t")),
-            Some("t"),
-            TenancyMode::Tenanted
-        ));
-        assert!(!caller_may_act_on(
-            &verified_caller(Some("t")),
-            Some("u"),
-            TenancyMode::Untenanted
-        ));
-        // Team-less caller vs tenanted approval: permissive only when untenanted.
-        assert!(caller_may_act_on(
-            &verified_caller(None),
-            Some("t"),
-            TenancyMode::Untenanted
-        ));
-        assert!(!caller_may_act_on(
-            &verified_caller(None),
-            Some("t"),
-            TenancyMode::Tenanted
-        ));
-        // Untenanted approval stays permissive in either mode.
-        assert!(caller_may_act_on(
-            &verified_caller(Some("t")),
-            None,
-            TenancyMode::Tenanted
-        ));
-        assert!(caller_may_act_on(&verified_caller(None), None, TenancyMode::Tenanted));
+    fn caller_may_act_on_matrix() {
+        // Same-tenant match / cross-tenant mismatch.
+        assert!(caller_may_act_on(&verified_caller(Some("t")), Some("t")));
+        assert!(!caller_may_act_on(&verified_caller(Some("t")), Some("u")));
+        // Team-less caller vs a tenanted approval: fail safe — denied (AAASM-4140).
+        assert!(!caller_may_act_on(&verified_caller(None), Some("t")));
+        // Untenanted approval stays permissive for any caller.
+        assert!(caller_may_act_on(&verified_caller(Some("t")), None));
+        assert!(caller_may_act_on(&verified_caller(None), None));
     }
 
     #[tokio::test]

--- a/aa-gateway/src/service/mod.rs
+++ b/aa-gateway/src/service/mod.rs
@@ -1,27 +1,27 @@
 //! gRPC service layer — wires tonic-generated services to business logic.
 
-/// Deployment tenancy posture governing the cross-tenant `caller_may_*` checks
-/// (AAASM-4021).
+/// Deployment tenancy posture governing team-less agent **registration**
+/// (AAASM-4021, AAASM-4032).
 ///
-/// The cross-tenant guards fall back to *allow* whenever either the caller or
-/// the resource is untenanted, so a single-tenant / OSS deployment (where
-/// nothing carries a `team_id`) works with zero configuration. That same
-/// fallback, however, lets a **registered but team-less caller** pass every
-/// tenant's check — reading or acting on another tenant's resource — once
-/// tenancy is actually in use. This posture makes the distinction explicit:
+/// Cross-tenant *access* is always fail-safe: since AAASM-4140 a team-less
+/// caller can never act on or read a resource owned by a tenant, in any posture
+/// (see `approval_service::caller_may_act_on` and
+/// `topology_service::caller_may_read`). An untenanted resource stays accessible
+/// with zero configuration. This posture therefore governs only whether a
+/// *team-less registration* is admitted:
 ///
-/// * [`Untenanted`](TenancyMode::Untenanted) — the legacy permissive fallback;
-///   a team-less caller is unconfined. This is the default so OSS/single-tenant
-///   deployments are unaffected.
-/// * [`Tenanted`](TenancyMode::Tenanted) — tenancy is enforced; a team-less
-///   caller may **not** be treated as cross-tenant-allowed against a tenanted
-///   resource.
+/// * [`Untenanted`](TenancyMode::Untenanted) — team-less registration is
+///   allowed. This is the default so OSS/single-tenant deployments register with
+///   zero configuration.
+/// * [`Tenanted`](TenancyMode::Tenanted) — every agent must belong to a team;
+///   a team-less registration is rejected up front (AAASM-4032).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TenancyMode {
-    /// Single-tenant / OSS: a team-less caller is unconfined (legacy fallback).
+    /// Single-tenant / OSS: team-less registration is admitted.
     #[default]
     Untenanted,
-    /// Multi-tenant: a team-less caller cannot act on a tenanted resource.
+    /// Multi-tenant: every agent must belong to a team; team-less registration
+    /// is rejected.
     Tenanted,
 }
 

--- a/aa-gateway/src/service/topology_service.rs
+++ b/aa-gateway/src/service/topology_service.rs
@@ -15,34 +15,16 @@ use aa_proto::assembly::topology::v1::{
 use crate::edges::InMemoryEdgeRepo;
 use crate::iam::VerifiedCaller;
 use crate::registry::{AgentRecord, AgentRegistry, AgentStatus};
-use crate::service::TenancyMode;
 
 /// gRPC service implementation for topology queries.
 pub struct TopologyServiceImpl {
     registry: Arc<AgentRegistry>,
     edge_repo: InMemoryEdgeRepo,
-    /// Deployment tenancy posture for the cross-tenant guard (AAASM-4021).
-    /// Defaults to [`TenancyMode::Untenanted`] so OSS/single-tenant deployments
-    /// keep the permissive fallback.
-    tenancy_mode: TenancyMode,
 }
 
 impl TopologyServiceImpl {
     pub fn new(registry: Arc<AgentRegistry>, edge_repo: InMemoryEdgeRepo) -> Self {
-        Self {
-            registry,
-            edge_repo,
-            tenancy_mode: TenancyMode::default(),
-        }
-    }
-
-    /// Set the deployment tenancy posture (AAASM-4021).
-    ///
-    /// In [`TenancyMode::Tenanted`] a team-less caller can no longer read or
-    /// enumerate a tenanted resource via the untenanted fallback.
-    pub fn with_tenancy_mode(mut self, mode: TenancyMode) -> Self {
-        self.tenancy_mode = mode;
-        self
+        Self { registry, edge_repo }
     }
 }
 
@@ -71,24 +53,22 @@ fn format_id(id: &[u8; 16]) -> String {
 /// untenanted access is allowed (the untenanted/single-tenant deployment
 /// fallback).
 ///
-/// AAASM-4021: in [`TenancyMode::Tenanted`] the fallback is tightened so a
-/// registered but team-less (resp. org-less) caller can no longer read a
-/// *tenanted* resource — that permissive path is kept only for the untenanted
-/// posture. Untenanted resources stay readable in either mode.
-fn caller_may_read(
-    caller: &VerifiedCaller,
-    resource_team: Option<&str>,
-    resource_org: Option<&str>,
-    mode: TenancyMode,
-) -> bool {
+/// AAASM-4140: the fallback is fail-safe — a registered but team-less (resp.
+/// org-less) caller can never read a *tenanted* resource, in any deployment
+/// posture. The permissive path survives only where the resource itself is
+/// untenanted; untenanted resources stay readable and same-tenant access is
+/// unchanged (the AAASM-4133 item-5 residual).
+fn caller_may_read(caller: &VerifiedCaller, resource_team: Option<&str>, resource_org: Option<&str>) -> bool {
     let team_ok = match (caller.team_id.as_deref(), resource_team) {
         (Some(caller_team), Some(resource_team)) => caller_team == resource_team,
-        (None, Some(_)) => mode == TenancyMode::Untenanted,
+        // Team-less caller vs a tenanted resource: fail safe — deny (AAASM-4140).
+        (None, Some(_)) => false,
         _ => true,
     };
     let org_ok = match (caller.org_id.as_deref(), resource_org) {
         (Some(caller_org), Some(resource_org)) => caller_org == resource_org,
-        (None, Some(_)) => mode == TenancyMode::Untenanted,
+        // Org-less caller vs a tenanted resource: fail safe — deny (AAASM-4140).
+        (None, Some(_)) => false,
         _ => true,
     };
     team_ok && org_ok
@@ -159,12 +139,7 @@ impl TopologyService for TopologyServiceImpl {
         // AAASM-3846 — confine a tenanted caller to its own team/org so one team
         // cannot read another team's delegation tree.
         if let Some(caller) = &caller {
-            if !caller_may_read(
-                caller,
-                record.team_id.as_deref(),
-                record.org_id.as_deref(),
-                self.tenancy_mode,
-            ) {
+            if !caller_may_read(caller, record.team_id.as_deref(), record.org_id.as_deref()) {
                 return Err(Status::permission_denied("agent belongs to a different tenant"));
             }
         }
@@ -197,12 +172,7 @@ impl TopologyService for TopologyServiceImpl {
         // AAASM-3846 — a tenanted caller may only trace lineage for an agent in
         // its own team/org.
         if let Some(caller) = &caller {
-            if !caller_may_read(
-                caller,
-                record.team_id.as_deref(),
-                record.org_id.as_deref(),
-                self.tenancy_mode,
-            ) {
+            if !caller_may_read(caller, record.team_id.as_deref(), record.org_id.as_deref()) {
                 return Err(Status::permission_denied("agent belongs to a different tenant"));
             }
         }
@@ -237,10 +207,9 @@ impl TopologyService for TopologyServiceImpl {
                 Some(caller_team) if caller_team != req.team_id => {
                     return Err(Status::permission_denied("team belongs to a different tenant"));
                 }
-                // AAASM-4021: a team-less caller may enumerate an arbitrary
-                // team's roster only in the untenanted posture; when tenancy is
-                // enforced it is confined out of another team's roster.
-                None if self.tenancy_mode == TenancyMode::Tenanted => {
+                // AAASM-4140: fail safe — a team-less caller may not enumerate a
+                // team's roster (a tenanted resource); deny in every posture.
+                None => {
                     return Err(Status::permission_denied("team belongs to a different tenant"));
                 }
                 _ => {}
@@ -307,7 +276,6 @@ impl TopologyService for TopologyServiceImpl {
             &caller,
             source_record.team_id.as_deref(),
             source_record.org_id.as_deref(),
-            self.tenancy_mode,
         ) {
             return Err(Status::permission_denied("source agent belongs to a different tenant"));
         }
@@ -319,7 +287,6 @@ impl TopologyService for TopologyServiceImpl {
             &caller,
             target_record.team_id.as_deref(),
             target_record.org_id.as_deref(),
-            self.tenancy_mode,
         ) {
             return Err(Status::permission_denied("target agent belongs to a different tenant"));
         }
@@ -466,11 +433,12 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
     }
 
+    // AAASM-4140 — zero-config preserved: a team-less caller may still read an
+    // *untenanted* agent (single-tenant deployment fallback).
     #[tokio::test]
-    async fn untenanted_caller_is_allowed_cross_team() {
-        // Single-tenant deployment fallback: an untenanted caller is not confined.
+    async fn teamless_caller_allowed_reading_untenanted_agent() {
         let root: [u8; 16] = [0xd0; 16];
-        let svc = service_with(vec![make_record(root, "root", None, Some("team-b"), Some("org-b"))]);
+        let svc = service_with(vec![make_record(root, "root", None, None, None)]);
 
         let mut req = Request::new(GetAgentTreeRequest {
             agent_id: format_id(&root),
@@ -482,16 +450,12 @@ mod tests {
         assert_eq!(resp.root.unwrap().agent.unwrap().id, format_id(&root));
     }
 
-    fn service_tenanted(records: Vec<AgentRecord>) -> TopologyServiceImpl {
-        service_with(records).with_tenancy_mode(TenancyMode::Tenanted)
-    }
-
-    // AAASM-4021 — the untenanted fallback must not let a registered but
-    // team-less caller read a tenanted agent once tenancy is enforced.
+    // AAASM-4140 — fail-safe fallback: a registered but team-less caller may not
+    // read a tenanted agent, in the default (Untenanted) posture too.
     #[tokio::test]
-    async fn tenanted_mode_teamless_caller_denied_reading_tenanted_agent() {
+    async fn teamless_caller_denied_reading_tenanted_agent() {
         let root: [u8; 16] = [0xf0; 16];
-        let svc = service_tenanted(vec![make_record(root, "root", None, Some("team-b"), Some("org-b"))]);
+        let svc = service_with(vec![make_record(root, "root", None, Some("team-b"), Some("org-b"))]);
 
         let mut req = Request::new(GetAgentTreeRequest {
             agent_id: format_id(&root),
@@ -503,10 +467,12 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
     }
 
+    // AAASM-4140 — fail-safe fallback: a team-less caller may not enumerate a
+    // team's roster, in the default (Untenanted) posture too.
     #[tokio::test]
-    async fn tenanted_mode_teamless_caller_denied_enumerating_team() {
+    async fn teamless_caller_denied_enumerating_team() {
         let agent: [u8; 16] = [0xf1; 16];
-        let svc = service_tenanted(vec![make_record(agent, "a", None, Some("team-b"), None)]);
+        let svc = service_with(vec![make_record(agent, "a", None, Some("team-b"), None)]);
 
         let mut req = Request::new(GetTeamMembersRequest {
             team_id: "team-b".into(),
@@ -518,34 +484,17 @@ mod tests {
     }
 
     #[test]
-    fn caller_may_read_tenancy_matrix() {
-        // Team-less caller vs tenanted resource: permissive only when untenanted.
-        assert!(caller_may_read(
-            &caller(None, None),
-            Some("t"),
-            None,
-            TenancyMode::Untenanted
-        ));
-        assert!(!caller_may_read(
-            &caller(None, None),
-            Some("t"),
-            None,
-            TenancyMode::Tenanted
-        ));
-        // Untenanted resource stays readable in either mode.
-        assert!(caller_may_read(
-            &caller(Some("t"), None),
-            None,
-            None,
-            TenancyMode::Tenanted
-        ));
-        // Same-tenant match is mode-independent.
-        assert!(caller_may_read(
-            &caller(Some("t"), Some("o")),
-            Some("t"),
-            Some("o"),
-            TenancyMode::Tenanted
-        ));
+    fn caller_may_read_matrix() {
+        // Team-less (resp. org-less) caller vs a tenanted resource: fail safe —
+        // denied (AAASM-4140).
+        assert!(!caller_may_read(&caller(None, None), Some("t"), None));
+        assert!(!caller_may_read(&caller(None, None), None, Some("o")));
+        // Untenanted resource stays readable for any caller.
+        assert!(caller_may_read(&caller(Some("t"), None), None, None));
+        assert!(caller_may_read(&caller(None, None), None, None));
+        // Same-tenant match; cross-tenant mismatch.
+        assert!(caller_may_read(&caller(Some("t"), Some("o")), Some("t"), Some("o")));
+        assert!(!caller_may_read(&caller(Some("t"), Some("o")), Some("u"), Some("o")));
     }
 
     // ── report_edge tenant authz (AAASM-3855) ──────────────────────────────


### PR DESCRIPTION
## Description

The gateway's cross-tenant guards fell back to *allow* whenever the caller was untenanted, so a **registered but team-less** authenticated caller could act on or read a resource owned by a team/org (approvals, agent tree/lineage, team rosters, topology edges). The `TenancyMode` posture only closed this hole when an operator opted into `Tenanted` mode; under the default `Untenanted` posture the fallback stayed permissive.

This makes the fallback **fail-safe unconditionally**: a team-less (resp. org-less) caller acting on a *tenanted* resource is now denied in every posture (`aa-gateway` `approval_service::caller_may_act_on`, `topology_service::caller_may_read`, and `get_team_members`). Untenanted resources stay accessible, same-tenant access is unchanged, and distinct-team isolation is unchanged. `TenancyMode` is retained solely for the team-less-registration gate (`AgentLifecycleServiceImpl`, AAASM-4032); its now-dead access plumbing is removed from the approval/topology services and the server wiring.

This is the AAASM-4133 item-5 residual (parent Epic AAASM-4139).

## Type of Change

- [x] 🐛 Bug fix
- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

Zero-config / single-tenant behavior is unchanged: nothing carries a `team_id`, so callers and resources are both untenanted and every access still falls through to *allow*. Team-less agent **registration** is still admitted under the default `Untenanted` posture (unchanged). The only behavior change is that a team-less caller can no longer reach a resource that *does* belong to a tenant — the vulnerability being closed.

## Related Issues

- Related Jira ticket: AAASM-4140

## Testing

- [x] Unit tests added / updated

Regression tests cover the full matrix, mode-independently, in both `approval_service` and `topology_service`: team-less caller → tenanted resource = **deny**; team-less → untenanted resource = **allow** (zero-config preserved); same-team = **allow**; cross-team = **deny**; plus team-less enumeration of a team roster = **deny**.

Validated from the worktree (`RUSTUP_TOOLCHAIN=stable`):
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p aa-gateway --all-targets -- -D warnings` — clean (only pre-existing workspace `Cargo.toml default-features` manifest notices)
- `cargo nextest run -p aa-gateway` (service + lifecycle) — 57 passed

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz