### PR TITLE
[AAASM-4147] ⚡ (audit): Add server-side time-window filtering to AuditReader

### DIFF
--- a/aa-api/src/routes/analytics.rs
+++ b/aa-api/src/routes/analytics.rs
@@ -357,33 +357,30 @@ fn scope_entries(caller: &AuthenticatedCaller, entries: Vec<AuditEntry>) -> Vec<
 /// Upper bound on the number of audit events a single analytics request pulls
 /// from the audit log.
 ///
-/// [`AuditReader::list`] returns entries newest-first, so this caps each
-/// analytics aggregation to the most recent `MAX_ANALYTICS_AUDIT_EVENTS` events
-/// and then narrows them to the query's time window — bounding per-request work
-/// instead of the former unbounded `usize::MAX` full-log read (AAASM-4145). The
-/// ceiling is high enough that realistic dashboard windows are never truncated,
-/// yet fixed so a growing log can't turn one analytics call into an unbounded
-/// scan. A window holding more than the cap counts only its most recent events.
-///
-/// Follow-up: the reader still scans every JSONL file before slicing to this
-/// limit; a server-side time-windowed reader (filtering by `since_ns` during the
-/// scan) would remove that cost entirely and is tracked separately.
+/// [`AuditReader::list_windowed`] returns entries newest-first, so this caps
+/// each analytics aggregation to the most recent `MAX_ANALYTICS_AUDIT_EVENTS`
+/// events within the query's time window — bounding per-request work instead of
+/// the former unbounded `usize::MAX` full-log read (AAASM-4145). The ceiling is
+/// high enough that realistic dashboard windows are never truncated, yet fixed
+/// so a growing log can't turn one analytics call into an unbounded scan. A
+/// window holding more than the cap counts only its most recent events.
 const MAX_ANALYTICS_AUDIT_EVENTS: usize = 100_000;
 
 /// Fetch audit entries at or after `since_ns`, confined to the caller's tenant.
 ///
-/// Reads the most recent [`MAX_ANALYTICS_AUDIT_EVENTS`] entries via
-/// [`AuditReader::list`] (newest-first) and filters by timestamp; the in-process
-/// reader holds the same entries the other audit aggregations read, so no new
-/// data source is introduced. The read is bounded (AAASM-4145): a window with
-/// more events than the cap aggregates only its most recent ones.
+/// Pushes the `since_ns` window into [`AuditReader::list_windowed`] so entries
+/// older than the window are dropped during the directory scan and never
+/// collected (AAASM-4147) — no client-side timestamp re-filter is needed. The
+/// read stays bounded by [`MAX_ANALYTICS_AUDIT_EVENTS`] (AAASM-4145): a window
+/// with more events than the cap aggregates only its most recent ones. The
+/// in-process reader holds the same entries the other audit aggregations read,
+/// so no new data source is introduced.
 async fn fetch_window_entries(caller: &AuthenticatedCaller, state: &AppState, since_ns: u64) -> Vec<AuditEntry> {
     let (entries, _total) = state
         .audit_reader
-        .list(MAX_ANALYTICS_AUDIT_EVENTS, 0, None, None, None)
+        .list_windowed(since_ns, MAX_ANALYTICS_AUDIT_EVENTS, 0, None, None, None)
         .await
         .unwrap_or_default();
-    let entries: Vec<AuditEntry> = entries.into_iter().filter(|e| e.timestamp_ns() >= since_ns).collect();
     scope_entries(caller, entries)
 }
 

--- a/aa-api/src/routes/analytics.rs
+++ b/aa-api/src/routes/analytics.rs
@@ -1055,6 +1055,64 @@ mod tests {
         assert_eq!(delta_ratio(8, 10), -0.2);
     }
 
+    /// AAASM-4147: `fetch_window_entries` now pushes the `since_ns` window into
+    /// the reader (`list_windowed`) instead of over-reading then client-filtering.
+    /// For a window inside the data the result must be exactly the in-window
+    /// entries — identical to the pre-change `list()`-then-`>= since` behaviour —
+    /// so analytics aggregations are unaffected.
+    #[tokio::test]
+    async fn fetch_window_entries_returns_only_in_window_entries() {
+        use aa_core::audit::Lineage;
+        use aa_core::{AgentId, SessionId};
+        use aa_gateway::AuditReader;
+        use std::sync::Arc;
+
+        fn entry(seq: u64, ts: u64) -> AuditEntry {
+            AuditEntry::new_with_lineage(
+                seq,
+                ts,
+                AuditEventType::ToolCallIntercepted,
+                AgentId::from_bytes([0xAB; 16]),
+                SessionId::from_bytes([0xEE; 16]),
+                "{}".to_string(),
+                [0u8; 32],
+                Lineage::default(),
+            )
+        }
+
+        // Seed a temp audit dir: two entries older than the window, two within.
+        let dir = std::env::temp_dir().join(format!("aa-4147-fetch-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create audit dir");
+        let entries = [entry(0, 100), entry(1, 200), entry(2, 300), entry(3, 400)];
+        let mut contents = String::new();
+        for e in &entries {
+            contents.push_str(&serde_json::to_string(e).unwrap());
+            contents.push('\n');
+        }
+        std::fs::write(dir.join("audit.jsonl"), contents).expect("write jsonl");
+
+        let mut state = AppState::local_in_memory().expect("state builds");
+        state.audit_reader = Arc::new(AuditReader::new(dir.clone()));
+
+        // Admin caller so tenant scoping is the identity and can't mask the window.
+        let caller = AuthenticatedCaller {
+            key_id: "k".to_string(),
+            scopes: vec![Scope::Admin],
+            tenant: crate::auth::Tenant {
+                team_id: None,
+                org_id: None,
+            },
+        };
+
+        let since = 300;
+        let got = fetch_window_entries(&caller, &state, since).await;
+
+        let mut seqs: Vec<u64> = got.iter().map(|e| e.seq()).collect();
+        seqs.sort_unstable();
+        assert_eq!(seqs, vec![2, 3], "only entries with timestamp_ns >= since are returned");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
     #[test]
     fn analytics_audit_read_is_bounded_not_unbounded() {
         // AAASM-4145: the analytics handlers must cap the audit-log read rather

--- a/aa-gateway/src/audit_reader.rs
+++ b/aa-gateway/src/audit_reader.rs
@@ -39,7 +39,49 @@ impl AuditReader {
         event_type: Option<&str>,
         org_id: Option<&str>,
     ) -> io::Result<(Vec<AuditEntry>, u64)> {
-        let mut all_entries = self.read_all_entries().await?;
+        self.list_inner(None, limit, offset, agent_id, event_type, org_id).await
+    }
+
+    /// List audit entries within a server-side time window, else identical to
+    /// [`list`](Self::list).
+    ///
+    /// Entries older than `since_ns` (`timestamp_ns() < since_ns`) are dropped
+    /// during the directory scan and never collected — so `total` and the
+    /// returned page reflect only the window, and a windowed consumer no longer
+    /// over-reads the whole audit log (AAASM-4147). Newest-first ordering, the
+    /// `limit`/`offset` paging, and the agent/event/org filter semantics are
+    /// exactly those of [`list`](Self::list). Callers that want no window use
+    /// [`list`](Self::list).
+    pub async fn list_windowed(
+        &self,
+        since_ns: u64,
+        limit: usize,
+        offset: usize,
+        agent_id: Option<&str>,
+        event_type: Option<&str>,
+        org_id: Option<&str>,
+    ) -> io::Result<(Vec<AuditEntry>, u64)> {
+        self.list_inner(Some(since_ns), limit, offset, agent_id, event_type, org_id)
+            .await
+    }
+
+    /// Shared paginated-listing path for [`list`](Self::list) and
+    /// [`list_windowed`](Self::list_windowed).
+    ///
+    /// `since_ns` is pushed into the directory scan so out-of-window entries are
+    /// never collected; the remaining agent/event/org filtering, newest-first
+    /// sort, and `limit`/`offset` slicing are applied identically for both
+    /// entry points.
+    async fn list_inner(
+        &self,
+        since_ns: Option<u64>,
+        limit: usize,
+        offset: usize,
+        agent_id: Option<&str>,
+        event_type: Option<&str>,
+        org_id: Option<&str>,
+    ) -> io::Result<(Vec<AuditEntry>, u64)> {
+        let mut all_entries = self.read_all_entries_windowed(since_ns).await?;
 
         // Parse filter values once.
         let agent_filter: Option<AgentId> = agent_id.and_then(parse_agent_id);
@@ -97,6 +139,25 @@ impl AuditReader {
 
     /// Read and parse all JSONL files in the audit directory.
     async fn read_all_entries(&self) -> io::Result<Vec<AuditEntry>> {
+        self.read_all_entries_windowed(None).await
+    }
+
+    /// Read and parse JSONL entries, optionally dropping entries older than a
+    /// time window during the scan.
+    ///
+    /// When `since_ns` is `Some(w)`, an entry is collected only if
+    /// `timestamp_ns() >= w`; out-of-window entries are discarded as they are
+    /// parsed and never enter the returned `Vec`. This is the point of the
+    /// windowed read (AAASM-4147): a consumer that only wants a recent window no
+    /// longer materialises the whole log in memory. `None` collects everything,
+    /// preserving the original `read_all_entries` behaviour.
+    ///
+    /// Follow-up: files are still all opened and every line parsed before the
+    /// window test. JSONL files are rotated roughly in time order, so skipping
+    /// whole files outside the window would be the larger win — but that needs a
+    /// stable filename→time contract from the writer's rotation scheme, so it is
+    /// deferred to a separate ticket rather than guessed at here.
+    async fn read_all_entries_windowed(&self, since_ns: Option<u64>) -> io::Result<Vec<AuditEntry>> {
         let mut entries = Vec::new();
 
         let mut dir = match tokio::fs::read_dir(&self.dir).await {
@@ -121,7 +182,10 @@ impl AuditReader {
                 }
                 // Skip incomplete or corrupt lines (e.g. partial writes).
                 if let Ok(audit_entry) = serde_json::from_str::<AuditEntry>(&line) {
-                    entries.push(audit_entry);
+                    // Drop entries older than the window before collecting.
+                    if since_ns.map_or(true, |since| audit_entry.timestamp_ns() >= since) {
+                        entries.push(audit_entry);
+                    }
                 }
             }
         }

--- a/aa-gateway/src/audit_reader.rs
+++ b/aa-gateway/src/audit_reader.rs
@@ -604,6 +604,92 @@ mod tests {
         assert!(result.is_empty());
     }
 
+    // ── list_windowed (AAASM-4147) ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_windowed_excludes_entries_older_than_since_ns() {
+        let tmp = TempDir::new().expect("tempdir");
+        let child = AgentId::from_bytes(CHILD_BYTES);
+        let entries = vec![
+            make_entry(0, 100, ToolCallIntercepted, child, None),
+            make_entry(1, 200, ToolCallIntercepted, child, None),
+            make_entry(2, 300, ToolCallIntercepted, child, None),
+        ];
+        write_entries(tmp.path(), &entries);
+
+        let reader = AuditReader::new(tmp.path().to_path_buf());
+        let (page, total) = reader
+            .list_windowed(200, 100, 0, None, None, None)
+            .await
+            .expect("list_windowed");
+
+        // 200 and 300 satisfy >= 200; 100 is excluded. Newest-first ordering.
+        assert_eq!(total, 2, "total counts only in-window entries");
+        let seqs: Vec<u64> = page.iter().map(|e| e.seq()).collect();
+        assert_eq!(seqs, vec![2, 1], "newest-first, older entry dropped");
+        assert!(page.iter().all(|e| e.timestamp_ns() >= 200));
+    }
+
+    #[tokio::test]
+    async fn list_windowed_does_not_collect_out_of_window_entries() {
+        let tmp = TempDir::new().expect("tempdir");
+        let child = AgentId::from_bytes(CHILD_BYTES);
+        // Only one of five entries is inside the window.
+        let entries = vec![
+            make_entry(0, 10, ToolCallIntercepted, child, None),
+            make_entry(1, 20, ToolCallIntercepted, child, None),
+            make_entry(2, 30, ToolCallIntercepted, child, None),
+            make_entry(3, 40, ToolCallIntercepted, child, None),
+            make_entry(4, 1000, ToolCallIntercepted, child, None),
+        ];
+        write_entries(tmp.path(), &entries);
+
+        let reader = AuditReader::new(tmp.path().to_path_buf());
+        // Ask for far more than the window holds: the page can only contain the
+        // in-window entry, and `total` proves the out-of-window rows were never
+        // collected (not merely paged out).
+        let (page, total) = reader
+            .list_windowed(1000, 100, 0, None, None, None)
+            .await
+            .expect("list_windowed");
+
+        assert_eq!(total, 1, "out-of-window entries are never collected or counted");
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0].seq(), 4);
+    }
+
+    #[tokio::test]
+    async fn list_windowed_matches_list_then_client_filter() {
+        // The exact transformation `analytics::fetch_window_entries` performs:
+        // `list_windowed(since, ..)` must equal `list(..)` re-filtered by
+        // `timestamp_ns >= since`, so pushing the window into the reader leaves
+        // analytics results unchanged for a window inside the data.
+        let tmp = TempDir::new().expect("tempdir");
+        let child = AgentId::from_bytes(CHILD_BYTES);
+        let entries = vec![
+            make_entry(0, 100, ToolCallIntercepted, child, None),
+            make_entry(1, 250, PolicyViolation, child, None),
+            make_entry(2, 400, ApprovalGranted, child, None),
+            make_entry(3, 550, ToolCallIntercepted, child, None),
+        ];
+        write_entries(tmp.path(), &entries);
+
+        let reader = AuditReader::new(tmp.path().to_path_buf());
+        let since = 250;
+
+        let (windowed, windowed_total) = reader
+            .list_windowed(since, 100, 0, None, None, None)
+            .await
+            .expect("list_windowed");
+
+        let (all, _all_total) = reader.list(100, 0, None, None, None).await.expect("list");
+        let expected: Vec<AuditEntry> = all.into_iter().filter(|e| e.timestamp_ns() >= since).collect();
+
+        let windowed_seqs: Vec<u64> = windowed.iter().map(|e| e.seq()).collect();
+        let expected_seqs: Vec<u64> = expected.iter().map(|e| e.seq()).collect();
+        assert_eq!(windowed_seqs, expected_seqs, "windowed read must match list+filter");
+        assert_eq!(windowed_total as usize, expected.len());
+    }
     #[test]
     fn payload_has_dry_run_true_accepts_only_explicit_true() {
         assert!(payload_has_dry_run_true(r#"{"dry_run":true}"#));


### PR DESCRIPTION
## Description

Adds server-side time-window filtering to `AuditReader` so windowed consumers no longer over-read the whole JSONL audit log (AAASM-4147, a follow-up to the AAASM-4145 analytics bounded-read mitigation).

- `aa-gateway/src/audit_reader.rs`: new `read_all_entries_windowed(since_ns: Option<u64>)` drops entries with `timestamp_ns() < since_ns` **during** the directory scan (they are never collected). New public `AuditReader::list_windowed(since_ns, limit, offset, agent_id, event_type, org_id)` shares `list`'s filter/sort/paginate path via a private `list_inner`, so newest-first ordering, `limit`/`offset` paging, and agent/event/org filter semantics are identical to `list`.
- `aa-api/src/routes/analytics.rs`: `fetch_window_entries` now calls `list_windowed(since_ns, ..)` and drops the client-side `.filter(|e| e.timestamp_ns() >= since_ns)`. The `MAX_ANALYTICS_AUDIT_EVENTS` safety cap is retained, so worst-case work stays bounded. Response shapes and aggregation results are unchanged for realistic windows.

**API shape chosen:** a dedicated `list_windowed` method (not a `since_ns` param on `list`). Rationale: lowest blast radius — the four other callers (`health.rs`, `audit.rs`, `traces.rs`, `logs.rs`) keep calling `list` untouched, so there is zero risk to their behavior; only analytics takes the new path.

**File-skip bonus:** deferred. Skipping whole JSONL files outside the window is the bigger win, but it needs a stable filename→time contract from the writer's rotation scheme; guessing at it here would risk correctness. Documented as a `// Follow-up:` note on `read_all_entries_windowed` for a separate ticket. The correctness win (out-of-window entries never collected) is delivered now.

## Type of Change

- [x] 🍀 Performance improvement
- [x] 🐛 Bug fix

## Breaking Changes

- [x] No — `list_windowed` is additive; `list` and all existing callers are unchanged. No public HTTP/OpenAPI surface changes (`openapi/v1.yaml` diff is empty).

## Related Issues

- Related Jira ticket: AAASM-4147

## Testing

- [x] Unit tests added / updated

New tests:
- `aa-gateway` `list_windowed_excludes_entries_older_than_since_ns` — older entries excluded, newest-first + paging preserved.
- `aa-gateway` `list_windowed_does_not_collect_out_of_window_entries` — `total` reflects only in-window rows, proving out-of-window entries are never collected (not merely paged out).
- `aa-gateway` `list_windowed_matches_list_then_client_filter` — windowed read equals `list()` re-filtered by `>= since`, i.e. the exact transform analytics previously did.
- `aa-api` `fetch_window_entries_returns_only_in_window_entries` — the analytics path returns exactly `timestamp_ns >= since` for a window inside the data.

Validation (from worktree, `RUSTUP_TOOLCHAIN=stable`):
- `cargo fmt --all --check` — clean
- `cargo clippy -p aa-gateway -p aa-api --all-targets -- -D warnings` — exit 0
- `cargo nextest run -p aa-gateway -p aa-api` — 2253 passed, 0 failed
- `git diff remote/master -- openapi/v1.yaml` — empty

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention
