### PR TITLE
[AAASM-4762] 🔧 (ci): emit SBOM for published Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,6 +102,11 @@ jobs:
           file: aa-runtime/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          # AAASM-4762: generate + push an SBOM attestation alongside the image.
+          # Without this, buildx pushes provenance but `.SBOM == {}`, leaving
+          # consumers with no machine-readable inventory of the image's contents
+          # for vulnerability scanning / supply-chain audit.
+          sbom: true
           tags: |
             ghcr.io/ai-agent-assembly/aa-runtime:${{ github.ref_name }}
             ghcr.io/ai-agent-assembly/aa-runtime:latest
@@ -146,6 +151,11 @@ jobs:
           file: aa-gateway/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          # AAASM-4762: generate + push an SBOM attestation alongside the image.
+          # Without this, buildx pushes provenance but `.SBOM == {}`, leaving
+          # consumers with no machine-readable inventory of the image's contents
+          # for vulnerability scanning / supply-chain audit.
+          sbom: true
           tags: |
             ghcr.io/ai-agent-assembly/aa-gateway:${{ github.ref_name }}
             ghcr.io/ai-agent-assembly/aa-gateway:latest
@@ -321,6 +331,11 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
+          # AAASM-4762: generate + push an SBOM attestation alongside each
+          # published language image. Without this, buildx pushes provenance but
+          # `.SBOM == {}`, leaving consumers with no machine-readable inventory of
+          # the image's contents for vulnerability scanning / supply-chain audit.
+          sbom: true
           build-args: |
             SDK_VERSION=${{ steps.sdkver.outputs.version }}
           tags: |


### PR DESCRIPTION
## Description

The `docker/build-push-action` steps that publish to GHCR emitted provenance (buildx default `provenance=min`) but **no SBOM** — `.SBOM == {}` on all 5 published images (aa-runtime, aa-gateway, python, node, go). Consumers therefore had no machine-readable software inventory to feed vulnerability scanning / supply-chain audit.

This adds `sbom: true` to each of the three publishing invocations in `.github/workflows/docker.yml`:
- `publish-runtime` → aa-runtime
- `publish-gateway` → aa-gateway
- `publish-language-images` matrix → python / node / go

so buildx generates and pushes an SBOM attestation alongside each image. Provenance is left unchanged — this PR is scoped strictly to SBOM. The PR-validation (`push: false`) build steps are untouched.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4762](https://lightning-dust-mite.atlassian.net/browse/AAASM-4762)

## Testing

- [x] No tests required (explain why)

Workflow-YAML-only change. Validated locally: the file parses (`python -c "import yaml; yaml.safe_load(...)"` → OK, 6 jobs) and `sbom` is a supported `docker/build-push-action` input. Actions cannot run locally — the real SBOM emission is verified on the next image build in CI (`docker buildx imagetools inspect <image> --format '{{ json .SBOM }}'` should no longer be `{}` for each of the 5 published images).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (WHY comment added at each step)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NafDDcehs2ez4Ax9kuWfi


[AAASM-4762]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ