### PR TITLE
[AAASM-4152] 🐛 (gateway): Honor tools "*" wildcard so deny-unknown-tools policies fail closed

### DIFF
--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -534,6 +534,68 @@ mod tests {
         assert!(matches!(d, PolicyDecision::Deny { .. }));
     }
 
+    // ── Stage 3: tool allow/deny wildcard fail-closed (AAASM-4152) ──────────
+
+    fn tool_action(name: &str) -> GovernanceAction {
+        GovernanceAction::ToolCall {
+            name: name.into(),
+            args: "{}".into(),
+        }
+    }
+
+    fn doc_with_tools(tools: &[(&str, bool)]) -> PolicyDocument {
+        let mut doc = minimal_doc(None);
+        doc.tools = tools
+            .iter()
+            .map(|(name, allow)| {
+                (
+                    (*name).to_string(),
+                    crate::policy::document::ToolPolicy {
+                        allow: *allow,
+                        limit_per_hour: None,
+                        requires_approval_if: None,
+                    },
+                )
+            })
+            .collect();
+        doc
+    }
+
+    #[test]
+    fn stage_tool_wildcard_deny_denies_unlisted_tool() {
+        // AAASM-4152: `tools: { "*": { allow: false }, read_file: { allow: true } }`
+        // must deny an unlisted tool — the `"*"` key is a wildcard fallback, not a
+        // literal name. Previously the unlisted tool fell through to allow-by-default.
+        let doc = doc_with_tools(&[("*", false), ("read_file", true)]);
+        let d = stage_tool_allow(&doc, &tool_action("exfiltrate_secrets")).expect("deny");
+        assert!(matches!(d, PolicyDecision::Deny { .. }));
+    }
+
+    #[test]
+    fn stage_tool_wildcard_deny_allows_explicitly_listed_tool() {
+        // An explicit per-tool entry takes precedence over the `"*"` fallback.
+        let doc = doc_with_tools(&[("*", false), ("read_file", true)]);
+        assert_eq!(stage_tool_allow(&doc, &tool_action("read_file")), None);
+    }
+
+    #[test]
+    fn stage_tool_explicit_entry_overrides_wildcard_allow() {
+        // A per-tool deny beats a permissive `"*": allow` fallback.
+        let doc = doc_with_tools(&[("*", true), ("dangerous", false)]);
+        let d = stage_tool_allow(&doc, &tool_action("dangerous")).expect("deny");
+        assert!(matches!(d, PolicyDecision::Deny { .. }));
+        // And an unlisted tool falls back to the permissive wildcard → allow.
+        assert_eq!(stage_tool_allow(&doc, &tool_action("anything_else")), None);
+    }
+
+    #[test]
+    fn stage_tool_no_matching_entry_is_noop() {
+        // No exact entry and no `"*"` fallback → stage abstains (returns None),
+        // deferring to later stages / the engine default.
+        let doc = doc_with_tools(&[("read_file", true)]);
+        assert_eq!(stage_tool_allow(&doc, &tool_action("write_file")), None);
+    }
+
     // ── Stage 1: schedule timezone fail-closed (AAASM-3133) ─────────────────
 
     fn doc_with_schedule(tz: &str, start: &str, end: &str) -> PolicyDocument {

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -175,11 +175,19 @@ pub(crate) fn network_request_url_allowed(url: &str, np: &crate::policy::Network
 }
 
 /// Stage 3 — Tool allow/deny: deny a `ToolCall` whose tool policy is not allowed.
+///
+/// AAASM-4152: the `"*"` tools key is a wildcard fallback, not a literal tool
+/// name. An exact per-tool entry takes precedence; a tool with no explicit
+/// entry falls back to the `"*"` policy. This mirrors the network stage's
+/// wildcard support and lets `tools: { "*": { allow: false } }` deny unknown
+/// tools (fail closed). Previously the exact-only `get(name)` returned `None`
+/// for any unlisted tool, so the stage fell through to the engine's
+/// allow-by-default — a fail-open tool control.
 fn stage_tool_allow(doc: &PolicyDocument, action: &aa_core::GovernanceAction) -> Option<PolicyDecision> {
     let aa_core::GovernanceAction::ToolCall { name, .. } = action else {
         return None;
     };
-    let tp = doc.tools.get(name)?;
+    let tp = doc.tools.get(name).or_else(|| doc.tools.get("*"))?;
     if !tp.allow {
         return Some(PolicyDecision::Deny {
             reason: "tool denied by policy".into(),

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2180,6 +2180,45 @@ mod tests {
     }
 
     #[test]
+    fn tool_wildcard_deny_blocks_unlisted_tool() {
+        // AAASM-4152: the single-file `evaluate_primary` path must honour the
+        // `"*"` wildcard so `tools: { "*": { allow: false }, read_file: allow }`
+        // denies an unlisted tool. Previously the exact-only lookup let it fall
+        // through to allow-by-default — the behaviourally-proven fail-open.
+        let mut doc = empty_doc();
+        doc.tools.insert(
+            "*".to_string(),
+            ToolPolicy {
+                allow: false,
+                limit_per_hour: None,
+                requires_approval_if: None,
+            },
+        );
+        doc.tools.insert(
+            "read_file".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: None,
+                requires_approval_if: None,
+            },
+        );
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        // Explicitly-allowed tool passes.
+        assert_eq!(
+            engine.evaluate(&ctx, &tool_call("read_file", "")).decision,
+            PolicyResult::Allow
+        );
+        // Unlisted tool falls back to the `"*"` deny.
+        assert_eq!(
+            engine.evaluate(&ctx, &tool_call("exfiltrate_secrets", "")).decision,
+            PolicyResult::Deny {
+                reason: "tool denied by policy".into()
+            }
+        );
+    }
+
+    #[test]
     fn rate_limit_denies_after_capacity_exhausted() {
         let mut doc = empty_doc();
         doc.tools.insert(

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -927,8 +927,17 @@ impl PolicyEngine {
     ) -> Option<EvaluationResult> {
         let tool_policy = policy.tools.get(name);
 
-        // Stage 3 — Tool allow/deny.
-        if let Some(tp) = tool_policy {
+        // Stage 3 — Tool allow/deny. AAASM-4152: fall back to the `"*"` wildcard
+        // entry when the tool has no explicit policy, so a
+        // `tools: { "*": { allow: false } }` document denies unknown tools
+        // (fail closed) instead of letting them through the engine's
+        // allow-by-default. Explicit per-tool entries take precedence. This is
+        // the single-file twin of the cascade path's `decision::stage_tool_allow`
+        // — both must honour the wildcard or they diverge (the twin the network
+        // stage shares via `network_request_url_allowed`). Rate-limit (stage 4)
+        // and approval (stage 5) keep the exact `tool_policy` lookup, matching
+        // the cascade twin where only the allow/deny check consults `"*"`.
+        if let Some(tp) = tool_policy.or_else(|| policy.tools.get("*")) {
             if !tp.allow {
                 return Some(EvaluationResult::deny("tool denied by policy"));
             }


### PR DESCRIPTION
## Description

`tools: { "*": { allow: false } }` "deny unknown tools" policies were failing **open**: the tool-allow stage looked up tool policy by exact key, so the `"*"` entry was treated as a literal tool name and any unlisted tool fell through to the engine's allow-by-default. The shipped `policy-examples/strict.yaml` bases its entire tool lockdown on this key, so its documented "Deny every tool that is not explicitly allowed" guarantee did not hold.

The fix mirrors the network egress stage (which is already wildcard/fail-closed-aware): fall back to the `"*"` entry when the exact tool name isn't listed. Explicit per-tool entries still take precedence over `"*"`.

**Two twin paths were affected** (the tool stage, unlike the network stage, did not yet share one matcher):
- `engine/decision.rs::stage_tool_allow` — the scoped-cascade path.
- `engine/mod.rs::eval_toolcall_stages` — the single-file `evaluate_primary` path, which is what `aasm policy simulate` and the live gateway exercise when no scoped cascade is loaded. The behavioral repro only fails closed once **both** are fixed. Rate-limit and approval sub-stages keep the exact lookup, matching the cascade twin where only allow/deny consults `"*"`.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Policies that (incorrectly) relied on `"*"` being inert to allow unlisted tools will now see those tools denied — but that is the documented and intended fail-closed behavior; the prior state was the bug.

## Related Issues

- Related Jira ticket: AAASM-4152 (HIGH — policy fail-open, behaviorally proven)

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

New regression tests: `stage_tool_*` in `decision.rs` (cascade path) and `tool_wildcard_deny_blocks_unlisted_tool` in `mod.rs` (single-file path). Full `cargo nextest run -p aa-gateway` green (1388 passed).

**Behavioral before/after** (`aasm policy simulate` on `tools:{"*":{allow:false}, read_file:{allow:true}}`, replaying `read_file` then `exfiltrate_secrets`):

Before (master):
```
Allowed: 2   Denied: 0     ← exfiltrate_secrets ALLOWED (fail-open)
```
After (this PR):
```
Allowed: 1   Denied: 1
EVENT#  ACTION                   DECISION  REASON
1       tool:exfiltrate_secrets  deny      tool denied by policy
```
And the shipped `policy-examples/strict.yaml` now denies an unknown tool (`Denied: 1`), matching its documented intent.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

> Note: touches `engine/mod.rs` alongside `engine/decision.rs`. Sibling AAASM-4154 also edits `engine/mod.rs` (capability cascade) + `aa-core/capability.rs`; this PR's `mod.rs` change is confined to the tool-stage `eval_toolcall_stages` allow/deny check, so any overlap is a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
