### PR TITLE
[AAASM-4732] 📝 (docs): Normalize branch scheme to four-part

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -75,8 +75,9 @@ cargo doc --workspace --no-deps        # checked on push by hooks
 
 - **Commits:** `<emoji> (<scope>): <imperative summary>` (gitmoji.dev). One logical
   unit per commit; bisectable. Utils/mocks/tests are separate preceding commits.
-- **Branch:** `<release-or-phase>/<ticket>/<short_summary>`
-  (e.g. `v0.0.1/AAASM-42/add_agent_registry`).
+- **Branch:** `<release-or-phase>/<ticket>/<type>/<short_summary>`
+  (`<type>` = feat/fix/refactor/test/docs/config/deps/remove/lint;
+  e.g. `v0.0.1/AAASM-42/feat/add_agent_registry`).
 - **PR title:** `[<ticket>] <emoji> (<scope>): <summary>`; base branch **always
   `master`**; body follows the repo PR template; ≥1 Pioneer-team approval.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,22 +51,35 @@ on; the faster linker is opt-in.
 
 ## Branch Naming
 
-Use the three-part format:
+Use the four-part format:
 
 ```
-<release-or-phase>/<ticket>/<short_summary>
+<release-or-phase>/<ticket>/<type>/<short_summary>
 ```
 
 - `<release-or-phase>` — milestone or sprint identifier (e.g. `v0.0.1`, `phase1`).
 - `<ticket>` — the ticket reference (e.g. `AAASM-1`).
+- `<type>` — the change category (see table below).
 - `<short_summary>` — 2–4 words in `snake_case`.
 
-Example: `v0.0.1/AAASM-1/add_data_models`
+| `<type>` | When to use |
+|---|---|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `refactor` | Refactor with no behavior change |
+| `test` | Test-only change |
+| `docs` | Documentation change |
+| `config` | Configuration change |
+| `deps` | Dependency upgrade |
+| `remove` | Deletion or removal |
+| `lint` | Lint or type-error fix |
+
+Example: `v0.0.1/AAASM-42/feat/add_agent_registry`
 
 > **External contributors** — the `AAASM-NN` project tracker is private, so you
 > won't be able to mint a ticket. You don't need one: open a GitHub issue first
 > (or reference an existing one) and use your GitHub issue number in the
-> `<ticket>` slot (e.g. `v0.0.1/gh-123/add_data_models`), or `noticket` if
+> `<ticket>` slot (e.g. `v0.0.1/gh-123/feat/add_data_models`), or `noticket` if
 > there's no issue yet. A maintainer will create the tracking `AAASM-NN` ticket
 > and link it during review — a missing Jira reference will never block your PR.
 

--- a/docs/src/architecture/building.md
+++ b/docs/src/architecture/building.md
@@ -64,8 +64,9 @@ uncomment the block for your platform in
 
 ## Commit & branch conventions
 
-- **Branches:** `<version>/<ticket-number>/<short-summary>`, e.g.
-  `v0.0.1/AAASM-42/add_agent_registry`.
+- **Branches:** `<version>/<ticket-number>/<type>/<short-summary>` (`<type>` =
+  feat/fix/refactor/test/docs/config/deps/remove/lint), e.g.
+  `v0.0.1/AAASM-42/feat/add_agent_registry`.
 - **Commits:** Gitmoji-prefixed, `<emoji> (<scope>): <imperative summary>`, one
   logical unit per commit, bisectable. Example:
   `✨ (aa-core): Add AgentId newtype wrapper`.


### PR DESCRIPTION
## Description

Normalizes this repo's documented git branch-naming scheme to the org-wide
**four-part** format:

```
<release-or-phase>/<ticket>/<type>/<short_summary>
```

Several docs here were three-part (`<release-or-phase>/<ticket>/<short_summary>`),
missing the `<type>` segment. This adds `<type>`
(feat/fix/refactor/test/docs/config/deps/remove/lint) and a typed example
(`v0.0.1/AAASM-42/feat/add_agent_registry`) everywhere the scheme is documented.
This intentionally reverses an earlier three-part direction (including a
recently-merged change to `.claude/CLAUDE.md`) so all org repos converge on the
four-part convention.

Files changed (docs-only):
- `CONTRIBUTING.md` — Branch Naming section converted to four-part; adds a
  `<type>` category table and a typed example.
- `.claude/CLAUDE.md` — branch convention restored to four-part with typed example.
- `docs/src/architecture/building.md` — adds the `<type>` segment to the branch
  reference.

Historical `verification-reports/*.md` record actual past branch names (not the
scheme) and are intentionally left untouched.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4732](https://lightning-dust-mite.atlassian.net/browse/AAASM-4732)

## Testing

- [x] No tests required (docs-only change; pre-push `cargo doc` hook passed)

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NafDDcehs2ez4Ax9kuWfi


[AAASM-4732]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ