### PR TITLE
[AAASM-4816] ✅ (dashboard): Clear S9020/S8980 test-hygiene smells

### DIFF
--- a/dashboard/src/features/agents/api.test.tsx
+++ b/dashboard/src/features/agents/api.test.tsx
@@ -86,7 +86,7 @@ describe('FleetPage', () => {
       mockQuery<Agent[]>({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
     )
     render(<FleetPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
-    await waitFor(() => expect(screen.getByTestId('agents-empty')).toBeInTheDocument())
+    expect(await screen.findByTestId('agents-empty')).toBeInTheDocument()
   })
 
   it('shows error banner with retry button on failure', () => {
@@ -116,7 +116,7 @@ describe('AgentDetailPage', () => {
       </Wrapper>,
     )
 
-    await waitFor(() => expect(screen.getByTestId('agent-detail')).toBeInTheDocument())
+    expect(await screen.findByTestId('agent-detail')).toBeInTheDocument()
     expect(screen.getByText('test-agent')).toBeInTheDocument()
     // Framework chip + recent events table both surface "langgraph" / "enforced".
     expect(screen.getAllByText('langgraph').length).toBeGreaterThan(0)

--- a/dashboard/src/features/alerts/AlertRuleForm.test.tsx
+++ b/dashboard/src/features/alerts/AlertRuleForm.test.tsx
@@ -108,17 +108,15 @@ describe('AlertRuleForm', () => {
     const onClose = vi.fn()
     render(<AlertRuleForm open={true} onClose={onClose} />, { wrapper: Wrapper })
 
-    await waitFor(() =>
-      expect(screen.getByTestId('rule-destination-d-slack')).toBeInTheDocument(),
-    )
+    expect(await screen.findByTestId('rule-destination-d-slack')).toBeInTheDocument()
     await user.click(screen.getByTestId('rule-destination-d-slack'))
     await user.type(screen.getByTestId('rule-name'), 'Budget guardrail')
     await user.clear(screen.getByTestId('rule-threshold'))
     await user.click(screen.getByTestId('alert-rule-form-submit'))
 
-    await waitFor(() =>
-      expect(screen.getByText(/threshold must be (a number|a finite number)/i)).toBeInTheDocument(),
-    )
+    expect(
+      await screen.findByText(/threshold must be (a number|a finite number)/i),
+    ).toBeInTheDocument()
     expect(onClose).not.toHaveBeenCalled()
     expect(calls.some((c) => c.init.method === 'POST' && c.url.endsWith('/rules'))).toBe(false)
   })
@@ -129,11 +127,9 @@ describe('AlertRuleForm', () => {
     render(<AlertRuleForm open={true} onClose={vi.fn()} />, { wrapper: Wrapper })
     await user.type(screen.getByTestId('rule-name'), 'Budget guardrail')
     await user.click(screen.getByTestId('alert-rule-form-submit'))
-    await waitFor(() =>
-      expect(
-        screen.getByText(/at least one destination is required/i),
-      ).toBeInTheDocument(),
-    )
+    expect(
+      await screen.findByText(/at least one destination is required/i),
+    ).toBeInTheDocument()
   })
 
   it('POSTs to /alerts/rules on a valid create submit and closes the modal', async () => {
@@ -147,9 +143,7 @@ describe('AlertRuleForm', () => {
       { wrapper: Wrapper },
     )
 
-    await waitFor(() =>
-      expect(screen.getByTestId('rule-destination-d-slack')).toBeInTheDocument(),
-    )
+    expect(await screen.findByTestId('rule-destination-d-slack')).toBeInTheDocument()
     await user.type(screen.getByTestId('rule-name'), 'Budget guardrail')
     await user.click(screen.getByTestId('rule-destination-d-slack'))
     await user.click(screen.getByTestId('alert-rule-form-submit'))
@@ -191,9 +185,7 @@ describe('AlertRuleForm', () => {
     const onClose = vi.fn()
     render(<AlertRuleForm open={true} onClose={onClose} />, { wrapper: Wrapper })
 
-    await waitFor(() =>
-      expect(screen.getByTestId('rule-destination-d-slack')).toBeInTheDocument(),
-    )
+    expect(await screen.findByTestId('rule-destination-d-slack')).toBeInTheDocument()
     await user.type(screen.getByTestId('rule-name'), 'Budget guardrail')
     await user.click(screen.getByTestId('rule-destination-d-slack'))
     await user.click(screen.getByTestId('alert-rule-form-submit'))

--- a/dashboard/src/features/alerts/AlertRulesTable.test.tsx
+++ b/dashboard/src/features/alerts/AlertRulesTable.test.tsx
@@ -97,7 +97,7 @@ describe('AlertRulesTable', () => {
       { wrapper: Wrapper },
     )
 
-    await waitFor(() => expect(screen.getByTestId('alert-rules-table')).toBeInTheDocument())
+    expect(await screen.findByTestId('alert-rules-table')).toBeInTheDocument()
     const rows = screen.getAllByTestId('alert-rules-row')
     expect(rows).toHaveLength(2)
     expect(rows[0]).toHaveAttribute('data-rule-id', 'r-a')
@@ -128,9 +128,7 @@ describe('AlertRulesTable', () => {
       { wrapper: Wrapper },
     )
 
-    await waitFor(() =>
-      expect(screen.getByTestId('alerts-empty-no-rules')).toBeInTheDocument(),
-    )
+    expect(await screen.findByTestId('alerts-empty-no-rules')).toBeInTheDocument()
     // The shared empty-state CTA opens the rule form in create mode.
     await userEvent.click(screen.getByTestId('alerts-empty-create-cta'))
     expect(onCreate).toHaveBeenCalledOnce()
@@ -149,7 +147,7 @@ describe('AlertRulesTable', () => {
       { wrapper: Wrapper },
     )
 
-    await waitFor(() => screen.getByTestId('alert-rules-table'))
+    await screen.findByTestId('alert-rules-table')
     await userEvent.click(screen.getByTestId('alert-rules-create'))
     expect(onCreate).toHaveBeenCalledOnce()
 
@@ -169,7 +167,7 @@ describe('AlertRulesTable', () => {
       { wrapper: Wrapper },
     )
 
-    await waitFor(() => screen.getByTestId('alert-rules-table'))
+    await screen.findByTestId('alert-rules-table')
     const editButtons = screen.getAllByTestId('alert-rules-row-edit')
     expect(editButtons).toHaveLength(2)
     await userEvent.click(editButtons[1])
@@ -190,7 +188,7 @@ describe('AlertRulesTable', () => {
       { wrapper: Wrapper },
     )
 
-    await waitFor(() => screen.getByTestId('alert-rules-table'))
+    await screen.findByTestId('alert-rules-table')
     await userEvent.click(screen.getByTestId('alert-rules-row-delete'))
 
     // The DELETE fetch fires against the canonical endpoint.
@@ -217,6 +215,6 @@ describe('AlertRulesTable', () => {
       { wrapper: Wrapper },
     )
 
-    await waitFor(() => expect(screen.getByTestId('alert-rules-error')).toBeInTheDocument())
+    expect(await screen.findByTestId('alert-rules-error')).toBeInTheDocument()
   })
 })

--- a/dashboard/src/features/alerts/DedupAndSuppressionFields.test.tsx
+++ b/dashboard/src/features/alerts/DedupAndSuppressionFields.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -78,9 +78,7 @@ describe('DedupAndSuppressionFields', () => {
     const user = userEvent.setup()
     render(<Harness defaults={{ suppressionLabels: [{ key: '1bad', value: '' }] }} />)
 
-    await act(async () => {
-      await user.click(screen.getByTestId('validate'))
-    })
+    await user.click(screen.getByTestId('validate'))
 
     expect(await screen.findByText(/key must match/i)).toBeInTheDocument()
     expect(screen.getByText(/value cannot be empty/i)).toBeInTheDocument()
@@ -90,9 +88,7 @@ describe('DedupAndSuppressionFields', () => {
     const user = userEvent.setup()
     render(<Harness defaults={{ dedupWindowSeconds: -5 }} />)
 
-    await act(async () => {
-      await user.click(screen.getByTestId('validate'))
-    })
+    await user.click(screen.getByTestId('validate'))
 
     expect(await screen.findByText(/dedup window cannot be negative/i)).toBeInTheDocument()
   })

--- a/dashboard/src/features/alerts/RuleYamlViewer.test.tsx
+++ b/dashboard/src/features/alerts/RuleYamlViewer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Theme } from '../../theme/useTheme'
 import { RuleYamlViewer } from './RuleYamlViewer'
@@ -49,19 +49,19 @@ describe('RuleYamlViewer', () => {
     expect(wrapper).toBeInTheDocument()
 
     // The lazy-loaded Editor resolves via the vi.mock above; wait for it.
-    const editor = await waitFor(() => screen.getByTestId('monaco-editor-mock'))
+    const editor = await screen.findByTestId('monaco-editor-mock')
     expect(wrapper.contains(editor)).toBe(true)
   })
 
   it('passes the YAML body verbatim to the Monaco Editor', async () => {
     render(<RuleYamlViewer yaml={YAML_SAMPLE} />)
-    const editor = await waitFor(() => screen.getByTestId('monaco-editor-mock'))
+    const editor = await screen.findByTestId('monaco-editor-mock')
     expect(editor.textContent).toBe(YAML_SAMPLE)
   })
 
   it('configures Monaco for read-only YAML rendering at 200px height', async () => {
     render(<RuleYamlViewer yaml={YAML_SAMPLE} />)
-    const editor = await waitFor(() => screen.getByTestId('monaco-editor-mock'))
+    const editor = await screen.findByTestId('monaco-editor-mock')
 
     expect(editor).toHaveAttribute('data-language', 'yaml')
     expect(editor).toHaveAttribute('data-height', '200')
@@ -82,14 +82,14 @@ describe('RuleYamlViewer', () => {
   it("uses Monaco's light theme 'vs' when the app theme is light", async () => {
     mockTheme = 'light'
     render(<RuleYamlViewer yaml={YAML_SAMPLE} />)
-    const editor = await waitFor(() => screen.getByTestId('monaco-editor-mock'))
+    const editor = await screen.findByTestId('monaco-editor-mock')
     expect(editor).toHaveAttribute('data-theme', 'vs')
   })
 
   it("uses Monaco's dark theme 'vs-dark' when the app theme is dark", async () => {
     mockTheme = 'dark'
     render(<RuleYamlViewer yaml={YAML_SAMPLE} />)
-    const editor = await waitFor(() => screen.getByTestId('monaco-editor-mock'))
+    const editor = await screen.findByTestId('monaco-editor-mock')
     expect(editor).toHaveAttribute('data-theme', 'vs-dark')
   })
 })

--- a/dashboard/src/features/approvals/ApprovalsBellButton.test.tsx
+++ b/dashboard/src/features/approvals/ApprovalsBellButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { describe, it, expect, vi, afterEach } from 'vitest'
@@ -35,7 +35,7 @@ describe('ApprovalsBellButton', () => {
       mockQuery<Approval[]>({ data: [] }),
     )
     render(<ApprovalsBellButton />, { wrapper: Wrapper })
-    await waitFor(() => expect(screen.getByTestId('approvals-bell')).toBeInTheDocument())
+    expect(await screen.findByTestId('approvals-bell')).toBeInTheDocument()
     expect(screen.queryByTestId('approvals-bell-badge')).not.toBeInTheDocument()
   })
 
@@ -53,7 +53,7 @@ describe('ApprovalsBellButton', () => {
       mockQuery<Approval[]>({ data: undefined }),
     )
     render(<ApprovalsBellButton />, { wrapper: Wrapper })
-    await waitFor(() => expect(screen.getByTestId('approvals-bell')).toBeInTheDocument())
+    expect(await screen.findByTestId('approvals-bell')).toBeInTheDocument()
     expect(screen.queryByTestId('approvals-bell-badge')).not.toBeInTheDocument()
   })
 

--- a/dashboard/src/features/approvals/api.test.tsx
+++ b/dashboard/src/features/approvals/api.test.tsx
@@ -133,7 +133,7 @@ describe('ApprovalsPage', () => {
 
   it('shows empty state when no pending approvals', async () => {
     setup([])
-    await waitFor(() => expect(screen.getByTestId('empty-state-approvals')).toBeInTheDocument())
+    expect(await screen.findByTestId('empty-state-approvals')).toBeInTheDocument()
   })
 
   it('shows loading skeletons while fetching', () => {
@@ -205,11 +205,9 @@ describe('ApprovalsPage', () => {
     fireEvent.click(checkboxes[0])
     fireEvent.click(checkboxes[1])
 
-    await waitFor(() => expect(screen.getByTestId('bulk-toolbar')).toBeInTheDocument())
+    expect(await screen.findByTestId('bulk-toolbar')).toBeInTheDocument()
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('bulk-approve-btn'))
-    })
+    fireEvent.click(screen.getByTestId('bulk-approve-btn'))
 
     await waitFor(() => {
       expect(approveFn).toHaveBeenCalledTimes(2)
@@ -223,7 +221,7 @@ describe('ApprovalsPage', () => {
     await waitFor(() => expect(screen.getAllByTestId('approval-row')).toHaveLength(1))
 
     fireEvent.click(screen.getByTestId('reject-btn'))
-    await waitFor(() => expect(screen.getByTestId('reject-dialog')).toBeInTheDocument())
+    expect(await screen.findByTestId('reject-dialog')).toBeInTheDocument()
 
     // Confirm should be disabled with empty reason
     expect(screen.getByTestId('reject-confirm-btn')).toBeDisabled()
@@ -258,17 +256,15 @@ describe('ApprovalsPage', () => {
     fireEvent.click(checkboxes[0])
     fireEvent.click(checkboxes[1])
 
-    await waitFor(() => expect(screen.getByTestId('bulk-toolbar')).toBeInTheDocument())
+    expect(await screen.findByTestId('bulk-toolbar')).toBeInTheDocument()
     fireEvent.click(screen.getByTestId('bulk-reject-btn'))
-    await waitFor(() => expect(screen.getByTestId('reject-dialog')).toBeInTheDocument())
+    expect(await screen.findByTestId('reject-dialog')).toBeInTheDocument()
 
     fireEvent.change(screen.getByTestId('reject-reason-input'), {
       target: { value: 'policy violation' },
     })
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('reject-confirm-btn'))
-    })
+    fireEvent.click(screen.getByTestId('reject-confirm-btn'))
 
     await waitFor(() => {
       expect(rejectFn).toHaveBeenCalledTimes(2)

--- a/dashboard/src/features/iam/AccessLogPanel.test.tsx
+++ b/dashboard/src/features/iam/AccessLogPanel.test.tsx
@@ -156,9 +156,7 @@ describe('AccessLogPanel (AAASM-1398)', () => {
     expect(screen.getByTestId('access-log-error')).toBeInTheDocument()
 
     await userEvent.click(retry)
-    await waitFor(() =>
-      expect(screen.getByTestId('access-log-row-evt-after-retry')).toBeInTheDocument(),
-    )
+    expect(await screen.findByTestId('access-log-row-evt-after-retry')).toBeInTheDocument()
   })
 
   it('clicking the row View link still resolves to the audit event path', async () => {

--- a/dashboard/src/features/iam/RevealOnceModal.test.tsx
+++ b/dashboard/src/features/iam/RevealOnceModal.test.tsx
@@ -41,13 +41,11 @@ describe('RevealOnceModal', () => {
     Object.assign(navigator, { clipboard: { writeText } })
     const { onCopied } = renderModal()
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('copy-secret-button'))
-    })
+    fireEvent.click(screen.getByTestId('copy-secret-button'))
 
+    expect(await screen.findByTestId('toast')).toHaveAttribute('data-variant', 'success')
     expect(writeText).toHaveBeenCalledWith('aa-secret-xyz')
     expect(onCopied).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId('toast')).toHaveAttribute('data-variant', 'success')
   })
 
   it('surfaces a clipboard failure as an error toast', async () => {
@@ -55,14 +53,12 @@ describe('RevealOnceModal', () => {
     Object.assign(navigator, { clipboard: { writeText } })
     const { onCopied } = renderModal()
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('copy-secret-button'))
-    })
+    fireEvent.click(screen.getByTestId('copy-secret-button'))
 
-    expect(onCopied).not.toHaveBeenCalled()
-    const toast = screen.getByTestId('toast')
+    const toast = await screen.findByTestId('toast')
     expect(toast).toHaveAttribute('data-variant', 'error')
     expect(toast).toHaveTextContent('denied')
+    expect(onCopied).not.toHaveBeenCalled()
   })
 
   it('treats a backdrop click before copy as an attempted early close', () => {

--- a/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
+++ b/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
@@ -301,9 +301,7 @@ describe('ServiceIdentitiesPanel — rotate', () => {
     await waitFor(() =>
       expect(screen.queryByTestId('api-key-rotate-key-1')).not.toBeInTheDocument(),
     )
-    await waitFor(() =>
-      expect(screen.getByTestId('api-key-row-gen-rotated-1')).toBeInTheDocument(),
-    )
+    expect(await screen.findByTestId('api-key-row-gen-rotated-1')).toBeInTheDocument()
     expect(
       screen.getByTestId('api-key-row-gen-rotated-1').textContent,
     ).toContain('aa_live_zzzz')

--- a/dashboard/src/features/onboarding/steps/Step2InstallSdk.test.tsx
+++ b/dashboard/src/features/onboarding/steps/Step2InstallSdk.test.tsx
@@ -34,9 +34,10 @@ describe('Step2InstallSdk', () => {
     Object.assign(navigator, { clipboard: { writeText } })
 
     render(<Step2InstallSdk state={EMPTY_STATE} onVerified={vi.fn()} />)
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('onboarding-install-copy'))
-    })
+    fireEvent.click(screen.getByTestId('onboarding-install-copy'))
+    // Flush the async clipboard handler's state update (setCopied) without
+    // wrapping the fireEvent call itself — the label flips on a microtask.
+    await act(async () => {})
 
     expect(writeText).toHaveBeenCalledWith('pip install agent-assembly')
     expect(screen.getByTestId('onboarding-install-copy')).toHaveTextContent('✓ copied')
@@ -52,9 +53,10 @@ describe('Step2InstallSdk', () => {
     Object.assign(navigator, { clipboard: { writeText } })
 
     render(<Step2InstallSdk state={EMPTY_STATE} onVerified={vi.fn()} />)
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('onboarding-install-copy'))
-    })
+    fireEvent.click(screen.getByTestId('onboarding-install-copy'))
+    // Flush the async clipboard handler's state update (setCopied) without
+    // wrapping the fireEvent call itself — the label flips on a microtask.
+    await act(async () => {})
     expect(screen.getByTestId('onboarding-install-copy')).toHaveTextContent('✓ copied')
   })
 

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -209,7 +209,7 @@ describe('AgentDetailPage tab navigation', () => {
     mockHappyPath()
     renderApp('/agents/abc123')
     fireEvent.click(await screen.findByTestId('agent-detail-tab-capability'))
-    await waitFor(() => expect(screen.getByTestId('inherited-permissions-empty')).toBeInTheDocument())
+    expect(await screen.findByTestId('inherited-permissions-empty')).toBeInTheDocument()
     expect(screen.queryByTestId('agent-detail-posture')).not.toBeInTheDocument()
   })
 
@@ -218,7 +218,7 @@ describe('AgentDetailPage tab navigation', () => {
     renderApp('/agents/abc123')
     for (const id of ['traffic', 'policies', 'lineage', 'config'] as const) {
       fireEvent.click(screen.getByTestId(`agent-detail-tab-${id}`))
-      await waitFor(() => expect(screen.getByTestId(`ad-tab-empty-${id}`)).toBeInTheDocument())
+      expect(await screen.findByTestId(`ad-tab-empty-${id}`)).toBeInTheDocument()
     }
   })
 })

--- a/dashboard/src/pages/ApprovalsPage.test.tsx
+++ b/dashboard/src/pages/ApprovalsPage.test.tsx
@@ -1,6 +1,6 @@
 // Smoke tests for the refactored ApprovalsPage.
 // Comprehensive feature tests live in src/features/approvals/api.test.tsx.
-import { act, render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
@@ -82,13 +82,13 @@ describe('ApprovalsPage', () => {
   it('renders the page heading', async () => {
     setupMocks([])
     render(<ApprovalsPage />, { wrapper: Wrapper })
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Approvals' })).toBeInTheDocument())
+    expect(await screen.findByRole('heading', { name: 'Approvals' })).toBeInTheDocument()
   })
 
   it('shows shared empty state when no pending approvals', async () => {
     setupMocks([])
     render(<ApprovalsPage />, { wrapper: Wrapper })
-    await waitFor(() => expect(screen.getByTestId('empty-state-approvals')).toBeInTheDocument())
+    expect(await screen.findByTestId('empty-state-approvals')).toBeInTheDocument()
   })
 
   it('shows shared error state on query failure', async () => {
@@ -102,7 +102,7 @@ describe('ApprovalsPage', () => {
       mockMutation({ mutateAsync: vi.fn(), isPending: false }),
     )
     render(<ApprovalsPage />, { wrapper: Wrapper })
-    await waitFor(() => expect(screen.getByTestId('error-state-generic')).toBeInTheDocument())
+    expect(await screen.findByTestId('error-state-generic')).toBeInTheDocument()
   })
 
   it('renders a row for each pending approval', async () => {
@@ -177,7 +177,7 @@ describe('ApprovalsPage', () => {
 
     render(<ApprovalsPage />, { wrapper: SeededWrapper })
     const toggle = await screen.findByTestId('expired-toggle')
-    act(() => { fireEvent.click(toggle) })
+    fireEvent.click(toggle)
     expect(screen.getAllByTestId('expired-row')).toHaveLength(1)
   })
 })
@@ -214,7 +214,7 @@ describe('ApprovalsPage — decision flows', () => {
 
     const selectAll = screen.getByTestId('select-all-checkbox')
     fireEvent.click(selectAll)
-    await waitFor(() => expect(screen.getByTestId('bulk-toolbar')).toBeInTheDocument())
+    expect(await screen.findByTestId('bulk-toolbar')).toBeInTheDocument()
 
     fireEvent.click(selectAll)
     await waitFor(() => expect(screen.queryByTestId('bulk-toolbar')).not.toBeInTheDocument())
@@ -226,9 +226,7 @@ describe('ApprovalsPage — decision flows', () => {
     render(<ApprovalsPage />, { wrapper: SeededWrapper })
     await waitFor(() => expect(screen.getAllByTestId('approval-row')).toHaveLength(1))
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('approve-btn'))
-    })
+    fireEvent.click(screen.getByTestId('approve-btn'))
     await waitFor(() => expect(approveAsync).toHaveBeenCalledWith({ id: 'a1b2c3d4' }))
     expect(client.getQueryData<Approval[]>(['approvals'])).toEqual([])
 
@@ -248,11 +246,9 @@ describe('ApprovalsPage — decision flows', () => {
     await waitFor(() => expect(screen.getAllByTestId('approval-row')).toHaveLength(2))
 
     fireEvent.click(screen.getByTestId('select-all-checkbox'))
-    await waitFor(() => expect(screen.getByTestId('bulk-toolbar')).toBeInTheDocument())
+    expect(await screen.findByTestId('bulk-toolbar')).toBeInTheDocument()
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('bulk-approve-btn'))
-    })
+    fireEvent.click(screen.getByTestId('bulk-approve-btn'))
 
     // One of the two rows is restored into the active cache after the failure.
     await waitFor(() => {
@@ -273,14 +269,12 @@ describe('ApprovalsPage — decision flows', () => {
     await waitFor(() => expect(screen.getAllByTestId('approval-row')).toHaveLength(2))
 
     fireEvent.click(screen.getByTestId('select-all-checkbox'))
-    await waitFor(() => expect(screen.getByTestId('bulk-toolbar')).toBeInTheDocument())
+    expect(await screen.findByTestId('bulk-toolbar')).toBeInTheDocument()
     fireEvent.click(screen.getByTestId('bulk-reject-btn'))
     fireEvent.change(await screen.findByTestId('reject-reason-input'), {
       target: { value: 'policy violation' },
     })
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('reject-confirm-btn'))
-    })
+    fireEvent.click(screen.getByTestId('reject-confirm-btn'))
 
     await waitFor(() => {
       const active = client.getQueryData<Approval[]>(['approvals']) ?? []

--- a/dashboard/src/pages/FleetPage.test.tsx
+++ b/dashboard/src/pages/FleetPage.test.tsx
@@ -72,7 +72,7 @@ describe('FleetPage chrome', () => {
       }),
     )
     renderFleet()
-    await waitFor(() => expect(screen.getByTestId('fleet-page-head')).toBeInTheDocument())
+    expect(await screen.findByTestId('fleet-page-head')).toBeInTheDocument()
     expect(screen.getByTestId('fleet-page-count').textContent).toContain('2 of 2 agents')
     expect(screen.getByTestId('fleet-action-register')).toBeDisabled()
     expect(screen.getByTestId('fleet-action-export')).toBeDisabled()
@@ -84,7 +84,7 @@ describe('FleetPage chrome', () => {
     )
     renderFleet()
     fireEvent.click(screen.getByTestId('fleet-tab-sessions'))
-    await waitFor(() => expect(screen.getByTestId('fleet-sessions-empty')).toBeInTheDocument())
+    expect(await screen.findByTestId('fleet-sessions-empty')).toBeInTheDocument()
     expect(screen.queryByTestId('agents-table')).not.toBeInTheDocument()
   })
 })
@@ -335,7 +335,7 @@ describe('FleetPage bulk action bar', () => {
     expect(screen.queryByTestId('fleet-bulkbar')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('fleet-select-a'))
-    await waitFor(() => expect(screen.getByTestId('fleet-bulkbar')).toBeInTheDocument())
+    expect(await screen.findByTestId('fleet-bulkbar')).toBeInTheDocument()
     expect(screen.getByTestId('fleet-bulkbar-count').textContent).toContain('1 selected')
   })
 
@@ -368,7 +368,7 @@ describe('FleetPage bulk action bar', () => {
     )
     renderFleet()
     fireEvent.click(screen.getByTestId('fleet-select-all'))
-    await waitFor(() => expect(screen.getByTestId('fleet-bulkbar-shadow')).toBeInTheDocument())
+    expect(await screen.findByTestId('fleet-bulkbar-shadow')).toBeInTheDocument()
     expect(screen.getByTestId('fleet-bulkbar-suspend')).toBeInTheDocument()
   })
 })
@@ -395,7 +395,7 @@ describe('FleetPage bulk suspend fan-out', () => {
     fireEvent.change(await screen.findByTestId('suspend-dialog-input'), { target: { value: 'budget' } })
     fireEvent.click(screen.getByTestId('suspend-dialog-confirm'))
 
-    await waitFor(() => expect(screen.getByText('2 suspended')).toBeInTheDocument())
+    expect(await screen.findByText('2 suspended')).toBeInTheDocument()
     expect(post).toHaveBeenCalledTimes(2)
     await waitFor(() => expect(screen.queryByTestId('fleet-bulkbar')).not.toBeInTheDocument())
   })
@@ -429,7 +429,7 @@ describe('FleetPage bulk suspend fan-out', () => {
     fireEvent.change(await screen.findByTestId('suspend-dialog-input'), { target: { value: 'budget' } })
     fireEvent.click(screen.getByTestId('suspend-dialog-confirm'))
 
-    await waitFor(() => expect(screen.getByText('2 suspended, 1 failed')).toBeInTheDocument())
+    expect(await screen.findByText('2 suspended, 1 failed')).toBeInTheDocument()
     expect(post).toHaveBeenCalledTimes(3)
     expect(screen.getByTestId('fleet-bulkbar-count').textContent).toContain('1 selected')
     expect(screen.getByTestId('fleet-select-b')).toBeChecked()
@@ -456,7 +456,7 @@ describe('FleetPage bulk suspend fan-out', () => {
     fireEvent.change(await screen.findByTestId('suspend-dialog-input'), { target: { value: 'noop' } })
     fireEvent.click(screen.getByTestId('suspend-dialog-confirm'))
 
-    await waitFor(() => expect(screen.getByText('2 failed')).toBeInTheDocument())
+    expect(await screen.findByText('2 failed')).toBeInTheDocument()
     expect(screen.getByTestId('fleet-bulkbar-count').textContent).toContain('2 selected')
   })
 })
@@ -481,7 +481,7 @@ describe('FleetPage bulk resume fan-out', () => {
     fireEvent.click(await screen.findByTestId('fleet-select-all'))
     fireEvent.click(screen.getByTestId('fleet-bulkbar-resume'))
 
-    await waitFor(() => expect(screen.getByText('2 resumed')).toBeInTheDocument())
+    expect(await screen.findByText('2 resumed')).toBeInTheDocument()
     expect(post).toHaveBeenCalledTimes(2)
     expect(post.mock.calls[0]?.[0]).toBe('/api/v1/agents/{id}/resume')
     await waitFor(() => expect(screen.queryByTestId('fleet-bulkbar')).not.toBeInTheDocument())
@@ -514,7 +514,7 @@ describe('FleetPage bulk resume fan-out', () => {
     fireEvent.click(await screen.findByTestId('fleet-select-all'))
     fireEvent.click(screen.getByTestId('fleet-bulkbar-resume'))
 
-    await waitFor(() => expect(screen.getByText('2 resumed, 1 failed')).toBeInTheDocument())
+    expect(await screen.findByText('2 resumed, 1 failed')).toBeInTheDocument()
     expect(screen.getByTestId('fleet-bulkbar-count').textContent).toContain('1 selected')
     expect(screen.getByTestId('fleet-select-b')).toBeChecked()
   })
@@ -538,7 +538,7 @@ describe('FleetPage bulk resume fan-out', () => {
     fireEvent.click(await screen.findByTestId('fleet-select-all'))
     fireEvent.click(screen.getByTestId('fleet-bulkbar-resume'))
 
-    await waitFor(() => expect(screen.getByText('2 failed')).toBeInTheDocument())
+    expect(await screen.findByText('2 failed')).toBeInTheDocument()
     expect(screen.getByTestId('fleet-bulkbar-count').textContent).toContain('2 selected')
   })
 

--- a/dashboard/src/pages/LoginPage.test.tsx
+++ b/dashboard/src/pages/LoginPage.test.tsx
@@ -41,7 +41,7 @@ describe('LoginPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
 
     await waitFor(() => expect(login).toHaveBeenCalledWith('aa_key'))
-    await waitFor(() => expect(screen.getByTestId('home')).toBeInTheDocument())
+    expect(await screen.findByTestId('home')).toBeInTheDocument()
   })
 
   it('shows an error message and stays on the page when login fails', async () => {
@@ -50,9 +50,7 @@ describe('LoginPage', () => {
     fireEvent.change(screen.getByLabelText('API Key'), { target: { value: 'aa_bad' } })
     fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
 
-    await waitFor(() =>
-      expect(screen.getByText(/Authentication failed \(401\)/)).toBeInTheDocument(),
-    )
+    expect(await screen.findByText(/Authentication failed \(401\)/)).toBeInTheDocument()
     expect(screen.queryByTestId('home')).not.toBeInTheDocument()
     // Button label resets after the failed attempt.
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument()

--- a/dashboard/src/pages/PoliciesPage.test.tsx
+++ b/dashboard/src/pages/PoliciesPage.test.tsx
@@ -315,7 +315,7 @@ describe('PoliciesPage — save flow', () => {
     await screen.findByTestId('policy-editor-overlay')
     await user.click(screen.getByTestId('editor-save-btn'))
     await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1))
-    await waitFor(() => expect(screen.getByText('Failed to save policy')).toBeInTheDocument())
+    expect(await screen.findByText('Failed to save policy')).toBeInTheDocument()
     // Overlay is still mounted
     expect(screen.getByTestId('policy-editor-overlay')).toBeInTheDocument()
   })

--- a/dashboard/src/pages/TeamDetailPage.actions.test.tsx
+++ b/dashboard/src/pages/TeamDetailPage.actions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -76,7 +76,7 @@ describe('TeamDetailPage action bar', () => {
     vi.spyOn(teamsApi, 'useResumeTeam').mockReturnValue(mockMutation({ mutate: vi.fn(), isPending: false }))
 
     render(<TeamDetailPage />, { wrapper: Wrapper })
-    await waitFor(() => expect(screen.getByTestId('team-detail-header')).toBeInTheDocument())
+    expect(await screen.findByTestId('team-detail-header')).toBeInTheDocument()
     expect(screen.queryByTestId('team-action-bar')).not.toBeInTheDocument()
   })
 

--- a/dashboard/src/pages/TeamDetailPage.test.tsx
+++ b/dashboard/src/pages/TeamDetailPage.test.tsx
@@ -89,7 +89,7 @@ describe('TeamDetailPage', () => {
     mockCosts()
     mockLineage('a'.repeat(32))
     render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/team-alpha']}>{children}</Wrapper> })
-    await waitFor(() => expect(screen.getByTestId('team-detail-header')).toBeInTheDocument())
+    expect(await screen.findByTestId('team-detail-header')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'team-alpha' })).toBeInTheDocument()
     expect(screen.getByTestId('team-member-count')).toHaveTextContent('5 members')
     expect(screen.getByTestId('team-total-spend')).toHaveTextContent('$42.00')
@@ -101,7 +101,7 @@ describe('TeamDetailPage', () => {
     mockCosts()
     mockLineage('x')
     render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/team-beta']}>{children}</Wrapper> })
-    await waitFor(() => expect(screen.getByTestId('team-members-empty')).toBeInTheDocument())
+    expect(await screen.findByTestId('team-members-empty')).toBeInTheDocument()
   })
 
   it('renders NotFoundPage when team id is unknown', async () => {
@@ -109,7 +109,7 @@ describe('TeamDetailPage', () => {
     mockCosts()
     mockLineage('x')
     render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/missing']}>{children}</Wrapper> })
-    await waitFor(() => expect(screen.getByRole('heading', { name: /404/ })).toBeInTheDocument())
+    expect(await screen.findByRole('heading', { name: /404/ })).toBeInTheDocument()
   })
 
   it('navigates to /topology?root=<topmost ancestor> when Open in topology clicked', async () => {
@@ -121,7 +121,7 @@ describe('TeamDetailPage', () => {
     render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/team-alpha']}>{children}</Wrapper> })
     await waitFor(() => expect(screen.getAllByTestId('open-in-topology')).toHaveLength(5))
     await user.click(screen.getAllByTestId('open-in-topology')[0])
-    await waitFor(() => expect(screen.getByTestId('topology-page')).toBeInTheDocument())
+    expect(await screen.findByTestId('topology-page')).toBeInTheDocument()
     expect(screen.getByTestId('location')).toHaveTextContent(`/topology?root=${rootId}`)
   })
 

--- a/dashboard/src/pages/TeamsPage.test.tsx
+++ b/dashboard/src/pages/TeamsPage.test.tsx
@@ -62,7 +62,7 @@ describe('TeamsPage', () => {
   it('shows empty state when no teams exist', async () => {
     setupMocks(makeOverview(0))
     render(<TeamsPage />, { wrapper: Wrapper })
-    await waitFor(() => expect(screen.getByTestId('teams-empty')).toBeInTheDocument())
+    expect(await screen.findByTestId('teams-empty')).toBeInTheDocument()
   })
 
   it('renders a row per team with burn % from cost summary', async () => {

--- a/dashboard/src/pages/ViolationHeatmapPage.test.tsx
+++ b/dashboard/src/pages/ViolationHeatmapPage.test.tsx
@@ -62,9 +62,9 @@ describe("ViolationHeatmapPage", () => {
 
     render(<ViolationHeatmapPage />);
 
-    await waitFor(() =>
-      expect(screen.getByText(/No violations recorded in this window\./)).toBeInTheDocument(),
-    );
+    expect(
+      await screen.findByText(/No violations recorded in this window\./),
+    ).toBeInTheDocument();
     expect(screen.getByText(/0 agents with violations/)).toBeInTheDocument();
   });
 
@@ -79,7 +79,7 @@ describe("ViolationHeatmapPage", () => {
 
     render(<ViolationHeatmapPage />);
 
-    await waitFor(() => expect(screen.getByText(/3 agents with violations/)).toBeInTheDocument());
+    expect(await screen.findByText(/3 agents with violations/)).toBeInTheDocument();
     expect(
       screen.getByTestId("heatmap-node-aaaa0000000000000000000000000001"),
     ).toBeInTheDocument();
@@ -96,7 +96,7 @@ describe("ViolationHeatmapPage", () => {
 
     render(<ViolationHeatmapPage />);
 
-    await waitFor(() => expect(screen.getByText(/1 agent with violations/)).toBeInTheDocument());
+    expect(await screen.findByText(/1 agent with violations/)).toBeInTheDocument();
     // Should not pluralize.
     expect(screen.queryByText(/1 agents with violations/)).not.toBeInTheDocument();
   });
@@ -106,7 +106,7 @@ describe("ViolationHeatmapPage", () => {
 
     render(<ViolationHeatmapPage />);
 
-    await waitFor(() => expect(screen.getByText(/Error: HTTP 500/)).toBeInTheDocument());
+    expect(await screen.findByText(/Error: HTTP 500/)).toBeInTheDocument();
   });
 
   it("renders error state when fetch rejects (network error)", async () => {
@@ -114,7 +114,7 @@ describe("ViolationHeatmapPage", () => {
 
     render(<ViolationHeatmapPage />);
 
-    await waitFor(() => expect(screen.getByText(/Error: network unreachable/)).toBeInTheDocument());
+    expect(await screen.findByText(/Error: network unreachable/)).toBeInTheDocument();
   });
 
   it("refetches with new ?window= when the window selector changes", async () => {


### PR DESCRIPTION
## Description

Clears **71 SonarCloud test-hygiene smells** across the dashboard test suite — no
production code touched, only `dashboard/**/*.test.tsx`.

- **`typescript:S9020` (59)** — "Prefer `findBy*` over `waitFor` + `getBy*`".
  Replaced `await waitFor(() => expect(screen.getBy*(x)).toBeInTheDocument())`
  with `expect(await screen.findBy*(x)).toBeInTheDocument()`, mapping each query
  variant faithfully (`getByTestId→findByTestId`, `getByText→findByText`,
  `getByRole→findByRole`). Only the existence-check shape Sonar flagged was
  converted; `waitFor` calls that assert something else (`toHaveLength`,
  `toHaveTextContent`, negative `queryBy` assertions) were left untouched.
- **`typescript:S8980` (12)** — "Remove this redundant `act()` call". Removed the
  `act()` / `await act(async () => …)` wrappers around `fireEvent`/`userEvent`
  calls that already flush their own updates, keeping the inner statements.

Two `act()` removals wrapped an async clipboard handler whose `setCopied` state
update is flushed via a microtask under fake timers, so a naïve removal would
break the test. These preserve the flush without wrapping the event call:
`Step2InstallSdk` uses an empty `await act(async () => {})`, and `RevealOnceModal`
awaits the resulting toast with `findByTestId`. Every element queried and every
assertion is unchanged.

## Type of Change

- [x] ♻️ Refactoring (test-only hygiene)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4816](https://lightning-dust-mite.atlassian.net/browse/AAASM-4816)

## Testing

- [x] Unit tests added / updated (refactored in place; behaviour-preserving)
- [x] No new tests required — the transformation is behaviour-preserving and the
  passing suite is the proof.

Validation (in `dashboard/`):
- `pnpm test` → **1491 passed / 1491** (168 files).
- `pnpm type-check` (`tsc --noEmit`) → **clean**.
- `pnpm lint` → **clean on all touched files**. (Two pre-existing
  `no-unused-vars` errors remain in the untouched e2e `alerts.spec.ts` /
  `governance-dashboard.spec.ts` — byte-identical to `master`, out of scope for
  this ticket.)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed — n/a (no behaviour change)
- [ ] All CI checks passing — org Actions is billing-blocked; validated locally
- [x] Commits follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdxntF32Wi278LGD22dVS4


[AAASM-4816]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ