### PR TITLE
[AAASM-4819] 🔒 (aa-api): Fix cross-tenant IDOR in topology tree + lineage

### DIFF
--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -155,12 +155,23 @@ const MAX_TREE_DEPTH: u32 = 10;
 
 fn build_tree(
     registry: &AgentRegistry,
+    caller: &AuthenticatedCaller,
     agent_id: &[u8; 16],
     remaining_depth: u32,
     status_filter: Option<&str>,
     show_budget: bool,
 ) -> Option<AgentTree> {
     let record = registry.get(agent_id)?;
+    // AAASM-4819 — the handler authorizes only the root; `children_of` recursion
+    // otherwise walks into descendants registered under other teams and leaks
+    // their name / team_id / delegation_reason. Enforce the tenant boundary on
+    // every recursively-discovered node: an out-of-tenant node is omitted, and
+    // because that returns `None` its whole subtree is pruned too, so the walk
+    // never crosses a tenant boundary (mirrors the edges.rs BFS guard,
+    // AAASM-3825).
+    if !record_visible_to(caller, &record) {
+        return None;
+    }
     if let Some(f) = status_filter {
         if !matches_status_filter(&record.status, f) {
             return None;
@@ -170,7 +181,16 @@ fn build_tree(
         registry
             .children_of(agent_id)
             .iter()
-            .filter_map(|child_id| build_tree(registry, child_id, remaining_depth - 1, status_filter, show_budget))
+            .filter_map(|child_id| {
+                build_tree(
+                    registry,
+                    caller,
+                    child_id,
+                    remaining_depth - 1,
+                    status_filter,
+                    show_budget,
+                )
+            })
             .collect()
     } else {
         vec![]
@@ -399,6 +419,7 @@ pub async fn get_tree(
 
     let tree = build_tree(
         &state.agent_registry,
+        &caller,
         &agent_id,
         max_depth,
         params.status.as_deref(),
@@ -552,21 +573,31 @@ pub async fn get_lineage(
     }
 
     // ancestors_of returns parent-first (direct parent at [0], root at end).
-    // Reverse to root-first, then append the requested agent as the final element.
-    let mut ancestor_ids = state.agent_registry.ancestors_of(&agent_id);
-    ancestor_ids.reverse();
-
-    let mut ancestors: Vec<LineageStep> = ancestor_ids
-        .iter()
-        .filter_map(|id| state.agent_registry.get(id))
-        .map(|r| LineageStep {
+    // AAASM-4819 — walk outward from the requested agent (which is already
+    // authorized) toward the root and stop at the first ancestor outside the
+    // caller's tenant: a cross-tenant parent's name / team_id / delegation_reason
+    // (and everything above it) must not leak. This mirrors the edges.rs BFS
+    // tenant boundary (AAASM-3825), which never continues through an
+    // unauthorized node. The visible ancestors are then reversed to the
+    // root-first order the response expects.
+    let ancestor_ids = state.agent_registry.ancestors_of(&agent_id);
+    let mut ancestors: Vec<LineageStep> = Vec::new();
+    for id in &ancestor_ids {
+        let Some(r) = state.agent_registry.get(id) else {
+            continue;
+        };
+        if !record_visible_to(&caller, &r) {
+            break;
+        }
+        ancestors.push(LineageStep {
             id: format_id(&r.agent_id),
             name: r.name.clone(),
             depth: r.depth,
             delegation_reason: r.delegation_reason.clone(),
             team_id: r.team_id.clone(),
-        })
-        .collect();
+        });
+    }
+    ancestors.reverse();
 
     ancestors.push(LineageStep {
         id: format_id(&record.agent_id),

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -102,6 +102,20 @@ fn hex_id(id_byte: u8) -> String {
     format!("{id_byte:02x}").repeat(16)
 }
 
+/// Turn a root record into a depth-1 delegated child of `parent_byte`, so the
+/// registry links it under the parent (`register` pushes it into the parent's
+/// `children`, and `ancestors_of` walks back up via `parent_key`). Used by the
+/// AAASM-4819 tree/lineage cross-tenant tests, where a child and its parent
+/// deliberately belong to different tenants.
+fn child_of(mut rec: AgentRecord, parent_byte: u8) -> AgentRecord {
+    rec.depth = 1;
+    rec.parent_key = Some([parent_byte; 16]);
+    rec.parent_agent_id = Some(format!("{parent_byte}"));
+    rec.root_agent_id = Some([parent_byte; 16]);
+    rec.delegation_reason = Some("subtask".to_string());
+    rec
+}
+
 #[tokio::test]
 async fn costs_tenant_caller_sees_only_its_own_team() {
     let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
@@ -500,6 +514,122 @@ async fn topology_tree_cross_tenant_read_is_404() {
     let uri = format!("/api/v1/topology/tree/{}", hex_id(0x71));
     let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// AAASM-4819 — the tree recursion must enforce the tenant boundary on every
+/// descendant, not just the root. A visible root whose subtree contains a
+/// different-team child must return a tree WITHOUT that child (and without its
+/// name / team_id), while the same-team child is still returned.
+#[tokio::test]
+async fn topology_tree_omits_cross_tenant_descendant() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    // Root and one child in team alpha; a second child delegated into team beta.
+    state.agent_registry.register(agent_with_team(0x01, "alpha")).unwrap();
+    state
+        .agent_registry
+        .register(child_of(agent_with_team(0x02, "alpha"), 0x01))
+        .unwrap();
+    state
+        .agent_registry
+        .register(child_of(agent_with_team(0x03, "beta"), 0x01))
+        .unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/topology/tree/{}", hex_id(0x01));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+
+    let children = json["children"].as_array().unwrap();
+    // Only the same-team child survives; the beta child is pruned entirely.
+    assert_eq!(
+        children.len(),
+        1,
+        "cross-tenant descendant must be omitted from the tree"
+    );
+    assert_eq!(children[0]["name"], "agent-2");
+    assert_eq!(children[0]["team_id"], "alpha");
+    // The beta child's identifying fields must not leak anywhere in the response.
+    let raw = json.to_string();
+    assert!(!raw.contains("agent-3"), "beta child name leaked: {raw}");
+    assert!(!raw.contains("beta"), "beta team_id leaked: {raw}");
+    assert!(!raw.contains(&hex_id(0x03)), "beta child id leaked: {raw}");
+}
+
+/// A same-team subtree is returned in full — the boundary check must not prune
+/// legitimately-visible descendants.
+#[tokio::test]
+async fn topology_tree_keeps_same_tenant_descendant() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x11, "alpha")).unwrap();
+    state
+        .agent_registry
+        .register(child_of(agent_with_team(0x12, "alpha"), 0x11))
+        .unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/topology/tree/{}", hex_id(0x11));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let children = json["children"].as_array().unwrap();
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0]["name"], "agent-18");
+}
+
+/// AAASM-4819 — the lineage ancestor chain must stop at the first ancestor
+/// outside the caller's tenant. A visible agent with a cross-team parent must
+/// return a lineage WITHOUT that ancestor (and without its name / team_id).
+#[tokio::test]
+async fn topology_lineage_omits_cross_tenant_ancestor() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    // A beta root delegates to an alpha child; the alpha caller owns the child.
+    state.agent_registry.register(agent_with_team(0x21, "beta")).unwrap();
+    state
+        .agent_registry
+        .register(child_of(agent_with_team(0x22, "alpha"), 0x21))
+        .unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/topology/lineage/{}", hex_id(0x22));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+
+    // Only the requested agent itself remains; the beta ancestor is dropped.
+    assert_eq!(json["ancestor_count"], 1, "cross-tenant ancestor must be omitted");
+    let ancestors = json["ancestors"].as_array().unwrap();
+    assert_eq!(ancestors.len(), 1);
+    assert_eq!(ancestors[0]["name"], "agent-34");
+    let raw = json.to_string();
+    assert!(!raw.contains("agent-33"), "beta ancestor name leaked: {raw}");
+    assert!(!raw.contains("beta"), "beta team_id leaked: {raw}");
+}
+
+/// A same-team ancestor chain is returned in full, root-first.
+#[tokio::test]
+async fn topology_lineage_keeps_same_tenant_ancestor() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0x31, "alpha")).unwrap();
+    state
+        .agent_registry
+        .register(child_of(agent_with_team(0x32, "alpha"), 0x31))
+        .unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/topology/lineage/{}", hex_id(0x32));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    // root-first: [root 0x31, self 0x32]
+    assert_eq!(json["ancestor_count"], 2);
+    let ancestors = json["ancestors"].as_array().unwrap();
+    assert_eq!(ancestors[0]["name"], "agent-49");
+    assert_eq!(ancestors[1]["name"], "agent-50");
 }
 
 /// Stats aggregate only the caller's own tenant, never every tenant's counts.


### PR DESCRIPTION
## Description

Fixes a cross-tenant IDOR (AAASM-4819) in two topology read endpoints in `aa-api`:

- `GET /api/v1/topology/tree/{root_id}` — `record_visible_to` was checked only on the root; `build_tree` then recursed via `children_of()` with only a status filter, so a team-scoped caller received descendants registered under **other** teams (name, team_id, delegation_reason, etc.).
- `GET /api/v1/topology/lineage/{agent_id}` — visibility was checked only on the requested agent; the ancestor chain had no per-ancestor filter, leaking cross-team ancestors.

The fix threads `caller` + `record_visible_to` into the tree recursion (an out-of-tenant node returns `None`, pruning its whole subtree) and into the lineage ancestor walk (stop at the first out-of-tenant ancestor). This mirrors the existing `edges.rs` `get_agent_graph` BFS tenant-boundary guard (AAASM-3825), which never continues through a node outside the caller's tenant. Status filtering and the response shape for visible nodes are unchanged.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4819](https://lightning-dust-mite.atlassian.net/browse/AAASM-4819)

## Testing

- [x] Integration tests added (`aa-api/tests/tenant_scope.rs`)
  - tree omits a cross-tenant descendant (and its name/team_id/id don't leak) while keeping the same-team child
  - lineage drops a cross-tenant ancestor while returning a same-team ancestor chain root-first in full
- Validated locally: `cargo nextest run -p aa-api topology` → 55 passed, 0 failed. `cargo fmt` + commit-time `cargo clippy` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Integration tests added / updated
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-4819]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ