### PR TITLE
[AAASM-4647] 📝 (contributing): Unify branch-naming scheme to one canonical format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ To add a new crate to the workspace:
 
 ## Developer Certificate of Origin (DCO)
 
-Every commit must be signed off under the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — this licenses your contribution to the project under the [Apache License 2.0](LICENSE).
+We ask that you sign off each commit under the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — this licenses your contribution to the project under the [Apache License 2.0](LICENSE). Sign-off is **currently advisory** (see the note below), consistent with the org-wide [contribution guide](https://github.com/ai-agent-assembly/.github/blob/main/CONTRIBUTING.md).
 
 Sign off by adding a `Signed-off-by` trailer to each commit message:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,11 @@ Thank you for your interest in contributing! This guide explains how to set up y
 ## Prerequisites
 
 - **Rust stable** (≥ 1.75) — install via [rustup](https://rustup.rs/)
+- **protoc** — Protocol Buffers compiler (`brew install protobuf` on macOS, `apt-get install protobuf-compiler` on Debian/Ubuntu); required by the `aa-proto` and `aa-gateway` build scripts, so the first `cargo build --workspace` fails without it
 - **cargo-nextest** — `cargo install cargo-nextest`
 - **cargo-deny** — `cargo install cargo-deny`
 - **Lefthook** — `brew install lefthook` (macOS) or see [install guide](https://github.com/evilmartians/lefthook/blob/master/docs/install.md); the hook configuration lives in [`lefthook.toml`](lefthook.toml)
+- **Rust nightly toolchain** (Linux, only for eBPF work) — the `aa-ebpf` crates compile for `bpfel-unknown-none` and require a recent kernel with BTF plus a nightly toolchain (see `aa-ebpf/README.md`); not needed for non-eBPF contributions
 
 ## Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,11 +51,18 @@ on; the faster linker is opt-in.
 
 ## Branch Naming
 
+Use the four-part format (matching the org-wide [contribution guide](https://github.com/ai-agent-assembly/.github/blob/main/CONTRIBUTING.md)):
+
 ```
-<version>/<ticket-number>/<short-summary>
+<release-or-phase>/<ticket-number>/<type>/<short-summary>
 ```
 
-Example: `v0.0.1/AAASM-42/add_agent_registry`
+- `<release-or-phase>` — milestone or sprint identifier (e.g. `v0.0.1`, `phase1`).
+- `<ticket-number>` — the ticket reference (e.g. `AAASM-42`).
+- `<type>` — change category: `feat`, `fix`, `refactor`, `test`, `docs`, `config`, `deps`, `remove`, or `lint`.
+- `<short-summary>` — 2–4 words in `snake_case`.
+
+Example: `v0.0.1/AAASM-42/feat/add_agent_registry`
 
 ## Commit Style
 


### PR DESCRIPTION
## Description

The repo `CONTRIBUTING.md` documented a **3-part** branch format (`<version>/<ticket-number>/<short-summary>`) while the org-wide `.github/CONTRIBUTING.md` documents a **4-part** format with a required `<type>` segment (`<release-or-phase>/<ticket-number>/<type>/<short-summary>`) — both using the same example ticket, so contributors saw two contradictory "canonical" formats. This unifies the repo guide onto the **4-part** format (adds the `<type>` segment + a segment breakdown and matching example), so the repo now agrees with the org guide.

**Canonical choice:** 4-part (with `<type>`), matching the existing org `.github/CONTRIBUTING.md` and the project's own branch convention. **Alternative:** drop `<type>` from the org guide to standardize on 3-part instead — reviewer's call; only the repo file is edited here.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4647 — https://lightning-dust-mite.atlassian.net/browse/AAASM-4647
- **Fix Version: agent-assembly v0.0.1-rc.6**

## Testing

- [x] No tests required (docs-only reconciliation)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated
- [x] Commits are small and follow the Gitmoji convention

---
**Stacked on #1512** (merge in order). Stack: #1511 → #1512 → this → 4646.