### PR TITLE
[AAASM-4321] 📝 (readme): Correct crate-map member count to 29

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ can move from this repo to the SDKs, the install tap, or the canonical docs.
 
 ## Crate Map
 
-The Cargo workspace declares **28 members** in the top-level `Cargo.toml`. The table below lists the core architectural crates; storage drivers, dev-tool adapters, and test harnesses are omitted for brevity. Two additional eBPF-target crates live alongside but are intentionally outside the workspace because they compile for the `bpfel-unknown-none` target.
+The Cargo workspace declares **29 members** in the top-level `Cargo.toml`. The table below lists the core architectural crates; storage drivers, dev-tool adapters, and test harnesses are omitted for brevity. Two additional eBPF-target crates live alongside but are intentionally outside the workspace because they compile for the `bpfel-unknown-none` target.
 
 ### Workspace members (core)
 


### PR DESCRIPTION
## Description

The README "Crate map" section stated the Cargo workspace has **28 members**, but `Cargo.toml` `[workspace] members = [...]` actually lists **29** entries at 757e447f (master HEAD). This one-line fix realigns the two.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Jira: [AAASM-4321](https://lightning-dust-mite.atlassian.net/browse/AAASM-4321)
- Parent Epic: [AAASM-4307](https://lightning-dust-mite.atlassian.net/browse/AAASM-4307) (11th sweep)

## Testing

- [x] Manual verification: counted `Cargo.toml` `[workspace] members` entries.
- [x] No tests required (docs-only change).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated
- [x] Commit follows Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-4321]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-4307]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ