### PR TITLE
[AAASM-4863] 🔒 (aa-proxy): Redact target in the debug log path

### DIFF
--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -1101,7 +1101,13 @@ impl ProxyServer {
         method: &str,
         target: &str,
     ) -> Result<(), ProxyError> {
-        tracing::debug!(method = method, target = target, "plain HTTP request");
+        // AAASM-4863: a secret can ride in the plain-HTTP target's query string
+        // (`?token=…`, a presigned `?X-Amz-Signature=…`) exactly as in the audit
+        // path, so it is redacted through the same scanner (AAASM-4738) before
+        // reaching this debug log — the raw target must never be logged in
+        // cleartext.
+        let redacted_target = self.interceptor.redact_target(target);
+        tracing::debug!(method = method, target = %redacted_target, "plain HTTP request");
 
         // Consume remaining request headers.
         // AAASM-3922: cap the head (per-line + total budget + count) so an

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -1382,6 +1382,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn plain_http_debug_target_is_redacted() {
+        // AAASM-4863 regression: the `handle_plain_http` debug log renders the
+        // target through `redact_target` (the AAASM-4738 helper) so a secret
+        // riding in the query string never reaches the log in cleartext. This
+        // pins the exact value the `target = %…` field would carry.
+        let server = server_with(vec![], vec![]).await;
+        // A well-known synthetic OpenAI key the default scanner detects. Not real.
+        let target = "/v1/chat?token=sk-TESTONLY-NOT-REAL-1234567890abcdef1234567890ab";
+        // `redact_target` returns the exact String the `target = %…` debug field
+        // renders (its `Display` is identity).
+        let logged = server.interceptor.redact_target(target);
+        assert!(
+            !logged.contains("sk-TESTONLY-NOT-REAL"),
+            "debug target must not contain the raw secret: {logged}"
+        );
+        assert!(
+            logged.contains("[REDACTED:"),
+            "debug target must carry a redaction label: {logged}"
+        );
+    }
+
+    #[tokio::test]
     async fn connect_deny_reason_blocks_metadata_ip_literal() {
         // SSRF: the cloud metadata endpoint as an IP literal must be denied
         // even with an empty allowlist (which is otherwise allow-all).


### PR DESCRIPTION
## Description

`aa-proxy`'s `handle_plain_http` logged the raw request target in a `tracing::debug!` line (`aa-proxy/src/proxy/mod.rs`), so a secret riding in the target's query string — an API key (`?token=…`) or a presigned URL signature (`?X-Amz-Signature=…`) — reached the debug log in cleartext. The sibling audit-JSONL path already redacts the target via the `redact_target` helper introduced by AAASM-4738; this path was simply missed.

This PR routes the target through that same `redact_target` helper before it is logged, so the raw secret is replaced with a `[REDACTED:<kind>]` label. No behavior changes beyond redaction.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4863
- Sibling redaction path / origin of the helper: AAASM-4738

## Testing

- [x] Unit tests added / updated

Added `plain_http_debug_target_is_redacted`, which asserts the value the debug line renders (`redact_target` output) contains no raw secret and carries a `[REDACTED:…]` label when the target query string holds a synthetic API key. Validated locally:

- `cargo nextest run -p aa-proxy` — 226 passed, 3 skipped
- `cargo clippy -p aa-proxy --all-targets -- -D warnings` — clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4863

🤖 Generated with [Claude Code](https://claude.com/claude-code)
