### PR TITLE
[AAASM-4654] 📝 (aa-proxy): Fix stale McpDecision::Redact doc contract

### DIFF
--- a/aa-proxy/src/mcp_enforce.rs
+++ b/aa-proxy/src/mcp_enforce.rs
@@ -58,9 +58,19 @@ pub enum McpDecision {
     /// to the client and never dials upstream. `reason` is copied from the
     /// gateway response so the client sees the policy rule that fired.
     Deny { reason: String },
-    /// Forward the call, but rewrite matching fields in the upstream
-    /// response before returning it to the client. `instructions` carries
-    /// the field-path / replacement rules from the gateway.
+    /// Forward the call to upstream. Redaction of sensitive payloads is
+    /// enforced independently by the proxy's own DLP scanner — request
+    /// bodies via `intercept::intercept_request` and upstream responses via
+    /// `intercept::redact_response_body` — not by replaying these gateway
+    /// instructions field-by-field. The proxy data path therefore buckets
+    /// `Redact` together with [`Allow`](McpDecision::Allow) as a forward.
+    ///
+    /// `instructions` carries the gateway's field-path / replacement rules
+    /// verbatim so they survive the response and remain available to
+    /// consumers (audit, future instruction-driven rewriting). At this layer
+    /// they are advisory: the proxy does not separately apply them, because
+    /// its scanner already redacts both directions of the tunnel regardless
+    /// of what the gateway matched.
     Redact { instructions: RedactInstructions },
 }
 

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -426,6 +426,10 @@ impl ProxyServer {
         let args_bytes = serde_json::to_vec(&call.arguments).unwrap_or_default();
 
         match evaluate_mcp_call(gateway, &call, &target_url, "", "").await {
+            // `Redact` is bucketed with `Allow` as a forward: the proxy's own
+            // DLP scanner redacts both request and upstream response (see the
+            // `McpDecision::Redact` doc), so the gateway's `RedactInstructions`
+            // need no separate replay here.
             Ok(McpDecision::Allow) | Ok(McpDecision::Redact { .. }) => {
                 tracing::info!(
                     tool_name = %call.tool_name,


### PR DESCRIPTION
## Description

The doc comment on `McpDecision::Redact` (in `aa-proxy/src/mcp_enforce.rs`) claimed the proxy rewrites matching fields in the upstream response per the gateway-supplied `RedactInstructions`. That is not what the proxy does: at the bucketing site in `aa-proxy/src/proxy/mod.rs`, `Redact` is grouped with `Allow` and forwarded, and the `RedactInstructions` are never separately consumed. The actual redaction is performed independently by the proxy's own DLP scanner — request bodies via `intercept::intercept_request` and upstream responses via `intercept::redact_response_body`.

This corrects the variant doc to describe the real contract and adds a clarifying inline comment at the bucketing site. This is a doc-only change — no runtime behavior is altered, and there is no data-leak: the proxy's scanner already redacts both directions of the tunnel regardless of the gateway match.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-4654](https://lightning-dust-mite.atlassian.net/browse/AAASM-4654)
- Related GitHub issues: n/a

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

Doc-only change with no runtime behavior change. Verified locally with `cargo build -p aa-proxy`, `cargo doc -p aa-proxy --no-deps` (doc compiles, no broken intra-doc links), and `cargo fmt -p aa-proxy`; pre-commit clippy passed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMnPRm9T3fdrS4uNYXkzg6

[AAASM-4654]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ