### PR TITLE
[AAASM-4645] 📝 (contributing): Reconcile DCO sign-off wording with org policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ To add a new crate to the workspace:
 
 ## Developer Certificate of Origin (DCO)
 
-Every commit must be signed off under the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — this licenses your contribution to the project under the [Apache License 2.0](LICENSE).
+We ask that you sign off each commit under the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — this licenses your contribution to the project under the [Apache License 2.0](LICENSE). Sign-off is **currently advisory** (see the note below), consistent with the org-wide [contribution guide](https://github.com/ai-agent-assembly/.github/blob/main/CONTRIBUTING.md).
 
 Sign off by adding a `Signed-off-by` trailer to each commit message:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,11 @@ Thank you for your interest in contributing! This guide explains how to set up y
 ## Prerequisites
 
 - **Rust stable** (≥ 1.75) — install via [rustup](https://rustup.rs/)
+- **protoc** — Protocol Buffers compiler (`brew install protobuf` on macOS, `apt-get install protobuf-compiler` on Debian/Ubuntu); required by the `aa-proto` and `aa-gateway` build scripts, so the first `cargo build --workspace` fails without it
 - **cargo-nextest** — `cargo install cargo-nextest`
 - **cargo-deny** — `cargo install cargo-deny`
 - **Lefthook** — `brew install lefthook` (macOS) or see [install guide](https://github.com/evilmartians/lefthook/blob/master/docs/install.md); the hook configuration lives in [`lefthook.toml`](lefthook.toml)
+- **Rust nightly toolchain** (Linux, only for eBPF work) — the `aa-ebpf` crates compile for `bpfel-unknown-none` and require a recent kernel with BTF plus a nightly toolchain (see `aa-ebpf/README.md`); not needed for non-eBPF contributions
 
 ## Setup
 


### PR DESCRIPTION
## Description

The repo `CONTRIBUTING.md` DCO section opened with "Every commit **must** be signed off" (mandatory) but closed with "Sign-off is **currently advisory**" — internally contradictory, and the org-wide `.github/CONTRIBUTING.md` states sign-off is advisory until the DCO GitHub App is enabled (AAASM-13). This aligns the repo guide's opening sentence to the advisory org baseline so both files agree: sign-off is requested and advisory today, and will become blocking once the DCO app is enabled.

Aligned repo → org (advisory). If the intended canonical policy is actually "mandatory now", flip both files the other way instead.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4645 — https://lightning-dust-mite.atlassian.net/browse/AAASM-4645
- **Fix Version: agent-assembly v0.0.1-rc.6**

## Testing

- [x] No tests required (docs-only wording reconciliation)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated
- [x] Commits are small and follow the Gitmoji convention

---
**Stacked on #1511** (merge in order). Stack: #1511 → this → 4647 → 4646.