### PR TITLE
[AAASM-4674] 📝 (template): Add DCO sign-off checkbox to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,3 +41,4 @@ Describe the testing performed for this PR:
 - [ ] Documentation updated if behaviour changed
 - [ ] All CI checks passing
 - [ ] Commits are small and follow the Gitmoji convention
+- [ ] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced


### PR DESCRIPTION
## Description

Adds a DCO sign-off checkbox to `.github/PULL_REQUEST_TEMPLATE.md`, consistent
with the advisory DCO policy reconciled in AAASM-4645 / #1512. The checkbox is
explicitly optional/advisory (not enforced), matching the reconciled wording.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-4674 — https://lightning-dust-mite.atlassian.net/browse/AAASM-4674
- Fix Version: agent-assembly v0.0.1-rc.6

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

Template-only change; nothing to test.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
