### PR TITLE
[AAASM-4635] 🐛 (docs): Repoint README architecture/cli/dashboard links after docs reorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The three interception layers, lowest-latency first:
 - **eBPF** (Linux kernel) — catches everything else, including bypass attempts.
 
 Each layer reports to the same gateway, so you get one unified view no matter
-which layers a deployment runs. See the [Architecture overview](docs/src/architecture.md)
+which layers a deployment runs. See the [Architecture overview](docs/src/architecture/README.md)
 for the full picture, or jump straight to the [Quickstart](#quickstart).
 
 ## Ecosystem
@@ -298,7 +298,7 @@ dev-verify passed (22s total)
 ### Next steps
 
 - [SDK repositories](#ecosystem) — Python, Node.js, and Go SDK guides
-- [Architecture Overview](docs/src/architecture.md) — three-layer interception model
+- [Architecture Overview](docs/src/architecture/README.md) — three-layer interception model
 - [Policy examples](policy-examples/) — reference governance policies
 - [Runnable examples](https://github.com/ai-agent-assembly/examples) — learn the runtime, CLI, and policy behavior by running small, framework-specific examples for Python, Node.js/TypeScript, Go, policy enforcement, approvals, audit, trace, and runtime workflows
 
@@ -377,11 +377,11 @@ mdbook serve docs --open
 | Chapter | Description |
 |---|---|
 | [Introduction](docs/src/README.md) | Book overview and audience |
-| [Architecture Overview](docs/src/architecture.md) | Crate dependency graph, three-layer interception, IPC, sidecar lifecycle, policy evaluation |
+| [Architecture Overview](docs/src/architecture/README.md) | Crate dependency graph, three-layer interception, IPC, sidecar lifecycle, policy evaluation |
 | [API Reference](docs/src/api-reference.md) | rustdoc generation flow and per-crate API surface map |
-| [Command-Line Interface](docs/src/cli.md) | `aasm` global flags, command groups, and examples |
+| [Command-Line Interface](docs/src/cli/overview.md) | `aasm` global flags, command groups, and examples |
 | [Policy YAML Reference](docs/src/policy-reference.md) | Complete per-section policy field reference, `requires_approval_if` expression syntax, and example policies |
-| [Dashboard](docs/src/dashboard.md) | Web console and terminal (TUI) governance dashboards |
+| [Dashboard](docs/src/cli/dashboard.md) | Web console and terminal (TUI) governance dashboards |
 | [Local Development](docs/src/development/local-development.md) | From-clone setup, everyday build/test loop, git hooks |
 | [Releases](docs/src/releases.md) | Release state, distribution channels, and process |
 | [Compatibility Matrix](docs/src/compatibility.md) | Which `aa-runtime` versions work with which SDK versions |


### PR DESCRIPTION
## Description

Three links in the root `README.md` pointed at flat doc pages that no longer
exist after the docs reorganization into subdirectories, so all three 404'd.
This PR repoints them to their real current paths (no content or wording
changes — only the link targets):

- `docs/src/architecture.md` → `docs/src/architecture/README.md` (3 occurrences)
- `docs/src/cli.md` → `docs/src/cli/overview.md`
- `docs/src/dashboard.md` → `docs/src/cli/dashboard.md`

The new targets match the current `docs/src/SUMMARY.md` navigation
(Architecture chapter index, CLI Overview, and `aasm dashboard` pages).

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-4635](https://lightning-dust-mite.atlassian.net/browse/AAASM-4635)
- Fix Version: rc.6
- Related GitHub issues: none

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (explain why)

Docs-only link fix — no code paths change. Verified each new target file
actually exists in the worktree (`docs/src/architecture/README.md`,
`docs/src/cli/overview.md`, `docs/src/cli/dashboard.md`) and confirmed the old
broken targets no longer appear anywhere in `README.md`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-4635]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ