### PR TITLE
[AAASM-4829] 🔒 (core): LOW cluster — capability read scope, proxy host/IPv6, auth double-validate, cert-cache panic

### DIFF
--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -24,7 +24,7 @@ use aa_gateway::policy::rbac::MutationKind;
 use aa_gateway::policy::scope::PolicyScope;
 
 use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
-use crate::auth::scope::RequireRead;
+use crate::auth::scope::{RequireRead, Scope};
 use crate::error::ProblemDetail;
 use crate::models::capability::{
     AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, CapabilityOverrideRequest,
@@ -416,19 +416,30 @@ pub struct ListOverridesParams {
     params(("agent_id" = Option<String>, Query, description = "Filter results to overrides that affect this agent id")),
     responses(
         (status = 200, description = "Active override records", body = Vec<OverrideRecord>),
-        (status = 401, description = "Missing or invalid credentials")
+        (status = 401, description = "Missing or invalid credentials"),
+        (status = 403, description = "Caller lacks the admin role required to read the global override log")
     ),
     tag = "capability"
 )]
 pub async fn list_overrides(
-    // AAASM-3846 — require an authenticated reader before disclosing the
-    // override log.
-    RequireRead(_caller): RequireRead,
+    // AAASM-3846 / AAASM-4829 — the override log is global control-plane state:
+    // it discloses every capability override applied across the whole fleet and
+    // carries no per-team partition (an `OverrideRecord` names agent ids but no
+    // team scope), so there is no tenant slice to hand a team-scoped caller.
+    // Applying or revoking an override is a `PolicyScope::Global` / `OrgAdmin`
+    // mutation (see `apply_override` / `revoke_override`); reading the log of
+    // those mutations is gated to the same admin posture rather than to any
+    // authenticated reader.
+    RequireRead(caller): RequireRead,
     Query(params): Query<ListOverridesParams>,
     Extension(state): Extension<AppState>,
-) -> (StatusCode, Json<Vec<OverrideRecord>>) {
+) -> Result<(StatusCode, Json<Vec<OverrideRecord>>), ProblemDetail> {
+    if !caller.scopes.contains(&Scope::Admin) {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("Reading the capability override log requires admin scope".to_string()));
+    }
     let overrides = state.capability_store.list_overrides(params.agent_id.as_deref()).await;
-    (StatusCode::OK, Json(overrides))
+    Ok((StatusCode::OK, Json(overrides)))
 }
 
 /// `DELETE /api/v1/capability/override/{id}` — revert a previously applied
@@ -736,6 +747,74 @@ fn seeded_sample_calls() -> Vec<SampleCall> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::{AuthenticatedCaller, Tenant};
+
+    fn reader(scopes: Vec<Scope>) -> RequireRead {
+        RequireRead(AuthenticatedCaller {
+            key_id: "k".to_string(),
+            scopes,
+            tenant: Tenant {
+                team_id: None,
+                org_id: None,
+            },
+        })
+    }
+
+    #[tokio::test]
+    async fn list_overrides_denies_non_admin_reader() {
+        // AAASM-4829: the override log is global control-plane state; a mere
+        // read-scoped caller must be refused, mirroring the admin posture of the
+        // apply/revoke mutation handlers.
+        let state = AppState::local_in_memory().expect("state builds");
+        let err = list_overrides(
+            reader(vec![Scope::Read]),
+            Query(ListOverridesParams { agent_id: None }),
+            Extension(state),
+        )
+        .await
+        .expect_err("non-admin is forbidden");
+        assert_eq!(err.status, StatusCode::FORBIDDEN.as_u16());
+    }
+
+    #[tokio::test]
+    async fn list_overrides_admin_sees_applied_override_and_filter_works() {
+        let state = AppState::local_in_memory().expect("state builds");
+        let target = state.capability_store.snapshot().await.agents[0].id.clone();
+        Arc::clone(&state.capability_store)
+            .apply_override(&CapabilityOverrideRequest {
+                agent_ids: vec![target.clone()],
+                resource_id: "pg".into(),
+                verb: Verb::Write,
+                decision: Decision::Deny,
+                ttl_seconds: None,
+            })
+            .await
+            .expect("override applies");
+
+        // Admin caller: 200 with the applied override visible.
+        let (status, Json(all)) = list_overrides(
+            reader(vec![Scope::Admin]),
+            Query(ListOverridesParams { agent_id: None }),
+            Extension(state.clone()),
+        )
+        .await
+        .expect("admin may list");
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(all.len(), 1);
+        assert!(all[0].agent_ids.contains(&target));
+
+        // The agent_id filter still narrows the result for an admin.
+        let (_status, Json(filtered)) = list_overrides(
+            reader(vec![Scope::Admin]),
+            Query(ListOverridesParams {
+                agent_id: Some("no-such-agent".into()),
+            }),
+            Extension(state),
+        )
+        .await
+        .expect("admin may list filtered");
+        assert!(filtered.is_empty(), "filter to an unaffected agent yields nothing");
+    }
 
     #[tokio::test]
     async fn seeded_store_contains_eight_resources() {

--- a/aa-auth/src/gate.rs
+++ b/aa-auth/src/gate.rs
@@ -33,7 +33,13 @@ pub async fn require_authentication(request: Request, next: Next) -> Response {
     // `()` is a valid `S: Send + Sync` state for the extractor — all auth
     // inputs come from request extensions, not router state.
     match AuthenticatedCaller::from_request_parts(&mut parts, &()).await {
-        Ok(_caller) => {
+        Ok(caller) => {
+            // AAASM-4829: cache the resolved caller in request extensions so a
+            // downstream extractor (`AuthenticatedCaller` / `RequireRead` / …)
+            // reuses it instead of re-running argon2 validation and a SECOND
+            // `RateLimiter::check` — the double rate-check halved each key's
+            // effective limit for every gated request.
+            parts.extensions.insert(caller);
             let request = Request::from_parts(parts, body);
             next.run(request).await
         }

--- a/aa-auth/src/lib.rs
+++ b/aa-auth/src/lib.rs
@@ -176,6 +176,16 @@ where
     type Rejection = AuthError;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        // AAASM-4829: reuse a caller already resolved earlier in this request's
+        // lifecycle (e.g. by the `require_authentication` route-layer gate, which
+        // inserts it into extensions). Re-running the full resolution here would
+        // repeat the argon2 API-key/JWT validation AND a second
+        // `RateLimiter::check`, double-charging the per-key rate limit for every
+        // gated request. A cached caller short-circuits both.
+        if let Some(cached) = parts.extensions.get::<AuthenticatedCaller>() {
+            return Ok(cached.clone());
+        }
+
         // 1. Read auth config from extensions.
         let auth_config = parts
             .extensions
@@ -321,5 +331,42 @@ mod tenant_guard_tests {
     fn no_tenant_scope_yields_none_not_a_client_value() {
         let caller = caller_with_org(None, vec![Scope::Read, Scope::Admin]);
         assert_eq!(caller.storage_tenant_org(), None);
+    }
+
+    /// AAASM-4829: a caller cached in request extensions (by the
+    /// `require_authentication` gate) is reused verbatim — the extractor never
+    /// re-runs credential validation or the rate-limit check. Two things prove
+    /// it: (1) the future resolves synchronously (`Poll::Ready` on first poll,
+    /// no await), and (2) neither the `AuthConfig` nor `RateLimiter` extension is
+    /// present — the resolution path would panic on the missing `AuthConfig`
+    /// rather than return the cached caller.
+    #[test]
+    fn cached_caller_in_extensions_is_reused_without_revalidation() {
+        use std::future::Future;
+        use std::pin::pin;
+        use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+        fn noop_waker() -> Waker {
+            const VTABLE: RawWakerVTable = RawWakerVTable::new(|_| RAW, |_| {}, |_| {}, |_| {});
+            const RAW: RawWaker = RawWaker::new(std::ptr::null(), &VTABLE);
+            // SAFETY: the vtable's clone/wake/drop are all no-ops over a null
+            // pointer, so the waker is inert and never dereferences the data.
+            unsafe { Waker::from_raw(RAW) }
+        }
+
+        let cached = caller_with_org(Some("org-A"), vec![Scope::Read, Scope::Write]);
+        let (mut parts, _body) = axum::http::Request::new(()).into_parts();
+        parts.extensions.insert(cached.clone());
+
+        let mut fut = pin!(AuthenticatedCaller::from_request_parts(&mut parts, &()));
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let resolved = match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(r) => r.expect("cached caller is reused"),
+            Poll::Pending => panic!("cached-caller path must complete synchronously"),
+        };
+        assert_eq!(resolved.key_id, cached.key_id);
+        assert_eq!(resolved.scopes, cached.scopes);
+        assert_eq!(resolved.tenant.org_id.as_deref(), Some("org-A"));
     }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -705,7 +705,10 @@ impl ProxyServer {
         // express "but not internal addresses". Names are re-validated after
         // resolution in `dial_upstream_tls` (DNS-rebind defense).
         if !self.config.allow_private_connect_targets {
-            if let Some(true) = crate::ssrf::blocked_ip_literal(host) {
+            // AAASM-4829: strip brackets/port first so a bracketed IPv6 literal
+            // like `[::1]:443` still parses as `::1` — otherwise the SSRF guard
+            // silently misses it (the bracketed form fails `parse::<IpAddr>()`).
+            if let Some(true) = crate::ssrf::blocked_ip_literal(strip_host_port(host)) {
                 return Some("ssrf: blocked address range");
             }
         }
@@ -746,8 +749,17 @@ impl ProxyServer {
     /// CONNECT-time check already covered the destination, so this is a no-op.
     /// An empty allowlist keeps the default-open behaviour unchanged.
     fn in_tunnel_deny_reason(&self, req: &HttpRequest) -> Option<&'static str> {
-        let host = Self::effective_request_host(req)?;
-        self.connect_deny_reason(host)
+        // AAASM-4829: defense-in-depth against in-tunnel header host-splitting.
+        // Check BOTH the absolute-form request target host AND the `Host` header
+        // and deny if EITHER is disallowed — an agent must not pass the egress
+        // check by pointing the target at an allowlisted host while smuggling a
+        // disallowed host in the `Host` header (or vice versa). Previously only
+        // the target-preferred "effective" host was checked, so a mismatched
+        // pair let the un-checked half slip past the allowlist.
+        [Self::target_request_host(req), Self::header_request_host(req)]
+            .into_iter()
+            .flatten()
+            .find_map(|host| self.connect_deny_reason(host))
     }
 
     /// Extract the effective upstream host the in-tunnel request addresses.
@@ -755,24 +767,31 @@ impl ProxyServer {
     /// Prefers an absolute-form request target (`https://host/...`); otherwise
     /// falls back to the `Host` header. The port (if any) is stripped so the
     /// result is comparable against the allowlist/denylist host grammar.
-    /// Returns `None` when neither yields a host.
+    /// Returns `None` when neither yields a host. Used for logging; the egress
+    /// decision in [`Self::in_tunnel_deny_reason`] checks *both* hosts, not just
+    /// this preferred one.
     fn effective_request_host(req: &HttpRequest) -> Option<&str> {
-        // Absolute-form target, e.g. "https://evil.attacker.com/v1/..." or
-        // "http://evil.attacker.com/...". Strip the scheme, then keep up to the
-        // first '/' (path) — leaving "host[:port]".
-        let from_target = req
+        Self::target_request_host(req).or_else(|| Self::header_request_host(req))
+    }
+
+    /// Host named by an absolute-form request target (`https://host/...` or
+    /// `http://host/...`), with brackets/port stripped, or `None` for an
+    /// origin-form target (`/path`).
+    fn target_request_host(req: &HttpRequest) -> Option<&str> {
+        let rest = req
             .target
             .strip_prefix("https://")
-            .or_else(|| req.target.strip_prefix("http://"))
-            .map(|rest| rest.split('/').next().unwrap_or(rest));
+            .or_else(|| req.target.strip_prefix("http://"))?;
+        let host_port = rest.split('/').next().unwrap_or(rest);
+        let host = strip_host_port(host_port);
+        (!host.is_empty()).then_some(host)
+    }
 
-        let host_port = from_target.or_else(|| req.header("host"))?;
-        let host = host_port.split(':').next().unwrap_or(host_port).trim();
-        if host.is_empty() {
-            None
-        } else {
-            Some(host)
-        }
+    /// Host named by the `Host` header, with brackets/port stripped, or `None`
+    /// when the header is absent or empty.
+    fn header_request_host(req: &HttpRequest) -> Option<&str> {
+        let host = strip_host_port(req.header("host")?);
+        (!host.is_empty()).then_some(host)
     }
 
     /// Inspect, enforce, and forward an LLM-pattern HTTPS request inside an
@@ -1118,7 +1137,7 @@ impl ProxyServer {
         // bypasses `denied_hosts`/`network_allowlist` — the SSRF resolved-IP
         // recheck below only guards address ranges, not policy hosts. Deny here
         // (before any upstream dial), mirroring the CONNECT path's 403.
-        let deny_host = host.split(':').next().unwrap_or(&host);
+        let deny_host = strip_host_port(&host);
         if let Some(reason) = self.connect_deny_reason(deny_host) {
             tracing::info!(host = %deny_host, "plain-HTTP egress denied: {reason}");
             self.interceptor.emit_policy_decision(deny_host, true).await;
@@ -1208,9 +1227,44 @@ impl ProxyServer {
 /// trailing dot. Canonicalising once — strip the port, strip a single trailing
 /// dot, lowercase — closes that bypass. The result carries no port.
 fn canonical_host(host: &str) -> String {
-    let no_port = host.split(':').next().unwrap_or(host);
+    let no_port = strip_host_port(host);
     let no_dot = no_port.strip_suffix('.').unwrap_or(no_port);
     no_dot.to_ascii_lowercase()
+}
+
+/// Strip an optional `:port` suffix from a host, correctly handling a bracketed
+/// IPv6 literal (AAASM-4829).
+///
+/// A bare `host.split(':').next()` mangles IPv6 literals: `[::1]:443` becomes
+/// `[`, which both lets the CONNECT-time `ssrf::blocked_ip_literal` check miss
+/// the real address (it can no longer `parse::<IpAddr>()`) and over-blocks
+/// legitimate IPv6 under a denylist. This unwraps the brackets and drops the
+/// port so the returned value is the real literal (`::1`).
+///
+/// Rules:
+/// - `[<ipv6>]:port` / `[<ipv6>]` → `<ipv6>` (brackets and port removed).
+/// - `host:port` (single `:`) → `host`.
+/// - a bare, unbracketed IPv6 literal (multiple `:`, no brackets) is returned
+///   whole — an IPv6 address requires brackets to carry a port, so every colon
+///   is part of the address.
+/// - anything else is returned unchanged (trimmed).
+fn strip_host_port(host: &str) -> &str {
+    let host = host.trim();
+    if let Some(rest) = host.strip_prefix('[') {
+        // Bracketed IPv6 literal — take the text up to the closing bracket,
+        // discarding any `:port` that follows it. A malformed value with no
+        // closing bracket falls back to the un-bracketed remainder.
+        return match rest.find(']') {
+            Some(end) => &rest[..end],
+            None => rest,
+        };
+    }
+    match host.rfind(':') {
+        // More than one colon and no brackets → bare IPv6 literal, no port.
+        Some(idx) if host[..idx].contains(':') => host,
+        Some(idx) => &host[..idx],
+        None => host,
+    }
 }
 
 /// Parse the upstream host for a plain (non-CONNECT) HTTP request from the
@@ -1367,6 +1421,43 @@ mod tests {
         assert_eq!(canonical_host("evil.com"), "evil.com");
     }
 
+    #[test]
+    fn strip_host_port_handles_bracketed_ipv6() {
+        // AAASM-4829: a bracketed IPv6 literal must yield the real address, not
+        // the mangled `[` that `split(':')` produced.
+        assert_eq!(strip_host_port("[::1]:443"), "::1");
+        assert_eq!(strip_host_port("[::1]"), "::1");
+        assert_eq!(strip_host_port("[2001:db8::1]:8443"), "2001:db8::1");
+        // Bare (unbracketed) IPv6 literal has no port — every colon is address.
+        assert_eq!(strip_host_port("::1"), "::1");
+        assert_eq!(strip_host_port("2001:db8::1"), "2001:db8::1");
+        // IPv4 / DNS host:port and bare hosts behave as before.
+        assert_eq!(strip_host_port("1.2.3.4:80"), "1.2.3.4");
+        assert_eq!(strip_host_port("api.openai.com:443"), "api.openai.com");
+        assert_eq!(strip_host_port("api.openai.com"), "api.openai.com");
+    }
+
+    #[test]
+    fn canonical_host_preserves_bracketed_ipv6_literal() {
+        // AAASM-4829: the previous `split(':')` mangled `[::1]:443` into `[`,
+        // breaking both denylist compares and the SSRF check.
+        assert_eq!(canonical_host("[::1]:443"), "::1");
+        assert_eq!(canonical_host("[2001:DB8::1]:8443"), "2001:db8::1");
+    }
+
+    #[tokio::test]
+    async fn connect_deny_reason_blocks_bracketed_ipv6_loopback() {
+        // AAASM-4829: `[::1]:443` must be caught by the SSRF guard. Before the
+        // bracket-aware port strip, `blocked_ip_literal("[::1]:443")` failed to
+        // parse and the loopback literal slipped through fail-open.
+        let server = server_with(vec![], vec![]).await;
+        assert_eq!(
+            server.connect_deny_reason("[::1]:443"),
+            Some("ssrf: blocked address range")
+        );
+        assert_eq!(server.connect_deny_reason("[::1]"), Some("ssrf: blocked address range"));
+    }
+
     #[tokio::test]
     async fn connect_deny_reason_denylist_defeats_case_and_trailing_dot_evasion() {
         // AAASM-3983: a lowercase `evil.com` denylist entry must catch the
@@ -1425,6 +1516,29 @@ mod tests {
         assert_eq!(server.in_tunnel_deny_reason(&forged), Some("network allowlist"));
         // The allowlisted host inside the tunnel is permitted.
         let ok = req_with(vec![("Host", "api.openai.com")], "/v1/chat/completions");
+        assert_eq!(server.in_tunnel_deny_reason(&ok), None);
+    }
+
+    #[tokio::test]
+    async fn in_tunnel_deny_reason_blocks_disallowed_host_header_with_allowed_target() {
+        // AAASM-4829: header host-splitting defense. The absolute-form target
+        // points at the allowlisted host, but the `Host` header smuggles a
+        // disallowed one. Because BOTH hosts are now checked, the forged header
+        // is denied even though the target alone would have passed.
+        let server = server_with(vec![], vec!["api.openai.com".to_string()]).await;
+        let split = req_with(
+            vec![("Host", "evil.attacker.com")],
+            "https://api.openai.com/v1/chat/completions",
+        );
+        assert_eq!(server.in_tunnel_deny_reason(&split), Some("network allowlist"));
+        // The symmetric case: allowed header, disallowed absolute target.
+        let split2 = req_with(
+            vec![("Host", "api.openai.com")],
+            "https://evil.attacker.com/v1/chat/completions",
+        );
+        assert_eq!(server.in_tunnel_deny_reason(&split2), Some("network allowlist"));
+        // Both halves allowlisted → permitted.
+        let ok = req_with(vec![("Host", "api.openai.com")], "https://api.openai.com/v1/chat");
         assert_eq!(server.in_tunnel_deny_reason(&ok), None);
     }
 

--- a/aa-proxy/src/tls/cert.rs
+++ b/aa-proxy/src/tls/cert.rs
@@ -11,6 +11,14 @@ use lru::LruCache;
 use crate::error::ProxyError;
 use crate::tls::ca::{CaStore, CertifiedKey};
 
+/// Fallback capacity used when a caller passes `0`.
+///
+/// A zero-capacity LRU is meaningless and `NonZeroUsize::new(0)` would panic, so
+/// a misconfiguration such as `AA_PROXY_CERT_CACHE_CAPACITY=0` must degrade to a
+/// sane default rather than abort the proxy at boot. Mirrors the config-layer
+/// default in `crate::config::parse_cert_cache_capacity`.
+const DEFAULT_CERT_CACHE_CAPACITY: usize = 1000;
+
 /// Thread-safe LRU cache mapping domain names to their signed [`CertifiedKey`].
 pub struct CertCache {
     inner: Mutex<LruCache<String, Arc<CertifiedKey>>>,
@@ -19,14 +27,16 @@ pub struct CertCache {
 impl CertCache {
     /// Create a new cache with the given `capacity` (maximum number of entries).
     ///
-    /// # Panics
-    ///
-    /// Panics if `capacity` is zero.
+    /// A `capacity` of `0` is clamped up to [`DEFAULT_CERT_CACHE_CAPACITY`]
+    /// rather than panicking, so an operator setting
+    /// `AA_PROXY_CERT_CACHE_CAPACITY=0` gets a working (default-sized) cache
+    /// instead of a crash at startup.
     pub fn new(capacity: usize) -> Self {
+        let capacity = NonZeroUsize::new(capacity).unwrap_or_else(|| {
+            NonZeroUsize::new(DEFAULT_CERT_CACHE_CAPACITY).expect("default cert cache capacity is non-zero")
+        });
         Self {
-            inner: Mutex::new(LruCache::new(
-                NonZeroUsize::new(capacity).expect("cert cache capacity must be non-zero"),
-            )),
+            inner: Mutex::new(LruCache::new(capacity)),
         }
     }
 
@@ -66,6 +76,21 @@ mod tests {
         let ck2 = cache.get_or_insert("api.openai.com", &ca).unwrap();
         // Identical Arc pointer proves cache hit — no re-signing occurred.
         assert!(Arc::ptr_eq(&ck1, &ck2), "second call must return the cached Arc");
+    }
+
+    #[tokio::test]
+    async fn zero_capacity_falls_back_to_default_without_panicking() {
+        // AAASM-4829: an operator setting AA_PROXY_CERT_CACHE_CAPACITY=0 must not
+        // crash the proxy at boot. `new(0)` clamps to the default capacity and
+        // yields a working, caching store.
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let cache = CertCache::new(0);
+        let ck1 = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        let ck2 = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        // A default-sized (non-zero) cache retains the entry, so the second call
+        // is a hit returning the same Arc.
+        assert!(Arc::ptr_eq(&ck1, &ck2), "zero-capacity must clamp to a caching default");
     }
 
     #[tokio::test]

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -5574,6 +5574,13 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Caller lacks the admin role required to read the global override log */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     apply_override: {

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1708,6 +1708,8 @@ paths:
                   $ref: '#/components/schemas/OverrideRecord'
         '401':
           description: Missing or invalid credentials
+        '403':
+          description: Caller lacks the admin role required to read the global override log
     post:
       tags:
       - capability


### PR DESCRIPTION
## Description

Fixes the AAASM-4829 LOW cluster — five low-severity correctness/security gaps in the core Rust crates. The scanner.rs entropy-clamp item is excluded (owned by AAASM-4820); redis tenant-namespacing is deferred (no concrete path).

- **aa-api `list_overrides`** bound `RequireRead(_caller)` but never used it — any authenticated reader could read the global capability override log. The log is global control-plane state with no per-team partition, and apply/revoke are `PolicyScope::Global`/`OrgAdmin` mutations, so the read is now gated to the same admin posture (403 for non-admin). Doc comment records the intentional global posture.
- **aa-proxy in-tunnel egress** now denies a request if *either* the absolute-form target host *or* the `Host` header host is disallowed (defense-in-depth against header host-splitting), instead of only the target-preferred host.
- **aa-proxy host parsing** correctly handles bracketed IPv6 literals: `[::1]:443` previously mangled to `[` via `split(':')`, which let the CONNECT-time `blocked_ip_literal` SSRF check miss internal IPv6 (fail-open) and over-blocked legit IPv6 under a denylist. New bracket-aware `strip_host_port` feeds canonical_host, the SSRF guard, and the plain-HTTP deny path.
- **aa-auth gate** inserts the resolved `AuthenticatedCaller` into request extensions and the extractor reuses it, eliminating a second full validation + a second `RateLimiter::check` (double argon2, halved per-key rate limit) on every gated route.
- **aa-proxy cert cache** clamps `AA_PROXY_CERT_CACHE_CAPACITY=0` to the default instead of panicking at boot on `NonZeroUsize::new(0).expect(...)`.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4829](https://lightning-dust-mite.atlassian.net/browse/AAASM-4829)

## Testing

- [x] Unit tests added / updated

Regression tests added: capability override admin-gate + filter; `strip_host_port`/`canonical_host` on `[::1]:443`; CONNECT SSRF block of bracketed IPv6 loopback; in-tunnel both-host (target vs Host header) egress deny; cert-cache capacity 0 → default (no panic); gate-cached caller reuse (no re-validation/rate-check).

Validated locally (org CI is billing-blocked): `cargo nextest run -p aa-auth` (44 pass), `-p aa-proxy` (225 pass), `-p aa-api capability` (21 pass); `cargo fmt --all -- --check` and `cargo clippy -p aa-auth -p aa-proxy -p aa-api --all-targets --all-features -- -D warnings` clean. `openapi/v1.yaml` regenerated for the new 403 response.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention


[AAASM-4829]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ