### PR TITLE
[AAASM-4864] 🔒 (aa-auth): Redact ApiKey Debug to avoid plaintext leak

### DIFF
--- a/aa-auth/src/api_key.rs
+++ b/aa-auth/src/api_key.rs
@@ -327,6 +327,22 @@ mod tests {
     }
 
     #[test]
+    fn test_api_key_debug_redacts_plaintext() {
+        let key = ApiKey::generate();
+        let plaintext = key.as_str().to_string();
+        let rendered = format!("{key:?}");
+        assert!(
+            !rendered.contains(&plaintext),
+            "Debug output must not contain the plaintext credential"
+        );
+        // The hex portion alone must not leak either.
+        assert!(
+            !rendered.contains(&plaintext[3..]),
+            "Debug output must not contain the key's hex material"
+        );
+    }
+
+    #[test]
     fn test_api_key_parse_invalid_prefix() {
         let result = ApiKey::parse("bb_00112233445566778899aabbccddeeff");
         assert!(matches!(result, Err(ApiKeyError::InvalidPrefix)));

--- a/aa-auth/src/api_key.rs
+++ b/aa-auth/src/api_key.rs
@@ -29,8 +29,20 @@ const API_KEY_HEX_LEN: usize = 32;
 const KEY_LOOKUP_HEX_LEN: usize = 16;
 
 /// An Agent Assembly API key in `aa_<32-hex-chars>` format.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is hand-written to redact the key material: a derived `Debug` would
+/// print the full plaintext credential, so this mirrors the redacting `Debug`
+/// impls on the repo's other secret-bearing types (`aa-proxy::Secret`,
+/// `aa-sdk-client::IpcCommand`) as defense-in-depth against accidental logging.
+#[derive(Clone)]
 pub struct ApiKey(String);
+
+impl std::fmt::Debug for ApiKey {
+    /// Redact the key material — never print the plaintext credential.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ApiKey(REDACTED)")
+    }
+}
 
 impl ApiKey {
     /// Parse and validate a raw API key string.


### PR DESCRIPTION
## Description

`aa-auth`'s `ApiKey(String)` derived `Debug`, which would print the full
plaintext credential via `{:?}`. No call site formats it that way today, so
this is a latent footgun rather than an active leak — but the derive is a
landmine. This drops the derive and hand-writes a redacting `Debug` impl that
renders `ApiKey(REDACTED)`, mirroring the existing redacting `Debug` impls on
the repo's other secret-bearing types (`aa-proxy::Secret`,
`aa-sdk-client::IpcCommand`). `Clone` and all other behavior are unchanged.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

`ApiKey` still implements `Debug`; only the rendered output changes (redacted
instead of plaintext).

## Related Issues

- Related Jira ticket: AAASM-4864

## Testing

- [x] Unit tests added / updated

Added `test_api_key_debug_redacts_plaintext`, which formats an `ApiKey` with
`{:?}` and asserts the output contains neither the full credential nor its hex
material. Validated locally:

- `cargo nextest run -p aa-auth` — 45 passed, 0 failed
- `cargo clippy -p aa-auth --all-targets -- -D warnings` — clean (exit 0)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4864

🤖 Generated with [Claude Code](https://claude.com/claude-code)
