### PR TITLE
[AAASM-4579] ✅ (aa-runtime): Harden flaky eBPF layer-integration test

### DIFF
--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1775,20 +1775,35 @@ mod layer_integration {
         // Give the perf reader tasks time to start their polling loops.
         // They are spawned via tokio::spawn inside start_event_reader and
         // need at least one poll cycle before they can receive events.
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
-        // Trigger file I/O events repeatedly so the kprobes capture at
-        // least one, even if the first trigger races with reader startup.
+        // Poll-until-event instead of a fixed collect window: a fixed 3s
+        // window races the kernel perf-capture path (kprobe -> perf-buffer ->
+        // reader -> broadcast), which is inherently best-effort and can lag on
+        // loaded CI runners, producing intermittent "got none" failures. Each
+        // iteration triggers one file I/O event AND drains whatever has been
+        // captured so far (so the broadcast(64) can't overflow), accumulating
+        // into `events`, and breaks as soon as an eBPF audit event is seen or a
+        // generous overall deadline elapses. This removes the timing race
+        // without weakening the assertion — a real eBPF event is still required.
+        const EBPF_CAPTURE_DEADLINE: Duration = Duration::from_secs(30);
         let trigger_path = "/tmp/aa-integration-test-trigger";
-        for _ in 0..5 {
+        let mut events: Vec<PipelineEvent> = Vec::new();
+        let deadline = tokio::time::Instant::now() + EBPF_CAPTURE_DEADLINE;
+        loop {
             std::fs::write(trigger_path, b"integration-test").expect("write trigger file");
             let _ = std::fs::read_to_string(trigger_path);
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            let mut batch = collect_events(&mut rx, Duration::from_millis(500)).await;
+            events.append(&mut batch);
+
+            let have_ebpf = events
+                .iter()
+                .any(|e| matches!(e, PipelineEvent::Audit(ref a) if a.source == EventSource::EBpf));
+            if have_ebpf || tokio::time::Instant::now() >= deadline {
+                break;
+            }
         }
         let _ = std::fs::remove_file(trigger_path);
-
-        // Collect events.
-        let events = collect_events(&mut rx, Duration::from_secs(3)).await;
 
         // Assert at least one eBPF-sourced audit event arrived.
         let ebpf_events: Vec<_> = events


### PR DESCRIPTION
## Description

Hardens the flaky `aa-runtime` integration test
`runtime::layer_integration::both_layers_emit_events_on_shared_channel`
(`aa-runtime/src/runtime.rs`) by replacing its fixed capture window with a
poll-until-event loop.

**Root cause.** The test asserted that at least one eBPF-sourced audit event
arrives within a fixed **1s warmup + 3s collect** window after triggering file
I/O. That window races the inherently best-effort kernel perf-capture path
(kprobe -> perf-buffer -> reader -> broadcast). On loaded nightly-Linux CI
runners the path exceeds the window, so the test intermittently panics at
`assert!(!ebpf_events.is_empty())` -- a timing assumption, not a real defect in
the capture path.

**Flake evidence (pre-existing, not a regression).** The identical tree passed
on PR #1501 head `0589745f` (`eBPF probes build (Linux nightly): success`) but
failed on the master merge `82e06e6d` (same content); recent unrelated
dependabot merges `34748ad9` and `ef554208` also failed the same job. The rc.5
bump touched zero runtime/eBPF code. The flake currently blocks the rc.5
release tag (the `CI Success` required aggregator is red on master).

**Fix.** Poll-until-event with a generous deadline:
- Bump the perf-reader warmup from 1s to 2s.
- Add `const EBPF_CAPTURE_DEADLINE: Duration = Duration::from_secs(30)` and loop
  until an eBPF-sourced audit event is seen or the deadline elapses. Each
  iteration triggers one file I/O event and then drains the broadcast channel
  (`collect_events(&mut rx, 500ms)`) into an accumulator -- this keeps
  triggering AND draining so the `broadcast(64)` can't lag, and waits as long
  as needed for slow capture.
- The degraded-skip (`if degraded.contains("ebpf/file_io") { return; }`), the
  `!ebpf_events.is_empty()` assertion (same helpful message), the
  sequence-number unique+monotonic check, the trigger-file cleanup, and the
  task cleanup block are all **unchanged** -- a real eBPF event is still
  required.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4579

## Testing

- [x] Unit tests added / updated (test-only change -- hardens an existing test)

Validation of the eBPF happy path **cannot run on this macOS host** -- the test
requires Linux + root (CAP_BPF + CAP_PERFMON) to load the kprobes; on macOS it
hits the degraded-skip early return. The authoritative validation is CI's
**`eBPF probes build (Linux nightly)`** job. Local gates run and passing:
`cargo build -p aa-runtime`, `cargo clippy -p aa-runtime --all-targets -- -D
warnings`, and `cargo fmt -p aa-runtime --check` (pre-commit re-ran
fmt/clippy/deny and pre-push re-ran `cargo doc`, all green).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (added a WHY comment on the loop)
- [ ] All CI checks passing (pending CI; local gates green)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rk7iwwAuGv6HbwK8hY8Fbr
