### PR TITLE
[AAASM-4862] 🔒 (aa-ebpf): Emit signal when PID_FILTER map is full

### DIFF
--- a/aa-ebpf-probes/src/syscall_guard.rs
+++ b/aa-ebpf-probes/src/syscall_guard.rs
@@ -83,7 +83,7 @@ use aa_ebpf_common::syscall::MAX_SYSCALL_ALLOWLIST;
 use aya_ebpf::{
     helpers::{bpf_get_current_pid_tgid, bpf_send_signal},
     macros::{map, tracepoint},
-    maps::HashMap,
+    maps::{HashMap, PerCpuArray},
     programs::TracePointContext,
 };
 
@@ -96,6 +96,25 @@ static PID_FILTER: HashMap<u32, u8> = HashMap::with_max_entries(1024, 0);
 /// Syscall allowlist keyed by syscall number; a present key = permitted.
 #[map]
 static SYSCALL_ALLOWLIST: HashMap<u32, u8> = HashMap::with_max_entries(MAX_SYSCALL_ALLOWLIST, 0);
+
+/// Per-CPU counter (single slot) of fork-propagation drops caused by a full
+/// `PID_FILTER` (AAASM-4862).
+///
+/// When [`try_fork_propagate`]'s `insert` fails, `PID_FILTER` is at its
+/// 1024-entry cap and the just-forked child runs **UNCONFINED** — an
+/// unavoidable fail-open at the fork tracepoint (it cannot block the fork, and
+/// a child that never gets a `PID_FILTER` entry also escapes the enforcement
+/// tracepoint, which is the very lookup that gates the kill — so "kill the
+/// child" is not achievable here). This counter makes that otherwise-silent
+/// degradation observable: userspace (`SyscallGuardLoader::fork_map_full_drops`
+/// in `aa-ebpf`) sums the per-CPU slots and surfaces the total.
+///
+/// A *per-CPU counter* rather than a per-event perf/ring record is deliberate:
+/// a fork burst against a full map would otherwise emit an event storm at the
+/// worst possible moment, while a monotonic counter conveys the same "N
+/// children escaped confinement" signal without amplifying the pressure.
+#[map]
+static FORK_MAP_FULL_DROPS: PerCpuArray<u64> = PerCpuArray::with_max_entries(1, 0);
 
 /// `SIGKILL` — sent to a monitored process that issues a non-allowlisted
 /// syscall.
@@ -181,9 +200,13 @@ fn try_syscall_guard(ctx: &TracePointContext) -> Result<(), i64> {
 /// copy `PID_FILTER` membership from a monitored parent to the new child so the
 /// child is confined from its first syscall.
 ///
-/// Returns `0` always; the propagation is a best-effort map write and any
-/// failure (map full) leaves the child unconfined — fail-open is unavoidable
-/// here because the tracepoint cannot block the fork.
+/// Returns `0` always; the propagation is a best-effort map write. If it fails,
+/// `PID_FILTER` is at its 1024-entry cap and the child runs unconfined —
+/// fail-open is unavoidable here because the tracepoint cannot block the fork
+/// (and a child with no `PID_FILTER` entry also escapes the enforcement
+/// tracepoint, so killing it is not achievable). That drop is recorded in
+/// [`FORK_MAP_FULL_DROPS`] so the degradation is observable in userspace
+/// instead of silent (AAASM-4862).
 #[tracepoint]
 pub fn aa_syscall_guard_fork(ctx: TracePointContext) -> u32 {
     let _ = try_fork_propagate(&ctx);
@@ -204,8 +227,18 @@ fn try_fork_propagate(ctx: &TracePointContext) -> Result<(), i64> {
     // and is reaped by [`try_exit_cleanup`] when that thread exits (AAASM-3982).
     let child_pid = unsafe { ctx.read_at::<u32>(SCHED_FORK_CHILD_PID_OFFSET) }?;
 
-    // Confine the child by mirroring the parent's PID_FILTER membership.
-    let _ = PID_FILTER.insert(&child_pid, &PID_MONITORED, 0);
+    // Confine the child by mirroring the parent's PID_FILTER membership. A full
+    // map (1024 cap) makes this insert fail and the child then runs UNCONFINED;
+    // bump the per-CPU FORK_MAP_FULL_DROPS counter so the fail-open is
+    // observable rather than silent (AAASM-4862). See that map's docs for why a
+    // counter — not a per-fork perf/ring event — is used here.
+    if PID_FILTER.insert(&child_pid, &PID_MONITORED, 0).is_err() {
+        if let Some(dropped) = FORK_MAP_FULL_DROPS.get_ptr_mut(0) {
+            unsafe {
+                *dropped += 1;
+            }
+        }
+    }
     Ok(())
 }
 

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -732,6 +732,19 @@ mod tests {
         ));
     }
 
+    // Documents the AAASM-4862 observability contract: the fork-map-full drop
+    // counter is readable through the loader. On non-Linux the BPF object is a
+    // stub so the accessor surfaces the map error rather than a bogus zero.
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn fork_map_full_drops_returns_error_on_non_linux() {
+        let loader = SyscallGuardLoader::new(1);
+        assert!(matches!(
+            loader.fork_map_full_drops().unwrap_err(),
+            EbpfError::MapUpdate(_)
+        ));
+    }
+
     #[test]
     #[cfg(not(target_os = "linux"))]
     fn load_returns_error_on_non_linux() {

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -661,6 +661,47 @@ impl SyscallGuardLoader {
             Ok(())
         }
     }
+
+    /// Sum of fork-propagation drops caused by a full `PID_FILTER` (AAASM-4862).
+    ///
+    /// A non-zero value means at least that many forked children of a confined
+    /// process ran **UNCONFINED** because `PID_FILTER` had hit its 1024-entry
+    /// cap when their `sched_process_fork` fired — the fail-open the fork
+    /// tracepoint cannot prevent (it can neither block the fork nor kill an
+    /// unfiltered child). This accessor is the observability surface for that
+    /// otherwise-silent degradation: it reads the BPF-side `FORK_MAP_FULL_DROPS`
+    /// per-CPU counter and returns the total across CPUs. The count is
+    /// monotonic for the life of the loaded program.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EbpfError::MapUpdate`] on non-Linux or if the map is missing /
+    /// cannot be read.
+    pub fn fork_map_full_drops(&self) -> Result<u64, EbpfError> {
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(EbpfError::MapUpdate("eBPF is only supported on Linux".into()))
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let bpf = self
+                .bpf
+                .as_ref()
+                .ok_or_else(|| EbpfError::MapUpdate("BPF not loaded — call load() first".into()))?;
+
+            let counter: aya::maps::PerCpuArray<_, u64> = aya::maps::PerCpuArray::try_from(
+                bpf.map("FORK_MAP_FULL_DROPS")
+                    .ok_or_else(|| EbpfError::MapUpdate("FORK_MAP_FULL_DROPS map not found".into()))?,
+            )
+            .map_err(|e| EbpfError::MapUpdate(e.to_string()))?;
+
+            // Per-CPU array: one slot (index 0) holds a private counter per CPU;
+            // the fleet-wide drop total is their sum.
+            let per_cpu = counter.get(&0, 0).map_err(|e| EbpfError::MapUpdate(e.to_string()))?;
+            Ok(per_cpu.iter().copied().sum())
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

`aa-syscall-guard`'s fork tracepoint copies `PID_FILTER` membership from a confined parent to each newly forked child so the child is confined from its first syscall (AAASM-3916). When `PID_FILTER` is at its 1024-entry cap the membership `insert` fails, and the previous code discarded that failure (`let _ = PID_FILTER.insert(...)`) — the overflow child then ran with **zero syscall confinement and no signal at all**.

This PR makes that degradation **observable**:

- The fork tracepoint now increments a new per-CPU counter map, `FORK_MAP_FULL_DROPS`, whenever the `PID_FILTER` insert fails.
- Userspace reads it via a new accessor, `SyscallGuardLoader::fork_map_full_drops()`, which sums the per-CPU slots — a non-zero total means that many forked children escaped confinement because the map was full.

A **per-CPU counter** (not a perf/ring event) is deliberate: a fork burst against a full map would otherwise emit an event storm at the worst possible moment; a monotonic counter conveys the same "N children escaped confinement" signal without amplifying the pressure. This matches the codebase's existing eBPF observability channels (perf array / ring buffer) as a lighter-weight metric variant appropriate for a degradation counter.

### Scope: why this is the observability half only

The ticket also raises a "fail-closed — kill the unconfinable child" alternative. **That is not achievable at the `sched_process_fork` tracepoint** and this PR does not attempt it:

- The tracepoint **cannot block the fork** — it is an observe-point, not a gate.
- A child that never receives a `PID_FILTER` entry also **escapes the `raw_syscalls/sys_enter` enforcement probe** — that probe's `PID_FILTER` lookup is the very thing that gates the SIGKILL, so there is no confined PID to signal.

So the only actionable half is emitting a signal on map-full, which is exactly AAASM-4862's stated acceptance criterion. This PR delivers that.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4862

## Testing

- [x] Unit tests added / updated — `fork_map_full_drops_returns_error_on_non_linux` pins the accessor's non-Linux contract; full `aa-ebpf` suite green (106 passed).
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- Notes: `cargo check -p aa-ebpf`, `cargo clippy -p aa-ebpf --all-targets --all-features -- -D warnings`, and `cargo nextest run -p aa-ebpf` all pass on macOS. The BPF probe object (`aa-ebpf-probes`) targets `bpfel-unknown-none` and is not compiled on macOS (per repo policy `cargo check -p aa-ebpf` is sufficient there); the aya-ebpf `PerCpuArray` API used was verified against the pinned crate source.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4862
