### PR TITLE
[AAASM-4869] 📝 (cli-docs): Sync topology docs to actual table render

### DIFF
--- a/docs/src/cli/topology.md
+++ b/docs/src/cli/topology.md
@@ -18,8 +18,9 @@ aasm topology <SUBCOMMAND> [OPTIONS]
 | [`stats`](#aasm-topology-stats) | Show aggregate topology statistics. |
 
 All subcommands accept the [global options](overview.md#global-options),
-including `--output table|json|yaml` (tables render via box-drawing trees for
-`tree`/`lineage`).
+including `--output table|json|yaml`. Only `tree` renders as a box-drawing tree;
+`overview`, `team`, `lineage`, and `stats` render as tables in the default
+`table` mode.
 
 ---
 
@@ -30,7 +31,7 @@ Show a fleet-wide topology overview across all teams and root agents.
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--status <STATUS>` | string | — | Filter agents by status (`active`, `suspended`, `deregistered`). |
-| `--show-budget` | flag | off | Include governance level in agent nodes. |
+| `--show-budget` | flag | off | Request each agent's governance level from the server. Only surfaced in `--output json`/`yaml`; the `table` view has no governance column, so this flag has no visible effect in table mode. |
 
 ```bash
 aasm topology overview --status active
@@ -45,19 +46,23 @@ Render a delegation subtree rooted at one agent, using box-drawing characters.
 | Name | Type | Default | Description |
 |---|---|---|---|
 | `<AGENT_ID>` | string (arg) | — | Root agent ID (hex-encoded UUID). |
-| `--max-depth <DEPTH>` | integer | `10` | Maximum traversal depth from the root. |
+| `--max-depth <DEPTH>` | integer | — | Maximum traversal depth from the root. When omitted, the depth parameter is not sent and the server applies its own default (there is no client-side default). Must be at least `1`. |
 | `--status <STATUS>` | string | — | Filter tree nodes by status. |
-| `--show-budget` | flag | off | Include governance level in tree nodes. |
+| `--show-budget` | flag | off | Request each node's governance level from the server. Only surfaced in `--output json`/`yaml`; the tree view has no governance column, so this flag has no visible effect in table mode. |
 
 ```bash
 aasm topology tree a1b2c3… --max-depth 3
 ```
 
+Each node prints as `<name> [<status>] <<team_id>>` (the `<team_id>` segment is
+shown only when the agent has a team). Agent IDs are not printed in tree mode —
+use `--output json` if you need them.
+
 ```text
-research-bot (a1b2c3…)
-├── fetch-worker (d4e5f6…)
-│   └── parse-worker (778899…)
-└── summarize-worker (aabbcc…)
+└── research-bot [active] <research>
+    ├── fetch-worker [active] <research>
+    │   └── parse-worker [active] <research>
+    └── summarize-worker [active] <research>
 ```
 
 ---
@@ -70,7 +75,7 @@ Show all agents belonging to a single team.
 |---|---|---|---|
 | `<TEAM_ID>` | string (arg) | — | Team ID. |
 | `--status <STATUS>` | string | — | Filter members by status. |
-| `--show-budget` | flag | off | Include governance level in agent nodes. |
+| `--show-budget` | flag | off | Request each member's governance level from the server. Only surfaced in `--output json`/`yaml`; the `table` view has no governance column, so this flag has no visible effect in table mode. |
 
 ```bash
 aasm topology team research --status active
@@ -80,7 +85,10 @@ aasm topology team research --status active
 
 ## aasm topology lineage
 
-Show an agent's complete ancestry chain, ordered root-first.
+Show an agent's complete ancestry chain, ordered root-first. In `table` mode the
+lineage renders as a flat table with columns
+`DEPTH | AGENT_ID | NAME | TEAM | DELEGATION_REASON`, followed by a
+`(this is a root agent)` note when the agent has no ancestors above it.
 
 | Name | Type | Default | Description |
 |---|---|---|---|
@@ -92,28 +100,45 @@ aasm topology lineage 778899… --show-permissions
 ```
 
 ```text
-root-bot (a1b2c3…)
-└── fetch-worker (d4e5f6…)
-    └── parse-worker (778899…)   ← target
+Agent: 778899…  |  Ancestors: 3
+
+┌───────┬──────────┬──────────────┬──────────┬───────────────────┐
+│ DEPTH ┆ AGENT_ID ┆ NAME         ┆ TEAM     ┆ DELEGATION_REASON │
+╞═══════╪══════════╪══════════════╪══════════╪═══════════════════╡
+│ 0     ┆ a1b2c3…  ┆ root-bot     ┆ research ┆ -                 │
+│ 1     ┆ d4e5f6…  ┆ fetch-worker ┆ research ┆ fetch upstream    │
+│ 2     ┆ 778899…  ┆ parse-worker ┆ research ┆ parse response    │
+└───────┴──────────┴──────────────┴──────────┴───────────────────┘
 ```
 
 ---
 
 ## aasm topology stats
 
-Show aggregate topology statistics — total/root/active/suspended counts, max
-depth, team sizes, and depth/spawn histograms. Takes no flags of its own
-(uses the global `--output`).
+Show aggregate topology statistics — total/root/active/suspended/deregistered
+counts, max depth, teams, orphans, and average children per parent. Takes no
+flags of its own (uses the global `--output`). In `table` mode each metric is
+its own row.
 
 ```bash
 aasm topology stats --output json
 ```
 
 ```text
-Total agents:    42
-Root agents:     5
-Max depth:       4
-Active:          38   Suspended: 3   Deregistered: 1
-Teams:           5
-Avg children/parent: 2.31
+┌─────────────────────┬───────┐
+│ METRIC              ┆ VALUE │
+╞═════════════════════╪═══════╡
+│ Total agents        ┆ 42    │
+│ Root agents         ┆ 5     │
+│ Max depth           ┆ 4     │
+│ Active              ┆ 38    │
+│ Suspended           ┆ 3     │
+│ Deregistered        ┆ 1     │
+│ Teams               ┆ 5     │
+│ Orphans             ┆ 0     │
+│ Avg children/parent ┆ 2.31  │
+└─────────────────────┴───────┘
 ```
+
+When present, a `Depth histogram` (`DEPTH | COUNT`) and a `Team-size histogram`
+(`TEAM_SIZE | COUNT`) are printed as additional tables below the summary.


### PR DESCRIPTION
## Description

Docs-only. Syncs `docs/src/cli/topology.md` to what `aa-cli` actually renders. The page claimed behaviour the code never produces:

- **Lineage** was documented as a box-drawing tree ending in `parse-worker (778899…) ← target`. Actual: `render/mod.rs` routes `Lineage` to `render_lineage_table` — a comfy-table (`DEPTH | AGENT_ID | NAME | TEAM | DELEGATION_REASON`). The box-drawing `render_lineage_chain` exists but is **dead code** (zero callers); there is no `← target` marker anywhere.
- **Tree** output was shown with parenthesized agent IDs (`research-bot (a1b2c3…)`); `render/tree.rs` only prints `{name} [status] <team>` — the id is never printed. Also the root node itself gets a `└── ` connector.
- **Stats** was shown as one combined line `Active: 38 Suspended: 3 …`; actual is a per-metric comfy-table that also includes an undocumented `Orphans` row plus optional Depth / Team-size histograms.
- **`--max-depth`** was documented with a client-side default of `10`; `TreeArgs.depth` is `Option<u32>` with no `default_value` — when omitted the param is simply not sent and the server applies its own default.
- **`--show-budget`** was documented as adding governance level to nodes; `governance_level` is only emitted in `json`/`yaml`, never in table/tree columns — so it has no visible effect in table mode.

Rewrote the examples and flag docs accordingly.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4869](https://lightning-dust-mite.atlassian.net/browse/AAASM-4869)

## Testing

- [x] No tests required (docs-only). Verified against pinned-commit source (`render/mod.rs`, `render/table.rs`, `render/tree.rs`, `topology/tree.rs`) and built the site locally with `mdbook build` (clean).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

---

**Stacking:** first PR in a stacked chain of three doc-drift fixes that share pages. **AAASM-4872 stacks on this PR**, and **AAASM-4873 stacks on 4872**. Base is `master`; merge in order 4869 → 4872 → 4873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-4869]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ