### PR TITLE
[AAASM-4304] 📝 (readme): Refresh stale project-status block

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ packages, and container image:
 
 | Channel | Status |
 |---|---|
-| GitHub Releases | ✅ Pre-releases published (`v0.0.1-alpha.1` … `alpha.9`) |
+| GitHub Releases | ✅ Pre-releases published (`v0.0.1-alpha.1` … `alpha.9`, `v0.0.1-beta.1`, `beta.2`, `beta.4`, `v0.0.1-rc.1`, `rc.2`, `rc.3`) |
 | crates.io | ✅ Workspace crates published at the pre-release version |
 | Homebrew tap | ✅ `aasm` formula published for tagged releases |
 | PyPI / npm | ✅ SDK pre-releases published from the release tag |

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ public API and wire protocol are **not** stable; do not use in production.
 
 Releases are published as GitHub pre-releases — latest
 [`v0.0.1-rc.3`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-rc.3)
-(2026-06-20). The coordinated release tag also publishes the CLI, crates, SDK
+(2026-07-03). The coordinated release tag also publishes the CLI, crates, SDK
 packages, and container image:
 
 | Channel | Status |

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ These two are built by `aa-ebpf/build.rs` (via `aya-build`) for the BPF target �
 
 ## Project Status
 
-🚧 **Alpha — `v0.0.1` pre-release series** _(status as of 2026-06-13)_. The
+🚧 **Alpha — `v0.0.1` pre-release series** _(status as of 2026-07-03)_. The
 public API and wire protocol are **not** stable; do not use in production.
 
 Releases are published as GitHub pre-releases — latest


### PR DESCRIPTION
## Description

Refresh the "Project Status" block in the top-level README that had drifted through several release cycles. Three targeted fixes:

1. **Status timestamp** — bumped `_(status as of 2026-06-13)_` to `_(status as of 2026-07-03)_` to match the latest rc.3 release date.
2. **v0.0.1-rc.3 release date** — corrected the parenthesized date from `(2026-06-20)` to `(2026-07-03)`, matching the authoritative value in `CHANGELOG.md` (`## [0.0.1-rc.3] — 2026-07-03`).
3. **GitHub Releases row** — extended from just `v0.0.1-alpha.1 … alpha.9` to include the full release history: alpha series, `v0.0.1-beta.1`, `beta.2`, `beta.4`, `v0.0.1-rc.1`, `rc.2`, `rc.3`.

No other section of `README.md` touched. `CHANGELOG.md` untouched.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-4304
- Parent Epic: AAASM-4300 (10.5 mini-sweep — recovery of AAASM-4281 lost findings)

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (explain why)

Documentation-only change. Verified the rc.3 release date against `CHANGELOG.md` (`## [0.0.1-rc.3] — 2026-07-03`) and confirmed the release history additions match the tags referenced in the changelog.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention