### PR TITLE
[AAASM-4191] 🐛 (policy): Fail-closed on unknown/misspelled policy section keys

### DIFF
--- a/aa-cli/src/commands/policy/validate.rs
+++ b/aa-cli/src/commands/policy/validate.rs
@@ -89,14 +89,29 @@ spec:
     }
 
     #[test]
-    fn unknown_key_produces_warning_not_error() {
+    fn unknown_top_level_key_exits_failure() {
+        // AAASM-4191: unknown top-level keys must fail closed (exit 1), not
+        // silently pass with a warning. A typo'd section would otherwise drop
+        // the restriction entirely.
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "risk_tier: high").unwrap();
 
         let args = ValidateArgs {
             file: tmp.path().to_path_buf(),
         };
-        assert_eq!(run(args), ExitCode::SUCCESS);
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn misspelled_section_key_exits_failure() {
+        // AAASM-4191: a typo'd section (e.g. `capabilties`) must fail closed.
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "capabilties:\n  deny:\n    - file_delete").unwrap();
+
+        let args = ValidateArgs {
+            file: tmp.path().to_path_buf(),
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
     }
 
     #[test]

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -46,6 +46,13 @@ impl PolicyValidator {
         // a fail-OPEN on a misformatted/legacy policy. Fail closed instead:
         // refuse to load the document rather than silently allowing
         // everything. (Full multi-schema support is a follow-up.)
+        //
+        // AAASM-4191: extend fail-closed to ALL unknown top-level keys, not
+        // just `rules`. A typo'd section key (e.g. `capabilties` instead of
+        // `capabilities`) was silently dropped, allowing restrictions to
+        // vanish without any error. Now every unknown top-level key is a
+        // hard validation error — consistent with the product's fail-closed
+        // posture everywhere else.
         for key in raw.unknown.keys() {
             if key == "rules" {
                 errors.push(ValidationError::new(
@@ -55,7 +62,14 @@ impl PolicyValidator {
                      refuses to load this document to avoid an allow-all fallback",
                 ));
             } else {
-                warnings.push(ValidationWarning::unknown_key(key));
+                errors.push(ValidationError::new(
+                    key,
+                    format!(
+                        "unknown top-level key '{}'; valid keys are: version, scope, network, \
+                         schedule, budget, data, tools, capabilities, approval_timeout_secs, approval",
+                        key
+                    ),
+                ));
             }
         }
 
@@ -556,13 +570,36 @@ fn is_hhmm(s: &str) -> bool {
 mod tests {
     use super::*;
 
-    // ── Unknown key warnings ────────────────────────────────────────────────
+    // ── Unknown key errors (AAASM-4191: fail-closed on unknown top-level keys) ─
 
     #[test]
-    fn top_level_unknown_key_produces_warning() {
+    fn top_level_unknown_key_is_validation_error() {
+        // AAASM-4191: unknown top-level keys must fail closed (error), not
+        // silently vanish with a warning. A typo'd section (e.g. `capabilties`)
+        // would otherwise drop the restriction entirely.
         let yaml = "risk_tier: high\n";
-        let out = PolicyValidator::from_yaml(yaml).unwrap();
-        assert!(out.warnings.iter().any(|w| w.field == "risk_tier"));
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err(), "unknown top-level key must be rejected");
+        let errs = result.unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "risk_tier"),
+            "expected error on 'risk_tier' field, got: {:?}",
+            errs,
+        );
+    }
+
+    #[test]
+    fn misspelled_capabilities_section_is_validation_error() {
+        // AAASM-4191: a typo'd section key must not silently drop the restriction.
+        let yaml = "capabilties:\n  deny:\n    - file_delete\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err(), "misspelled section key must be rejected");
+        let errs = result.unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "capabilties" && e.message.contains("unknown")),
+            "expected error mentioning 'capabilties', got: {:?}",
+            errs,
+        );
     }
 
     #[test]

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -596,7 +596,8 @@ mod tests {
         assert!(result.is_err(), "misspelled section key must be rejected");
         let errs = result.unwrap_err();
         assert!(
-            errs.iter().any(|e| e.field == "capabilties" && e.message.contains("unknown")),
+            errs.iter()
+                .any(|e| e.field == "capabilties" && e.message.contains("unknown")),
             "expected error mentioning 'capabilties', got: {:?}",
             errs,
         );


### PR DESCRIPTION
## Summary
- Unknown/misspelled top-level policy keys now fail validation (error) instead of being silently dropped (warning)
- `aasm policy validate` exits non-zero when policy has unknown section keys
- Error message lists valid keys for discoverability

## Problem
A typo'd section key (e.g. `capabilties` instead of `capabilities`) was silently swallowed into the `unknown` HashMap and dropped from enforcement. The operator's restriction was NOT enforced - this was fail-OPEN on a misformatted policy.

Example:
```yaml
spec:
  capabilties:            # <-- typo
    deny: [file_delete]
```
Previously: `aasm policy validate` → prints warning, exits 0, says "Policy is valid". The delete-deny restriction was silently dropped.

Now: `aasm policy validate` → exits 1 with error: `unknown top-level key 'capabilties'; valid keys are: version, scope, network, schedule, budget, data, tools, capabilities, approval_timeout_secs, approval`

## Changes
- `aa-gateway/src/policy/validator.rs`: Changed unknown top-level key handling from `warnings.push(ValidationWarning::unknown_key(key))` to `errors.push(ValidationError::new(...))`
- `aa-cli/src/commands/policy/validate.rs`: Tests updated to expect FAILURE exit code

## Test plan
- [x] `cargo test -p aa-gateway --lib -- policy::validator` — 80 tests pass
- [x] `cargo test -p aa-cli --lib -- commands::policy::validate` — 6 tests pass
- [x] `cargo clippy -p aa-gateway -p aa-cli -- -D warnings` — clean

Closes AAASM-4191

🤖 Generated with [Claude Code](https://claude.ai/code)