### PR TITLE
[AAASM-4641] 📝 (contributing): Add protoc to build prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,11 @@ Thank you for your interest in contributing! This guide explains how to set up y
 ## Prerequisites
 
 - **Rust stable** (≥ 1.75) — install via [rustup](https://rustup.rs/)
+- **protoc** — Protocol Buffers compiler (`brew install protobuf` on macOS, `apt-get install protobuf-compiler` on Debian/Ubuntu); required by the `aa-proto` and `aa-gateway` build scripts, so the first `cargo build --workspace` fails without it
 - **cargo-nextest** — `cargo install cargo-nextest`
 - **cargo-deny** — `cargo install cargo-deny`
 - **Lefthook** — `brew install lefthook` (macOS) or see [install guide](https://github.com/evilmartians/lefthook/blob/master/docs/install.md); the hook configuration lives in [`lefthook.toml`](lefthook.toml)
+- **Rust nightly toolchain** (Linux, only for eBPF work) — the `aa-ebpf` crates compile for `bpfel-unknown-none` and require a recent kernel with BTF plus a nightly toolchain (see `aa-ebpf/README.md`); not needed for non-eBPF contributions
 
 ## Setup
 


### PR DESCRIPTION
## Description

CONTRIBUTING.md "Prerequisites" listed only Rust stable, cargo-nextest, cargo-deny, and Lefthook — but the very first `cargo build --workspace` in Setup invokes the `aa-proto` / `aa-gateway` build scripts (tonic-prost-build), which require the system `protoc`. Without it a first-time contributor hits a build-script failure before writing any code. The README already lists `protoc` (and the eBPF nightly toolchain) under Requirements, so the two canonical docs disagreed. This adds the `protoc` bullet (copied from README) and an eBPF nightly-toolchain note to the CONTRIBUTING Prerequisites.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4641 — https://lightning-dust-mite.atlassian.net/browse/AAASM-4641
- **Fix Version: agent-assembly v0.0.1-rc.6**

## Testing

- [x] No tests required (docs-only change; verified `protoc` bullet matches README Requirements wording)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated
- [x] Commits are small and follow the Gitmoji convention

---
First PR of a 4-PR stack (all edit `CONTRIBUTING.md`): **#this → 4645 → 4647 → 4646**. Merge in order.