### PR TITLE
[AAASM-4156] 🔒 (proxy): Decompress-then-scan or fail-closed on Content-Encoding bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "clap",
  "criterion",
  "dirs",
+ "flate2",
  "hyper",
  "hyper-util",
  "libc",

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -30,6 +30,15 @@ time         = { workspace = true }
 lru          = "0.18"
 serde        = { workspace = true }
 serde_json   = { workspace = true }
+# AAASM-4156: decompress `Content-Encoding: gzip`/`deflate` MitM'd bodies so the
+# credential/DLP scanner inspects the plaintext instead of the opaque compressed
+# bytes (a gzip'd secret otherwise slips past). flate2 1.1.9 is already resolved
+# in the workspace lock (via tower-http/async-compression and zip), so this adds
+# no new crate to the tree. Default features use the pure-Rust miniz_oxide
+# backend — no C/zlib system dependency. `br` (brotli) is intentionally NOT
+# pulled in: it would be a genuinely new dependency, so the scanner fails closed
+# on brotli-encoded bodies rather than adding one (see decompress_content_encoding).
+flate2       = "1.1"
 anyhow       = { workspace = true }
 thiserror    = { workspace = true }
 dirs                = { workspace = true }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -65,6 +65,22 @@ pub struct InterceptVerdict {
     pub redacted_body: Option<Bytes>,
 }
 
+/// Outcome of [`Interceptor::redact_response_body`] for an upstream response
+/// body the MCP data path is about to relay to the client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResponseScan {
+    /// Forward the original upstream body unchanged — the scanner is disabled
+    /// or the (decoded) payload is clean.
+    Forward,
+    /// Forward these bytes in place of the original: findings were replaced with
+    /// the scanner's `[REDACTED:<kind>]` markers.
+    Redact(Vec<u8>),
+    /// The body could not be inspected — an undecodable `Content-Encoding`, or a
+    /// compressed body carrying findings that cannot be safely re-encoded here.
+    /// The caller must withhold the upstream body and fail closed (AAASM-4156).
+    Withhold,
+}
+
 /// The bytes the credential/DLP scanner should inspect for a body that may
 /// carry a `Content-Encoding`, or a signal that the body is un-inspectable.
 ///
@@ -288,24 +304,45 @@ impl Interceptor {
     /// Scan a response-side payload for credentials and return the redacted
     /// form when findings are present.
     ///
-    /// Returns `None` when the scanner is disabled or the payload is clean.
-    /// On `Some(redacted)`, the secret bytes have been replaced with the
-    /// scanner's `[REDACTED:<kind>]` markers and the caller should forward
-    /// the redacted bytes in place of the original.
+    /// Returns [`ResponseScan::Forward`] when the scanner is disabled or the
+    /// (decoded) payload is clean; [`ResponseScan::Redact`] with the redacted
+    /// bytes when findings are replaced with `[REDACTED:<kind>]` markers; and
+    /// [`ResponseScan::Withhold`] when the body cannot be inspected and the
+    /// caller must fail closed.
+    ///
+    /// `content_encoding` is the response's `Content-Encoding` header value (if
+    /// present). A non-identity encoding is decompressed before scanning
+    /// (AAASM-4156) so a `gzip`/`deflate`-encoded secret in an upstream response
+    /// is inspected as plaintext rather than relayed as opaque compressed bytes.
+    /// An encoding the proxy cannot decode, and findings inside a compressed body
+    /// (which cannot be re-encoded to the declared encoding without leaking the
+    /// secret), both return [`ResponseScan::Withhold`].
     ///
     /// Used by the AAASM-1930 MCP data path to redact upstream response
     /// bodies before they reach the client (ST-Q-3). The proxy's default
     /// scanner carries the same `aa_security::CredentialScanner` patterns the
     /// gateway uses for ToolResult evaluation, so the redaction shape
     /// matches what `mcp_redact_secrets.yaml` would produce gateway-side.
-    pub fn redact_response_body(&self, body: &[u8]) -> Option<Vec<u8>> {
-        let scanner = self.scanner.as_ref()?;
-        let text = String::from_utf8_lossy(body);
+    pub fn redact_response_body(&self, body: &[u8], content_encoding: Option<&str>) -> ResponseScan {
+        let Some(scanner) = self.scanner.as_ref() else {
+            return ResponseScan::Forward;
+        };
+        let (bytes, encoded) = match scan_source(body, content_encoding) {
+            ScanSource::Plaintext { bytes, encoded } => (bytes, encoded),
+            ScanSource::Uninspectable => return ResponseScan::Withhold,
+        };
+        let text = String::from_utf8_lossy(&bytes);
         let scan = scanner.scan(&text);
         if scan.is_clean() {
-            return None;
+            return ResponseScan::Forward;
         }
-        Some(scan.redact(&text).into_bytes())
+        if encoded {
+            // Findings inside a compressed body cannot be re-encoded to the
+            // declared Content-Encoding here, and forwarding the original
+            // compressed bytes would relay the secret. Withhold (fail closed).
+            return ResponseScan::Withhold;
+        }
+        ResponseScan::Redact(scan.redact(&text).into_bytes())
     }
 
     /// Emit an audit event recording the gateway's decision for an MCP
@@ -837,24 +874,27 @@ mod tests {
     // ── redact_response_body ────────────────────────────────────────────────
 
     #[test]
-    fn redact_response_body_disabled_scanner_returns_none() {
+    fn redact_response_body_disabled_scanner_forwards() {
         let (tx, _rx) = broadcast::channel(16);
         let interceptor = Interceptor::with_scanner(tx, None);
-        assert!(interceptor.redact_response_body(CRED_BODY).is_none());
+        assert_eq!(interceptor.redact_response_body(CRED_BODY, None), ResponseScan::Forward);
     }
 
     #[test]
-    fn redact_response_body_clean_payload_returns_none() {
+    fn redact_response_body_clean_payload_forwards() {
         let interceptor = make_interceptor();
-        assert!(interceptor.redact_response_body(b"clean upstream response").is_none());
+        assert_eq!(
+            interceptor.redact_response_body(b"clean upstream response", None),
+            ResponseScan::Forward
+        );
     }
 
     #[test]
     fn redact_response_body_with_credential_returns_redacted() {
         let interceptor = make_interceptor();
-        let redacted = interceptor
-            .redact_response_body(CRED_BODY)
-            .expect("a credential payload must yield redacted bytes");
+        let ResponseScan::Redact(redacted) = interceptor.redact_response_body(CRED_BODY, None) else {
+            panic!("a credential payload must yield redacted bytes");
+        };
         assert!(
             !redacted
                 .windows(b"TESTONLY-NOT-REAL".len())

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -973,6 +973,53 @@ mod tests {
         );
     }
 
+    #[test]
+    fn redact_response_gzip_credential_is_withheld() {
+        // A gzip'd upstream response carrying a secret was previously relayed
+        // compressed (unredacted). It must now decompress, detect the secret,
+        // and — unable to re-encode a redaction — withhold the body (fail closed).
+        let interceptor = make_interceptor();
+        assert_eq!(
+            interceptor.redact_response_body(&gzip(CRED_BODY), Some("gzip")),
+            ResponseScan::Withhold
+        );
+    }
+
+    #[test]
+    fn redact_response_gzip_clean_body_forwards() {
+        let interceptor = make_interceptor();
+        assert_eq!(
+            interceptor.redact_response_body(&gzip(b"clean upstream response"), Some("gzip")),
+            ResponseScan::Forward
+        );
+    }
+
+    #[test]
+    fn redact_response_unsupported_encoding_is_withheld() {
+        // An encoding the proxy cannot decode is un-inspectable → withhold.
+        let interceptor = make_interceptor();
+        assert_eq!(
+            interceptor.redact_response_body(b"\x1b\x00\x00brotli", Some("br")),
+            ResponseScan::Withhold
+        );
+    }
+
+    #[test]
+    fn redact_response_identity_still_redacts() {
+        // An identity (plaintext) response with findings redacts exactly as
+        // before — the encoding handling must not disturb the identity path.
+        let interceptor = make_interceptor();
+        let ResponseScan::Redact(redacted) = interceptor.redact_response_body(CRED_BODY, Some("identity")) else {
+            panic!("a plaintext credential payload must redact");
+        };
+        assert!(
+            !redacted
+                .windows(b"TESTONLY-NOT-REAL".len())
+                .any(|w| w == b"TESTONLY-NOT-REAL"),
+            "redacted response must not contain the raw secret"
+        );
+    }
+
     // ── emit_policy_decision (CONNECT tunnel audit) ─────────────────────────
 
     #[tokio::test]

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -19,10 +19,13 @@ use aa_runtime::pipeline::PipelineEvent;
 use aa_security::{CredentialFinding, CredentialScanner};
 use bytes::Bytes;
 
+use std::borrow::Cow;
+
 use crate::config::CredentialAction;
 use crate::error::ProxyError;
 use crate::intercept::detect::LlmApiPattern;
 use crate::intercept::extract::{extract_anthropic, extract_cohere, extract_openai, ExtractionError, LlmFields};
+use crate::proxy::http::decompress_content_encoding;
 
 /// What the proxy should do with an intercepted request body after the
 /// scanner has run.
@@ -62,6 +65,47 @@ pub struct InterceptVerdict {
     pub redacted_body: Option<Bytes>,
 }
 
+/// The bytes the credential/DLP scanner should inspect for a body that may
+/// carry a `Content-Encoding`, or a signal that the body is un-inspectable.
+///
+/// AAASM-4156: a `gzip`/`deflate` body must be decompressed before scanning —
+/// scanning the compressed bytes lets an encoded secret slip past. An encoding
+/// the proxy cannot decode yields [`ScanSource::Uninspectable`] so the caller
+/// fails closed (refuse the request / withhold the response) rather than
+/// forwarding a body it never inspected.
+enum ScanSource<'a> {
+    /// Scan these bytes. `encoded` is `true` when they were decompressed from a
+    /// non-identity `Content-Encoding` (the original wire body is compressed).
+    Plaintext { bytes: Cow<'a, [u8]>, encoded: bool },
+    /// The `Content-Encoding` cannot be decoded here — fail closed.
+    Uninspectable,
+}
+
+/// Resolve the [`ScanSource`] for `body` given its `Content-Encoding` header
+/// value (if any). An absent or `identity` encoding is scanned verbatim; a
+/// recognized encoding is decompressed (bounded by `MAX_BODY_LEN`); anything
+/// else is [`ScanSource::Uninspectable`].
+fn scan_source<'a>(body: &'a [u8], content_encoding: Option<&str>) -> ScanSource<'a> {
+    let token = content_encoding.map(str::trim).filter(|s| !s.is_empty());
+    match token {
+        None => ScanSource::Plaintext {
+            bytes: Cow::Borrowed(body),
+            encoded: false,
+        },
+        Some(enc) if enc.eq_ignore_ascii_case("identity") => ScanSource::Plaintext {
+            bytes: Cow::Borrowed(body),
+            encoded: false,
+        },
+        Some(enc) => match decompress_content_encoding(enc, body) {
+            Ok(decoded) => ScanSource::Plaintext {
+                bytes: Cow::Owned(decoded),
+                encoded: true,
+            },
+            Err(_) => ScanSource::Uninspectable,
+        },
+    }
+}
+
 /// Inspects a decrypted HTTP request/response pair, decides whether it is an
 /// LLM API call, and extracts audit-relevant fields from the body.
 ///
@@ -88,7 +132,26 @@ impl Interceptor {
     ///
     /// When the proxy's scanner is disabled (constructed via
     /// `with_scanner(None)`) this returns `Forward` with no findings.
-    pub fn intercept_request(&self, body: &[u8], action: CredentialAction) -> InterceptVerdict {
+    ///
+    /// `content_encoding` is the request's `Content-Encoding` header value (if
+    /// present). A non-identity encoding is decompressed before scanning
+    /// (AAASM-4156) so a `gzip`/`deflate`-encoded secret cannot slip past the
+    /// scanner as opaque compressed bytes. Two fail-closed cases return
+    /// [`VerdictDecision::Block`] with no findings — mirroring the chunked-TE
+    /// stance of refusing an un-inspectable body rather than forwarding it:
+    ///
+    /// * an encoding the proxy cannot decode (`br`, `zstd`, layered lists, or a
+    ///   malformed/oversized stream), and
+    /// * `RedactOnly` findings inside a compressed body — the redacted plaintext
+    ///   cannot be re-encoded to the declared encoding here, and forwarding the
+    ///   original compressed bytes would leak the secret, so the request is
+    ///   blocked. Identity bodies still redact and forward as before.
+    pub fn intercept_request(
+        &self,
+        body: &[u8],
+        content_encoding: Option<&str>,
+        action: CredentialAction,
+    ) -> InterceptVerdict {
         let Some(scanner) = self.scanner.as_ref() else {
             return InterceptVerdict {
                 decision: VerdictDecision::Forward,
@@ -97,7 +160,20 @@ impl Interceptor {
             };
         };
 
-        let text = String::from_utf8_lossy(body);
+        let (bytes, encoded) = match scan_source(body, content_encoding) {
+            ScanSource::Plaintext { bytes, encoded } => (bytes, encoded),
+            ScanSource::Uninspectable => {
+                // Fail closed: the body's Content-Encoding cannot be decoded, so
+                // the scanner never saw the real content. Refuse the forward.
+                return InterceptVerdict {
+                    decision: VerdictDecision::Block,
+                    findings: Vec::new(),
+                    redacted_body: None,
+                };
+            }
+        };
+
+        let text = String::from_utf8_lossy(&bytes);
         let scan = scanner.scan(&text);
         if scan.is_clean() {
             return InterceptVerdict {
@@ -113,6 +189,16 @@ impl Interceptor {
                 findings: scan.findings,
                 redacted_body: None,
             },
+            CredentialAction::RedactOnly if encoded => {
+                // Cannot re-encode the redacted plaintext to the declared
+                // Content-Encoding, and forwarding the original compressed bytes
+                // would relay the secret. Fail closed rather than leak.
+                InterceptVerdict {
+                    decision: VerdictDecision::Block,
+                    findings: scan.findings,
+                    redacted_body: None,
+                }
+            }
             CredentialAction::RedactOnly => {
                 let redacted = scan.redact(&text);
                 InterceptVerdict {
@@ -698,7 +784,7 @@ mod tests {
     fn intercept_request_disabled_scanner_forwards_even_with_credential() {
         let (tx, _rx) = broadcast::channel(16);
         let interceptor = Interceptor::with_scanner(tx, None);
-        let verdict = interceptor.intercept_request(CRED_BODY, CredentialAction::Block);
+        let verdict = interceptor.intercept_request(CRED_BODY, None, CredentialAction::Block);
         assert_eq!(verdict.decision, VerdictDecision::Forward);
         assert!(verdict.findings.is_empty());
         assert!(verdict.redacted_body.is_none());
@@ -707,7 +793,7 @@ mod tests {
     #[test]
     fn intercept_request_clean_body_forwards() {
         let interceptor = make_interceptor();
-        let verdict = interceptor.intercept_request(b"nothing secret here", CredentialAction::Block);
+        let verdict = interceptor.intercept_request(b"nothing secret here", None, CredentialAction::Block);
         assert_eq!(verdict.decision, VerdictDecision::Forward);
         assert!(verdict.findings.is_empty());
         assert!(verdict.redacted_body.is_none());
@@ -716,7 +802,7 @@ mod tests {
     #[test]
     fn intercept_request_block_action_blocks_on_finding() {
         let interceptor = make_interceptor();
-        let verdict = interceptor.intercept_request(CRED_BODY, CredentialAction::Block);
+        let verdict = interceptor.intercept_request(CRED_BODY, None, CredentialAction::Block);
         assert_eq!(verdict.decision, VerdictDecision::Block);
         assert!(!verdict.findings.is_empty(), "a finding must be reported");
         // Block never forwards bytes, so no redacted body is produced.
@@ -726,7 +812,7 @@ mod tests {
     #[test]
     fn intercept_request_redact_only_returns_redacted_bytes() {
         let interceptor = make_interceptor();
-        let verdict = interceptor.intercept_request(CRED_BODY, CredentialAction::RedactOnly);
+        let verdict = interceptor.intercept_request(CRED_BODY, None, CredentialAction::RedactOnly);
         assert_eq!(verdict.decision, VerdictDecision::ForwardRedacted);
         assert!(!verdict.findings.is_empty());
         let redacted = verdict.redacted_body.expect("redact_only must populate the body");
@@ -741,7 +827,7 @@ mod tests {
     #[test]
     fn intercept_request_alert_only_forwards_original_with_findings() {
         let interceptor = make_interceptor();
-        let verdict = interceptor.intercept_request(CRED_BODY, CredentialAction::AlertOnly);
+        let verdict = interceptor.intercept_request(CRED_BODY, None, CredentialAction::AlertOnly);
         assert_eq!(verdict.decision, VerdictDecision::AlertAndForward);
         assert!(!verdict.findings.is_empty());
         // alert_only forwards the original body unmodified, so no redaction.

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -871,6 +871,76 @@ mod tests {
         assert!(verdict.redacted_body.is_none());
     }
 
+    // ── Content-Encoding request-body DLP (AAASM-4156) ──────────────────────
+
+    /// gzip-compress `data` for building encoded test bodies.
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        let mut e = GzEncoder::new(Vec::new(), Compression::default());
+        e.write_all(data).unwrap();
+        e.finish().unwrap()
+    }
+
+    #[test]
+    fn intercept_request_gzip_credential_is_blocked_not_forwarded() {
+        // The headline gap: a gzip'd secret was scanned compressed (matching
+        // nothing) and forwarded. It must now be decompressed, detected, and
+        // blocked.
+        let interceptor = make_interceptor();
+        let verdict = interceptor.intercept_request(&gzip(CRED_BODY), Some("gzip"), CredentialAction::Block);
+        assert_eq!(verdict.decision, VerdictDecision::Block);
+        assert!(!verdict.findings.is_empty(), "decompressed secret must be detected");
+    }
+
+    #[test]
+    fn intercept_request_gzip_clean_body_forwards() {
+        // A clean gzip'd body decompresses to clean plaintext and forwards
+        // (the original compressed bytes) unchanged.
+        let interceptor = make_interceptor();
+        let verdict =
+            interceptor.intercept_request(&gzip(b"nothing secret here"), Some("gzip"), CredentialAction::Block);
+        assert_eq!(verdict.decision, VerdictDecision::Forward);
+        assert!(verdict.findings.is_empty());
+    }
+
+    #[test]
+    fn intercept_request_unsupported_encoding_fails_closed() {
+        // An encoding the proxy cannot decode is un-inspectable, so the request
+        // is blocked even though no secret was (or could be) seen.
+        let interceptor = make_interceptor();
+        let verdict = interceptor.intercept_request(b"\x1b\x00\x00brotli", Some("br"), CredentialAction::Block);
+        assert_eq!(verdict.decision, VerdictDecision::Block);
+        assert!(
+            verdict.findings.is_empty(),
+            "fail-closed block reports no findings (the body was never inspected)"
+        );
+    }
+
+    #[test]
+    fn intercept_request_identity_encoding_is_unchanged() {
+        // An explicit `identity` (and the absent-header path) scans the raw body
+        // exactly as before — a clean plaintext body forwards.
+        let interceptor = make_interceptor();
+        let verdict = interceptor.intercept_request(b"nothing secret here", Some("identity"), CredentialAction::Block);
+        assert_eq!(verdict.decision, VerdictDecision::Forward);
+        assert!(verdict.findings.is_empty());
+    }
+
+    #[test]
+    fn intercept_request_redact_only_compressed_fails_closed() {
+        // RedactOnly cannot re-encode a redacted plaintext to the declared
+        // encoding, and forwarding the original compressed bytes would leak the
+        // secret — so it escalates to a fail-closed Block rather than forwarding.
+        let interceptor = make_interceptor();
+        let verdict = interceptor.intercept_request(&gzip(CRED_BODY), Some("gzip"), CredentialAction::RedactOnly);
+        assert_eq!(verdict.decision, VerdictDecision::Block);
+        assert!(!verdict.findings.is_empty());
+        assert!(verdict.redacted_body.is_none());
+    }
+
     // ── redact_response_body ────────────────────────────────────────────────
 
     #[test]

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -12,6 +12,9 @@
 //! an un-scanned body. The response side still parses the head and leaves a
 //! chunked body empty (the MCP path falls back to a transparent relay).
 
+use std::io::Read;
+
+use flate2::read::{DeflateDecoder, GzDecoder, ZlibDecoder};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 
 use crate::error::ProxyError;
@@ -94,6 +97,76 @@ where
     let text = String::from_utf8(line).map_err(|_| ProxyError::Config("invalid UTF-8 in HTTP header line".into()))?;
     out.push_str(&text);
     Ok(n)
+}
+
+/// Decompress a MitM'd body carrying a single recognized `Content-Encoding`
+/// token, returning the plaintext the DLP scanner should inspect.
+///
+/// AAASM-4156 (fail-closed): scanning a compressed body scans opaque bytes, so a
+/// `gzip`/`deflate`-encoded secret matches no literal/entropy rule and slips past
+/// DLP — the same un-inspectable-body gap the chunked-`Transfer-Encoding` path
+/// fails closed on (see [`read_http_request`]). This decompresses recognized
+/// encodings so the scanner sees the real content, and **fails closed** for
+/// anything it cannot decode:
+///
+/// * `gzip` / `x-gzip` and `deflate` (zlib-wrapped or raw) are decompressed.
+/// * Any other token — notably `br` (brotli, which would need a *new*
+///   dependency), `zstd`, `compress`, or a layered `a, b` list — returns
+///   [`ProxyError::Config`] so the caller withholds the body rather than
+///   forwarding one it could not inspect.
+///
+/// The output is bounded by [`MAX_BODY_LEN`]: decompression is read through a
+/// `Read::take` limiter and any output exceeding the cap is rejected, so a
+/// small compressed payload cannot expand into a decompression-bomb OOM.
+///
+/// Callers must handle the `identity` (or absent) encoding themselves — this
+/// function is only for a non-identity token and always attempts a decode.
+pub fn decompress_content_encoding(encoding: &str, body: &[u8]) -> Result<Vec<u8>, ProxyError> {
+    let token = encoding.trim();
+    // A comma-separated list is a layered encoding (e.g. `gzip, br`); this
+    // parser decodes at most one layer, so refuse rather than half-inspect.
+    if token.contains(',') {
+        return Err(ProxyError::Config(format!(
+            "layered Content-Encoding {token:?} is not inspectable; refusing (fail-closed)"
+        )));
+    }
+    if token.eq_ignore_ascii_case("gzip") || token.eq_ignore_ascii_case("x-gzip") {
+        read_bounded(GzDecoder::new(body), token)
+    } else if token.eq_ignore_ascii_case("deflate") {
+        // HTTP `deflate` is ambiguous: RFC 7230 means zlib-wrapped (RFC 1950),
+        // but some servers send raw DEFLATE (RFC 1951). Try zlib first, then
+        // fall back to raw; if neither decodes cleanly (or either exceeds the
+        // cap), fail closed below.
+        match read_bounded(ZlibDecoder::new(body), token) {
+            Ok(plain) => Ok(plain),
+            Err(_) => read_bounded(DeflateDecoder::new(body), token),
+        }
+    } else {
+        Err(ProxyError::Config(format!(
+            "unsupported Content-Encoding {token:?} is not inspectable; refusing (fail-closed)"
+        )))
+    }
+}
+
+/// Read a decoder to completion, bounded by [`MAX_BODY_LEN`]. Returns
+/// [`ProxyError::Config`] if the decoded stream would exceed the cap (a
+/// decompression bomb) or the compressed input is malformed.
+fn read_bounded<R: Read>(decoder: R, token: &str) -> Result<Vec<u8>, ProxyError> {
+    let mut out = Vec::new();
+    // Read one byte past the cap so an exactly-cap-sized body is accepted while
+    // anything larger is detected without buffering the whole expansion.
+    let mut limited = decoder.take(MAX_BODY_LEN as u64 + 1);
+    limited.read_to_end(&mut out).map_err(|e| {
+        ProxyError::Config(format!(
+            "failed to decompress {token} body: {e}; refusing (fail-closed)"
+        ))
+    })?;
+    if out.len() > MAX_BODY_LEN {
+        return Err(ProxyError::Config(format!(
+            "decompressed {token} body exceeds maximum {MAX_BODY_LEN} bytes; refusing (fail-closed)"
+        )));
+    }
+    Ok(out)
 }
 
 /// A parsed HTTP request from the proxy's MitM tunnel.

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -979,4 +979,119 @@ mod tests {
             "expected over-cap header rejection, got: {err:?}"
         );
     }
+
+    // ── Content-Encoding decompression (AAASM-4156) ─────────────────────────
+
+    use std::io::Write;
+
+    use flate2::write::{DeflateEncoder, GzEncoder, ZlibEncoder};
+    use flate2::Compression;
+
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        let mut e = GzEncoder::new(Vec::new(), Compression::default());
+        e.write_all(data).unwrap();
+        e.finish().unwrap()
+    }
+
+    fn zlib(data: &[u8]) -> Vec<u8> {
+        let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
+        e.write_all(data).unwrap();
+        e.finish().unwrap()
+    }
+
+    fn raw_deflate(data: &[u8]) -> Vec<u8> {
+        let mut e = DeflateEncoder::new(Vec::new(), Compression::default());
+        e.write_all(data).unwrap();
+        e.finish().unwrap()
+    }
+
+    #[test]
+    fn decompress_gzip_roundtrips_plaintext() {
+        let plain = b"a secret sk-TESTONLY-NOT-REAL body the scanner must see";
+        let out = decompress_content_encoding("gzip", &gzip(plain)).unwrap();
+        assert_eq!(out, plain);
+    }
+
+    #[test]
+    fn decompress_encoding_token_is_case_insensitive_and_trimmed() {
+        let plain = b"hello";
+        assert_eq!(decompress_content_encoding("  GZip  ", &gzip(plain)).unwrap(), plain);
+    }
+
+    #[test]
+    fn decompress_deflate_accepts_zlib_wrapped() {
+        let plain = b"zlib-wrapped deflate body";
+        assert_eq!(decompress_content_encoding("deflate", &zlib(plain)).unwrap(), plain);
+    }
+
+    #[test]
+    fn decompress_deflate_accepts_raw_stream() {
+        // Some servers send raw RFC-1951 DEFLATE for `Content-Encoding: deflate`;
+        // the zlib-then-raw fallback must decode it too.
+        let plain = b"raw deflate body";
+        assert_eq!(
+            decompress_content_encoding("deflate", &raw_deflate(plain)).unwrap(),
+            plain
+        );
+    }
+
+    #[test]
+    fn decompress_unsupported_brotli_fails_closed() {
+        // `br` would need a new dependency, so it is intentionally refused rather
+        // than forwarded un-inspected.
+        let err = decompress_content_encoding("br", b"\x1b\x00\x00").unwrap_err();
+        assert!(
+            matches!(&err, ProxyError::Config(m) if m.contains("unsupported") && m.contains("fail-closed")),
+            "expected unsupported-encoding fail-closed, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn decompress_layered_encoding_fails_closed() {
+        // A comma-separated list is a layered encoding this one-layer decoder
+        // cannot fully invert, so it must fail closed.
+        let err = decompress_content_encoding("gzip, br", &gzip(b"x")).unwrap_err();
+        assert!(
+            matches!(&err, ProxyError::Config(m) if m.contains("layered")),
+            "expected layered-encoding fail-closed, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn decompress_malformed_stream_fails_closed() {
+        // Bytes that are not a valid gzip stream must error rather than yield a
+        // partial/empty body the scanner would treat as clean.
+        let err = decompress_content_encoding("gzip", b"this is not a gzip stream").unwrap_err();
+        assert!(
+            matches!(err, ProxyError::Config(_)),
+            "expected Config error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn decompress_bomb_is_bounded_by_max_body_len() {
+        // A tiny gzip stream that expands past MAX_BODY_LEN must be rejected —
+        // the Read::take limiter caps the expansion so a decompression bomb
+        // cannot OOM the proxy.
+        let bomb = gzip(&vec![0u8; MAX_BODY_LEN + 1024]);
+        assert!(
+            bomb.len() < 1024 * 1024,
+            "a highly-compressible bomb is tiny on the wire ({} bytes)",
+            bomb.len()
+        );
+        let err = decompress_content_encoding("gzip", &bomb).unwrap_err();
+        assert!(
+            matches!(&err, ProxyError::Config(m) if m.contains("exceeds maximum")),
+            "expected decompression-bomb rejection, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn decompress_at_cap_boundary_is_accepted() {
+        // A body that decompresses to exactly MAX_BODY_LEN is allowed (the cap is
+        // inclusive); only strictly-larger expansions are rejected.
+        let plain = vec![0u8; MAX_BODY_LEN];
+        let out = decompress_content_encoding("gzip", &gzip(&plain)).unwrap();
+        assert_eq!(out.len(), MAX_BODY_LEN);
+    }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -26,7 +26,7 @@ use crate::error::ProxyError;
 use crate::intercept::detect::{detect_api, LlmApiPattern};
 use crate::intercept::event::ProxyEvent;
 use crate::intercept::mcp::{is_unenforceable_tool_call, parse_mcp_request};
-use crate::intercept::{InterceptVerdict, Interceptor, VerdictDecision};
+use crate::intercept::{InterceptVerdict, Interceptor, ResponseScan, VerdictDecision};
 use crate::mcp_enforce::{evaluate_mcp_call, McpDecision};
 use crate::proxy::http::{
     read_http_request, read_http_response, read_line_capped, serialize_http_request, serialize_http_request_with_auth,
@@ -614,21 +614,54 @@ impl ProxyServer {
             let mut upstream_reader = BufReader::new(upstream_read);
             match read_http_response(&mut upstream_reader).await {
                 Ok(Some(resp)) => {
-                    let body_to_forward = match self.interceptor.redact_response_body(&resp.body) {
-                        Some(redacted) => {
-                            tracing::info!(
+                    let content_encoding = resp
+                        .headers
+                        .iter()
+                        .find(|(k, _)| k.eq_ignore_ascii_case("content-encoding"))
+                        .map(|(_, v)| v.as_str());
+                    match self.interceptor.redact_response_body(&resp.body, content_encoding) {
+                        ResponseScan::Withhold => {
+                            // AAASM-4156: the upstream body's Content-Encoding is
+                            // not inspectable (undecodable encoding, or a
+                            // compressed body carrying findings we cannot safely
+                            // re-encode). Relaying it would leak an un-scanned —
+                            // possibly credential-bearing — body to the agent, the
+                            // same leak AAASM-3997 closes for an unparseable
+                            // response. Fail closed: withhold and return a
+                            // JSON-RPC error envelope.
+                            tracing::warn!(
                                 tool_name = %call.tool_name,
-                                "MCP response carried sensitive payload, redacting before forwarding to client",
+                                "MCP response body not inspectable (content-encoding); withholding (fail-closed)",
                             );
                             self.interceptor
-                                .emit_mcp_decision(&call.tool_name, &args_bytes, false, "response redacted")
+                                .emit_mcp_decision(
+                                    &call.tool_name,
+                                    &args_bytes,
+                                    true,
+                                    "response encoding not inspectable, withheld (fail-closed)",
+                                )
                                 .await;
-                            redacted
+                            client_tls.write_all(&mcp_unparseable_response_bytes()).await?;
                         }
-                        None => resp.body.clone(),
-                    };
-                    let modified = serialize_http_response(&resp, &body_to_forward);
-                    client_tls.write_all(&modified).await?;
+                        outcome => {
+                            let body_to_forward = match outcome {
+                                ResponseScan::Redact(redacted) => {
+                                    tracing::info!(
+                                        tool_name = %call.tool_name,
+                                        "MCP response carried sensitive payload, redacting before forwarding to client",
+                                    );
+                                    self.interceptor
+                                        .emit_mcp_decision(&call.tool_name, &args_bytes, false, "response redacted")
+                                        .await;
+                                    redacted
+                                }
+                                // ResponseScan::Forward — Withhold is handled above.
+                                _ => resp.body.clone(),
+                            };
+                            let modified = serialize_http_response(&resp, &body_to_forward);
+                            client_tls.write_all(&modified).await?;
+                        }
+                    }
                 }
                 Ok(None) => {
                     // Upstream closed without writing a response — nothing to forward.

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -556,9 +556,11 @@ impl ProxyServer {
         // A `Block` verdict refuses the forward (403); a redact verdict forwards
         // the redacted bytes. An MCP `Deny`/unenforceable body already returned
         // above, so this only runs on bodies that are about to be forwarded.
-        let verdict = self
-            .interceptor
-            .intercept_request(&req.body, self.config.credential_action);
+        let verdict = self.interceptor.intercept_request(
+            &req.body,
+            req.header("content-encoding"),
+            self.config.credential_action,
+        );
         if verdict.decision == VerdictDecision::Block {
             tracing::info!(
                 %host,
@@ -788,9 +790,11 @@ impl ProxyServer {
             return Ok(());
         }
 
-        let verdict = self
-            .interceptor
-            .intercept_request(&req.body, self.config.credential_action);
+        let verdict = self.interceptor.intercept_request(
+            &req.body,
+            req.header("content-encoding"),
+            self.config.credential_action,
+        );
 
         // Emit the legacy ProxyEvent for the audit broadcast — keeps
         // existing subscribers wired up unchanged.


### PR DESCRIPTION
## What changed

The aa-proxy credential/DLP scanner ran over MitM'd request and MCP response bodies **as-is**, so a `Content-Encoding: gzip`/`deflate`/`br` body was scanned in its compressed form. Literal/entropy passes match nothing on compressed bytes, so a gzip'd secret produced a `Forward` verdict and was relayed upstream — inconsistent with the `Transfer-Encoding: chunked` path, which already fails closed on an un-inspectable body (`http.rs`, AAASM-3864).

This makes a non-identity `Content-Encoding` **decompress-then-scan**, or **fail closed** when it can't:

- New `decompress_content_encoding` helper (`aa-proxy/src/proxy/http.rs`) decodes `gzip`/`x-gzip` and `deflate` (zlib-wrapped or raw), **bounded by the existing `MAX_BODY_LEN` (64 MiB)** via a `Read::take` limiter so a small payload cannot expand into a decompression-bomb OOM.
- Request path (`intercept_request`): decompresses the body before scanning, so a gzip'd secret is now **detected and blocked** instead of forwarded. Identity bodies are unchanged.
- MCP response path (`redact_response_body`, now returning a `ResponseScan` enum): decompresses before scanning; on findings/undecodable encoding it **withholds** the upstream body and returns a JSON-RPC error envelope — the same fail-closed posture AAASM-3997 uses for an unparseable response.

### Encodings: decompress vs fail-closed

| Encoding | Behavior |
|---|---|
| `gzip` / `x-gzip` | Decompress-then-scan |
| `deflate` (zlib or raw) | Decompress-then-scan |
| `identity` / absent | Scanned verbatim (unchanged) |
| `br` (brotli), `zstd`, layered (`a, b`), malformed, over-cap | **Fail closed** (Block request / Withhold response) |

**Dependency decision:** `flate2` (gzip/deflate) is added as a direct aa-proxy dependency — it was **already resolved** in the workspace lock (transitively via `tower-http`/`async-compression` and `zip`), so this adds **no new crate** and uses the pure-Rust miniz_oxide backend (no C/zlib). `br` (brotli) would require a **genuinely new** dependency, so per the fail-closed-over-new-deps guidance the proxy **rejects** brotli-encoded bodies rather than pulling one in. `cargo deny check` passes (advisories/bans/licenses ok).

Also fail-closed: `RedactOnly` findings inside a *compressed* body escalate to Block/Withhold, because the redacted plaintext cannot be re-encoded to the declared encoding here and forwarding the original compressed bytes would leak the secret.

## Why

Severity LOW / defense-in-depth: closes a concrete inconsistency with the fail-closed-on-uninspectable philosophy the chunked-TE path establishes. Content DLP remains best-effort vs a cooperating exfiltrator, and the SDK + eBPF layers still observe plaintext.

## How to verify

`cargo nextest run -p aa-proxy` — 219 tests pass (18 new):
- `decompress_*` helper: gzip round-trip, deflate (zlib + raw), brotli/layered/malformed fail-closed, decompression-bomb bounded by `MAX_BODY_LEN`, inclusive cap boundary.
- Request path: gzip'd secret blocked (was forwarded), clean gzip forwards, unsupported encoding fail-closed, identity unchanged, RedactOnly-compressed escalates to Block.
- Response path: gzip'd secret withheld (was relayed compressed), clean gzip forwards, unsupported withheld, identity still redacts.

Validated locally: `cargo nextest run -p aa-proxy`, `cargo fmt --all -- --check`, `cargo clippy -p aa-proxy --all-targets -- -D warnings`, `cargo deny check`, `cargo doc --workspace --no-deps` — all green.

Closes AAASM-4156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
