### PR TITLE
[AAASM-4867] 📝 (cli-docs): Sync sandbox docs to actual output

### DIFF
--- a/docs/src/cli/sandbox.md
+++ b/docs/src/cli/sandbox.md
@@ -35,11 +35,14 @@ aasm sandbox run ./tool.wasm --fuel 50000000 --wall-clock-ms 10000
 ```
 
 ```text
-Sandbox run: ./tool.wasm
-  Outcome:    completed
-  Fuel used:  3,201,884 / 50,000,000
-  Wall time:  812ms / 10000ms
+sandbox exited cleanly (exit_code=0)
 ```
+
+On success the command prints a single line with the module's exit code. If the
+sandbox refuses or traps the module (fuel exhaustion, memory-cap or wall-clock
+overrun, or a WASI trap), it instead writes `sandbox refused or trapped the
+module: <reason>` to stderr and exits non-zero. Fuel and wall-time usage are not
+tracked or reported.
 
 ---
 
@@ -52,8 +55,9 @@ aasm sandbox info
 ```
 
 ```text
-Default sandbox limits:
-  Fuel:           10,000,000 units
-  Memory pages:   16  (1 MiB)
-  Wall clock:     5000 ms
+aasm sandbox — WASI preview 1 tool-execution sandbox
+  fuel (instructions):      10000000
+  memory ceiling:           16 pages (1024 KiB)
+  wall-clock deadline (ms): 5000
+  preopened dirs:           (none — fully sealed FS)
 ```


### PR DESCRIPTION
## Description

Fixes doc/code drift in `docs/src/cli/sandbox.md` against `aa-cli/src/commands/sandbox.rs`. Both output examples on the sandbox CLI doc page described output the code never produces:

- **`sandbox run`** — the doc claimed a `Sandbox run: … / Outcome / Fuel used / Wall time` telemetry block. The code (`sandbox.rs:88-96`) only ever prints `sandbox exited cleanly (exit_code=…)` on success, or writes `sandbox refused or trapped the module: <reason>` to stderr on failure. No fuel or wall-time usage is tracked or reported anywhere. Removed the fabricated block and documented the real one-line output plus the stderr failure path.
- **`sandbox info`** — the doc claimed a `Default sandbox limits:` header with `Fuel / Memory pages (1 MiB) / Wall clock` labels. The code (`print_info`, `sandbox.rs:100-110`) prints header `aasm sandbox — WASI preview 1 tool-execution sandbox` with labels `fuel (instructions):`, `memory ceiling: {} pages ({} KiB)` (KiB, not MiB), `wall-clock deadline (ms):`, and a `preopened dirs:` line. Corrected the header, labels, units, and added the missing line.

The option-table defaults (10M fuel, 16 pages = 1 MiB, 5000 ms) were verified against `SandboxLimits::default()` and are already correct — left unchanged.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4867

## Testing

- [x] No tests required (explain why)

Docs-only change. Verified by reading current source and by `mdbook build` (succeeds).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4867

🤖 Generated with [Claude Code](https://claude.com/claude-code)