### PR TITLE
[AAASM-4889] 📝 (docs): Document AA_PROXY_GATEWAY_ENDPOINT for the proxy upstream

### DIFF
--- a/docs/src/quick-start/configuration.md
+++ b/docs/src/quick-start/configuration.md
@@ -103,12 +103,18 @@ value, the precedence is noted.
 | `AA_POLICY` | `aasm gateway start` | Default policy path; overridden by `--policy` |
 | `AA_DATA_DIR` | gateway / proxy / dashboard | Directory for PID files and managed-process state |
 | `AA_PROXY_ADDR` | `aasm proxy start` | Proxy listen address (default `127.0.0.1:8899`) |
-| `AA_GATEWAY_URL` | `aasm proxy start` | Gateway URL the proxy reports to |
+| `AA_PROXY_GATEWAY_ENDPOINT` | `aasm proxy start` | Upstream gateway endpoint the proxy reports to (e.g. `http://127.0.0.1:50051`) |
 | `AA_CA_DIR` | `aasm proxy` | Per-host CA material directory |
 
 > Note the two prefixes: **`AASM_*`** variables configure the CLI surface, while
 > **`AA_*`** variables configure the underlying daemons the CLI launches
 > (gateway, proxy). They are not interchangeable.
+
+> Three similarly-named gateway-endpoint variables are **distinct** and not
+> interchangeable: `AA_PROXY_GATEWAY_ENDPOINT` (the proxy's upstream gateway,
+> above), `AA_GATEWAY_ENDPOINT` (used by the runtime / SDK client), and
+> `AA_GATEWAY_URL` (used by the Windsurf devtool). Only
+> `AA_PROXY_GATEWAY_ENDPOINT` affects `aasm proxy start`.
 
 ## Output format
 


### PR DESCRIPTION
## Description

`docs/src/quick-start/configuration.md` documented `AA_GATEWAY_URL` as the environment variable `aasm proxy start` reads for its upstream gateway. That is wrong: `aa-proxy` reads `AA_PROXY_GATEWAY_ENDPOINT` (`aa-proxy/src/config.rs:176` — `gateway_endpoint: env_optional("AA_PROXY_GATEWAY_ENDPOINT")`). `AA_GATEWAY_URL` is read only by the Windsurf devtool (`aa-devtool-windsurf/src/lib.rs:244`), never by `aa-proxy`, so the documented knob was inert and the operator's upstream override was silently ignored.

This corrects the table row and adds a note distinguishing the three similarly-named gateway-endpoint variables (`AA_PROXY_GATEWAY_ENDPOINT`, `AA_GATEWAY_ENDPOINT`, `AA_GATEWAY_URL`).

Doc-only change; the diff touches `docs/src/quick-start/configuration.md` and nothing else.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4889

## Testing

- [x] No tests required (docs-only) — validated with `mdbook build` (book renders clean) and confirmed `rg 'AA_GATEWAY_URL' aa-proxy/` returns 0 hits while `AA_PROXY_GATEWAY_ENDPOINT` is the real read at `aa-proxy/src/config.rs:176`.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-4889