### PR TITLE
[AAASM-4761] 📝 (release-docs-sync): sync docker base-image SDK pins each release

### DIFF
--- a/.claude/skills/release-docs-sync/SKILL.md
+++ b/.claude/skills/release-docs-sync/SKILL.md
@@ -111,6 +111,18 @@ The verifier (`scripts/check-docs-versions.sh X`) asserts every one of them.
 5. **`docs/release/vX.md`** — the per-tag release notes file. `release-tag-cut`
    owns creating this; confirm it exists for `X` (do not duplicate its work).
 
+6. **`docker/sdk-versions.json`** — the **single source of truth** for the SDK
+   release pinned into each governed language **base image** (`ghcr.io/…/{python,
+   node,go}`); `docker.yml` reads `.sdk.<lang>` and passes it as the `SDK_VERSION`
+   build-arg. Bump all three to the release's SDK versions for `X` (note the
+   per-ecosystem forms: python PEP 440 `0.0.1rc6`, node `0.0.1-rc.6`, go
+   `v0.0.1-rc.6`). **Forgetting this ships base images with a stale SDK** — the
+   AAASM-4761 drift, where the images stayed on `beta.5`/`beta.3` while the core
+   release was `rc.6`, so a developer building an agent `FROM` them got an old
+   (and, for python, enforcement-broken) SDK. Keep in step with
+   `docs/src/compatibility.md` row for `X`. *(Not yet gated by
+   `check-docs-versions.sh` — until it is, this is a manual can't-forget item.)*
+
 > `agent-assembly.toml.example` carries **no** version literal today — nothing to
 > bump there. Re-check with `grep -nE 'version|0\.0\.1' agent-assembly.toml.example`
 > in case that changes.


### PR DESCRIPTION
## _Target_
* ### Task summary:
    Follow-up to **AAASM-4761**: prevent the base-image SDK drift at its source. The python/node/go base images shipped a stale SDK (beta.5/beta.3 while core was rc.6) because the release process never bumped `docker/sdk-versions.json` — that file (the single source `docker.yml` reads as the `SDK_VERSION` build-arg) was absent from the `release-docs-sync` checklist.
* ### Task tickets:
    * Task ID: [AAASM-4761](https://lightning-dust-mite.atlassian.net/browse/AAASM-4761)
* ### Key point change:
    Adds `docker/sdk-versions.json` as item 6 of `release-docs-sync` Step 1 — bump `.sdk.{python,node,go}` to the release's SDK versions each release (with the per-ecosystem version forms), so base images never again ship a stale SDK.

## _Effecting Scope_
* Action Types:
    * [x] 📝 Documentation / release-process skill
* Scopes:
    * [x] 🚀 Building — release process (`.claude/skills/release-docs-sync`)
* Additional description:
    Skill/checklist only — no code, no runtime change. Notes the mechanical backstop `check-docs-versions.sh` doesn't yet gate this file (a manual can't-forget item until it does).

## _Description_
* `.claude/skills/release-docs-sync/SKILL.md` — new Step 1 item 6 documenting `docker/sdk-versions.json`, why it must move each release (the AAASM-4761 drift), and the per-ecosystem forms (python `0.0.1rc6`, node `0.0.1-rc.6`, go `v0.0.1-rc.6`).


[AAASM-4761]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ