### PR TITLE
[AAASM-4573] 🐛 (docs): De-link installation overview table anchors

### DIFF
--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -5,10 +5,10 @@ then how to verify it works. Pick **one** method:
 
 | Method | Best for | Needs a published release? |
 |---|---|---|
-| [Quick-install script](#quick-install-script) | Fast, reproducible install on macOS / Linux | Yes |
-| [Homebrew tap](#homebrew-macos--linux) | macOS / Linux users who already use Homebrew | Yes |
-| [Pre-built binaries](#pre-built-binaries-manual) | Air-gapped or scripted installs, custom verification | Yes |
-| [`cargo install` / from source](#build-from-source) | Contributors and bleeding-edge builds | No |
+| **Quick-install script** | Fast, reproducible install on macOS / Linux | Yes |
+| **Homebrew tap** | macOS / Linux users who already use Homebrew | Yes |
+| **Pre-built binaries** | Air-gapped or scripted installs, custom verification | Yes |
+| **`cargo install` / from source** | Contributors and bleeding-edge builds | No |
 
 > **Alpha note.** Agent Assembly is in the `v0.0.1` pre-release series; published
 > releases are GitHub **pre-releases**. The public API and wire protocol are not


### PR DESCRIPTION
## Description

PR #1491 (AAASM-4567) converted the four install-method sections in
`docs/src/quick-start/installation.md` from `##` headings into a hand-rolled
`.tabbed` widget (`<div class="tab-panel" data-title="...">`). That removed the
heading anchors the overview comparison table at the top of the page linked to
(`#quick-install-script`, `#homebrew-macos--linux`, `#pre-built-binaries-manual`,
`#build-from-source`), leaving all 4 table links dangling.

This PR de-links only: the 4 anchor links become plain bold text. The tab widget
below is now how a reader picks a method; the table is just a comparison. Nothing
else in the file changes (tabs, intro, verify, and troubleshooting sections are
untouched).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4573](https://lightning-dust-mite.atlassian.net/browse/AAASM-4573)
- Related GitHub issues: regression from #1491

## Testing

- [x] Manual testing performed
- [x] No tests required (explain why)

`mdbook build docs` exits 0 (only the pre-existing mdbook-mermaid version-mismatch
warning; no new warnings about `installation.md`). Verified
`grep -nE '\]\(#' docs/src/quick-start/installation.md` returns zero matches.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention


[AAASM-4573]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ