### PR TITLE
[AAASM-4175] 🐛 (aa-cli): Fail simulate exit code on unparseable audit events

### DIFF
--- a/aa-cli/src/commands/policy/simulate.rs
+++ b/aa-cli/src/commands/policy/simulate.rs
@@ -40,8 +40,10 @@ pub struct SimulateArgs {
 
 /// Execute the simulate command.
 ///
-/// Returns [`ExitCode::SUCCESS`] if no violations were found,
-/// or [`ExitCode::FAILURE`] if the simulation detected policy violations.
+/// Returns [`ExitCode::SUCCESS`] only when every event evaluated cleanly with no
+/// denials. Returns [`ExitCode::FAILURE`] if the simulation detected policy
+/// violations **or** any event could not be evaluated (e.g. an unparseable /
+/// schema-drifted audit log) — otherwise a fully-broken log would gate as PASS.
 /// This allows CI pipelines to gate on `aasm policy simulate` exit status.
 pub fn run(args: SimulateArgs) -> ExitCode {
     // Load the policy engine from the provided YAML file.
@@ -97,7 +99,18 @@ pub fn run(args: SimulateArgs) -> ExitCode {
 
     print_report(&report);
 
-    if report.denied > 0 {
+    // An event that could not be evaluated (e.g. an unparseable / schema-drifted
+    // payload) must fail the run loudly: a simulation that could not actually
+    // evaluate its input is not a PASS, so CI gating on the exit status catches a
+    // malformed audit log instead of treating it as SUCCESS.
+    if report.errored > 0 {
+        eprintln!(
+            "error: {} event(s) failed to parse and could not be evaluated",
+            report.errored
+        );
+    }
+
+    if report.denied > 0 || report.errored > 0 {
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS

--- a/aa-cli/tests/policy_history_simulate_cov.rs
+++ b/aa-cli/tests/policy_history_simulate_cov.rs
@@ -37,6 +37,18 @@ fn tool_call_jsonl(tool: &str) -> String {
     .unwrap()
 }
 
+/// Serialize one audit-log line whose `payload` is not a valid
+/// `GovernanceAction`, so the replay yields a per-event `decision = "error"`
+/// outcome (a malformed / schema-drifted event).
+fn unparseable_jsonl() -> String {
+    serde_json::to_string(&serde_json::json!({
+        "event_type": "ToolCallIntercepted",
+        "agent_id": "test-agent",
+        "payload": "this is not a serialized governance action",
+    }))
+    .unwrap()
+}
+
 fn write_temp(contents: &str) -> tempfile::NamedTempFile {
     let mut f = tempfile::NamedTempFile::new().unwrap();
     f.write_all(contents.as_bytes()).unwrap();
@@ -96,6 +108,51 @@ fn simulate_unreadable_against_file_returns_failure() {
     let args = SimulateArgs {
         policy: policy.path().to_path_buf(),
         against: Some(std::path::PathBuf::from("/nonexistent/aaasm-3812/audit-log.jsonl")),
+        live: false,
+        duration: None,
+        output_file: None,
+    };
+    assert_eq!(simulate::run(args), ExitCode::FAILURE);
+}
+
+#[test]
+fn simulate_unparseable_events_return_failure() {
+    // AAASM-4175: a fully-unparseable / schema-drifted audit log must fail the
+    // exit gate. Previously the exit code keyed only on `denied`, so every
+    // event erroring out still yielded exit 0 — CI gating on the exit status
+    // treated a broken log as PASS.
+    let policy = write_temp(ALLOW_ALL_POLICY);
+    let log = write_temp(&format!("{}\n{}\n", unparseable_jsonl(), unparseable_jsonl()));
+    let report_path = tempfile::NamedTempFile::new().unwrap();
+
+    let args = SimulateArgs {
+        policy: policy.path().to_path_buf(),
+        against: Some(log.path().to_path_buf()),
+        live: false,
+        duration: None,
+        output_file: Some(report_path.path().to_path_buf()),
+    };
+    assert_eq!(simulate::run(args), ExitCode::FAILURE);
+
+    // The report tallies the unparseable events as errored, with no denials —
+    // the errored count, not denied, is what drives the failure here.
+    let written = std::fs::read_to_string(report_path.path()).unwrap();
+    let report: serde_json::Value = serde_json::from_str(&written).unwrap();
+    assert_eq!(report["total_events"], 2);
+    assert_eq!(report["errored"], 2);
+    assert_eq!(report["denied"], 0);
+}
+
+#[test]
+fn simulate_one_unparseable_among_allowed_returns_failure() {
+    // A single unparseable event among otherwise-allowed events must still
+    // fail: the old `denied > 0` gate would have passed this log as SUCCESS.
+    let policy = write_temp(ALLOW_ALL_POLICY);
+    let log = write_temp(&format!("{}\n{}\n", tool_call_jsonl("read_file"), unparseable_jsonl()));
+
+    let args = SimulateArgs {
+        policy: policy.path().to_path_buf(),
+        against: Some(log.path().to_path_buf()),
         live: false,
         duration: None,
         output_file: None,

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -92,6 +92,7 @@ impl SimulationEngine {
         let mut allowed = 0usize;
         let mut denied = 0usize;
         let mut approval_required = 0usize;
+        let mut errored = 0usize;
         let mut flagged_outcomes = Vec::new();
 
         for (i, event) in events.iter().enumerate() {
@@ -107,7 +108,9 @@ impl SimulationEngine {
                     flagged_outcomes.push(outcome);
                 }
                 _ => {
-                    // "error" or unknown — treat as flagged
+                    // "error" or unknown — an event that could not be evaluated.
+                    // Counted so an exit-gated run can fail on an unparseable log.
+                    errored += 1;
                     flagged_outcomes.push(outcome);
                 }
             }
@@ -118,6 +121,7 @@ impl SimulationEngine {
             denied,
             allowed,
             approval_required,
+            errored,
             budget_impact_usd: None,
             flagged_outcomes,
         }

--- a/aa-gateway/src/simulation/live.rs
+++ b/aa-gateway/src/simulation/live.rs
@@ -50,6 +50,7 @@ impl LiveSimulation {
             denied: 0,
             allowed: 0,
             approval_required: 0,
+            errored: 0,
             budget_impact_usd: None,
             flagged_outcomes: Vec::new(),
         })

--- a/aa-gateway/src/simulation/report.rs
+++ b/aa-gateway/src/simulation/report.rs
@@ -26,6 +26,11 @@ pub struct SimulationReport {
     pub allowed: usize,
     /// Number of events that would have required human approval.
     pub approval_required: usize,
+    /// Number of events that could not be evaluated — e.g. a payload that
+    /// failed to deserialize (a malformed or schema-drifted audit log). These
+    /// yield a per-event `decision = "error"` and must fail an exit-gated run:
+    /// a simulation that could not actually evaluate its input is not a PASS.
+    pub errored: usize,
     /// Estimated budget impact in USD (if budget policy is present).
     pub budget_impact_usd: Option<f64>,
     /// Per-event outcomes for events that were not simply allowed.

--- a/aa-integration-tests/tests/cli_policy.rs
+++ b/aa-integration-tests/tests/cli_policy.rs
@@ -350,16 +350,26 @@ async fn policy_simulate_with_output_file_writes_report() {
     let fixture = CliFixture::start().await.expect("fixture should start");
     let policy = CliFixture::fixture_path("policies/allow_all.yaml");
 
-    // HistoricalReplay::from_file expects JSONL with {event_type, agent_id, payload}.
+    // HistoricalReplay::from_file expects JSONL with {event_type, agent_id, payload},
+    // where `payload` is a serialized `GovernanceAction`. Use a real ToolCall so
+    // the events actually evaluate (allow-all) instead of erroring on an
+    // unparseable payload — otherwise the run now fails the errored>0 exit gate.
     let scratch = tempfile::tempdir().expect("scratch tempdir");
     let log_path = scratch.path().join("events.jsonl");
-    std::fs::write(
-        &log_path,
-        r#"{"event_type":"ToolCallIntercepted","agent_id":"a1","payload":"{}"}
-{"event_type":"ToolCallIntercepted","agent_id":"a2","payload":"{}"}
-"#,
-    )
-    .expect("write replay log");
+    let payload = serde_json::to_string(&aa_core::GovernanceAction::ToolCall {
+        name: "search".to_string(),
+        args: "{}".to_string(),
+    })
+    .expect("serialize governance action");
+    let line = |agent: &str| {
+        serde_json::to_string(&serde_json::json!({
+            "event_type": "ToolCallIntercepted",
+            "agent_id": agent,
+            "payload": payload,
+        }))
+        .expect("serialize audit line")
+    };
+    std::fs::write(&log_path, format!("{}\n{}\n", line("a1"), line("a2"))).expect("write replay log");
     let report_path = scratch.path().join("report.json");
 
     let out = fixture


### PR DESCRIPTION
## Description

`aasm policy simulate --against <audit.jsonl>` replays serialized `GovernanceAction` events against a policy and gates its exit code so CI pipelines can fail on policy violations. The exit code was gated only on `report.denied > 0`. An event whose payload fails to deserialize yields a per-event `decision = "error"` outcome (already shown in the report table) but was **not** counted toward `denied` — so a fully unparseable / schema-drifted audit log returned **exit 0 (SUCCESS)**. A CI pipeline gating on the exit status treated a broken or drifted log as a PASS.

This is a **CI-signal correctness** fix, not a policy-enforcement change: `simulate` is a replay/reporting tool, not the live gateway enforcement path.

Changes:
- Add an `errored: usize` count to `SimulationReport` and tally the per-event `error` outcomes in `SimulationEngine::run` (also serialized into the `--output-file` JSON report).
- Gate the CLI exit on `report.denied > 0 || report.errored > 0`.
- Emit a loud stderr line (`error: N event(s) failed to parse and could not be evaluated`) so the failure is visible.
- The report table (stdout summary + flagged-outcomes table) is unchanged; only the exit code and the added stderr line change.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

A run that could previously exit 0 on an unparseable log now exits non-zero — this is the intended correction of a false-PASS signal, not an API change. All-allowed and denied behaviours are unchanged.

## Related Issues

- Related Jira ticket: AAASM-4175

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`cargo nextest run -p aa-cli -E 'test(simulate)'` → 9 passed. Broader `-p aa-cli -p aa-gateway` simulation run → 22 passed. `cargo fmt --all` clean; `cargo clippy -p aa-cli -p aa-gateway --all-targets -- -D warnings` clean (only pre-existing `Cargo.toml` `default-features` manifest warnings). New tests: all-unparseable log → `ExitCode::FAILURE` with `errored == 2, denied == 0` in the report JSON; a single unparseable event among allowed events → `ExitCode::FAILURE`. The existing all-allowed → SUCCESS and denied → FAILURE cases are unchanged.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4175

🤖 Generated with [Claude Code](https://claude.com/claude-code)