### PR TITLE
[AAASM-4859] 🔒 (aa-api): Close SSRF blocklist gaps in destination-test

### DIFF
--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -341,6 +341,53 @@ mod tests {
     }
 
     #[test]
+    fn egress_rejects_newly_closed_ranges() {
+        // AAASM-4859: ranges the local blocklist previously missed, now covered
+        // by the shared aa_core::net set. Each embeds an internal/non-routable
+        // target (several encode the 169.254.169.254 metadata endpoint).
+        for url in [
+            // CGNAT 100.64.0.0/10 and "this network" 0.0.0.0/8.
+            "http://100.64.0.1/hook",
+            "http://0.1.2.3/hook",
+            // 169.254.169.254 via each IPv6 encoding a translator could forward.
+            "http://[::ffff:a9fe:a9fe]/hook",   // IPv4-mapped
+            "http://[64:ff9b::a9fe:a9fe]/hook", // NAT64 64:ff9b::/96
+            "http://[2002:a9fe:a9fe::1]/hook",  // 6to4 2002::/16
+            "http://[::a9fe:a9fe]/hook",        // IPv4-compatible ::/96
+        ] {
+            assert_eq!(
+                egress(url),
+                Err(ValidationError::InvalidConfig(
+                    "webhook.url resolves to a disallowed internal address"
+                )),
+                "{url} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn egress_rejects_metadata_via_every_encoding() {
+        // The 169.254.169.254 cloud-metadata endpoint must be refused however it
+        // is spelled — as a v4 literal and through each IPv6 form.
+        for url in [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[::ffff:169.254.169.254]/",
+            "http://[::ffff:a9fe:a9fe]/",
+            "http://[64:ff9b::a9fe:a9fe]/",
+            "http://[2002:a9fe:a9fe::1]/",
+            "http://[::a9fe:a9fe]/",
+        ] {
+            assert_eq!(
+                egress(url),
+                Err(ValidationError::InvalidConfig(
+                    "webhook.url resolves to a disallowed internal address"
+                )),
+                "{url} must be rejected"
+            );
+        }
+    }
+
+    #[test]
     fn egress_allows_public_ip() {
         // A public literal IP carries no DNS dependency and must be allowed.
         assert!(egress("http://8.8.8.8/hook").is_ok());

--- a/aa-api/src/destinations/validate.rs
+++ b/aa-api/src/destinations/validate.rs
@@ -111,29 +111,15 @@ fn private_egress_allowed() -> bool {
         .unwrap_or(false)
 }
 
-/// True when `ip` is an address an SSRF guard must refuse: loopback, RFC1918
-/// private, link-local (incl. the `169.254.169.254` cloud-metadata endpoint),
-/// IPv4 broadcast, the unspecified address, or — for IPv6 — loopback,
-/// unspecified, unique-local (`fc00::/7`), or link-local (`fe80::/10`).
-/// IPv4-mapped IPv6 addresses are unwrapped and re-checked against the v4 rules.
+/// True when `ip` is an address the webhook egress guard must refuse.
+///
+/// Delegates to the shared [`aa_core::net::is_blocked_ip`] so this guard and the
+/// proxy's CONNECT guard enforce one identical range set. The local copy used to
+/// miss CGNAT `100.64.0.0/10`, `0.0.0.0/8`, and the IPv6 transition prefixes
+/// (NAT64 `64:ff9b::/96`, 6to4 `2002::/16`, IPv4-compatible `::/96`) that can
+/// embed an internal IPv4 such as `169.254.169.254` (AAASM-4859).
 fn ip_is_internal(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified() || v4.is_broadcast()
-        }
-        IpAddr::V6(v6) => {
-            if let Some(mapped) = v6.to_ipv4_mapped() {
-                return ip_is_internal(IpAddr::V4(mapped));
-            }
-            let octets = v6.octets();
-            v6.is_loopback()
-                || v6.is_unspecified()
-                // fc00::/7 unique-local
-                || (octets[0] & 0xfe) == 0xfc
-                // fe80::/10 link-local
-                || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80)
-        }
-    }
+    aa_core::net::is_blocked_ip(ip)
 }
 
 /// Reject an address that resolves into a disallowed internal range.

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod evaluators;
 pub mod identity;
 #[cfg(feature = "alloc")]
 pub mod llm;
+pub mod net;
 pub mod policy;
 pub mod risk_tier;
 #[cfg(feature = "std")]

--- a/aa-core/src/net.rs
+++ b/aa-core/src/net.rs
@@ -1,0 +1,178 @@
+//! Shared SSRF IP blocklist (AAASM-4859).
+//!
+//! Every interception layer that dials an address on an agent's (or operator's)
+//! behalf must refuse the same set of non-globally-routable ranges — otherwise
+//! an attacker coaxes one layer into reaching loopback services, RFC-1918
+//! networks, or the cloud metadata endpoint (`169.254.169.254`) for a confused-
+//! deputy SSRF.
+//!
+//! This module is the single source of truth for that range set, so the proxy's
+//! CONNECT guard (`aa-proxy/src/ssrf.rs`) and the webhook-destination egress
+//! guard (`aa-api/src/destinations/validate.rs`) can't drift apart again — the
+//! original drift is exactly what AAASM-4859 fixed, where the AAASM-3997
+//! hardening lived only in the proxy.
+//!
+//! Fail-closed: any address whose reachability is not unambiguously public is
+//! treated as blocked. Lives in `aa-core` (`no_std` via `core::net`) so it
+//! carries no I/O or std dependency.
+
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// Returns `true` when `ip` is in a range no interception layer may dial on
+/// another party's behalf: loopback, private (RFC 1918 / unique-local),
+/// link-local (including the `169.254.169.254` cloud metadata endpoint),
+/// unspecified, broadcast, documentation, CGNAT, or other non-globally-routable
+/// space — including IPv6 encodings that embed an internal IPv4.
+///
+/// Fail-closed: any address whose reachability is not unambiguously public is
+/// treated as blocked.
+pub fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_blocked_ipv4(v4),
+        // Map IPv4-mapped forms back to v4 so `::ffff:127.0.0.1` and
+        // `::ffff:169.254.169.254` cannot smuggle a blocked v4 past the filter.
+        // Only `to_ipv4_mapped` is used — the deprecated `to_ipv4` also maps
+        // `::1` to `0.0.0.1`, which would slip IPv6 loopback past the v4 path.
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => is_blocked_ipv4(v4),
+            None => is_blocked_ipv6(v6),
+        },
+    }
+}
+
+/// Returns `true` when the IPv4 address is in a range that must never be dialed.
+///
+/// See [`is_blocked_ip`] for the rationale; the ranges beyond the standard
+/// loopback/private/link-local set (CGNAT `100.64.0.0/10` and `0.0.0.0/8`) were
+/// added under AAASM-3997.
+pub fn is_blocked_ipv4(v4: Ipv4Addr) -> bool {
+    v4.is_loopback()
+        || v4.is_private()
+        || v4.is_link_local()
+        || v4.is_broadcast()
+        || v4.is_documentation()
+        || v4.is_unspecified()
+        // Carrier-grade NAT (100.64.0.0/10) — not globally routable.
+        || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 0x40)
+        // "This network" (0.0.0.0/8) — non-routable source space; on many
+        // stacks 0.x.x.x is treated as loopback/local. `is_unspecified` only
+        // covers the single 0.0.0.0, so block the whole /8 (AAASM-3997).
+        || v4.octets()[0] == 0
+}
+
+/// Returns `true` when the IPv6 address is in a range that must never be dialed.
+///
+/// Beyond loopback/unspecified/ULA/link-local, this rejects the transition
+/// prefixes (NAT64 `64:ff9b::/96`, 6to4 `2002::/16`, IPv4-compatible `::/96`)
+/// that can embed an internal IPv4 a translator would forward to (AAASM-3997).
+pub fn is_blocked_ipv6(v6: Ipv6Addr) -> bool {
+    let seg = v6.segments();
+    v6.is_loopback()
+        || v6.is_unspecified()
+        // Unique-local (fc00::/7).
+        || (seg[0] & 0xfe00) == 0xfc00
+        // Link-local (fe80::/10).
+        || (seg[0] & 0xffc0) == 0xfe80
+        // NAT64 well-known prefix (64:ff9b::/96): embeds an IPv4 in the low 32
+        // bits that a translator forwards to — an attacker can embed an
+        // internal IPv4 here, so reject the whole prefix (AAASM-3997).
+        || (seg[0] == 0x0064 && seg[1] == 0xff9b && seg[2] == 0 && seg[3] == 0 && seg[4] == 0 && seg[5] == 0)
+        // 6to4 (2002::/16): embeds an IPv4 in seg[1..3] that could be internal;
+        // reject the whole range rather than trust the embedded address.
+        || seg[0] == 0x2002
+        // IPv4-compatible IPv6 (::/96, deprecated): the low 32 bits are an IPv4
+        // literal, so `::a.b.c.d` could smuggle an internal v4. `::`/`::1` are
+        // already covered above; this catches the rest of ::/96.
+        || (seg[0] == 0 && seg[1] == 0 && seg[2] == 0 && seg[3] == 0 && seg[4] == 0 && seg[5] == 0)
+}
+
+/// When `host` is an IP literal, returns whether it is blocked. Returns `None`
+/// when `host` is not an IP literal (i.e. a name that must be resolved and
+/// re-validated separately).
+pub fn blocked_ip_literal(host: &str) -> Option<bool> {
+    host.parse::<IpAddr>().ok().map(is_blocked_ip)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_endpoint_is_blocked() {
+        assert!(is_blocked_ip("169.254.169.254".parse().unwrap()));
+    }
+
+    #[test]
+    fn loopback_is_blocked() {
+        assert!(is_blocked_ip("127.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn rfc1918_is_blocked() {
+        assert!(is_blocked_ip("10.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("172.16.5.4".parse().unwrap()));
+        assert!(is_blocked_ip("192.168.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn link_local_and_cgnat_are_blocked() {
+        assert!(is_blocked_ip("169.254.1.1".parse().unwrap()));
+        assert!(is_blocked_ip("100.64.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("fe80::1".parse().unwrap()));
+        assert!(is_blocked_ip("fc00::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ipv4_mapped_v6_cannot_smuggle_blocked_v4() {
+        assert!(is_blocked_ip("::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("::ffff:169.254.169.254".parse().unwrap()));
+    }
+
+    #[test]
+    fn this_network_0_0_0_0_8_is_blocked() {
+        // 0.0.0.0/8 — "this network"; not just the single unspecified address.
+        assert!(is_blocked_ip("0.0.0.0".parse().unwrap()));
+        assert!(is_blocked_ip("0.1.2.3".parse().unwrap()));
+        assert!(is_blocked_ip("0.255.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn nat64_well_known_prefix_is_blocked() {
+        // 64:ff9b::/96 embedding 10.0.0.1 and 169.254.169.254.
+        assert!(is_blocked_ip("64:ff9b::a00:1".parse().unwrap()));
+        assert!(is_blocked_ip("64:ff9b::a9fe:a9fe".parse().unwrap()));
+        assert!(is_blocked_ip("64:ff9b::".parse().unwrap()));
+    }
+
+    #[test]
+    fn six_to_four_2002_16_is_blocked() {
+        // 2002::/16 (6to4) embedding a private and a metadata v4.
+        assert!(is_blocked_ip("2002:0a00:0001::1".parse().unwrap()));
+        assert!(is_blocked_ip("2002:a9fe:a9fe::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ipv4_compatible_ipv6_is_blocked() {
+        // ::/96 (deprecated IPv4-compatible) — low 32 bits are an IPv4 literal.
+        assert!(is_blocked_ip("::a00:1".parse().unwrap())); // ::10.0.0.1
+        assert!(is_blocked_ip("::a9fe:a9fe".parse().unwrap())); // ::169.254.169.254
+        assert!(is_blocked_ip("::808:808".parse().unwrap())); // ::8.8.8.8 — still deprecated space
+    }
+
+    #[test]
+    fn public_ips_are_allowed() {
+        assert!(!is_blocked_ip("1.1.1.1".parse().unwrap()));
+        assert!(!is_blocked_ip("8.8.8.8".parse().unwrap()));
+        assert!(!is_blocked_ip("2606:4700:4700::1111".parse().unwrap()));
+        // A global IPv6 that merely starts with 0x20 (but is not 6to4/2002) stays allowed.
+        assert!(!is_blocked_ip("2001:4860:4860::8888".parse().unwrap()));
+    }
+
+    #[test]
+    fn blocked_ip_literal_distinguishes_names() {
+        assert_eq!(blocked_ip_literal("169.254.169.254"), Some(true));
+        assert_eq!(blocked_ip_literal("8.8.8.8"), Some(false));
+        assert_eq!(blocked_ip_literal("api.openai.com"), None);
+    }
+}

--- a/aa-proxy/src/ssrf.rs
+++ b/aa-proxy/src/ssrf.rs
@@ -14,72 +14,13 @@
 //!    still resolve to a blocked address, and a DNS-rebinding attacker can flip
 //!    the answer between the policy check and the dial. We therefore re-validate
 //!    every resolved address immediately before connecting.
+//!
+//! The blocked-range set itself lives in [`aa_core::net`] so this CONNECT guard
+//! and the webhook-destination egress guard in `aa-api` share one definition
+//! and can't drift apart (AAASM-4859). This module re-exports it for the
+//! proxy's existing call sites.
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-
-/// Returns `true` when `ip` is in a range the proxy must never dial on an
-/// agent's behalf: loopback, private (RFC 1918 / unique-local), link-local
-/// (including the `169.254.169.254` cloud metadata endpoint), unspecified,
-/// broadcast, or other non-globally-routable space.
-///
-/// Fail-closed: any address whose reachability is not unambiguously public is
-/// treated as blocked.
-pub fn is_blocked_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => is_blocked_ipv4(v4),
-        // Map IPv4-mapped forms back to v4 so `::ffff:127.0.0.1` and
-        // `::ffff:169.254.169.254` cannot smuggle a blocked v4 past the filter.
-        // Only `to_ipv4_mapped` is used — the deprecated `to_ipv4` also maps
-        // `::1` to `0.0.0.1`, which would slip IPv6 loopback past the v4 path.
-        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
-            Some(v4) => is_blocked_ipv4(v4),
-            None => is_blocked_ipv6(v6),
-        },
-    }
-}
-
-fn is_blocked_ipv4(v4: Ipv4Addr) -> bool {
-    v4.is_loopback()
-        || v4.is_private()
-        || v4.is_link_local()
-        || v4.is_broadcast()
-        || v4.is_documentation()
-        || v4.is_unspecified()
-        // Carrier-grade NAT (100.64.0.0/10) — not globally routable.
-        || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 0x40)
-        // "This network" (0.0.0.0/8) — non-routable source space; on many
-        // stacks 0.x.x.x is treated as loopback/local. `is_unspecified` only
-        // covers the single 0.0.0.0, so block the whole /8 (AAASM-3997).
-        || v4.octets()[0] == 0
-}
-
-fn is_blocked_ipv6(v6: Ipv6Addr) -> bool {
-    let seg = v6.segments();
-    v6.is_loopback()
-        || v6.is_unspecified()
-        // Unique-local (fc00::/7).
-        || (seg[0] & 0xfe00) == 0xfc00
-        // Link-local (fe80::/10).
-        || (seg[0] & 0xffc0) == 0xfe80
-        // NAT64 well-known prefix (64:ff9b::/96): embeds an IPv4 in the low 32
-        // bits that a translator forwards to — an attacker can embed an
-        // internal IPv4 here, so reject the whole prefix (AAASM-3997).
-        || (seg[0] == 0x0064 && seg[1] == 0xff9b && seg[2] == 0 && seg[3] == 0 && seg[4] == 0 && seg[5] == 0)
-        // 6to4 (2002::/16): embeds an IPv4 in seg[1..3] that could be internal;
-        // reject the whole range rather than trust the embedded address.
-        || seg[0] == 0x2002
-        // IPv4-compatible IPv6 (::/96, deprecated): the low 32 bits are an IPv4
-        // literal, so `::a.b.c.d` could smuggle an internal v4. `::`/`::1` are
-        // already covered above; this catches the rest of ::/96.
-        || (seg[0] == 0 && seg[1] == 0 && seg[2] == 0 && seg[3] == 0 && seg[4] == 0 && seg[5] == 0)
-}
-
-/// When `host` is an IP literal, returns whether it is blocked. Returns `None`
-/// when `host` is not an IP literal (i.e. a name that must be resolved and
-/// re-validated separately).
-pub fn blocked_ip_literal(host: &str) -> Option<bool> {
-    host.parse::<IpAddr>().ok().map(is_blocked_ip)
-}
+pub use aa_core::net::{blocked_ip_literal, is_blocked_ip};
 
 #[cfg(test)]
 mod tests {
@@ -119,7 +60,6 @@ mod tests {
 
     #[test]
     fn this_network_0_0_0_0_8_is_blocked() {
-        // 0.0.0.0/8 — "this network"; not just the single unspecified address.
         assert!(is_blocked_ip("0.0.0.0".parse().unwrap()));
         assert!(is_blocked_ip("0.1.2.3".parse().unwrap()));
         assert!(is_blocked_ip("0.255.255.255".parse().unwrap()));
@@ -127,7 +67,6 @@ mod tests {
 
     #[test]
     fn nat64_well_known_prefix_is_blocked() {
-        // 64:ff9b::/96 embedding 10.0.0.1 and 169.254.169.254.
         assert!(is_blocked_ip("64:ff9b::a00:1".parse().unwrap()));
         assert!(is_blocked_ip("64:ff9b::a9fe:a9fe".parse().unwrap()));
         assert!(is_blocked_ip("64:ff9b::".parse().unwrap()));
@@ -135,17 +74,15 @@ mod tests {
 
     #[test]
     fn six_to_four_2002_16_is_blocked() {
-        // 2002::/16 (6to4) embedding a private and a metadata v4.
         assert!(is_blocked_ip("2002:0a00:0001::1".parse().unwrap()));
         assert!(is_blocked_ip("2002:a9fe:a9fe::1".parse().unwrap()));
     }
 
     #[test]
     fn ipv4_compatible_ipv6_is_blocked() {
-        // ::/96 (deprecated IPv4-compatible) — low 32 bits are an IPv4 literal.
-        assert!(is_blocked_ip("::a00:1".parse().unwrap())); // ::10.0.0.1
-        assert!(is_blocked_ip("::a9fe:a9fe".parse().unwrap())); // ::169.254.169.254
-        assert!(is_blocked_ip("::808:808".parse().unwrap())); // ::8.8.8.8 — still deprecated space
+        assert!(is_blocked_ip("::a00:1".parse().unwrap()));
+        assert!(is_blocked_ip("::a9fe:a9fe".parse().unwrap()));
+        assert!(is_blocked_ip("::808:808".parse().unwrap()));
     }
 
     #[test]
@@ -153,7 +90,6 @@ mod tests {
         assert!(!is_blocked_ip("1.1.1.1".parse().unwrap()));
         assert!(!is_blocked_ip("8.8.8.8".parse().unwrap()));
         assert!(!is_blocked_ip("2606:4700:4700::1111".parse().unwrap()));
-        // A global IPv6 that merely starts with 0x20 (but is not 6to4/2002) stays allowed.
         assert!(!is_blocked_ip("2001:4860:4860::8888".parse().unwrap()));
     }
 


### PR DESCRIPTION
## Description

The SSRF blocklist reached via `POST /api/v1/alerts/destinations/{id}/test` (`aa-api`'s `ip_is_internal`) blocked loopback / private / link-local / unspecified / broadcast, but **missed** several non-routable ranges that can embed an internal target such as the `169.254.169.254` cloud-metadata endpoint: CGNAT `100.64.0.0/10`, `0.0.0.0/8`, NAT64 `64:ff9b::/96`, 6to4 `2002::/16`, and IPv4-compatible `::/96`. The sibling proxy guard (`aa-proxy/src/ssrf.rs`, AAASM-3997) already blocked all of these, but the hardening had never been shared with `aa-api` — the two copies had drifted.

**Fix (preferred, drift-proof extraction):** the range set is now a single shared module `aa_core::net` (`no_std` via `core::net`), which both crates depend on:

- `aa-core::net` — new source of truth (`is_blocked_ip` / `is_blocked_ipv4` / `is_blocked_ipv6` / `blocked_ip_literal`) carrying the full range set.
- `aa-proxy/src/ssrf.rs` — re-exports the shared functions; the CONNECT-path range set is **unchanged (not weakened)**.
- `aa-api/src/destinations/validate.rs` — `ip_is_internal` delegates to `aa_core::net::is_blocked_ip`, closing the gaps at the test endpoint.

The two blocklists can no longer drift apart.

## Type of Change

- [x] 🐛 Bug fix
- [x] ♻️ Refactoring (extract shared module)

## Breaking Changes

- [x] No

`aa-proxy`'s public `ssrf::is_blocked_ip` / `ssrf::blocked_ip_literal` remain callable (now re-exports); `aa-api`'s behavior only becomes *stricter*.

## Related Issues

- Related Jira ticket: AAASM-4859
- Sibling guard / origin of the range set: AAASM-3997

## Testing

- [x] Unit tests added / updated
- `aa-core net::` — 11 tests over the full range set (incl. the newly-shared ranges).
- `aa-api destinations::validate` — two new regression tests: `egress_rejects_newly_closed_ranges` and `egress_rejects_metadata_via_every_encoding` assert the endpoint rejects CGNAT `100.64.x`, `0.x`, and `169.254.169.254` through every IPv6 encoding (IPv4-mapped, NAT64, 6to4, IPv4-compatible).
- `aa-proxy ssrf` — 13 tests still green through the re-export.

Local validation (macOS, stable 1.97):
- `cargo build --workspace` — clean
- `cargo nextest run -p aa-api destinations::validate` — 22 passed
- `cargo nextest run -p aa-proxy ssrf` — 13 passed
- `cargo nextest run -p aa-core net::` — 11 passed
- `cargo clippy -p aa-api --all-targets -- -D warnings` — clean
- `cargo check -p aa-core --no-default-features` — clean (no_std)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module/why-comments cite AAASM-4859)
- [ ] All CI checks passing (org Actions is billing-blocked; validated locally)
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4859

🤖 Generated with [Claude Code](https://claude.com/claude-code)
