### PR TITLE
🔒 (release): Security-gate PASS sign-off for v0.0.1-rc.6

### DIFF
--- a/docs/release/security-signoff/v0.0.1-rc.6.md
+++ b/docs/release/security-signoff/v0.0.1-rc.6.md
@@ -1,48 +1,60 @@
 # Security sign-off — v0.0.1-rc.6
 
-> **PLACEHOLDER — not yet signed off.** This artifact exists so the release-docs
-> footprint is complete, but the security review has **not** run yet. The
-> `/release-security-gate` SKILL owns filling in the Inputs / Findings tables and
-> setting the final `Verdict:` line. `scripts/release-readiness.sh` check 11 keeps
-> the tag blocked while the verdict is anything other than `PASS` — do **not** tag
-> `v0.0.1-rc.6` until the gate has run against the `rc.5 → rc.6` delta and set
-> `Verdict: PASS` here.
-
 - **Version:** v0.0.1-rc.6
 - **Release type:** patch (same `rc` pre-release channel; counter rc.5 → rc.6)
 - **Previous tag:** v0.0.1-rc.5
-- **Reviewer:** _(to be filled by `/release-security-gate`)_
-- **Date:** _(to be filled by `/release-security-gate`)_
+- **Reviewer:** Claude Code (`/release-security-gate`)
+- **Date:** 2026-07-16
 
 ## Inputs reviewed
 
-- `cargo deny check advisories` — _(to be filled by the gate)_
-- Open CodeQL alerts — _(to be filled by the gate)_
-- Open Dependabot alerts — _(to be filled by the gate)_
-- Release diff — `git log v0.0.1-rc.5..HEAD` (56 commits) — _(to be reviewed by the gate)_
-- Native `/security-review` (Anthropic diff scanner) on the release delta — _(to be filled by the gate)_
+- `cargo deny check advisories` — **`advisories ok`** (clean). The rc.5 `spin 0.9.8`
+  yanked-crate finding is **remediated**: the committed `Cargo.lock` on `remote/master`
+  now pins `spin 0.9.9`, so there is no yank and no RUSTSEC advisory in this window.
+  `bans` / `licenses` / `sources` unaffected. Verified against the exact
+  `remote/master` (`b358534a`) lockfile.
+- Open CodeQL / code-scanning alerts (agent-assembly) — **none open** (`gh api …/code-scanning/alerts` filtered to `state=="open"` returned empty).
+- Open Dependabot alerts (agent-assembly) — **none open** (`gh api …/dependabot/alerts` filtered to `state=="open"` returned empty). The seven dependency bumps in this window are Dependabot PRs already merged to `master`.
+- Release diff — `git log v0.0.1-rc.5..remote/master` (56 commits; 69 files, +733 / −223). No `proto/` or `aa-proto` change — **no wire-protocol change** (`protocol/v1` unchanged).
+- Native `/security-review` (Anthropic diff scanner) on the release delta — **not applicable as-invoked**: the built-in scanner targets *pending working-tree changes*, and the release delta `v0.0.1-rc.5..remote/master` is fully committed (worktree clean). The release-diff review was therefore performed **manually** against the trust-boundary-touching commits (see Findings), per the patch-tier procedure.
 
-> The release-diff review **wraps** the built-in `/security-review`; the gate folds
-> its findings into the table below. The non-trivial surface in this window to
-> review: tenant-ownership enforcement in `register_op`, the non-clobbering
-> `OpsRegistry::register`, the `aa-cli` audit/logs `Authorization` header, the new
-> `/health` alias, the `DOCS_RS` eBPF build guard, and the dependency bumps.
+> The release-diff review wraps the built-in `/security-review`; where the native
+> scanner does not fit the committed-delta model, the equivalent manual review is
+> folded into the Findings table below.
 
 ## Findings
 
 | Severity | Finding | Status (fixed / accepted-with-justification / open) |
 |---|---|---|
-| _(to be filled by `/release-security-gate`)_ | | |
+| Info | `cargo deny check advisories` reports **`advisories ok`**. The rc.5 `spin` yank is remediated (`Cargo.lock` now pins `spin 0.9.9`). `bans` / `licenses` / `sources` all pass. | Reviewed — no action (rc.5 yank remediated) |
+| Info | **AAASM-4653 — `register_op` now enforces tenant ownership + `OpsRegistry::register` is preserve-idempotent.** Fixes a real cross-tenant gap: a write-scoped caller in one team could clobber another tenant's op record (overwrite → reset to `Running`). `register_op` now calls `authorize_op_access` when the `op_id` already exists (fail-closed; existing op with no resolvable team is admin-only), and the registry itself preserves an existing record instead of overwriting. Two-layer **hardening**, with regression tests. | Fixed (hardening) |
+| Info | **AAASM-4659 — `aasm` audit/logs commands now send `Authorization: Bearer`.** The blocking GET path skipped auth (401 against the default auth-required gateway). Routed through a new `client::blocking_get()` that attaches the bearer token like the async read path. Client-side correctness fix; no server-side trust boundary loosened. | Fixed (correctness) |
+| Info | **AAASM-4666 — `GET /health` alias added.** Unprefixed/trailing-`z`-less path bound to the **same** `routes::health::health` handler as the pre-existing `/healthz` and `/api/v1/health`. Returns health JSON (no sensitive data); previously fell through to the SPA catch-all and returned HTML. Health endpoints are conventionally unauthenticated; no new sensitive surface, no new auth path. | Reviewed — no action |
+| Info | **AAASM-4694 — dashboard SonarCloud quality refactors, incl. JWT-scope validation (`Set.has`, S7776) and base64url decode (`replaceAll`, S7781).** Both are **semantics-preserving** refactors: `VALID_SCOPES.includes()` → `Set.has()` filters the identical whitelist, and `.replace(/-/g,…)` → `.replaceAll('-',…)` is behaviorally identical global replacement. Operates on an *unverified* client-side JWT (cosmetic UI scope-gating only). Net **neutral** — not a hardening, not a risk. Companion changes (symmetric setter rename, parameterized tests, heatmap keyed by date) are test/style only. | Reviewed — no action (behavior-preserving) |
+| Info | **AAASM-4654 — `McpDecision::Redact` doc corrected in `aa-proxy`.** Documentation-only: corrects the variant doc + a bucketing comment to state the actual contract (the proxy's own DLP scanner redacts both request and upstream response; the gateway's `RedactInstructions` are carried but advisory at this layer). No change to the redaction data path. | Reviewed — no action (doc-only) |
+| Info | **AAASM-4715 — `aa-ebpf` skips the probe subprocess build under `DOCS_RS`.** Build-guard for the read-only docs.rs environment; no runtime/product-code surface. | Reviewed — no action |
+| Info | Seven dependency bumps in the window: `clap` 4.6.1→4.6.2, `which` 8.0.4→8.0.5, `regex` 1.13.0→1.13.1, `redis` 1.3.0→1.4.0, `toml` 1.1.2→1.1.3, `SonarSource/sonarqube-scan-action` 8.2.0→8.2.1, `actions/setup-node` 6.4.0→7.0.0. In-range/minor upgrades and SHA-pinned action bumps; `cargo deny` advisories clean. | Reviewed — no action |
+| Info | Remaining delta: README/docs link fixes after the docs reorg, a CI internal doc-link check, CONTRIBUTING/PR-template/DCO wording, and release-process skill/docs updates. No product-code or trust-boundary surface. | Reviewed — no action |
 
-> An **unaddressed Critical or High** finding forces `Verdict: BLOCK`.
+> No unaddressed Critical or High finding. The genuinely-new/changed trust-boundary
+> surface in this window is **net neutral-to-tightening**: the `register_op` /
+> `OpsRegistry` change closes a cross-tenant clobber (fail-closed, tested), the
+> `aa-cli` change correctly attaches auth, the `/health` alias reuses an existing
+> handler with no sensitive data, and the dashboard JWT/base64url refactors are
+> behavior-preserving. Consistent with the patch-tier gate (BLOCK only on
+> unaddressed Critical/High).
 
 ## Threat-model refresh / trust-boundary checklist
 
-_(to be filled by `/release-security-gate` — patch tier; expected neutral-to-tightening.)_
+n/a — patch tier (same `rc` pre-release channel). Net trust-boundary effect of the
+delta is **neutral-to-tightening**: a cross-tenant op-clobber path is closed at two
+layers (API authz + registry preserve-idempotency), the CLI now sends the bearer
+token it previously omitted, and the new `/health` alias is bound to the existing
+health handler (no new listener, no new sensitive route, no new auth path). No
+wire-protocol change (`protocol/v1` unchanged); no policy default loosened.
 
 ## Verdict
 
 <!-- The token `Verdict: PASS` is what release-readiness.sh greps for. -->
-<!-- Left as PENDING deliberately: the security gate is a separate later step. -->
 
-Verdict: PENDING
+Verdict: PASS


### PR DESCRIPTION
## Summary

Fills in the placeholder security sign-off for **v0.0.1-rc.6** with a **PASS** verdict, unblocking `scripts/release-readiness.sh` check 11 for the tag cut.

- **Tier:** patch (same `rc` channel; rc.5 → rc.6). Gate = dependency/advisory audit + release-diff trust-boundary review (no major-tier full Action).
- **`cargo deny check advisories`:** **`advisories ok`** — clean. The rc.5 `spin 0.9.8` yank is remediated (`Cargo.lock` now pins `spin 0.9.9`). Verified against `remote/master` `b358534a`.
- **Alerts:** no open CodeQL or Dependabot alerts on master.
- **Diff review (`git log v0.0.1-rc.5..master`, 56 commits):** net **neutral-to-tightening**.
  - `register_op` tenant-ownership authz + non-clobbering `OpsRegistry::register` (AAASM-4653) — closes a cross-tenant op-clobber, fail-closed, tested (**hardening**).
  - `aa-cli` audit/logs now send `Authorization: Bearer` (AAASM-4659) — correctness.
  - `/health` alias (AAASM-4666) — reuses the existing health handler; no sensitive surface.
  - dashboard JWT-scope `Set.has` (S7776) + base64url `replaceAll` (S7781) refactors (AAASM-4694) — **semantics-preserving**, neither hardening nor risk.
  - `aa-proxy` `McpDecision::Redact` doc correction (AAASM-4654, doc-only); `aa-ebpf` `DOCS_RS` build guard (AAASM-4715); 7 in-range dependency bumps.
  - **No wire-protocol change** (`protocol/v1` unchanged).

**Verdict: PASS** — no unaddressed High/Critical finding.

## Scope

Touches only `docs/release/security-signoff/v0.0.1-rc.6.md`. Does not tag or publish (that is `/release-tag-cut`).