### PR TITLE
[AAASM-4715] 🐛 (aa-ebpf): Skip probe subprocess build under DOCS_RS

### DIFF
--- a/aa-ebpf/build.rs
+++ b/aa-ebpf/build.rs
@@ -77,7 +77,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let release_dir = target_dir.join("bpfel-unknown-none/release");
         let binaries = ["aa-file-io", "aa-exec-probes", "aa-tls-probes", "aa-syscall-guard"];
 
-        let build_ok = if let Some(dir) = probes_dir.as_ref() {
+        // docs.rs's sandbox mounts everything except OUT_DIR/CARGO_TARGET_DIR
+        // read-only, but `current_dir(dir)` below points at the probes'
+        // *source* directory — cargo writing there (e.g. Cargo.lock) hard-fails
+        // the whole build.rs with a raw io::Error instead of falling through to
+        // the stub path. docs.rs sets DOCS_RS=1 for exactly this situation:
+        // skip the subprocess entirely and go straight to stubs (AAASM-4715).
+        let build_ok = if env::var_os("DOCS_RS").is_some() {
+            false
+        } else if let Some(dir) = probes_dir.as_ref() {
             // Run `cargo build --release` inside the probes workspace.
             // aa-ebpf-probes/.cargo/config.toml sets:
             //   target      = "bpfel-unknown-none"


### PR DESCRIPTION
## What changed
`aa-ebpf/build.rs` now checks the `DOCS_RS` env var and skips the BPF-probe cross-compile subprocess entirely when set, falling straight through to the crate's existing empty-stub fallback path (previously only reached when the nightly toolchain was missing).

## Why
docs.rs mounts the crate source tree read-only except `$OUT_DIR`/`$CARGO_TARGET_DIR`. The subprocess call ran `rustup run nightly cargo build --release` with `current_dir` pointed at the sibling `aa-ebpf-probes` **source** directory — cargo's write there (e.g. `Cargo.lock`) hit `ReadOnlyFilesystem`, and because `main()` uses bare `?`, that hard-failed the whole `build.rs` (exit 1) instead of degrading gracefully. This broke docs.rs documentation builds for `aa-cli`, `aa-gateway`, `aa-proxy`, and `aa-runtime` — all four transitively depend on `aa-ebpf`, so all four show a red "build failed" badge on crates.io/docs.rs despite being correctly published (`v0.0.1-rc.5`, not yanked).

docs.rs sets `DOCS_RS=1` in its build env specifically so build scripts can detect and skip this kind of work — `build.rs` never checked for it until now.

## How to verify
- `cargo check -p aa-ebpf` / `cargo clippy -p aa-ebpf --all-targets -- -D warnings` — green (ran via pre-commit hook, plus full-workspace clippy/fmt/doc gates all passed).
- Real validation is the docs.rs rebuild once this ships in rc.6 — confirmed the actual failure via docs.rs's build logs (build #3850327 for aa-cli, same `doc_status:false` pattern on aa-gateway/aa-proxy/aa-runtime) before making this change.
- No behavior change outside `DOCS_RS=1`: real Linux CI/dev builds and non-Linux builds take the same code paths as before.

## Jira Ticket
https://lightning-dust-mite.atlassian.net/browse/AAASM-4715

Fix version: `agent-assembly v0.0.1-rc.6` (next release — rc.5 is already shipped; docs.rs's rc.5 badges stay red until rc.6 republishes with this fix, which is expected).