### PR TITLE
[AAASM-4670] 👷 (ci): Add internal doc-link check for README

### DIFF
--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -1,0 +1,32 @@
+name: Doc Links
+
+# Guards repo-relative Markdown links in the README from silently re-rotting
+# after a docs reorg — the AAASM-4635 regression (README links to
+# docs/src/architecture.md etc. 404'd) that AAASM-4670 makes un-repeatable.
+# Internal-link only: no network calls, so no flaky external-URL failures and
+# no new heavy dependency (portable bash in scripts/check-doc-links.sh).
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'README.md'
+      - 'scripts/check-doc-links.sh'
+      - '.github/workflows/doc-links.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'README.md'
+      - 'scripts/check-doc-links.sh'
+      - '.github/workflows/doc-links.yml'
+
+jobs:
+  check-links:
+    name: Check internal doc links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Validate internal Markdown links in README
+        run: bash scripts/check-doc-links.sh README.md

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# check-doc-links.sh — verify that repo-relative Markdown links resolve.
+#
+# WHY: after a docs reorg the README's links to docs/src/architecture.md etc.
+# 404'd and nothing guarded against recurrence (AAASM-4635 → AAASM-4670). This
+# is the guard: it fails (exit 1) if any *internal* Markdown link in the given
+# file(s) points at a path that does not exist in the working tree.
+#
+# Scope is deliberately narrow — internal links only. External URLs
+# (http/https/mailto/tel), protocol-relative (//host), and pure-anchor (#frag)
+# links are skipped, so there is no network call: the check is deterministic,
+# fast, and needs no new dependency (portable bash + grep/sed only).
+#
+# Usage: scripts/check-doc-links.sh <file.md> [<file.md> ...]
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+status=0
+
+for doc in "$@"; do
+  if [[ ! -f "$doc" ]]; then
+    echo "::error::check-doc-links: file not found: $doc"
+    status=1
+    continue
+  fi
+  doc_dir="$(dirname "$doc")"
+
+  # Extract every inline-link / image target: the `target` in `](target)`.
+  # A trailing optional `"title"` and surrounding whitespace are stripped below.
+  while IFS= read -r target; do
+    # Drop an optional link title: `](path "Title")` -> `path`.
+    target="${target%%[[:space:]]*}"
+    [[ -z "$target" ]] && continue
+
+    case "$target" in
+      http://*|https://*|mailto:*|tel:*|//*|\#*) continue ;;  # external / anchor
+    esac
+
+    # Strip any #fragment or ?query — we only resolve the path portion.
+    path="${target%%#*}"
+    path="${path%%\?*}"
+    [[ -z "$path" ]] && continue
+
+    # Root-absolute ("/x") resolves from the repo root; else relative to the doc.
+    if [[ "$path" == /* ]]; then
+      resolved="${repo_root}${path}"
+    else
+      resolved="${doc_dir}/${path}"
+    fi
+
+    if [[ ! -e "$resolved" ]]; then
+      echo "::error file=${doc}::broken internal link -> ${target}"
+      status=1
+    fi
+  done < <(grep -oE '\]\([^)]+\)' "$doc" | sed -E 's/^\]\(//; s/\)$//')
+done
+
+if [[ "$status" -eq 0 ]]; then
+  echo "check-doc-links: all internal links resolve in: $*"
+fi
+exit "$status"


### PR DESCRIPTION
## Description

Adds a lightweight CI check that validates the **internal** Markdown links in
`README.md` resolve to real paths in the repo, failing the build on a broken
internal link. Follow-up of AAASM-4635, where README links to
`docs/src/architecture.md` / `cli.md` / `dashboard.md` 404'd after a docs
reorg (repointed in #1509) with nothing guarding against recurrence.

New files:
- `scripts/check-doc-links.sh` — portable bash + grep/sed; parses `](target)`
  links, skips external (`http`/`https`/`mailto`/`tel`/`//`) and anchor-only
  (`#…`) links, strips `#frag`/`?query`, and resolves the path relative to the
  doc (root-absolute `/x` from repo root). Exits 1 on any missing target. No
  network calls, no new dependency.
- `.github/workflows/doc-links.yml` — runs the checker over `README.md` on PRs
  and master pushes that touch the README, the script, or the workflow.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-4670 — https://lightning-dust-mite.atlassian.net/browse/AAASM-4670
- Fix Version: agent-assembly v0.0.1-rc.6

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Manual validation (local):
- `bash scripts/check-doc-links.sh README.md` → exit 0, "all internal links resolve"
  (all 22 current README internal links pass).
- A file with a deliberately-broken internal link (`docs/src/architecture.md`)
  amid valid ones → exit 1, only the broken link flagged; external, anchor,
  nested, trailing-slash-dir, and `#frag "title"` links correctly handled.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
