### PR TITLE
[AAASM-4666] ✨ (aa-api): Add /health alias returning health JSON

### DIFF
--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -60,6 +60,11 @@ pub fn build_app_with_spa(state: AppState, spa_dist: Option<&std::path::Path>) -
         // is the SPA `ServeDir`.
         Some(dist) => Router::new()
             .route("/healthz", get(routes::health::health))
+            // `/health` alias (AAASM-4666): unprefixed, trailing-`z`-less health
+            // path a naive probe reaches for. Without it, `/health` falls through
+            // to the SPA catch-all below and returns HTML instead of the health
+            // JSON. Registered before the `.merge`d SPA fallback so it wins.
+            .route("/health", get(routes::health::health))
             .nest("/api/v1", routes::v1_router().fallback(routes::fallback_404))
             .merge(aa_gateway::dashboard_server::dashboard_router(dist))
             .with_state(()),

--- a/aa-api/tests/serve_local_spa.rs
+++ b/aa-api/tests/serve_local_spa.rs
@@ -39,6 +39,22 @@ async fn response_to(app: axum::Router, uri: &str) -> (StatusCode, Vec<u8>) {
     (status, bytes.to_vec())
 }
 
+async fn response_with_content_type(app: axum::Router, uri: &str) -> (StatusCode, String, Vec<u8>) {
+    let response = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).expect("build request"))
+        .await
+        .expect("router.oneshot");
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    let bytes = to_bytes(response.into_body(), 64 * 1024).await.expect("read body");
+    (status, content_type, bytes.to_vec())
+}
+
 #[tokio::test]
 async fn healthz_is_served_alongside_spa() {
     let dist = fake_dist();
@@ -46,6 +62,22 @@ async fn healthz_is_served_alongside_spa() {
     assert_eq!(status, StatusCode::OK, "/healthz must be served by aa-api-server");
     let json: serde_json::Value = serde_json::from_slice(&body).expect("healthz returns JSON");
     assert_eq!(json["status"], "ok");
+}
+
+#[tokio::test]
+async fn health_alias_serves_json_not_spa_html() {
+    // AAASM-4666: `/health` (no `/api/v1` prefix, no trailing `z`) must return
+    // the health JSON, not fall through to the SPA catch-all and return HTML.
+    let dist = fake_dist();
+    let (status, content_type, body) = response_with_content_type(local_app_with_spa(dist.path()), "/health").await;
+    assert_eq!(status, StatusCode::OK, "/health alias must return 200");
+    assert!(
+        content_type.starts_with("application/json"),
+        "/health must serve JSON, not SPA HTML; got content-type {content_type:?}"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("/health returns JSON");
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["api_version"], "v1");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description

`GET /health` (no `/api/v1` prefix, no trailing `z`) was undefined and fell through to the dashboard SPA catch-all, returning HTML instead of health data. This adds a `/health` alias bound to the same `routes::health::health` handler as `/healthz` (liveness) and `/api/v1/health` (JSON). It is registered before the merged SPA fallback so it wins, and only in the SPA-enabled branch (mirroring exactly how `/healthz` is wired). `/healthz`, `/api/v1/health`, and the SPA catch-all for other paths are unchanged.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-4666](https://lightning-dust-mite.atlassian.net/browse/AAASM-4666)
- Related GitHub issues: none

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Added `health_alias_serves_json_not_spa_html` in `aa-api/tests/serve_local_spa.rs`: `GET /health` returns 200 with `application/json` and the health payload (`status: ok`, `api_version: v1`), guarding against a regression back to the SPA HTML catch-all. Verified locally: `cargo build -p aa-api`, `cargo clippy -p aa-api --all-targets -- -D warnings`, `cargo fmt -p aa-api`, and `cargo nextest run -p aa-api health_alias_serves_json_not_spa_html` all green.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMnPRm9T3fdrS4uNYXkzg6

[AAASM-4666]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ