### PR TITLE
[AAASM-4733] 🐛 (aa-cli): Send auth header on aasm status aggregation sub-requests

### DIFF
--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -187,4 +187,84 @@ mod tests {
         let resp = client.fetch_admin_status().await.expect("admin status decodes");
         assert_eq!(resp.mode, "remote");
     }
+
+    /// AAASM-4733: the `list_agents` aggregation sub-request must carry the
+    /// configured bearer. The mock only matches with the header present, so a
+    /// successful decode proves `Authorization` was sent.
+    #[tokio::test]
+    async fn list_agents_sends_bearer_when_key_set() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/agents"))
+            .and(header("authorization", "Bearer aa_test_key"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "items": [], "page": 1, "per_page": 100, "total": 0 })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = StatusClient::new(&server.uri()).with_api_key(Some("aa_test_key".to_string()));
+        let agents = client.list_agents().await.expect("agents list decodes");
+        assert!(agents.is_empty());
+    }
+
+    /// AAASM-4733: the `list_approvals` aggregation sub-request must carry the
+    /// configured bearer.
+    #[tokio::test]
+    async fn list_approvals_sends_bearer_when_key_set() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/approvals"))
+            .and(header("authorization", "Bearer aa_test_key"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "items": [], "page": 1, "per_page": 100, "total": 0 })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = StatusClient::new(&server.uri()).with_api_key(Some("aa_test_key".to_string()));
+        let approvals = client.list_approvals().await.expect("approvals list decodes");
+        assert!(approvals.is_empty());
+    }
+
+    /// AAASM-4733: the `get_costs` aggregation sub-request must carry the
+    /// configured bearer.
+    #[tokio::test]
+    async fn get_costs_sends_bearer_when_key_set() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/costs"))
+            .and(header("authorization", "Bearer aa_test_key"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "daily_spend_usd": "0.00", "date": "2026-04-30" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = StatusClient::new(&server.uri()).with_api_key(Some("aa_test_key".to_string()));
+        let costs = client.get_costs().await.expect("costs decode");
+        assert_eq!(costs.daily_spend_usd, "0.00");
+    }
+
+    /// With no key configured the aggregation fetches still work against a
+    /// bypass-default gateway — no `Authorization` header is required by the mock.
+    #[tokio::test]
+    async fn aggregation_fetches_work_without_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/agents"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "items": [], "page": 1, "per_page": 100, "total": 0 })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = StatusClient::new(&server.uri());
+        let agents = client.list_agents().await.expect("agents list decodes");
+        assert!(agents.is_empty());
+    }
 }

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -90,31 +90,44 @@ impl StatusClient {
 
     /// List all agents via `GET /api/v1/agents`.
     pub async fn list_agents(&self) -> Result<Vec<AgentResponse>, CliError> {
-        let resp = self
-            .http
-            .get(self.url("/api/v1/agents"))
-            .query(&[("per_page", "100")])
-            .send()
-            .await?;
+        // AAASM-4733: this aggregation sub-request hits the same auth-gated
+        // resource as `aasm agent list`, so it must carry the configured bearer
+        // (matching `fetch_admin_status`); otherwise it 401s against an
+        // auth-enforcing API and the ACTIVE AGENTS section renders empty.
+        let mut req = self.http.get(self.url("/api/v1/agents")).query(&[("per_page", "100")]);
+        if let Some(ref key) = self.api_key {
+            req = req.bearer_auth(key);
+        }
+        let resp = req.send().await?;
         let body = resp.json::<PaginatedResponse<AgentResponse>>().await?;
         Ok(body.items)
     }
 
     /// List all approvals via `GET /api/v1/approvals`.
     pub async fn list_approvals(&self) -> Result<Vec<ApprovalResponse>, CliError> {
-        let resp = self
+        // AAASM-4733: same auth-gated resource as `aasm approvals list` — attach
+        // the bearer so PENDING APPROVALS is not silently empty under auth.
+        let mut req = self
             .http
             .get(self.url("/api/v1/approvals"))
-            .query(&[("per_page", "100")])
-            .send()
-            .await?;
+            .query(&[("per_page", "100")]);
+        if let Some(ref key) = self.api_key {
+            req = req.bearer_auth(key);
+        }
+        let resp = req.send().await?;
         let body = resp.json::<PaginatedResponse<ApprovalResponse>>().await?;
         Ok(body.items)
     }
 
     /// Fetch cost summary via `GET /api/v1/costs`.
     pub async fn get_costs(&self) -> Result<CostResponse, CliError> {
-        let resp = self.http.get(self.url("/api/v1/costs")).send().await?;
+        // AAASM-4733: same auth-gated resource as `aasm cost summary` — attach
+        // the bearer so BUDGET STATUS is not silently empty under auth.
+        let mut req = self.http.get(self.url("/api/v1/costs"));
+        if let Some(ref key) = self.api_key {
+            req = req.bearer_auth(key);
+        }
+        let resp = req.send().await?;
         let body = resp.json::<CostResponse>().await?;
         Ok(body)
     }


### PR DESCRIPTION
## Description

`aasm status` fans out to several backend endpoints to aggregate fleet health. Three of those aggregation sub-requests — `GET /api/v1/agents`, `GET /api/v1/approvals`, `GET /api/v1/costs` — were built in `StatusClient` without attaching the configured bearer `Authorization` header, even though the dedicated commands (`aasm agent list`, `aasm approvals list`, `aasm cost summary`) and `status`'s own `/api/v1/admin/status` probe all authenticate correctly.

Against an auth-enforcing HTTP API these sub-fetches 401, so the ACTIVE AGENTS, PENDING APPROVALS, and BUDGET STATUS sections render empty even with a valid operator key. This is the same defect class AAASM-4659 fixed for `audit`/`logs`/`export`, on a command path that fix did not cover.

The fix attaches `bearer_auth(key)` on those three requests when an API key is configured, mirroring the existing `fetch_admin_status` pattern. Health probes (`/api/v1/health`, `/healthz`) remain unauthenticated per the ticket's scope note. No auth is weakened; no tokens are logged.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4733](https://lightning-dust-mite.atlassian.net/browse/AAASM-4733)

## Testing

- [x] Unit tests added / updated

Added wiremock regression tests in `aa-cli/src/commands/status/client.rs`: each mock only matches when the `Authorization: Bearer` header is present, so a successful decode proves the header is sent for `list_agents` / `list_approvals` / `get_costs`, plus a no-key case confirming the fetches still work against a bypass-default gateway.

Verified locally (macOS): `cargo build -p aa-cli` clean, `cargo nextest run -p aa-cli` 812/812 pass, `cargo clippy -p aa-cli --all-targets -- -D warnings` clean, `cargo fmt -p aa-cli -- --check` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NafDDcehs2ez4Ax9kuWfi

[AAASM-4733]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ