### PR TITLE
[AAASM-4574] 🐛 (docs): Restore anchor IDs for installation.md's tab sections

### DIFF
--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -16,7 +16,7 @@ then how to verify it works. Pick **one** method:
 
 <div class="aaasm-tabs">
 
-<div class="aaasm-tab" data-title="Quick-install script">
+<div class="aaasm-tab" id="quick-install-script" data-title="Quick-install script">
 
 The one-line installer downloads the matching pre-built tarball plus its
 `SHA256SUMS` file from the GitHub Release, verifies the checksum, and installs
@@ -84,7 +84,7 @@ AASM_REQUIRE_SIGNATURE=1 curl -sSf https://agent-assembly.com/install.sh | sh
 
 </div>
 
-<div class="aaasm-tab" data-title="Homebrew">
+<div class="aaasm-tab" id="homebrew-macos--linux" data-title="Homebrew">
 
 Install the latest tagged `aasm` release from the
 [Homebrew tap](https://github.com/ai-agent-assembly/homebrew-tap):
@@ -95,7 +95,7 @@ brew install ai-agent-assembly/tap/aasm
 
 </div>
 
-<div class="aaasm-tab" data-title="Pre-built binaries">
+<div class="aaasm-tab" id="pre-built-binaries-manual" data-title="Pre-built binaries">
 
 Each [GitHub Release](https://github.com/ai-agent-assembly/agent-assembly/releases)
 publishes per-platform tarballs plus a `SHA256SUMS` file and a
@@ -130,7 +130,7 @@ install -m755 aasm ~/.local/bin/aasm
 
 </div>
 
-<div class="aaasm-tab" data-title="Build from source">
+<div class="aaasm-tab" id="build-from-source" data-title="Build from source">
 
 Contributors and anyone who wants the bleeding edge can build from the Cargo
 workspace. This needs the [build prerequisites](requirements.md#building-from-source)

--- a/docs/theme/tabs.js
+++ b/docs/theme/tabs.js
@@ -11,6 +11,12 @@
 // from the `data-title` of its direct `.aaasm-tab` children, and toggles
 // which child is visible. No preprocessor/build step — loaded via
 // book.toml's `additional-js`, same mechanism as mermaid-init.js.
+//
+// A tab div may carry an author-supplied `id` (AAASM-4574) — e.g. to keep a
+// pre-existing heading anchor working after the section was converted to a
+// tab. When present it's kept as the panel id instead of being overwritten,
+// and `activateHash()` below makes `#that-id` links actually switch to and
+// reveal the tab, rather than just scrolling to a hidden panel.
 (function () {
   'use strict';
 
@@ -28,7 +34,7 @@
 
     panels.forEach(function (panel, panelIndex) {
       var tabId = 'aaasm-tab-' + index + '-' + panelIndex;
-      var panelId = 'aaasm-panel-' + index + '-' + panelIndex;
+      var panelId = panel.id || ('aaasm-panel-' + index + '-' + panelIndex);
       var selected = panelIndex === 0;
 
       panel.classList.remove('aaasm-tab');
@@ -70,11 +76,38 @@
     container.insertBefore(list, panels[0]);
   }
 
+  // Switches to whichever tab's panel matches `location.hash`, so a link to
+  // an old heading anchor (or a same-page click on the overview table) lands
+  // on visible content instead of a hidden panel. No-op if the hash doesn't
+  // match a panel id.
+  function activateHash() {
+    var hash = window.location.hash;
+    if (!hash || hash.length < 2) {
+      return;
+    }
+    var target = document.getElementById(hash.slice(1));
+    if (!target || !target.classList.contains('aaasm-tabs__panel')) {
+      return;
+    }
+    var container = target.closest('.aaasm-tabs');
+    if (!container) {
+      return;
+    }
+    container.querySelectorAll('.aaasm-tabs__panel').forEach(function (panel) {
+      panel.hidden = panel !== target;
+    });
+    container.querySelectorAll('.aaasm-tabs__button').forEach(function (button) {
+      button.setAttribute('aria-selected', String(button.getAttribute('aria-controls') === target.id));
+    });
+    target.scrollIntoView();
+  }
+
   function init() {
     var containers = document.querySelectorAll('.aaasm-tabs');
     containers.forEach(function (container, index) {
       initTabs(container, index);
     });
+    activateHash();
   }
 
   if (document.readyState === 'loading') {
@@ -82,4 +115,6 @@
   } else {
     init();
   }
+
+  window.addEventListener('hashchange', activateHash);
 })();


### PR DESCRIPTION
## Description

PR #1489 (AAASM-4566) added a hand-rolled `.aaasm-tabs` widget, and PR #1491
(AAASM-4567) used it to convert the 4 install-method sections in
`docs/src/quick-start/installation.md` from `##`/`###` headings into
`<div class="aaasm-tab" data-title="...">` panels. That dropped the
auto-generated heading-ID anchors the page's own comparison table links to
(`#quick-install-script`, `#homebrew-macos--linux`,
`#pre-built-binaries-manual`, `#build-from-source`), leaving all 4 table
links dangling — and even if a panel had kept its old id, `tabs.js` had no
`location.hash` handling, so navigating to the anchor would only scroll to a
panel that stayed hidden behind whichever tab was selected.

This PR restores the anchors properly (rather than de-linking them):

1. **`docs/theme/tabs.js`** — keep an author-supplied `id` on a `.aaasm-tab`
   div instead of always overwriting it with a generated one, and add
   `activateHash()` (run on load and on `hashchange`) so a link to a panel's
   anchor switches to and reveals that tab, not just scrolls to a hidden one.
2. **`docs/src/quick-start/installation.md`** — give each `aaasm-tab` div the
   exact `id` its old heading anchor used, so the 4 table links resolve to
   real, matching, revealable panels again.

Note: mdBook's left-sidebar TOC still won't list the 4 install methods as
sub-entries, since they're no longer headings — that's an inherent
consequence of the AAASM-4567 tab conversion, out of scope for this
anchor-restoration fix.

**Heads-up for reviewers:** PR #1492 (AAASM-4573) is an open, alternative fix
for the same regression that instead de-links the table (turns the 4 links
into plain bold text). This PR and #1492 conflict — only one should merge.
This PR restores full anchor + tab-reveal functionality instead of removing
the links.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4574](https://lightning-dust-mite.atlassian.net/browse/AAASM-4574)
- Related GitHub issues: regression from #1491 (AAASM-4567); alternative to #1492 (AAASM-4573)

## Testing

- [x] Manual testing performed
- [x] No tests required (explain why): docs-only change, verified via `mdbook build`/`mdbook serve` + Playwright

`mdbook build docs` exits 0 (only the pre-existing mdbook-mermaid version-mismatch
warning; no new warnings). Verified with Playwright by navigating directly to each
of the 4 anchor URLs (`installation.html#quick-install-script`,
`#homebrew-macos--linux`, `#pre-built-binaries-manual`, `#build-from-source`) against
a local `mdbook serve` and confirming the matching tab's content is visible (not
hidden behind the default tab) in each case, plus confirmed programmatically that
clicking the table's link while already on the page (same-page `hashchange`) also
switches `panel.hidden` to `false` and the tab button's `aria-selected` to `true`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

[AAASM-4574]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ