### PR TITLE
[AAASM-4454] ✅ (conformance): Add SDK↔gateway protocol contract test suite

### DIFF
--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -11,6 +11,11 @@
 //! 3. `policy_query`    — CheckActionRequest / CheckActionResponse round-trips
 //! 4. `cred_detection`  — CredentialScanner::scan() + ScanResult::redact()
 //! 5. `session_lifecycle` — agent Register → Heartbeat → Deregister → ControlStream
+//! 6. `integration_surface_contract` — the SDK-relied-on network surface is
+//!    actually present on the server(s) the CLI starts (AAASM-4454)
+
+/// Source-introspection helpers for the integration-surface contract tests.
+pub mod surface;
 
 use serde::de::DeserializeOwned;
 use std::path::Path;

--- a/conformance/src/surface.rs
+++ b/conformance/src/surface.rs
@@ -1,0 +1,198 @@
+//! Source-introspection helpers for the integration-surface contract tests
+//! (AAASM-4454).
+//!
+//! # Why read source instead of starting servers
+//!
+//! The contract these helpers support is *"the network surface the SDK depends
+//! on is actually present on the server(s) the CLI starts"*. Proving that by
+//! booting the real processes would require a gateway build, `protoc`, bound
+//! ports, and a live gRPC/HTTP round-trip inside a unit-test — heavy, flaky, and
+//! platform-bound. Instead these helpers treat the repository's own source files
+//! as the authoritative description of each surface: which binary
+//! `aasm start --mode local` launches, which gRPC services a crate registers,
+//! which REST routes it declares. That is enough to detect the drift class that
+//! AAASM-4447 uncovered (SDK speaks gRPC `AgentLifecycleService`, but the
+//! local-mode server exposes only REST) without running anything.
+//!
+//! The trade-off: these assertions track the *declared* surface, not a live
+//! handshake. That is the right altitude for a fast, deterministic contract test
+//! that lives next to the code and fails the moment the wiring diverges.
+
+use std::path::{Path, PathBuf};
+
+/// Absolute path to the Cargo workspace root.
+///
+/// The `conformance` crate sits one level below the workspace root, so the
+/// root is this crate's manifest-dir parent.
+pub fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("conformance crate always has a parent (the workspace root)")
+        .to_path_buf()
+}
+
+/// Read a workspace-relative source file to a `String`.
+///
+/// Panics with a descriptive message if the file cannot be read, so a contract
+/// test that names a moved/renamed file fails loudly rather than silently
+/// skipping its assertion.
+pub fn read_repo_file(rel: &str) -> String {
+    let path = workspace_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read repo file {}: {}", path.display(), e))
+}
+
+/// Recursively collect every `*.rs` file under `<crate_dir>/src`.
+///
+/// `target/` and other build outputs live outside `src/`, so a plain walk of
+/// `src/` is enough and needs no ignore handling.
+pub fn crate_src_files(crate_dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let src = crate_dir.join("src");
+    collect_rs(&src, &mut out);
+    out.sort();
+    out
+}
+
+fn collect_rs(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs(&path, out);
+        } else if path.extension().map(|x| x == "rs").unwrap_or(false) {
+            out.push(path);
+        }
+    }
+}
+
+/// Whether any `*.rs` file under `<crate_dir>/src` contains `needle`.
+///
+/// Used to check that a crate references a specific generated tonic server type
+/// (e.g. `AgentLifecycleServiceServer`). It is a textual, not semantic, check —
+/// deliberately so: the point is to detect that the wiring exists at all, and to
+/// fail when it is deleted or renamed.
+pub fn crate_src_contains(crate_dir: &Path, needle: &str) -> bool {
+    crate_src_files(crate_dir)
+        .iter()
+        .any(|p| std::fs::read_to_string(p).map(|s| s.contains(needle)).unwrap_or(false))
+}
+
+/// Locate the crate directory whose `src/bin/<bin>.rs` provides the binary
+/// named `bin`.
+///
+/// Returns `None` if no workspace crate ships that binary. Lets a contract test
+/// map a spawned program name (`aa-api-server`) back to the crate whose surface
+/// must satisfy the contract (`aa-api`), instead of hard-coding the mapping.
+pub fn crate_dir_for_binary(bin: &str) -> Option<PathBuf> {
+    let root = workspace_root();
+    let entries = std::fs::read_dir(&root).ok()?;
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if dir.is_dir() && dir.join("src/bin").join(format!("{bin}.rs")).exists() {
+            return Some(dir);
+        }
+    }
+    None
+}
+
+/// Extract the `rpc <Name>` method names declared inside `service <service>`
+/// in a `.proto` file's text.
+///
+/// Returns the method names in declaration order. Returns an empty vec if the
+/// service is not found. Brace-matches the service body so `rpc` tokens in
+/// other services or in comments outside the block are not picked up.
+pub fn proto_service_rpcs(proto_src: &str, service: &str) -> Vec<String> {
+    let needle = format!("service {service}");
+    let Some(start) = proto_src.find(&needle) else {
+        return Vec::new();
+    };
+    // Find the opening brace of the service body, then walk to its match.
+    let Some(open_rel) = proto_src[start..].find('{') else {
+        return Vec::new();
+    };
+    let open = start + open_rel;
+    let mut depth = 0usize;
+    let mut end = open;
+    for (i, ch) in proto_src[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = open + i;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let body = &proto_src[open + 1..end];
+    body.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let rest = line.strip_prefix("rpc ")?;
+            let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').collect();
+            (!name.is_empty()).then_some(name)
+        })
+        .collect()
+}
+
+/// The program name that `aasm start --mode local` launches, parsed from the
+/// CLI's `start` command source.
+///
+/// Reads the mapping actually encoded in `start.rs`
+/// (`ModeArg::Local => Command::new("…")`) rather than assuming it, so this
+/// contract test re-evaluates automatically if the local-mode entrypoint is
+/// ever changed. Returns `None` if the arm can't be located.
+pub fn local_mode_server_program(start_src: &str) -> Option<String> {
+    let arm = start_src.find("ModeArg::Local")?;
+    let after = &start_src[arm..];
+    let cn = after.find("Command::new(")?;
+    let after_cn = &after[cn + "Command::new(".len()..];
+    let q1 = after_cn.find('"')?;
+    let after_q = &after_cn[q1 + 1..];
+    let q2 = after_q.find('"')?;
+    Some(after_q[..q2].to_string())
+}
+
+/// Whether a crate declares a REST route whose path plausibly registers an
+/// agent — i.e. a `.route("…")` path literal containing `register`.
+///
+/// This is the REST half of the AAASM-4447 contract: a documented REST
+/// registration path is an acceptable alternative to serving the gRPC
+/// `AgentLifecycleService`. Matching on the path literal (not the handler name)
+/// avoids false positives from unrelated handlers such as `ops::register_op`
+/// mounted at `/ops`.
+pub fn crate_has_registration_rest_route(crate_dir: &Path) -> bool {
+    for file in crate_src_files(crate_dir) {
+        let Ok(src) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        for path in route_path_literals(&src) {
+            if path.to_ascii_lowercase().contains("register") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Collect the path literals from `.route("<path>", …)` declarations in a
+/// source file (the first string argument of each `.route(` call).
+pub fn route_path_literals(src: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = src;
+    while let Some(idx) = rest.find(".route(") {
+        rest = &rest[idx + ".route(".len()..];
+        // Skip whitespace to the first argument.
+        let trimmed = rest.trim_start();
+        if let Some(after_quote) = trimmed.strip_prefix('"') {
+            if let Some(end) = after_quote.find('"') {
+                out.push(after_quote[..end].to_string());
+            }
+        }
+    }
+    out
+}

--- a/conformance/tests/integration_surface_contract.rs
+++ b/conformance/tests/integration_surface_contract.rs
@@ -113,3 +113,48 @@ fn gateway_serves_sdk_registration_service() {
         "aa-gateway does not register any tonic service via `.add_service(...)`",
     );
 }
+
+// ── Test 3: the AAASM-4447 gap (ignored, documents the required surface) ─────
+
+/// The server that `aasm start --mode local` launches must expose the agent-
+/// registration surface the SDK's native path needs — **either** the gRPC
+/// `AgentLifecycleService` **or** a documented REST registration route.
+///
+/// This is the exact drift AAASM-4447 uncovered and this ticket exists to catch:
+/// local mode spawns `aa-api-server`, whose crate (`aa-api`) serves only REST
+/// `/api/v1/*` — no `AgentLifecycleServiceServer`, and no registration route —
+/// while the SDK dials gRPC `Register` on `:50051`. So this assertion fails
+/// today.
+///
+/// It is `#[ignore]`d (not deleted, not inverted) so it is a standing, runnable
+/// record of the required surface: once 4447's ADR lands — whether by adding a
+/// gRPC listener to local mode or a REST registration endpoint with a matching
+/// contract — remove the `#[ignore]` and this goes green unmodified.
+#[test]
+#[ignore = "blocked on AAASM-4447: local-mode server (aa-api-server) exposes no \
+            agent-registration surface (neither gRPC AgentLifecycleService nor a REST \
+            registration route) that the SDK's native gRPC Register path can reach"]
+fn local_mode_server_exposes_sdk_registration_surface() {
+    // Which binary does `aasm start --mode local` launch? Read it from the CLI
+    // source so this tracks real behavior instead of a hard-coded assumption.
+    let start_src = surface::read_repo_file("aa-cli/src/commands/start.rs");
+    let program = surface::local_mode_server_program(&start_src)
+        .expect("could not determine the binary `aasm start --mode local` launches from start.rs");
+
+    // Map that binary back to the crate whose surface must satisfy the contract.
+    let crate_dir = surface::crate_dir_for_binary(&program)
+        .unwrap_or_else(|| panic!("no workspace crate provides the `{program}` binary"));
+
+    let serves_grpc = surface::crate_src_contains(&crate_dir, SDK_REGISTRATION_SERVER_TYPE);
+    let has_rest_registration = surface::crate_has_registration_rest_route(&crate_dir);
+
+    assert!(
+        serves_grpc || has_rest_registration,
+        "`aasm start --mode local` launches `{program}` (crate {}), but that crate exposes no \
+         agent-registration surface the SDK can use: it neither serves gRPC \
+         `{SDK_REGISTRATION_SERVICE}` (via `{SDK_REGISTRATION_SERVER_TYPE}`) nor declares a REST \
+         registration route. The SDK's native path dials gRPC `{SDK_REGISTRATION_RPC}`, so an \
+         agent started against local mode can never register. See AAASM-4447.",
+        crate_dir.file_name().and_then(|n| n.to_str()).unwrap_or("?"),
+    );
+}

--- a/conformance/tests/integration_surface_contract.rs
+++ b/conformance/tests/integration_surface_contract.rs
@@ -1,0 +1,82 @@
+//! Integration-surface contract tests (AAASM-4454).
+//!
+//! # What broke, and why these tests exist
+//!
+//! AAASM-4447 found that `aasm start --mode local` brings up `aa-api-server`,
+//! which serves **only** the REST `/api/v1/*` surface — while the SDK's native
+//! agent-registration path (`aa-sdk-client`) speaks **gRPC**
+//! `AgentLifecycleService.Register` against `:50051`. The two can never connect,
+//! and nothing in the suite caught the drift because no test tied the surface
+//! the SDK *depends on* to the surface the CLI *actually starts*.
+//!
+//! These tests encode that contract. They read the repository's own source as
+//! the source of truth (see `conformance::surface`) rather than booting
+//! processes — fast, deterministic, and enough to catch this drift class.
+//!
+//! The architecture fix for 4447 itself is being handled separately as an ADR;
+//! this ticket is the *preventive* net. Where the contract cannot hold today,
+//! the test is `#[ignore]`d with a message linking 4447 — a red/ignored contract
+//! that documents the required surface, not a test rigged to pass on the gap.
+
+use conformance::surface;
+
+/// The gRPC service the SDK's native registration path binds to.
+///
+/// Source of truth: `aa-sdk-client/src/gateway.rs`, which connects an
+/// `AgentLifecycleServiceClient` and calls `.register(...)`.
+const SDK_REGISTRATION_SERVICE: &str = "AgentLifecycleService";
+
+/// The specific RPC the SDK invokes to register.
+const SDK_REGISTRATION_RPC: &str = "Register";
+
+/// The full lifecycle RPC set the runtime + SDK depend on being present on the
+/// service. Ordered as declared in `proto/agent.proto`.
+const REQUIRED_LIFECYCLE_RPCS: &[&str] = &[
+    "RequestChallenge",
+    "Register",
+    "Heartbeat",
+    "Deregister",
+    "ControlStream",
+];
+
+// ── Test 1: proto surface (passes today) ─────────────────────────────────────
+
+/// The agent-lifecycle gRPC service the SDK relies on must declare every RPC in
+/// the registration/heartbeat lifecycle.
+///
+/// This is the schema anchor for the whole contract: if someone renames or
+/// drops `Register` (or any lifecycle RPC) in `proto/agent.proto`, the SDK's
+/// native path silently loses its entrypoint. This test fails loudly instead.
+///
+/// It also references the generated tonic client/server types, so the proto
+/// text and the *compiled* code cannot drift apart: the module path below only
+/// exists if the service was code-generated under that name.
+#[test]
+fn sdk_registration_service_declares_full_lifecycle() {
+    // Compile-time tie between proto text and generated code: these paths only
+    // resolve if `AgentLifecycleService` was generated with client + server.
+    #[allow(unused_imports)]
+    use aa_proto::assembly::agent::v1::agent_lifecycle_service_client::AgentLifecycleServiceClient;
+    #[allow(unused_imports)]
+    use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
+
+    let proto = surface::read_repo_file("proto/agent.proto");
+    let rpcs = surface::proto_service_rpcs(&proto, SDK_REGISTRATION_SERVICE);
+
+    assert!(
+        !rpcs.is_empty(),
+        "service `{SDK_REGISTRATION_SERVICE}` not found in proto/agent.proto — the SDK's \
+         native registration surface has moved or been renamed",
+    );
+    for required in REQUIRED_LIFECYCLE_RPCS {
+        assert!(
+            rpcs.iter().any(|r| r == required),
+            "proto/agent.proto `{SDK_REGISTRATION_SERVICE}` is missing rpc `{required}`; \
+             declared rpcs = {rpcs:?}",
+        );
+    }
+    assert!(
+        rpcs.iter().any(|r| r == SDK_REGISTRATION_RPC),
+        "the SDK registration RPC `{SDK_REGISTRATION_RPC}` must exist on `{SDK_REGISTRATION_SERVICE}`",
+    );
+}

--- a/conformance/tests/integration_surface_contract.rs
+++ b/conformance/tests/integration_surface_contract.rs
@@ -29,6 +29,10 @@ const SDK_REGISTRATION_SERVICE: &str = "AgentLifecycleService";
 /// The specific RPC the SDK invokes to register.
 const SDK_REGISTRATION_RPC: &str = "Register";
 
+/// The tonic-generated server type a gateway registers via `.add_service(...)`
+/// to actually serve [`SDK_REGISTRATION_SERVICE`].
+const SDK_REGISTRATION_SERVER_TYPE: &str = "AgentLifecycleServiceServer";
+
 /// The full lifecycle RPC set the runtime + SDK depend on being present on the
 /// service. Ordered as declared in `proto/agent.proto`.
 const REQUIRED_LIFECYCLE_RPCS: &[&str] = &[
@@ -78,5 +82,34 @@ fn sdk_registration_service_declares_full_lifecycle() {
     assert!(
         rpcs.iter().any(|r| r == SDK_REGISTRATION_RPC),
         "the SDK registration RPC `{SDK_REGISTRATION_RPC}` must exist on `{SDK_REGISTRATION_SERVICE}`",
+    );
+}
+
+// ── Test 2: gateway serves that surface (passes today) ───────────────────────
+
+/// The `aa-gateway` binary — what `aasm start --mode remote` launches — must
+/// actually *serve* the gRPC registration service the SDK depends on.
+///
+/// Declaring the service in the proto (Test 1) is necessary but not sufficient:
+/// a server has to register it via `.add_service(...)`. This test asserts that
+/// remote mode wires up the surface, so a refactor that drops the registration
+/// service from the gateway's tonic router is caught. Passes today; provides
+/// ongoing regression value for the mode that *does* satisfy the contract.
+#[test]
+fn gateway_serves_sdk_registration_service() {
+    let gateway = surface::workspace_root().join("aa-gateway");
+    assert!(
+        gateway.join("src").is_dir(),
+        "expected aa-gateway crate at {}",
+        gateway.display()
+    );
+    assert!(
+        surface::crate_src_contains(&gateway, SDK_REGISTRATION_SERVER_TYPE),
+        "aa-gateway no longer references `{SDK_REGISTRATION_SERVER_TYPE}` — the gRPC \
+         registration surface the SDK depends on may have been removed from the gateway",
+    );
+    assert!(
+        surface::crate_src_contains(&gateway, ".add_service("),
+        "aa-gateway does not register any tonic service via `.add_service(...)`",
     );
 }


### PR DESCRIPTION
## Description

Adds a **protocol / functional-surface contract test suite** so SDK↔gateway
integration surfaces can no longer drift silently out of sync. This is the
**preventive follow-up to AAASM-4447**, which found that `aasm start --mode local`
brings up `aa-api-server` (REST-only `/api/v1/*` on `:7391`) while the SDK's
native agent-registration path (`aa-sdk-client`) speaks **gRPC**
`AgentLifecycleService.Register` on `:50051` — the two can never connect, and
nothing in the suite caught it.

The **architecture fix for 4447 itself is being handled separately as an ADR**;
this PR is additive test-harness work only and does **not** touch the gRPC/REST
architecture.

New tests live in the existing `conformance` crate. They read the repository's
own source as the authoritative description of each network surface (which binary
the CLI starts, which gRPC services a crate registers, which REST routes it
declares) rather than booting real processes — fast, deterministic, no `protoc`
round-trip or bound ports required. Helpers are in a new `conformance::surface`
module.

### What each test asserts

| Test | Asserts | Status |
|---|---|---|
| `sdk_registration_service_declares_full_lifecycle` | `proto/agent.proto`'s `AgentLifecycleService` (the service the SDK dials) declares the full `RequestChallenge`/`Register`/`Heartbeat`/`Deregister`/`ControlStream` lifecycle; also references the generated tonic client + server types so proto text and compiled code can't drift apart | **passes** |
| `gateway_serves_sdk_registration_service` | `aa-gateway` (remote-mode entrypoint) actually serves the service via `AgentLifecycleServiceServer` + `.add_service(...)` | **passes** |
| `local_mode_server_exposes_sdk_registration_surface` | The binary `aasm start --mode local` launches (parsed from `start.rs` → `aa-api-server`, crate `aa-api`) exposes the SDK registration surface — **either** gRPC `AgentLifecycleService` **or** a REST registration route | **`#[ignore]`d — genuinely red, documents the 4447 gap** |

The ignored test is a standing, runnable record of the *required* surface, not a
test inverted to pass on the broken state. When 4447's ADR lands (a gRPC listener
on local mode, or a REST registration endpoint with a matching contract), remove
the `#[ignore]` and it goes green unmodified.

## Type of Change

- [x] ✨ New feature (test harness + contract tests)
- [x] 🔧 Configuration / CI change (adds a test module to `conformance`)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4454](https://lightning-dust-mite.atlassian.net/browse/AAASM-4454)
- Preventive follow-up to [AAASM-4447](https://lightning-dust-mite.atlassian.net/browse/AAASM-4447) (architecture fix handled separately via ADR)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`cargo nextest run -p conformance` → **48 passed, 1 skipped** (the ignored 4447
contract). Running the ignored test explicitly
(`--run-ignored all -E 'test(local_mode_server_exposes)'`) **fails** with a
message naming the missing surface, confirming it is a real red contract.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module + item docs explain the WHY)
- [ ] All CI checks passing (org CI is billing-blocked; validated locally)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rk7iwwAuGv6HbwK8hY8Fbr


[AAASM-4454]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ