### PR TITLE
[AAASM-4480] 🔧 (docker): Publish aa-gateway image to GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,6 +108,50 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  publish-gateway:
+    # AAASM-4480: tag-only publish path for the aa-gateway image. The
+    # `live-core-enforcement` docker-compose scenario (and the AAASM-4475 live
+    # CI lane) pull ghcr.io/ai-agent-assembly/aa-gateway, which nothing built
+    # before this job existed. Mirrors publish-runtime: `packages: write` lives
+    # here (never on the PR build path) so registry write scope is only granted
+    # on a v* tag. Per ADR-0009 the release tag (`github.ref_name`) is the
+    # immutable product-version coordinate; `latest` is the moving pointer.
+    name: Publish aa-gateway image (tag)
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4
+
+      - name: Set up QEMU (ARM emulation for multi-arch)
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push multi-arch image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: aa-gateway/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/ai-agent-assembly/aa-gateway:${{ github.ref_name }}
+            ghcr.io/ai-agent-assembly/aa-gateway:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   prep:
     name: Resolve language matrix (full 9-image matrix on PR and tag)
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ on:
     branches: [master]
     paths:
       - "aa-runtime/**"
+      - "aa-gateway/**"
       - "docker/**"
       - ".github/workflows/docker.yml"
       - "!**/*.md"
@@ -51,6 +52,20 @@ jobs:
           platforms: linux/amd64
           push: false
           tags: ghcr.io/ai-agent-assembly/aa-runtime:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build aa-gateway image (PR validation, no push)
+        # AAASM-4480: exercise aa-gateway/Dockerfile on every PR that touches it
+        # (mirrors the aa-runtime PR build). Still no `packages: write` — this
+        # PR path only builds; the tag-only `publish-gateway` job pushes.
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: aa-gateway/Dockerfile
+          platforms: linux/amd64
+          push: false
+          tags: ghcr.io/ai-agent-assembly/aa-gateway:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/aa-gateway/Dockerfile
+++ b/aa-gateway/Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.7
+
+# AAASM-4480: container image for the aa-gateway daemon (the policy/registry
+# "brain"). Published to ghcr.io/ai-agent-assembly/aa-gateway so the
+# `live-core-enforcement` docker-compose scenario (and the AAASM-4475 live CI
+# lane) can pull it. Structure mirrors aa-runtime/Dockerfile — cargo-chef +
+# BuildKit cache mounts reuse the dependency build layer across PRs as long as
+# Cargo.lock is unchanged, and persist the cargo registry / git / target dirs.
+
+FROM rust:alpine AS chef
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo install cargo-chef --locked
+WORKDIR /app
+
+# Planner: emit recipe.json describing the dependency graph. This layer's
+# output only changes when Cargo.toml / Cargo.lock change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json --bin aa-gateway
+
+# Builder: install system deps, pick the musl target for TARGETARCH,
+# cook (compile) dependencies from recipe.json, then compile app code.
+# The cook step is layer-cached on Cargo.lock; the final cargo build only
+# rebuilds workspace crates.
+FROM chef AS builder
+RUN apk add --no-cache \
+    musl-dev \
+    protobuf-dev \
+    openssl-dev \
+    pkgconfig
+
+ARG TARGETARCH
+RUN case "$TARGETARCH" in \
+      amd64) TARGET=x86_64-unknown-linux-musl ;; \
+      arm64) TARGET=aarch64-unknown-linux-musl ;; \
+      *) echo "Unsupported arch: $TARGETARCH" && exit 1 ;; \
+    esac && \
+    rustup target add "$TARGET" && \
+    echo "$TARGET" > /tmp/rust_target
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target,id=aa-gateway-target-${TARGETARCH} \
+    TARGET=$(cat /tmp/rust_target) && \
+    cargo chef cook --release --target "$TARGET" --recipe-path recipe.json --bin aa-gateway
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target,id=aa-gateway-target-${TARGETARCH} \
+    TARGET=$(cat /tmp/rust_target) && \
+    cargo build --release --target "$TARGET" -p aa-gateway && \
+    strip "target/$TARGET/release/aa-gateway" && \
+    cp "target/$TARGET/release/aa-gateway" /aa-gateway-bin
+
+# Final stage: minimal distroless image running as non-root.
+FROM gcr.io/distroless/static:nonroot AS runtime
+
+COPY --from=builder /aa-gateway-bin /aa-gateway
+
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="aa-gateway daemon — AI agent assembly policy/registry gateway" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+ENTRYPOINT ["/aa-gateway"]


### PR DESCRIPTION
## Description

The `examples/scenarios/live-core-enforcement` docker-compose path (and the AAASM-4475 live CI lane) pull `ghcr.io/ai-agent-assembly/aa-gateway`, but no release or CI workflow ever built or published that image — a `docker pull` fails because the package does not exist.

This PR makes the pipeline build and publish it:

- **New `aa-gateway/Dockerfile`** — distroless, non-root, multi-arch (amd64/arm64), built with cargo-chef + BuildKit cache mounts. Structurally mirrors `aa-runtime/Dockerfile`, just targeting `-p aa-gateway`.
- **`docker.yml`**: a PR-validation build of the gateway image (no push, mirrors the aa-runtime PR build) + a tag-only `publish-gateway` job mirroring `publish-runtime`, publishing `ghcr.io/ai-agent-assembly/aa-gateway:<ref_name>` (immutable per ADR-0009) and `:latest`. `packages: write` lives only on the tag path. `aa-gateway/**` added to the PR trigger paths.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4480
- Related: AAASM-4449 (sibling — missing `aa-api-server` binary), AAASM-4475 (surfaced this), AAASM-3765 / ADR-0009 (base-image versioning followed).

## Testing

- [x] Manual testing performed
- `actionlint .github/workflows/docker.yml` — clean.
- `docker build -f aa-gateway/Dockerfile --platform linux/amd64 .` — image builds (see PR checks / local build log).
- [ ] No unit tests required (container-publishing config; validated via actionlint + a real image build).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
