### PR TITLE
[AAASM-4731] 🔧 (dev-setup): install Lefthook instead of pre-commit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
       "version": "3.12"
     }
   },
-  "postCreateCommand": "sudo apt-get install -y protobuf-compiler && cargo install cargo-nextest --locked && cargo install cargo-deny --locked && pip install pre-commit && pre-commit install",
+  "postCreateCommand": "sudo apt-get install -y protobuf-compiler && cargo install cargo-nextest --locked && cargo install cargo-deny --locked && npm install -g lefthook && lefthook install",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,9 @@ build-baseline:
 standalone-smoke:
 	@bash scripts/standalone-build-smoke.sh
 
-## install-hooks: Install git pre-commit hooks via pre-commit
+## install-hooks: Install git hooks via Lefthook (the repo's hook manager; config in lefthook.toml)
 install-hooks:
-	@pre-commit install
+	@lefthook install
 
 ## install-tools: Check required toolchains via scripts/install.sh
 install-tools:


### PR DESCRIPTION
## Description

The repo standardizes git hooks on **Lefthook** (`lefthook.toml` at repo root; `CONTRIBUTING.md` Setup says `lefthook install`), but the automated onboarding paths ran the **pre-commit** framework instead. Since there is no `.pre-commit-config.yaml`, a first-time contributor following `make dev-setup` (or opening the devcontainer) hit `pre-commit install` — which errors ("No .pre-commit-config.yaml file was found") or registers no hooks, so none of the documented fmt/clippy/deny/doc hooks ran. The manual (`lefthook install`) and automated paths disagreed.

This PR reconciles both automated paths to Lefthook:

- `Makefile` `install-hooks` target: `pre-commit install` → `lefthook install` (and updated its `## help` comment).
- `.devcontainer/devcontainer.json` `postCreateCommand`: dropped `pip install pre-commit && pre-commit install`; now `npm install -g lefthook && lefthook install` (using the devcontainer's node feature) so the container matches the repo's hook manager.

Scope is limited to hook/setup wiring only — no Rust or other files touched.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-4731](https://lightning-dust-mite.atlassian.net/browse/AAASM-4731)
- Related GitHub issues: N/A

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (explain why)

Hook/setup wiring change with no runtime surface, so no automated tests apply. Verified locally:
- `.devcontainer/devcontainer.json` is valid JSON (`python3 -c 'json.load(...)'`).
- `make -n install-hooks` prints `lefthook install`; `make -n dev-setup` resolves with the Lefthook step in the chain.
- No residual `pre-commit` references remain in `Makefile` or `.devcontainer/`.
- Pre-push `cargo doc` hook (from `lefthook.toml`) passed on push.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced


[AAASM-4731]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ