### PR TITLE
[AAASM-4759] ✨ (aa-gateway): add gRPC health endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
+ "tonic-health",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -740,7 +741,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -751,7 +752,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1805,7 +1806,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2629,7 +2630,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2843,7 +2844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4673,7 +4674,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5619,7 +5620,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6357,7 +6358,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6426,7 +6427,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6945,7 +6946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7326,10 +7327,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7351,7 +7352,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7626,6 +7627,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7805,6 +7807,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
+dependencies = [
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -9028,7 +9043,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,10 @@ metrics-util = "0.20"
 # Protobuf / gRPC
 prost = "0.14"
 tonic = { version = "0.14", features = ["transport"] }
+# Standard gRPC Health Checking Protocol (grpc.health.v1.Health) service so the
+# published gateway container is probeable by orchestrators/liveness checks
+# (AAASM-4759). Version-locked to tonic 0.14.
+tonic-health = "0.14"
 # HTTP / web
 axum = "0.8"
 hyper = "1"

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -50,6 +50,10 @@ subtle       = "2"
 similar      = "3"
 tokio-stream = { workspace = true }
 tonic        = { workspace = true }
+# Standard gRPC Health Checking Protocol service (grpc.health.v1.Health) so the
+# published gateway container answers `Health/Check` instead of Unimplemented,
+# making it probeable by orchestrators/liveness checks (AAASM-4759).
+tonic-health = { workspace = true }
 tracing      = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 reqwest      = { workspace = true, features = ["json", "rustls"] }

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -533,6 +533,43 @@ fn final_budget_save(tracker: &BudgetTracker, budget_path: &Path) {
     }
 }
 
+/// Build the standard gRPC Health Checking Protocol service
+/// (`grpc.health.v1.Health`) with every gateway service — and the overall
+/// server (`""`) — reported as `SERVING`.
+///
+/// AAASM-4759: the published `aa-gateway` container previously exposed no
+/// health endpoint, so `Health/Check` answered `Unimplemented` and
+/// orchestrators/liveness probes had nothing to call. This is registered
+/// **without** the credential interceptor (unlike every agent-plane service)
+/// so an unauthenticated probe can confirm liveness — the health protocol
+/// carries no sensitive data.
+///
+/// `health_reporter()` seeds the overall server (`""`) as `Serving`; we also
+/// advertise each registered service by name so a per-service `Check` returns
+/// `SERVING` rather than `NotFound`. The trait bound is spelled via
+/// `tonic_health::pb::health_server::Health` because `tonic_health::server`
+/// only re-exports the trait privately.
+async fn serving_health_service(
+) -> tonic_health::pb::health_server::HealthServer<impl tonic_health::pb::health_server::Health + use<>> {
+    let (reporter, health_service) = tonic_health::server::health_reporter();
+    reporter.set_serving::<PolicyServiceServer<PolicyServiceImpl>>().await;
+    reporter.set_serving::<AuditServiceServer<AuditServiceImpl>>().await;
+    reporter
+        .set_serving::<AgentLifecycleServiceServer<AgentLifecycleServiceImpl>>()
+        .await;
+    reporter
+        .set_serving::<ApprovalServiceServer<ApprovalServiceImpl>>()
+        .await;
+    reporter
+        .set_serving::<TopologyServiceServer<TopologyServiceImpl>>()
+        .await;
+    reporter.set_serving::<SecretsServiceServer<SecretsServiceImpl>>().await;
+    reporter
+        .set_serving::<InvalidationServiceServer<InvalidationServiceImpl>>()
+        .await;
+    health_service
+}
+
 /// Start the gRPC server on a TCP address.
 ///
 /// Loads the policy from `policy_path`, wraps it in a `PolicyServiceImpl`, and
@@ -650,6 +687,8 @@ pub async fn serve_tcp(
     tracing::info!(%addr, "starting gRPC server on TCP (per-RPC credential auth enforced)");
 
     Server::builder()
+        // AAASM-4759: unauthenticated liveness endpoint — see `serving_health_service`.
+        .add_service(serving_health_service().await)
         .add_service(InterceptedService::new(
             PolicyServiceServer::new(policy_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
             enrich.clone(),
@@ -793,6 +832,8 @@ pub async fn serve_uds(
     let incoming = tokio_stream::wrappers::UnixListenerStream::new(uds);
 
     Server::builder()
+        // AAASM-4759: unauthenticated liveness endpoint — see `serving_health_service`.
+        .add_service(serving_health_service().await)
         .add_service(InterceptedService::new(
             PolicyServiceServer::new(policy_svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
             enrich.clone(),

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -883,6 +883,66 @@ mod tests {
     use aa_core::{AgentContext, GovernanceAction, PolicyResult};
     use std::collections::BTreeMap;
 
+    /// AAASM-4759 — the gRPC Health Checking service must answer `Health/Check`
+    /// with `SERVING` (not `Unimplemented`) once the gateway is up, so
+    /// orchestrators/liveness probes can health-check the published container.
+    /// Exercises the real wire path: serve the same `serving_health_service()`
+    /// that `serve_tcp`/`serve_uds` register, then Check it with a gRPC client.
+    #[tokio::test]
+    async fn health_check_reports_serving() {
+        use tonic::server::NamedService;
+        use tonic_health::pb::health_check_response::ServingStatus;
+        use tonic_health::pb::health_client::HealthClient;
+        use tonic_health::pb::HealthCheckRequest;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(serving_health_service().await)
+                .serve_with_incoming_shutdown(incoming, async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        // Build the channel via aa-gateway's own tonic transport: tonic-health
+        // itself is compiled without the transport feature, so `HealthClient::
+        // connect` does not exist — construct the channel here and hand it in.
+        let channel = tonic::transport::Channel::from_shared(format!("http://{addr}"))
+            .unwrap()
+            .connect()
+            .await
+            .unwrap();
+        let mut client = HealthClient::new(channel);
+
+        // Overall server health ("") — what a k8s gRPC liveness probe checks.
+        let overall = client
+            .check(HealthCheckRequest { service: String::new() })
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(overall.status, ServingStatus::Serving as i32);
+
+        // A specific registered service resolves too (not NotFound).
+        let policy_name = <PolicyServiceServer<PolicyServiceImpl> as NamedService>::NAME;
+        let per_service = client
+            .check(HealthCheckRequest {
+                service: policy_name.to_string(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(per_service.status, ServingStatus::Serving as i32);
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
     fn new_tracker() -> Arc<BudgetTracker> {
         Arc::new(BudgetTracker::new(
             crate::budget::PricingTable::default_table(),


### PR DESCRIPTION
## Description

The published `aa-gateway` container exposed **no health endpoint** — `grpc.health.v1.Health/Check` returned `Unimplemented` and there was no HTTP health surface — so operators and orchestrators (k8s gRPC liveness/readiness probes, `grpcurl`, load balancers) had no way to health-check it.

This PR registers the standard **gRPC Health Checking Protocol** service (`grpc.health.v1.Health`) via `tonic-health` on the gateway's gRPC server, on **both** the TCP and UDS serve paths. `Health/Check` now returns `SERVING` for the overall server (empty service name `""`) and for each registered gateway service, once the gateway is up. The health service is registered **without** the per-RPC credential interceptor so an unauthenticated probe can confirm liveness (the health protocol carries no sensitive data).

Scope is limited to `aa-gateway/src/` (+ the `tonic-health` dependency). Docker/CI/examples are intentionally untouched — owned by other lanes.

> The **docs half** of AAASM-4759 (self-host docs referencing the GHCR image / container operation) is tracked and handled **separately** in the docs lane; this PR is the gateway-code half only.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature

## Breaking Changes

- [x] No

Purely additive — a new unauthenticated health service alongside the existing services; no existing RPC or wire behaviour changes.

## Related Issues

- Related Jira ticket: AAASM-4759 — https://lightning-dust-mite.atlassian.net/browse/AAASM-4759

## Testing

- [x] Unit tests added / updated

Added `server::tests::health_check_reports_serving`: serves the same `serving_health_service()` that `serve_tcp`/`serve_uds` register and drives it with a real gRPC `HealthClient` over TCP, asserting both the overall server (`""`) and a named service report `SERVING`.

Local validation (macOS, `protoc` 34.1):
- `cargo build -p aa-gateway` — green
- `cargo nextest run -p aa-gateway` — **1422 passed, 0 failed**
- `cargo clippy -p aa-gateway --all-targets --all-features -- -D warnings` — clean
- `cargo fmt -p aa-gateway -- --check` — clean
- `cargo deny check` (licenses/bans) — ok
- `cargo doc --workspace --no-deps` (pre-push gate) — ok

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed — docs half tracked separately (see above)
- [ ] All CI checks passing — org GitHub Actions is billing-blocked; validated locally
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NafDDcehs2ez4Ax9kuWfi
