### PR TITLE
[AAASM-4145] ⚡ (aa-api): Bound the analytics endpoints' audit-log read

### DIFF
--- a/aa-api/src/routes/analytics.rs
+++ b/aa-api/src/routes/analytics.rs
@@ -354,15 +354,33 @@ fn scope_entries(caller: &AuthenticatedCaller, entries: Vec<AuditEntry>) -> Vec<
     }
 }
 
+/// Upper bound on the number of audit events a single analytics request pulls
+/// from the audit log.
+///
+/// [`AuditReader::list`] returns entries newest-first, so this caps each
+/// analytics aggregation to the most recent `MAX_ANALYTICS_AUDIT_EVENTS` events
+/// and then narrows them to the query's time window — bounding per-request work
+/// instead of the former unbounded `usize::MAX` full-log read (AAASM-4145). The
+/// ceiling is high enough that realistic dashboard windows are never truncated,
+/// yet fixed so a growing log can't turn one analytics call into an unbounded
+/// scan. A window holding more than the cap counts only its most recent events.
+///
+/// Follow-up: the reader still scans every JSONL file before slicing to this
+/// limit; a server-side time-windowed reader (filtering by `since_ns` during the
+/// scan) would remove that cost entirely and is tracked separately.
+const MAX_ANALYTICS_AUDIT_EVENTS: usize = 100_000;
+
 /// Fetch audit entries at or after `since_ns`, confined to the caller's tenant.
 ///
-/// Reads the full JSONL log via [`AuditReader::list`] and filters by timestamp;
-/// the in-process reader holds the same entries the other audit aggregations
-/// read, so no new data source is introduced.
+/// Reads the most recent [`MAX_ANALYTICS_AUDIT_EVENTS`] entries via
+/// [`AuditReader::list`] (newest-first) and filters by timestamp; the in-process
+/// reader holds the same entries the other audit aggregations read, so no new
+/// data source is introduced. The read is bounded (AAASM-4145): a window with
+/// more events than the cap aggregates only its most recent ones.
 async fn fetch_window_entries(caller: &AuthenticatedCaller, state: &AppState, since_ns: u64) -> Vec<AuditEntry> {
     let (entries, _total) = state
         .audit_reader
-        .list(usize::MAX, 0, None, None, None)
+        .list(MAX_ANALYTICS_AUDIT_EVENTS, 0, None, None, None)
         .await
         .unwrap_or_default();
     let entries: Vec<AuditEntry> = entries.into_iter().filter(|e| e.timestamp_ns() >= since_ns).collect();

--- a/aa-api/src/routes/analytics.rs
+++ b/aa-api/src/routes/analytics.rs
@@ -1057,4 +1057,14 @@ mod tests {
         assert_eq!(delta_ratio(12, 10), 0.2);
         assert_eq!(delta_ratio(8, 10), -0.2);
     }
+
+    #[test]
+    fn analytics_audit_read_is_bounded_not_unbounded() {
+        // AAASM-4145: the analytics handlers must cap the audit-log read rather
+        // than pull the whole log (`usize::MAX`) per request. `black_box` keeps
+        // this a runtime check so a regression to an unbounded read is caught.
+        let cap = std::hint::black_box(MAX_ANALYTICS_AUDIT_EVENTS);
+        assert!(cap < usize::MAX, "analytics audit read must be bounded, not usize::MAX");
+        assert_eq!(cap, 100_000);
+    }
 }


### PR DESCRIPTION
## Description

The audit-derived analytics endpoints (`action-volume`, `tool-usage`, `policy-effectiveness`, and the audit part of `kpis`) all share `fetch_window_entries`, which read the **entire** JSONL audit log per request via `audit_reader.list(usize::MAX, 0, ..)` — an unbounded synchronous full-log read that doesn't scale as the log grows.

This PR bounds that read to a named `const MAX_ANALYTICS_AUDIT_EVENTS: usize = 100_000`. `AuditReader::list` returns entries newest-first with no server-side time-window filter, so the handler now pulls the most recent 100k events and then narrows to the query's time window exactly as before. Response shapes and aggregation semantics are unchanged for any window under the cap (the overwhelming common case); a window holding more events than the cap aggregates only its most recent ones. The cap is documented in a `///` doc-comment on the const and on `fetch_window_entries`.

**Deeper follow-up (noted, not done here):** `AuditReader::list` still scans every JSONL file before slicing to the limit — the proper fix is a server-side time-windowed reader that filters by `since_ns` during the file scan, removing the scan cost entirely. That is a separate, larger change; this PR is the non-blocking perf-hardening bound the ticket scopes.

## Type of Change

- [x] 🍀 Performance improvement

## Breaking Changes

- [x] No

Internal read bound only. No route, schema, or response-shape change (`openapi/v1.yaml` is untouched).

## Related Issues

- Related Jira ticket: AAASM-4145 (cleanup follow-up from AAASM-4141, Epic AAASM-4144)

## Testing

- [x] Unit tests added / updated

Added `analytics_audit_read_is_bounded_not_unbounded`, which guards the const against a regression back to `usize::MAX`. Validated locally (aa-api scope):

- `cargo nextest run -p aa-api` — **869 passed, 0 failed**
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p aa-api --all-targets -- -D warnings` — clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz