### PR TITLE
[AAASM-4447] ✨ (aa-api): Serve gRPC agent registration in local mode over a shared durable registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "aa-proto",
  "aa-runtime",
  "aa-sandbox",
+ "aa-sdk-client",
  "aa-security",
  "argon2",
  "async-trait",

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -49,8 +49,11 @@ futures = { workspace = true }
 hex = { workspace = true }
 moka = { workspace = true, features = ["future"] }
 rust_decimal = { workspace = true, features = ["serde-str"] }
-tokio-stream = { workspace = true }
+tokio-stream = { workspace = true, features = ["net"] }
 tokio-util = { workspace = true }
+# AAASM-4447: serve the gRPC AgentLifecycleService on loopback :50051 in local
+# mode so SDK agent registration reaches the same process the dashboard reads.
+tonic = { workspace = true }
 ulid = "1"
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
@@ -67,7 +70,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
 tokio-tungstenite = { workspace = true }
-tonic = { workspace = true }
+aa-sdk-client = { path = "../aa-sdk-client" }
 tower = { workspace = true }
 
 [lints]

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -22,7 +22,10 @@ use crate::state::AppState;
 /// off-host. This matches the SDK's `DEFAULT_GATEWAY_ENDPOINT`
 /// (`http://127.0.0.1:50051`) so `RuntimeClient.register` reaches the same
 /// process that serves the REST/dashboard surface, with zero SDK change.
-const LOCAL_GRPC_ADDR: &str = "127.0.0.1:50051";
+///
+/// `pub` so the security test can assert the shipped bind target is loopback
+/// (never `0.0.0.0`) without reaching into private internals.
+pub const LOCAL_GRPC_ADDR: &str = "127.0.0.1:50051";
 
 /// Max accepted gRPC decode size (4 MiB). Parity with `aa-gateway`'s legacy-grpc
 /// services (`aa-gateway/src/server.rs`): the registration endpoint is

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -1,13 +1,34 @@
 //! Server builder wiring router, middleware, state, and graceful shutdown.
 
+use std::sync::Arc;
+
 use axum::routing::get;
 use axum::Router;
 use tokio::net::TcpListener;
+use tonic::service::interceptor::InterceptedService;
+use tonic::transport::Server;
+
+use aa_gateway::registry::AgentRegistry;
+use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
 
 use crate::config::ApiConfig;
 use crate::middleware::apply_middleware;
 use crate::routes;
 use crate::state::AppState;
+
+/// Loopback gRPC endpoint for SDK agent registration in local mode (AAASM-4447).
+///
+/// Loopback-only by design: the agent-registration plane must never be exposed
+/// off-host. This matches the SDK's `DEFAULT_GATEWAY_ENDPOINT`
+/// (`http://127.0.0.1:50051`) so `RuntimeClient.register` reaches the same
+/// process that serves the REST/dashboard surface, with zero SDK change.
+const LOCAL_GRPC_ADDR: &str = "127.0.0.1:50051";
+
+/// Max accepted gRPC decode size (4 MiB). Parity with `aa-gateway`'s legacy-grpc
+/// services (`aa-gateway/src/server.rs`): the registration endpoint is
+/// attacker-influenceable, so the response/request buffer is bounded explicitly
+/// rather than relying on tonic's implicit default.
+const MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 
 /// Build the full Axum application with middleware and state.
 ///
@@ -84,7 +105,10 @@ pub async fn serve_local(
     addr: std::net::SocketAddr,
     auth: crate::state::LocalAuth,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let state = AppState::local_hardened(auth).await?;
+    // AAASM-4447: back the registry with the durable `~/.aasm/local.db` shared
+    // with `aa-gateway` (not the hermetic temp DB `local_hardened` defaults to),
+    // so agents survive restart and match the gateway's legacy-grpc store.
+    let state = AppState::local_hardened_at(auth, crate::state::resolve_local_registry_db_path()).await?;
     let config = ApiConfig {
         bind_addr: addr,
         auth: (*state.auth_config).clone(),
@@ -102,7 +126,86 @@ pub async fn serve_local(
              `pnpm --dir dashboard build` to enable the SPA"
         );
     }
-    run_server_with_spa(config, state, dist.as_deref()).await
+
+    // AAASM-4447: alongside the axum REST/dashboard server, serve the gRPC
+    // `AgentLifecycleService` on loopback :50051 over the SAME
+    // `Arc<AgentRegistry>` the REST surface reads. This closes the local-mode
+    // registration gap — the SDK's gRPC `RuntimeClient.register` dials
+    // `127.0.0.1:50051`, which local mode previously never served — so a
+    // registered agent is immediately visible in the dashboard. Both servers run
+    // concurrently and drain on the same shutdown signal; a port-in-use gRPC bind
+    // degrades gracefully to REST-only (see `serve_local_grpc`).
+    let registry = std::sync::Arc::clone(&state.agent_registry);
+    let grpc_addr: std::net::SocketAddr = LOCAL_GRPC_ADDR
+        .parse()
+        .expect("LOCAL_GRPC_ADDR is a valid loopback address");
+
+    let rest = run_server_with_spa(config, state, dist.as_deref());
+    let grpc = serve_local_grpc(grpc_addr, registry);
+    tokio::try_join!(rest, grpc)?;
+    Ok(())
+}
+
+/// Bind the local-mode gRPC `AgentLifecycleService` on `addr` and serve until
+/// shutdown, reusing `aa-gateway`'s service impl and possession-proof
+/// enrich interceptor (AAASM-4447 / AAASM-4460 / AAASM-4461).
+///
+/// `addr` must be a loopback address ([`LOCAL_GRPC_ADDR`]); the caller controls
+/// that. If the port is already in use (e.g. an `aa-gateway` process is already
+/// serving it) the bind failure is downgraded to a warning and this returns
+/// `Ok(())` so the REST surface still comes up — the process degrades to
+/// REST-only rather than failing to start. Any other bind error propagates.
+async fn serve_local_grpc(
+    addr: std::net::SocketAddr,
+    registry: Arc<AgentRegistry>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let listener = match TcpListener::bind(addr).await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            tracing::warn!(
+                target: "aa_api::serve_local",
+                %addr,
+                error = %e,
+                "gRPC agent-registration port already in use — serving REST only; \
+                 SDK registration to this endpoint is handled by the process that \
+                 owns the port"
+            );
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+    tracing::info!(%addr, "aa-api local gRPC AgentLifecycleService listening (loopback-only)");
+    serve_lifecycle_grpc(listener, registry, crate::shutdown::shutdown_signal()).await
+}
+
+/// Serve the gRPC `AgentLifecycleService` on an already-bound `listener` over
+/// `registry`, until `shutdown` resolves (AAASM-4460).
+///
+/// Extracted so tests can drive the exact production wiring on an ephemeral
+/// port. Reuses `aa-gateway`'s [`AgentLifecycleServiceImpl`] (Register +
+/// RequestChallenge + heartbeat/deregister — the RPCs `RuntimeClient` uses)
+/// rather than duplicating it, and applies the same `enrich_interceptor` the
+/// gateway wraps its lifecycle service with. The `Register` RPC self-validates
+/// the possession-proof challenge, so this adds no new unauthenticated surface.
+pub async fn serve_lifecycle_grpc(
+    listener: TcpListener,
+    registry: Arc<AgentRegistry>,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tenancy_mode = aa_gateway::service::TenancyMode::from_env();
+    let lifecycle =
+        aa_gateway::service::AgentLifecycleServiceImpl::new(Arc::clone(&registry)).with_tenancy_mode(tenancy_mode);
+    let enrich = aa_gateway::iam::enrich_interceptor(registry);
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+    Server::builder()
+        .add_service(InterceptedService::new(
+            AgentLifecycleServiceServer::new(lifecycle).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
+            enrich,
+        ))
+        .serve_with_incoming_shutdown(incoming, shutdown)
+        .await?;
+    Ok(())
 }
 
 /// Start the HTTP server and block until shutdown.

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -391,7 +391,38 @@ impl AppState {
     /// The alert-rule evaluator metric source is still wired by `run_server`; see
     /// [`crate::alerts::rules::evaluator::BudgetMetricSource`] for the real
     /// budget-spent source this entrypoint installs.
+    ///
+    /// AAASM-4447 — the agent registry is backed by a durable SQLite store and
+    /// rehydrated on boot (see [`local_hardened_at`](Self::local_hardened_at)).
+    /// This constructor uses a hermetic per-process temp database so tests stay
+    /// isolated; the shipped [`serve_local`](crate::serve_local) entrypoint
+    /// instead binds the durable `~/.aasm/local.db` shared with `aa-gateway` via
+    /// [`resolve_local_registry_db_path`].
     pub async fn local_hardened(auth: LocalAuth) -> Result<Self, LocalStateError> {
+        use std::sync::atomic::AtomicUsize;
+
+        // Hermetic default: a unique per-process temp registry DB so concurrent
+        // tests / processes do not collide or read a developer's real
+        // `~/.aasm/local.db`.
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let uniq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let pid = std::process::id();
+        let registry_db_path = std::env::temp_dir()
+            .join(format!("aa-api-local-registry-{pid}-{uniq}"))
+            .join("local.db");
+        Self::local_hardened_at(auth, registry_db_path).await
+    }
+
+    /// Same as [`local_hardened`](Self::local_hardened) but backs the agent
+    /// registry with the durable SQLite database at `registry_db_path`
+    /// (AAASM-4447 / AAASM-4459).
+    ///
+    /// Split out so the shipped entrypoint can bind the production
+    /// `~/.aasm/local.db` while tests supply a hermetic per-test path.
+    pub async fn local_hardened_at(
+        auth: LocalAuth,
+        registry_db_path: std::path::PathBuf,
+    ) -> Result<Self, LocalStateError> {
         use std::sync::atomic::AtomicUsize;
 
         let mut state = Self::local_in_memory()?;
@@ -508,7 +539,63 @@ impl AppState {
             }
         }
 
+        // --- Durable agent registry (AAASM-4447 / AAASM-4459). ---
+        // `local_in_memory` seeds a throwaway in-memory `AgentRegistry`. Replace
+        // it with one backed by a durable SQLite store and rehydrated on boot,
+        // mirroring the aa-gateway legacy-grpc path (aa-gateway/src/main.rs). The
+        // embedded gRPC `AgentLifecycleService` (AAASM-4460) and the
+        // REST/dashboard surface then share this SAME `Arc<AgentRegistry>`, so an
+        // SDK-registered agent is immediately visible to the dashboard and
+        // persists across restarts.
+        if let Some(parent) = registry_db_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(|source| LocalStateError::PolicyWrite {
+                    path: registry_db_path.clone(),
+                    source,
+                })?;
+            }
+        }
+        let registry_storage = aa_gateway::storage::open_sqlite_backend(&registry_db_path)
+            .await
+            .map_err(|e| LocalStateError::Storage(format!("{e}")))?;
+        let registry = Arc::new(AgentRegistry::new().with_storage(registry_storage));
+        let restored = registry
+            .rehydrate_from_storage()
+            .await
+            .map_err(|e| LocalStateError::Storage(format!("registry rehydrate failed: {e}")))?;
+        if restored > 0 {
+            tracing::info!(
+                restored,
+                path = %registry_db_path.display(),
+                "rehydrated agents from durable registry store"
+            );
+        }
+        state.agent_registry = registry;
+
         Ok(state)
+    }
+}
+
+/// Resolve the durable local-mode registry database path (AAASM-4447).
+///
+/// Matches the `aa-gateway` legacy-grpc path exactly: reads
+/// `GatewayConfig.local.storage_path` (default `~/.aasm/local.db`, with `~`
+/// expanded by `GatewayConfig::load`). This is why an agent registered over the
+/// embedded gRPC listener lands in the *same* durable store a gateway process
+/// would use. Falls back to the expanded default when the config cannot be
+/// loaded so an unconfigured host still resolves the shared location.
+pub fn resolve_local_registry_db_path() -> std::path::PathBuf {
+    match aa_core::config::GatewayConfig::load() {
+        Ok(cfg) => cfg.local.storage_path,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "gateway config load failed — using default local registry path"
+            );
+            let mut cfg = aa_core::config::GatewayConfig::default();
+            cfg.expand_paths();
+            cfg.local.storage_path
+        }
     }
 }
 

--- a/aa-api/tests/serve_local_grpc_loopback_only.rs
+++ b/aa-api/tests/serve_local_grpc_loopback_only.rs
@@ -1,0 +1,72 @@
+//! Security test: the local-mode gRPC agent-registration listener is
+//! loopback-only and never reachable off `127.0.0.1` (AAASM-4447 / AAASM-4463).
+//!
+//! The registration plane mints credential tokens, so it must not be exposed on
+//! a routable interface. Two guarantees are asserted:
+//!
+//! 1. The shipped bind target ([`aa_api::server::LOCAL_GRPC_ADDR`]) is a loopback
+//!    address on the SDK's expected port — so `serve_local` can never bind
+//!    `0.0.0.0`.
+//! 2. When actually served, the bound socket is loopback (not the unspecified
+//!    `0.0.0.0` wildcard), and a loopback client reaches it while the address
+//!    proves it is not listening on any external interface.
+
+use std::future::pending;
+use std::net::SocketAddr;
+
+/// The shipped registration endpoint must always be a loopback address on the
+/// port the SDK dials — the static half of the off-host-unreachability
+/// guarantee. A regression to `0.0.0.0:50051` (all interfaces) fails here.
+#[test]
+fn shipped_grpc_addr_is_loopback_only() {
+    let addr: SocketAddr = aa_api::server::LOCAL_GRPC_ADDR
+        .parse()
+        .expect("LOCAL_GRPC_ADDR parses as a socket address");
+    assert!(
+        addr.ip().is_loopback(),
+        "the gRPC registration listener must bind a loopback address, got {addr}"
+    );
+    assert!(
+        !addr.ip().is_unspecified(),
+        "the gRPC registration listener must never bind the 0.0.0.0 wildcard, got {addr}"
+    );
+    assert_eq!(addr.port(), 50051, "must match the SDK DEFAULT_GATEWAY_ENDPOINT port");
+}
+
+/// When the registration service is actually served, the socket it accepts on
+/// is loopback — reachable from `127.0.0.1` but not from any external interface.
+#[tokio::test]
+async fn served_grpc_listener_is_bound_to_loopback() {
+    let registry = std::sync::Arc::new(aa_gateway::registry::AgentRegistry::new());
+
+    // Bind on the loopback host with an ephemeral port (parallel-safe); the
+    // shipped binary uses the fixed loopback :50051 verified above.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback gRPC port");
+    let bound: SocketAddr = listener.local_addr().expect("local_addr");
+
+    // The accepting socket is loopback and not the 0.0.0.0 wildcard — i.e. it is
+    // not listening on any routable interface, so it cannot be reached off-host.
+    assert!(
+        bound.ip().is_loopback(),
+        "served gRPC socket must be loopback, got {bound}"
+    );
+    assert!(
+        !bound.ip().is_unspecified(),
+        "served gRPC socket must not be the 0.0.0.0 wildcard, got {bound}"
+    );
+
+    // A loopback client can still reach it (the endpoint is functional, just
+    // confined to localhost). Race the never-terminating server against a short
+    // connect probe.
+    let serve = aa_api::server::serve_lifecycle_grpc(listener, registry, pending::<()>());
+    let probe = async {
+        let stream = tokio::net::TcpStream::connect(bound).await;
+        assert!(stream.is_ok(), "loopback client must reach the registration listener");
+    };
+    tokio::select! {
+        served = serve => panic!("gRPC server exited before the probe finished: {served:?}"),
+        () = probe => {}
+    }
+}

--- a/aa-api/tests/serve_local_grpc_registration.rs
+++ b/aa-api/tests/serve_local_grpc_registration.rs
@@ -1,0 +1,118 @@
+//! Integration test for the local-mode gRPC agent-registration path (AAASM-4447).
+//!
+//! Reproduces the end-to-end scenario the fix targets: an SDK registers over the
+//! gRPC `AgentLifecycleService` (the exact `aa-sdk-client` wire path, including
+//! the possession-proof challenge handshake) and the agent must immediately be
+//! visible on the REST `/api/v1/agents` surface — because both are served over
+//! the SAME `Arc<AgentRegistry>`.
+//!
+//! This test goes RED if the fix is reverted: without the embedded gRPC listener
+//! there is nothing to connect to on the registration port, and without the
+//! shared durable registry a gRPC-registered agent would not appear in REST.
+
+use std::future::pending;
+
+use aa_sdk_client::config::AssemblyConfig;
+use aa_sdk_client::gateway::{build_challenge_request, build_register_request, GatewayRegistrationClient};
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+/// Build an `AssemblyConfig` pointing at the given gateway gRPC endpoint.
+fn sdk_config(agent_id: &str, endpoint: String) -> AssemblyConfig {
+    AssemblyConfig {
+        agent_id: agent_id.to_string(),
+        socket_path: None,
+        gateway_endpoint: Some(endpoint),
+        team_id: None,
+        parent_agent_id: None,
+        sdk_version: None,
+    }
+}
+
+#[tokio::test]
+async fn grpc_registered_agent_is_visible_via_rest() {
+    // A hermetic per-test durable registry DB — never the developer's real
+    // `~/.aasm/local.db`.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("local.db");
+
+    // Auth off so the bypass caller is admin and can list team-less agents
+    // (the SDK registers without a team).
+    let state = aa_api::AppState::local_hardened_at(aa_api::LocalAuth::Off, db_path)
+        .await
+        .expect("local_hardened_at must construct");
+    let registry = std::sync::Arc::clone(&state.agent_registry);
+
+    // Bind an ephemeral loopback port so the test is parallel-safe (the shipped
+    // binary uses the fixed :50051; the serving logic is identical).
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral gRPC port");
+    let grpc_addr = listener.local_addr().expect("local_addr");
+    let endpoint = format!("http://{grpc_addr}");
+
+    // The gRPC server future never completes on its own (pending shutdown); race
+    // it against the client work so it is dropped when the assertions finish.
+    let serve = aa_api::server::serve_lifecycle_grpc(listener, registry, pending::<()>());
+
+    let work = async {
+        // --- SDK registration over gRPC (the real aa-sdk-client wire path). ---
+        let config = sdk_config("grpc-reg-test-agent", endpoint.clone());
+        let mut client = GatewayRegistrationClient::connect(endpoint)
+            .await
+            .expect("connect to embedded gRPC AgentLifecycleService");
+        let challenge = client
+            .request_challenge(build_challenge_request(&config))
+            .await
+            .expect("request_challenge succeeds");
+        let request = build_register_request(
+            &config,
+            "grpc-reg-test-agent".to_string(),
+            "langgraph".to_string(),
+            &challenge.nonce,
+        );
+        let response = client.register(request).await.expect("register succeeds");
+        assert!(
+            !response.credential_token.is_empty(),
+            "registration must mint a credential token"
+        );
+
+        // --- The agent must now be visible on the REST surface (shared registry). ---
+        let app = aa_api::build_app(state);
+        let rest_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("REST request");
+        assert_eq!(rest_response.status(), StatusCode::OK);
+
+        let bytes = to_bytes(rest_response.into_body(), usize::MAX).await.expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+
+        assert!(
+            json["total"].as_u64().unwrap_or(0) >= 1,
+            "the gRPC-registered agent must be counted in /api/v1/agents; got {json}"
+        );
+        let names: Vec<&str> = json["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .filter_map(|it| it["name"].as_str())
+            .collect();
+        assert!(
+            names.contains(&"grpc-reg-test-agent"),
+            "the registered agent name must appear in the REST listing; got {names:?}"
+        );
+    };
+
+    tokio::select! {
+        served = serve => panic!("gRPC server exited before the client work finished: {served:?}"),
+        () = work => {}
+    }
+}


### PR DESCRIPTION
## Description

`aasm start --mode local` launches `aa-api-server`, which served only the axum
REST/dashboard surface. The SDK's native registration (`RuntimeClient.register`)
is gRPC-only and dials `127.0.0.1:50051` — a port local mode never served — so
SDK agents could never register in local mode. The local REST registry was also
a throwaway in-memory `AgentRegistry` over a temp DB, not the durable
`~/.aasm/local.db` the gateway's gRPC path writes.

This PR implements the approved **Option A1**: serve the gRPC
`AgentLifecycleService` on loopback `127.0.0.1:50051` **inside** `aa-api-server`,
alongside the existing REST/dashboard server, over the **same**
`Arc<AgentRegistry>` — now backed by the durable SQLite store. An SDK-registered
agent is therefore immediately visible in the dashboard. **Zero SDK change** (the
SDK already targets `:50051`).

Implements subtasks **AAASM-4459 – AAASM-4463**:

- **AAASM-4459** — `local_hardened` backs the agent registry with a durable
  SQLite store and rehydrates on boot (adds `local_hardened_at(auth, db_path)` +
  `resolve_local_registry_db_path()`, resolving the same `~/.aasm/local.db` the
  gateway uses). `local_hardened` keeps a hermetic per-process temp DB so
  existing tests stay isolated; `serve_local` uses the durable path.
- **AAASM-4460 / AAASM-4461** — `serve_local` embeds the gRPC
  `AgentLifecycleService` on loopback `:50051`, running concurrently with the
  axum server via `try_join!` and draining on the same shutdown signal. A
  port-in-use gRPC bind degrades gracefully to REST-only. **Reuses** aa-gateway's
  `AgentLifecycleServiceImpl` and its possession-proof `enrich_interceptor`
  rather than duplicating the service.
- **AAASM-4462** — integration test: register over gRPC (real aa-sdk-client wire
  path incl. the challenge handshake), assert the agent appears via REST
  `/api/v1/agents`. Goes RED if the fix is reverted.
- **AAASM-4463** — security test: the registration listener binds loopback only
  (never `0.0.0.0`), so the credential-minting plane is not reachable off
  `127.0.0.1`.

Follow-ups (not in this PR): **AAASM-4464** (e2e), **AAASM-4465** (docs),
**AAASM-4466** (verify).

### Security note

The gRPC listener binds `127.0.0.1:50051` (loopback-only, never `0.0.0.0`). It
reuses the existing possession-proof `Register` auth (server-issued challenge
nonce + Ed25519 possession proof) and the gateway's `enrich_interceptor` — **no
new unauthenticated surface** is added. AAASM-4463 asserts the loopback-only
posture.

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4447](https://lightning-dust-mite.atlassian.net/browse/AAASM-4447)
  (subtasks AAASM-4459–AAASM-4463)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed — `cargo nextest run -p aa-api`: **878 passed**
  (incl. the 2 new tests); the new gRPC-registration integration test and the
  loopback-only security tests pass. Org CI is billing-blocked, so validation was
  local.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy` — enforced by pre-commit)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed (docs are follow-up AAASM-4465)
- [ ] All CI checks passing (org CI billing-blocked; validated locally)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rk7iwwAuGv6HbwK8hY8Fbr


[AAASM-4447]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ