### PR TITLE
[AAASM-4190] 🐛 (gateway): Fix anonymous rate-limit bypass via agent_id rotation

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1043,18 +1043,39 @@ impl PolicyEngine {
     /// from the authoritative registry owner via [`Self::authoritative_tenancy`]
     /// — NOT the client-supplied `ctx.team_id` — so a caller cannot forge a
     /// fresh team id to mint an unshared bucket and slip past the limit (the
-    /// same trust anchor AAASM-3138 established for budget keying). When no team
-    /// is assigned the scope falls back to the agent id, so two teamless agents
-    /// still never share a bucket; the fallback never collapses to a shared or
-    /// empty key, so a missing team can only ever narrow isolation — never
-    /// disable the limit (fail closed).
+    /// same trust anchor AAASM-3138 established for budget keying).
+    ///
+    /// AAASM-4190: when no team is assigned, the fallback depends on whether the
+    /// agent is *registered*:
+    /// - **Registered** agents (found in registry) → `agent:{hex}` where the
+    ///   agent_id is token-authenticated, so each registered teamless agent gets
+    ///   its own isolated bucket.
+    /// - **Unregistered/anonymous** agents (not in registry) → `anon` shared
+    ///   bucket. The client-supplied `agent_id` is unauthenticated, so rotating
+    ///   it on every request would mint fresh buckets and bypass the rate limit.
+    ///   Collapsing all anonymous callers into one shared bucket closes this
+    ///   bypass — they share the same rate-limit pool.
+    ///
+    /// The fallback never collapses to an empty key, so a missing team can only
+    /// ever narrow isolation — never disable the limit (fail closed).
     fn rate_scope(&self, ctx: &aa_core::AgentContext) -> String {
+        // Check registry to determine if the agent is registered (authenticated).
+        let is_registered = self
+            .registry
+            .as_ref()
+            .is_some_and(|r| r.get(ctx.agent_id.as_bytes()).is_some());
+
         let (team_id, _org_id) = self.authoritative_tenancy(ctx);
         match team_id {
             Some(team) => format!("team:{team}"),
-            None => {
+            None if is_registered => {
+                // Registered but teamless: agent_id is token-authenticated, safe to isolate.
                 let hex: String = ctx.agent_id.as_bytes().iter().map(|b| format!("{b:02x}")).collect();
                 format!("agent:{hex}")
+            }
+            None => {
+                // Unregistered/anonymous: agent_id is client-controlled, use shared bucket.
+                "anon".to_string()
             }
         }
     }
@@ -4504,5 +4525,77 @@ mod tests {
         );
 
         drop(tmp);
+    }
+
+    // ── AAASM-4190: rate-limit scope for anonymous callers ────────────────────
+
+    #[test]
+    fn rate_scope_unregistered_agents_share_anon_bucket() {
+        // AAASM-4190: unregistered/anonymous agents must share a single "anon"
+        // bucket. Rotating the client-supplied agent_id must NOT mint a fresh
+        // bucket (that would bypass the rate limit).
+        let registry = Arc::new(crate::registry::AgentRegistry::new());
+        let engine = make_engine(empty_doc()).with_registry(registry);
+
+        // Two different agent_ids that are NOT in the registry.
+        let mut ctx_a = make_ctx();
+        ctx_a.agent_id = AgentId::from_bytes([0xAA; 16]);
+        ctx_a.team_id = None;
+
+        let mut ctx_b = make_ctx();
+        ctx_b.agent_id = AgentId::from_bytes([0xBB; 16]);
+        ctx_b.team_id = None;
+
+        // Both should resolve to the same "anon" scope.
+        let scope_a = engine.rate_scope(&ctx_a);
+        let scope_b = engine.rate_scope(&ctx_b);
+
+        assert_eq!(scope_a, "anon", "unregistered agent should use 'anon' scope");
+        assert_eq!(scope_b, "anon", "unregistered agent should use 'anon' scope");
+        assert_eq!(scope_a, scope_b, "rotating agent_id must not change the scope");
+    }
+
+    #[test]
+    fn rate_scope_registered_teamless_agent_gets_isolated_bucket() {
+        // AAASM-4190: a registered but teamless agent uses its authenticated
+        // agent_id for isolation — distinct from the shared "anon" bucket.
+        let registry = Arc::new(crate::registry::AgentRegistry::new());
+        // Register agent without a team.
+        let mut record = registry_record([0xCC; 16], "placeholder", None);
+        record.team_id = None; // explicitly teamless
+        registry.register(record).expect("register");
+
+        let engine = make_engine(empty_doc()).with_registry(registry);
+
+        let mut ctx = make_ctx();
+        ctx.agent_id = AgentId::from_bytes([0xCC; 16]);
+        ctx.team_id = None;
+
+        let scope = engine.rate_scope(&ctx);
+        // Hex-encoded agent_id for [0xCC; 16] = "cccccccc..." (32 chars).
+        assert!(
+            scope.starts_with("agent:"),
+            "registered teamless agent should use 'agent:<hex>' scope, got: {scope}"
+        );
+        assert_ne!(scope, "anon", "registered agent must not share the anon bucket");
+    }
+
+    #[test]
+    fn rate_scope_registered_with_team_uses_team_scope() {
+        // Sanity check: registered agent with a team uses team scope.
+        let registry = Arc::new(crate::registry::AgentRegistry::new());
+        registry
+            .register(registry_record([0xDD; 16], "my-team", None))
+            .expect("register");
+
+        let engine = make_engine(empty_doc()).with_registry(registry);
+
+        let mut ctx = make_ctx();
+        ctx.agent_id = AgentId::from_bytes([0xDD; 16]);
+        // Note: ctx.team_id is client-supplied and should be ignored.
+        ctx.team_id = Some("forged-team".to_string());
+
+        let scope = engine.rate_scope(&ctx);
+        assert_eq!(scope, "team:my-team", "should use registered team, not client-supplied");
     }
 }

--- a/aa-gateway/src/registry/mod.rs
+++ b/aa-gateway/src/registry/mod.rs
@@ -32,6 +32,14 @@ pub enum RegistryError {
     /// `rehydrate_from_storage` (Epic 18 Story S-I.2) returned an error.
     #[error("storage backend error: {0}")]
     Storage(#[from] crate::storage::StorageError),
+    /// AAASM-4190: the team_id or org_id contains invalid characters (e.g.
+    /// control characters like `\u{1}` that could cause bucket-key collisions
+    /// in rate-limit or budget scoping).
+    #[error("invalid tenant id: {field} contains control characters")]
+    InvalidTenantId {
+        /// Which field failed validation ("team_id" or "org_id").
+        field: &'static str,
+    },
 }
 
 /// Error returned when agent lineage validation fails during registration.

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -273,9 +273,29 @@ impl AgentRegistry {
         Ok(())
     }
 
+    /// AAASM-4190: validate that a tenant id (team_id or org_id) contains no
+    /// control characters. Control characters in the id could cause bucket-key
+    /// collisions when the id is used as part of a composite key with a
+    /// separator (e.g. `\u{1}` in rate-limit bucket keys).
+    fn validate_tenant_id(id: Option<&str>, field: &'static str) -> Result<(), RegistryError> {
+        if let Some(s) = id {
+            if s.chars().any(|c| c.is_control()) {
+                return Err(RegistryError::InvalidTenantId { field });
+            }
+        }
+        Ok(())
+    }
+
     /// Insert a new agent record. Returns an error if the ID is already registered.
     pub fn register(&self, record: AgentRecord) -> Result<(), RegistryError> {
         use dashmap::mapref::entry::Entry;
+
+        // AAASM-4190: reject tenant ids containing control characters to prevent
+        // bucket-key collision attacks (e.g. team_id containing `\u{1}` could
+        // alias onto a different team's rate-limit bucket).
+        Self::validate_tenant_id(record.team_id.as_deref(), "team_id")?;
+        Self::validate_tenant_id(record.org_id.as_deref(), "org_id")?;
+
         let agent_id = record.agent_id;
         let parent_key = record.parent_key;
         let team_id = record.team_id.clone();
@@ -2135,5 +2155,121 @@ mod sweep_aged_agents_tests {
 
         assert!(evicted.is_empty(), "unconfigured team must not trigger eviction");
         assert_eq!(reg.get(&id).unwrap().status, AgentStatus::Active);
+    }
+}
+
+#[cfg(test)]
+mod tenant_id_validation_tests {
+    use super::*;
+    use crate::registry::{AgentStatus, RegistryError};
+
+    fn minimal_record(id: [u8; 16], team_id: Option<&str>, org_id: Option<&str>) -> AgentRecord {
+        AgentRecord {
+            agent_id: id,
+            name: "test-agent".into(),
+            framework: "test".into(),
+            version: "0.0.1".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: "deadbeef".into(),
+            credential_token: "tok".into(),
+            metadata: Default::default(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: vec![],
+            recent_events: Default::default(),
+            recent_traces: vec![],
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: team_id.map(str::to_string),
+            org_id: org_id.map(str::to_string),
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: None,
+            children: vec![],
+            parent_key: None,
+            enforcement_mode: None,
+        }
+    }
+
+    #[test]
+    fn register_rejects_team_id_with_control_chars() {
+        // AAASM-4190: team_id containing control characters (e.g. SOH \u{1})
+        // must be rejected to prevent bucket-key collision attacks.
+        let reg = AgentRegistry::new();
+        let record = minimal_record([1u8; 16], Some("team\u{1}evil"), None);
+        let result = reg.register(record);
+
+        assert!(
+            matches!(result, Err(RegistryError::InvalidTenantId { field: "team_id" })),
+            "expected InvalidTenantId for team_id with control char, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn register_rejects_org_id_with_control_chars() {
+        // AAASM-4190: org_id containing control characters must be rejected.
+        let reg = AgentRegistry::new();
+        let record = minimal_record([2u8; 16], Some("valid-team"), Some("org\u{0}bad"));
+        let result = reg.register(record);
+
+        assert!(
+            matches!(result, Err(RegistryError::InvalidTenantId { field: "org_id" })),
+            "expected InvalidTenantId for org_id with control char, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn register_accepts_valid_tenant_ids() {
+        // Valid team_id and org_id (no control characters) should succeed.
+        let reg = AgentRegistry::new();
+        let record = minimal_record([3u8; 16], Some("valid-team-123"), Some("org_456"));
+        let result = reg.register(record);
+
+        assert!(result.is_ok(), "valid tenant ids should be accepted");
+        assert!(reg.get(&[3u8; 16]).is_some(), "agent should be registered");
+    }
+
+    #[test]
+    fn register_accepts_none_tenant_ids() {
+        // None team_id and org_id should be accepted (anonymous/unregistered path).
+        let reg = AgentRegistry::new();
+        let record = minimal_record([4u8; 16], None, None);
+        let result = reg.register(record);
+
+        assert!(result.is_ok(), "None tenant ids should be accepted");
+    }
+
+    #[test]
+    fn register_rejects_team_id_with_newline() {
+        // Newline is also a control character.
+        let reg = AgentRegistry::new();
+        let record = minimal_record([5u8; 16], Some("team\ninjection"), None);
+        let result = reg.register(record);
+
+        assert!(
+            matches!(result, Err(RegistryError::InvalidTenantId { field: "team_id" })),
+            "expected InvalidTenantId for team_id with newline"
+        );
+    }
+
+    #[test]
+    fn register_rejects_team_id_with_tab() {
+        // Tab is also a control character.
+        let reg = AgentRegistry::new();
+        let record = minimal_record([6u8; 16], Some("team\tevil"), None);
+        let result = reg.register(record);
+
+        assert!(
+            matches!(result, Err(RegistryError::InvalidTenantId { field: "team_id" })),
+            "expected InvalidTenantId for team_id with tab"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Unregistered/anonymous agents now share a single "anon" rate-limit bucket instead of each getting an isolated `agent:{hex}` bucket keyed by the client-controlled agent_id
- Registered-but-teamless agents retain per-agent isolation since their agent_id IS token-authenticated
- Added validation to reject control characters in team_id/org_id at registration to prevent bucket-key collision attacks via the `\u{1}` separator

## Security Fix

Previously, anonymous callers could bypass rate limits by rotating the client-supplied `agent_id` on every request, minting fresh buckets each time. The `rate_scope()` function in the policy engine now distinguishes between:

1. **Registered agents** (in registry) - use `agent:{hex}` scope (agent_id is authenticated)
2. **Unregistered/anonymous agents** (not in registry) - use shared `anon` scope

Additionally, tenant IDs (team_id, org_id) containing control characters are now rejected at registration to prevent bucket-key collision attacks where a malicious team_id like `team\u{1}evil` could alias onto another team's bucket.

## Test plan
- [x] `rate_scope_unregistered_agents_share_anon_bucket` - verifies rotating agent_id on anonymous path does not mint new buckets
- [x] `rate_scope_registered_teamless_agent_gets_isolated_bucket` - verifies registered but teamless agents still get isolated buckets
- [x] `rate_scope_registered_with_team_uses_team_scope` - verifies team-scoped buckets work correctly
- [x] `register_rejects_team_id_with_control_chars` - verifies SOH and other control chars rejected
- [x] `register_rejects_org_id_with_control_chars` - verifies org_id validation
- [x] `register_accepts_valid_tenant_ids` - verifies normal tenant IDs work
- [x] `register_accepts_none_tenant_ids` - verifies None tenant IDs accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)