### PR TITLE
[AAASM-4793] 🔒 (core): Scan label keys, wire custom pricing file, note health version exposure

### DIFF
--- a/aa-api/src/routes/health.rs
+++ b/aa-api/src/routes/health.rs
@@ -61,15 +61,15 @@ async fn subsystem_checks(state: &AppState) -> BTreeMap<String, String> {
 /// Returns `200` when all subsystems report healthy; `503` when any subsystem
 /// is degraded. The `checks` map in the response body carries per-subsystem
 /// status strings (`"ok"` or `"degraded"`).
-///
-/// Deliberately unauthenticated, including the `version` field (AAASM-4793):
-/// this is a liveness/readiness probe consumed by orchestrators (k8s, load
-/// balancers) before any credential exchange is possible, so it must be
-/// reachable pre-auth. The version string is the same value already public in
-/// release artifacts and `Cargo.toml`, not sensitive on its own — gating it
-/// would need a second, differently-shaped response for authenticated callers
-/// and would risk breaking existing health-check parsers for no material
-/// security gain.
+// AAASM-4793: this endpoint is deliberately unauthenticated, `version` field
+// included. It is a liveness/readiness probe consumed by orchestrators (k8s,
+// load balancers) before any credential exchange is possible, so it must be
+// reachable pre-auth. The version string is the same value already public in
+// release artifacts and `Cargo.toml`, not sensitive on its own — gating it
+// would need a second, differently-shaped response for authenticated callers
+// and would risk breaking existing health-check parsers for no material
+// security gain. Kept as an inline `//` note (not `///`) so it stays out of the
+// generated OpenAPI operation description.
 #[utoipa::path(
     get,
     path = "/api/v1/health",

--- a/aa-api/src/routes/health.rs
+++ b/aa-api/src/routes/health.rs
@@ -61,6 +61,15 @@ async fn subsystem_checks(state: &AppState) -> BTreeMap<String, String> {
 /// Returns `200` when all subsystems report healthy; `503` when any subsystem
 /// is degraded. The `checks` map in the response body carries per-subsystem
 /// status strings (`"ok"` or `"degraded"`).
+///
+/// Deliberately unauthenticated, including the `version` field (AAASM-4793):
+/// this is a liveness/readiness probe consumed by orchestrators (k8s, load
+/// balancers) before any credential exchange is possible, so it must be
+/// reachable pre-auth. The version string is the same value already public in
+/// release artifacts and `Cargo.toml`, not sensitive on its own — gating it
+/// would need a second, differently-shaped response for authenticated callers
+/// and would risk breaking existing health-check parsers for no material
+/// security gain.
 #[utoipa::path(
     get,
     path = "/api/v1/health",

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -277,7 +277,9 @@ impl AppState {
         );
 
         let budget_tracker = Arc::new(BudgetTracker::new(
-            aa_gateway::budget::pricing::PricingTable::default_table(),
+            // AAASM-4793: honours AA_PRICING_FILE when the operator has set it,
+            // falling back to default_table() unchanged when unset.
+            aa_gateway::budget::pricing::PricingTable::from_env(),
             None,
             None,
             chrono_tz::UTC,

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -2,6 +2,11 @@
 
 use rust_decimal::Decimal;
 
+/// Environment variable naming a custom pricing overrides JSON file
+/// (AAASM-4793). Read by [`PricingTable::from_env`]; unset means
+/// [`PricingTable::default_table`].
+pub const PRICING_FILE_ENV_VAR: &str = "AA_PRICING_FILE";
+
 /// USD cost per 1,000 tokens for one direction (input or output).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PricingEntry {
@@ -108,6 +113,22 @@ impl PricingTable {
                 Self::default_table()
             }),
             Err(_) => Self::default_table(),
+        }
+    }
+
+    /// Build the pricing table for this process (AAASM-4793).
+    ///
+    /// [`load_from_file`](Self::load_from_file) and [`load_from_json_str`](Self::load_from_json_str)
+    /// had no production caller — every `BudgetTracker` construction site hardcoded
+    /// [`default_table`](Self::default_table), so a custom pricing table (and with
+    /// it, the AAASM-4744 partial-table fail-closed fallback) was unreachable
+    /// outside tests. This is the wiring: when [`PRICING_FILE_ENV_VAR`] is set, load
+    /// the operator-supplied overrides from that path; otherwise fall back to
+    /// `default_table()` unchanged, so unset behaviour is identical to before.
+    pub fn from_env() -> Self {
+        match std::env::var_os(PRICING_FILE_ENV_VAR) {
+            Some(path) => Self::load_from_file(std::path::Path::new(&path)),
+            None => Self::default_table(),
         }
     }
 
@@ -284,6 +305,50 @@ mod tests {
         let table = PricingTable::load_from_file(path);
         use crate::budget::types::{Model, Provider};
         assert!(table.entry(Provider::OpenAi, Model::Gpt4o).is_some());
+    }
+
+    #[test]
+    fn from_env_loads_custom_pricing_file_when_env_var_set() {
+        // AAASM-4793: this is the wiring the BudgetTracker construction sites
+        // now call — prove the env var actually reaches a loaded custom table,
+        // not just `default_table()`.
+        use crate::budget::types::{Model, Provider};
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("aa-pricing-test-{}.json", std::process::id()));
+        std::fs::write(
+            &path,
+            r#"[
+              { "provider": "open_ai", "model": "gpt4o",
+                "input_per_1k_usd": "0.001", "output_per_1k_usd": "0.002" }
+            ]"#,
+        )
+        .unwrap();
+        std::env::set_var(PRICING_FILE_ENV_VAR, &path);
+
+        let table = PricingTable::from_env();
+
+        std::env::remove_var(PRICING_FILE_ENV_VAR);
+        std::fs::remove_file(&path).ok();
+
+        let entry = table.entry(Provider::OpenAi, Model::Gpt4o).expect("gpt4o present");
+        assert_eq!(entry.input_per_1k_usd, "0.001".parse().unwrap());
+        assert_eq!(entry.output_per_1k_usd, "0.002".parse().unwrap());
+    }
+
+    #[test]
+    fn from_env_falls_back_to_default_table_when_unset() {
+        std::env::remove_var(PRICING_FILE_ENV_VAR);
+        use crate::budget::types::{Model, Provider};
+        let table = PricingTable::from_env();
+        let default_entry = PricingTable::default_table()
+            .entry(Provider::OpenAi, Model::Gpt4o)
+            .unwrap()
+            .input_per_1k_usd;
+        assert_eq!(
+            table.entry(Provider::OpenAi, Model::Gpt4o).unwrap().input_per_1k_usd,
+            default_entry,
+            "unset env var must behave identically to default_table()"
+        );
     }
 
     #[test]

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -191,7 +191,9 @@ fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAle
     };
 
     let mut tracker = BudgetTracker::with_state_and_alert_sender(
-        crate::budget::PricingTable::default_table(),
+        // AAASM-4793: honours AA_PRICING_FILE when the operator has set it,
+        // falling back to default_table() unchanged when unset.
+        crate::budget::PricingTable::from_env(),
         daily_limit,
         monthly_limit,
         persisted,

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -1327,10 +1327,11 @@ mod runtime_bypass {
         // The *authoritative* outcome — the security decision the runtime commits
         // to — must be identical whether or not the SDK forged a preflight label:
         // the same secret is found, redacted identically, and neither event is
-        // clean. AAASM-4744 additionally scans label *values* for secrets, so the
-        // raw `scanned_bytes` work counter is deliberately excluded from the
-        // authoritative comparison here: the forged event carries an extra label
-        // value, so the runtime does strictly MORE scan work on it, never less.
+        // clean. AAASM-4744/4793 additionally scans label *keys and values* for
+        // secrets, so the raw `scanned_bytes` work counter is deliberately excluded
+        // from the authoritative comparison here: the forged event carries an extra
+        // label key and value, so the runtime does strictly MORE scan work on it,
+        // never less.
         assert_eq!(
             outcome_without.findings, outcome_with.findings,
             "the same secret must be found and redacted identically either way"
@@ -1355,13 +1356,14 @@ mod runtime_bypass {
         );
         assert!(!outcome_without.is_clean(), "the secret is caught in both cases");
         // The only divergence is the observability counter: scanning the forged
-        // label's value adds exactly its byte length to the work total. A forged
+        // label's key and value adds exactly their combined byte length to the
+        // work total (AAASM-4793 scans label keys as well as values). A forged
         // preflight label can therefore only lengthen — never shorten — the
         // authoritative scan, which is itself the fail-safe invariant.
         assert_eq!(
             outcome_with.scanned_bytes,
-            outcome_without.scanned_bytes + "clean".len(),
-            "the forged label only adds scan work equal to its value length"
+            outcome_without.scanned_bytes + "x-aa-preflight".len() + "clean".len(),
+            "the forged label adds scan work equal to its key + value length"
         );
     }
 }

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -187,18 +187,28 @@ impl RuntimeScanner {
         outcome
     }
 
-    /// Scan and redact every surviving label *value* in place (AAASM-4744).
+    /// Scan and redact every surviving label *key and value* in place
+    /// (AAASM-4744, extended by AAASM-4793).
     ///
-    /// `labels` is an SDK-supplied map, so a secret can ride in a label value
-    /// exactly as it can in a detail field. Trust-marker keys are already
-    /// stripped by [`strip_trust_markers`] before this runs; every remaining
-    /// value is passed through the same [`scan_string`](Self::scan_string) path
-    /// (size cap + credential scan + redaction) so a leaked secret is redacted,
-    /// not forwarded. Keys are identifiers and are left untouched.
+    /// `labels` is an SDK-supplied map, so a secret can ride in a label key
+    /// exactly as easily as in a label value — nothing on the wire prevents an
+    /// agent from smuggling a credential into the map's key instead of its
+    /// value. Trust-marker keys are already stripped by [`strip_trust_markers`]
+    /// before this runs; every remaining key and value is passed through the
+    /// same [`scan_string`](Self::scan_string) path (size cap, credential scan,
+    /// and redaction) so a leaked secret is redacted, not forwarded, regardless
+    /// of which side of the map it rode in on. The map is rebuilt because
+    /// `HashMap` keys cannot be mutated in place.
     fn scan_labels(&self, labels: &mut std::collections::HashMap<String, String>, outcome: &mut EnforcementOutcome) {
-        for value in labels.values_mut() {
-            self.scan_string(value, outcome);
-        }
+        let scanned: Vec<(String, String)> = std::mem::take(labels)
+            .into_iter()
+            .map(|(mut key, mut value)| {
+                self.scan_string(&mut key, outcome);
+                self.scan_string(&mut value, outcome);
+                (key, value)
+            })
+            .collect();
+        labels.extend(scanned);
     }
 
     /// Scan and redact the allowlisted secret-bearing fields of `detail`.
@@ -733,6 +743,29 @@ mod tests {
             event.inner.labels.get("team").map(String::as_str),
             Some("payments"),
             "a clean label value is left untouched"
+        );
+        assert!(!outcome.is_clean());
+        assert_eq!(outcome.findings.len(), 1);
+    }
+
+    #[test]
+    fn secret_in_label_key_is_redacted() {
+        // AAASM-4793: the SDK controls the whole labels map, key and value
+        // alike, so a secret smuggled into a label *key* must be redacted just
+        // like one riding in the value.
+        let scanner = RuntimeScanner::new();
+        let poisoned_key = format!("note-{AWS_KEY}");
+        let mut event = event_with_labels(&[(poisoned_key.as_str(), "some-value")]);
+
+        let outcome = scanner.enforce(&mut event);
+
+        assert!(
+            !event.inner.labels.keys().any(|k| k.contains(AWS_KEY)),
+            "raw secret must not survive in a label key"
+        );
+        assert!(
+            event.inner.labels.keys().any(|k| k.contains("[REDACTED:")),
+            "redacted label key carries the redaction marker"
         );
         assert!(!outcome.is_clean());
         assert_eq!(outcome.findings.len(), 1);


### PR DESCRIPTION
## Description

Three LOW-severity core-defense findings from the AAASM security/QA sweep,
each a separate atomic commit:

1. **`aa-runtime` label-key scanning** — `RuntimeScanner::scan_labels` only
   scanned label *values* for smuggled secrets, not *keys*. A secret riding in
   a label key (e.g. `note-<AWS_KEY>`) was forwarded/audited unredacted.
   `scan_labels` now rebuilds the labels map, passing every key and value
   through the same `scan_string` (size cap + credential scan + redaction)
   path.
2. **Custom pricing wiring** — `PricingTable::load_from_file` /
   `load_from_json_str` had no production caller; every `BudgetTracker`
   construction site hardcoded `PricingTable::default_table()`, so an
   operator-supplied pricing override (and with it, the AAASM-4744
   partial-table fail-closed fallback) was unreachable outside tests. Adds
   `PricingTable::from_env()`, which loads from the `AA_PRICING_FILE` env var
   when set and falls back to `default_table()` unchanged when unset, and
   wires it into the two production `BudgetTracker` construction sites:
   `aa-gateway/src/server.rs` (`setup_budget`) and `aa-api/src/state.rs`
   (`local_in_memory`).
3. **`/health` version exposure** — the unauthenticated `/health` endpoint
   returns the gateway version string. This is intentional (liveness/readiness
   probes run pre-auth, and the version is already public via release
   artifacts), so the minimal safe change is a code comment documenting that
   rather than gating the field and risking breaking existing health-check
   consumers.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

`AA_PRICING_FILE` is opt-in: unset behavior is byte-for-byte identical to
before (`default_table()`).

## Related Issues

- Related Jira ticket: [AAASM-4793](https://lightning-dust-mite.atlassian.net/browse/AAASM-4793)
- Fixes AAASM-4793

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

- `aa-runtime`: `secret_in_label_key_is_redacted` — a secret in a label key is
  redacted; existing label/value/trust-marker tests unaffected.
- `aa-gateway`: `from_env_loads_custom_pricing_file_when_env_var_set` and
  `from_env_falls_back_to_default_table_when_unset`.
- Verified locally: `cargo check -p aa-runtime -p aa-gateway -p aa-api`,
  `cargo nextest run -p aa-runtime pipeline::enforcement`, `cargo nextest run
  -p aa-gateway budget::pricing`, `cargo nextest run -p aa-api state::`,
  `cargo fmt --all -- --check`, `cargo clippy -p aa-runtime -p aa-gateway -p
  aa-api --all-targets -- -D warnings`. Full workspace suite was intentionally
  not run (out of scope per ticket instructions).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing _(org GitHub Actions is billing-blocked; validated locally per repo convention)_
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced


[AAASM-4793]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ