### PR TITLE
[AAASM-4331] 🔒 (dashboard): Render identity claim instead of raw JWT in top bar

### DIFF
--- a/dashboard/src/auth/jwtScopes.test.ts
+++ b/dashboard/src/auth/jwtScopes.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { getSubject } from './jwtScopes'
+
+/** Build a real 3-part JWT with the given payload (unpadded base64url). */
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (o: object) =>
+    btoa(JSON.stringify(o)).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+  return `${b64url({ alg: 'none' })}.${b64url(payload)}.sig`
+}
+
+describe('getSubject', () => {
+  it('returns the `sub` claim when present', () => {
+    expect(getSubject(makeJwt({ sub: 'alice@acme.io' }))).toBe('alice@acme.io')
+  })
+
+  it('falls back to username, then email, then preferred_username', () => {
+    expect(getSubject(makeJwt({ username: 'bob' }))).toBe('bob')
+    expect(getSubject(makeJwt({ email: 'carol@acme.io' }))).toBe('carol@acme.io')
+    expect(getSubject(makeJwt({ preferred_username: 'dave' }))).toBe('dave')
+  })
+
+  it('prefers `sub` over the other identity claims', () => {
+    expect(getSubject(makeJwt({ sub: 's', username: 'u', email: 'e' }))).toBe('s')
+  })
+
+  it('never returns the raw token string', () => {
+    const jwt = makeJwt({ sub: 'alice' })
+    expect(getSubject(jwt)).not.toBe(jwt)
+  })
+
+  it('returns null for a null, malformed, or identity-less token', () => {
+    expect(getSubject(null)).toBeNull()
+    expect(getSubject('not-a-jwt')).toBeNull()
+    expect(getSubject('a.b')).toBeNull()
+    expect(getSubject('a.!!!.c')).toBeNull()
+    expect(getSubject(makeJwt({ scope: ['read'] }))).toBeNull()
+    expect(getSubject(makeJwt({ sub: '' }))).toBeNull()
+  })
+})

--- a/dashboard/src/auth/jwtScopes.ts
+++ b/dashboard/src/auth/jwtScopes.ts
@@ -5,7 +5,7 @@ const VALID_SCOPES: readonly Scope[] = ['read', 'write', 'admin']
 /**
  * Extract the `scope` claim from an unverified JWT payload.
  *
- * The dashboard only persists the token string in localStorage, so after a
+ * The dashboard only persists the token string in sessionStorage, so after a
  * reload the token-issue response (which carries `scopes`) is gone — this
  * recovers the caller's scopes from the token itself so the UI can reflect
  * them. The signature is deliberately NOT verified here: the gateway validates

--- a/dashboard/src/auth/jwtScopes.ts
+++ b/dashboard/src/auth/jwtScopes.ts
@@ -25,6 +25,32 @@ export function parseScopesFromJwt(token: string | null): Scope[] {
   }
 }
 
+/**
+ * Extract a display identity from an unverified JWT payload.
+ *
+ * Returns the first present of the `sub`, `username`, `email`, or
+ * `preferred_username` claims so the top bar can show *who* is signed in
+ * without ever rendering the bearer credential itself (AAASM-4331). The
+ * signature is deliberately NOT verified — same rationale as
+ * `parseScopesFromJwt`: the gateway is the sole authority. Returns `null` for a
+ * missing, malformed, or identity-less token, which the caller renders as blank.
+ */
+export function getSubject(token: string | null): string | null {
+  if (!token) return null
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+  try {
+    const payload = JSON.parse(base64UrlDecode(parts[1])) as Record<string, unknown>
+    for (const key of ['sub', 'username', 'email', 'preferred_username']) {
+      const value = payload[key]
+      if (typeof value === 'string' && value.length > 0) return value
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
 /** Decode a base64url segment (JWT parts are unpadded base64url). */
 function base64UrlDecode(segment: string): string {
   const base64 = segment.replace(/-/g, '+').replace(/_/g, '/')

--- a/dashboard/src/auth/tokenStorage.test.ts
+++ b/dashboard/src/auth/tokenStorage.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { clearToken, getToken, setToken } from './tokenStorage'
+
+describe('tokenStorage', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+  })
+
+  it('round-trips the token through sessionStorage', () => {
+    setToken('jwt-abc')
+    expect(getToken()).toBe('jwt-abc')
+    expect(localStorage.getItem('aa_token')).toBeNull()
+  })
+
+  it('clearToken removes both the sessionStorage token and the legacy localStorage key', () => {
+    setToken('jwt-abc')
+    // Simulate a stale token left by a pre-4322 build that used localStorage.
+    localStorage.setItem('aa_token', 'legacy-jwt')
+
+    clearToken()
+
+    expect(getToken()).toBeNull()
+    expect(sessionStorage.getItem('aa_token')).toBeNull()
+    expect(localStorage.getItem('aa_token')).toBeNull()
+  })
+})

--- a/dashboard/src/auth/tokenStorage.ts
+++ b/dashboard/src/auth/tokenStorage.ts
@@ -25,4 +25,11 @@ export function setToken(token: string): void {
 
 export function clearToken(): void {
   storage()?.removeItem(TOKEN_KEY)
+  // Also purge any pre-4322 token left behind in localStorage by old builds
+  // that persisted it there. sessionStorage is the sole store now (see module
+  // header); this one-time cleanup stops a stale credential lingering across
+  // the migration (AAASM-4331).
+  if (typeof localStorage !== 'undefined') {
+    localStorage.removeItem(TOKEN_KEY)
+  }
 }

--- a/dashboard/src/components/AppShell.test.tsx
+++ b/dashboard/src/components/AppShell.test.tsx
@@ -38,11 +38,20 @@ describe('AppShell', () => {
     expect(screen.getByTestId('page')).toHaveTextContent('page body')
   })
 
-  it('shows the logged-in token in the topbar and logs out on click', async () => {
-    sessionStorage.setItem('aa_token', 'jwt-123')
+  it('shows the identity claim in the topbar, never the raw token, and logs out on click', async () => {
+    // A real 3-part JWT carrying a `sub` identity claim.
+    const b64url = (o: object) =>
+      btoa(JSON.stringify(o)).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+    const jwt = `${b64url({ alg: 'none' })}.${b64url({ sub: 'alice@acme.io' })}.sig`
+    sessionStorage.setItem('aa_token', jwt)
     const user = userEvent.setup()
     renderShell()
-    expect(screen.getByTestId('appshell-user')).toHaveTextContent('jwt-123')
+
+    const userSpan = screen.getByTestId('appshell-user')
+    expect(userSpan).toHaveTextContent('alice@acme.io')
+    // The raw bearer token must never appear in the DOM (AAASM-4331).
+    expect(userSpan.textContent).not.toContain(jwt)
+    expect(document.body.innerHTML).not.toContain(jwt)
 
     await user.click(screen.getByTestId('logout-btn'))
     expect(screen.getByTestId('appshell-user')).toHaveTextContent('')

--- a/dashboard/src/components/AppShell.tsx
+++ b/dashboard/src/components/AppShell.tsx
@@ -1,6 +1,7 @@
 import { useState, Component, type ReactNode, type ErrorInfo } from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
 import { useAuth } from '../auth/useAuth'
+import { getSubject } from '../auth/jwtScopes'
 import { OverlayProvider } from './OverlayProvider'
 import { OVERLAY_NAMES } from './OverlayContext'
 import { ApprovalsBellButton } from '../features/approvals/ApprovalsBellButton'
@@ -53,6 +54,9 @@ class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryStat
 
 export function AppShell() {
   const { token, logout } = useAuth()
+  // Show the signed-in identity, never the raw bearer token — rendering the
+  // credential in the DOM leaks it via screenshots/screen-share (AAASM-4331).
+  const subject = getSubject(token)
   const [navOpen, setNavOpen] = useState(false)
 
   return (
@@ -112,7 +116,7 @@ export function AppShell() {
           <div />
           <div className="appshell__user">
             <ApprovalsBellButton />
-            <span data-testid="appshell-user">{token ?? ''}</span>
+            <span data-testid="appshell-user">{subject ?? ''}</span>
             <ThemeToggle />
             <NavLink
               to="/settings"


### PR DESCRIPTION
## Description

Hardens the AAASM-4322 token work: the dashboard top bar was rendering the **raw JWT bearer token** as visible plaintext (`AppShell.tsx:115` — `{token ?? ''}`) on every authenticated page, leaking the credential via shoulder-surfing, screenshots, and screen-share/record. This PR renders the **user identity** instead of the credential, and cleans up two bundled AAASM-4322 follow-ups in the same auth area.

Three changes:

1. **Identity, not credential (MED)** — new `getSubject(token)` in `auth/jwtScopes.ts` decodes the JWT and returns the first present of `sub` / `username` / `email` / `preferred_username`. `AppShell` now renders that (blank when no claim); the raw token is never put in the DOM. `data-testid="appshell-user"` is preserved.
2. **Purge legacy localStorage token (LOW)** — `clearToken()` now also removes a pre-4322 `localStorage['aa_token']` left by old builds, so a stale credential no longer lingers after logout. The sessionStorage-only write path (4322) is untouched.
3. **Docstring fix (LOW)** — `jwtScopes.ts` docstring corrected from "lives in localStorage" to sessionStorage (4322 moved it).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4331

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

Automated (all in `dashboard/`):
- `getSubject` claim extraction + fallbacks + null/malformed/identity-less cases (`auth/jwtScopes.test.ts`).
- Top bar renders the identity and the raw JWT is absent from the DOM; logout clears the token (`components/AppShell.test.tsx`).
- `clearToken` purges both the sessionStorage and legacy localStorage keys (`auth/tokenStorage.test.ts`).
- Full suite: **1483 passed** (167 files). `pnpm type-check` clean, `pnpm build` OK. `eslint` clean on all changed files (2 remaining errors are pre-existing in untouched e2e specs `alerts.spec.ts` / `governance-dashboard.spec.ts`).

Manual (Playwright, vite dev + prism mock):
- Seeded a real JWT (`sub: alice@acme.io`) and loaded a protected page. Top bar rendered **`alice@acme.io`**; a full-DOM scan confirmed the raw token, its payload segment, and its signature segment are **all absent**. Screenshot attached to the ticket.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
