### PR TITLE
[AAASM-4450] 🐛 (aa-cli): Name actual binary in aasm start spawn/exec errors

### DIFF
--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -308,6 +308,24 @@ mod tests {
     }
 
     #[test]
+    fn binary_name_names_launched_binary_per_mode() {
+        // AAASM-4450: the spawn/exec failure messages interpolate
+        // binary_name(mode), so it must name the binary command() actually
+        // launches — otherwise a `--mode local` failure blames aa-gateway.
+        let addr: SocketAddr = "127.0.0.1:7391".parse().unwrap();
+        assert_eq!(binary_name(ModeArg::Local), "aa-api-server");
+        assert_eq!(binary_name(ModeArg::Remote), "aa-gateway");
+        assert_eq!(
+            ProcessSpawner::new(ModeArg::Local).command(addr).get_program(),
+            binary_name(ModeArg::Local),
+        );
+        assert_eq!(
+            ProcessSpawner::new(ModeArg::Remote).command(addr).get_program(),
+            binary_name(ModeArg::Remote),
+        );
+    }
+
+    #[test]
     fn resolve_listen_addr_local_binds_loopback() {
         let addr = resolve_listen_addr(ModeArg::Local, 7391);
         assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -147,6 +147,20 @@ pub trait GatewaySpawner {
     fn exec_foreground(&self, addr: SocketAddr) -> std::io::Result<std::process::ExitStatus>;
 }
 
+/// Name of the entrypoint binary launched for `mode` (AAASM-3382):
+/// local mode runs `aa-api-server`, remote mode runs `aa-gateway`.
+///
+/// Single source of truth so the spawn/exec failure messages name the
+/// binary that was actually invoked instead of a hardcoded default —
+/// otherwise a `--mode local` failure misleadingly blames `aa-gateway`
+/// (AAASM-4450).
+fn binary_name(mode: ModeArg) -> &'static str {
+    match mode {
+        ModeArg::Local => "aa-api-server",
+        ModeArg::Remote => "aa-gateway",
+    }
+}
+
 /// Default [`GatewaySpawner`].
 ///
 /// * **Local mode** invokes the `aa-api-server` binary (AAASM-3382), which
@@ -170,12 +184,12 @@ impl ProcessSpawner {
     fn command(&self, addr: SocketAddr) -> Command {
         match self.mode {
             ModeArg::Local => {
-                let mut cmd = Command::new("aa-api-server");
+                let mut cmd = Command::new(binary_name(self.mode));
                 cmd.env("AA_API_ADDR", addr.to_string());
                 cmd
             }
             ModeArg::Remote => {
-                let mut cmd = Command::new("aa-gateway");
+                let mut cmd = Command::new(binary_name(self.mode));
                 cmd.arg("--listen").arg(addr.to_string());
                 cmd
             }
@@ -236,7 +250,7 @@ pub fn run_with_spawner<S: GatewaySpawner>(args: StartArgs, spawner: &S, pid_fil
             Ok(status) if status.success() => ExitCode::SUCCESS,
             Ok(_) => ExitCode::FAILURE,
             Err(e) => {
-                eprintln!("aasm start: failed to exec aa-gateway: {e}");
+                eprintln!("aasm start: failed to exec {}: {e}", binary_name(args.mode));
                 ExitCode::FAILURE
             }
         };
@@ -245,7 +259,7 @@ pub fn run_with_spawner<S: GatewaySpawner>(args: StartArgs, spawner: &S, pid_fil
     let pid = match spawner.spawn_background(addr) {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("aasm start: failed to spawn aa-gateway: {e}");
+            eprintln!("aasm start: failed to spawn {}: {e}", binary_name(args.mode));
             return ExitCode::FAILURE;
         }
     };


### PR DESCRIPTION
## Description

`aasm start`'s failure paths hardcoded `"aa-gateway"` in both the foreground
exec error (`failed to exec aa-gateway`) and the background spawn error
(`failed to spawn aa-gateway`). But `--mode local` actually launches
`aa-api-server` (AAASM-3382), so a local-mode failure blamed the wrong binary
and misdirected debugging.

This introduces a single-source-of-truth `binary_name(mode)` helper
(`aa-api-server` for local, `aa-gateway` for remote), uses it in both
`command()` and the two error messages, so the message always names the binary
that was actually invoked and the name can never drift from what is launched.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Only failure-path log text changes; behaviour is otherwise unchanged.

## Related Issues

- Related Jira ticket: [AAASM-4450](https://lightning-dust-mite.atlassian.net/browse/AAASM-4450)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Added `binary_name_names_launched_binary_per_mode`, which pins the name per
mode and asserts it agrees with the program `command()` launches. Local run:
`cargo nextest run -p aa-cli` — 806 passed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention


[AAASM-4450]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ