### PR TITLE
[AAASM-4715] 🐛 (aa-ebpf): Gate probes_dir resolution on DOCS_RS too

### DIFF
--- a/aa-ebpf/build.rs
+++ b/aa-ebpf/build.rs
@@ -52,7 +52,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Resolve the probes source dir. Sibling takes priority over _embedded;
     // never touch _embedded outside of the publish-staging flow.
-    let probes_dir: Option<PathBuf> = if sibling_probes.join("Cargo.toml").exists() {
+    //
+    // docs.rs mounts the crate source tree read-only outside OUT_DIR. It
+    // always builds from the published tarball (never a sibling workspace
+    // checkout), so it would otherwise always take the _embedded branch and
+    // call restore_manifest_from_stage(), which renames a file *inside*
+    // that read-only tree and hard-fails the build (AAASM-4715 — the first
+    // fix only guarded the later `rustup`/Command call below, not this
+    // earlier and unconditional one). Skip resolution entirely under
+    // DOCS_RS: the Linux build_ok check further down already routes a
+    // `None` probes_dir to the stub-emission fallback.
+    let probes_dir: Option<PathBuf> = if std::env::var_os("DOCS_RS").is_some() {
+        None
+    } else if sibling_probes.join("Cargo.toml").exists() {
         println!("cargo:rerun-if-changed={}", sibling_probes.display());
         Some(sibling_probes)
     } else if embedded_probes.join(STAGED_MANIFEST).exists() || embedded_probes.join("Cargo.toml").exists() {


### PR DESCRIPTION
## What changed
Follow-up to #1526 (merged into rc.6). That fix only guarded the `rustup`/`cargo build` subprocess call under `DOCS_RS`. This gates the earlier, unconditional `probes_dir` resolution too — specifically the call to `restore_manifest_from_stage()`, which is the actual crash site on docs.rs.

## Why the first fix didn't work
Verified rc.6 shipped (crates.io `max_version: 0.0.1-rc.6`) but docs.rs still shows `doc_status:false` for all 4 crates — **identical** `ReadOnlyFilesystem` error, same crate, on the rc.6 build. Root cause: `probes_dir` resolution runs *before* the block #1526 patched, and is unconditional. docs.rs always builds from the published tarball (never a sibling workspace checkout), so it always takes the `_embedded` branch and calls `restore_manifest_from_stage()`, which does `fs::rename()` **inside** `_embedded/aa-ebpf-probes/` — part of the read-only source tree. That rename fails via the same bare-`?` propagation, before execution ever reaches the DOCS_RS check added last time.

I traced every filesystem-mutating call in `build.rs` this time (not just the one that looked most obviously connected):
1. `restore_manifest_from_stage()` (line 60, unconditional) — **the actual bug**, now fixed here.
2. `Command::new("rustup")...current_dir(dir)` (line 93) — already guarded by #1526.
3. `create_dir_all`/`write` for stub binaries, `read` for digests — all under `OUT_DIR`, always safe.

## How to verify
Reproduced locally without Docker: `probes_dir` resolution isn't Linux-gated (it runs on any host), so I built a minimal harness reproducing the exact logic against a `chmod`-read-only `_embedded/aa-ebpf-probes/` directory with a staged manifest present (the same shape docs.rs's read-only mount + published-tarball layout produces):
- **Old logic**: `Error: Os { code: 13, kind: PermissionDenied, ... }`, exit 1 — reproduces the bug class (write rejected by the OS; docs.rs's Linux mount reports `ReadOnlyFilesystem` for the same rejection, macOS reports `PermissionDenied` — same failure, different `errno` message per OS).
- **New logic**: skips resolution cleanly under `DOCS_RS`, exits 0.

Also: `cargo check -p aa-ebpf`, `cargo clippy -p aa-ebpf --all-targets -- -D warnings`, full-workspace fmt/clippy pre-commit gate, and `cargo doc --workspace --no-deps` pre-push gate — all green.

## Jira Ticket
https://lightning-dust-mite.atlassian.net/browse/AAASM-4715 (reopened after rc.6 confirmed the first fix incomplete)

Fix version: `agent-assembly v0.0.1-rc.7` (next — rc.6 already shipped with the incomplete fix).