### PR TITLE
[AAASM-4572] 🐛 (aa-api): Emit serving banner only after key validation + bind

### DIFF
--- a/aa-api/src/bin/aa-api-server.rs
+++ b/aa-api/src/bin/aa-api-server.rs
@@ -45,6 +45,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     let (auth, generated) = LocalAuth::from_env();
+
+    // AAASM-4572: validate the API key's format BEFORE printing the "serving"
+    // banner. `LocalAuth::from_env` only checks `AASM_API_KEY` is non-empty; the
+    // authoritative format check (`aa_… + 32 hex`) lives inside `serve_local`'s
+    // `local_hardened_at`, which runs *after* the banner below. Without this
+    // early gate a malformed key made the process announce "serving full REST
+    // surface on …" and then exit 1 without ever binding the port — a
+    // false-positive readiness signal for any script/monitor scraping the log.
+    // `local_hardened_at` re-validates as the source of truth; this only gates
+    // banner ordering so announce and abort stay mutually exclusive.
+    if let LocalAuth::ApiKey { key } = &auth {
+        if let Err(e) = aa_api::auth::api_key::ApiKey::parse(key) {
+            return Err(format!("invalid AASM_API_KEY: {e}").into());
+        }
+    }
+
     match &auth {
         LocalAuth::Off => {
             eprintln!(

--- a/aa-api/tests/api_server_banner_ordering.rs
+++ b/aa-api/tests/api_server_banner_ordering.rs
@@ -1,0 +1,48 @@
+//! Regression test for AAASM-4572.
+//!
+//! `aa-api-server` must not print its "serving full /api/v1/* REST surface"
+//! banner when startup will abort on a malformed `AASM_API_KEY`. The banner
+//! implies the port is bound and the server is up; a script, systemd
+//! `ExecStartPost` probe, or container readiness scraper reading stdout/stderr
+//! top-to-bottom would treat it as a successful start. Announcing "serving" and
+//! then exiting non-zero must be mutually exclusive — never both.
+//!
+//! This drives the shipped binary end-to-end (not an internal helper) because
+//! the bug was purely one of ordering in `main()`: the format validation must
+//! run before the banner is emitted.
+
+use std::process::Command;
+
+/// A too-short (7-char hex) key that `ApiKey::parse` rejects for length.
+const MALFORMED_KEY: &str = "aa_test123";
+
+/// The exact substring the success banner prints — the thing that must NOT
+/// appear on the abort path.
+const SERVING_BANNER: &str = "serving full /api/v1/* REST surface";
+
+#[test]
+fn malformed_api_key_aborts_without_printing_serving_banner() {
+    let output = Command::new(env!("CARGO_BIN_EXE_aa-api-server"))
+        .env("AASM_API_KEY", MALFORMED_KEY)
+        // Never actually reached (parse fails first), but keep the run hermetic.
+        .env("AA_API_ADDR", "127.0.0.1:0")
+        .output()
+        .expect("spawn aa-api-server");
+
+    assert!(
+        !output.status.success(),
+        "expected a non-zero exit for a malformed AASM_API_KEY, got {:?}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains(SERVING_BANNER),
+        "the '{SERVING_BANNER}' banner must NOT be printed when startup aborts on \
+         a malformed key — the banner implies the server is up. stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("invalid AASM_API_KEY"),
+        "expected a clear 'invalid AASM_API_KEY' error on the abort path. stderr was:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Description

`aa-api-server`'s `main()` printed its `aa-api serving full /api/v1/* REST surface on http://…` banner **before** the `AASM_API_KEY` format was validated. `LocalAuth::from_env()` only checks the env var is non-empty; the authoritative `aa_… + 32-hex` check (`ApiKey::parse`) runs later, inside `serve_local` → `local_hardened_at`. A malformed key therefore made the process announce it was serving and then exit `1` without ever binding the port — a false-positive readiness signal for anything scraping stdout/stderr (deploy scripts, `systemd ExecStartPost`, container readiness probes, or a human reading logs top-to-bottom).

This PR adds an early `ApiKey::parse` gate in `main()` immediately after `LocalAuth::from_env()` and **before** the banner, so the announce and an abort-on-bad-key are mutually exclusive. `local_hardened_at` remains the source of truth for validation; the early check governs banner ordering only. Same class of defect as AAASM-4450 (a status message that didn't match actual program state).

Reproduction (before):
```
$ AASM_API_KEY="aa_test123" aa-api-server
aa-api: using admin API key from AASM_API_KEY
aa-api serving full /api/v1/* REST surface on http://127.0.0.1:7700 (API-key auth; …)
Error: PolicyLoad("invalid AASM_API_KEY: API key hex portion must be 32 characters (got 7)")
$ echo $?   # 1 — but the "serving" banner already printed
```
After: the malformed key prints `Error: invalid AASM_API_KEY: …` and exits non-zero, with **no** "serving" banner.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4572](https://lightning-dust-mite.atlassian.net/browse/AAASM-4572)

## Testing

- [x] Integration tests added / updated
- [x] Manual testing performed

New regression test `aa-api/tests/api_server_banner_ordering.rs` drives the shipped `aa-api-server` binary (via `CARGO_BIN_EXE_aa-api-server`) with a malformed `AASM_API_KEY` and asserts it exits non-zero, prints **no** `serving full /api/v1/* REST surface` banner, and surfaces a clear `invalid AASM_API_KEY` error.

Validated locally:
- `cargo build -p aa-api` — clean
- `cargo nextest run -p aa-api` — 880 passed, 0 skipped (incl. the new test)
- `cargo fmt -p aa-api --check` — clean
- `cargo clippy -p aa-api --all-targets -- -D warnings` — clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rk7iwwAuGv6HbwK8hY8Fbr

[AAASM-4572]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ