### PR TITLE
[AAASM-4195] 🔒 (csp): Resolve Content Security Policy issues for production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "hex",
  "include_dir",
  "libc",
+ "mime",
  "mime_guess",
  "open",
  "owo-colors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -46,6 +46,7 @@ futures-util   = "0.3"
 hex            = { workspace = true }
 include_dir    = "0.7"
 libc           = { workspace = true }
+mime           = "0.3"
 mime_guess     = "2"
 open           = "5"
 owo-colors     = "4"

--- a/aa-cli/src/commands/dashboard/start.rs
+++ b/aa-cli/src/commands/dashboard/start.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::{header, HeaderMap, Method, StatusCode, Uri};
+use axum::http::{header, HeaderMap, HeaderValue, Method, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
 use axum::routing::any;
 use axum::Router;
@@ -19,6 +19,31 @@ use crate::config::{resolve_dashboard_port, CliConfig, ResolvedContext};
 use super::pid;
 
 static ASSETS: Dir = include_dir!("$CARGO_MANIFEST_DIR/_embedded/dashboard/dist");
+
+/// Content-Security-Policy for production deployment.
+///
+/// Policy rationale:
+/// - `default-src 'self'`: baseline — only same-origin resources by default
+/// - `script-src 'self'`: scripts must come from same origin (no inline)
+/// - `style-src 'self' 'unsafe-inline'`: allow inline styles for React/CSS-in-JS
+/// - `img-src 'self' data: blob:`: images from same origin + data URIs (icons, charts)
+/// - `font-src 'self'`: fonts from same origin
+/// - `connect-src 'self'`: XHR/fetch to same origin (API calls via proxy)
+/// - `frame-ancestors 'none'`: prevent clickjacking via iframes
+/// - `form-action 'self'`: forms only submit to same origin
+/// - `base-uri 'self'`: restrict <base> tag to same origin
+/// - `object-src 'none'`: block plugins (Flash, Java, etc.)
+const CSP_HEADER: &str = "\
+default-src 'self'; \
+script-src 'self'; \
+style-src 'self' 'unsafe-inline'; \
+img-src 'self' data: blob:; \
+font-src 'self'; \
+connect-src 'self'; \
+frame-ancestors 'none'; \
+form-action 'self'; \
+base-uri 'self'; \
+object-src 'none'";
 
 /// Arguments for `aasm dashboard start`.
 #[derive(Debug, Args)]
@@ -84,6 +109,23 @@ async fn run(args: StartArgs, ctx: &ResolvedContext, config: &CliConfig) -> Exit
     ExitCode::SUCCESS
 }
 
+/// Build security headers for HTML responses.
+fn security_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    // CSP: restrict resource loading to mitigate XSS and injection attacks.
+    headers.insert(header::CONTENT_SECURITY_POLICY, HeaderValue::from_static(CSP_HEADER));
+    // Prevent MIME-sniffing which can lead to XSS.
+    headers.insert(header::X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
+    // Deny framing to prevent clickjacking (belt-and-suspenders with frame-ancestors).
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    // Opt into stricter referrer policy.
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
+    headers
+}
+
 /// Serve embedded static files; fall back to `index.html` for SPA routing.
 async fn static_handler(uri: Uri) -> impl IntoResponse {
     let raw = uri.path().trim_start_matches('/');
@@ -91,23 +133,35 @@ async fn static_handler(uri: Uri) -> impl IntoResponse {
 
     if let Some(file) = ASSETS.get_file(path) {
         let mime = mime_guess::from_path(path).first_or_octet_stream();
-        return (
-            [(header::CONTENT_TYPE, mime.as_ref().to_string())],
-            file.contents().to_vec(),
-        )
-            .into_response();
+        let is_html = mime.type_() == mime::TEXT && mime.subtype() == mime::HTML;
+        let mut response = Response::new(Body::from(file.contents().to_vec()));
+        response.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_str(mime.as_ref()).unwrap_or(HeaderValue::from_static("application/octet-stream")),
+        );
+        // Apply security headers to HTML responses only; static assets (JS/CSS/images)
+        // inherit the page's CSP and don't need their own.
+        if is_html {
+            response.headers_mut().extend(security_headers());
+        }
+        return response;
     }
 
-    // SPA fallback: any unmatched path returns index.html.
+    // SPA fallback: any unmatched path returns index.html with security headers.
     if let Some(index) = ASSETS.get_file("index.html") {
-        return (
-            [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
-            index.contents().to_vec(),
-        )
-            .into_response();
+        let mut response = Response::new(Body::from(index.contents().to_vec()));
+        response.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/html; charset=utf-8"),
+        );
+        response.headers_mut().extend(security_headers());
+        return response;
     }
 
-    (StatusCode::NOT_FOUND, "Not found").into_response()
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::from("Not found"))
+        .unwrap()
 }
 
 /// Reverse-proxy `/api/*` to the configured gateway address.

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,25 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Agent Assembly Dashboard</title>
-    <!-- Apply the saved/OS theme before first paint to avoid a flash of the
-         wrong theme. Mirrors getInitialTheme() in src/theme/useTheme.ts. -->
-    <script>
-      (function () {
-        try {
-          var k = 'aa-dashboard-theme';
-          var s = localStorage.getItem(k);
-          var t =
-            s === 'light' || s === 'dark'
-              ? s
-              : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-                ? 'dark'
-                : 'light';
-          document.documentElement.setAttribute('data-theme', t);
-        } catch (e) {
-          /* no-op: theme will be applied by React on mount */
-        }
-      })();
-    </script>
+    <!-- Theme initialization: external script for CSP compliance.
+         Applies saved/OS theme before first paint to avoid FOUC.
+         Keep public/theme-init.js in sync with src/theme/useTheme.ts. -->
+    <script src="./theme-init.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/dashboard/public/theme-init.js
+++ b/dashboard/public/theme-init.js
@@ -1,0 +1,27 @@
+/**
+ * Theme initialization script — CSP-compliant external version.
+ *
+ * This script applies the saved or OS-preferred theme before first paint to
+ * avoid a flash of the wrong theme. It mirrors getInitialTheme() in
+ * src/theme/useTheme.ts.
+ *
+ * IMPORTANT: Keep this logic in sync with useTheme.ts. This file exists solely
+ * to satisfy strict Content-Security-Policy requirements that forbid inline
+ * scripts.
+ */
+(function () {
+  'use strict';
+  try {
+    var THEME_STORAGE_KEY = 'aa-dashboard-theme';
+    var stored = localStorage.getItem(THEME_STORAGE_KEY);
+    var theme =
+      stored === 'light' || stored === 'dark'
+        ? stored
+        : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light';
+    document.documentElement.setAttribute('data-theme', theme);
+  } catch (e) {
+    // no-op: theme will be applied by React on mount
+  }
+})();


### PR DESCRIPTION
## Summary

- Move inline theme initialization script from `index.html` to external `public/theme-init.js` to comply with CSP directives that forbid inline scripts
- Add comprehensive Content-Security-Policy headers to the embedded dashboard server (`aasm dashboard start`)
- Include additional security headers: X-Content-Type-Options, X-Frame-Options, Referrer-Policy

## CSP Policy

The following Content-Security-Policy is applied to HTML responses:

```
default-src 'self';
script-src 'self';
style-src 'self' 'unsafe-inline';
img-src 'self' data: blob:;
font-src 'self';
connect-src 'self';
frame-ancestors 'none';
form-action 'self';
base-uri 'self';
object-src 'none'
```

**Design decisions:**
- `'unsafe-inline'` for styles is required for React/CSS-in-JS libraries
- `data:` and `blob:` for images support charts and dynamically generated content
- All scripts must now be external files loaded from same origin

## Test Plan

- [x] Dashboard builds successfully (`pnpm build`)
- [x] All 1455 dashboard tests pass (`pnpm test`)
- [x] Rust code compiles (`cargo check -p aa-cli`)
- [x] All aa-cli tests pass (`cargo test -p aa-cli`)
- [x] Clippy clean (`cargo clippy -p aa-cli`)
- [x] Formatting clean (`cargo fmt --check`)
- [ ] Manual: Start dashboard and verify theme switching works
- [ ] Manual: Verify CSP headers in browser DevTools Network tab

## Files Changed

- `dashboard/public/theme-init.js` (new) — External theme initialization script
- `dashboard/index.html` — Reference external script instead of inline
- `aa-cli/Cargo.toml` — Add `mime` crate dependency
- `aa-cli/src/commands/dashboard/start.rs` — Add CSP and security headers to static handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)