### PR TITLE
[AAASM-4871] 📝 (cli-docs): Sync agent/audit/cost/policy/context/proxy docs

### DIFF
--- a/docs/src/cli/agent.md
+++ b/docs/src/cli/agent.md
@@ -40,9 +40,12 @@ aasm agent list --status Active --framework langgraph
 ```
 
 ```text
-ID        NAME           FRAMEWORK   VERSION   STATUS    TOOLS
-a1b2c3…   research-bot   langgraph   1.2.0     Active    search, fetch
+AGENT_ID   NAME           FRAMEWORK   VERSION   STATUS   PID     SESSIONS   LAST_EVENT
+a1b2c3…    research-bot   langgraph   1.2.0     Active   48213   3          2026-06-09T14:02:11Z
 ```
+
+Columns that the server did not supply render as `-` (e.g. `PID`, `SESSIONS`,
+`LAST_EVENT` for an agent with no live process or events).
 
 ---
 

--- a/docs/src/cli/audit.md
+++ b/docs/src/cli/audit.md
@@ -43,8 +43,8 @@ aasm audit list --result deny --since 2h --limit 20
 ```
 
 ```text
-SEQ   TIMESTAMP             AGENT     EVENT             RESULT
-142   2026-06-09T14:01:00Z  a1b2c3…   PolicyViolation   deny
+TIMESTAMP             AGENT     ACTION            TOOL         RESULT   POLICY
+2026-06-09T14:01:00Z  a1b2c3…   PolicyViolation   file_write   deny     block-system-paths
 ```
 
 ---
@@ -87,7 +87,7 @@ aasm audit verify-chain ./audit/session-7f3a.jsonl
 ```
 
 ```text
-✓ chain valid — 412 entries, genesis → entry 0xab12…
+OK — 412 entries verified
 ```
 
 ---

--- a/docs/src/cli/context.md
+++ b/docs/src/cli/context.md
@@ -30,10 +30,13 @@ aasm context list
 ```
 
 ```text
-NAME         API URL                       DEFAULT
-production   https://api.example.com       *
-staging      https://staging.example.com
+production *  https://api.example.com (key set)
+staging  https://staging.example.com
 ```
+
+One line per context — no header row. A ` *` marker follows the default
+context's name, and ` (key set)` follows the URL when an API key is stored for
+that context.
 
 ---
 

--- a/docs/src/cli/cost.md
+++ b/docs/src/cli/cost.md
@@ -31,13 +31,22 @@ aasm cost summary --period month --group-by agent
 ```
 
 ```text
-Cost Summary (month, 2026-06)
-  Total: $312.40 / $1,000.00  (31.2%)
+AGENT_ID   DAILY_SPEND   MONTHLY_SPEND
+a1b2c3…    $6.00         $180.10
+d4e5f6…    $4.41         $132.30
 
-  AGENT      MONTHLY SPEND
-  a1b2c3…    $180.10
-  d4e5f6…    $132.30
+COST SUMMARY (Monthly)
+──────────────────
+  Monthly spend: $312.40
+  Budget limit:  $1,000.00
+  Utilization:   31.2%
+  Date:          2026-06
 ```
+
+With `--group-by agent`, the per-agent table (always three columns:
+`AGENT_ID`, `DAILY_SPEND`, `MONTHLY_SPEND`) prints first, followed by the
+global summary. The spend and limit labels read `Daily` for `--period today`
+and `Monthly` for `--period month`.
 
 ---
 
@@ -52,9 +61,12 @@ aasm cost forecast
 ```
 
 ```text
-Cost Forecast (2026-06-09, day 9 of 30)
-  Current daily spend:      $12.50
-  Projected monthly spend:  $375.00
-  Monthly limit:            $1,000.00
-  Projected utilization:    37.5%
+COST FORECAST
+─────────────
+  Date:              2026-06-09
+  Day of month:      9/30
+  Current daily:     $12.50
+  Projected monthly: $375.00
+  Monthly limit:     $1,000.00
+  Projected util:    37.5%
 ```

--- a/docs/src/cli/policy.md
+++ b/docs/src/cli/policy.md
@@ -39,7 +39,11 @@ aasm policy apply ./policies/prod.yaml --applied-by alice@example.com
 ```
 
 ```text
-Applied policy 9f2c1a (version 2026-06-09T14:00:00Z) — active, 12 rules
+Policy applied successfully.
+  Version:    9f2c1a
+  Timestamp:  2026-06-09T14:00:00Z
+  Active:     true
+  Rules:      12
 ```
 
 ---
@@ -107,10 +111,22 @@ aasm policy simulate --policy ./candidate.yaml --against ./audit/session.jsonl
 ```
 
 ```text
-Simulation: 412 events, 3 would-be violations
-  deny  file_write  /etc/passwd   (rule: block-system-paths)
-exit status: 1
+Simulation Report
+--------------------------------------------------
+Total events:       412
+Allowed:            409
+Denied:             3
+Approval required:  0
+Budget impact:      $0.00
+
+EVENT#   ACTION               DECISION     REASON
+----------------------------------------------------------------------
+0        file_write           deny         block-system-paths
 ```
+
+The command exits non-zero when the report has any denied or errored outcome
+(so it can gate CI). The `EVENT#` table is printed only when there are flagged
+outcomes, and the `Budget impact` line only when a budget impact is computed.
 
 ---
 
@@ -128,7 +144,7 @@ aasm policy validate ./policies/prod.yaml
 ```
 
 ```text
-✓ policy valid — 12 rules
+Policy is valid: ./policies/prod.yaml
 ```
 
 ---
@@ -157,9 +173,9 @@ aasm policy list --output json
 ```
 
 ```text
-NAME      VERSION                  ACTIVE   RULES
-9f2c1a    2026-06-09T14:00:00Z     yes      12
-7ab310    2026-06-01T09:30:00Z     no       11
+NAME      STATUS     UPDATED_AT               RULES
+9f2c1a    Active     2026-06-09T14:00:00Z     12
+7ab310    Inactive   2026-06-01T09:30:00Z     11
 ```
 
 ---

--- a/docs/src/cli/proxy.md
+++ b/docs/src/cli/proxy.md
@@ -24,7 +24,11 @@ aasm proxy <SUBCOMMAND> [OPTIONS]
 ## aasm proxy start
 
 Spawn `aa-proxy` in the background (or foreground with `--no-detach`). The
-binary is resolved from `$PATH`, then `~/.cargo/bin`, then `./target/release`.
+binary is resolved from `$PATH`, then `~/.cargo/bin` — trusted, absolute
+locations only. A cwd-relative `./target/release` fallback was deliberately
+removed as a security fix (AAASM-4020): resolving relative to the current
+working directory would let whoever controls where `aasm` runs substitute an
+attacker-planted `aa-proxy`.
 
 | Flag | Type | Default | Description |
 |---|---|---|---|


### PR DESCRIPTION
## Description

Docs-only sync of six `docs/src/cli/*.md` pages whose example output had drifted
from the actual `aa-cli/src/commands/**` output. Each example was re-verified
against current source before editing. One page per commit.

- **agent.md** — `agent list` header is `AGENT_ID … STATUS PID SESSIONS LAST_EVENT`; removed the stale `TOOLS` column.
- **audit.md** — `audit list` header is `TIMESTAMP AGENT ACTION TOOL RESULT POLICY` (no `SEQ`/`EVENT`); `verify-chain` prints `OK — {n} entries verified`.
- **context.md** — `context list` prints one line per context, no header row: `{name}{ *}  {url}{ (key set)}`.
- **cost.md** — `cost summary --group-by agent` prints the 3-column per-agent table first, then a labeled global summary; `forecast` uses a `COST FORECAST` header with `Current daily`/`Projected monthly`/`Projected util` labels.
- **policy.md** — `apply` prints labeled `Version`/`Timestamp`/`Active`/`Rules` lines; `simulate` prints a multi-line `Simulation Report` + `EVENT#` table; `validate` prints `Policy is valid: {file}`; `list` header is `NAME STATUS UPDATED_AT RULES` with `Active`/`Inactive`.
- **proxy.md** (security-doc fix) — removed the documented `./target/release` cwd binary-resolution fallback. `resolve_binary` in `proxy/start.rs` checks only `$PATH` (`which`) + `~/.cargo/bin`; the cwd-relative fallback was **deliberately removed as a security fix ([AAASM-4020](https://lightning-dust-mite.atlassian.net/browse/AAASM-4020))** because resolving relative to cwd let whoever controls where `aasm` runs substitute an attacker-planted `aa-proxy`. The doc had reinstated a description of that patched, removed vulnerable path.

Item 12 in the finding (`version.md`) is intentionally **not** touched here — it is owned by a separate ticket.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4871

## Testing

- [x] Manual testing performed — `mdbook build` succeeds (only a benign mdbook-mermaid version-mismatch warning); every corrected example checked line-by-line against the current command source at the finding commit `3f9cd074`.
- [x] No tests required (docs-only; no runtime code change).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

> Published via the GitHub Git Data API replay (the repo's prescribed path for
> docs-only branches, since the `cargo doc` pre-push hook can't be satisfied on
> macOS/eBPF). Remote tree verified identical to local `HEAD`.

Closes AAASM-4871


[AAASM-4020]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ