### PR TITLE
[AAASM-4738] 🐛 (aa-proxy): Redact credentials in audit-log request target

### DIFF
--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -231,6 +231,24 @@ impl Interceptor {
         }
     }
 
+    /// Redact any credentials embedded in a request target (path + query
+    /// string) so it can be persisted in an audit record without leaking a
+    /// secret.
+    ///
+    /// The request target reaches the proxy audit JSONL verbatim, and a secret
+    /// can ride in a query parameter (`?key=…`, `?token=…`, a presigned
+    /// `?X-Amz-Signature=…`) just as it can in the body. It must therefore pass
+    /// through the same [`CredentialScanner`] as the body before being written
+    /// (AAASM-4738). When scanning is disabled (`with_scanner(None)`) there is
+    /// no scanner to consult and the target is returned unchanged, mirroring
+    /// the body path.
+    pub fn redact_target(&self, target: &str) -> String {
+        match self.scanner.as_ref() {
+            Some(scanner) => scanner.scan(target).redact(target),
+            None => target.to_owned(),
+        }
+    }
+
     /// Create a new `Interceptor` with default credential scanning enabled.
     pub fn new(event_tx: broadcast::Sender<PipelineEvent>) -> Self {
         Self {

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -1536,4 +1536,76 @@ mod tests {
             "trailing-dot cleartext request to an LLM host must be refused with 403, got: {buf:?}"
         );
     }
+
+    #[tokio::test]
+    async fn audit_entry_never_writes_raw_secret_in_request_target() {
+        // AAASM-4738 regression: a secret carried in the request target's query
+        // string (e.g. `?key=…`, `?token=…`, a presigned `?X-Amz-Signature=…`)
+        // must be redacted before it reaches the proxy audit JSONL, exactly as
+        // the body is. Previously `emit_audit_entry` stored `req.target`
+        // verbatim, leaking the secret in cleartext.
+        use crate::audit_jsonl::JsonlWriter;
+
+        // Synthetic AWS access key from AWS public documentation. Not real.
+        const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+        let dir = tempfile::tempdir().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let config = ProxyConfig {
+            bind_addr: ([127, 0, 0, 1], 0).into(),
+            ca_dir: dir.path().to_path_buf(),
+            cert_cache_capacity: 8,
+            llm_only: true,
+            mitm_hosts: Vec::new(),
+            denied_hosts: Vec::new(),
+            network_allowlist: Vec::new(),
+            skip_upstream_tls_verify: false,
+            credential_action: crate::config::CredentialAction::default(),
+            upstream_override: None,
+            gateway_endpoint: None,
+            mcp_fail_open: false,
+            allow_private_connect_targets: false,
+        };
+
+        let jsonl_path = dir.path().join("proxy-audit.jsonl");
+        let (audit_tx, rx) = mpsc::channel(4);
+        let writer = JsonlWriter::new(&jsonl_path, rx).await.expect("open jsonl writer");
+        let handle = tokio::spawn(writer.run());
+
+        let (event_tx, _event_rx) = broadcast::channel(8);
+        let server = ProxyServer::new_with_audit_sink(config, ca, event_tx, Some(audit_tx));
+
+        let req = HttpRequest {
+            method: "POST".into(),
+            target: format!("/v1/upload?X-Amz-Credential=demo&key={FAKE_AWS_ACCESS_KEY}"),
+            version: "HTTP/1.1".into(),
+            headers: Vec::new(),
+            body: Vec::new(),
+        };
+        // A clean body verdict — the secret rides only in the target, so this
+        // isolates target redaction from the already-covered body path.
+        let verdict = InterceptVerdict {
+            decision: VerdictDecision::Forward,
+            findings: Vec::new(),
+            redacted_body: None,
+        };
+        server
+            .emit_audit_entry("api.example.com", &req, &verdict, ProxyAuditDecision::Forwarded)
+            .await;
+
+        // Drop the last server reference so its audit sender closes and the
+        // writer task drains and exits.
+        drop(server);
+        handle.await.expect("writer task joins cleanly");
+
+        let on_disk = tokio::fs::read_to_string(&jsonl_path).await.expect("read JSONL");
+        assert!(
+            !on_disk.contains(FAKE_AWS_ACCESS_KEY),
+            "SECURITY INVARIANT VIOLATED: raw secret from request target present in proxy audit JSONL: {on_disk}",
+        );
+        assert!(
+            on_disk.contains("[REDACTED:AwsAccessKey]"),
+            "JSONL must carry the [REDACTED:AwsAccessKey] marker for the target secret, got: {on_disk}",
+        );
+    }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -311,7 +311,11 @@ impl ProxyServer {
             agent_id: None,
             host: host.to_owned(),
             method: req.method.clone(),
-            path: req.target.clone(),
+            // The target can carry a secret in its query string (`?key=…`,
+            // `?token=…`, a presigned `?X-Amz-Signature=…`), so it is redacted
+            // through the same scanner as the body before being persisted — the
+            // body-only redaction left target secrets in cleartext (AAASM-4738).
+            path: self.interceptor.redact_target(&req.target),
             decision,
             credential_findings: verdict.findings.clone(),
             redacted_body,


### PR DESCRIPTION
## Description

The proxy MitM data path redacted intercepted **request bodies** through the
`CredentialScanner` before persisting them, but wrote the **request target**
(`ProxyAuditEntry.path`) verbatim. A secret carried in a URL query parameter —
`?key=…`, `?token=…`, or a presigned `?X-Amz-Signature=…` — therefore landed in
the proxy audit JSONL in cleartext, defeating the whole point of the scanner on
that field.

This PR routes `req.target` through the **same** `CredentialScanner` used for the
body before building the `ProxyAuditEntry`, in `aa-proxy::proxy::emit_audit_entry`.
A new `Interceptor::redact_target` helper reuses the interceptor's existing scanner
(no second scanner constructed) and fails toward redaction — when scanning is
disabled the target is returned unchanged, mirroring the body path. Body redaction
is untouched.

Jira Ticket: https://lightning-dust-mite.atlassian.net/browse/AAASM-4738

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

No public wire/schema change — `ProxyAuditEntry.path` is now a redacted
projection of the target rather than the raw target.

## Related Issues

- Related Jira ticket: AAASM-4738
- Related GitHub issues: N/A

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Added `aa-proxy proxy::tests::audit_entry_never_writes_raw_secret_in_request_target`:
it drives `emit_audit_entry` with a **clean body** but an AWS access key in the
target's query string, then asserts the raw key is **absent** from — and the
`[REDACTED:AwsAccessKey]` marker **present** in — the JSONL written to disk. The
test fails against the pre-fix verbatim `req.target` and passes with the fix.

```
cargo nextest run -p aa-proxy audit_entry_never_writes_raw_secret_in_request_target
    PASS aa-proxy proxy::tests::audit_entry_never_writes_raw_secret_in_request_target
```

`cargo fmt --all --check` and `cargo clippy --all-targets --all-features -D warnings`
are clean (enforced by the pre-commit hook on every commit).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced

Fixes AAASM-4738
