### PR TITLE
[AAASM-4566] ✨ (docs): Add tabs mechanism for mdBook (hand-rolled JS/CSS widget)

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -10,8 +10,8 @@ default-theme = "light"
 preferred-dark-theme = "navy"
 git-repository-url = "https://github.com/ai-agent-assembly/agent-assembly"
 edit-url-template = "https://github.com/ai-agent-assembly/agent-assembly/edit/master/docs/{path}"
-additional-css = ["theme/aaasm-brand.css"]
-additional-js = ["mermaid.min.js", "mermaid-init.js"]
+additional-css = ["theme/aaasm-brand.css", "theme/tabs.css"]
+additional-js = ["mermaid.min.js", "mermaid-init.js", "theme/tabs.js"]
 
 [preprocessor]
 

--- a/docs/theme/tabs.css
+++ b/docs/theme/tabs.css
@@ -1,0 +1,77 @@
+/* AI Agent Assembly — hand-rolled mdBook tabs widget (AAASM-4566).
+   Markup contract (authored in .md via raw HTML blocks):
+     <div class="aaasm-tabs">
+       <div class="aaasm-tab" data-title="Python">...markdown/html...</div>
+       <div class="aaasm-tab" data-title="Node.js">...markdown/html...</div>
+     </div>
+   tabs.js turns each `data-title` child into a clickable tab button and
+   shows exactly one panel at a time. No preprocessor/build-time dependency —
+   this is pure additional-css/additional-js per book.toml.
+   Tab-title font-size is intentionally smaller/tighter than body text
+   (readability goal shared with the sibling-repo Tabs work in AAASM-4548). */
+
+.aaasm-tabs {
+  margin: 1.25rem 0;
+  border: 1px solid var(--table-border-color);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.aaasm-tabs__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-bottom: 1px solid var(--table-border-color);
+  background: var(--sidebar-bg);
+}
+
+.aaasm-tabs__button {
+  appearance: none;
+  cursor: pointer;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 0.8rem;          /* deliberately tighter than .content body text */
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.4;
+  padding: 0.5rem 0.9rem;
+  white-space: nowrap;
+}
+
+.aaasm-tabs__button:hover {
+  color: var(--links);
+}
+
+.aaasm-tabs__button:focus-visible {
+  outline: 2px solid var(--links);
+  outline-offset: -2px;
+}
+
+.aaasm-tabs__button[aria-selected="true"] {
+  color: var(--links);
+  border-bottom-color: var(--links);
+}
+
+.aaasm-tabs__panel {
+  padding: 0.9rem 1.1rem;
+}
+
+.aaasm-tabs__panel[hidden] {
+  display: none;
+}
+
+/* .aaasm-tabs__panel wraps the original .aaasm-tab content node in place, so
+   nested content (code blocks, lists, etc.) keeps normal .content styling. */
+.aaasm-tabs__panel > :first-child {
+  margin-top: 0;
+}
+
+.aaasm-tabs__panel > :last-child {
+  margin-bottom: 0;
+}

--- a/docs/theme/tabs.js
+++ b/docs/theme/tabs.js
@@ -1,0 +1,85 @@
+// AI Agent Assembly — hand-rolled mdBook tabs widget (AAASM-4566).
+//
+// Authors write plain markup in .md files:
+//
+//   <div class="aaasm-tabs">
+//     <div class="aaasm-tab" data-title="Python">...</div>
+//     <div class="aaasm-tab" data-title="Node.js">...</div>
+//   </div>
+//
+// This script finds each `.aaasm-tabs` container, builds a tab-button list
+// from the `data-title` of its direct `.aaasm-tab` children, and toggles
+// which child is visible. No preprocessor/build step — loaded via
+// book.toml's `additional-js`, same mechanism as mermaid-init.js.
+(function () {
+  'use strict';
+
+  function initTabs(container, index) {
+    var panels = Array.prototype.filter.call(container.children, function (child) {
+      return child.classList.contains('aaasm-tab');
+    });
+    if (panels.length === 0) {
+      return;
+    }
+
+    var list = document.createElement('ul');
+    list.className = 'aaasm-tabs__list';
+    list.setAttribute('role', 'tablist');
+
+    panels.forEach(function (panel, panelIndex) {
+      var tabId = 'aaasm-tab-' + index + '-' + panelIndex;
+      var panelId = 'aaasm-panel-' + index + '-' + panelIndex;
+      var selected = panelIndex === 0;
+
+      panel.classList.remove('aaasm-tab');
+      panel.classList.add('aaasm-tabs__panel');
+      panel.id = panelId;
+      panel.setAttribute('role', 'tabpanel');
+      panel.setAttribute('aria-labelledby', tabId);
+      if (!selected) {
+        panel.hidden = true;
+      }
+
+      var item = document.createElement('li');
+      item.setAttribute('role', 'presentation');
+
+      var button = document.createElement('button');
+      button.type = 'button';
+      button.id = tabId;
+      button.className = 'aaasm-tabs__button';
+      button.setAttribute('role', 'tab');
+      button.setAttribute('aria-selected', String(selected));
+      button.setAttribute('aria-controls', panelId);
+      button.textContent = panel.getAttribute('data-title') || 'Tab ' + (panelIndex + 1);
+
+      button.addEventListener('click', function () {
+        panels.forEach(function (p) {
+          p.hidden = true;
+        });
+        list.querySelectorAll('.aaasm-tabs__button').forEach(function (b) {
+          b.setAttribute('aria-selected', 'false');
+        });
+        panel.hidden = false;
+        button.setAttribute('aria-selected', 'true');
+      });
+
+      item.appendChild(button);
+      list.appendChild(item);
+    });
+
+    container.insertBefore(list, panels[0]);
+  }
+
+  function init() {
+    var containers = document.querySelectorAll('.aaasm-tabs');
+    containers.forEach(function (container, index) {
+      initTabs(container, index);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Description

Adds a tabs mechanism to the `docs/` mdBook site. Today `book.toml`'s
`[preprocessor]` only configures `mdbook-mermaid` and the custom
`last-changed.py` footer — there is no tabs-capable preprocessor and
`docs/theme/` ships no tab-widget CSS/JS. This subtask adds the
mechanism only; converting an actual page to use it
(`quick-start/installation.md`) is the separate stacked subtask
AAASM-4567.

## Decision note — why a hand-rolled widget instead of a preprocessor

Before implementing, I checked whether mdBook has a natively-maintained
tabs preprocessor worth preferring over a hand-rolled widget.
`mdbook-tabs` (crates.io, `RustForWeb/mdbook-plugins`) exists, is small
(~292 lines Rust / 59 JS / 21 CSS per its crates.io listing), and looks
reasonably maintained (v1.0.4, last published 2026-06, 21 versions
since mid-2024).

I did not use it. Adding it means a new Rust build-time dependency
(`cargo install mdbook-tabs`, a new `[preprocessor.tabs]` entry, a new
line in the CI docs workflow's tool cache/install steps) for something
that mdBook's existing `additional-css`/`additional-js` mechanism
already covers with zero new dependencies — raw HTML passes through
mdBook's Markdown renderer untouched, so a small CSS+JS pair is
sufficient. This also matches this org's "don't add new dependencies
without asking first" policy, and keeps the docs toolchain exactly as
it is today (`mdbook` + `mdbook-mermaid`, no additions).

## What changed

- **`docs/theme/tabs.css`** (new) — styles for `.aaasm-tabs` /
  `.aaasm-tab` markup: a bordered widget, a button-based tab list, and
  active/inactive panel visibility. Tab-title font-size (`0.8rem`) is
  deliberately tighter than body text, matching the readability goal
  from the sibling-repo Tabs work in this same Epic (AAASM-4548). Uses
  the existing `aaasm-brand.css` CSS custom properties (`--fg`,
  `--links`, `--sidebar-bg`, `--table-border-color`) so it themes
  correctly across all four mdBook themes (light/rust/navy/coal).
- **`docs/theme/tabs.js`** (new) — vanilla JS, no dependencies. Finds
  each `.aaasm-tabs` container's direct `.aaasm-tab[data-title]`
  children, builds an ARIA `tablist`/`tab`/`tabpanel` structure from
  their `data-title` attributes, and toggles panel visibility on
  click. Author-facing markup contract:

  ```html
  <div class="aaasm-tabs">
    <div class="aaasm-tab" data-title="Python">...</div>
    <div class="aaasm-tab" data-title="Node.js">...</div>
  </div>
  ```

- **`docs/book.toml`** — registers `theme/tabs.css` /
  `theme/tabs.js` in `[output.html]`'s `additional-css` /
  `additional-js`, the same mechanism already used for
  `aaasm-brand.css` and the mermaid assets.

## Why

AAASM-4566: framework-specific quick-start content (Python / Node.js /
Go) needs a tabbed presentation in the docs site, and today there is no
mechanism to do that at all. This ticket builds the mechanism;
AAASM-4567 (stacked on this branch — `v0.1.0/AAASM-4566/feat/mdbook_tabs_mechanism`)
converts `quick-start/installation.md` to actually use it.

## How to verify

- `cd docs && mdbook build` — builds clean (the only console output is
  a pre-existing, unrelated `mdbook-mermaid` version-mismatch notice
  that's present on `master` today too).
- Locally, I temporarily added a 3-tab (`Python` / `Node.js` / `Go`)
  test block to `quick-start/requirements.md`, built the book, served
  it, and drove it with Playwright: the tablist renders with correct
  ARIA roles, only one panel is visible at a time, and clicking a tab
  switches `aria-selected` and the visible panel. That scratch content
  was removed before committing — it is not part of this diff.
- Inspect `book/theme/tabs-*.css` / `tabs-*.js` (mdBook's normal
  cache-busting hash suffix) and the `<link>`/`<script>` tags in any
  built page to confirm both assets are wired in.

## Related Issues

- Related Jira ticket: AAASM-4566
  (https://lightning-dust-mite.atlassian.net/browse/AAASM-4566)
- Stacked follow-up: AAASM-4567 will branch from
  `v0.1.0/AAASM-4566/feat/mdbook_tabs_mechanism` to convert
  `quick-start/installation.md` to use this mechanism.

## Testing

- [x] Manual testing performed (see "How to verify")
- [ ] Unit tests added / updated — n/a, no Rust/testable logic; this is
      static CSS/JS shipped via mdBook's `additional-css`/`additional-js`
- [ ] Integration tests added / updated
- [ ] No tests required (explain why) — static asset addition;
      correctness was verified via a manual mdbook build + Playwright
      drive of the widget (see above)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — n/a, no Rust changed
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — this PR *is* the doc-tooling change
- [x] All CI checks passing — validated locally via `mdbook build`; org CI is billing-blocked intermittently, see repo `.claude/CLAUDE.md`
- [x] Commits are small and follow the Gitmoji convention

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)