### PR TITLE
[AAASM-4646] 📝 (contributing): Add no-ticket community contribution path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,9 @@ labels: ["🐛 bug"]
 assignees: ""
 ---
 
+> No Jira ticket required — the `AAASM` tracker is private. Just file this issue;
+> a maintainer will create and link an `AAASM` tracking ticket during triage.
+
 ## Description
 
 A clear, concise description of the bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,9 @@ labels: ["✨ enhancement"]
 assignees: ""
 ---
 
+> No Jira ticket required — the `AAASM` tracker is private. Just file this issue;
+> a maintainer will create and link an `AAASM` tracking ticket during triage.
+
 ## Motivation
 
 Why is this feature needed? What problem does it solve, or what value does it add?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Does this PR introduce any breaking changes to public APIs or behaviour?
 
 ## Related Issues
 
-- Related Jira ticket: AAASM-XX
+- Related Jira ticket: AAASM-XX _(optional — leave as `N/A` if you don't have Jira access; a maintainer will assign a tracking ticket)_
 - Related GitHub issues: #XX
 
 ## Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ To add a new crate to the workspace:
 
 ## Developer Certificate of Origin (DCO)
 
-Every commit must be signed off under the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — this licenses your contribution to the project under the [Apache License 2.0](LICENSE).
+We ask that you sign off each commit under the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — this licenses your contribution to the project under the [Apache License 2.0](LICENSE). Sign-off is **currently advisory** (see the note below), consistent with the org-wide [contribution guide](https://github.com/ai-agent-assembly/.github/blob/main/CONTRIBUTING.md).
 
 Sign off by adding a `Signed-off-by` trailer to each commit message:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,11 @@ Thank you for your interest in contributing! This guide explains how to set up y
 ## Prerequisites
 
 - **Rust stable** (≥ 1.75) — install via [rustup](https://rustup.rs/)
+- **protoc** — Protocol Buffers compiler (`brew install protobuf` on macOS, `apt-get install protobuf-compiler` on Debian/Ubuntu); required by the `aa-proto` and `aa-gateway` build scripts, so the first `cargo build --workspace` fails without it
 - **cargo-nextest** — `cargo install cargo-nextest`
 - **cargo-deny** — `cargo install cargo-deny`
 - **Lefthook** — `brew install lefthook` (macOS) or see [install guide](https://github.com/evilmartians/lefthook/blob/master/docs/install.md); the hook configuration lives in [`lefthook.toml`](lefthook.toml)
+- **Rust nightly toolchain** (Linux, only for eBPF work) — the `aa-ebpf` crates compile for `bpfel-unknown-none` and require a recent kernel with BTF plus a nightly toolchain (see `aa-ebpf/README.md`); not needed for non-eBPF contributions
 
 ## Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,14 @@ Use the four-part format (matching the org-wide [contribution guide](https://git
 
 Example: `v0.0.1/AAASM-42/feat/add_agent_registry`
 
+> **External contributors** — the `AAASM-NN` project tracker is private, so you
+> won't be able to mint a ticket. You don't need one: open a GitHub issue first
+> (or reference an existing one) and use your GitHub issue number in the
+> `<ticket-number>` slot (e.g. `v0.0.1/gh-123/feat/add_agent_registry`), or
+> `noticket` if there's no issue yet. A maintainer will create the tracking
+> `AAASM-NN` ticket and link it during review — a missing Jira reference will
+> never block your PR.
+
 ## Commit Style
 
 Use [Gitmoji](https://gitmoji.dev/) prefixed messages:
@@ -104,7 +112,10 @@ To add a new crate to the workspace:
 ## Pull Requests
 
 - Open a PR against `master`.
-- Title format: `[<ticket>] <emoji> (<scope>): <summary>`
+- Title format: `[<ticket>] <emoji> (<scope>): <summary>` — external contributors
+  without Jira access may use a GitHub issue reference (e.g. `[#123]`) or `[N/A]`
+  in place of the `AAASM-NN` ticket; the Jira field in the PR template is
+  optional for community PRs.
 - Fill in the PR template — all checklist items must be addressed.
 - CI must be green before review is requested.
 - At least **1 approval** from the Pioneer team is required to merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,11 +51,18 @@ on; the faster linker is opt-in.
 
 ## Branch Naming
 
+Use the four-part format (matching the org-wide [contribution guide](https://github.com/ai-agent-assembly/.github/blob/main/CONTRIBUTING.md)):
+
 ```
-<version>/<ticket-number>/<short-summary>
+<release-or-phase>/<ticket-number>/<type>/<short-summary>
 ```
 
-Example: `v0.0.1/AAASM-42/add_agent_registry`
+- `<release-or-phase>` — milestone or sprint identifier (e.g. `v0.0.1`, `phase1`).
+- `<ticket-number>` — the ticket reference (e.g. `AAASM-42`).
+- `<type>` — change category: `feat`, `fix`, `refactor`, `test`, `docs`, `config`, `deps`, `remove`, or `lint`.
+- `<short-summary>` — 2–4 words in `snake_case`.
+
+Example: `v0.0.1/AAASM-42/feat/add_agent_registry`
 
 ## Commit Style
 


### PR DESCRIPTION
## Description

The documented contribution workflow was gated on an `AAASM-NN` Jira reference that outside contributors cannot mint (the tracker is private): branch names, the PR title format, and the PR template's "Related Jira ticket" field all required it, with no escape hatch. This adds an explicit external-contributor path:

- **CONTRIBUTING.md** — a note under Branch Naming that external contributors may use a GitHub issue number (e.g. `gh-123`) or `noticket` in the `<ticket-number>` slot, and a note under Pull Requests that the `[<ticket>]` title may be a GitHub issue ref or `[N/A]`; a maintainer creates/links the tracking ticket.
- **PR template** — the Jira field is marked optional (`N/A` if no Jira access).
- **Issue templates** (bug / feature) — a short banner stating no Jira ticket is required.

Docs/process only — no enforcement is added or changed.

## Type of Change

- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change (issue/PR templates)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4646 — https://lightning-dust-mite.atlassian.net/browse/AAASM-4646
- **Fix Version: agent-assembly v0.0.1-rc.6**

## Testing

- [x] No tests required (docs/template change)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated
- [x] Commits are small and follow the Gitmoji convention

---
**Stacked on #1513** (merge in order). Final PR of the stack: #1511 → #1512 → #1513 → this.