### PR TITLE
[AAASM-4787] 🔒 (aa-gateway): Bind did:key agent_id to the possession-proof public_key

### DIFF
--- a/aa-gateway/src/registry/convert.rs
+++ b/aa-gateway/src/registry/convert.rs
@@ -216,4 +216,43 @@ mod tests {
         let id = proto_id("did:key:z0OIl");
         assert!(validate_proto_agent_id(&id).is_err());
     }
+
+    // ── did:key ↔ public_key binding (AAASM-4787) ────────────────────────────
+
+    /// Build a well-formed Ed25519 `did:key` that embeds `pubkey`.
+    fn ed25519_did_key(pubkey: &[u8; 32]) -> String {
+        let mut bytes = ED25519_PUB_MULTICODEC.to_vec();
+        bytes.extend_from_slice(pubkey);
+        format!("did:key:z{}", bs58::encode(bytes).into_string())
+    }
+
+    #[test]
+    fn binding_accepts_did_key_matching_public_key() {
+        let pubkey = [3u8; 32];
+        let did = ed25519_did_key(&pubkey);
+        assert_eq!(assert_did_key_binds_public_key(&did, &hex::encode(pubkey)), Ok(()));
+    }
+
+    #[test]
+    fn binding_rejects_did_key_not_matching_public_key() {
+        // did:key embeds one key; the caller supplies a different public_key.
+        let did = ed25519_did_key(&[3u8; 32]);
+        let other = hex::encode([9u8; 32]);
+        assert_eq!(
+            assert_did_key_binds_public_key(&did, &other),
+            Err(DidKeyBindingError::Mismatch)
+        );
+    }
+
+    #[test]
+    fn binding_rejects_non_ed25519_multicodec_did_key() {
+        // secp256k1-pub multicodec is code 0xe7 → varint [0xe7, 0x01].
+        let mut bytes = vec![0xe7, 0x01];
+        bytes.extend_from_slice(&[3u8; 32]);
+        let did = format!("did:key:z{}", bs58::encode(bytes).into_string());
+        assert!(matches!(
+            assert_did_key_binds_public_key(&did, &hex::encode([3u8; 32])),
+            Err(DidKeyBindingError::Malformed(_))
+        ));
+    }
 }

--- a/aa-gateway/src/registry/convert.rs
+++ b/aa-gateway/src/registry/convert.rs
@@ -59,6 +59,106 @@ fn validate_did_key(value: &str) -> Result<(), &'static str> {
     Ok(())
 }
 
+/// Multicodec varint prefix identifying an `ed25519-pub` key inside a `did:key`.
+///
+/// `did:key` encodes the key type as an unsigned-varint multicodec code ahead of
+/// the raw key bytes; `ed25519-pub` is code `0xed`, whose varint encoding is the
+/// two bytes `[0xed, 0x01]`.
+const ED25519_PUB_MULTICODEC: [u8; 2] = [0xed, 0x01];
+
+/// Why a `did:key` `agent_id` failed to bind to a separately-supplied
+/// `public_key` (AAASM-4787).
+///
+/// The variant drives the gRPC status the caller returns: a malformed or
+/// non-Ed25519 `did:key` (or a malformed `public_key`) is the caller's own input
+/// error (`InvalidArgument`), whereas a well-formed Ed25519 `did:key` whose
+/// embedded key simply differs from the supplied `public_key` is an
+/// identity-squatting attempt (`Unauthenticated`).
+#[derive(Debug, PartialEq, Eq)]
+pub enum DidKeyBindingError {
+    /// The `did:key` is not a base58btc Ed25519 `did:key`, or the supplied
+    /// `public_key` is not 32 bytes of hex.
+    Malformed(&'static str),
+    /// The `did:key`'s embedded Ed25519 key does not equal the supplied
+    /// `public_key` — the caller is presenting a DID whose key it does not hold.
+    Mismatch,
+}
+
+impl std::fmt::Display for DidKeyBindingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed(msg) => write!(f, "{msg}"),
+            Self::Mismatch => write!(
+                f,
+                "agent_id did:key embedded public key does not match the supplied public_key"
+            ),
+        }
+    }
+}
+
+/// Extract the raw 32-byte Ed25519 public key that a `did:key` `agent_id`
+/// cryptographically encodes.
+///
+/// A `did:key` is `did:key:z<base58btc(<multicodec-varint><key-bytes>)>`; for
+/// Ed25519 the multicodec is `ed25519-pub` (`[0xed, 0x01]`) followed by the 32
+/// raw public-key bytes. Returns the embedded key so `Register` /
+/// `RequestChallenge` can bind it to the separately-supplied `public_key`
+/// (AAASM-4787) — without that binding an attacker can present a victim's
+/// `did:key` alongside their own `public_key` plus a proof under their own key
+/// and squat the victim's identity.
+///
+/// Unlike [`validate_did_key`], this asserts the multicodec key type: it errors
+/// when the value is not a base58btc `did:key`, carries a non-Ed25519
+/// multicodec, or does not decode to exactly the 2-byte prefix plus 32 key bytes.
+pub fn did_key_ed25519_public_key(value: &str) -> Result<[u8; 32], &'static str> {
+    let multibase = value
+        .strip_prefix("did:key:")
+        .ok_or("agent_id is not a did:key DID (missing \"did:key:\" prefix)")?;
+
+    let encoded = multibase
+        .strip_prefix('z')
+        .ok_or("agent_id is not a valid did:key DID (expected base58btc \"z\" multibase prefix)")?;
+
+    let decoded = bs58::decode(encoded)
+        .into_vec()
+        .map_err(|_| "agent_id is not a valid did:key DID (multibase value is not valid base58btc)")?;
+
+    let key_bytes = decoded
+        .strip_prefix(&ED25519_PUB_MULTICODEC)
+        .ok_or("agent_id did:key is not an ed25519-pub multicodec key")?;
+
+    key_bytes
+        .try_into()
+        .map_err(|_| "agent_id did:key does not encode a 32-byte Ed25519 public key")
+}
+
+/// Assert that the Ed25519 key embedded in the `did:key` `agent_id` equals the
+/// separately-supplied `public_key_hex` (AAASM-4787).
+///
+/// This is the cryptographic binding that stops did:key identity squatting: the
+/// registration possession proof only proves the caller holds the private key
+/// for `public_key`, *not* that `public_key` is the key the `did:key` actually
+/// names. Both are supplied by the caller, so without this check an attacker can
+/// pair a victim's `did:key` with their own key pair. Callers map
+/// [`DidKeyBindingError::Malformed`] to `InvalidArgument` and
+/// [`DidKeyBindingError::Mismatch`] to `Unauthenticated`.
+pub fn assert_did_key_binds_public_key(agent_id: &str, public_key_hex: &str) -> Result<(), DidKeyBindingError> {
+    let embedded = did_key_ed25519_public_key(agent_id).map_err(DidKeyBindingError::Malformed)?;
+
+    let supplied =
+        hex::decode(public_key_hex).map_err(|_| DidKeyBindingError::Malformed("public_key is not valid hex"))?;
+    if supplied.len() != 32 {
+        return Err(DidKeyBindingError::Malformed(
+            "public_key must be 32 bytes (64 hex chars)",
+        ));
+    }
+
+    if embedded[..] != supplied[..] {
+        return Err(DidKeyBindingError::Mismatch);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -22,7 +22,9 @@ use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
 
 use crate::engine::PolicyEngine;
 use crate::events::publisher::agent_status_changed_to_envelope;
-use crate::registry::convert::{proto_agent_id_to_key, validate_proto_agent_id};
+use crate::registry::convert::{
+    assert_did_key_binds_public_key, proto_agent_id_to_key, validate_proto_agent_id, DidKeyBindingError,
+};
 use crate::registry::store::AgentRecord;
 use crate::registry::token::{generate_credential_token, validate_token};
 use crate::registry::{AgentRegistry, AgentStatus, LineageError, OrphanMode, RegistryError, SuspendReason};
@@ -216,6 +218,26 @@ fn authoritative_enforcement_mode(proto_value: i32) -> Option<aa_core::Enforceme
     }
 }
 
+/// Enforce the AAASM-4787 did:key ↔ public_key binding, mapping the outcome onto
+/// a gRPC status.
+///
+/// `agent_id` (a `did:key`) and `public_key` are both caller-supplied, and the
+/// possession proof only proves the caller holds `public_key` — not that it is
+/// the key the `did:key` names. Without this check an attacker can pair a
+/// victim's `did:key` with their own key pair and squat the victim's identity, so
+/// this must gate any path that issues or consumes a nonce for the pair. A
+/// non-Ed25519 or malformed `did:key`/`public_key` is `InvalidArgument`; a
+/// well-formed `did:key` whose embedded key differs from `public_key` is
+/// `Unauthenticated`.
+fn enforce_did_key_binding(agent_id: &str, public_key: &str) -> Result<(), Status> {
+    assert_did_key_binds_public_key(agent_id, public_key).map_err(|e| match e {
+        DidKeyBindingError::Malformed(msg) => Status::invalid_argument(msg),
+        DidKeyBindingError::Mismatch => {
+            Status::unauthenticated("agent_id did:key embedded public key does not match the supplied public_key")
+        }
+    })
+}
+
 fn verify_possession_proof(
     verifying_key: &ed25519_dalek::VerifyingKey,
     challenge: &[u8],
@@ -356,6 +378,11 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
         ed25519_dalek::VerifyingKey::from_bytes(&pk_array)
             .map_err(|_| Status::invalid_argument("invalid Ed25519 public key"))?;
 
+        // AAASM-4787: only ever issue a nonce for a did:key whose embedded
+        // Ed25519 key matches this public_key, so a caller cannot obtain a
+        // challenge for a victim's DID paired with its own key pair.
+        enforce_did_key_binding(&proto_id.agent_id, &req.public_key)?;
+
         let (nonce, expires_at_unix_ms) = self.challenges.issue(&proto_id.agent_id, &req.public_key).await?;
 
         tracing::debug!(agent_id = ?proto_id.agent_id, "registration challenge issued");
@@ -400,6 +427,14 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
                 .map_err(|_| Status::invalid_argument("public_key must be 32 bytes (64 hex chars)"))?,
         )
         .map_err(|_| Status::invalid_argument("invalid Ed25519 public key"))?;
+
+        // AAASM-4787: cryptographically bind the did:key agent_id to public_key
+        // BEFORE consuming the nonce / verifying the proof. The possession proof
+        // only proves the caller holds `public_key`; it says nothing about which
+        // key the did:key names. Without this, an attacker can present a victim's
+        // did:key together with their OWN public_key + a proof under their own
+        // key and squat/register the victim's DID.
+        enforce_did_key_binding(&proto_id.agent_id, &req.public_key)?;
 
         // AAASM-3591 / AAASM-3866: prove the caller actually HOLDS the private
         // key for `public_key` before minting a credential_token. Without this,

--- a/aa-gateway/tests/enforcement_mode_self_registration_test.rs
+++ b/aa-gateway/tests/enforcement_mode_self_registration_test.rs
@@ -27,25 +27,25 @@ use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decisi
 use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
 use aa_proto::assembly::policy::v1::{action_context::Action, ActionContext, CheckActionRequest, ToolCallContext};
-use ed25519_dalek::Signer;
 use tokio::net::TcpListener;
 use tonic::transport::{Channel, Server};
 
-/// Deterministic Ed25519 test key; its public half is used as the agent's
-/// `public_key` and the challenge is signed with the private half.
-fn test_signing_key() -> ed25519_dalek::SigningKey {
-    ed25519_dalek::SigningKey::from_bytes(&[42u8; 32])
+/// Deterministic Ed25519 test keypair. Register/RequestChallenge bind the
+/// `agent_id` did:key to `public_key` (AAASM-4787), so the did:key, the
+/// `public_key`, and the possession proof are all derived from one keypair.
+fn test_keypair() -> aa_sdk_client::AgentKeypair {
+    aa_sdk_client::AgentKeypair::derive("aaasm-enforce-selfreg-agent")
 }
 
 fn test_public_key_hex() -> String {
-    hex::encode(test_signing_key().verifying_key().as_bytes())
+    test_keypair().public_key_hex()
 }
 
 fn test_agent_id() -> ProtoAgentId {
     ProtoAgentId {
         org_id: "org-test".into(),
         team_id: "team-test".into(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+        agent_id: test_keypair().did_key(),
     }
 }
 
@@ -111,7 +111,7 @@ async fn register_with_challenge(
         .await
         .unwrap()
         .into_inner();
-    req.possession_proof = test_signing_key().sign(&challenge.nonce).to_bytes().to_vec();
+    req.possession_proof = test_keypair().sign(&challenge.nonce).to_vec();
     req.registration_nonce = challenge.nonce;
     client.register(req).await.unwrap().into_inner().credential_token
 }

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -19,29 +19,47 @@ use tonic::transport::{Channel, Server};
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-/// The deterministic test signing key whose public half is
-/// [`test_ed25519_public_key_hex`].
-fn test_signing_key() -> ed25519_dalek::SigningKey {
-    ed25519_dalek::SigningKey::from_bytes(&[42u8; 32])
+/// The deterministic test keypair. Register/RequestChallenge now bind the
+/// `agent_id` did:key to `public_key` (AAASM-4787) — rejecting a did:key that
+/// does not encode the same Ed25519 key as `public_key` — so the fixture derives
+/// the did:key, the `public_key`, and the possession proof from one keypair. The
+/// identity matches [`register_with_sdk_derived_did_key_is_accepted`] so both
+/// resolve to the same did:key.
+fn test_keypair() -> aa_sdk_client::AgentKeypair {
+    aa_sdk_client::AgentKeypair::derive("my-agent-001")
 }
 
-/// Generate a hex-encoded Ed25519 public key for testing.
+/// The fixture's hex-encoded Ed25519 public key — the same key its `agent_id`
+/// did:key encodes.
 fn test_ed25519_public_key_hex() -> String {
-    hex::encode(test_signing_key().verifying_key().as_bytes())
+    test_keypair().public_key_hex()
 }
 
 /// AAASM-3866: drive the two-step registration handshake against a live server.
 ///
 /// Requests a fresh server nonce for `req`'s `agent_id` + `public_key`, signs it
-/// with the test key, and submits Register with the nonce + proof. Any
-/// `possession_proof` / `registration_nonce` already set on `req` is overwritten
-/// — the server-issued nonce is authoritative. Negative cases where the server
-/// rejects the challenge itself (e.g. malformed key/id) surface that error.
+/// with the shared [`test_keypair`], and submits Register with the nonce + proof.
+/// Any `possession_proof` / `registration_nonce` already set on `req` is
+/// overwritten — the server-issued nonce is authoritative. Negative cases where
+/// the server rejects the challenge itself (e.g. malformed key/id) surface that
+/// error. Use [`register_with_challenge_as`] when a request carries a `public_key`
+/// other than the shared fixture's.
 async fn register_with_challenge(
     client: &mut AgentLifecycleServiceClient<Channel>,
+    req: RegisterRequest,
+) -> Result<tonic::Response<RegisterResponse>, tonic::Status> {
+    register_with_challenge_as(client, &test_keypair(), req).await
+}
+
+/// Like [`register_with_challenge`] but signs the possession proof with `kp` — for
+/// topology tests where each agent carries its own keypair so its `agent_id`
+/// did:key binds to its own `public_key` (AAASM-4787). `kp` must be the keypair
+/// whose `public_key` the request declares.
+async fn register_with_challenge_as(
+    client: &mut AgentLifecycleServiceClient<Channel>,
+    kp: &aa_sdk_client::AgentKeypair,
     mut req: RegisterRequest,
 ) -> Result<tonic::Response<RegisterResponse>, tonic::Status> {
-    use ed25519_dalek::Signer;
     let agent_id = req.agent_id.clone().expect("agent_id must be set for challenge");
     let public_key = req.public_key.clone();
     let challenge = client
@@ -51,7 +69,7 @@ async fn register_with_challenge(
         })
         .await?
         .into_inner();
-    req.possession_proof = test_signing_key().sign(&challenge.nonce).to_bytes().to_vec();
+    req.possession_proof = kp.sign(&challenge.nonce).to_vec();
     req.registration_nonce = challenge.nonce;
     client.register(req).await
 }
@@ -60,7 +78,7 @@ fn test_agent_id() -> ProtoAgentId {
     ProtoAgentId {
         org_id: "org-test".into(),
         team_id: "team-test".into(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+        agent_id: test_keypair().did_key(),
     }
 }
 
@@ -632,14 +650,17 @@ async fn register_echoes_parent_agent_id_and_team_id() {
         .await
         .unwrap();
 
-    // Register the parent first so the sub-agent can be accepted.
+    // Register the parent first so the sub-agent can be accepted. Each agent
+    // carries its own keypair so its did:key binds to its own public_key.
+    let parent_kp = aa_sdk_client::AgentKeypair::derive("echo-parent");
     let parent_id = ProtoAgentId {
         org_id: "org-echo".into(),
         team_id: "team-echo".into(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into(),
+        agent_id: parent_kp.did_key(),
     };
-    register_with_challenge(
+    register_with_challenge_as(
         &mut client,
+        &parent_kp,
         RegisterRequest {
             agent_id: Some(parent_id),
             name: "parent-agent".into(),
@@ -647,7 +668,7 @@ async fn register_echoes_parent_agent_id_and_team_id() {
             version: "1.0.0".into(),
             risk_tier: 0,
             tool_names: vec![],
-            public_key: test_ed25519_public_key_hex(),
+            public_key: parent_kp.public_key_hex(),
             metadata: Default::default(),
             ..Default::default()
         },
@@ -655,14 +676,16 @@ async fn register_echoes_parent_agent_id_and_team_id() {
     .await
     .unwrap();
 
+    let child_kp = aa_sdk_client::AgentKeypair::derive("echo-child");
     let agent_id = ProtoAgentId {
         org_id: "org-echo".into(),
         team_id: "team-echo".into(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T".into(),
+        agent_id: child_kp.did_key(),
     };
 
-    let reg_resp = register_with_challenge(
+    let reg_resp = register_with_challenge_as(
         &mut client,
+        &child_kp,
         RegisterRequest {
             agent_id: Some(agent_id),
             name: "echo-agent".into(),
@@ -670,9 +693,9 @@ async fn register_echoes_parent_agent_id_and_team_id() {
             version: "1.0.0".into(),
             risk_tier: 0,
             tool_names: vec![],
-            public_key: test_ed25519_public_key_hex(),
+            public_key: child_kp.public_key_hex(),
             metadata: Default::default(),
-            parent_agent_id: Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into()),
+            parent_agent_id: Some(parent_kp.did_key()),
             ..Default::default()
         },
     )
@@ -680,10 +703,7 @@ async fn register_echoes_parent_agent_id_and_team_id() {
     .unwrap()
     .into_inner();
 
-    assert_eq!(
-        reg_resp.parent_agent_id,
-        Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into())
-    );
+    assert_eq!(reg_resp.parent_agent_id, Some(parent_kp.did_key()));
     assert_eq!(reg_resp.team_id, Some("team-echo".into()));
     // root_agent_id must be echoed back — parent is root so root = parent's key
     assert!(reg_resp.root_agent_id.is_some());
@@ -700,7 +720,7 @@ async fn register_without_topology_returns_none_echo_fields() {
     let agent_id = ProtoAgentId {
         org_id: "org-no-topo".into(),
         team_id: String::new(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+        agent_id: test_keypair().did_key(),
     };
 
     let reg_resp = register_with_challenge(
@@ -737,7 +757,7 @@ async fn root_agent_id_for_root_agent_is_set_to_self() {
     let agent_proto_id = ProtoAgentId {
         org_id: "root-org".into(),
         team_id: "root-team".into(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+        agent_id: test_keypair().did_key(),
     };
     let expected_key = aa_gateway::registry::convert::proto_agent_id_to_key(&agent_proto_id);
 
@@ -777,15 +797,17 @@ async fn root_agent_id_chains_3_levels() {
     let org = "chain-org";
     let team = "chain-team";
 
-    // Register A (root).
+    // Register A (root). Each agent carries its own keypair (AAASM-4787).
+    let kp_a = aa_sdk_client::AgentKeypair::derive("chain-A");
     let proto_a = ProtoAgentId {
         org_id: org.into(),
         team_id: team.into(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into(),
+        agent_id: kp_a.did_key(),
     };
     let key_a = aa_gateway::registry::convert::proto_agent_id_to_key(&proto_a);
-    register_with_challenge(
+    register_with_challenge_as(
         &mut client,
+        &kp_a,
         RegisterRequest {
             agent_id: Some(proto_a),
             name: "A".into(),
@@ -793,7 +815,7 @@ async fn root_agent_id_chains_3_levels() {
             version: "1.0.0".into(),
             risk_tier: 0,
             tool_names: vec![],
-            public_key: test_ed25519_public_key_hex(),
+            public_key: kp_a.public_key_hex(),
             metadata: Default::default(),
             ..Default::default()
         },
@@ -802,13 +824,15 @@ async fn root_agent_id_chains_3_levels() {
     .unwrap();
 
     // Register B (parent = A).
+    let kp_b = aa_sdk_client::AgentKeypair::derive("chain-B");
     let proto_b = ProtoAgentId {
         org_id: org.into(),
         team_id: team.into(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T".into(),
+        agent_id: kp_b.did_key(),
     };
-    register_with_challenge(
+    register_with_challenge_as(
         &mut client,
+        &kp_b,
         RegisterRequest {
             agent_id: Some(proto_b),
             name: "B".into(),
@@ -816,9 +840,9 @@ async fn root_agent_id_chains_3_levels() {
             version: "1.0.0".into(),
             risk_tier: 0,
             tool_names: vec![],
-            public_key: test_ed25519_public_key_hex(),
+            public_key: kp_b.public_key_hex(),
             metadata: Default::default(),
-            parent_agent_id: Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into()),
+            parent_agent_id: Some(kp_a.did_key()),
             ..Default::default()
         },
     )
@@ -826,13 +850,15 @@ async fn root_agent_id_chains_3_levels() {
     .unwrap();
 
     // Register C (parent = B). C's root_agent_id must equal A's key.
+    let kp_c = aa_sdk_client::AgentKeypair::derive("chain-C");
     let proto_c = ProtoAgentId {
         org_id: org.into(),
         team_id: team.into(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD4T".into(),
+        agent_id: kp_c.did_key(),
     };
-    let resp_c = register_with_challenge(
+    let resp_c = register_with_challenge_as(
         &mut client,
+        &kp_c,
         RegisterRequest {
             agent_id: Some(proto_c),
             name: "C".into(),
@@ -840,9 +866,9 @@ async fn root_agent_id_chains_3_levels() {
             version: "1.0.0".into(),
             risk_tier: 0,
             tool_names: vec![],
-            public_key: test_ed25519_public_key_hex(),
+            public_key: kp_c.public_key_hex(),
             metadata: Default::default(),
-            parent_agent_id: Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T".into()),
+            parent_agent_id: Some(kp_b.did_key()),
             ..Default::default()
         },
     )
@@ -1033,7 +1059,7 @@ async fn root_agent_id_when_parent_unknown_returns_invalid_argument() {
             agent_id: Some(ProtoAgentId {
                 org_id: "unknown-org".into(),
                 team_id: "unknown-team".into(),
-                agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+                agent_id: test_keypair().did_key(),
             }),
             name: "orphan".into(),
             framework: "custom".into(),
@@ -1075,7 +1101,7 @@ async fn register_drops_client_supplied_weaker_enforcement_mode() {
     let proto_id = ProtoAgentId {
         org_id: "org-obs".into(),
         team_id: "team-obs".into(),
-        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+        agent_id: test_keypair().did_key(),
     };
 
     register_with_challenge(
@@ -1124,8 +1150,7 @@ async fn connect(addr: SocketAddr) -> AgentLifecycleServiceClient<Channel> {
 
 /// Sign `payload` with the test key and return the raw 64-byte proof.
 fn sign(payload: &[u8]) -> Vec<u8> {
-    use ed25519_dalek::Signer;
-    test_signing_key().sign(payload).to_bytes().to_vec()
+    test_keypair().sign(payload).to_vec()
 }
 
 #[tokio::test]
@@ -1269,7 +1294,7 @@ async fn untenanted_default_accepts_team_less_registration() {
             ProtoAgentId {
                 org_id: "org-untenanted".into(),
                 team_id: String::new(),
-                agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+                agent_id: test_keypair().did_key(),
             },
             "team-less-untenanted",
         ),
@@ -1293,7 +1318,7 @@ async fn tenanted_rejects_team_less_registration() {
             ProtoAgentId {
                 org_id: "org-tenanted".into(),
                 team_id: String::new(),
-                agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+                agent_id: test_keypair().did_key(),
             },
             "team-less-tenanted",
         ),
@@ -1320,7 +1345,7 @@ async fn tenanted_accepts_registration_with_team() {
             ProtoAgentId {
                 org_id: "org-tenanted".into(),
                 team_id: "team-alpha".into(),
-                agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
+                agent_id: test_keypair().did_key(),
             },
             "teamed-tenanted",
         ),


### PR DESCRIPTION
## Description

The gateway did not cryptographically bind a `did:key` `agent_id` to the possession-proof `public_key`. `validate_did_key` in `aa-gateway/src/registry/convert.rs` only checked that `agent_id` was a syntactically-valid base58btc `did:key` — it deliberately never decoded the Ed25519 key the `did:key` embeds — while `lifecycle_service.rs` verified the possession proof against the *separately-supplied* `public_key`. Because both `agent_id` and `public_key` are caller-supplied, an attacker could present `agent_id = did:key:z<victim DID>` together with their **own** `public_key` and a proof signed by their **own** key, and register/squat the victim's DID.

This PR adds the missing binding without weakening the existing possession proof:

- `convert.rs` gains `did_key_ed25519_public_key` (decodes the base58btc multibase + `ed25519-pub` multicodec `[0xed, 0x01]` prefix, extracts the embedded 32-byte key) and `assert_did_key_binds_public_key` (asserts the embedded key equals `hex::decode(public_key)`), returning a `DidKeyBindingError` (`Malformed` → `InvalidArgument`, `Mismatch` → `Unauthenticated`).
- `lifecycle_service.rs` calls `enforce_did_key_binding` in **both** `RequestChallenge` (before a nonce is issued) and `Register` (before the nonce is consumed / proof verified), so a nonce is only ever issued or accepted for a `did:key` whose embedded key matches `public_key`.

`validate_did_key` is left unchanged (it stays a syntactic check); the binding is an additive, stricter gate layered on top of the existing possession proof.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] No

A legitimate agent already supplies a `public_key` matching its `did:key`, so it is unaffected. Only a caller pairing a `did:key` with a non-matching `public_key` — the attack this closes — is now rejected.

## Related Issues

- Related Jira ticket: [AAASM-4787](https://lightning-dust-mite.atlassian.net/browse/AAASM-4787)

Fixes AAASM-4787

## Testing

- [x] Unit tests added / updated

Added three unit tests in `convert.rs`: (1) a `did:key` whose embedded Ed25519 key matches `public_key` is accepted; (2) a `did:key` whose embedded key does **not** match is rejected (`Mismatch`); (3) a non-ed25519 multicodec `did:key` is rejected (`Malformed`). Ran `cargo nextest run -p aa-gateway registry::convert service::lifecycle_service` — 24 tests pass (3 new binding tests + all 21 existing convert/lifecycle tests still green). `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and the pre-push `cargo doc` gate all pass.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (docstrings capture the binding rationale)
- [ ] All CI checks passing (org GHA may be billing-blocked; validated locally)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-4787]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ