### PR TITLE
[AAASM-4671] 📝 (skill): Cover README maturity/version string in release-docs-sync

### DIFF
--- a/.claude/skills/release-docs-sync/SKILL.md
+++ b/.claude/skills/release-docs-sync/SKILL.md
@@ -91,6 +91,13 @@ The verifier (`scripts/check-docs-versions.sh X`) asserts every one of them.
 
 3. **`README.md`** (repo root):
    - the **`AASM_VERSION=vX`** quick-install snippet,
+   - the **Project Status maturity banner** — the `🚧 <maturity> — `v0.0.1-<channel>`
+     series` line and its `_(status as of <date>)_` marker. The maturity word +
+     channel segment must match the channel `X` belongs to (alpha / beta / rc /
+     official). This is the AAASM-4636 drift: the banner still read "Alpha" while
+     the release was `rc`. On a **channel promotion** (alpha→beta→rc→official),
+     bump both the maturity word **and** the `v0.0.1-<channel>` series label; on a
+     same-channel forward-roll, just refresh the "status as of" date.
    - the **Project Status** "latest [`vX`]" release line (and its date).
 
 4. **`docs/src/quick-start/configuration.md`** and
@@ -237,6 +244,9 @@ you touched the script.
 ## Done when
 
 - `scripts/check-docs-versions.sh X` exits 0 in agent-assembly.
+- The **README Project Status maturity banner** names the channel `X` belongs to
+  (maturity word + `v0.0.1-<channel>` series label + refreshed "status as of"
+  date) — not a stale channel (the AAASM-4636 "Alpha"-while-`rc` drift).
 - A new compat-matrix row for `X` exists in **both** the core and hub
   compatibility files.
 - The hub's **static** core/Go badges read `X`.


### PR DESCRIPTION
## Description

Adds the **README maturity/version string** (Project Status maturity banner +
its "status as of" date) to the `release-docs-sync` skill checklist so it's
bumped in lockstep on every release cut. Follow-up of AAASM-4636, where the
README banner drifted to "Alpha" while docs/release were `rc` (fixed in #1510)
— nothing in the checklist named the banner, so it could drift again.

Edits `.claude/skills/release-docs-sync/SKILL.md`:
- Step 3 (README) now has an explicit bullet for the `🚧 <maturity> —
  v0.0.1-<channel> series` banner + `_(status as of <date>)_` marker, with the
  channel-promotion vs same-channel forward-roll rule.
- "Done when" gains a matching completion criterion referencing the AAASM-4636
  drift.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-4671 — https://lightning-dust-mite.atlassian.net/browse/AAASM-4671
- Fix Version: agent-assembly v0.0.1-rc.6

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

Documentation-only change to a skill checklist (`.claude/skills/…`); no code
or runtime surface to test.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
