### PR TITLE
[AAASM-4841] 🔒 (aa-api): Fix subtree-burn cross-tenant IDOR + admin-gate capability matrix

### DIFF
--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -56,6 +56,23 @@ fn authorize_agent_access(
     Ok(())
 }
 
+/// Whether a descendant discovered while walking an authorized root's subtree
+/// is itself visible to `caller` (AAASM-4841).
+///
+/// A subtree endpoint authorizes its root once (via [`authorize_agent_access`]),
+/// but the root's descendants can be delegated into *other* teams — the same
+/// cross-tenant hazard the topology tree closed in AAASM-4819. Emitting such a
+/// node's id / name / spend, or folding it into a subtree aggregate, is a
+/// cross-tenant IDOR. Gate every descendant on the same team boundary as
+/// [`list_agents`] (AAASM-3865): an admin sees all; a team-scoped caller sees
+/// only its own team's nodes; a team-less node is admin-only.
+fn descendant_visible_to(caller: &AuthenticatedCaller, record: &aa_gateway::registry::AgentRecord) -> bool {
+    match record.team_id.as_deref() {
+        Some(team) => caller.can_access_team(team),
+        None => caller.scopes.contains(&Scope::Admin),
+    }
+}
+
 /// Parse a hex-encoded agent ID string into a 16-byte array.
 ///
 /// Decodes via [`hex::decode`] rather than slicing the input by byte index: the
@@ -632,7 +649,23 @@ pub async fn get_agent_budget(
         return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
             .with_detail("Reading this agent's budget rollup requires admin scope or membership in its team"));
     }
-    let descendants = state.agent_registry.descendants_of(&agent_id_bytes);
+    // AAASM-4841: descendants can be delegated into other teams, and
+    // `subtree_spend` sums every descendant's spend regardless of team. Without
+    // filtering, the "subtree" row would fold a cross-tenant descendant's spend
+    // into the aggregate shown to this caller — an aggregate cross-tenant leak
+    // of the same class as the per-child subtree-burn IDOR. Confine the subtree
+    // to descendants the caller may see (an admin sees all).
+    let descendants: Vec<[u8; 16]> = state
+        .agent_registry
+        .descendants_of(&agent_id_bytes)
+        .into_iter()
+        .filter(|d| {
+            state
+                .agent_registry
+                .get(d)
+                .is_some_and(|rec| descendant_visible_to(&caller, &rec))
+        })
+        .collect();
 
     let rollup = aa_gateway::budget::compute_budget_rollup(
         &agent_id,
@@ -775,20 +808,27 @@ pub async fn get_agent_subtree_burn(
     children.sort();
     for child_id_bytes in children {
         let child_id = aa_core::identity::AgentId::from_bytes(child_id_bytes);
+        // AAASM-4841: the root was authorized by `authorize_agent_access`, but a
+        // direct child may be delegated into another team. Emitting its id /
+        // name / daily spend without a per-child tenant check leaks a
+        // cross-tenant child, exactly the class AAASM-4819 closed in the
+        // topology tree. Omit any child the caller may not see (a missing
+        // record is likewise skipped) so the series never crosses the boundary.
+        let Some(child_record) = state.agent_registry.get(&child_id_bytes) else {
+            continue;
+        };
+        if !descendant_visible_to(&caller, &child_record) {
+            continue;
+        }
         let series = state.budget_tracker.agent_spend_history(&child_id, period_days);
         // Skip children with no recorded spend across the entire window — they
         // would render as a flat zero band and add noise to the legend.
         if !series.iter().any(|(_, amount)| *amount > rust_decimal::Decimal::ZERO) {
             continue;
         }
-        let child_name = state
-            .agent_registry
-            .get(&child_id_bytes)
-            .map(|rec| rec.name)
-            .unwrap_or_else(|| hex::encode(child_id_bytes));
         grids.push(ChildGrid {
             agent_id_hex: hex::encode(child_id_bytes),
-            name: child_name,
+            name: child_record.name,
             series,
         });
     }

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -295,17 +295,27 @@ pub struct MatrixQueryParams {
     params(MatrixQueryParams),
     responses(
         (status = 200, description = "Capability matrix snapshot (filtered)", body = CapabilityMatrix),
-        (status = 401, description = "Missing or invalid credentials")
+        (status = 401, description = "Missing or invalid credentials"),
+        (status = 403, description = "Caller lacks the admin role required to read the capability matrix")
     ),
     tag = "capability"
 )]
 pub async fn get_matrix(
     // AAASM-3846 — the capability matrix is sensitive policy state; require an
     // authenticated reader rather than serving it unauthenticated.
-    RequireRead(_caller): RequireRead,
+    // AAASM-4841 — like its `list_overrides` sibling (AAASM-4829), the matrix is
+    // global control-plane state with no per-team partition: a `CapabilityAgent`
+    // row names an agent but carries no team scope, so there is no tenant slice
+    // to hand a team-scoped caller. Gate it to the same admin posture as the
+    // apply/revoke mutation handlers rather than to any authenticated reader.
+    RequireRead(caller): RequireRead,
     Query(params): Query<MatrixQueryParams>,
     Extension(state): Extension<AppState>,
-) -> (StatusCode, Json<CapabilityMatrix>) {
+) -> Result<(StatusCode, Json<CapabilityMatrix>), ProblemDetail> {
+    if !caller.scopes.contains(&Scope::Admin) {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("Reading the capability matrix requires admin scope".to_string()));
+    }
     let mut matrix = state.capability_store.snapshot().await;
 
     if let Some(ref tid) = params.team_id {
@@ -328,7 +338,7 @@ pub async fn get_matrix(
         }
     }
 
-    (StatusCode::OK, Json(matrix))
+    Ok((StatusCode::OK, Json(matrix)))
 }
 
 /// `POST /api/v1/capability/override` — apply a capability override across

--- a/aa-api/tests/capability.rs
+++ b/aa-api/tests/capability.rs
@@ -83,6 +83,50 @@ async fn revoke_override_rejects_viewer_scope_with_403() {
     );
 }
 
+/// `GET /capability/matrix` is global control-plane state with no per-team
+/// partition (AAASM-4841), so a mere read-scoped caller must be refused with
+/// 403 — mirroring the admin posture of `list_overrides` (AAASM-4829).
+#[tokio::test]
+async fn get_matrix_rejects_viewer_scope_with_403() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/capability/matrix")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a read-only caller must not read the capability matrix"
+    );
+}
+
+/// An admin-scoped caller may read the capability matrix.
+#[tokio::test]
+async fn get_matrix_admin_scope_is_allowed() {
+    let (token, entry) = common::generate_test_api_key("admin-key", vec![Scope::Admin]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/capability/matrix")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "an admin caller may read the matrix");
+}
+
 #[tokio::test]
 async fn get_matrix_returns_200_with_dashboard_shape() {
     let app = common::test_app();

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -825,6 +825,87 @@ async fn subtree_burn_cross_tenant_read_is_403() {
     );
 }
 
+/// AAASM-4841 — subtree-burn authorizes only its root; a direct child delegated
+/// into another team leaks its id / name / daily spend to a caller from the
+/// root's team. The cross-team child must be omitted from the per-child series
+/// while the same-team child is kept, mirroring the AAASM-4819 topology-tree
+/// pruning.
+#[tokio::test]
+async fn subtree_burn_omits_cross_tenant_child() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    // Root and one child in team alpha; a second child delegated into team beta.
+    state.agent_registry.register(agent_with_team(0xD1, "alpha")).unwrap();
+    state
+        .agent_registry
+        .register(child_of(agent_with_team(0xD2, "alpha"), 0xD1))
+        .unwrap();
+    state
+        .agent_registry
+        .register(child_of(agent_with_team(0xD3, "beta"), 0xD1))
+        .unwrap();
+
+    // Record spend for both children so each would otherwise emit a per-child row.
+    state.budget_tracker.record_raw_spend(
+        aa_core::identity::AgentId::from_bytes([0xD2; 16]),
+        Some("alpha"),
+        None,
+        Decimal::new(500, 2),
+    );
+    state.budget_tracker.record_raw_spend(
+        aa_core::identity::AgentId::from_bytes([0xD3; 16]),
+        Some("beta"),
+        None,
+        Decimal::new(900, 2),
+    );
+
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}/subtree-burn", hex_id(0xD1));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+
+    // The same-team child is present; the beta child's identifying fields must
+    // not leak anywhere in the response.
+    let raw = json.to_string();
+    assert!(
+        raw.contains("agent-210"),
+        "same-team child (0xD2) must be present: {raw}"
+    );
+    assert!(raw.contains(&hex_id(0xD2)), "same-team child id must be present: {raw}");
+    assert!(!raw.contains("agent-211"), "beta child name (0xD3) leaked: {raw}");
+    assert!(!raw.contains(&hex_id(0xD3)), "beta child id leaked: {raw}");
+}
+
+/// AAASM-4841 — a same-team subtree-burn child is kept in full; the per-child
+/// tenant gate must not prune a legitimately-visible child.
+#[tokio::test]
+async fn subtree_burn_keeps_same_tenant_child() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xE1, "alpha")).unwrap();
+    state
+        .agent_registry
+        .register(child_of(agent_with_team(0xE2, "alpha"), 0xE1))
+        .unwrap();
+    state.budget_tracker.record_raw_spend(
+        aa_core::identity::AgentId::from_bytes([0xE2; 16]),
+        Some("alpha"),
+        None,
+        Decimal::new(500, 2),
+    );
+
+    let app = aa_api::build_app(state);
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}/subtree-burn", hex_id(0xE1));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let raw = body_json(response).await.to_string();
+    assert!(
+        raw.contains(&hex_id(0xE2)),
+        "same-team child must survive the tenant gate: {raw}"
+    );
+}
+
 // AAASM-3790 — report_edge took no caller, letting any key poison another team's
 // topology; the per-agent edge listing leaked cross-team edges.
 #[tokio::test]

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -5544,6 +5544,13 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Caller lacks the admin role required to read the capability matrix */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     list_overrides: {

--- a/docs/src/adr/0010-gateway-distribution-self-host-examples.md
+++ b/docs/src/adr/0010-gateway-distribution-self-host-examples.md
@@ -16,13 +16,19 @@ real, locally-running core — cannot run out of the box. Two coupled gaps cause
 
 ### Gap 1 — there is no published gateway image
 
-The org publishes only `aa-runtime`, `go`, `python`, and `node` images to GHCR.
-**`ghcr.io/ai-agent-assembly/aa-gateway` is not published.** The
+> **Update (2026-07, [AAASM-4480](https://lightning-dust-mite.atlassian.net/browse/AAASM-4480)):**
+> this gap is now **closed** — the `publish-gateway` job in `docker.yml` publishes
+> `ghcr.io/ai-agent-assembly/aa-gateway` (version tag + `:latest`) on release tags, exactly the
+> Option A distribution this ADR adopts. The description below records the state at the time of
+> writing (2026-06) that motivated the decision.
+
+At the time of writing, the org published only `aa-runtime`, `go`, `python`, and `node`
+images to GHCR; **`ghcr.io/ai-agent-assembly/aa-gateway` was not yet published.** The
 [examples](https://lightning-dust-mite.atlassian.net/browse/AAASM-3791) scenario — and
-any limited-function OSS self-host of the gateway over Docker — therefore has no gateway
+any limited-function OSS self-host of the gateway over Docker — therefore had no gateway
 image to pull. PR #166 had to *build* `aa-gateway` from the monorepo just to verify agent
-registration. Verified on macOS+Docker: only `:8080` is open on the runtime image, there
-is no `aa-gateway` image in GHCR, and `docker inspect` shows the runtime image is
+registration. Verified on macOS+Docker: only `:8080` was open on the runtime image, there
+was no `aa-gateway` image in GHCR, and `docker inspect` showed the runtime image is
 distroless.
 
 This is in tension with the existing, **accepted** policy decision in
@@ -204,10 +210,12 @@ Rationale, grounded in policy:
 
 ### What this blocks / defers (follow-up work, gated on ratification)
 
-1. **Implementation ticket — publish `aa-gateway` image.** Add the crate's image to
-   `docker.yml`, the `docker/sdk-versions.json`-style version/pin manifest, the
-   compatibility matrix, and the release fan-out; ship it labelled **limited-function**;
-   then point the examples Compose at the pinned tag. (Distribution scope of this ADR.)
+1. **Implementation ticket — publish `aa-gateway` image.** ✅ **Done
+   ([AAASM-4480](https://lightning-dust-mite.atlassian.net/browse/AAASM-4480)):** the
+   `publish-gateway` job in `docker.yml` now builds and pushes
+   `ghcr.io/ai-agent-assembly/aa-gateway` (version tag + `:latest`) on release tags, labelled
+   **limited-function**. Remaining wiring — the version/pin manifest, compatibility matrix, and
+   pointing the examples Compose at the pinned tag — follows the ADR 0009 model.
 2. **Core follow-up — per-tool policy resolution (Gap 2).** Confirm/clarify and, if needed,
    implement the path so the live runtime emits a gateway `CheckAction` for tool checks, so
    the demo's `read_file` allow / `delete_file` deny is actually evaluated by the gateway

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1677,6 +1677,8 @@ paths:
                 $ref: '#/components/schemas/CapabilityMatrix'
         '401':
           description: Missing or invalid credentials
+        '403':
+          description: Caller lacks the admin role required to read the capability matrix
   /api/v1/capability/override:
     get:
       tags:


### PR DESCRIPTION
## Description

Fixes AAASM-4841 — a MED cross-tenant IDOR plus a LOW-severity cluster in the `aa-api` HTTP surface.

**1. MED — subtree-burn cross-tenant child leak (`agents.rs`).** `get_agent_subtree_burn` authorized only the root agent, then emitted each direct child's `child_agent_id` / `child_name` / daily `spent_usd` with no per-child tenant check — a child delegated into a *different* team leaked its id, name, and daily spend to a caller from the root's team. This is the exact class AAASM-4819 closed in `topology.rs`. Every subtree-burn child is now gated on the caller's tenant boundary (admin sees all; team-scoped sees only its own team; team-less is admin-only), mirroring `topology.rs::build_tree`.

**Budget rollup subtree aggregate (`agents.rs`).** Confirmed the sibling `get_agent_budget` had the same root cause: `subtree_spend` sums every descendant's spend regardless of team, so the "subtree" row folded a cross-tenant descendant's spend into the aggregate. Descendants are now filtered to those the caller may see before the rollup is computed.

**2. LOW (latent MED) — capability matrix served to any reader (`capability.rs`).** `GET /capability/matrix` required only `RequireRead` and ignored the caller, serving the full fleet-wide agent × resource × verb matrix to any authenticated key. Like its `list_overrides` sibling (AAASM-4829), the matrix is global control-plane state with no per-team partition, so it is now admin-gated (403 otherwise), matching the apply/revoke mutation posture.

**3. LOW — stale ADR text (`docs/src/adr/0010`).** The ADR's Gap 1 stated `ghcr.io/ai-agent-assembly/aa-gateway` "is not published"; the `docker.yml` `publish-gateway` job (AAASM-4480) now publishes it on release tags. Added a dated update note, past-tensed the historical gap description, and marked the publish follow-up done.

## Type of Change

- [x] 🐛 Bug fix
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

The capability matrix now returns 403 for non-admin callers (previously 200). This is the intended security fix; the endpoint backs an admin-only dashboard surface. OpenAPI spec and dashboard codegen regenerated for the added 403 response.

## Related Issues

- Related Jira ticket: [AAASM-4841](https://lightning-dust-mite.atlassian.net/browse/AAASM-4841)

## Testing

- [x] Integration tests added / updated

`cargo nextest run -p aa-api --test capability --test tenant_scope --test agents --test agents_detail` — 116 passed, 0 failed. New tests: `subtree_burn_omits_cross_tenant_child`, `subtree_burn_keeps_same_tenant_child`, `get_matrix_rejects_viewer_scope_with_403`, `get_matrix_admin_scope_is_allowed`. `cargo fmt` + commit-time `clippy` clean on every commit.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention


[AAASM-4841]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ