### PR TITLE
[AAASM-4636] 📝 (readme): Align maturity string with current rc release

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,17 +191,17 @@ These two are built by `aa-ebpf/build.rs` (via `aya-build`) for the BPF target �
 
 ## Project Status
 
-🚧 **Alpha — `v0.0.1` pre-release series** _(status as of 2026-07-03)_. The
+🚧 **Release candidate — `v0.0.1-rc` series** _(status as of 2026-07-15)_. The
 public API and wire protocol are **not** stable; do not use in production.
 
 Releases are published as GitHub pre-releases — latest
-[`v0.0.1-rc.3`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-rc.3)
-(2026-07-03). The coordinated release tag also publishes the CLI, crates, SDK
+[`v0.0.1-rc.5`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-rc.5)
+(2026-07-15). The coordinated release tag also publishes the CLI, crates, SDK
 packages, and container image:
 
 | Channel | Status |
 |---|---|
-| GitHub Releases | ✅ Pre-releases published (`v0.0.1-alpha.1` … `alpha.9`, `v0.0.1-beta.1`, `beta.2`, `beta.4`, `v0.0.1-rc.1`, `rc.2`, `rc.3`) |
+| GitHub Releases | ✅ Pre-releases published (`v0.0.1-alpha.1` … `alpha.9`, `v0.0.1-beta.1`, `beta.2`, `beta.4`, `v0.0.1-rc.1` … `rc.5`) |
 | crates.io | ✅ Workspace crates published at the pre-release version |
 | Homebrew tap | ✅ `aasm` formula published for tagged releases |
 | PyPI / npm | ✅ SDK pre-releases published from the release tag |


### PR DESCRIPTION
## Description

The core README's Project Status maturity banner read `🚧 Alpha — v0.0.1 pre-release series (status as of 2026-07-03)`, while docs.agent-assembly.com and the shipped release line both say **release candidate** (current tag `v0.0.1-rc.5`). A newcomer comparing the two canonical public surfaces saw a contradictory version signal, and the "Alpha" word undersold the actual rc maturity.

This aligns the README with the current rc channel:
- Maturity banner → `🚧 Release candidate — v0.0.1-rc series (status as of 2026-07-15)`.
- Latest-release pointer `v0.0.1-rc.3 (2026-07-03)` → `v0.0.1-rc.5 (2026-07-15)`.
- GitHub Releases channel row extended `… v0.0.1-rc.1 … rc.5`.

Docs-only text change; no code touched.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-4636 — https://lightning-dust-mite.atlassian.net/browse/AAASM-4636
- **Fix Version: agent-assembly v0.0.1-rc.6**

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

Documentation-only text change; verified by reading the rendered Project Status section. Acceptance check per ticket: README and docs.agent-assembly.com now show the same maturity word and rc channel.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

> Note: the ticket also suggests wiring the maturity/version string into `release-docs-sync` so it cannot drift again — left as a follow-up to keep this PR a minimal text fix.
