### PR TITLE
[AAASM-4343] 📝 (docs): update repo URL references after prefix rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ dev-verify passed (22s total)
 - [SDK repositories](#ecosystem) — Python, Node.js, and Go SDK guides
 - [Architecture Overview](docs/src/architecture.md) — three-layer interception model
 - [Policy examples](policy-examples/) — reference governance policies
-- [Runnable examples](https://github.com/ai-agent-assembly/agent-assembly-examples) — learn the runtime, CLI, and policy behavior by running small, framework-specific examples for Python, Node.js/TypeScript, Go, policy enforcement, approvals, audit, trace, and runtime workflows
+- [Runnable examples](https://github.com/ai-agent-assembly/examples) — learn the runtime, CLI, and policy behavior by running small, framework-specific examples for Python, Node.js/TypeScript, Go, policy enforcement, approvals, audit, trace, and runtime workflows
 
 ## Running with Docker Compose
 

--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -2,7 +2,7 @@
 
 The pages in this guide explain *how* governance works. When you want to **run**
 it, the framework-specific, end-to-end examples live in the dedicated
-[`agent-assembly-examples`](https://github.com/ai-agent-assembly/agent-assembly-examples)
+[`agent-assembly-examples`](https://github.com/ai-agent-assembly/examples)
 repository rather than in this book — that keeps the runnable code versioned and
 testable on its own, while these pages stay focused on the concepts.
 
@@ -20,10 +20,10 @@ brain, at least one interception layer (SDK shim, `aa-proxy` sidecar, or eBPF),
 and a policy. Pick the language you are integrating, or browse the cross-cutting
 scenarios:
 
-- **Node** — [examples-repo/node](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node)
-- **Python** — [examples-repo/python](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/python)
-- **Go** — [examples-repo/go](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/go)
-- **Scenarios** (cross-cutting: approval-gates, audit-trace, budget-limits, policy-enforcement, sidecar-runtime) — [examples-repo/scenarios](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/scenarios)
+- **Node** — [examples-repo/node](https://github.com/ai-agent-assembly/examples/tree/master/node)
+- **Python** — [examples-repo/python](https://github.com/ai-agent-assembly/examples/tree/master/python)
+- **Go** — [examples-repo/go](https://github.com/ai-agent-assembly/examples/tree/master/go)
+- **Scenarios** (cross-cutting: approval-gates, audit-trace, budget-limits, policy-enforcement, sidecar-runtime) — [examples-repo/scenarios](https://github.com/ai-agent-assembly/examples/tree/master/scenarios)
 
 ## Per-SDK example docs
 


### PR DESCRIPTION
Cosmetic sweep of stale repo URL references after the org-wide `agent-assembly-` prefix rename.

The `agent-assembly-examples` repo was renamed to `examples`, so GitHub links of the form `ai-agent-assembly/agent-assembly-examples` are now stale. GitHub already 301-redirects the old URLs, so this is purely cosmetic cleanup of live documentation.

## What changed
- `README.md` — runnable-examples link updated to `ai-agent-assembly/examples`
- `docs/src/usage-guide/examples.md` — 5 GitHub anchor URLs updated to `ai-agent-assembly/examples`

## Intentionally excluded
- `versioned_docs/` / `versioned_sidebars/` — frozen shipped-release snapshots (left to the redirect)
- `CHANGELOG.md`, `docs/release/*`, `verification-reports/*` — historical entries that name repos at a past point in time (accuracy preserved)
- Bare prose mentions without the `ai-agent-assembly/` org prefix were left as-is per the scoped pattern
- Bare `agent-assembly` (core monorepo) and `agent-assembly-spec` (archived) were not touched

Refs AAASM-4343