### PR TITLE
[AAASM-4270] ♻️ (rust): Reduce cognitive complexity Phase 2 (partial)

### DIFF
--- a/aa-api/src/routes/destinations.rs
+++ b/aa-api/src/routes/destinations.rs
@@ -106,45 +106,69 @@ impl From<Destination> for DestinationResponse {
 fn restore_masked_secrets(incoming: &mut DestinationConfig, stored: Option<DestinationConfig>) {
     match incoming {
         DestinationConfig::Webhook { secret_header, .. } => {
-            if secret_header.as_deref() == Some(SECRET_MASK) {
-                *secret_header = match stored {
-                    Some(DestinationConfig::Webhook { secret_header, .. }) => secret_header,
-                    _ => None,
-                };
-            }
+            restore_webhook_secret(secret_header, stored);
         }
         DestinationConfig::Slack { webhook_url, .. } => {
-            if webhook_url == SECRET_MASK {
-                if let Some(DestinationConfig::Slack {
-                    webhook_url: stored_url,
-                    ..
-                }) = stored
-                {
-                    *webhook_url = stored_url;
-                }
-            }
+            restore_slack_secret(webhook_url, stored);
         }
         DestinationConfig::PagerDuty { routing_key, .. } => {
-            if routing_key == SECRET_MASK {
-                if let Some(DestinationConfig::PagerDuty {
-                    routing_key: stored_key,
-                    ..
-                }) = stored
-                {
-                    *routing_key = stored_key;
-                }
-            }
+            restore_pagerduty_secret(routing_key, stored);
         }
         DestinationConfig::OpsGenie { api_key, .. } => {
-            if api_key == SECRET_MASK {
-                if let Some(DestinationConfig::OpsGenie {
-                    api_key: stored_key, ..
-                }) = stored
-                {
-                    *api_key = stored_key;
-                }
-            }
+            restore_opsgenie_secret(api_key, stored);
         }
+    }
+}
+
+/// Restore the webhook `secret_header` from stored config when masked.
+fn restore_webhook_secret(secret_header: &mut Option<String>, stored: Option<DestinationConfig>) {
+    if secret_header.as_deref() != Some(SECRET_MASK) {
+        return;
+    }
+    *secret_header = match stored {
+        Some(DestinationConfig::Webhook { secret_header, .. }) => secret_header,
+        _ => None,
+    };
+}
+
+/// Restore the Slack `webhook_url` from stored config when masked.
+fn restore_slack_secret(webhook_url: &mut String, stored: Option<DestinationConfig>) {
+    if webhook_url != SECRET_MASK {
+        return;
+    }
+    if let Some(DestinationConfig::Slack {
+        webhook_url: stored_url,
+        ..
+    }) = stored
+    {
+        *webhook_url = stored_url;
+    }
+}
+
+/// Restore the PagerDuty `routing_key` from stored config when masked.
+fn restore_pagerduty_secret(routing_key: &mut String, stored: Option<DestinationConfig>) {
+    if routing_key != SECRET_MASK {
+        return;
+    }
+    if let Some(DestinationConfig::PagerDuty {
+        routing_key: stored_key,
+        ..
+    }) = stored
+    {
+        *routing_key = stored_key;
+    }
+}
+
+/// Restore the OpsGenie `api_key` from stored config when masked.
+fn restore_opsgenie_secret(api_key: &mut String, stored: Option<DestinationConfig>) {
+    if api_key != SECRET_MASK {
+        return;
+    }
+    if let Some(DestinationConfig::OpsGenie {
+        api_key: stored_key, ..
+    }) = stored
+    {
+        *api_key = stored_key;
     }
 }
 

--- a/aa-cli/src/sanitize.rs
+++ b/aa-cli/src/sanitize.rs
@@ -1,5 +1,44 @@
 //! Terminal output sanitization for server-supplied text.
 
+/// Char cursor type used by the escape-sequence consumers.
+type CharCursor<'a> = std::iter::Peekable<std::str::Chars<'a>>;
+
+/// Consume a CSI sequence: parameters/intermediates up to a final byte (`0x40`–`0x7e`).
+/// Called after the `ESC [` introducer has been consumed.
+fn consume_csi(chars: &mut CharCursor) {
+    for tail in chars.by_ref() {
+        if ('\u{40}'..='\u{7e}').contains(&tail) {
+            break;
+        }
+    }
+}
+
+/// Consume an OSC sequence: data terminated by BEL (`0x07`) or ST (`ESC \`).
+/// Called after the `ESC ]` introducer has been consumed.
+fn consume_osc(chars: &mut CharCursor) {
+    while let Some(&t) = chars.peek() {
+        if t == '\u{07}' {
+            chars.next();
+            break;
+        }
+        if t == '\u{1b}' {
+            chars.next();
+            if chars.peek() == Some(&'\\') {
+                chars.next();
+            }
+            break;
+        }
+        chars.next();
+    }
+}
+
+/// Whether `c` is a control character that should be stripped: C0 (`0x00`–`0x1f`),
+/// DEL (`0x7f`), or C1 (`0x80`–`0x9f`).
+fn is_control_char(c: char) -> bool {
+    let code = c as u32;
+    code < 0x20 || code == 0x7f || (0x80..=0x9f).contains(&code)
+}
+
 /// Strip terminal control sequences from server-supplied text before it is
 /// printed to the operator's terminal.
 ///
@@ -28,48 +67,31 @@ pub fn sanitize_terminal(input: &str) -> String {
     let mut chars = input.chars().peekable();
     while let Some(c) = chars.next() {
         match c {
-            // ESC: consume the escape sequence it introduces.
-            '\u{1b}' => match chars.peek() {
-                Some('[') => {
-                    // CSI: parameters/intermediates up to a final byte.
-                    chars.next();
-                    for tail in chars.by_ref() {
-                        if ('\u{40}'..='\u{7e}').contains(&tail) {
-                            break;
-                        }
-                    }
-                }
-                Some(']') => {
-                    // OSC: data terminated by BEL or ST (ESC \).
-                    chars.next();
-                    while let Some(&t) = chars.peek() {
-                        if t == '\u{07}' {
-                            chars.next();
-                            break;
-                        }
-                        if t == '\u{1b}' {
-                            chars.next();
-                            if chars.peek() == Some(&'\\') {
-                                chars.next();
-                            }
-                            break;
-                        }
-                        chars.next();
-                    }
-                }
-                Some(_) => {
-                    // Other two-byte escape (e.g. `ESC c`, `ESC ( B`).
-                    chars.next();
-                }
-                None => {}
-            },
-            // Drop all other C0 control characters, DEL, and C1 controls
-            // (`0x80`–`0x9f`, e.g. `U+009B` 8-bit CSI).
-            c if (c as u32) < 0x20 || c as u32 == 0x7f || (0x80..=0x9f).contains(&(c as u32)) => {}
+            '\u{1b}' => consume_escape_sequence(&mut chars),
+            c if is_control_char(c) => {}
             c => out.push(c),
         }
     }
     out
+}
+
+/// Consume an escape sequence starting after the ESC (`0x1b`) byte.
+fn consume_escape_sequence(chars: &mut CharCursor) {
+    match chars.peek() {
+        Some('[') => {
+            chars.next();
+            consume_csi(chars);
+        }
+        Some(']') => {
+            chars.next();
+            consume_osc(chars);
+        }
+        Some(_) => {
+            // Other two-byte escape (e.g. `ESC c`, `ESC ( B`).
+            chars.next();
+        }
+        None => {}
+    }
 }
 
 #[cfg(test)]

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -162,88 +162,100 @@ impl ProxyConfig {
     /// Build a `ProxyConfig` from environment variables, falling back to
     /// defaults where variables are not set.
     pub fn from_env() -> Result<Self, ProxyError> {
-        let bind_addr = match std::env::var("AA_PROXY_ADDR") {
-            Ok(val) => val
-                .parse::<SocketAddr>()
-                .map_err(|e| ProxyError::Config(format!("invalid AA_PROXY_ADDR: {e}")))?,
-            Err(_) => SocketAddr::from(([127, 0, 0, 1], 8899)),
-        };
-
-        let ca_dir = match std::env::var("AA_CA_DIR") {
-            Ok(val) => PathBuf::from(val),
-            Err(_) => dirs::home_dir()
-                .ok_or_else(|| ProxyError::Config("cannot determine home directory".into()))?
-                .join(".aa")
-                .join("ca"),
-        };
-
-        let cert_cache_capacity = match std::env::var("AA_PROXY_CERT_CACHE_CAPACITY") {
-            Ok(val) => val
-                .parse::<usize>()
-                .map_err(|e| ProxyError::Config(format!("invalid AA_PROXY_CERT_CACHE_CAPACITY: {e}")))?,
-            Err(_) => 1000,
-        };
-
-        let llm_only = match std::env::var("AA_PROXY_LLM_ONLY") {
-            Ok(val) => val != "0" && val.to_lowercase() != "false",
-            Err(_) => true,
-        };
-
-        let denied_hosts = env_csv("AA_PROXY_DENIED_HOSTS");
-
-        let network_allowlist = env_csv("AA_PROXY_NETWORK_ALLOWLIST");
-
-        // AAASM-4126: extra hosts to MitM + DLP-scan even under llm_only.
-        let mitm_hosts = env_csv("AA_PROXY_MITM_HOSTS");
-
-        let skip_upstream_tls_verify_requested = env_truthy("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY");
-        // AAASM-3131: this flag disables upstream certificate verification and
-        // is for integration tests only. In a release (production) build it must
-        // be unreachable — silently ignore the request and shout, so a stray env
-        // var in a deployed binary cannot quietly turn the proxy into a MitM that
-        // trusts any upstream certificate.
-        let skip_upstream_tls_verify = if cfg!(debug_assertions) {
-            skip_upstream_tls_verify_requested
-        } else {
-            if skip_upstream_tls_verify_requested {
-                tracing::error!(
-                    "AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY is set but IGNORED in a release build — \
-                     upstream TLS verification stays ENABLED. This flag is debug-only."
-                );
-            }
-            false
-        };
-
-        let credential_action = match std::env::var("AA_PROXY_CREDENTIAL_ACTION") {
-            Ok(val) => parse_credential_action(&val)?,
-            Err(_) => CredentialAction::default(),
-        };
-
-        let gateway_endpoint = match std::env::var("AA_PROXY_GATEWAY_ENDPOINT") {
-            Ok(val) if !val.is_empty() => Some(val),
-            _ => None,
-        };
-
-        // AAASM-3357: default fail-closed. Only an explicit truthy value
-        // opts into the historical fail-open soft-degradation behaviour.
-        let mcp_fail_open = env_truthy("AA_PROXY_MCP_FAIL_OPEN");
-
         Ok(Self {
-            bind_addr,
-            ca_dir,
-            cert_cache_capacity,
-            llm_only,
-            mitm_hosts,
-            denied_hosts,
-            network_allowlist,
-            skip_upstream_tls_verify,
-            credential_action,
+            bind_addr: parse_bind_addr()?,
+            ca_dir: parse_ca_dir()?,
+            cert_cache_capacity: parse_cert_cache_capacity()?,
+            llm_only: parse_llm_only(),
+            mitm_hosts: env_csv("AA_PROXY_MITM_HOSTS"),
+            denied_hosts: env_csv("AA_PROXY_DENIED_HOSTS"),
+            network_allowlist: env_csv("AA_PROXY_NETWORK_ALLOWLIST"),
+            skip_upstream_tls_verify: resolve_skip_upstream_tls_verify(),
+            credential_action: parse_credential_action_env()?,
             upstream_override: None,
-            gateway_endpoint,
-            mcp_fail_open,
+            gateway_endpoint: env_optional("AA_PROXY_GATEWAY_ENDPOINT"),
+            // AAASM-3357: default fail-closed. Only an explicit truthy value
+            // opts into the historical fail-open soft-degradation behaviour.
+            mcp_fail_open: env_truthy("AA_PROXY_MCP_FAIL_OPEN"),
             // No env var: production binaries can never relax the SSRF guard.
             allow_private_connect_targets: false,
         })
+    }
+}
+
+/// Parse the `AA_PROXY_ADDR` env var or return the default bind address.
+fn parse_bind_addr() -> Result<SocketAddr, ProxyError> {
+    match std::env::var("AA_PROXY_ADDR") {
+        Ok(val) => val
+            .parse::<SocketAddr>()
+            .map_err(|e| ProxyError::Config(format!("invalid AA_PROXY_ADDR: {e}"))),
+        Err(_) => Ok(SocketAddr::from(([127, 0, 0, 1], 8899))),
+    }
+}
+
+/// Parse the `AA_CA_DIR` env var or return the default CA directory.
+fn parse_ca_dir() -> Result<PathBuf, ProxyError> {
+    match std::env::var("AA_CA_DIR") {
+        Ok(val) => Ok(PathBuf::from(val)),
+        Err(_) => dirs::home_dir()
+            .ok_or_else(|| ProxyError::Config("cannot determine home directory".into()))
+            .map(|h| h.join(".aa").join("ca")),
+    }
+}
+
+/// Parse the `AA_PROXY_CERT_CACHE_CAPACITY` env var or return the default.
+fn parse_cert_cache_capacity() -> Result<usize, ProxyError> {
+    match std::env::var("AA_PROXY_CERT_CACHE_CAPACITY") {
+        Ok(val) => val
+            .parse::<usize>()
+            .map_err(|e| ProxyError::Config(format!("invalid AA_PROXY_CERT_CACHE_CAPACITY: {e}"))),
+        Err(_) => Ok(1000),
+    }
+}
+
+/// Parse the `AA_PROXY_LLM_ONLY` env var (default `true`).
+fn parse_llm_only() -> bool {
+    match std::env::var("AA_PROXY_LLM_ONLY") {
+        Ok(val) => val != "0" && val.to_lowercase() != "false",
+        Err(_) => true,
+    }
+}
+
+/// Resolve the skip-upstream-TLS-verify flag, enforcing debug-only semantics.
+///
+/// AAASM-3131: this flag disables upstream certificate verification and is for
+/// integration tests only. In a release (production) build it must be
+/// unreachable — silently ignore the request and shout, so a stray env var in a
+/// deployed binary cannot quietly turn the proxy into a MitM that trusts any
+/// upstream certificate.
+fn resolve_skip_upstream_tls_verify() -> bool {
+    let requested = env_truthy("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY");
+    if cfg!(debug_assertions) {
+        requested
+    } else {
+        if requested {
+            tracing::error!(
+                "AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY is set but IGNORED in a release build — \
+                 upstream TLS verification stays ENABLED. This flag is debug-only."
+            );
+        }
+        false
+    }
+}
+
+/// Parse the `AA_PROXY_CREDENTIAL_ACTION` env var or return the default.
+fn parse_credential_action_env() -> Result<CredentialAction, ProxyError> {
+    match std::env::var("AA_PROXY_CREDENTIAL_ACTION") {
+        Ok(val) => parse_credential_action(&val),
+        Err(_) => Ok(CredentialAction::default()),
+    }
+}
+
+/// Read an env var as `Some(value)` when set and non-empty, otherwise `None`.
+fn env_optional(name: &str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(val) if !val.is_empty() => Some(val),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Reduce cognitive complexity in 3 Rust files to below the SonarCloud threshold of 15
- Pure refactoring with no functional changes

## Changes

| Crate | File | Before | After |
|-------|------|--------|-------|
| aa-cli | src/sanitize.rs | 36 | ~12 |
| aa-api | src/routes/destinations.rs | 21 | ~12 |
| aa-proxy | src/config.rs | 17 | ~12 |

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] No functional changes - pure refactoring

## Note

This is a partial fix for AAASM-4270. Additional functions with high complexity remain in:
- aa-gateway/src/policy/expr.rs (complexity 33, 29 - complex expression parser)
- aa-gateway/src/engine/mod.rs (complexity 22)
- aa-gateway/src/service/approval_service.rs (complexity 21)
- aa-cli/src/commands/dashboard/mod.rs (complexity 19)
- aa-api/src/routes/edges.rs (complexity 19)
- aa-gateway/src/budget/tracker.rs (complexity 16)
- aa-gateway/src/iam/grpc_auth.rs (complexity 16)

These require more careful refactoring to avoid breaking business logic and will be addressed in follow-up PRs.

Closes #1447 (partial)

🤖 Generated with [Claude Code](https://claude.ai/code)