### PR TITLE
[AAASM-4330] 🔒 (aa-gateway): Fail closed on unknown nested policy section keys

### DIFF
--- a/aa-cli/src/commands/policy/validate.rs
+++ b/aa-cli/src/commands/policy/validate.rs
@@ -115,6 +115,37 @@ spec:
     }
 
     #[test]
+    fn nested_unknown_key_exits_failure() {
+        // AAASM-4330: a typo INSIDE a section (e.g. `capabilities.dney` for
+        // `deny`) must fail closed at the CLI (exit 1), not pass with a warning
+        // while silently dropping the restriction.
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "capabilities:\n  dney:\n    - file_delete").unwrap();
+
+        let args = ValidateArgs {
+            file: tmp.path().to_path_buf(),
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn valid_nested_policy_exits_success() {
+        // AAASM-4330 over-rejection guard: a policy whose nested keys are all
+        // spelled correctly must still validate (exit 0).
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            tmp,
+            "capabilities:\n  deny:\n    - file_delete\ntools:\n  bash:\n    allow: true\n    limit_per_hour: 5"
+        )
+        .unwrap();
+
+        let args = ValidateArgs {
+            file: tmp.path().to_path_buf(),
+        };
+        assert_eq!(run(args), ExitCode::SUCCESS);
+    }
+
+    #[test]
     fn multiple_errors_all_reported() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -3203,6 +3203,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn load_from_file_nested_unknown_key_fails_closed() {
+        // AAASM-4330: a typo INSIDE a section (`capabilities.dney` for `deny`)
+        // drops the intended restriction. The engine load path must abort
+        // rather than enforce a weaker policy than the author wrote.
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(tmp, "capabilities:\n  dney:\n    - file_delete\n").unwrap();
+        tmp.flush().unwrap();
+        let (alert_tx, _) = tokio::sync::broadcast::channel::<crate::budget::BudgetAlert>(64);
+        let result = PolicyEngine::load_from_file(tmp.path(), alert_tx);
+        assert!(
+            matches!(result, Err(PolicyLoadError::Validation(_))),
+            "expected fail-closed Validation error, got: {:?}",
+            result.err()
+        );
+    }
+
     // ── PolicyEvaluator trait impl ────────────────────────────────────────────
 
     #[test]

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -9,7 +9,8 @@ use serde::Deserialize;
 pub struct RawNetworkPolicy {
     /// Domain glob patterns the agent may connect to.
     pub allowlist: Option<Vec<String>>,
-    /// Unknown keys captured for warning emission.
+    /// Stray keys captured so the validator can reject them (AAASM-4330
+    /// fail-closed: a nested typo must not silently drop a restriction).
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
@@ -23,7 +24,8 @@ pub struct RawActiveHours {
     pub end: Option<String>,
     /// IANA timezone name (e.g. `"Asia/Taipei"`).
     pub timezone: Option<String>,
-    /// Unknown keys captured for warning emission.
+    /// Stray keys captured so the validator can reject them (AAASM-4330
+    /// fail-closed: a nested typo must not silently drop a restriction).
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
@@ -33,7 +35,8 @@ pub struct RawActiveHours {
 pub struct RawSchedulePolicy {
     /// Time window during which the agent is permitted to run.
     pub active_hours: Option<RawActiveHours>,
-    /// Unknown keys captured for warning emission.
+    /// Stray keys captured so the validator can reject them (AAASM-4330
+    /// fail-closed: a nested typo must not silently drop a restriction).
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
@@ -59,7 +62,8 @@ pub struct RawBudgetPolicy {
     /// (e.g. `"5s"`, `"30m"`, `"1h30m"`). When absent the tracker rolls at the
     /// calendar-day boundary (the historical default). AAASM-1600.
     pub window: Option<String>,
-    /// Unknown keys captured for warning emission.
+    /// Stray keys captured so the validator can reject them (AAASM-4330
+    /// fail-closed: a nested typo must not silently drop a restriction).
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
@@ -73,7 +77,8 @@ pub struct RawDataPolicy {
     /// `"alert_only"`, or `"alert_and_redact"`. Validated into a
     /// [`crate::policy::document::CredentialAction`].
     pub credential_action: Option<String>,
-    /// Unknown keys captured for warning emission.
+    /// Stray keys captured so the validator can reject them (AAASM-4330
+    /// fail-closed: a nested typo must not silently drop a restriction).
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
@@ -85,7 +90,8 @@ pub struct RawCapabilitySet {
     pub allow: Option<Vec<String>>,
     /// Capability strings that are explicitly denied.
     pub deny: Option<Vec<String>>,
-    /// Unknown keys captured for warning emission.
+    /// Stray keys captured so the validator can reject them (AAASM-4330
+    /// fail-closed: a nested typo must not silently drop a restriction).
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
@@ -128,7 +134,8 @@ pub struct RawApprovalPolicy {
     pub timeout_seconds: Option<u32>,
     /// Override the escalation role / approver group for this policy.
     pub escalation_role: Option<String>,
-    /// Unknown keys captured for warning emission.
+    /// Stray keys captured so the validator can reject them (AAASM-4330
+    /// fail-closed: a nested typo must not silently drop a restriction).
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
@@ -159,7 +166,8 @@ pub struct RawPolicyDocument {
     pub approval_timeout_secs: Option<u32>,
     /// Per-policy approval escalation override.
     pub approval: Option<RawApprovalPolicy>,
-    /// Unknown top-level keys captured for warning emission.
+    /// Unknown top-level keys captured so the validator can reject them
+    /// (AAASM-4191 fail-closed).
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
@@ -173,7 +181,8 @@ pub struct RawToolPolicy {
     pub limit_per_hour: Option<u32>,
     /// CEL expression that triggers human-in-the-loop approval.
     pub requires_approval_if: Option<String>,
-    /// Unknown keys captured for warning emission.
+    /// Stray keys captured so the validator can reject them (AAASM-4330
+    /// fail-closed: a nested typo must not silently drop a restriction).
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
 }

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -53,6 +53,12 @@ impl PolicyValidator {
         // vanish without any error. Now every unknown top-level key is a
         // hard validation error — consistent with the product's fail-closed
         // posture everywhere else.
+        //
+        // AAASM-4330: the same silent-drop existed one level DOWN — a typo
+        // INSIDE an enforced section (e.g. `capabilities.dney` for `deny`) was
+        // only warned about, so the restriction still vanished and the policy
+        // loaded fail-open. Each section validator now calls
+        // `reject_unknown_keys`, mirroring this top-level rule for nested keys.
         for key in raw.unknown.keys() {
             if key == "rules" {
                 errors.push(ValidationError::new(
@@ -74,13 +80,13 @@ impl PolicyValidator {
         }
 
         // Step 3 — validate each section
-        let network = Self::validate_network(raw.network, &mut errors, &mut warnings);
-        let schedule = Self::validate_schedule(raw.schedule, &mut errors, &mut warnings);
+        let network = Self::validate_network(raw.network, &mut errors);
+        let schedule = Self::validate_schedule(raw.schedule, &mut errors);
         let budget = Self::validate_budget(raw.budget, &mut errors);
         let data = Self::validate_data(raw.data, &mut errors);
-        let tools = Self::validate_tools(raw.tools, &mut errors, &mut warnings);
+        let tools = Self::validate_tools(raw.tools, &mut errors);
         let capabilities = Self::validate_capabilities(raw.capabilities, &mut errors, &mut warnings);
-        let approval_policy = Self::validate_approval_policy(raw.approval, &mut errors, &mut warnings);
+        let approval_policy = Self::validate_approval_policy(raw.approval, &mut errors);
 
         let approval_timeout_secs = match raw.approval_timeout_secs {
             Some(0) => {
@@ -153,13 +159,10 @@ impl PolicyValidator {
     fn validate_network(
         raw: Option<crate::policy::raw::RawNetworkPolicy>,
         errors: &mut Vec<ValidationError>,
-        warnings: &mut Vec<ValidationWarning>,
     ) -> Option<NetworkPolicy> {
         let raw = raw?;
 
-        for key in raw.unknown.keys() {
-            warnings.push(ValidationWarning::unknown_key(format!("network.{}", key)));
-        }
+        reject_unknown_keys("network", &raw.unknown, errors);
 
         let allowlist = raw.allowlist.unwrap_or_default();
         for (i, entry) in allowlist.iter().enumerate() {
@@ -177,17 +180,12 @@ impl PolicyValidator {
     fn validate_schedule(
         raw: Option<crate::policy::raw::RawSchedulePolicy>,
         errors: &mut Vec<ValidationError>,
-        warnings: &mut Vec<ValidationWarning>,
     ) -> Option<SchedulePolicy> {
         let raw = raw?;
 
-        for key in raw.unknown.keys() {
-            warnings.push(ValidationWarning::unknown_key(format!("schedule.{}", key)));
-        }
+        reject_unknown_keys("schedule", &raw.unknown, errors);
 
-        let active_hours = raw
-            .active_hours
-            .and_then(|ah| Self::validate_active_hours(ah, errors, warnings));
+        let active_hours = raw.active_hours.and_then(|ah| Self::validate_active_hours(ah, errors));
 
         Some(SchedulePolicy { active_hours })
     }
@@ -195,11 +193,8 @@ impl PolicyValidator {
     fn validate_active_hours(
         raw: crate::policy::raw::RawActiveHours,
         errors: &mut Vec<ValidationError>,
-        warnings: &mut Vec<ValidationWarning>,
     ) -> Option<ActiveHours> {
-        for key in raw.unknown.keys() {
-            warnings.push(ValidationWarning::unknown_key(format!("schedule.active_hours.{}", key)));
-        }
+        reject_unknown_keys("schedule.active_hours", &raw.unknown, errors);
 
         let start = match raw.start {
             Some(s) => {
@@ -280,6 +275,8 @@ impl PolicyValidator {
         errors: &mut Vec<ValidationError>,
     ) -> Option<BudgetPolicy> {
         let raw = raw?;
+
+        reject_unknown_keys("budget", &raw.unknown, errors);
 
         validate_budget_limit_pair(
             raw.daily_limit_usd,
@@ -362,6 +359,8 @@ impl PolicyValidator {
     ) -> Option<DataPolicy> {
         let raw = raw?;
 
+        reject_unknown_keys("data", &raw.unknown, errors);
+
         let patterns = raw.sensitive_patterns.unwrap_or_default();
         for (i, pattern) in patterns.iter().enumerate() {
             if regex::Regex::new(pattern).is_err() {
@@ -403,9 +402,7 @@ impl PolicyValidator {
     ) -> Option<aa_core::CapabilitySet> {
         let raw = raw?;
 
-        for key in raw.unknown.keys() {
-            warnings.push(ValidationWarning::unknown_key(format!("capabilities.{}", key)));
-        }
+        reject_unknown_keys("capabilities", &raw.unknown, errors);
 
         let mut allow = std::collections::BTreeSet::new();
         for (i, s) in raw.allow.unwrap_or_default().iter().enumerate() {
@@ -457,7 +454,6 @@ impl PolicyValidator {
     fn validate_tools(
         raw: Option<HashMap<String, crate::policy::raw::RawToolPolicy>>,
         errors: &mut Vec<ValidationError>,
-        warnings: &mut Vec<ValidationWarning>,
     ) -> HashMap<String, ToolPolicy> {
         let raw = match raw {
             Some(m) => m,
@@ -466,9 +462,7 @@ impl PolicyValidator {
 
         let mut tools = HashMap::new();
         for (name, rt) in raw {
-            for key in rt.unknown.keys() {
-                warnings.push(ValidationWarning::unknown_key(format!("tools.{}.{}", name, key)));
-            }
+            reject_unknown_keys(&format!("tools.{}", name), &rt.unknown, errors);
 
             if let Some(expr) = &rt.requires_approval_if {
                 if expr.trim().is_empty() {
@@ -509,19 +503,40 @@ impl PolicyValidator {
 
     fn validate_approval_policy(
         raw: Option<crate::policy::raw::RawApprovalPolicy>,
-        _errors: &mut Vec<ValidationError>,
-        warnings: &mut Vec<ValidationWarning>,
+        errors: &mut Vec<ValidationError>,
     ) -> Option<ApprovalPolicy> {
         let raw = raw?;
 
-        for key in raw.unknown.keys() {
-            warnings.push(ValidationWarning::unknown_key(format!("approval.{}", key)));
-        }
+        reject_unknown_keys("approval", &raw.unknown, errors);
 
         Some(ApprovalPolicy {
             timeout_seconds: raw.timeout_seconds,
             escalation_role: raw.escalation_role,
         })
+    }
+}
+
+/// AAASM-4330: reject an unknown key inside an enforced policy section as a hard
+/// validation error (fail-closed), mirroring the top-level AAASM-4191 rule.
+///
+/// Every raw section struct captures stray keys via `#[serde(flatten)] unknown`.
+/// Previously these only produced a warning (and `budget`/`data` dropped them
+/// with no diagnostic at all), so a nested typo — e.g. `dney` for `deny` under
+/// `capabilities` — silently discarded the intended restriction while the policy
+/// still loaded: a fail-OPEN. Promoting to an error means both the CLI `validate`
+/// and the engine `load_from_file` refuse the document rather than enforce a
+/// weaker policy than the author wrote. `section` is the dotted path prefix of
+/// the enclosing section (e.g. `"capabilities"`, `"tools.bash"`).
+fn reject_unknown_keys(section: &str, unknown: &HashMap<String, serde_yaml::Value>, errors: &mut Vec<ValidationError>) {
+    for key in unknown.keys() {
+        errors.push(ValidationError::new(
+            format!("{section}.{key}"),
+            format!(
+                "unknown key '{key}' in the '{section}' policy section; a typo here would \
+                 silently drop the intended restriction, so the document is rejected rather \
+                 than loaded fail-open"
+            ),
+        ));
     }
 }
 

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -636,17 +636,21 @@ mod tests {
     }
 
     #[test]
-    fn network_unknown_key_produces_warning() {
+    fn network_unknown_key_is_validation_error() {
+        // AAASM-4330: an unknown key inside `network` must fail closed (error),
+        // not warn — a typo like `blocklist` would otherwise silently drop the
+        // author's intent while the policy still loads.
         let yaml = "network:\n  allowlist:\n    - api.openai.com\n  blocklist:\n    - \"*\"\n";
-        let out = PolicyValidator::from_yaml(yaml).unwrap();
-        assert!(out.warnings.iter().any(|w| w.field == "network.blocklist"));
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "network.blocklist"));
     }
 
     #[test]
-    fn tool_unknown_key_produces_warning() {
+    fn tool_unknown_key_is_validation_error() {
+        // AAASM-4330: an unknown key inside a tool entry must fail closed.
         let yaml = "tools:\n  bash:\n    allow: true\n    constraint: read-only\n";
-        let out = PolicyValidator::from_yaml(yaml).unwrap();
-        assert!(out.warnings.iter().any(|w| w.field == "tools.bash.constraint"));
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "tools.bash.constraint"));
     }
 
     // ── Network allowlist validation ────────────────────────────────────────
@@ -1004,10 +1008,11 @@ mod tests {
     }
 
     #[test]
-    fn capabilities_unknown_key_produces_warning() {
+    fn capabilities_unknown_key_is_validation_error() {
+        // AAASM-4330: an unknown key inside `capabilities` must fail closed.
         let yaml = "capabilities:\n  allow: []\n  extra_key: true\n";
-        let out = PolicyValidator::from_yaml(yaml).unwrap();
-        assert!(out.warnings.iter().any(|w| w.field == "capabilities.extra_key"));
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "capabilities.extra_key"));
     }
 
     #[test]
@@ -1373,7 +1378,7 @@ spec:
     }
 
     #[test]
-    fn approval_policy_unknown_key_produces_warning() {
+    fn approval_policy_unknown_key_is_validation_error() {
         let yaml = r#"
 apiVersion: agent-assembly/v1
 kind: Policy
@@ -1385,35 +1390,38 @@ spec:
     timeout_seconds: 300
     unknown_field: surprise
 "#;
-        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        // AAASM-4330: an unknown key inside `approval` must fail closed.
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
         assert!(
-            out.warnings.iter().any(|w| w.field.contains("unknown_field")),
-            "expected warning for unknown approval field, got: {:?}",
-            out.warnings,
+            errs.iter().any(|e| e.field.contains("unknown_field")),
+            "expected error for unknown approval field, got: {:?}",
+            errs,
         );
     }
 
     // ── Schedule active_hours missing/unknown fields ────────────────────────
 
     #[test]
-    fn schedule_unknown_key_produces_warning() {
+    fn schedule_unknown_key_is_validation_error() {
+        // AAASM-4330: an unknown key inside `schedule` must fail closed.
         let yaml = "schedule:\n  surprise: 1\n";
-        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
         assert!(
-            out.warnings.iter().any(|w| w.field == "schedule.surprise"),
-            "expected warning for unknown schedule key, got: {:?}",
-            out.warnings,
+            errs.iter().any(|e| e.field == "schedule.surprise"),
+            "expected error for unknown schedule key, got: {:?}",
+            errs,
         );
     }
 
     #[test]
-    fn schedule_active_hours_unknown_key_produces_warning() {
+    fn schedule_active_hours_unknown_key_is_validation_error() {
+        // AAASM-4330: an unknown key inside `schedule.active_hours` must fail closed.
         let yaml = "schedule:\n  active_hours:\n    start: \"09:00\"\n    end: \"18:00\"\n    timezone: \"UTC\"\n    surprise: 1\n";
-        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
         assert!(
-            out.warnings.iter().any(|w| w.field == "schedule.active_hours.surprise"),
-            "expected warning for unknown active_hours key, got: {:?}",
-            out.warnings,
+            errs.iter().any(|e| e.field == "schedule.active_hours.surprise"),
+            "expected error for unknown active_hours key, got: {:?}",
+            errs,
         );
     }
 
@@ -1500,6 +1508,142 @@ spec:
         assert!(
             errs.iter().any(|e| e.field == "capabilities.deny[0]"),
             "invalid deny capability must be rejected, got: {errs:?}"
+        );
+    }
+
+    // ── Nested unknown-key fail-closed (AAASM-4330) ─────────────────────────
+    //
+    // Each case is a realistic single-letter typo of a real nested key. The
+    // typo lands in `#[serde(flatten)] unknown`, so the intended restriction is
+    // dropped. The validator must reject the document (fail-closed) rather than
+    // load a weaker policy than the author wrote.
+
+    #[test]
+    fn nested_capabilities_deny_typo_is_rejected_not_dropped() {
+        // `dney` instead of `deny` → the deny-list is empty → file_delete would
+        // NOT be denied. Must be a hard error, not a silent fail-open.
+        let yaml = "capabilities:\n  dney:\n    - file_delete\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "capabilities.dney"),
+            "typo'd capabilities key must be rejected, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn nested_tool_limit_typo_is_rejected() {
+        // `limt_per_hour` instead of `limit_per_hour` → the rate limit vanishes.
+        let yaml = "tools:\n  bash:\n    allow: true\n    limt_per_hour: 5\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "tools.bash.limt_per_hour"),
+            "typo'd tool key must be rejected, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn nested_network_allowlist_typo_is_rejected() {
+        // `alowlist` instead of `allowlist` → egress restriction silently lost.
+        let yaml = "network:\n  alowlist:\n    - api.openai.com\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "network.alowlist"),
+            "typo'd network key must be rejected, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn nested_approval_typo_is_rejected() {
+        let yaml = "approval:\n  timeuot_seconds: 600\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "approval.timeuot_seconds"),
+            "typo'd approval key must be rejected, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn nested_budget_typo_is_rejected() {
+        // `dayly_limit_usd` → the daily cap vanishes. Budget previously dropped
+        // unknown keys with no diagnostic at all — now a hard error.
+        let yaml = "budget:\n  dayly_limit_usd: 5.0\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "budget.dayly_limit_usd"),
+            "typo'd budget key must be rejected, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn nested_data_typo_is_rejected() {
+        // `credential_actn` → the credential action reverts to the default,
+        // silently weakening a `block` intent.
+        let yaml = "data:\n  credential_actn: block\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "data.credential_actn"),
+            "typo'd data key must be rejected, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn nested_schedule_active_hours_typo_is_rejected() {
+        let yaml = "schedule:\n  active_hours:\n    start: \"09:00\"\n    end: \"18:00\"\n    timezoen: \"UTC\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "schedule.active_hours.timezoen"),
+            "typo'd active_hours key must be rejected, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn valid_policy_exercising_every_nested_key_still_loads() {
+        // Over-rejection guard: a policy that spells every enforced nested key
+        // correctly must still load cleanly (exit 0) with no warnings — the
+        // fail-closed rule must not reject genuinely-valid documents.
+        let yaml = r#"
+version: "1.0"
+scope: global
+approval_timeout_secs: 300
+network:
+  allowlist:
+    - api.openai.com
+schedule:
+  active_hours:
+    start: "09:00"
+    end: "18:00"
+    timezone: "Asia/Taipei"
+budget:
+  daily_limit_usd: 25.0
+  monthly_limit_usd: 400.0
+  org_daily_limit_usd: 50.0
+  org_monthly_limit_usd: 800.0
+  timezone: "UTC"
+  action_on_exceed: deny
+  window: "30m"
+data:
+  sensitive_patterns:
+    - "sk-[a-zA-Z0-9]{48}"
+  credential_action: block
+capabilities:
+  allow:
+    - file_read
+  deny:
+    - terminal_exec
+tools:
+  bash:
+    allow: true
+    limit_per_hour: 10
+    requires_approval_if: "agent.depth > 1"
+approval:
+  timeout_seconds: 600
+  escalation_role: org-admin
+"#;
+        let out = PolicyValidator::from_yaml(yaml).unwrap_or_else(|e| panic!("valid policy must load, got: {e:?}"));
+        assert!(
+            out.warnings.is_empty(),
+            "a fully-valid policy must produce no warnings, got: {:?}",
+            out.warnings
         );
     }
 }


### PR DESCRIPTION
## Description

Incomplete-fix follow-up to **AAASM-4191**. 4191 promoted an unknown **top-level** policy key to a hard validation error (fail-closed), but nested **section-body** unknown keys were only warned about — and `budget`/`data` dropped them with no diagnostic at all. Every raw section struct still carries `#[serde(flatten)] unknown`, so a typo one level down (e.g. `capabilities: { dney: [file_delete] }`) captured the key as "unknown", left `deny` empty, and the policy still **loaded (exit 0, warning)** — the restriction silently vanished. This is a **fail-OPEN**, and arguably the more common typo case (misspelling a key *inside* a section).

This PR extends the 4191 fail-closed rule down one level: a new `reject_unknown_keys` helper is called from every **enforced** section validator, mirroring the top-level error idiom with the nested dotted path (e.g. `capabilities.dney`).

**Sections covered:** `network`, `schedule`, `schedule.active_hours`, `budget`, `data`, `capabilities`, `tools.<name>` (per-tool), `approval`.

**Both load paths fail closed:** `from_yaml` accumulates the unknown-key error and returns `Err`, which is consumed by *both* the CLI `aasm policy validate` (exit 1) and the engine `PolicyEngine::load_from_file` (`PolicyLoadError::Validation`) — no separate wiring needed.

**Over-rejection decision:** every enforced section's real key vocabulary is closed today — there are no genuinely forward-compatible optional keys inside these sections — so the default is fail-closed with no exceptions. Verified the full shipped `policy-examples/*.yaml` corpus and `schemas/examples/*.yaml` use only known nested keys; the cross-layer example-corpus test still passes (no valid policy is newly rejected). The top-level `metadata.description` and `budget.window`/`org_*` etc. are all explicit struct fields, unaffected.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] Yes (describe below)

A policy file with a typo'd (or otherwise unrecognized) key **inside** an enforced section now fails validation instead of loading with a warning. This is intentional and fail-closed: such a document was silently enforcing a weaker policy than its author wrote. Correctly-spelled policies are unaffected.

## Related Issues

- Related Jira ticket: AAASM-4330 (incomplete fix of AAASM-4191)

## Testing

- [x] Unit tests added / updated

- Converted the six nested `*_produces_warning` validator tests to assert a hard error.
- Regression cases for realistic typos: `capabilities.dney`, `tools.bash.limt_per_hour`, `network.alowlist`, `approval.timeuot_seconds`, `budget.dayly_limit_usd`, `data.credential_actn`, `schedule.active_hours.timezoen` — each asserts the restriction is rejected, not dropped.
- Over-rejection guard: a policy exercising every real nested key loads cleanly with no warnings.
- CLI `validate`: nested typo exits 1; valid nested policy exits 0.
- Engine `load_from_file`: nested typo → `PolicyLoadError::Validation`.
- Local run: `cargo nextest run -p aa-gateway -p aa-cli` — all policy/validate/engine tests green (327 policy tests pass); the only failure is the Docker-dependent postgres testcontainer test (unrelated, Docker not running). `cargo fmt --check` and `cargo clippy -p aa-gateway -p aa-cli --all-targets -- -D warnings` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz