### PR TITLE
[AAASM-4820] 🐛 (aa-security): Fix SSN redaction bypass on trailing separator

### DIFF
--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -644,7 +644,11 @@ fn scan_digit_sequences(text: &str, findings: &mut Vec<CredentialFinding>) {
                     digits.push(b as char);
                     j += 1;
                 }
-                b' ' | b'-' if !digits.is_empty() => {
+                // Only consume a separator that sits *between* digits. A trailing
+                // separator must not be swallowed into the segment, or an SSN like
+                // "123-45-6789 " would become 12 bytes and fail the exact-11-byte
+                // `is_ssn` check, letting the PII through unredacted (AAASM-4820).
+                b' ' | b'-' if !digits.is_empty() && j + 1 < limit && bytes[j + 1].is_ascii_digit() => {
                     j += 1;
                 }
                 _ => break,
@@ -1329,6 +1333,32 @@ mod tests {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("SSN: 123-45-6789");
         assert!(result.findings.iter().any(|f| f.kind == CredentialKind::SsnPattern));
+    }
+
+    #[test]
+    fn detects_ssn_trailed_by_space() {
+        // Regression (AAASM-4820): a trailing space must not be swallowed into the
+        // digit segment, which would defeat the exact-11-byte SSN check and forward
+        // the PII unredacted.
+        let scanner = CredentialScanner::new();
+        let text = "SSN 123-45-6789 was leaked";
+        let result = scanner.scan(text);
+        assert!(result.findings.iter().any(|f| f.kind == CredentialKind::SsnPattern));
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("123-45-6789"));
+        assert!(redacted.contains("[REDACTED:SsnPattern]"));
+    }
+
+    #[test]
+    fn detects_ssn_trailed_by_hyphen() {
+        // Regression (AAASM-4820): a trailing hyphen must likewise not be consumed.
+        let scanner = CredentialScanner::new();
+        let text = "SSN 123-45-6789-leaked";
+        let result = scanner.scan(text);
+        assert!(result.findings.iter().any(|f| f.kind == CredentialKind::SsnPattern));
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("123-45-6789"));
+        assert!(redacted.contains("[REDACTED:SsnPattern]"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

The credential scanner's `scan_digit_sequences` failed to detect an SSN (`DDD-DD-DDDD`) whenever it was immediately followed by a space or hyphen. The digit-run loop unconditionally consumed a trailing `' '`/`'-'` into the segment, pushing a value like `"123-45-6789 "` to 12 bytes and failing the exact-11-byte `is_ssn` check — so `scan()` reported clean and the PII was forwarded **unredacted**. Only a trailing space or hyphen evaded detection; other trailing characters (comma, period, etc.) already broke the loop and were detected.

The fix only consumes a separator that is followed by another digit (i.e. a separator genuinely *between* digit groups), so a trailing separator is no longer swallowed. Credit-card Luhn validation (run against the digit-only string) is unaffected.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4820](https://lightning-dust-mite.atlassian.net/browse/AAASM-4820)

## Testing

- [x] Unit tests added / updated

Added two regression tests (`detects_ssn_trailed_by_space`, `detects_ssn_trailed_by_hyphen`) asserting both an `SsnPattern` finding and that `redact()` removes the SSN. The existing end-of-string `detects_ssn` case still passes. `cargo nextest run -p aa-security` → 81 passed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-4820]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ