### PR TITLE
[AAASM-4653] 🐛 (aa-api): Enforce tenant ownership on register_op

### DIFF
--- a/aa-api/src/routes/ops.rs
+++ b/aa-api/src/routes/ops.rs
@@ -481,7 +481,7 @@ pub async fn register_op(
     // AAASM-3865: registering an op is a mutation; its lifecycle siblings
     // (pause/resume/terminate) all require write scope, but the register path
     // was missed, letting any read-only key create ops.
-    RequireWrite(_caller): RequireWrite,
+    RequireWrite(caller): RequireWrite,
     Extension(state): Extension<AppState>,
     Json(req): Json<RegisterOpRequest>,
 ) -> Result<impl IntoResponse, ProblemDetail> {
@@ -490,6 +490,14 @@ pub async fn register_op(
         return Err(
             ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail("op_id must not be empty".to_string())
         );
+    }
+    // AAASM-4653: a brand-new op_id is created under the caller, but if one
+    // already exists it may belong to another tenant — enforce ownership so a
+    // write-scoped caller in one team cannot clobber another tenant's op record
+    // (its lifecycle siblings already gate on `authorize_op_access`). Fail-closed:
+    // an existing op with no resolvable team is admin-only, like the siblings.
+    if state.ops_registry.get(&op_id).is_some() {
+        authorize_op_access(&caller, &state, &op_id)?;
     }
     let record = state.ops_registry.register(op_id);
     tracing::info!(target: "aa_api::ops", op_id = %record.op_id, "op registered");

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -1056,6 +1056,70 @@ async fn register_op_write_token_is_allowed() {
     );
 }
 
+/// AAASM-4653 — register_op required write scope but did no tenant-ownership
+/// check, and `OpsRegistry::register` overwrote any existing record. A
+/// write-scoped caller in team "alpha" could therefore clobber and reset a
+/// "beta" op. A write caller may register a new op under its own team (a), but
+/// must not overwrite a foreign tenant's op (b) — and the beta op's state is
+/// left intact.
+#[tokio::test]
+async fn register_op_cross_tenant_clobber_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xD4, "beta")).unwrap();
+    // Seed a beta-owned op in the Pending state (via a policy-check ingest path).
+    state.ops_registry.ingest_with_agent(
+        "op-beta-register".to_string(),
+        ProtoAgentId {
+            org_id: String::new(),
+            team_id: "beta".to_string(),
+            agent_id: hex_id(0xD4),
+        },
+    );
+    let app = aa_api::build_app(state.clone());
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Write], "alpha");
+
+    // (a) a write caller may register a brand-new op of its own.
+    let created = app
+        .clone()
+        .oneshot(json_bearer(
+            "POST",
+            "/api/v1/ops",
+            &token,
+            r#"{"op_id":"op-alpha-new"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        created.status(),
+        StatusCode::CREATED,
+        "a write caller may register a new op under its own team"
+    );
+
+    // (b) it must not clobber the beta-owned op.
+    let denied = app
+        .oneshot(json_bearer(
+            "POST",
+            "/api/v1/ops",
+            &token,
+            r#"{"op_id":"op-beta-register"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        denied.status(),
+        StatusCode::FORBIDDEN,
+        "cross-tenant op register (clobber) is denied"
+    );
+
+    // The beta op's state must be untouched — not reset to Running.
+    assert_eq!(
+        state.ops_registry.get("op-beta-register").unwrap().state,
+        aa_gateway::ops::OpState::Pending,
+        "the denied register must not have reset the beta op"
+    );
+}
+
 /// The policy list read must reject an unauthenticated caller (it previously
 /// took no caller, so any request could dump the policy YAML).
 #[tokio::test]

--- a/aa-gateway/src/ops/mod.rs
+++ b/aa-gateway/src/ops/mod.rs
@@ -530,6 +530,26 @@ mod tests {
     }
 
     #[test]
+    fn register_is_idempotent_and_does_not_clobber_existing_op() {
+        // AAASM-4653: re-registering a known op_id must return the existing
+        // record unchanged rather than overwriting it and resetting the state
+        // to Running — a blind overwrite let a caller clobber another tenant's op.
+        let registry = OpsRegistry::new();
+        let first = registry.ingest("op-1".to_string());
+        registry.allow("op-1").unwrap();
+        registry.pause("op-1").unwrap();
+
+        let re_registered = registry.register("op-1".to_string());
+
+        assert_eq!(
+            re_registered.state,
+            OpState::Paused,
+            "register must not reset an existing op to Running"
+        );
+        assert_eq!(re_registered.registered_at, first.registered_at);
+    }
+
+    #[test]
     fn allow_transitions_pending_to_running() {
         let registry = OpsRegistry::new();
         registry.ingest("op-1".to_string());

--- a/aa-gateway/src/ops/mod.rs
+++ b/aa-gateway/src/ops/mod.rs
@@ -159,9 +159,17 @@ impl OpsRegistry {
 
     /// Register a new op in the `Running` state.
     ///
-    /// Overwrites any existing record with the same `op_id` (idempotent
-    /// re-registration resets state to `Running`).
+    /// Preserve-idempotent like [`ingest`](Self::ingest): re-registering an
+    /// already-known `op_id` returns the existing record unchanged rather than
+    /// overwriting it and resetting its state to `Running` (AAASM-4653). A
+    /// blind overwrite let a caller clobber another tenant's op record — the
+    /// authorization gate in `register_op` is the primary defense, this makes
+    /// the registry itself fail-closed against a reset even if an op is
+    /// re-registered.
     pub fn register(&self, op_id: String) -> OpRecord {
+        if let Some(existing) = self.ops.get(&op_id) {
+            return existing.clone();
+        }
         let now = chrono::Utc::now().to_rfc3339();
         let record = OpRecord {
             op_id: op_id.clone(),


### PR DESCRIPTION
## Description

`register_op` (`POST /api/v1/ops`) required write scope but discarded the caller and performed **no tenant-ownership check** — unlike its lifecycle siblings (`pause_op`/`resume_op`/`terminate_op`/`halt_agent_for_op`), which each call `authorize_op_access`. Combined with `OpsRegistry::register`, which **unconditionally overwrote** any existing record and reset its state to `Running` (unlike `ingest`, which preserves idempotently), a write-scoped caller in one team could clobber and reset another tenant's op record — a broken-access-control (cross-tenant) flaw.

This PR fixes it in two fail-closed layers:

1. **aa-api** — `register_op` now binds the caller and, when the `op_id` already exists, gates on `authorize_op_access(&caller, &state, &op_id)` before touching it (parity with the sibling handlers). A brand-new `op_id` is still created for any write-scoped caller; an existing op owned by another tenant is rejected `403`. An existing op with no resolvable team is admin-only, matching the siblings.
2. **aa-gateway** — `OpsRegistry::register` is now preserve-idempotent like `ingest`: re-registering a known `op_id` returns the existing record unchanged instead of overwriting it and resetting state. Defense-in-depth even if the authz gate is bypassed.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Re-registering an existing `op_id` now returns the existing record (preserving state) rather than resetting it to `Running`; the only production caller is this HTTP register path, and a reset was the vulnerable behavior.

## Related Issues

- Related Jira ticket: [AAASM-4653](https://lightning-dust-mite.atlassian.net/browse/AAASM-4653)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

- `aa-gateway`: `register_is_idempotent_and_does_not_clobber_existing_op` — re-registering a Paused op returns it unchanged (not reset to Running).
- `aa-api`: `register_op_cross_tenant_clobber_is_403` — a write caller registers a new op under its own team (201), but cannot overwrite a beta-owned op (403), and the beta op's state is left intact.
- Verified locally: `cargo build -p aa-api -p aa-gateway`, `cargo clippy -p aa-api -p aa-gateway --all-targets -- -D warnings` (via lefthook), `cargo fmt`, and the affected `-p aa-api -p aa-gateway` ops/register test set all green (59 tests). The only failures in the wider run were pre-existing NATS bridge tests that require Docker/testcontainers, unrelated to this change.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMnPRm9T3fdrS4uNYXkzg6

[AAASM-4653]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ