### PR TITLE
[AAASM-4868] 📝 (cli-docs): Sync status docs to actual output

### DIFF
--- a/docs/src/cli/status.md
+++ b/docs/src/cli/status.md
@@ -48,12 +48,24 @@ Agent Assembly Status
   Health:    ✓ ok
 ─────────────────────────────────────
 
-Active Agents
-  ID        NAME            FRAMEWORK   STATUS   SESSIONS   VIOLATIONS   LAST EVENT
-  a1b2…     research-bot    langgraph   active   3          0            2m ago tool_call
+ACTIVE AGENTS
+─────────────
+┌──────────┬──────────────┬───────────┬───────────┬──────────┬──────────────────┬──────────────────┬───────┐
+│ AGENT_ID │ NAME         │ STATUS    │ FRAMEWORK │ SESSIONS │ LAST_EVENT       │ VIOLATIONS_TODAY │ LAYER │
+╞══════════╪══════════════╪═══════════╪═══════════╪══════════╪══════════════════╪══════════════════╪═══════╡
+│ a1b2c3d4 │ research-bot │ ● Running │ langgraph │ 3        │ 2m ago tool_call │ 0                │ sdk   │
+└──────────┴──────────────┴───────────┴───────────┴──────────┴──────────────────┴──────────────────┴───────┘
 
-Pending Approvals: 1  (oldest 2m 15s)
-Budget: $12.50 / $50.00 daily  ███████░░░░░░░░░░░░░  25%
+PENDING APPROVALS
+─────────────────
+  Count:  1
+  Oldest: 2m ago
+
+BUDGET STATUS
+─────────────
+  Daily spend : $12.50 / $50.00  █████░░░░░░░░░░░░░░░  25%
+  Date:           2026-04-30
+  (no per-agent data)
 ```
 
 Continuously refresh:


### PR DESCRIPTION
## Description

Documentation-only fix. The `aasm status` example in `docs/src/cli/status.md` had drifted from the actual render code (`aa-cli/src/commands/status/render.rs` and `fetch.rs`). Corrected the example to match real output:

- **Active Agents table** — was `ID, NAME, FRAMEWORK, STATUS, SESSIONS, VIOLATIONS, LAST EVENT` (wrong names/order, omitted `LAYER`). Now the real header set/order: `AGENT_ID, NAME, STATUS, FRAMEWORK, SESSIONS, LAST_EVENT, VIOLATIONS_TODAY, LAYER`, uppercase `ACTIVE AGENTS` title, and the real status icon (e.g. `● Running`; the code only maps `Running`/`Idle`/`Suspended`, not the doc's old `active`).
- **Budget line** — label is `Daily spend `, not `Budget:`. `format_bar_chart` fills `(pct*20)/100` blocks, so 25% is **5** filled blocks, not the 7 the old example drew. Now shows the real `BUDGET STATUS` block with `█████░░░░░░░░░░░░░░░  25%`.
- **Pending Approvals** — the age is built by `fetch.rs::format_duration`, which has minute-minimum granularity (`5m` / `2h 15m` / `1d 3h`, never seconds), so the old `(oldest 2m 15s)` is impossible. Now the real multi-line block with `Oldest: 2m ago`.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4868

Closes AAASM-4868

## Testing

- [x] No tests required (docs-only). Validated with `mdbook build` (clean build) and hand-traced every example value against `render.rs`/`fetch.rs` at commit `3f9cd0746067f575179f3b8613bddba8616991d8`.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)