### PR TITLE
[AAASM-4150] 🐛 (aa-api): Use hex::decode for agent-id parsing in edges and topology routes

### DIFF
--- a/aa-api/src/routes/edges.rs
+++ b/aa-api/src/routes/edges.rs
@@ -85,14 +85,18 @@ fn authorize_edge_target(caller: &AuthenticatedCaller, state: &AppState, target:
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Parse a hex-encoded agent ID string into an [`AgentId`].
+///
+/// Decodes via [`hex::decode`] rather than slicing the input by byte index: the
+/// previous `&id[i..i + 2]` implementation panicked on an odd-length id (index
+/// past the end) or a multibyte path segment (a non-char-boundary slice),
+/// turning a malformed `{id}` path parameter into a request-thread panic
+/// (AAASM-4018 / AAASM-4150). `hex::decode` rejects odd-length and non-hex input
+/// with a clean `Err`, so every malformed id now surfaces as a `400` instead.
 fn parse_agent_id(id: &str) -> Result<AgentId, ProblemDetail> {
-    let bytes: Vec<u8> = (0..id.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&id[i..i + 2], 16))
-        .collect::<Result<Vec<u8>, _>>()
-        .map_err(|_| {
-            ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid agent ID format: {id}"))
-        })?;
+    let bytes = hex::decode(id).map_err(|_| {
+        ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid agent ID format: {id}"))
+    })?;
     let arr: [u8; 16] = bytes.try_into().map_err(|_| {
         ProblemDetail::from_status(StatusCode::BAD_REQUEST)
             .with_detail(format!("Agent ID must be 32 hex characters: {id}"))

--- a/aa-api/src/routes/edges.rs
+++ b/aa-api/src/routes/edges.rs
@@ -657,4 +657,11 @@ mod tests {
         // string and panicked; hex::decode must reject it as a clean error.
         assert!(parse_agent_id("abc").is_err());
     }
+
+    #[test]
+    fn parse_agent_id_rejects_multibyte() {
+        // AAASM-4150: a multibyte segment previously sliced a non-char-boundary
+        // and panicked; hex::decode must reject it as a clean error.
+        assert!(parse_agent_id("€0").is_err());
+    }
 }

--- a/aa-api/src/routes/edges.rs
+++ b/aa-api/src/routes/edges.rs
@@ -642,3 +642,19 @@ pub async fn list_topology_edges(
     let count = edges.len();
     Ok((StatusCode::OK, Json(TopologyEdgeListResponse { edges, count })))
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_agent_id_rejects_odd_length() {
+        // AAASM-4150: an odd-length id previously sliced past the end of the
+        // string and panicked; hex::decode must reject it as a clean error.
+        assert!(parse_agent_id("abc").is_err());
+    }
+}

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -729,6 +729,13 @@ mod tests {
     }
 
     #[test]
+    fn parse_agent_id_rejects_odd_length() {
+        // AAASM-4150: an odd-length id previously sliced past the end of the
+        // string and panicked; hex::decode must reject it as a clean error.
+        assert!(parse_agent_id("abc").is_err());
+    }
+
+    #[test]
     fn matches_status_filter_active() {
         let status = AgentStatus::Active;
         assert!(matches_status_filter(&status, "active"));

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -736,6 +736,13 @@ mod tests {
     }
 
     #[test]
+    fn parse_agent_id_rejects_multibyte() {
+        // AAASM-4150: a multibyte segment previously sliced a non-char-boundary
+        // and panicked; hex::decode must reject it as a clean error.
+        assert!(parse_agent_id("€0").is_err());
+    }
+
+    #[test]
     fn matches_status_filter_active() {
         let status = AgentStatus::Active;
         assert!(matches_status_filter(&status, "active"));

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -28,14 +28,18 @@ use crate::state::AppState;
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Parse a hex-encoded agent ID string into a 16-byte array.
+///
+/// Decodes via [`hex::decode`] rather than slicing the input by byte index: the
+/// previous `&id[i..i + 2]` implementation panicked on an odd-length id (index
+/// past the end) or a multibyte path segment (a non-char-boundary slice),
+/// turning a malformed `{id}` path parameter into a request-thread panic
+/// (AAASM-4018 / AAASM-4150). `hex::decode` rejects odd-length and non-hex input
+/// with a clean `Err`, so every malformed id now surfaces as a `400` instead.
 fn parse_agent_id(id: &str) -> Result<[u8; 16], ProblemDetail> {
-    let bytes: Vec<u8> = (0..id.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&id[i..i + 2], 16))
-        .collect::<Result<Vec<u8>, _>>()
-        .map_err(|_| {
-            ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid agent ID format: {id}"))
-        })?;
+    let bytes = hex::decode(id).map_err(|_| {
+        ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid agent ID format: {id}"))
+    })?;
     bytes.try_into().map_err(|_| {
         ProblemDetail::from_status(StatusCode::BAD_REQUEST)
             .with_detail(format!("Agent ID must be 32 hex characters: {id}"))


### PR DESCRIPTION
## Description

Completes AAASM-4018 by replacing the last two unsafe agent-id hex parsers. `aa-api`'s `edges.rs` and `topology.rs` both parsed a hex-encoded agent id with `(0..id.len()).step_by(2).map(|i| u8::from_str_radix(&id[i..i + 2], 16))`, which has no length or char-boundary guard:

- an **odd-length** id -> the final `&id[i..i + 2]` slices past the end -> `panic` "byte index out of bounds";
- a **multibyte** segment (e.g. the euro sign) -> slices mid-char -> `panic` "not a char boundary".

Both parsers are reachable by any authenticated read-scope caller (`GET /api/v1/agents/{id}/edges`, `/graph`, `/topology/tree/{root_id}`, `/topology/lineage/{agent_id}`) and via the `POST /api/v1/topology/edges` body (parsed before authz), so one malformed request panics the request thread -- a remote panic-DoS that, under `panic = "abort"`, takes down the whole gateway for all tenants.

The fix mirrors the safe `hex::decode`-based `parse_agent_id` already landed in `agents.rs` / `traces.rs` / `ops.rs` / `ws/tenant.rs` by AAASM-4018. `hex::decode` rejects odd-length and non-hex input with a clean `Err`, so every malformed id now returns `400` instead of panicking. No new dependency (`hex` is already used by these crates).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Behaviour changes only for previously-panicking input: malformed ids now return `400 Bad Request` instead of aborting the request. The `openapi/v1.yaml` contract is unchanged.

## Related Issues

- Related Jira ticket: AAASM-4150 (completes AAASM-4018)

## Testing

- [x] Unit tests added / updated

Added odd-length and multibyte regression tests to both `edges.rs` and `topology.rs` (the pre-existing topology test only covered even-length `"aabb"` and so missed this). Validated locally:

- `cargo nextest run -p aa-api parse_agent_id` -> 13 passed (incl. the 4 new tests)
- `cargo fmt --all -- --check` -> clean
- `cargo clippy --all-targets -- -D warnings` -> clean (enforced by pre-commit hook)
- `openapi/v1.yaml` diff empty

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
