### PR TITLE
[AAASM-4865] 📝 (readme): Correct workspace-member count

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ can move from this repo to the SDKs, the install tap, or the canonical docs.
 
 ## Crate Map
 
-The Cargo workspace declares **29 members** in the top-level `Cargo.toml`. The table below lists the core architectural crates; storage drivers, dev-tool adapters, and test harnesses are omitted for brevity. Two additional eBPF-target crates live alongside but are intentionally outside the workspace because they compile for the `bpfel-unknown-none` target.
+The Cargo workspace declares **30 members** in the top-level `Cargo.toml`. The table below lists the core architectural crates; storage drivers, dev-tool adapters, and test harnesses are omitted for brevity. Two additional eBPF-target crates live alongside but are intentionally outside the workspace because they compile for the `bpfel-unknown-none` target.
 
 ### Workspace members (core)
 


### PR DESCRIPTION
## Description

Corrects the workspace-member count in the README Crate Map. `README.md:164` stated the Cargo workspace declares **29 members**, but the top-level `Cargo.toml` `[workspace] members` array currently has **30 entries** (grep-counted / verified programmatically). The count regressed when `aa-integration-tests` was added to the workspace without updating the README. Fix is scoped to the number only (29 → 30).

Actual member count verified:

```
$ awk '/^members = \[/{f=1;next} /^\]/{f=0} f' Cargo.toml | grep -c '"'
30
```

**Possible follow-up (not in this PR):** this is the second recurrence of this drift (prior: AAASM-4321, 28 vs 29). The README count is manually maintained with no guard, so it will keep drifting whenever a workspace member is added/removed. A small CI check that greps the actual `Cargo.toml` member count and fails if it doesn't match the README's stated number would prevent a third recurrence. Filing/building that guard is left as a separate follow-up per the ticket's suggestion.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4865

## Testing

- [x] No tests required (explain why)

Doc-only change. Verified the new number equals the actual `Cargo.toml` `[workspace] members` count (30) via `grep -c`. No build required.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4865