### PR TITLE
[AAASM-4732] 📝 (github): Unify branch scheme to 3-part + add ISSUE_TEMPLATE/config.yml

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -75,8 +75,8 @@ cargo doc --workspace --no-deps        # checked on push by hooks
 
 - **Commits:** `<emoji> (<scope>): <imperative summary>` (gitmoji.dev). One logical
   unit per commit; bisectable. Utils/mocks/tests are separate preceding commits.
-- **Branch:** `<release-or-phase>/<ticket>/<type>/<short_summary>`
-  (e.g. `v0.0.1/AAASM-42/feat/add_agent_registry`).
+- **Branch:** `<release-or-phase>/<ticket>/<short_summary>`
+  (e.g. `v0.0.1/AAASM-42/add_agent_registry`).
 - **PR title:** `[<ticket>] <emoji> (<scope>): <summary>`; base branch **always
   `master`**; body follows the repo PR template; ≥1 Pioneer-team approval.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & Discussions
+    url: https://github.com/ai-agent-assembly/agent-assembly/discussions
+    about: Ask questions, share ideas, and discuss usage with the community. Please use Discussions rather than the issue tracker for open-ended questions.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/ai-agent-assembly/agent-assembly/security/advisories/new
+    about: Report vulnerabilities privately — do not open a public issue. See SECURITY.md for the full policy.


### PR DESCRIPTION
## Description

Resolves the two remaining Journey-33 acceptance items in AAASM-4732, both scoped to the **agent-assembly** repo's own contributor / community-health surface:

1. **Branch scheme reconciled to 3-part.** `CONTRIBUTING.md` already documents the canonical three-part format `<release-or-phase>/<ticket>/<short_summary>`, but `.claude/CLAUDE.md` still described the four-part `<release-or-phase>/<ticket>/<type>/<short_summary>` form. An in-repo reader got two contradictory branch rules; `.claude/CLAUDE.md` is now aligned to the three-part scheme (the only residual 4-part reference in the repo).
2. **`.github/ISSUE_TEMPLATE/config.yml` added.** The issue-template chooser had no `config.yml`, so blank issues were implicitly enabled and there were no contact links. Added `config.yml` that sets `blank_issues_enabled: false` (guiding reporters into the existing `bug_report` / `feature_request` forms) and routes open-ended questions to GitHub Discussions and vulnerabilities to private security reporting (per `SECURITY.md`).

Out of scope for this ticket: the separate org `ai-agent-assembly/.github` repo (the ticket's Defect-1 note references it, but this PR stays inside the agent-assembly repo per the ticket's component scoping).

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-4732](https://lightning-dust-mite.atlassian.net/browse/AAASM-4732)
- Related GitHub issues: N/A

## Testing

Docs / YAML-only change — no build affected.

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Validated locally: `config.yml` parses as valid YAML (`blank_issues_enabled: false`, two well-formed `contact_links`); both `ISSUE_TEMPLATE/*.md` front-matter blocks still parse; the branch-scheme wording is now consistent across `CONTRIBUTING.md` and `.claude/CLAUDE.md` with no residual 4-part reference anywhere in the repo.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced


[AAASM-4732]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ