### PR TITLE
[AAASM-4873] 📝 (cli-docs): Sync alerts/dashboard/gateway/version docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -37,6 +37,7 @@
 - [aasm config](cli/config.md)
 - [aasm context](cli/context.md)
 - [aasm admin](cli/admin.md)
+- [aasm uninstall](cli/uninstall.md)
 - [aasm version](cli/version.md)
 - [aasm completion](cli/completion.md)
 

--- a/docs/src/cli/admin.md
+++ b/docs/src/cli/admin.md
@@ -34,8 +34,12 @@ aasm admin run-retention --dry-run
 
 ```json
 {
-  "dry_run": true,
-  "audit_events_scanned": 14293,
-  "audit_events_dropped": 0
+  "ran_at": "2026-06-09T14:05:00Z",
+  "hot_rows": 14293,
+  "compressed_rows": 512,
+  "archived_rows": 128,
+  "dropped_rows": 0,
+  "freed_bytes": 0,
+  "dry_run": true
 }
 ```

--- a/docs/src/cli/agent.md
+++ b/docs/src/cli/agent.md
@@ -16,8 +16,9 @@ aasm agent <SUBCOMMAND> [OPTIONS]
 | [`resume`](#aasm-agent-resume) | Resume a suspended agent. |
 | [`kill`](#aasm-agent-kill) | Deregister and terminate an agent. |
 
-All subcommands accept the [global options](overview.md#global-options),
-including `--output table|json|yaml`.
+All subcommands accept the [global options](overview.md#global-options).
+`list`, `inspect`, `suspend`, and `resume` honor `--output table|json|yaml`;
+`kill` ignores `--output` and always prints a plain-text confirmation.
 
 ---
 
@@ -48,8 +49,10 @@ a1b2c3…   research-bot   langgraph   1.2.0     Active    search, fetch
 
 ## aasm agent inspect
 
-Render a detailed key-value view of a single agent: identity, status, tools,
-metadata, active sessions, recent events, and recent trace session IDs.
+Render a detailed view of a single agent as a two-column `Field | Value` table
+(identity, status, tools, PID, sessions, last event, policy violations, and
+metadata when present), followed by separate tables for active sessions, recent
+events, and recent traces when the agent has any.
 
 ### Arguments
 
@@ -64,17 +67,33 @@ aasm agent inspect a1b2c3d4e5f600112233445566778899
 ```
 
 ```text
-Agent a1b2c3d4…
-  Name:        research-bot
-  Framework:   langgraph 1.2.0
-  Status:      Active
-  PID:         48213
-  Sessions:    3
-  Violations:  0
-  Tools:       search, fetch, summarize
-  Recent traces:
-    7f3a…  2026-06-09T14:02:11Z   (aasm trace 7f3a…)
+┌───────────────────┬──────────────────────────────────┐
+│ Field             ┆ Value                            │
+╞═══════════════════╪══════════════════════════════════╡
+│ ID                ┆ a1b2c3d4e5f600112233445566778899 │
+│ Name              ┆ research-bot                     │
+│ Framework         ┆ langgraph                        │
+│ Version           ┆ 1.2.0                            │
+│ Status            ┆ Active                           │
+│ Tools             ┆ search, fetch, summarize         │
+│ PID               ┆ 48213                            │
+│ Sessions          ┆ 3                                │
+│ Last Event        ┆ 2026-06-09T14:02:11Z             │
+│ Policy Violations ┆ 0                                │
+└───────────────────┴──────────────────────────────────┘
+
+Recent Traces:
+┌────────────┬──────────────────────┐
+│ SESSION_ID ┆ TIMESTAMP            │
+╞════════════╪══════════════════════╡
+│ 7f3a…      ┆ 2026-06-09T14:02:11Z │
+└────────────┴──────────────────────┘
+Tip: run `aasm trace <session-id>` to visualize a trace
 ```
+
+`Framework` and `Version` are separate rows. When the agent has metadata,
+active sessions, or recent events, those render as their own rows/tables above
+the traces section.
 
 ---
 
@@ -97,7 +116,9 @@ aasm agent suspend a1b2c3… --reason "investigating cost spike" --force
 ```
 
 ```text
-Suspended a1b2c3… : Active → Suspended
+Agent a1b2c3… suspended.
+  Previous status: Active
+  New status:      Suspended(Manual)
 ```
 
 ---
@@ -119,7 +140,9 @@ aasm agent resume a1b2c3…
 ```
 
 ```text
-Resumed a1b2c3… : Suspended → Active
+Agent a1b2c3… resumed.
+  Previous status: Suspended(Manual)
+  New status:      Active
 ```
 
 ---
@@ -142,5 +165,5 @@ aasm agent kill a1b2c3… --force
 ```
 
 ```text
-Killed a1b2c3… — deregistered and terminated.
+Agent a1b2c3… has been killed.
 ```

--- a/docs/src/cli/alerts.md
+++ b/docs/src/cli/alerts.md
@@ -69,5 +69,5 @@ aasm alerts resolve al-301 --reason "raised team cap" --force
 ```
 
 ```text
-Resolved al-301.
+Alert al-301 resolved.
 ```

--- a/docs/src/cli/approvals.md
+++ b/docs/src/cli/approvals.md
@@ -72,7 +72,7 @@ aasm approvals approve ap-77 --reason "verified safe"
 ```
 
 ```text
-Approved ap-77.
+Approved: ap-77 (status: approved)
 ```
 
 ---
@@ -92,7 +92,7 @@ aasm approvals reject ap-77 --reason "writes outside allowed path"
 ```
 
 ```text
-Rejected ap-77.
+Rejected: ap-77 (status: rejected)
 ```
 
 ---
@@ -111,6 +111,13 @@ aasm approvals watch --interactive
 ```
 
 ```text
-▶ ap-78  a1b2c3…  network_egress  api.openai.com   3m 00s
-  a approve   r reject   ↑/↓ select   q quit
+  aasm approvals watch (interactive)
+  [a] approve  [r] reject  [Up/Down] navigate  [q] quit
+
+  > ap-78  a1b2c3…             network_egress                 3m 00s
 ```
+
+The interactive view marks the selected row with `>` and prints
+`id  agent  action  countdown` per row — it does **not** show a condition
+field. (The non-interactive stream prints `NEW  <id> | agent=… | action=… |
+condition=…` lines instead.)

--- a/docs/src/cli/context.md
+++ b/docs/src/cli/context.md
@@ -30,10 +30,14 @@ aasm context list
 ```
 
 ```text
-NAME         API URL                       DEFAULT
-production   https://api.example.com       *
-staging      https://staging.example.com
+production *  https://api.example.com (key set)
+staging  https://staging.example.com
 ```
+
+The default context is marked with a trailing ` *`, and ` (key set)` is
+appended when a context has a stored API key. When no contexts are configured,
+`aasm context list` prints `No contexts configured. Use \`aasm context set\` to
+add one.` instead.
 
 ---
 
@@ -45,14 +49,22 @@ Create or update a named context.
 |---|---|---|---|
 | `<NAME>` | string (arg) | — | Name of the context to create or update. |
 | `--api-url <API_URL>` | string | _required_ | API URL for this context. |
-| `--api-key <API_KEY>` | string | — | API key for this context (optional). |
+| `--api-key <API_KEY>` | string | — | API key for this context (optional). Prefer the `AASM_API_KEY` environment variable — see the note below. |
+
+> **`AASM_API_KEY` env var.** When `--api-key` is omitted, `aasm context set`
+> reads the key from the `AASM_API_KEY` environment variable (an empty value is
+> treated as unset). Passing `--api-key` on the command line prints a warning
+> and is discouraged, because argv is world-readable via `ps`,
+> `/proc/<pid>/cmdline`, and shell history, which leaks the operator bearer
+> token. The global [`--api-key`](overview.md#global-options) flag honors the
+> same `AASM_API_KEY` env var.
 
 ```bash
-aasm context set staging --api-url https://staging.example.com
+AASM_API_KEY=staging-key aasm context set staging --api-url https://staging.example.com
 ```
 
 ```text
-Saved context 'staging'.
+Context 'staging' saved.
 ```
 
 ---
@@ -70,5 +82,5 @@ aasm context use production
 ```
 
 ```text
-Default context set to 'production'.
+Switched to context 'production'.
 ```

--- a/docs/src/cli/dashboard.md
+++ b/docs/src/cli/dashboard.md
@@ -44,7 +44,8 @@ aasm dashboard start --port 8088 --open
 ```
 
 ```text
-Dashboard serving at http://127.0.0.1:8088  (Ctrl-C to stop)
+Dashboard running at http://127.0.0.1:8088
+Press Ctrl-C to stop.
 ```
 
 Once the server is up, the browser opens to the dashboard **home / overview** —

--- a/docs/src/cli/dashboard.md
+++ b/docs/src/cli/dashboard.md
@@ -90,5 +90,5 @@ aasm dashboard stop
 ```
 
 ```text
-Dashboard server stopped.
+Dashboard stopped.
 ```

--- a/docs/src/cli/gateway.md
+++ b/docs/src/cli/gateway.md
@@ -25,8 +25,9 @@ aasm gateway <SUBCOMMAND> [OPTIONS]
 ## aasm gateway start
 
 Spawn `aa-gateway` in the background (or foreground with `--no-detach`). The
-binary is resolved from `$PATH`, then `~/.cargo/bin`, then
-`./target/release`, then `./target/debug`.
+binary is resolved in priority order (highest first): alongside the `aasm`
+executable itself (a sibling `aa-gateway`), then `$PATH`, then `~/.cargo/bin`,
+then `./target/release`, then `./target/debug`.
 
 | Flag | Type | Default | Description |
 |---|---|---|---|

--- a/docs/src/cli/gateway.md
+++ b/docs/src/cli/gateway.md
@@ -67,7 +67,12 @@ aasm gateway status --json
 ```
 
 ```json
-{ "running": true, "pid": 48213, "listen": "127.0.0.1:50051", "uptime_seconds": 8133 }
+{
+  "running": true,
+  "pid": 48213,
+  "listen": "127.0.0.1:50051",
+  "uptime_seconds": 8133
+}
 ```
 
 ---

--- a/docs/src/cli/overview.md
+++ b/docs/src/cli/overview.md
@@ -125,6 +125,7 @@ Some commands give the exit code a documented meaning so it can gate CI:
 | [`aasm config`](config.md) | Local | Validate / boot an `agent-assembly.toml`. |
 | [`aasm context`](context.md) | Local | Manage `~/.aa/config.yaml` contexts. |
 | [`aasm admin`](admin.md) | Gateway HTTP | Administrative operations (retention). |
+| [`aasm uninstall`](uninstall.md) | Local | Remove Agent Assembly tools installed via the curl installer (`--purge` also removes local data; Homebrew installs are redirected to `brew uninstall`). |
 | [`aasm version`](version.md) | Gateway HTTP | CLI + gateway/api versions. |
 | [`aasm completion`](completion.md) | Local | Generate shell completion scripts. |
 

--- a/docs/src/cli/uninstall.md
+++ b/docs/src/cli/uninstall.md
@@ -1,0 +1,37 @@
+# aasm uninstall
+
+Uninstall Agent Assembly tools installed via the curl installer.
+
+`aasm uninstall` is a thin wrapper over the installer's uninstall engine. The
+curl installer (`scripts/install-cli.sh`) is the single source of truth for the
+manifest-driven removal and `--purge` logic; on install it persists a runnable
+copy at `${AASM_STATE_DIR:-~/.aasm}/aasm-uninstall`, and this command forwards
+to it so the CLI, the curl installer, and the offline fallback all share one
+engine. Homebrew-managed installs are detected by the engine and redirected to
+`brew uninstall`.
+
+If no local uninstaller is found, the command prints the Homebrew and curl
+fallbacks and exits non-zero.
+
+## Synopsis
+
+```text
+aasm uninstall [OPTIONS]
+```
+
+Safe by default: without `--purge`, only the installed components are removed;
+Agent Assembly-owned local data (config + state) is left in place.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--components <LIST>` | string | — | Remove only these components (comma-separated: `cli,runtime,proxy,ebpf`). |
+| `--component <NAME>` | string (repeatable) | — | Remove a single component; repeat the flag for several. |
+| `--all` | flag | off | Uninstall all components (the default scope; accepted for explicitness). |
+| `--purge` | flag | off | Also remove Agent Assembly-owned local data (config + state). |
+| `--dry-run` | flag | off | Show what would be removed without changing anything. |
+| `-y, --yes` | flag | off | Skip the `--purge` confirmation prompt (non-interactive). |
+
+```bash
+aasm uninstall --dry-run
+aasm uninstall --purge --yes
+```

--- a/docs/src/cli/version.md
+++ b/docs/src/cli/version.md
@@ -25,9 +25,9 @@ aasm version
 
 ```text
 COMPONENT   VERSION
-cli         0.0.1
-gateway     0.0.1
-api         0.0.1
+cli         0.0.1-rc.6
+gateway     0.0.1-rc.6
+api         0.0.1-rc.6
 ```
 
 JSON form:


### PR DESCRIPTION
## Description

Docs-only. Cosmetic wording/formatting fixes so `docs/src/cli/*.md` matches actual `aa-cli` output.

- **alerts.md** — `resolve` prints `Alert <id> resolved.` (not `Resolved <id>.`) — `alerts/resolve.rs`.
- **dashboard.md** — `stop` prints `Dashboard stopped.` — the doc's `Dashboard server stopped.` had an extra word the code (`dashboard/stop.rs`) does not emit. (Note: the finding text stated this inverted; I followed the source.)
- **gateway.md** — `status --json` is pretty-printed multi-line JSON (`gateway/status.rs` uses `serde_json::to_string_pretty`), not a single-line object.
- **version.md** — the `cli` row resolves from `env!("CARGO_PKG_VERSION")` = `0.0.1-rc.6` (`Cargo.toml:45`), replacing the `0.0.1` placeholder.

Verified against pinned-commit source; `mdbook build` is clean.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4873](https://lightning-dust-mite.atlassian.net/browse/AAASM-4873)

## Testing

- [x] No tests required (docs-only). Built the site locally with `mdbook build` (clean).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention (one per page)

---

**⚠️ Stacked PR — depends on AAASM-4872 → AAASM-4869.** This branch is stacked on `v0.0.1/AAASM-4872/cli_docs_admin_cluster` (itself stacked on `v0.0.1/AAASM-4869/cli_docs_topology`), so its diff against `master` also includes the 4869 (PR #1568) and 4872 (PR #1575) changes. **Merge order: #1568 → #1575 → this PR.** Once the two below land, this PR's diff reduces to only alerts.md / dashboard.md / gateway.md / version.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-4873]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ