### PR TITLE
[AAASM-4659] 🐛 (aa-cli): Send auth header on audit/logs requests

### DIFF
--- a/aa-cli/src/client.rs
+++ b/aa-cli/src/client.rs
@@ -112,3 +112,43 @@ pub async fn delete(ctx: &ResolvedContext, path: &str) -> Result<(), CliError> {
     req.send().await?.error_for_status()?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::AUTHORIZATION;
+
+    fn ctx(api_key: Option<&str>) -> ResolvedContext {
+        ResolvedContext {
+            name: None,
+            api_url: "http://127.0.0.1:7391".to_string(),
+            api_key: api_key.map(String::from),
+        }
+    }
+
+    /// Regression test for AAASM-4659: the audit/logs commands GET
+    /// `/api/v1/logs` through `blocking_get`, which must carry the operator
+    /// bearer token, or the default (auth-required) gateway answers 401.
+    #[test]
+    fn blocking_get_attaches_bearer_for_logs_endpoint() {
+        let req = blocking_get(
+            &ctx(Some("secret-token")),
+            "http://127.0.0.1:7391/api/v1/logs?per_page=50&page=1",
+        )
+        .build()
+        .unwrap();
+        let auth = req
+            .headers()
+            .get(AUTHORIZATION)
+            .expect("audit/logs request must carry an Authorization header");
+        assert_eq!(auth, "Bearer secret-token");
+    }
+
+    #[test]
+    fn blocking_get_omits_auth_when_no_api_key() {
+        let req = blocking_get(&ctx(None), "http://127.0.0.1:7391/api/v1/logs")
+            .build()
+            .unwrap();
+        assert!(req.headers().get(AUTHORIZATION).is_none());
+    }
+}

--- a/aa-cli/src/client.rs
+++ b/aa-cli/src/client.rs
@@ -11,6 +11,23 @@ pub fn build_client() -> reqwest::Client {
     reqwest::Client::new()
 }
 
+/// Build a blocking GET request to `url`, attaching the operator bearer token
+/// from the resolved context when one is present.
+///
+/// This is the blocking analog of the auth-header injection in [`get_json`]:
+/// the default gateway requires API-key auth, so every synchronous (`reqwest::blocking`)
+/// call site that hits the REST surface must send `Authorization: Bearer <key>`
+/// or the request comes back `401`. Routing those call sites through this helper
+/// keeps auth attachment in one place instead of each command re-deriving it
+/// (the audit/logs group regressed by skipping it — AAASM-4659).
+pub fn blocking_get(ctx: &ResolvedContext, url: &str) -> reqwest::blocking::RequestBuilder {
+    let mut req = reqwest::blocking::Client::new().get(url);
+    if let Some(ref key) = ctx.api_key {
+        req = req.bearer_auth(key);
+    }
+    req
+}
+
 /// Perform a GET request to the gateway and deserialize the JSON response.
 pub async fn get_json<T: DeserializeOwned>(ctx: &ResolvedContext, path: &str) -> Result<T, CliError> {
     let url = format!("{}{path}", ctx.api_url);

--- a/aa-cli/src/commands/audit/export.rs
+++ b/aa-cli/src/commands/audit/export.rs
@@ -189,7 +189,7 @@ fn write_to<W: Write>(
 pub fn run(args: ExportArgs, ctx: &ResolvedContext) -> ExitCode {
     let url = build_url(ctx, &args);
 
-    let response = match reqwest::blocking::get(&url) {
+    let response = match crate::client::blocking_get(ctx, &url).send() {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: failed to connect to {}: {e}", ctx.api_url);

--- a/aa-cli/src/commands/audit/list.rs
+++ b/aa-cli/src/commands/audit/list.rs
@@ -198,7 +198,7 @@ fn render_yaml(entries: &[AuditEntry]) {
 pub fn run(args: ListArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     let url = build_url(ctx, &args);
 
-    let response = match reqwest::blocking::get(&url) {
+    let response = match crate::client::blocking_get(ctx, &url).send() {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: failed to connect to {}: {e}", ctx.api_url);

--- a/aa-cli/src/commands/logs/fetch.rs
+++ b/aa-cli/src/commands/logs/fetch.rs
@@ -76,7 +76,7 @@ pub fn run(args: LogsArgs, ctx: &ResolvedContext) -> ExitCode {
     let since = args.since.as_deref().and_then(parse_since);
     let until = args.until.as_deref().and_then(parse_until);
 
-    let response = match reqwest::blocking::get(&url) {
+    let response = match crate::client::blocking_get(ctx, &url).send() {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: failed to connect to {}: {e}", ctx.api_url);


### PR DESCRIPTION
## Description

The whole `aasm audit` group (`audit list`, `audit export`) and the top-level `aasm logs` command built their blocking `GET /api/v1/logs` request via `reqwest::blocking::get()`, which sends **no** `Authorization` header — even when the operator key is supplied via `AASM_API_KEY` or `--api-key`. Against the default (auth-required) gateway every one of these returned `401 Unauthorized`, so the entire live audit-log observability + compliance-export surface was unusable outside-in. Sibling read commands (`policy list`, etc.) attach the Bearer header and worked with the same key.

Fix: add `client::blocking_get(ctx, url)` — the blocking analog of the existing async `get_json()` bearer-injection — and route the three `/api/v1/logs` call sites (`audit/list.rs`, `audit/export.rs`, `logs/fetch.rs`) through it. Offline file subcommands (`audit verify-chain`, `audit compliance-export`) and the WebSocket `logs --follow` path (different endpoint) are untouched.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4659](https://lightning-dust-mite.atlassian.net/browse/AAASM-4659)
- **Fix Version: agent-assembly v0.0.1-rc.6**

## Testing

- [x] Unit tests added / updated

Added a regression test in `client.rs`: `blocking_get_attaches_bearer_for_logs_endpoint` asserts the built request for `/api/v1/logs` carries `Authorization: Bearer <key>`, plus `blocking_get_omits_auth_when_no_api_key` for the no-key case. `cargo nextest run -p aa-cli client::tests` → 15 passed. `cargo build -p aa-cli` clean; pre-commit (fmt/clippy/deny) and pre-push (`cargo doc`) green.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention


[AAASM-4659]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ