### PR TITLE
[AAASM-4629] 🐛 docs(core): Fix dead introduction/architecture README.html links

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -4,7 +4,7 @@
 
 This book is the contributor and operator reference for the core. If you build *with* a language SDK instead, read the per-SDK guides below.
 
-New here? Start with the **[Introduction](introduction/README.md)** — it explains what Agent Assembly is, the problem it solves, the core concepts, and the three-layer interception model. Then move on to the [Quick Start](quick-start/requirements.md).
+New here? Start with the **[Introduction](introduction/index.md)** — it explains what Agent Assembly is, the problem it solves, the core concepts, and the three-layer interception model. Then move on to the [Quick Start](quick-start/requirements.md).
 
 > **Other docs:** [Docs Hub](https://docs.agent-assembly.com/stable/) · [Python SDK](https://docs.agent-assembly.com/python-sdk/stable/) · [Node SDK](https://docs.agent-assembly.com/node-sdk/stable/) · [Go SDK](https://docs.agent-assembly.com/go-sdk/stable/)
 
@@ -18,18 +18,18 @@ cd agent-assembly
 cargo run -p aa-gateway -- --policy policy-examples/low-risk.yaml
 ```
 
-From there, attach an SDK shim, the `aa-proxy` sidecar, or the eBPF layer to start intercepting agent actions. The [Architecture](architecture/README.md) chapter explains how those three layers fit together.
+From there, attach an SDK shim, the `aa-proxy` sidecar, or the eBPF layer to start intercepting agent actions. The [Architecture](architecture/index.md) chapter explains how those three layers fit together.
 
 ## Where to go next
 
 | You want to… | Read |
 |---|---|
-| Understand what this is and why | [Introduction](introduction/README.md) |
+| Understand what this is and why | [Introduction](introduction/index.md) |
 | Get a gateway running quickly | [Quick Start](quick-start/requirements.md) |
 | Look up an `aasm` command | [CLI Reference](cli/overview.md) |
 | Follow a task end-to-end | [Usage Guide](usage-guide/overview.md) |
 | Understand the threat model and defenses | [Security Model](security/overview.md) |
-| See how the crates fit together | [Architecture](architecture/README.md) |
+| See how the crates fit together | [Architecture](architecture/index.md) |
 | Check which SDK versions are compatible | [Compatibility matrix](compatibility.md) |
 | Read the wire-protocol contract | [Protocol changelog](protocol/CHANGELOG.md) |
 | See latency and build-time numbers | [Benchmarks — baseline](benchmarks/BASELINE.md) |

--- a/docs/src/introduction/README.md
+++ b/docs/src/introduction/README.md
@@ -22,4 +22,4 @@ Read the pages in order:
 When you are ready to run something, jump to the [Quick Start](../quick-start/requirements.md).
 For the security rationale behind the design, read the [Security
 Model](../security/overview.md); for the crate-level implementation, read
-[Architecture](../architecture/README.md).
+[Architecture](../architecture/index.md).

--- a/docs/src/introduction/concepts.md
+++ b/docs/src/introduction/concepts.md
@@ -9,7 +9,7 @@ An **agent** is the workload being governed: an LLM-driven program that decides,
 at runtime, which actions to take to accomplish a goal. From the runtime's point
 of view an agent is an identity that performs *actions* — calling a tool, making
 an LLM request, or reaching out over the network. Agents register with the
-[gateway](../architecture/README.md) and are organized under a **team** and an
+[gateway](../architecture/index.md) and are organized under a **team** and an
 **org**, which is the scope at which policy and budget are applied.
 
 Each governed action is described by an **action type** (for example, a tool call
@@ -30,7 +30,7 @@ broad organizational deny cannot be loosened by a narrower scope. Policy is
 evaluated **server-side, in the gateway** — never by the agent or a dashboard —
 so the decision cannot be tampered with by the workload it governs. The reference
 policies under `policy-examples/` are a good starting point. The detailed
-evaluation path is documented in [Architecture](../architecture/README.md).
+evaluation path is documented in [Architecture](../architecture/index.md).
 
 ## Budget
 

--- a/docs/src/introduction/overview.md
+++ b/docs/src/introduction/overview.md
@@ -66,7 +66,7 @@ Agent Assembly turns "trust the agent to behave" into "the runtime enforces what
 the agent may do." It provides:
 
 - **Policy enforcement at the action boundary.** Allow/deny decisions are made by
-  a central [gateway](../architecture/README.md) *before* an action executes,
+  a central [gateway](../architecture/index.md) *before* an action executes,
   driven by declarative policy rather than agent cooperation.
 - **Budget control.** Per-team spend is tracked and enforced; a request that
   would breach the budget is denied, so a runaway loop is stopped, not just

--- a/docs/src/introduction/three-layer-model.md
+++ b/docs/src/introduction/three-layer-model.md
@@ -3,9 +3,9 @@
 To govern an action, the runtime first has to *see* it. Agent Assembly intercepts
 agent actions at **three independent layers**, each catching what the layers
 above it might miss, and routes every observed action to one central
-[gateway](../architecture/README.md) for a decision. This page is a teaser; the
+[gateway](../architecture/index.md) for a decision. This page is a teaser; the
 [Security Model](../security/overview.md) covers *why* the layers are arranged this
-way and what each defends against, and [Architecture](../architecture/README.md)
+way and what each defends against, and [Architecture](../architecture/index.md)
 covers *how* each is implemented.
 
 ## The three layers
@@ -75,5 +75,5 @@ and appends the [audit](concepts.md#audit) record before answering allow or deny
 
 - [Security Model](../security/overview.md) — the threat model and *why* this layered
   defense closes the gaps, including what each layer is and is not trusted to do.
-- [Architecture](../architecture/README.md) — the crate-level *how*: the gateway,
+- [Architecture](../architecture/index.md) — the crate-level *how*: the gateway,
   the policy engine, the transports, and the full interception data flow.

--- a/docs/src/security/audit-assurance.md
+++ b/docs/src/security/audit-assurance.md
@@ -6,7 +6,7 @@ secrets**, **tamper-evident**, and supports **non-repudiation** — even when an
 upstream sender (an SDK, a proxy, an eBPF probe) emits something it should not.
 This page covers the write-boundary sanitizer, redaction, and the publish path.
 For where audit sits in the wider system, see
-[Architecture](../architecture/README.md).
+[Architecture](../architecture/index.md).
 
 ## The write-boundary sanitizer
 

--- a/docs/src/security/overview.md
+++ b/docs/src/security/overview.md
@@ -6,7 +6,7 @@ system protects, against whom, and how** — and, just as importantly, **where i
 refuses to place its trust**.
 
 This section is the *why*. For the *how* — concrete crates, types, and data
-paths — follow the cross-links into [Architecture](../architecture/README.md).
+paths — follow the cross-links into [Architecture](../architecture/index.md).
 
 ## What the Security Model protects
 

--- a/docs/src/security/protection-model.md
+++ b/docs/src/security/protection-model.md
@@ -6,7 +6,7 @@ on* and, where necessary, *blocked or scrubbed*. This page covers the
 enforcement machinery: policy evaluation, fail-closed behavior, network-egress
 control, credential scanning & redaction, and budgets as a control. Every claim
 below is grounded in the gateway, runtime, and security crates; for the broader
-component picture see [Architecture](../architecture/README.md).
+component picture see [Architecture](../architecture/index.md).
 
 ## Policy evaluation
 

--- a/docs/src/security/threat-model.md
+++ b/docs/src/security/threat-model.md
@@ -4,7 +4,7 @@ This page enumerates what the Security Model defends: the **assets** worth
 protecting, the **adversaries** who threaten them, and the concrete **threats**
 each control answers. It is specific to Agent Assembly — the system that governs
 AI agents at the [three interception layers](three-layer-defense.md) and a
-central [gateway](../architecture/README.md).
+central [gateway](../architecture/index.md).
 
 ## Assets
 

--- a/docs/src/security/three-layer-defense.md
+++ b/docs/src/security/three-layer-defense.md
@@ -3,11 +3,11 @@
 To govern an action, Agent Assembly must first *observe* it. It does so at
 **three independent interception layers**, each catching what the layers above
 it might miss, and routes every observed action to one central
-[gateway](../architecture/README.md) for the decision. This page explains why
+[gateway](../architecture/index.md) for the decision. This page explains why
 the layers are arranged the way they are and how they **compose** so an agent
 cannot quietly slip through. For the policy decision itself, see
 [Protection and enforcement](protection-model.md); for how implementation maps
-to crates, see [Architecture](../architecture/README.md).
+to crates, see [Architecture](../architecture/index.md).
 
 ## The latency-vs-authority trade-off
 


### PR DESCRIPTION
## Summary
- mdBook builds `README.md` source files into `index.html`, not `README.html` — several prose cross-links in the core docs still pointed at the pre-build markdown filename (`introduction/README.md`, `architecture/README.md`), producing dead `README.html` links on the built site.
- Fixed all 17 occurrences across 10 files. `SUMMARY.md`'s own chapter declarations correctly stay as `README.md` (that's mdBook's source-file syntax, not a built href) — only the prose links needed the `index.md` fix.

## Test plan
- [x] `mdbook build docs` succeeds clean, no warnings
- [x] Built output has zero remaining `README.html` references for introduction/architecture
- [x] Re-grepped `docs/src/` — zero remaining `introduction/README.md` / `architecture/README.md` prose-link matches

Closes AAASM-4629