### PR TITLE
[AAASM-4866] 📝 (cli-docs): Sync start/stop docs to actual CLI behavior

### DIFF
--- a/docs/src/cli/start-stop.md
+++ b/docs/src/cli/start-stop.md
@@ -25,16 +25,19 @@ aasm start [OPTIONS]
 |---|---|---|---|
 | `--mode <MODE>` | `local` \| `remote` | `local` | Deployment mode. `local` binds `127.0.0.1` (loopback only); `remote` binds `0.0.0.0`. |
 | `--port <PORT>` | integer | `7391` | TCP port the gateway listens on. |
-| `--config <CONFIG>` | path | `~/.aasm/config.yaml` | YAML config file consumed by the gateway. |
+| `--config <CONFIG>` | path | `~/.aasm/config.yaml` | Accepted for a stable operator surface but **not yet wired** — the value is currently a no-op and is not read by the spawned process. |
 | `--foreground` | flag | off | Stay in the foreground; do not daemonize. |
-| `--no-dashboard` | flag | off | Disable dashboard serving (even in local mode). |
+| `--no-dashboard` | flag | off | Accepted for a stable operator surface but **not yet wired** — currently a no-op. Dashboard serving is determined by the mode: local mode runs `aa-api-server`, which always serves the dashboard. |
 
 ### Behavior
 
 1. Resolve the listen address from `mode` + `port`.
 2. Exit early (idempotent) if a gateway is already running at that address —
    verified by a live PID file **and** a successful TCP probe.
-3. Spawn `aa-gateway` (background, or foreground with `--foreground`).
+3. Spawn the entrypoint binary for the selected mode (background, or foreground
+   with `--foreground`): local mode launches `aa-api-server` (which serves the
+   dashboard SPA **and** the full `/api/v1/*` REST surface from a single process);
+   remote mode launches `aa-gateway` via `--listen`.
 4. In background mode, write the PID file and wait for the listener before
    printing the success banner.
 
@@ -49,9 +52,10 @@ aasm start --mode local --port 7391
 ```
 
 ```text
-Agent Assembly gateway started (pid 48213)
-  Gateway:    http://localhost:7391
-  Dashboard:  http://localhost:7391
+✓ Agent Assembly gateway started
+  Mode:    local
+  Address: http://localhost:7391
+  PID:     48213
 ```
 
 ---
@@ -83,5 +87,5 @@ aasm stop --timeout 15
 ```
 
 ```text
-Sent SIGTERM to pid 48213; exited gracefully.
+Gateway stopped (PID 48213).
 ```


### PR DESCRIPTION
## Description

Doc-only fix. `docs/src/cli/start-stop.md` had drifted from the actual behavior of `aa-cli/src/commands/{start,stop}.rs`. This syncs the page to the current code, verified against the source.

The 5 corrections:

1. **Binary per mode** — local mode spawns `aa-api-server` (dashboard SPA + full `/api/v1/*` REST surface from one process); remote mode spawns `aa-gateway` via `--listen`. The doc previously said `aa-gateway` for both. (`start.rs` `binary_name`, ~157-160)
2. **Start success banner** — now shown as `✓ Agent Assembly gateway started` / `Mode:` / `Address:` / `PID:`. The doc previously showed a `Gateway:`/`Dashboard:` URL form that no code path produces. (`start.rs` `format_started_banner`, ~91-102)
3. **`--config`** — documented as accepted-but-not-yet-wired (a no-op; `args.config` is never read), not as "consumed by the gateway". (`start.rs` module doc, ~9-10)
4. **`--no-dashboard`** — documented as an accepted no-op (never referenced in the run/spawn path); dashboard serving is determined by which binary the mode spawns, not this flag. The doc previously claimed it disables dashboard serving.
5. **Stop output** — now `Gateway stopped (PID {pid}).`, matching `stop.rs` ~114. The doc previously showed `Sent SIGTERM to pid …; exited gracefully.`, which no code path emits.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4866
- Related GitHub issues: N/A

## Testing

- [x] No tests required (docs-only change). Validated with `mdbook build` in `docs/` — book builds cleanly.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — N/A, no code changed
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4866