### PR TITLE
[AAASM-4151] 🔧 (build): Make CatchPanicLayer effective by reconciling the panic strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,11 +147,19 @@ opt-level = 2
 lto = "thin"
 codegen-units = 16
 strip = true
-panic = "abort"
+# AAASM-4151: MUST stay "unwind", not "abort". The shipped aa-gateway daemon
+# (built with this profile via release.yml) installs a tower `CatchPanicLayer`
+# as its DoS backstop — a handler panic becomes a 500 instead of crashing the
+# whole multi-tenant worker. `catch_unwind` cannot intercept a panic under
+# `panic = "abort"`, which would silently make that layer inert in production.
+# The original AAASM-1206 switch to "abort" was a binary-size optimization only;
+# abort-on-panic is the wrong default for a long-lived server. The `dist` profile
+# below inherits this, so both shipped profiles keep unwinding.
+panic = "unwind"
 
 # Size-optimized profile for shipped binaries only (release.yml --profile dist).
-# Inherits release (strip + panic=abort) and restores the slowest, smallest
-# settings that the default `release` profile used to carry.
+# Inherits release (strip + panic=unwind — see AAASM-4151) and restores the
+# slowest, smallest settings that the default `release` profile used to carry.
 [profile.dist]
 inherits = "release"
 opt-level = "z"

--- a/aa-api/src/middleware/mod.rs
+++ b/aa-api/src/middleware/mod.rs
@@ -35,5 +35,11 @@ pub fn apply_middleware(router: Router) -> Router {
         // the request task and drop the connection; the outermost catch_panic
         // turns it into a `500 Internal Server Error` so one bad request cannot
         // take down the worker.
+        //
+        // AAASM-4151: this backstop only works when the crate is built with
+        // `panic = "unwind"` — `CatchPanicLayer` uses `std::panic::catch_unwind`,
+        // which is a no-op under `panic = "abort"` (the process aborts before the
+        // catch runs). The shipped `release`/`dist` profiles pin `panic = "unwind"`
+        // for exactly this reason; do not switch them back to "abort".
         .layer(CatchPanicLayer::new())
 }

--- a/aa-api/tests/middleware_catch_panic.rs
+++ b/aa-api/tests/middleware_catch_panic.rs
@@ -1,0 +1,29 @@
+//! Regression test for AAASM-4151 / AAASM-4018: the outermost
+//! `CatchPanicLayer` in the API middleware stack must convert a panic in a
+//! handler into a `500 Internal Server Error` instead of letting it unwind the
+//! request task (and, under a shipped `panic = "abort"` build, abort the whole
+//! process). This locks the middleware wiring; the shipped `release`/`dist`
+//! profiles pin `panic = "unwind"` so the layer is actually effective in prod.
+
+use aa_api::middleware::apply_middleware;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
+use tower::ServiceExt;
+
+async fn panicking_handler() -> &'static str {
+    panic!("simulated handler panic (AAASM-4151 regression)");
+}
+
+#[tokio::test]
+async fn handler_panic_is_caught_as_500() {
+    let app = apply_middleware(Router::new().route("/boom", get(panicking_handler)));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/boom").body(Body::empty()).unwrap())
+        .await
+        .expect("catch_panic must yield a response, not propagate the panic");
+
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}


### PR DESCRIPTION
## What changed

Set `panic = "unwind"` on the shipped `[profile.release]` profile in the workspace `Cargo.toml` (the `[profile.dist]` profile inherits it, so both shipped profiles now unwind). Added a doc-comment on the `CatchPanicLayer` recording the dependency, and a regression test asserting a handler panic yields `500`.

**Chosen option: (a)** — build the server/dist profile with `panic = "unwind"` so the documented `CatchPanicLayer` DoS backstop actually works in shipped binaries, rather than (b) demoting/deprecating the backstop.

**Rationale.** `aa-api/src/middleware/mod.rs` installs `CatchPanicLayer` (AAASM-4018) as defense-in-depth so a panic in any handler becomes a `500` instead of taking down the worker. But `CatchPanicLayer` relies on `std::panic::catch_unwind`, which is a **no-op under `panic = "abort"`** — the process aborts (SIGABRT) before the catch runs. The shipped `aa-gateway` daemon is built via `release.yml` (`cargo build --release`, and `dist` inherits `release`), both of which set `panic = "abort"`, so in production the layer was **inert**: every handler-reachable panic was silently fatal to the whole multi-tenant gateway.

The original switch to `panic = "abort"` (commit `bad388c7`, AAASM-1206) was a **binary-size optimization only** ("2–8 MB aasm binary size goal"). Abort-on-panic is the wrong default for a long-lived multi-tenant server, so unwinding on the server/dist profile is the correct reconciliation.

**Trade-off.** `panic = "unwind"` emits unwind tables, so the shipped binaries grow modestly versus abort. This is the accepted cost of making the availability backstop real; `opt-level = "z"` / `lto` / `codegen-units = 1` / `strip` on the `dist` profile are all unchanged, so the size impact is limited to the unwind tables. The sibling ticket **AAASM-4150** fixes the actual panicking parsers (edges.rs/topology.rs) regardless.

## Why

`Cargo.toml` `[profile.release]` `panic = "abort"` made the `aa-api` `CatchPanicLayer` (a documented DoS backstop) inert in the shipped `dist` binary — a single handler panic aborted the entire gateway process instead of returning `500`. HIGH severity, availability/systemic.

## How to verify

- `cargo nextest run -p aa-api --test middleware_catch_panic` — the new `handler_panic_is_caught_as_500` test builds the real middleware stack around a panicking handler and asserts `500 INTERNAL_SERVER_ERROR`. (Note: `cargo test` builds under the `test` profile, which already unwinds, so this test locks the *middleware wiring*; the profile change is what makes it hold in a `release`/`dist` build.)
- **Manual/behavioral:** with this change, a `--release` build of the gateway now returns `500` on a forced-panic route instead of aborting with SIGABRT (exit 134). Before the change, the same forced panic killed the process under `-C panic=abort`.
- `cargo build -p aa-api`, `cargo fmt -p aa-api --check`, `cargo clippy -p aa-api --all-targets -- -D warnings` all green locally.

Closes AAASM-4151

🤖 Generated with [Claude Code](https://claude.com/claude-code)