### PR TITLE
[AAASM-4744] 🔒 (core): Close low-severity defense-in-depth gaps

### DIFF
--- a/aa-api/src/bin/aa-api-server.rs
+++ b/aa-api/src/bin/aa-api-server.rs
@@ -70,7 +70,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         LocalAuth::ApiKey { key } => {
             if generated {
-                eprintln!("aa-api: generated admin API key (set AASM_API_KEY to reuse): {key}");
+                // AAASM-4744: print only a short prefix of the generated key, not
+                // the full secret. Dumping a live admin credential to stderr/logs
+                // is a disclosure gap; the prefix lets an operator correlate the
+                // key in the banner below without leaking it. Set AASM_API_KEY to
+                // run with a known, reusable key.
+                eprintln!(
+                    "aa-api: generated a random admin API key {prefix}… (set AASM_API_KEY to use a known key)",
+                    prefix = &key[..key.len().min(6)]
+                );
             } else {
                 eprintln!("aa-api: using admin API key from AASM_API_KEY");
             }

--- a/aa-api/src/destinations/connectors/opsgenie.rs
+++ b/aa-api/src/destinations/connectors/opsgenie.rs
@@ -59,7 +59,11 @@ impl NotificationConnector for OpsGenieConnector {
             .json(&body)
             .send()
             .await
-            .map_err(|e| ConnectorError::Transport(e.to_string()))?;
+            // AAASM-4744: strip the request URL from the surfaced error. A
+            // reqwest error's Display embeds the URL; `without_url` keeps it out
+            // of the 502 body and logs, consistent with the caller-controlled
+            // connectors.
+            .map_err(|e| ConnectorError::Transport(e.without_url().to_string()))?;
         let status = resp.status().as_u16();
         let resp_body = resp.text().await.unwrap_or_default();
         let resp_body = truncate_body(resp_body);

--- a/aa-api/src/destinations/connectors/pagerduty.rs
+++ b/aa-api/src/destinations/connectors/pagerduty.rs
@@ -60,7 +60,11 @@ impl NotificationConnector for PagerDutyConnector {
             .json(&body)
             .send()
             .await
-            .map_err(|e| ConnectorError::Transport(e.to_string()))?;
+            // AAASM-4744: strip the request URL from the surfaced error. A
+            // reqwest error's Display embeds the URL; `without_url` keeps it out
+            // of the 502 body and logs, consistent with the caller-controlled
+            // connectors.
+            .map_err(|e| ConnectorError::Transport(e.without_url().to_string()))?;
         let status = resp.status().as_u16();
         let resp_body = resp.text().await.unwrap_or_default();
         let resp_body = truncate_body(resp_body);

--- a/aa-api/src/destinations/connectors/slack.rs
+++ b/aa-api/src/destinations/connectors/slack.rs
@@ -58,7 +58,11 @@ impl NotificationConnector for SlackConnector {
             .json(&body)
             .send()
             .await
-            .map_err(|e| ConnectorError::Transport(e.to_string()))?;
+            // AAASM-4744: the Slack `webhook_url` is caller-controlled and can
+            // carry a token in its path/query. A reqwest error's Display embeds
+            // the request URL, so `without_url` strips it before it reaches the
+            // 502 body or logs.
+            .map_err(|e| ConnectorError::Transport(e.without_url().to_string()))?;
         let status = resp.status().as_u16();
         // AAASM-3827: do NOT capture or reflect the upstream response body. The
         // Slack `webhook_url` is caller-controlled, so reflecting the origin's

--- a/aa-api/src/destinations/connectors/webhook.rs
+++ b/aa-api/src/destinations/connectors/webhook.rs
@@ -55,7 +55,11 @@ impl NotificationConnector for WebhookConnector {
         let resp = builder
             .send()
             .await
-            .map_err(|e| ConnectorError::Transport(e.to_string()))?;
+            // AAASM-4744: strip the destination URL from the surfaced error. A
+            // reqwest error's Display embeds the request URL, which for a
+            // caller-controlled webhook can carry a query token; `without_url`
+            // drops it so the token never lands in the 502 body or logs.
+            .map_err(|e| ConnectorError::Transport(e.without_url().to_string()))?;
         let status = resp.status().as_u16();
         // AAASM-3789: do NOT capture or return the upstream response body. A
         // webhook test-fire must not reflect origin/internal response content

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -65,6 +65,16 @@ pub fn build_app_with_spa(state: AppState, spa_dist: Option<&std::path::Path>) -
             // to the SPA catch-all below and returns HTML instead of the health
             // JSON. Registered before the `.merge`d SPA fallback so it wins.
             .route("/health", get(routes::health::health))
+            // `/livez` + `/readyz` (AAASM-4744): Kubernetes-style liveness /
+            // readiness probe paths. Without explicit routes they fall through
+            // to the SPA catch-all below and return `200 index.html`, so an
+            // orchestrator reads the app as healthy regardless of subsystem
+            // state. Alias them to the same health handler (which returns 503
+            // when any subsystem is degraded) so a probe gets a correct status,
+            // not the SPA shell. Registered before the merged SPA fallback so
+            // they win.
+            .route("/livez", get(routes::health::health))
+            .route("/readyz", get(routes::health::health))
             .nest("/api/v1", routes::v1_router().fallback(routes::fallback_404))
             .merge(aa_gateway::dashboard_server::dashboard_router(dist))
             .with_state(()),

--- a/aa-api/tests/serve_local_spa.rs
+++ b/aa-api/tests/serve_local_spa.rs
@@ -81,6 +81,25 @@ async fn health_alias_serves_json_not_spa_html() {
 }
 
 #[tokio::test]
+async fn livez_and_readyz_serve_json_not_spa_html() {
+    // AAASM-4744: `/livez` and `/readyz` (K8s-style probe paths) must return the
+    // health JSON, not fall through to the SPA catch-all and answer 200 HTML —
+    // which would report the app healthy regardless of subsystem state.
+    let dist = fake_dist();
+    for path in ["/livez", "/readyz"] {
+        let (status, content_type, body) = response_with_content_type(local_app_with_spa(dist.path()), path).await;
+        assert_eq!(status, StatusCode::OK, "{path} must return 200");
+        assert!(
+            content_type.starts_with("application/json"),
+            "{path} must serve health JSON, not SPA HTML; got content-type {content_type:?}"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("probe returns JSON");
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["api_version"], "v1");
+    }
+}
+
+#[tokio::test]
 async fn api_health_is_served_alongside_spa() {
     let dist = fake_dist();
     let (status, body) = response_to(local_app_with_spa(dist.path()), "/api/v1/health").await;

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -224,8 +224,14 @@ impl FileIoLoader {
                         if buf.len() < core::mem::size_of::<FileIoEventRaw>() {
                             continue;
                         }
-                        let raw = unsafe { &*(buf.as_ptr() as *const FileIoEventRaw) };
-                        match FileIoEvent::from_raw(raw) {
+                        // AAASM-4744: the perf buffer is a `BytesMut` whose
+                        // backing allocation carries no alignment guarantee, so
+                        // forming a `&FileIoEventRaw` to `buf.as_ptr()` is UB when
+                        // the pointer is under-aligned. Copy the bytes out through
+                        // an unaligned read into an owned, properly-aligned value
+                        // (the technique `ringbuf::bytes_to` uses) and borrow that.
+                        let raw = unsafe { core::ptr::read_unaligned(buf.as_ptr() as *const FileIoEventRaw) };
+                        match FileIoEvent::from_raw(&raw) {
                             Ok(event) => {
                                 let _ = tx.send(event).await;
                             }

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -256,6 +256,29 @@ mod tests {
     }
 
     #[test]
+    fn partial_custom_table_prices_omitted_model_via_fallback_not_zero() {
+        // AAASM-4744: an override JSON that redefines only OpenAI models leaves
+        // Cohere's CommandRPlus in place via the merged defaults, but a *removed*
+        // pair would fall through. Prove the fail-closed path: a pair the table
+        // does not know is priced via the costliest-known fallback, never $0, so
+        // a partial custom table cannot silently zero-price and bypass the cap.
+        use crate::budget::types::{Model, Provider};
+        fn d(s: &str) -> rust_decimal::Decimal {
+            s.parse().unwrap()
+        }
+        let json = r#"[
+          { "provider": "open_ai", "model": "gpt4o",
+            "input_per_1k_usd": "0.001", "output_per_1k_usd": "0.002" }
+        ]"#;
+        let table = PricingTable::load_from_json_str(json).unwrap();
+        // A pair absent from the table (Cohere CommandR + wrong provider mix).
+        let cost = table.cost_usd(Provider::Anthropic, Model::CommandR, 10_000, 0);
+        assert_ne!(cost, rust_decimal::Decimal::ZERO, "omitted model must not price to $0");
+        assert_eq!(cost, table.fallback_cost_usd(10_000, 0));
+        assert_eq!(cost, d("0.15"), "priced at the Opus fallback input rate");
+    }
+
+    #[test]
     fn load_from_file_falls_back_to_defaults_on_missing_file() {
         let path = std::path::Path::new("/nonexistent/path/pricing.json");
         let table = PricingTable::load_from_file(path);

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -111,7 +111,14 @@ impl PricingTable {
         }
     }
 
-    /// Compute USD cost for a completed LLM call. Returns `Decimal::ZERO` for unknown pairs.
+    /// Compute USD cost for a completed LLM call.
+    ///
+    /// Fail-closed (AAASM-4744): a `(provider, model)` pair absent from the table
+    /// is priced through [`fallback_cost_usd`](Self::fallback_cost_usd) at the
+    /// costliest-known rate, never `$0`. A partial custom pricing table (an
+    /// override JSON that lists only some models) must not silently zero-price
+    /// the models it omits — a `$0` cost would trip the `cost <= 0` accrual
+    /// short-circuit in the gateway and bypass the budget cap entirely.
     pub fn cost_usd(
         &self,
         provider: crate::budget::types::Provider,
@@ -125,7 +132,7 @@ impl PricingTable {
                 let output_cost = entry.output_per_1k_usd * Decimal::from(output_tokens) / Decimal::from(1_000u64);
                 input_cost + output_cost
             }
-            None => Decimal::ZERO,
+            None => self.fallback_cost_usd(input_tokens, output_tokens),
         }
     }
 
@@ -206,13 +213,22 @@ mod tests {
     }
 
     #[test]
-    fn cost_usd_unknown_pair_returns_zero() {
+    fn cost_usd_unknown_pair_prices_via_fail_closed_fallback() {
         use crate::budget::types::{Model, Provider};
+        fn d(s: &str) -> rust_decimal::Decimal {
+            s.parse().unwrap()
+        }
         let table = PricingTable::default_table();
-        // Anthropic + CommandR is not a valid pair
+        // AAASM-4744: Anthropic + CommandR is not a tabled pair. It must price
+        // through the costliest-known fallback (Opus: $0.015 in + $0.075 out),
+        // never $0 — a zero cost would bypass the budget cap.
         assert_eq!(
             table.cost_usd(Provider::Anthropic, Model::CommandR, 1_000, 1_000),
-            rust_decimal::Decimal::ZERO,
+            d("0.09"),
+        );
+        assert_eq!(
+            table.cost_usd(Provider::Anthropic, Model::CommandR, 1_000, 1_000),
+            table.fallback_cost_usd(1_000, 1_000),
         );
     }
 

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -441,7 +441,15 @@ impl BudgetTracker {
         input_tokens: u64,
         output_tokens: u64,
     ) -> BudgetStatus {
-        let cost = self.pricing.cost_usd(provider, model, input_tokens, output_tokens);
+        // AAASM-4744 — clamp a non-positive computed cost to zero. A custom
+        // pricing override (JSON table) can carry a negative rate; the resulting
+        // cost would *decrement* accrued spend and reopen budget headroom, the
+        // same hazard `record_raw_spend` already clamps. Clamp here so both
+        // accrual entry points are fail-safe before folding into `record_cost`.
+        let cost = self
+            .pricing
+            .cost_usd(provider, model, input_tokens, output_tokens)
+            .max(Decimal::ZERO);
         self.record_cost(agent_id, team_id, org_id, cost)
     }
 

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -1126,6 +1126,36 @@ mod tests {
     }
 
     #[test]
+    fn record_usage_clamps_negative_custom_rate_to_zero() {
+        // AAASM-4744: a custom pricing override with a negative rate must not
+        // decrement accrued spend. record_usage clamps the computed cost to
+        // zero, so today's spend stays at zero rather than going negative.
+        let json = r#"[
+          { "provider": "open_ai", "model": "gpt4o",
+            "input_per_1k_usd": "-0.005", "output_per_1k_usd": "-0.015" }
+        ]"#;
+        let pricing = PricingTable::load_from_json_str(json).unwrap();
+        let t = BudgetTracker::new(pricing, None, None, chrono_tz::UTC);
+        let aid = agent(0xAB);
+        t.record_usage(
+            aid,
+            None,
+            None,
+            crate::budget::types::Provider::OpenAi,
+            crate::budget::types::Model::Gpt4o,
+            10_000,
+            10_000,
+        );
+        let history = t.agent_spend_history(&aid, 1);
+        assert_eq!(history.len(), 1);
+        assert_eq!(
+            history[0].1,
+            Decimal::ZERO,
+            "a negative custom rate must clamp to zero, never decrement spend"
+        );
+    }
+
+    #[test]
     fn agent_spend_history_zero_days_returns_empty_vec() {
         let t = new_tracker();
         let aid = AgentId::from_bytes([0xAA; 16]);

--- a/aa-gateway/src/remote_mode/server.rs
+++ b/aa-gateway/src/remote_mode/server.rs
@@ -8,6 +8,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use aa_auth::config::AuthMode;
 use aa_core::config::RemoteModeConfig;
 use axum::{routing::get, Extension, Router};
 use axum_server::tls_rustls::RustlsConfig;
@@ -31,23 +32,49 @@ use crate::storage::{open_postgres_backend, PostgresConfig, StorageBackend};
 /// `HealthzState`'s `"storage"` label tracks the chosen backend so the
 /// minimal `/healthz` body still surfaces `"memory"` vs `"postgres"`
 /// without requiring a backend round-trip.
-pub fn router(storage: Option<Arc<dyn StorageBackend>>, database_url: Option<String>) -> Router {
+///
+/// AAASM-4744 — fail-closed admin-status guard. `/api/v1/admin/status`
+/// discloses backend detail (database host, sqlite path, row counts) and in
+/// BYPASS-DEFAULT mode answers with no credential. That is acceptable on
+/// loopback (the zero-config `aasm status` contract), but exposing it to an
+/// off-loopback caller with no auth is a disclosure gap. `listen_addr` is
+/// consulted so the route is **omitted** when the gateway is bound off-loopback
+/// in bypass mode; the operator is told to enable auth to expose it.
+pub fn router(
+    storage: Option<Arc<dyn StorageBackend>>,
+    database_url: Option<String>,
+    listen_addr: SocketAddr,
+) -> Router {
     let storage_label = if storage.is_some() { "postgres" } else { "memory" };
     let healthz_state = HealthzState::new("remote", storage_label);
     let mut app = Router::new()
         .route("/healthz", get(healthz))
         .layer(Extension(healthz_state));
-    if let Some(backend) = storage {
-        let admin_state = AdminStatusState::new("remote", backend, None, database_url);
-        app = app
-            .route("/api/v1/admin/status", get(admin_status))
-            .layer(Extension(admin_state));
-    }
     // AAASM-3908: layer the four `aa-auth` extensions so the `RequireAdmin`
     // guard on `/api/v1/admin/status` can resolve. BYPASS-DEFAULT — with no
     // auth env set this builds an `AuthMode::Off` config so a bare gateway keeps
     // answering `aasm status` with no credential (AAASM-1591).
-    AuthExtensions::from_env().apply(app)
+    let auth = AuthExtensions::from_env();
+    if let Some(backend) = storage {
+        // Fail-closed (AAASM-4744): in bypass mode the admin endpoint is only
+        // exposed on loopback. Bound off-loopback with no auth, it would leak
+        // backend detail to any reachable caller — refuse to mount it and point
+        // the operator at the auth opt-in instead.
+        let bypass = auth.config.mode == AuthMode::Off;
+        if bypass && !listen_addr.ip().is_loopback() {
+            tracing::warn!(
+                addr = %listen_addr,
+                "not exposing /api/v1/admin/status: bound off-loopback with auth disabled. \
+                 Set AA_GATEWAY_AUTH=on (with AA_JWT_SECRET) to enable the admin endpoint"
+            );
+        } else {
+            let admin_state = AdminStatusState::new("remote", backend, None, database_url);
+            app = app
+                .route("/api/v1/admin/status", get(admin_status))
+                .layer(Extension(admin_state));
+        }
+    }
+    auth.apply(app)
 }
 
 /// Print the operator-facing startup banner via `tracing::info!`.
@@ -157,7 +184,7 @@ pub async fn start_remote_with_handle(cfg: &RemoteModeConfig, handle: Handle<Soc
         None
     };
 
-    let app = router(storage, cfg.database_url.clone()).into_make_service();
+    let app = router(storage, cfg.database_url.clone(), cfg.listen_addr).into_make_service();
 
     if let Some(tls_cfg) = &cfg.tls {
         // Pre-flight cert + key (existence, readability, PEM parse, expiry).
@@ -194,5 +221,71 @@ pub async fn start_remote_with_handle(cfg: &RemoteModeConfig, handle: Handle<Soc
             .serve(app)
             .await
             .map_err(GatewayError::Serve)
+    }
+}
+
+/// AAASM-4744 — the fail-closed guard on `/api/v1/admin/status`: in bypass mode
+/// the endpoint is exposed on loopback (the zero-config `aasm status` contract)
+/// but withheld off-loopback so its backend detail can't leak to an
+/// unauthenticated remote caller.
+#[cfg(test)]
+mod admin_status_bind_guard_tests {
+    use super::*;
+    use crate::storage::{SqliteBackend, SqliteConfig};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    /// Open a real SQLite-backed `StorageBackend` under a per-test tempdir.
+    async fn sqlite_backend() -> (tempfile::TempDir, Arc<dyn StorageBackend>) {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let backend = SqliteBackend::open(&SqliteConfig {
+            path: tmp.path().join("local.db"),
+        })
+        .await
+        .expect("open sqlite backend");
+        backend.migrate().await.expect("migrate");
+        (tmp, Arc::new(backend))
+    }
+
+    /// Ensure no auth opt-in leaks in from the ambient environment so the router
+    /// resolves to bypass (`AuthMode::Off`) — the posture under test.
+    fn clear_auth_env() {
+        std::env::remove_var("AA_GATEWAY_AUTH");
+        std::env::remove_var("AA_JWT_SECRET");
+    }
+
+    async fn admin_status_code(bind: &str) -> StatusCode {
+        let (_tmp, backend) = sqlite_backend().await;
+        let app = router(Some(backend), None, bind.parse().expect("listen_addr"));
+        app.oneshot(
+            Request::builder()
+                .uri("/api/v1/admin/status")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("oneshot")
+        .status()
+    }
+
+    #[tokio::test]
+    async fn bypass_on_loopback_exposes_admin_status() {
+        clear_auth_env();
+        assert_eq!(
+            admin_status_code("127.0.0.1:0").await,
+            StatusCode::OK,
+            "loopback bypass must keep /admin/status reachable (zero-config contract)"
+        );
+    }
+
+    #[tokio::test]
+    async fn bypass_off_loopback_withholds_admin_status() {
+        clear_auth_env();
+        assert_eq!(
+            admin_status_code("0.0.0.0:0").await,
+            StatusCode::NOT_FOUND,
+            "off-loopback bypass must not expose /admin/status without auth"
+        );
     }
 }

--- a/aa-gateway/tests/admin_status_e2e.rs
+++ b/aa-gateway/tests/admin_status_e2e.rs
@@ -36,6 +36,8 @@ async fn admin_status_returns_documented_storage_block_through_router() {
     let app = aa_gateway::remote_mode::router(
         Some(backend),
         Some("postgresql://aasm:secret@db.internal:5432/aasm".to_string()),
+        // Loopback bind: bypass-mode admin status stays mounted (AAASM-4744).
+        "127.0.0.1:0".parse().expect("listen_addr"),
     )
     .into_make_service();
 

--- a/aa-gateway/tests/remote_mode_e2e.rs
+++ b/aa-gateway/tests/remote_mode_e2e.rs
@@ -51,7 +51,7 @@ fn build_test_app(store: AgentStore) -> Router {
     // No storage handle in this test — exercises the /healthz-only
     // remote_mode router path (AAASM-1908 added /api/v1/admin/status
     // only when a backend is wired).
-    aa_gateway::remote_mode::router(None, None).merge(agents)
+    aa_gateway::remote_mode::router(None, None, "127.0.0.1:0".parse().expect("listen_addr")).merge(agents)
 }
 
 /// AAASM-1577 AC #5/#6 — bind the merged production+placeholder router

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -1324,9 +1324,29 @@ mod runtime_bypass {
         let outcome_without = scanner.enforce(&mut without_preflight);
         let outcome_with = scanner.enforce(&mut with_preflight);
 
+        // The *authoritative* outcome — the security decision the runtime commits
+        // to — must be identical whether or not the SDK forged a preflight label:
+        // the same secret is found, redacted identically, and neither event is
+        // clean. AAASM-4744 additionally scans label *values* for secrets, so the
+        // raw `scanned_bytes` work counter is deliberately excluded from the
+        // authoritative comparison here: the forged event carries an extra label
+        // value, so the runtime does strictly MORE scan work on it, never less.
         assert_eq!(
-            outcome_without, outcome_with,
-            "the authoritative outcome must be identical with and without preflight"
+            outcome_without.findings, outcome_with.findings,
+            "the same secret must be found and redacted identically either way"
+        );
+        assert_eq!(
+            outcome_without.oversized_fields, outcome_with.oversized_fields,
+            "the oversized-field verdict must not depend on the forged label"
+        );
+        assert_eq!(
+            outcome_without.forged_trust_markers, outcome_with.forged_trust_markers,
+            "an ordinary advisory label is not a trust marker; neither event strips one"
+        );
+        assert_eq!(
+            outcome_without.is_clean(),
+            outcome_with.is_clean(),
+            "the authoritative clean/dirty verdict must not depend on the forged label"
         );
         assert_eq!(
             tool_args_text(&without_preflight),
@@ -1334,5 +1354,14 @@ mod runtime_bypass {
             "the redacted bytes must be identical either way"
         );
         assert!(!outcome_without.is_clean(), "the secret is caught in both cases");
+        // The only divergence is the observability counter: scanning the forged
+        // label's value adds exactly its byte length to the work total. A forged
+        // preflight label can therefore only lengthen — never shorten — the
+        // authoritative scan, which is itself the fail-safe invariant.
+        assert_eq!(
+            outcome_with.scanned_bytes,
+            outcome_without.scanned_bytes + "clean".len(),
+            "the forged label only adds scan work equal to its value length"
+        );
     }
 }

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -718,6 +718,27 @@ mod tests {
     }
 
     #[test]
+    fn secret_in_label_value_is_redacted() {
+        // AAASM-4744: a secret smuggled into a label value must be redacted,
+        // just like one in a detail field — the SDK controls the label map.
+        let scanner = RuntimeScanner::new();
+        let mut event = event_with_labels(&[("team", "payments"), ("note", &format!("key={AWS_KEY}"))]);
+
+        let outcome = scanner.enforce(&mut event);
+
+        let note = event.inner.labels.get("note").expect("note label present");
+        assert!(!note.contains(AWS_KEY), "raw secret must not survive in a label value");
+        assert!(note.contains("[REDACTED:"), "label value carries the redaction marker");
+        assert_eq!(
+            event.inner.labels.get("team").map(String::as_str),
+            Some("payments"),
+            "a clean label value is left untouched"
+        );
+        assert!(!outcome.is_clean());
+        assert_eq!(outcome.findings.len(), 1);
+    }
+
+    #[test]
     fn no_trust_markers_leaves_outcome_unflagged() {
         let scanner = RuntimeScanner::new();
         let mut event = event_with_labels(&[("team", "payments")]);

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -179,11 +179,26 @@ impl RuntimeScanner {
         let started = Instant::now();
         let mut outcome = EnforcementOutcome::default();
         strip_trust_markers(&mut event.inner.labels, &mut outcome);
+        self.scan_labels(&mut event.inner.labels, &mut outcome);
         if let Some(detail) = event.inner.detail.as_mut() {
             self.scan_detail(detail, &mut outcome);
         }
         emit_metrics(&outcome, started.elapsed());
         outcome
+    }
+
+    /// Scan and redact every surviving label *value* in place (AAASM-4744).
+    ///
+    /// `labels` is an SDK-supplied map, so a secret can ride in a label value
+    /// exactly as it can in a detail field. Trust-marker keys are already
+    /// stripped by [`strip_trust_markers`] before this runs; every remaining
+    /// value is passed through the same [`scan_string`](Self::scan_string) path
+    /// (size cap + credential scan + redaction) so a leaked secret is redacted,
+    /// not forwarded. Keys are identifiers and are left untouched.
+    fn scan_labels(&self, labels: &mut std::collections::HashMap<String, String>, outcome: &mut EnforcementOutcome) {
+        for value in labels.values_mut() {
+            self.scan_string(value, outcome);
+        }
     }
 
     /// Scan and redact the allowlisted secret-bearing fields of `detail`.


### PR DESCRIPTION
## Description

Closes the seven independent LOW-severity defense-in-depth gaps bundled under
AAASM-4744. Each item is its own atomic commit (plus a test commit where
testable). No behaviour change beyond the specific hardening described per item.

Jira: https://lightning-dust-mite.atlassian.net/browse/AAASM-4744

### Sub-items (all fixed)

1. **`budget/pricing.rs` — untabled model no longer prices to `$0`.** `cost_usd`'s
   `None` arm now routes through the fail-closed `fallback_cost_usd` (costliest-
   known rate), so a partial custom pricing table can't silently zero-price an
   omitted model and bypass the budget cap. Also clamps a non-positive computed
   cost in `record_usage` (mirrors the existing `record_raw_spend` clamp) so a
   negative custom rate can't decrement accrued spend. **Fixed.**
2. **`remote_mode/server.rs` + `auth.rs` — admin status withheld off-loopback in
   bypass mode.** `GET /api/v1/admin/status` discloses backend detail and, in the
   `AuthMode::Off` zero-config default, answers with no credential. `listen_addr`
   is now threaded into `router()`; in bypass mode the route is mounted only on a
   loopback bind (preserving the zero-config `aasm status` contract) and withheld
   off-loopback with a warning pointing at the auth opt-in. **Fixed.**
3. **`aa-runtime/pipeline/enforcement.rs` — label values are now scanned.**
   `enforce()` scanned the event detail but left agent-supplied `labels` values
   unscanned; they now pass through the same scan/redact path, so a secret in a
   label value is redacted. **Fixed.**
4. **`aa-api/bin/aa-api-server.rs` — generated admin key no longer printed in
   full.** The self-generated key was `eprintln`'d whole; now only a 6-char
   prefix is printed (matching the from-env banner). Operators set `AASM_API_KEY`
   for a known, reusable key. **Fixed.**
5. **connectors (webhook/slack/pagerduty/opsgenie) — request URL stripped from
   surfaced transport errors.** `ConnectorError::Transport(e.to_string())` could
   embed a caller-controlled destination URL (with a query token); now uses
   `reqwest::Error::without_url()` before `to_string()`. **Fixed.**
6. **`aa-ebpf/src/loader.rs` — unaligned read fixed.** The perf-buffer path cast a
   possibly-unaligned `BytesMut` pointer to `*const FileIoEventRaw` and formed a
   reference to it (UB). Replaced with `ptr::read_unaligned` into an owned,
   aligned value (the technique `ringbuf::bytes_to` already uses). File-disjoint
   from AAASM-4739. **Fixed.**
7. **`aa-api/src/server.rs` — real `/livez` and `/readyz` handlers.** Both paths
   fell through to the SPA catch-all and returned `200 index.html`; they now alias
   the health handler, so a probe gets the real health JSON (and `503` on
   degradation) instead of the SPA shell. **Fixed.**

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change _(security hardening; no config change)_

## Breaking Changes

- [x] No

`remote_mode::router()` gained a `listen_addr` parameter (item 2) — an internal
API used by two in-repo e2e tests, both updated in the same commit. No public
wire/behaviour change on loopback (the zero-config `aasm status` contract is
preserved).

## Related Issues

- Related Jira ticket: AAASM-4744
- Fixes AAASM-4744

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Verified with `cargo check` / `cargo clippy --all-features -- -D warnings` (0
errors) on the impacted crates and targeted `cargo nextest` runs for the new
tests (all green):

- `budget::pricing::tests::cost_usd_unknown_pair_prices_via_fail_closed_fallback`
- `budget::pricing::tests::partial_custom_table_prices_omitted_model_via_fallback_not_zero`
- `budget::tracker::tests::record_usage_clamps_negative_custom_rate_to_zero`
- `remote_mode::server::admin_status_bind_guard_tests::{bypass_on_loopback_exposes_admin_status, bypass_off_loopback_withholds_admin_status}`
- `pipeline::enforcement::tests::secret_in_label_value_is_redacted`
- `aa-api::serve_local_spa::livez_and_readyz_serve_json_not_spa_html`

Item 6 (eBPF) is Linux-only; type-checked against `x86_64-unknown-linux-gnu`
(the only remaining errors are the pre-existing missing-BPF-artifact
`include_bytes_aligned!` reads, unrelated to this change). Item 4 is a bin
`main` startup print with no unit-test surface. The existing `admin_status_e2e`,
`remote_mode_e2e`, and `remote_mode_http` suites still pass after the `router()`
signature change.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed _(why-comments added at each site)_
- [ ] All CI checks passing _(org CI is billing-blocked intermittently; validated locally)_
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMnPRm9T3fdrS4uNYXkzg6
