### PR TITLE
[AAASM-4454] ✅ (conformance): Activate the 4447 catcher + add contract matrix and CI wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       schema: ${{ steps.filter.outputs.schema }}
       openapi: ${{ steps.filter.outputs.openapi }}
       storage: ${{ steps.filter.outputs.storage }}
+      conformance: ${{ steps.filter.outputs.conformance }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -120,6 +121,22 @@ jobs:
             storage:
               - 'aa-gateway/**'
               - 'aa-storage*/**'
+              - '.github/workflows/ci.yml'
+            # AAASM-4454: explicit, self-documenting trigger for the
+            # integration-surface contract tests, which police that the gRPC
+            # registration surface the SDK dials stays present on the server(s)
+            # the CLI starts. These paths are a strict subset of `rust` above
+            # (so this never loses coverage); the conformance job ORs the two,
+            # so the contract still runs if `rust` is ever narrowed. Every path
+            # here is covered by an `on.*.paths` entry (`aa-*/**`,
+            # `conformance/**`), so this is a live trigger, not a dead one.
+            conformance:
+              - 'aa-cli/src/commands/start.rs'
+              - 'aa-gateway/src/local_mode.rs'
+              - 'aa-gateway/src/main.rs'
+              - 'aa-api/src/**'
+              - 'conformance/**'
+              - 'proto/**'
               - '.github/workflows/ci.yml'
             # AAASM-2580: gate the slow eBPF --release jobs (fat-LTO BPF build +
             # bpf-linker compile) so they only run when eBPF code — or this
@@ -972,7 +989,11 @@ jobs:
 
   conformance:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true'
+    # AAASM-4454: run on the broad `rust` set OR the narrow surface-contract
+    # `conformance` filter, so the registration-surface contract is guaranteed to
+    # re-run when start.rs / aa-gateway main+local_mode / aa-api / the conformance
+    # crate change, even if `rust` is later narrowed.
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.conformance == 'true'
     name: Rust conformance suite
     runs-on: ubuntu-latest
     steps:

--- a/conformance/docs/sdk-gateway-contract-matrix.md
+++ b/conformance/docs/sdk-gateway-contract-matrix.md
@@ -1,0 +1,109 @@
+# SDK ↔ gateway registration contract matrix (AAASM-4454)
+
+This document enumerates every **gateway deployment mode** × **SDK
+registration / runtime path** combination and states, for each cell, whether an
+agent can register and be governed — and which contract test (if any) proves it.
+
+It exists because AAASM-4447 uncovered a silent drift: `aasm start --mode local`
+served only REST while the SDK's native path dials **gRPC**
+`AgentLifecycleService.Register` on `:50051`, so an agent started against local
+mode could never register and nothing in the suite caught it. The
+`conformance` integration-surface contract tests
+(`conformance/tests/integration_surface_contract.rs`) now police this by reading
+the repository's own source as the source of truth. This matrix is the
+human-readable index of what those tests cover and — just as importantly — what
+is a genuine, documented limitation rather than a silent gap.
+
+## The two orthogonal axes
+
+Registration and enforcement are **independent**:
+
+- **Registration** (does the agent get into the registry?) depends only on
+  whether the gateway endpoint the SDK dials serves the gRPC
+  `AgentLifecycleService`. The SDK's native client
+  (`aa-sdk-client/src/gateway.rs`) always connects an
+  `AgentLifecycleServiceClient` to a gateway endpoint (default
+  `http://127.0.0.1:50051`) and calls `.register(...)`, regardless of which
+  interception layers are active.
+- **Enforcement layer** (how are actions intercepted?) is the SDK runtime path —
+  the `LayerSet` in `aa-runtime/src/layer.rs`: `SDK` (always available), `PROXY`
+  (`aa-proxy`, Linux/macOS), `EBPF` (Linux ≥ 5.8 + BTF + loader daemon). The SDK
+  "mode" (`sdk-only` / `auto` / `proxy` / `ebpf`) selects which of these layers
+  it activates. It does **not** change the registration path.
+
+So a cell's status is: *registration reachability* (set by the deployment mode)
+combined with *enforcement-layer availability* (set by the SDK mode + platform).
+
+## Gateway deployment modes (rows)
+
+| Mode | Launches | Serves the SDK gRPC `AgentLifecycleService`? | Source of truth |
+|---|---|---|---|
+| `aasm start --mode local` | `aa-api-server` (`aa-api`) | **Yes** — REST `/api/v1/*` **and** gRPC on loopback `:50051` (AAASM-4447) | `aa-api/src/server.rs` (`serve_local` → `serve_lifecycle_grpc`, `.add_service(AgentLifecycleServiceServer::new(...))`) |
+| `aasm start --mode remote` | `aa-gateway --listen` | **Yes** — gRPC | `aa-gateway` (`.add_service(...)`, `AgentLifecycleServiceServer`) |
+| `aasm gateway start` (legacy-grpc) | `aa-gateway` (default `Mode::LegacyGrpc`, `127.0.0.1:50051`) | **Yes** — gRPC | `aa-gateway/src/main.rs` (`Mode::LegacyGrpc`), `aa-cli/src/commands/gateway/start.rs` (`DEFAULT_LISTEN = "127.0.0.1:50051"`) |
+| direct `gateway_url` | *(nothing — SDK dials an existing external gateway, e.g. SaaS/enterprise)* | **Depends on that endpoint** — must serve the same gRPC service | External to this repo; the wire contract is the proto (Test 1) |
+
+## SDK registration / runtime paths (columns)
+
+| SDK mode | Active layers | Platform availability |
+|---|---|---|
+| `sdk-only` | `SDK` | All platforms (in-process hooks always available) |
+| `auto` | `SDK` + `PROXY`/`EBPF` where detected | All platforms; degrades gracefully — absent layers are dropped, `SDK` always remains |
+| `proxy` | `SDK` + `PROXY` | Linux / macOS (`aa-proxy` binary); **not supported on Windows** |
+| `ebpf` | `SDK` + `EBPF` | **Linux only** (≥ 5.8 + BTF + `aa-ebpf-loaderd`); not supported on macOS / Windows |
+
+## Combined matrix
+
+Legend: **pass** = registration reachable and the layer runs on a supported
+platform · **covered-by-test** = a `conformance` contract test proves the
+registration surface · **not-supported** = genuine, documented limitation (not a
+silent gap).
+
+| Deployment mode ↓ / SDK mode → | `sdk-only` | `auto` | `proxy` | `ebpf` |
+|---|---|---|---|---|
+| `aasm start --mode local` | pass · covered-by-test¹ | pass · covered-by-test¹ | pass² · covered-by-test¹ | pass (Linux only)³ · covered-by-test¹ |
+| `aasm start --mode remote` | pass · covered-by-test⁴ | pass · covered-by-test⁴ | pass² · covered-by-test⁴ | pass (Linux only)³ · covered-by-test⁴ |
+| `aasm gateway start` (legacy-grpc) | pass · covered-by-test⁴ | pass · covered-by-test⁴ | pass² · covered-by-test⁴ | pass (Linux only)³ · covered-by-test⁴ |
+| direct `gateway_url` | pass-if-endpoint-serves-gRPC⁵ | pass-if-endpoint-serves-gRPC⁵ | pass-if²⁵ | pass-if (Linux only)³⁵ |
+
+### Footnotes — what backs each cell
+
+1. **Local-mode registration surface** is proven by
+   `local_mode_server_exposes_sdk_registration_surface`
+   (`integration_surface_contract.rs`). It resolves the binary
+   `aasm start --mode local` launches (`aa-api-server`, via `start.rs`'s
+   `fn binary_name` single source of truth), maps it to the `aa-api` crate, and
+   asserts that crate serves `AgentLifecycleServiceServer` (or a REST
+   registration route). Passes since AAASM-4447 added the loopback gRPC listener.
+2. **`proxy` enforcement is Linux/macOS only** — on Windows the `aa-proxy`
+   sidecar is unavailable, so the `PROXY` layer is not-supported there.
+   Registration itself is unaffected (still gRPC to the gateway).
+3. **`ebpf` enforcement is Linux-only** (`aa-runtime/src/layer.rs` gates it on
+   kernel ≥ 5.8 + BTF + the `aa-ebpf-loaderd` socket). On macOS / Windows the
+   `EBPF` layer is **not-supported**; the agent still registers and is governed
+   by the `SDK` layer. In `auto` mode the eBPF layer is simply dropped where
+   unavailable — no failure.
+4. **Gateway-served registration surface** (remote mode and legacy-grpc both run
+   the `aa-gateway` binary) is proven by `gateway_serves_sdk_registration_service`
+   (`integration_surface_contract.rs`), which asserts `aa-gateway` references
+   `AgentLifecycleServiceServer` and registers it via `.add_service(...)`.
+5. **direct `gateway_url` is a documented limitation of the in-repo suite.** The
+   endpoint is external (a SaaS / enterprise / already-running gateway), so no
+   `conformance` test can introspect its live surface. What *is* pinned is the
+   **wire contract** it must satisfy: `sdk_registration_service_declares_full_lifecycle`
+   asserts `proto/agent.proto`'s `AgentLifecycleService` declares the full
+   `RequestChallenge / Register / Heartbeat / Deregister / ControlStream`
+   lifecycle and that the tonic client/server types generate under that name. An
+   external gateway that serves that generated service satisfies the contract;
+   verifying a *specific* URL at runtime is out of scope for a source-level
+   contract test and is left to deployment-time / e2e checks.
+
+## Summary of genuine limitations (honest, not silent)
+
+- **`ebpf` off Linux** and **`proxy` on Windows** are not-supported enforcement
+  layers — registration still works via the always-available `SDK` layer.
+- **direct `gateway_url`** cannot be surface-tested in-repo because the endpoint
+  lives outside this repository; only the proto wire contract is enforced here.
+- Every deployment mode this repo ships (`local`, `remote`, `gateway start`
+  legacy-grpc) now serves the SDK's gRPC registration surface — the
+  local-mode gap AAASM-4447 found is closed and guarded by a contract test.

--- a/conformance/src/surface.rs
+++ b/conformance/src/surface.rs
@@ -142,17 +142,26 @@ pub fn proto_service_rpcs(proto_src: &str, service: &str) -> Vec<String> {
 /// The program name that `aasm start --mode local` launches, parsed from the
 /// CLI's `start` command source.
 ///
-/// Reads the mapping actually encoded in `start.rs`
-/// (`ModeArg::Local => Command::new("…")`) rather than assuming it, so this
-/// contract test re-evaluates automatically if the local-mode entrypoint is
-/// ever changed. Returns `None` if the arm can't be located.
+/// Reads the mapping actually encoded in `start.rs` rather than assuming it, so
+/// this contract test re-evaluates automatically if the local-mode entrypoint is
+/// ever changed. The binary name is resolved through `start.rs`'s own single
+/// source of truth — the `fn binary_name` match — whose `ModeArg::Local` arm is
+/// a bare string literal (`ModeArg::Local => "aa-api-server"`). This tracks the
+/// real indirection: the spawn site calls `Command::new(binary_name(self.mode))`
+/// rather than embedding the literal, so parsing `binary_name` (not the
+/// `Command::new(...)` call) is what actually mirrors the code. Returns `None`
+/// if the arm can't be located.
 pub fn local_mode_server_program(start_src: &str) -> Option<String> {
-    let arm = start_src.find("ModeArg::Local")?;
-    let after = &start_src[arm..];
-    let cn = after.find("Command::new(")?;
-    let after_cn = &after[cn + "Command::new(".len()..];
-    let q1 = after_cn.find('"')?;
-    let after_q = &after_cn[q1 + 1..];
+    // Scope to `fn binary_name` so we pick the binary-name mapping, not one of
+    // the other `ModeArg::Local =>` arms (listen addr, banner text, etc.).
+    let func = start_src.find("fn binary_name")?;
+    let after_fn = &start_src[func..];
+    let arm = after_fn.find("ModeArg::Local")?;
+    let after_arm = &after_fn[arm..];
+    let fat = after_arm.find("=>")?;
+    let after_fat = &after_arm[fat + "=>".len()..];
+    let q1 = after_fat.find('"')?;
+    let after_q = &after_fat[q1 + 1..];
     let q2 = after_q.find('"')?;
     Some(after_q[..q2].to_string())
 }

--- a/conformance/tests/integration_surface_contract.rs
+++ b/conformance/tests/integration_surface_contract.rs
@@ -13,10 +13,12 @@
 //! the source of truth (see `conformance::surface`) rather than booting
 //! processes — fast, deterministic, and enough to catch this drift class.
 //!
-//! The architecture fix for 4447 itself is being handled separately as an ADR;
-//! this ticket is the *preventive* net. Where the contract cannot hold today,
-//! the test is `#[ignore]`d with a message linking 4447 — a red/ignored contract
-//! that documents the required surface, not a test rigged to pass on the gap.
+//! AAASM-4447 has since landed: `serve_local` in `aa-api` now serves the gRPC
+//! `AgentLifecycleService` on loopback `:50051` alongside its REST surface, so
+//! the local-mode server finally exposes the registration surface the SDK dials.
+//! The contract test that documented that gap
+//! ([`local_mode_server_exposes_sdk_registration_surface`]) is therefore active
+//! (no longer `#[ignore]`d) and passes because the surface genuinely exists now.
 
 use conformance::surface;
 
@@ -114,26 +116,23 @@ fn gateway_serves_sdk_registration_service() {
     );
 }
 
-// ── Test 3: the AAASM-4447 gap (ignored, documents the required surface) ─────
+// ── Test 3: local mode serves that surface (passes since AAASM-4447) ─────────
 
 /// The server that `aasm start --mode local` launches must expose the agent-
 /// registration surface the SDK's native path needs — **either** the gRPC
 /// `AgentLifecycleService` **or** a documented REST registration route.
 ///
-/// This is the exact drift AAASM-4447 uncovered and this ticket exists to catch:
-/// local mode spawns `aa-api-server`, whose crate (`aa-api`) serves only REST
-/// `/api/v1/*` — no `AgentLifecycleServiceServer`, and no registration route —
-/// while the SDK dials gRPC `Register` on `:50051`. So this assertion fails
-/// today.
-///
-/// It is `#[ignore]`d (not deleted, not inverted) so it is a standing, runnable
-/// record of the required surface: once 4447's ADR lands — whether by adding a
-/// gRPC listener to local mode or a REST registration endpoint with a matching
-/// contract — remove the `#[ignore]` and this goes green unmodified.
+/// This is the exact drift AAASM-4447 uncovered: local mode spawns
+/// `aa-api-server`, whose crate is `aa-api`. That crate used to serve only REST
+/// `/api/v1/*` — no `AgentLifecycleServiceServer` — while the SDK dials gRPC
+/// `Register` on `:50051`, so an agent could never register in local mode and
+/// this assertion failed. AAASM-4447 closed the gap: `serve_local` now also
+/// serves the gRPC `AgentLifecycleService` on loopback `:50051` over the same
+/// registry (see `aa-api/src/server.rs`), so `aa-api`'s source now references
+/// `AgentLifecycleServiceServer` and this test passes for the right reason — the
+/// surface genuinely exists, detected by the same source-introspection helper
+/// [`gateway_serves_sdk_registration_service`] uses for remote mode.
 #[test]
-#[ignore = "blocked on AAASM-4447: local-mode server (aa-api-server) exposes no \
-            agent-registration surface (neither gRPC AgentLifecycleService nor a REST \
-            registration route) that the SDK's native gRPC Register path can reach"]
 fn local_mode_server_exposes_sdk_registration_surface() {
     // Which binary does `aasm start --mode local` launch? Read it from the CLI
     // source so this tracks real behavior instead of a hard-coded assumption.


### PR DESCRIPTION
## Description

Completes the remaining AC of **AAASM-4454** (the integration-surface contract
harness), now that **AAASM-4447** (#1481) has merged. Three additive changes:

1. **Activate the AAASM-4447 catcher.** `serve_local` in `aa-api` now serves the
   gRPC `AgentLifecycleService` on loopback `:50051` alongside REST, so the
   local-mode server finally exposes the registration surface the SDK's native
   gRPC `Register` path dials. The previously-`#[ignore]`d contract test
   `local_mode_server_exposes_sdk_registration_surface` is un-ignored and now
   passes **for the right reason** — `aa-api`'s source genuinely references
   `AgentLifecycleServiceServer` via `.add_service(...)`.

   The ignored test's binary-resolution helper (`local_mode_server_program`) had
   never actually run and assumed `ModeArg::Local => Command::new("literal")`;
   the real code resolves the binary through `binary_name(self.mode)`. Fixed the
   helper to read `start.rs`'s actual single source of truth (the `fn binary_name`
   match arm → `"aa-api-server"`). This is a correctness fix to the introspection,
   **not** a weakening of the assertion — the gRPC-surface check is unchanged.

2. **Contract matrix doc** — `conformance/docs/sdk-gateway-contract-matrix.md`.
   Enumerates every (gateway deployment mode) × (SDK registration/runtime path)
   combination — `local` / `remote` / `gateway start` legacy-grpc / direct
   `gateway_url` × `sdk-only` / `auto` / `proxy` / `ebpf` — marking each cell
   pass / covered-by-test / not-supported, grounded in the actual contract tests
   and source (`aa-api` `serve_local`, `aa-gateway`, `aa-runtime/src/layer.rs`,
   `proto/agent.proto`). Genuine limitations are stated explicitly: `ebpf` is
   Linux-only, `proxy` is not supported on Windows, and direct `gateway_url` is
   external so only the proto wire contract is enforced in-repo — honest
   limitations, not silent gaps.

3. **CI wiring (minimal, additive).** Added a dedicated `conformance`
   paths-filter router area naming the exact subsystems the surface-contract
   tests police (`aa-cli/src/commands/start.rs`, `aa-gateway/src/main.rs` +
   `local_mode.rs`, `aa-api/src/**`, the conformance crate, `proto/**`) and OR'd
   it into the existing `conformance` job's gate.

   > **⚠️ Reviewer attention (CI router):** these paths are a strict *subset* of
   > the existing broad `rust` filter, so CI behavior is **unchanged today** —
   > the conformance job already ran on all of them. The new filter is
   > self-documenting intent + future-proofing (the contract keeps running if
   > `rust` is ever narrowed), and every path is covered by an existing
   > `on.*.paths` entry (`aa-*/**`, `conformance/**`), so it is a live trigger,
   > not a dead one — per the repo's CI-router convention.

## Type of Change

- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [x] ✅ Test activation / fix (un-ignore + introspection-helper correctness)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4454](https://lightning-dust-mite.atlassian.net/browse/AAASM-4454)
- Builds on merged #1479 (harness) and #1481 (AAASM-4447 local-mode gRPC)

## Testing

- [x] Unit/contract tests added / updated
- [x] Manual testing performed

`cargo nextest run -p conformance` → **49 passed, 0 skipped** (previously 48
passed + 1 ignored). The un-ignored
`local_mode_server_exposes_sdk_registration_surface` passes because `aa-api`
genuinely serves `AgentLifecycleServiceServer` in local mode now. `cargo fmt`
and `cargo clippy` clean on the touched crate.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (org GitHub Actions may be billing-blocked; validated locally)
- [x] Commits are small and follow the Gitmoji convention


[AAASM-4454]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ