### PR TITLE
[AAASM-4891] 📝 (docs): Replace non-existent AA_CREDENTIAL in org-isolation snippet

### DIFF
--- a/docs/src/operations/org-isolation.md
+++ b/docs/src/operations/org-isolation.md
@@ -30,7 +30,7 @@ init_assembly(
         "team_id":  "platform",
         "agent_id": "research-bot-001",
     },
-    credential_token=os.environ["AA_CREDENTIAL"],
+    credential_token=os.environ["AA_API_KEY"],
 )
 ```
 


### PR DESCRIPTION
## Description

The multi-tenancy setup snippet in `docs/src/operations/org-isolation.md` read the agent credential from `os.environ["AA_CREDENTIAL"]`. That environment variable does not exist anywhere in the product — it is defined/read nowhere in the core and is absent from the SDK env table — so it presented an invented name as a real SDK contract. Copy-pasting the snippet would set a variable that nothing reads.

This replaces `AA_CREDENTIAL` with the canonical SDK-facing credential env var **`AA_API_KEY`**.

**Evidence:**
- `git grep AA_CREDENTIAL` over the repo returns only this one doc line (0 code definitions/reads).
- `docs/src/compatibility.md:185` documents `AA_API_KEY` as one of the three canonical `AA_*` SDK env vars (alongside `AA_GATEWAY_URL` / `AA_CONTROL_PLANE_URL`); `AA_*` is stated as the canonical SDK prefix.
- `AA_API_KEY` is the SDK-facing agent credential, also used across `examples/docker-compose/`, `docs/src/usage-guide/self-hosting.md`, and `examples/kubernetes/pod.yaml`.
- `AASM_API_KEY` (aa-api / aasm serving-banner key) was rejected as the substitute — it is the gateway's own key, not the SDK-facing credential.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4891](https://lightning-dust-mite.atlassian.net/browse/AAASM-4891)

Closes AAASM-4891

## Testing

- [x] No tests required (explain why)

Doc-only, single-line change. Validated with `mdbook build` (docs/) — book builds cleanly (only an unrelated mdbook-mermaid preprocessor version warning). Diff is limited to `docs/src/operations/org-isolation.md`.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

[AAASM-4891]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ