### PR TITLE
[AAASM-4567] ✨ (docs): Convert installation.md's 4 install methods to tabs

### DIFF
--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -14,7 +14,9 @@ then how to verify it works. Pick **one** method:
 > releases are GitHub **pre-releases**. The public API and wire protocol are not
 > yet stable — do not use in production.
 
-## Quick-install script
+<div class="aaasm-tabs">
+
+<div class="aaasm-tab" data-title="Quick-install script">
 
 The one-line installer downloads the matching pre-built tarball plus its
 `SHA256SUMS` file from the GitHub Release, verifies the checksum, and installs
@@ -80,7 +82,9 @@ AASM_REQUIRE_SIGNATURE=1 curl -sSf https://agent-assembly.com/install.sh | sh
 > default `AASM_REQUIRE_SIGNATURE=0` the installer warns and falls back to
 > checksum-only (the SHA-256 check is never skipped).
 
-## Homebrew (macOS / Linux)
+</div>
+
+<div class="aaasm-tab" data-title="Homebrew">
 
 Install the latest tagged `aasm` release from the
 [Homebrew tap](https://github.com/ai-agent-assembly/homebrew-tap):
@@ -89,7 +93,9 @@ Install the latest tagged `aasm` release from the
 brew install ai-agent-assembly/tap/aasm
 ```
 
-## Pre-built binaries (manual)
+</div>
+
+<div class="aaasm-tab" data-title="Pre-built binaries">
 
 Each [GitHub Release](https://github.com/ai-agent-assembly/agent-assembly/releases)
 publishes per-platform tarballs plus a `SHA256SUMS` file and a
@@ -122,7 +128,9 @@ tar -xzf "${ASSET}" aasm
 install -m755 aasm ~/.local/bin/aasm
 ```
 
-## Build from source
+</div>
+
+<div class="aaasm-tab" data-title="Build from source">
 
 Contributors and anyone who wants the bleeding edge can build from the Cargo
 workspace. This needs the [build prerequisites](requirements.md#building-from-source)
@@ -144,6 +152,10 @@ cargo install --path aa-cli      # installs `aasm` into ~/.cargo/bin
 > The eBPF-target crates (`aa-ebpf-probes`, `aa-ebpf-programs`) are intentionally
 > outside the workspace and are **not** built by `cargo build -p aa-cli`. See
 > [Requirements](requirements.md#requirements-per-interception-layer).
+
+</div>
+
+</div>
 
 ## Verify the install
 


### PR DESCRIPTION
## Description

Converts the 4 install-method sections in `docs/src/quick-start/installation.md` (Quick-install script, Homebrew, Pre-built binaries, Build from source) from sequential `##` headings into the `aaasm-tabs` widget added by AAASM-4566, so a reader only sees the one method they care about instead of scrolling past all four. All existing content per method (env-var pinning table, cosign/checksum verification steps, build commands, eBPF note) is preserved unchanged inside its tab panel. The comparison table at the top and the "Verify the install" / "Troubleshooting" sections after the tabs are left as-is.

**Stacked on #1489 (AAASM-4566)** — this branch is built on top of `v0.1.0/AAASM-4566/feat/mdbook_tabs_mechanism`, which is not yet merged. This PR's diff currently includes AAASM-4566's 3 commits (tabs.css, tabs.js, book.toml wiring) in addition to this one `installation.md` commit; it will shrink to just the installation.md change once #1489 merges and this branch is rebased onto master.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-4567
- Depends on: #1489 (AAASM-4566)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Ran `mdbook build docs` (matches CI's pinned mdbook 0.5.2 / mdbook-mermaid 0.17.0) — clean, no new warnings (the one pre-existing mdbook-mermaid version-compat warning is present identically on the unmodified AAASM-4566 branch, unrelated to this change). Also ran `mdbook serve` and drove the rendered page with Playwright: all 4 tab buttons render, the correct panel is shown by default, and clicking each tab (verified Homebrew and Build from source) correctly swaps the visible content including nested code blocks, tables, and blockquotes.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention