### PR TITLE
[AAASM-4724] 📝 (skills): Remind release-tag-cut to advance the Jira Fix Version ladder

### DIFF
--- a/.claude/skills/release-tag-cut/REFERENCE.md
+++ b/.claude/skills/release-tag-cut/REFERENCE.md
@@ -149,6 +149,12 @@ Surface both confirmations to the operator, then suggest:
 > matrix (GH Release, crates.io, Homebrew tap PR, ghcr.io images, npm,
 > PyPI) per `docs/release/RUNBOOK.md` sections 3–5.
 
+Then **advance the Jira Fix Version ladder** (SKILL.md → "advance the Jira Fix
+Version ladder"): mark the just-cut version released and create the next one for
+the `agent-assembly` core train and each affected SDK/component train, per
+`ticket-authoring`'s `references/fix-versions.md`. Reminder only — the operator
+(or a credentialed release job) creates the versions.
+
 ## What's expected when done
 
 When this skill exits cleanly, the operator should be able to confirm

--- a/.claude/skills/release-tag-cut/SKILL.md
+++ b/.claude/skills/release-tag-cut/SKILL.md
@@ -174,6 +174,23 @@ After step 6, both MUST hold (full detail in
 Surface both confirmations, then point the operator at
 `/release-validate-channels v<X>` for the downstream channel matrix.
 
+## Reminder — advance the Jira Fix Version ladder
+
+Cutting `v<X>` ships everything targeted at that version, so the **next** dev work
+needs a target. The release skills do **not** manage Jira versions, so after the cut
+remind the operator to, in Jira (project AAASM):
+
+1. Mark the just-cut version **released** (`released:true` + release date).
+2. **Create the next** Fix Version — for the `agent-assembly` **core** train *and*
+   each affected repo/component train (`python-sdk` / `node-sdk` / `go-sdk`) that
+   participates in this coordinated release — so their tickets have a target.
+
+Use `ticket-authoring`'s `references/fix-versions.md` for the exact REST
+create/release calls. This is a **manual reminder**: the Atlassian MCP has no
+version tool and version writes need a manage-versions token, so the operator (or a
+credentialed release job) does it. Automating this in `release.yml` is a separate
+follow-up, blocked on a CI manage-versions token.
+
 ## What's auto-handled (do NOT manually run)
 
 Once the tag is pushed, `release.yml` auto-runs GitHub Release creation,
@@ -190,6 +207,9 @@ for the full list and rationale.
 - Re-trigger failed `release-*.yml` workflows (RUNBOOK section 6).
 - Cut an `agent-assembly` tag for an SDK-only hotfix (RUNBOOK section 7).
 - Touch repos other than `ai-agent-assembly/agent-assembly`.
+- Create or release Jira Fix Versions — it **reminds** the operator (see
+  "advance the Jira Fix Version ladder"); the operator (or a credentialed release
+  job) creates/releases them. The Atlassian MCP has no version tool.
 
 ## Detailed references
 


### PR DESCRIPTION
## Description

Adds a Post-conditions **reminder** to the `release-tag-cut` skill: after a release cut, prompt the operator to (1) mark the just-cut Jira Fix Version **released** and (2) **create the next** Fix Version — for the `agent-assembly` core train *and* each affected repo/component train (`python-sdk` / `node-sdk` / `go-sdk`) participating in the coordinated release — per `ticket-authoring`'s `references/fix-versions.md`. Also a matching line in REFERENCE.md and a "does not do" bullet. **Reminder only, no automation.**

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No — docs-only `.claude/` skill change; no code, scripts, or behaviour touched.

## Related Issues

- Related Jira ticket: AAASM-4724 (standalone Task) — https://lightning-dust-mite.atlassian.net/browse/AAASM-4724

## Testing

- [x] No tests required — documentation-only change to a skill's markdown; the release scripts are untouched.

## Checklist

- [x] Self-review of the diff completed (+26 lines, 2 files, additions only)
- [x] Documentation updated
- [x] Commits are small and follow the Gitmoji convention

> Note: landed via the **GitHub Git Data API replay** — this repo's pre-push `cargo doc` hook fails on macOS/eBPF even for docs-only branches (per `.claude/CLAUDE.md`), so the branch was built server-side rather than `git push`. No `--no-verify`, no force-push.
> Follow-up (out of scope): *automating* version creation in `release.yml` is blocked on a CI manage-versions token (the Atlassian MCP has no version tool; the env token is invalid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
