### PR TITLE
[AAASM-4160] 🔗 (docs): Repoint doc references to canonical docs.agent-assembly.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ can move from this repo to the SDKs, the install tap, or the canonical docs.
 | [node-sdk](https://github.com/ai-agent-assembly/node-sdk) | TypeScript / Node.js SDK (napi-rs native + JS client) | [![release](https://img.shields.io/github/v/release/ai-agent-assembly/node-sdk?include_prereleases&sort=semver&label=release&logo=nodedotjs&logoColor=white)](https://github.com/ai-agent-assembly/node-sdk/releases) |
 | [go-sdk](https://github.com/ai-agent-assembly/go-sdk) | Go SDK | [![release](https://img.shields.io/github/v/release/ai-agent-assembly/go-sdk?include_prereleases&sort=semver&label=release&logo=go&logoColor=white)](https://github.com/ai-agent-assembly/go-sdk/releases) |
 | [homebrew-tap](https://github.com/ai-agent-assembly/homebrew-tap) | Homebrew tap for the `aasm` CLI | [![Homebrew tap](https://img.shields.io/badge/homebrew-tap-FBB040?logo=homebrew&logoColor=white)](https://github.com/ai-agent-assembly/homebrew-tap) |
-| [agent-assembly-docs](https://ai-agent-assembly.github.io/agent-assembly-docs/) | Canonical documentation site | [![docs](https://img.shields.io/badge/docs-live-2088FF)](https://docs.agent-assembly.com/) |
+| [agent-assembly-docs](https://docs.agent-assembly.com/) | Canonical documentation site | [![docs](https://img.shields.io/badge/docs-live-2088FF)](https://docs.agent-assembly.com/) |
 | agent-assembly-cloud | Hosted SaaS control plane | ![coming soon](https://img.shields.io/badge/SaaS-coming_soon-8957E5) |
 | agent-assembly-enterprise | Enterprise extensions (delivered via SaaS) | ![coming soon](https://img.shields.io/badge/enterprise-coming_soon-8957E5) |
 
@@ -364,7 +364,7 @@ agent-assembly/
 
 ## Documentation
 
-📖 **Canonical docs site:** <https://ai-agent-assembly.github.io/agent-assembly-docs/>
+📖 **Canonical docs site:** <https://docs.agent-assembly.com/>
 
 The contributor-facing documentation is also published as an [mdBook](https://rust-lang.github.io/mdBook/). Sources live under `docs/src/`. Build it locally with:
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -6,7 +6,7 @@ This book is the contributor and operator reference for the core. If you build *
 
 New here? Start with the **[Introduction](introduction/README.md)** — it explains what Agent Assembly is, the problem it solves, the core concepts, and the three-layer interception model. Then move on to the [Quick Start](quick-start/requirements.md).
 
-> **Other docs:** [Docs Hub](https://ai-agent-assembly.github.io/agent-assembly-docs/stable/) · [Python SDK](https://ai-agent-assembly.github.io/python-sdk/stable/) · [Node SDK](https://ai-agent-assembly.github.io/node-sdk/stable/) · [Go SDK](https://ai-agent-assembly.github.io/go-sdk/stable/)
+> **Other docs:** [Docs Hub](https://docs.agent-assembly.com/stable/) · [Python SDK](https://docs.agent-assembly.com/python-sdk/stable/) · [Node SDK](https://docs.agent-assembly.com/node-sdk/stable/) · [Go SDK](https://docs.agent-assembly.com/go-sdk/stable/)
 
 ## Run it locally
 

--- a/docs/src/introduction/overview.md
+++ b/docs/src/introduction/overview.md
@@ -90,6 +90,6 @@ This book is the reference for **contributors and operators of the
 `agent-assembly` core** — people running the gateway, writing policy, and
 deploying the interception layers. If you are instead building an application
 *with* a language SDK, start from the per-SDK guides: [Python
-SDK](https://ai-agent-assembly.github.io/python-sdk/stable/), [Node
-SDK](https://ai-agent-assembly.github.io/node-sdk/stable/), [Go
-SDK](https://ai-agent-assembly.github.io/go-sdk/stable/).
+SDK](https://docs.agent-assembly.com/python-sdk/stable/), [Node
+SDK](https://docs.agent-assembly.com/node-sdk/stable/), [Go
+SDK](https://docs.agent-assembly.com/go-sdk/stable/).

--- a/docs/src/reference/framework-compatibility.md
+++ b/docs/src/reference/framework-compatibility.md
@@ -21,9 +21,9 @@ compatibility page:
 
 | SDK | Frameworks (high level) | Authoritative compatibility doc |
 |---|---|---|
-| **Python** (`agent-assembly`) | LangChain · LangGraph · Pydantic AI · CrewAI · Google ADK · MCP · OpenAI Agents · LlamaIndex · Agno · Microsoft Agent Framework · Smolagents · Haystack | [python-sdk → Framework compatibility](https://ai-agent-assembly.github.io/python-sdk/stable/compatibility/frameworks/) |
-| **Node / TypeScript** (`@agent-assembly/sdk`) | LangChain.js · LangGraph.js · Vercel AI SDK · Mastra · OpenAI Agents | [node-sdk → Framework compatibility](https://ai-agent-assembly.github.io/node-sdk/stable/compatibility-versioning/compatibility/) |
-| **Go** (`go-sdk`) | LangChainGo (+ generic tool wrapping) | [go-sdk → Framework compatibility](https://ai-agent-assembly.github.io/go-sdk/stable/compatibility/) |
+| **Python** (`agent-assembly`) | LangChain · LangGraph · Pydantic AI · CrewAI · Google ADK · MCP · OpenAI Agents · LlamaIndex · Agno · Microsoft Agent Framework · Smolagents · Haystack | [python-sdk → Framework compatibility](https://docs.agent-assembly.com/python-sdk/stable/compatibility/frameworks/) |
+| **Node / TypeScript** (`@agent-assembly/sdk`) | LangChain.js · LangGraph.js · Vercel AI SDK · Mastra · OpenAI Agents | [node-sdk → Framework compatibility](https://docs.agent-assembly.com/node-sdk/stable/compatibility-versioning/compatibility/) |
+| **Go** (`go-sdk`) | LangChainGo (+ generic tool wrapping) | [go-sdk → Framework compatibility](https://docs.agent-assembly.com/go-sdk/stable/compatibility/) |
 
 The `/stable/` links resolve at the first GA release (consistent with the docs
 versioning convention); until then they 404 by design.

--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -42,6 +42,6 @@ repo links above, presented in the SDK's own docs site.
   build.) Do NOT "fix" these by switching to pre-release/latest.
 -->
 
-- **Python** — [python-sdk examples](https://ai-agent-assembly.github.io/python-sdk/stable/examples/)
-- **Node** — [node-sdk examples](https://ai-agent-assembly.github.io/node-sdk/stable/examples/)
-- **Go** — [go-sdk examples](https://ai-agent-assembly.github.io/go-sdk/stable/examples/)
+- **Python** — [python-sdk examples](https://docs.agent-assembly.com/python-sdk/stable/examples/)
+- **Node** — [node-sdk examples](https://docs.agent-assembly.com/node-sdk/stable/examples/)
+- **Go** — [go-sdk examples](https://docs.agent-assembly.com/go-sdk/stable/examples/)


### PR DESCRIPTION
## Description

Repoints legacy per-repo GitHub-Pages doc URLs (`ai-agent-assembly.github.io/<repo>/`) to the canonical `docs.agent-assembly.com` host, per the URL contract in ADR 0007.

**Files changed (5):**
- `README.md`
- `docs/src/README.md`
- `docs/src/introduction/overview.md`
- `docs/src/reference/framework-compatibility.md`
- `docs/src/usage-guide/examples.md`

**Mapping applied (longest prefix first):**

| From | To |
|---|---|
| `ai-agent-assembly.github.io/agent-assembly-docs` | `docs.agent-assembly.com` |
| `ai-agent-assembly.github.io/agent-assembly` | `docs.agent-assembly.com/core` |
| `ai-agent-assembly.github.io/python-sdk` | `docs.agent-assembly.com/python-sdk` |
| `ai-agent-assembly.github.io/node-sdk` | `docs.agent-assembly.com/node-sdk` |
| `ai-agent-assembly.github.io/go-sdk` | `docs.agent-assembly.com/go-sdk` |

Scheme (`https://`) and any trailing path (e.g. `/stable/…`) preserved unchanged.

**Left untouched** (redirect/contract source & frozen history):
- `infra/redirects/**`
- `docs/src/adr/0007-*` (the URL-contract ADR)
- `docs/release/v0.0.1-*.md`
- `verification-reports/**`

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4160

## Testing

- [x] Manual testing performed
- [x] No tests required (docs-only link repoint)

Validation: `mdbook build docs` succeeds. `curl -sI` on rewritten hosts — `https://docs.agent-assembly.com/` and `https://docs.agent-assembly.com/python-sdk/stable/` return 200; `https://docs.agent-assembly.com/go-sdk/stable/` currently 404 (docs content not yet published at that channel path — deployment concern, not a mapping error). Residual `github.io` refs remain only in the leave-bucket files above.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention
