### PR TITLE
[AAASM-4164] 🔒 (aa-gateway): Honor tools:"*" wildcard in rate-limit and approval stages

### DIFF
--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -230,8 +230,17 @@ fn stage_approval(
     policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
 ) -> Option<PolicyDecision> {
     match action {
+        // AAASM-4164: fall back to the `"*"` wildcard entry (exact entry wins) so a
+        // `tools: { "*": { requires_approval_if: "<guard>" } }` scope gates
+        // unlisted tools behind approval instead of skipping the check — the
+        // cascade twin of `eval_toolcall_stages`' stage-5 wildcard fallback.
         aa_core::GovernanceAction::ToolCall { name, .. }
-            if approval_condition_met(doc.tools.get(name), ctx, action, policy_ctx) =>
+            if approval_condition_met(
+                doc.tools.get(name).or_else(|| doc.tools.get("*")),
+                ctx,
+                action,
+                policy_ctx,
+            ) =>
         {
             Some(PolicyDecision::RequireApproval {
                 reason: format!("approval required for tool '{name}'"),

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1247,9 +1247,13 @@ impl PolicyEngine {
         let aa_core::GovernanceAction::ToolCall { name, .. } = action else {
             return None;
         };
+        // AAASM-4164: within each doc the exact per-tool entry wins, falling back
+        // to that doc's `"*"` wildcard, so a `tools: { "*": { limit_per_hour: N } }`
+        // scope rate-limits unlisted tools instead of leaving them uncapped —
+        // mirroring `stage_tool_allow`'s wildcard fallback.
         let min_limit = cascade
             .iter()
-            .filter_map(|doc| doc.tools.get(name))
+            .filter_map(|doc| doc.tools.get(name).or_else(|| doc.tools.get("*")))
             .filter_map(|tp| tp.limit_per_hour)
             .min()?;
         if !self.try_consume_rate(name, min_limit) {

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -934,9 +934,12 @@ impl PolicyEngine {
         // allow-by-default. Explicit per-tool entries take precedence. This is
         // the single-file twin of the cascade path's `decision::stage_tool_allow`
         // — both must honour the wildcard or they diverge (the twin the network
-        // stage shares via `network_request_url_allowed`). Rate-limit (stage 4)
-        // and approval (stage 5) keep the exact `tool_policy` lookup, matching
-        // the cascade twin where only the allow/deny check consults `"*"`.
+        // stage shares via `network_request_url_allowed`). AAASM-4164: rate-limit
+        // (stage 4) and approval (stage 5) below apply the same `"*"` fallback,
+        // so a wildcard entry carrying `limit_per_hour` / `requires_approval_if`
+        // gates unlisted tools rather than silently skipping those stages. The
+        // cascade twins (`Self::cascade_rate_limit`, `decision::stage_approval`)
+        // consult `"*"` too.
         if let Some(tp) = tool_policy.or_else(|| policy.tools.get("*")) {
             if !tp.allow {
                 return Some(EvaluationResult::deny("tool denied by policy"));

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -955,8 +955,11 @@ impl PolicyEngine {
             }
         }
 
-        // Stage 5 — Approval condition for ToolCall.
-        self.eval_approval_condition(policy, tool_policy, ctx, action)
+        // Stage 5 — Approval condition for ToolCall. AAASM-4164: fall back to the
+        // `"*"` wildcard entry (exact entry wins) so a
+        // `tools: { "*": { requires_approval_if: "<guard>" } }` document gates
+        // unlisted tools behind approval instead of skipping the check.
+        self.eval_approval_condition(policy, tool_policy.or_else(|| policy.tools.get("*")), ctx, action)
     }
 
     /// Evaluate a tool/channel policy's `requires_approval_if` expression for

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -943,8 +943,13 @@ impl PolicyEngine {
             }
         }
 
-        // Stage 4 — Tool rate limit.
-        if let Some(limit) = tool_policy.and_then(|tp| tp.limit_per_hour) {
+        // Stage 4 — Tool rate limit. AAASM-4164: fall back to the `"*"` wildcard
+        // entry (exact entry wins) so a `tools: { "*": { limit_per_hour: N } }`
+        // document rate-limits unlisted tools instead of leaving them uncapped.
+        if let Some(limit) = tool_policy
+            .or_else(|| policy.tools.get("*"))
+            .and_then(|tp| tp.limit_per_hour)
+        {
             if !self.try_consume_rate(name, limit) {
                 return Some(EvaluationResult::deny("rate limit exceeded"));
             }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2243,6 +2243,183 @@ mod tests {
     }
 
     #[test]
+    fn tool_wildcard_rate_limit_caps_unlisted_tool() {
+        // AAASM-4164: a `"*"` wildcard carrying `limit_per_hour` must rate-limit
+        // an unlisted tool on the single-file path (stage 4), not leave it
+        // uncapped. An explicit per-tool entry still takes precedence: a tool
+        // with its own entry (no limit) is never capped by the wildcard.
+        let mut doc = empty_doc();
+        doc.tools.insert(
+            "*".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: Some(1),
+                requires_approval_if: None,
+            },
+        );
+        doc.tools.insert(
+            "read_file".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: None,
+                requires_approval_if: None,
+            },
+        );
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+
+        // Unlisted tool falls back to the `"*"` cap: first call passes, second denies.
+        assert_eq!(
+            engine.evaluate(&ctx, &tool_call("search", "")).decision,
+            PolicyResult::Allow
+        );
+        assert_eq!(
+            engine.evaluate(&ctx, &tool_call("search", "")).decision,
+            PolicyResult::Deny {
+                reason: "rate limit exceeded".into()
+            }
+        );
+        // Explicit entry (no limit) wins over the wildcard — never rate-limited.
+        for _ in 0..3 {
+            assert_eq!(
+                engine.evaluate(&ctx, &tool_call("read_file", "")).decision,
+                PolicyResult::Allow
+            );
+        }
+    }
+
+    #[test]
+    fn tool_wildcard_approval_gates_unlisted_tool() {
+        // AAASM-4164: a `"*"` wildcard carrying `requires_approval_if` must gate
+        // an unlisted tool on the single-file path (stage 5), not skip approval.
+        // An explicit per-tool entry (no approval guard) still takes precedence.
+        let mut doc = empty_doc();
+        doc.tools.insert(
+            "*".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: None,
+                // Always true for any real tool name — proves the wildcard guard
+                // is consulted regardless of the unlisted tool's name.
+                requires_approval_if: Some(r#"tool != "__never_matches__""#.to_string()),
+            },
+        );
+        doc.tools.insert(
+            "read_file".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: None,
+                requires_approval_if: None,
+            },
+        );
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+
+        // Unlisted tool falls back to the `"*"` approval guard.
+        assert_eq!(
+            engine.evaluate(&ctx, &tool_call("exfiltrate_secrets", "")).decision,
+            PolicyResult::RequiresApproval { timeout_secs: 300 }
+        );
+        // Explicit entry (no guard) wins over the wildcard — allowed outright.
+        assert_eq!(
+            engine.evaluate(&ctx, &tool_call("read_file", "")).decision,
+            PolicyResult::Allow
+        );
+    }
+
+    #[test]
+    fn cascade_wildcard_rate_limit_caps_unlisted_tool() {
+        // AAASM-4164: the cascade path's `cascade_rate_limit` must honour a
+        // `"*"` wildcard `limit_per_hour` for an unlisted tool (stage 4), the
+        // twin of the single-file fix. Explicit entries still take precedence.
+        let mut doc = empty_doc();
+        doc.tools.insert(
+            "*".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: Some(1),
+                requires_approval_if: None,
+            },
+        );
+        doc.tools.insert(
+            "read_file".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: None,
+                requires_approval_if: None,
+            },
+        );
+        let engine = make_engine(empty_doc());
+        let ctx = make_ctx();
+        let cascade = vec![Arc::new(doc)];
+
+        assert_eq!(
+            engine
+                .evaluate_with_cascade(cascade.clone(), &ctx, &tool_call("search", ""))
+                .decision,
+            PolicyResult::Allow
+        );
+        assert_eq!(
+            engine
+                .evaluate_with_cascade(cascade.clone(), &ctx, &tool_call("search", ""))
+                .decision,
+            PolicyResult::Deny {
+                reason: "rate limit exceeded".into()
+            }
+        );
+        // Explicit entry (no limit) wins over the wildcard.
+        for _ in 0..3 {
+            assert_eq!(
+                engine
+                    .evaluate_with_cascade(cascade.clone(), &ctx, &tool_call("read_file", ""))
+                    .decision,
+                PolicyResult::Allow
+            );
+        }
+    }
+
+    #[test]
+    fn cascade_wildcard_approval_gates_unlisted_tool() {
+        // AAASM-4164: the cascade path's `stage_approval` must honour a `"*"`
+        // wildcard `requires_approval_if` for an unlisted tool (stage 5), the
+        // twin of the single-file fix. Explicit entries still take precedence.
+        let mut doc = empty_doc();
+        doc.tools.insert(
+            "*".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: None,
+                requires_approval_if: Some(r#"tool != "__never_matches__""#.to_string()),
+            },
+        );
+        doc.tools.insert(
+            "read_file".to_string(),
+            ToolPolicy {
+                allow: true,
+                limit_per_hour: None,
+                requires_approval_if: None,
+            },
+        );
+        let engine = make_engine(empty_doc());
+        let ctx = make_ctx();
+        let cascade = vec![Arc::new(doc)];
+
+        assert_eq!(
+            engine
+                .evaluate_with_cascade(cascade.clone(), &ctx, &tool_call("exfiltrate_secrets", ""))
+                .decision,
+            PolicyResult::RequiresApproval { timeout_secs: 300 }
+        );
+        // Explicit entry (no guard) wins over the wildcard.
+        assert_eq!(
+            engine
+                .evaluate_with_cascade(cascade, &ctx, &tool_call("read_file", ""))
+                .decision,
+            PolicyResult::Allow
+        );
+    }
+
+    #[test]
     fn rate_limit_denies_after_capacity_exhausted() {
         let mut doc = empty_doc();
         doc.tools.insert(


### PR DESCRIPTION
## Description

Incomplete-fix follow-up to **AAASM-4152**. That ticket made the tool `"*"` wildcard consulted at **stage 3 (allow/deny)** so `tools: { "*": { allow: false } }` fails closed for unlisted tools. But **stage 4 (rate-limit)** and **stage 5 (approval)** still used the exact `tools.get(name)` lookup on **both** the single-file path (`engine/mod.rs`) and the cascade path (`engine/decision.rs` + `cascade_rate_limit`).

Consequence: an operator who writes `tools: { "*": { allow: true, requires_approval_if: "<guard>", limit_per_hour: N } }` — intending "allow unlisted tools but gate them behind approval and a rate cap" — got the tool **allowed** via the wildcard but **silently skipping approval and the rate limit**, because the exact lookup returned `None` for the unlisted name.

This PR extends the `"*"` fallback to stages 4 and 5 on both paths, mirroring the stage-3 pattern:

- **Single-file (`engine/mod.rs`)** — stage-4 rate-limit and stage-5 approval now use `tool_policy.or_else(|| policy.tools.get("*"))`.
- **Cascade (`engine/decision.rs` `stage_approval`, `engine/mod.rs` `cascade_rate_limit`)** — each per-doc lookup falls back to that doc's `"*"` entry.

**Explicit-entry precedence is preserved** everywhere (exact per-tool entry wins over `"*"` via `or_else`). The **`"message"` SendMessage approval sentinel is untouched** — it remains a separate exact key and is deliberately not routed through `"*"`. Only the `ToolCall` `name` lookups gained the wildcard fallback.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Behaviour only tightens for the specific misconfiguration where a `"*"` entry carried `requires_approval_if` / `limit_per_hour` (previously a silent bypass). The common fail-closed form `{ "*": { allow: false } }` is unchanged.

## Related Issues

- Related Jira ticket: AAASM-4164 (incomplete-fix twin of AAASM-4152)

## Testing

- [x] Unit tests added / updated

Added 4 regression tests in `engine/mod.rs`:
- `tool_wildcard_rate_limit_caps_unlisted_tool` (single-file, stage 4)
- `tool_wildcard_approval_gates_unlisted_tool` (single-file, stage 5)
- `cascade_wildcard_rate_limit_caps_unlisted_tool` (cascade, stage 4)
- `cascade_wildcard_approval_gates_unlisted_tool` (cascade, stage 5)

Each asserts an unlisted tool matching `"*"` is now rate-limited / requires approval (not silently allowed), and that an explicit per-tool entry still takes precedence over the wildcard.

Local validation: `cargo nextest run -p aa-gateway` (971 pass; the sole failure is the Docker-dependent Postgres testcontainer test — Docker not running locally, unrelated), `cargo fmt --all` clean, `cargo clippy -p aa-gateway --all-targets -- -D warnings` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
