### PR TITLE
[AAASM-4870] 📝 (cli-docs): Sync trace docs to actual output

### DIFF
--- a/docs/src/cli/trace.md
+++ b/docs/src/cli/trace.md
@@ -36,13 +36,18 @@ aasm trace 7f3a1c2b
 ```
 
 ```text
-session 7f3a1c2b
-├─ 🧠 llm: gpt-4 (1200ms)
-│  ├─ 🔧 tool_call: search (340ms)
-│  │  └─ 📥 tool_result: search (12ms)
-│  └─ ⛔ deny: file_write — path outside allowlist
-└─ 🧠 llm: gpt-4 (800ms)
+Trace: 7f3a1c2b
+├─ ●  LLM gpt-4  1200ms
+│  ├─ ●  TOOL search  340ms
+│  │  └─ ←  RESULT search  12ms
+│  └─ ❌ DENY file_write  0ms  (path outside allowlist)
+└─ ●  LLM gpt-4  800ms
 ```
+
+Each event line is `<icon> <label>  <duration>`, where the icon encodes the
+event kind (`●  LLM`, `●  TOOL`, `←  RESULT`, `✅ ALLOW`, `❌ DENY`). Policy
+denials still carry a duration and are printed in red with the violation reason
+appended in parentheses.
 
 Timeline view:
 
@@ -50,8 +55,16 @@ Timeline view:
 aasm trace 7f3a1c2b --format timeline
 ```
 
+The timeline flattens every event (including nested ones) into one row each,
+prefixed with a `Timeline: <session_id>` header. Each row is a fixed-width
+uppercase kind tag and label, an ASCII bar sized relative to the longest event,
+and the duration:
+
 ```text
-llm: gpt-4        ████████████████████  1200ms
-tool_call: search ██████                 340ms
-llm: gpt-4        █████████████          800ms
+Timeline: 7f3a1c2b
+LLM    gpt-4                ████████████████████████████████████████  1200ms
+TOOL   search              ███████████                                340ms
+RESULT search              █                                          12ms
+DENY   file_write                                                     0ms
+LLM    gpt-4               ███████████████████████████                800ms
 ```


### PR DESCRIPTION
## Description

`docs/src/cli/trace.md` drifted from the actual `aasm trace` renderer in
`aa-cli/src/commands/trace/{tree,timeline}.rs`. The tree and timeline example
blocks showed output the CLI never produces. This rewrites both blocks to match
the real renderer:

- **Tree header** is `Trace: {session_id}` (`tree.rs:73`), not `session 7f3a1c2b`.
- **Event lines** are `<icon> <label>  <duration>` (`tree.rs:29-36`) with the icons
  `●  LLM` / `●  TOOL` / `←  RESULT` / `✅ ALLOW` / `❌ DENY` (`tree.rs:16-24`) —
  not the fabricated `🧠 llm: gpt-4` emoji/colon style. Deny lines carry a duration
  and append the violation reason in parentheses (printed in red).
- **Timeline** always prepends a `Timeline: {session_id}` header (`timeline.rs:58`)
  and uses uppercase fixed-width row labels via `{kind_tag:<6} {label:<20}`
  (`timeline.rs:25-34`), not the lowercase `llm: gpt-4` style; the doc example
  previously omitted the header entirely.

Docs-only; no runtime code change.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4870

## Testing

- [x] Manual testing performed — `mdbook build` succeeds; both example blocks
  verified line-by-line against the current renderer source.
- [x] No tests required (docs-only change; no runtime surface)

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4870
