### PR TITLE
[AAASM-4154] 🔒 (capability): Fail closed when merged cascade allow-list is empty

### DIFF
--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -683,4 +683,70 @@ mod tests {
         let deny = deny_set(&[Capability::NetworkOutbound]);
         assert!(!super::capability_is_denied(&deny, &Capability::FileDelete));
     }
+
+    // ------------------------------------------------------------------
+    // allow_restricted / allow_is_restricted (AAASM-4154)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn allow_is_restricted_true_when_allow_non_empty() {
+        // A non-empty allow-list is a restriction even without the flag set.
+        let cs = cap_set(&[Capability::FileRead], &[]);
+        assert!(cs.allow_is_restricted());
+    }
+
+    #[test]
+    fn allow_is_restricted_false_when_no_allow_declared() {
+        // Deny-only (or empty) set with no restriction flag → unrestricted.
+        let cs = cap_set(&[], &[Capability::TerminalExec]);
+        assert!(!cs.allow_is_restricted());
+    }
+
+    #[test]
+    fn allow_is_restricted_true_when_flag_set_but_allow_empty() {
+        // The collapsed-cascade shape: empty allow but restriction carried.
+        let cs = CapabilitySet {
+            allow: BTreeSet::new(),
+            deny: BTreeSet::new(),
+            allow_restricted: true,
+        };
+        assert!(cs.allow_is_restricted());
+    }
+
+    #[test]
+    fn merge_disjoint_allow_lists_stays_restricted_with_empty_allow() {
+        // AAASM-4154: two disjoint non-empty allow-lists intersect to empty, but
+        // the restriction must survive so the guard fails closed (deny-all)
+        // rather than reading empty allow as "no restriction" (allow-all).
+        let parent = cap_set(&[Capability::FileRead], &[]);
+        let child = cap_set(&[Capability::FileWrite], &[]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert!(result.allow.is_empty(), "disjoint allow-lists intersect to empty");
+        assert!(result.allow_restricted, "restriction must persist across the collapse");
+        assert!(
+            result.allow_is_restricted(),
+            "guard must treat the collapsed set as restricted (deny-all)"
+        );
+    }
+
+    #[test]
+    fn merge_single_tier_allow_is_restricted() {
+        // A lone declared allow-list is a restriction after merge.
+        let parent = CapabilitySet::default();
+        let child = cap_set(&[Capability::FileRead], &[]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert!(result.allow.contains(&Capability::FileRead));
+        assert!(result.allow_restricted);
+    }
+
+    #[test]
+    fn merge_no_allow_declared_is_unrestricted() {
+        // Deny-only tiers never manufacture an allow-list restriction.
+        let parent = cap_set(&[], &[Capability::FileWrite]);
+        let child = cap_set(&[], &[Capability::TerminalExec]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert!(result.allow.is_empty());
+        assert!(!result.allow_restricted);
+        assert!(!result.allow_is_restricted());
+    }
 }

--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -152,6 +152,10 @@ impl core::fmt::Display for Capability {
 ///   - Parent empty, child non-empty → `child.allow` minus merged deny.
 ///   - Parent non-empty, child empty → `parent.allow` minus merged deny.
 ///   - Both non-empty → intersection of `parent.allow` and `child.allow`, minus merged deny.
+/// - `allow_restricted` = set once either input restricts (carries its flag) or
+///   declares a non-empty allow-list. This preserves the restriction across a
+///   disjoint intersection that empties `allow`, so the guard fails *closed*
+///   (deny-all) instead of reading empty as "unrestricted" (AAASM-4154).
 ///
 /// Requires the `alloc` feature.
 #[cfg(feature = "alloc")]
@@ -175,10 +179,15 @@ pub fn merge_capabilities(parent: &CapabilitySet, child: &CapabilitySet) -> Capa
             .collect(),
     };
 
+    // A restriction is in force if either input already carries one or declares
+    // a non-empty allow-list — even when the intersection above empties `allow`.
+    let allow_restricted =
+        parent.allow_restricted || child.allow_restricted || !parent.allow.is_empty() || !child.allow.is_empty();
+
     CapabilitySet {
         allow,
         deny,
-        allow_restricted: false,
+        allow_restricted,
     }
 }
 

--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -42,6 +42,34 @@ pub struct CapabilitySet {
     pub allow: BTreeSet<Capability>,
     /// Capabilities explicitly denied.
     pub deny: BTreeSet<Capability>,
+    /// Whether an allow-list restriction is in force, independent of whether
+    /// `allow` currently lists anything.
+    ///
+    /// Set once any cascade tier contributes a non-empty allow-list. It exists
+    /// to disambiguate the two meanings an empty `allow` would otherwise
+    /// conflate: "no allow-list was ever declared" (unrestricted — only `deny`
+    /// governs) versus "an allow-list was declared but a disjoint multi-tier
+    /// intersection collapsed it to empty" (deny-all). Without this flag,
+    /// merging two disjoint restrictive whitelists produces an empty `allow`
+    /// that the guard reads as "no restriction", failing *open* to allow-all —
+    /// the inverse of most-restrictive-wins (AAASM-4154). `serde(default)` keeps
+    /// older serialized sets (which lack the field) deserializing unchanged.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub allow_restricted: bool,
+}
+
+impl CapabilitySet {
+    /// Whether an allow-list restriction governs this set.
+    ///
+    /// True when the set whitelists at least one capability, or when a prior
+    /// cascade tier declared a non-empty allow that a disjoint merge collapsed
+    /// to empty (`allow_restricted`). When this is true, the capability guard
+    /// must deny any capability absent from `allow`; an empty `allow` therefore
+    /// means deny-all, never "no restriction" (AAASM-4154).
+    #[must_use]
+    pub fn allow_is_restricted(&self) -> bool {
+        self.allow_restricted || !self.allow.is_empty()
+    }
 }
 
 impl Capability {
@@ -147,7 +175,11 @@ pub fn merge_capabilities(parent: &CapabilitySet, child: &CapabilitySet) -> Capa
             .collect(),
     };
 
-    CapabilitySet { allow, deny }
+    CapabilitySet {
+        allow,
+        deny,
+        allow_restricted: false,
+    }
 }
 
 /// Map a [`crate::GovernanceAction`] to the [`Capability`] it exercises,
@@ -392,6 +424,7 @@ mod tests {
         CapabilitySet {
             allow: allow.iter().cloned().collect(),
             deny: deny.iter().cloned().collect(),
+            allow_restricted: false,
         }
     }
 

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -350,6 +350,7 @@ mod tests {
         CapabilitySet {
             allow: allow.iter().cloned().collect::<BTreeSet<_>>(),
             deny: deny.iter().cloned().collect::<BTreeSet<_>>(),
+            allow_restricted: false,
         }
     }
 

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -190,7 +190,8 @@ fn stage_tool_allow(doc: &PolicyDocument, action: &aa_core::GovernanceAction) ->
 }
 
 /// Stage 3.5 — Capability check: deny when this doc's capability set blocks the
-/// action's capability (explicit deny, or omitted from a non-empty allow set).
+/// action's capability (explicit deny, or omitted while an allow-list
+/// restriction is in force — see `CapabilitySet::allow_is_restricted`).
 fn stage_capability(doc: &PolicyDocument, action: &aa_core::GovernanceAction) -> Option<PolicyDecision> {
     let caps = doc.capabilities.as_ref()?;
     let cap = aa_core::action_to_capability(action)?;
@@ -200,7 +201,9 @@ fn stage_capability(doc: &PolicyDocument, action: &aa_core::GovernanceAction) ->
             source_scope: doc.scope.clone(),
         });
     }
-    if !caps.allow.is_empty() && !caps.allow.contains(&cap) {
+    // Fail closed when a restriction is in force even if the allow-list is now
+    // empty (a disjoint cascade merge collapsed it) — never allow-all (AAASM-4154).
+    if caps.allow_is_restricted() && !caps.allow.contains(&cap) {
         return Some(PolicyDecision::Deny {
             reason: "capability not in allow list".into(),
             source_scope: doc.scope.clone(),

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -3169,6 +3169,7 @@ mod tests {
         aa_core::CapabilitySet {
             allow: allow.iter().cloned().collect::<BTreeSet<_>>(),
             deny: deny.iter().cloned().collect::<BTreeSet<_>>(),
+            allow_restricted: false,
         }
     }
 

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1184,9 +1184,15 @@ impl PolicyEngine {
 
     /// Capability authorization gate shared by BOTH the primary
     /// (`evaluate_primary`) and cascade (`cascade_capability_guard`) paths: deny
-    /// when `caps.deny` blocks the action's capability, or a non-empty
+    /// when `caps.deny` blocks the action's capability, or when an allow-list
+    /// restriction is in force (`CapabilitySet::allow_is_restricted`) and
     /// `caps.allow` omits it. `None` when the action maps to no capability or is
     /// permitted.
+    ///
+    /// The restriction check keys off `allow_is_restricted()` rather than
+    /// `!allow.is_empty()` so a disjoint multi-tier cascade that intersects two
+    /// whitelists down to an empty `allow` fails *closed* (deny-all) instead of
+    /// reading empty as "no allow-list" and permitting everything (AAASM-4154).
     ///
     /// Extracted so the single-file and directory-cascade paths can never
     /// diverge again (AAASM-4123): the primary path previously ran every stage
@@ -1201,7 +1207,10 @@ impl PolicyEngine {
         if aa_core::capability_is_denied(&caps.deny, &cap) {
             return Some(EvaluationResult::deny("capability denied by policy"));
         }
-        if !caps.allow.is_empty() && !caps.allow.contains(&cap) {
+        // Fail closed when a restriction is in force: an empty merged allow-list
+        // that carries `allow_restricted` means a disjoint cascade collapsed two
+        // whitelists to nothing — deny everything, never allow-all (AAASM-4154).
+        if caps.allow_is_restricted() && !caps.allow.contains(&cap) {
             return Some(EvaluationResult::deny("capability not in allow list"));
         }
         None

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -430,10 +430,13 @@ impl PolicyValidator {
             }
         }
 
+        // A non-empty allow-list at this scope is itself a restriction; record it
+        // so a later disjoint cascade merge cannot silently drop it (AAASM-4154).
+        let allow_restricted = !allow.is_empty();
         Some(aa_core::CapabilitySet {
             allow,
             deny,
-            allow_restricted: false,
+            allow_restricted,
         })
     }
 

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -430,7 +430,11 @@ impl PolicyValidator {
             }
         }
 
-        Some(aa_core::CapabilitySet { allow, deny })
+        Some(aa_core::CapabilitySet {
+            allow,
+            deny,
+            allow_restricted: false,
+        })
     }
 
     fn validate_tools(

--- a/aa-gateway/tests/capability_integration_test.rs
+++ b/aa-gateway/tests/capability_integration_test.rs
@@ -455,3 +455,53 @@ fn legacy_file_write_deny_still_blocks_delete() {
         result
     );
 }
+
+// ── Disjoint cascade allow-lists (AAASM-4154) ───────────────────────────────────
+
+/// The headline fail-open: two cascade tiers with DISJOINT non-empty allow-lists
+/// (Global `allow=[file_read]`, Team `allow=[file_write]`) intersect to an empty
+/// merged allow. Before the fix an empty merged allow was read as "no
+/// restriction", so an unlisted capability like `TerminalExec` was permitted —
+/// combining two restrictive whitelists escalated privilege to allow-all. The
+/// merged set must instead stay restricted and DENY the unlisted capability.
+#[test]
+fn cascade_disjoint_allow_lists_deny_unlisted_capability() {
+    let agent_id = AgentId::from_bytes([1u8; 16]);
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(PolicyScope::Global, &[Capability::FileRead], &[]));
+    engine.load_policy(cap_doc(PolicyScope::Agent(agent_id), &[Capability::FileWrite], &[]));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::ProcessExec { command: "sh".into() };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert!(
+        matches!(result, PolicyResult::Deny { .. }),
+        "expected Deny: disjoint allow-lists must not collapse to allow-all, got {:?}",
+        result
+    );
+}
+
+/// The same disjoint collapse must not nullify a delete restriction: with the
+/// merged allow-list emptied, `FileDelete` (whitelisted by neither tier) is not
+/// implicitly permitted — the set stays restricted and denies it (AAASM-4154).
+#[test]
+fn cascade_disjoint_allow_lists_deny_file_delete() {
+    let agent_id = AgentId::from_bytes([1u8; 16]);
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(PolicyScope::Global, &[Capability::FileRead], &[]));
+    engine.load_policy(cap_doc(PolicyScope::Agent(agent_id), &[Capability::FileWrite], &[]));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::FileAccess {
+        path: "/tmp/secret.txt".into(),
+        mode: aa_core::FileMode::Delete,
+    };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert!(
+        matches!(result, PolicyResult::Deny { .. }),
+        "expected Deny: a collapsed disjoint allow-list must still deny delete, got {:?}",
+        result
+    );
+}

--- a/aa-gateway/tests/capability_integration_test.rs
+++ b/aa-gateway/tests/capability_integration_test.rs
@@ -57,6 +57,7 @@ fn cap_doc(scope: PolicyScope, allow: &[Capability], deny: &[Capability]) -> Pol
         capabilities: Some(CapabilitySet {
             allow: allow.iter().cloned().collect::<BTreeSet<_>>(),
             deny: deny.iter().cloned().collect::<BTreeSet<_>>(),
+            allow_restricted: false,
         }),
     }
 }


### PR DESCRIPTION
## What changed

Merging two cascade tiers with **disjoint non-empty capability allow-lists** used to fail *open*. `merge_capabilities` intersects the two whitelists (`parent.allow ∩ child.allow`), which for disjoint lists is empty — and the capability guard read `!caps.allow.is_empty()` as the restriction test, so an empty merged allow was treated as "no allow-list restriction" and every capability not separately denied was permitted. Combining two restrictive whitelists therefore escalated privilege to allow-all, the inverse of most-restrictive-wins.

This PR distinguishes "no allow-list declared" (unrestricted) from "declared but merged empty" (deny-all):

- `aa_core::CapabilitySet` gains an additive `allow_restricted: bool` field (`serde(default)`) plus an `allow_is_restricted()` accessor (`flag || !allow.is_empty()`).
- `merge_capabilities` sets the flag whenever either input carries it or declares a non-empty allow-list, so the restriction survives a disjoint intersection that empties `allow`. The validator marks a parsed scope restricted when its allow-list is non-empty.
- Both capability guards (`capability_guard` on the cascade path, `stage_capability` on the primary path) now key off `allow_is_restricted()`. A collapsed disjoint cascade now denies every unlisted capability (deny-all) instead of allowing everything.

### Design choice: (b) additive flag, not (a) `Option<BTreeSet>`

The ticket offered (a) modelling `allow` as `Option<BTreeSet>` (`None`=unrestricted, `Some(∅)`=deny-all) or (b) an additive `allow_restricted` bool. I chose **(b)** on blast radius: (a) is a type change touching every `.allow` construction/read/serde site (~20+ across `aa-core`, `aa-gateway` validator/canonical/decision/engine, `aa-api`, CLI) **and** changes the serialized shape. (b) is additive — `serde(default)` keeps old JSON deserializing unchanged, `Default`/mutation sites (`aa-devtool` uses a *separate* `CapabilitySet` type anyway) need no edits, and only ~6 struct literals (5 of them test helpers) required the new field. No OpenAPI change: `aa-api` maps into its own `EffectivePermissionsResponse` DTO; policy hashing uses a separate `CanonCapabilitySet`.

Single-tier allow-lists, deny semantics, and the FileDelete fail-closed rules (`capability_is_denied`: write-deny ⇒ delete-deny; delete needs an explicit grant) are unchanged.

## Why

Fixes **AAASM-4154** (MED, policy fail-open inverting most-restrictive-wins). Adding a narrower-looking allow tier must never widen effective permissions.

## How to verify

- `cargo nextest run -p aa-core capability` — 49 passed, incl. new disjoint-merge / `allow_is_restricted` cases.
- `cargo nextest run -p aa-gateway -E 'test(capability) | test(cascade)'` — 43 passed, incl. new end-to-end tests: disjoint cascade allow-lists deny an unlisted `TerminalExec` and a `FileDelete`.
- `cargo fmt --all --check` clean; `cargo clippy -p aa-core -p aa-gateway --all-targets -- -D warnings` clean.

## Related

Closes AAASM-4154. Note: sibling AAASM-4152 touches `engine/decision.rs` (tool stage); this PR touches only the capability stage there — a trivial rebase at most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz