### PR TITLE
[AAASM-4860] 📝 (docs): Record WebSocket/browser credential handling in ADR 0012 + exposure warnings

### DIFF
--- a/.claude/skills/adr-governance/SKILL.md
+++ b/.claude/skills/adr-governance/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: adr-governance
+description: Enforce Architecture Decision Record discipline whenever a change embeds a MATERIAL decision — one that affects multiple components/repos, changes a public contract or a security/trust boundary, creates a long-lived constraint, or is expensive to reverse. Before editing, SEARCH the existing recorded decisions (docs/src/adr/, docs/architecture/, docs/security/, docs/decisions/, SECURITY.md, CONTRIBUTING.md, CLAUDE.md, relevant Jira, relevant merged PRs), produce an "Existing Decision Summary", pick exactly ONE ADR action (none / follow / amend / create / supersede / record-accepted-risk), STOP and surface conflicts rather than silently overriding a recorded decision, and link Jira → ADR → PR → evidence. Use this at the START of any task that looks architectural, security-relevant, protocol/persistence/deployment-shaping, or otherwise hard to reverse — not for minor, single-component, reversible details.
+---
+
+# adr-governance
+
+A **material decision** must never be made silently. This skill makes an agent
+*discover the decisions that already exist*, decide *how the current change
+relates to them*, and *leave a record future agents can find* — using the tools
+already in place (the `docs/src/adr/` ADR set, `SECURITY.md`, Jira, PRs), not a
+new tracking system.
+
+Run it at the **start** of a task, before writing code or docs, whenever the work
+might embed a material decision. If the change is minor and reversible, this skill
+exits immediately (Step 2) — it is not a tax on routine work.
+
+## Step 1 — Decide whether a decision is *material*
+
+A decision is **material** (ADR-worthy) if it meets **any** of:
+
+- **Cross-cutting** — affects multiple components, crates, or repos.
+- **Contract** — changes a public API, wire protocol, schema, or CLI surface.
+- **Boundary** — moves a security / trust / tenancy / privacy boundary.
+- **Long-lived constraint** — establishes an invariant others must keep honoring.
+- **Expensive to reverse** — data migrations, persistence choices, deployment
+  topology, an accepted risk with a real blast radius.
+
+It is **not** material (skip this skill) if it is a local, single-component,
+reversible implementation detail — naming, a private helper's shape, a bug fix
+with no contract change, a test refactor.
+
+> When genuinely unsure, do the search in Step 3 anyway — it is cheap, and it is
+> how you find out whether the decision was already made for you.
+
+## Step 2 — If not material, exit
+
+Say so in one line ("no material decision — no ADR action") and continue the task
+normally. Do not create an ADR for a minor detail; ADR noise is as harmful as ADR
+absence.
+
+## Step 3 — Search existing decisions FIRST (before editing anything)
+
+Search **at minimum** these sources for the topic at hand:
+
+- `docs/src/adr/` (this repo's ADRs; `docs/adr/`, `docs/architecture/`,
+  `docs/security/`, `docs/decisions/` in repos that use those paths)
+- `SECURITY.md`, `CONTRIBUTING.md`, `CLAUDE.md` (and `.claude/` rules)
+- Relevant **Jira** issues (search the ticket text + linked issues)
+- Relevant **merged PRs** (search titles/bodies for the concept)
+
+Read the ones that plausibly touch your decision. You are looking for: a decision
+already made (that you must follow), a decision that **conflicts** with what you
+were about to do, or the **absence** of a decision that your change now forces.
+
+## Step 4 — Produce an "Existing Decision Summary" (before editing)
+
+Emit this block **before** making changes:
+
+```
+### Existing Decision Summary
+- Applicable ADRs / recorded decisions: <IDs + one-line each, or "none found">
+- Prior decisions that bear on this change: <...>
+- Conflicts with what this change would do: <... or "none">
+- Missing decisions this change forces: <... or "none">
+- Proposed ADR action: <none | follow | amend | create | supersede | record-accepted-risk>
+```
+
+## Step 5 — Choose exactly ONE ADR action
+
+| Action | When |
+| --- | --- |
+| **none** | No material decision (you should have exited at Step 2). |
+| **follow** | A recorded decision already covers this; comply and cite it. |
+| **amend** | An existing ADR is right but incomplete; add an "Update — <ticket>" section. |
+| **create** | A material decision has no record; write a new sequential ADR. |
+| **supersede** | An existing decision is being replaced; new ADR links back, old one's status → `Superseded by NNNN`. |
+| **record-accepted-risk** | You are *not* fixing something and accepting the residual risk; record it as a scoped decision with assumptions + reconsideration triggers. |
+
+## Step 6 — Conflicts STOP; they do not get silently overridden
+
+If Step 4 found a **conflict** with a recorded decision, **stop and surface it**
+(escalate — see `.claude/rules/04-agent-escalation.md`). Do not quietly override a
+decision another engineer recorded. `supersede` is a deliberate, documented act,
+not a side effect of an unrelated change.
+
+## Step 7 — Write / update the ADR (create · amend · supersede · accepted-risk)
+
+- Use `adr-template.md` in this skill directory as the skeleton (lightweight
+  Nygard: Context / Threat models · Decision · Accepted risks · Forbidden designs
+  · Consequences · Operational guidance · Validation requirements · Reconsideration
+  triggers · Traceability).
+- Number sequentially (next unused `NNNN`); never rewrite a shipped ADR's history —
+  amend with an `Update` section or supersede.
+- An **accepted-risk** record is a real decision: state the assumptions it rests
+  on and the **reconsideration triggers** that invalidate it.
+
+## Step 8 — Register + link (Jira → ADR → PR → evidence)
+
+- Add the ADR to the index (`docs/src/adr/README.md`) **and** the book TOC
+  (`docs/src/SUMMARY.md`) — an unregistered ADR does not render and cannot be found.
+- The PR description **must reference the applicable ADR** (new or existing).
+- Link the chain both ways: the Jira ticket references the ADR; the ADR's
+  Traceability table references the ticket(s) and the implementation PR(s); the PR
+  references the ADR. That chain is how a future agent rediscovers *why*.
+
+## Step 9 — Pre-flight before opening the PR
+
+Run through `preflight-checklist.md` in this directory. Every box must be ticked
+(or explicitly N/A) before the PR is opened.
+
+## What this skill is not
+
+- Not a diff scanner or a security review (that is `/security-review` /
+  `/release-security-gate`).
+- Not a substitute for the escalation rule — a conflict you can't resolve is an
+  escalation, not a unilateral supersede.
+- Not a reason to ADR-ify small reversible changes.

--- a/.claude/skills/adr-governance/adr-template.md
+++ b/.claude/skills/adr-governance/adr-template.md
@@ -1,0 +1,62 @@
+# ADR NNNN: <Short decision title>
+
+**Status**: Proposed | Accepted | Superseded by NNNN
+**Date**: YYYY-MM
+**Ticket**: [AAASM-XXXX](https://lightning-dust-mite.atlassian.net/browse/AAASM-XXXX)
+
+<One paragraph: what this ADR records and why it exists. Name the other ADRs it
+complements or supersedes.>
+
+---
+
+## Context
+
+<The forces at play. If the decision is security- or tenancy-relevant, state the
+**threat model(s)** explicitly — different editions / deployment modes often have
+different adversaries and therefore different correct answers. Include the
+constraint that forced the design (an API limitation, a platform boundary, a
+compatibility requirement).>
+
+## Decision
+
+<What we are doing, stated so a future implementer can comply without guessing.
+Number the sub-decisions if there is more than one. Be concrete about the
+mechanism (endpoint, storage, flag, protocol), not just the intent.>
+
+## Accepted risks
+
+<What residual risk we are knowingly taking, and the assumptions that make it
+acceptable. Omit the section only if there genuinely are none.>
+
+## Explicitly forbidden designs
+
+<The alternatives that must NOT be used, so a later change doesn't reintroduce
+them. This is often the most valuable section — it stops silent regressions.>
+
+## Consequences
+
+<What changes for each affected audience (operators, SaaS, SDK/CLI, future
+contributors). Both the good and the costs.>
+
+## Operational guidance
+
+<What an operator / deployer must do or avoid as a result. Omit if not applicable.>
+
+## Validation requirements
+
+<The tests or checks that must exist to prove the decision holds — so a reviewer
+can confirm the ADR is actually enforced, not just written down.>
+
+## Reconsideration triggers
+
+<The specific future changes that should re-open this ADR (a new deployment
+topology, a shipped backend surface, a discovered vulnerability, a new edition).
+An accepted-risk record MUST list these.>
+
+## Traceability
+
+| Reference | Relation |
+| --- | --- |
+| [AAASM-XXXX](https://lightning-dust-mite.atlassian.net/browse/AAASM-XXXX) | <what it is> |
+| [ADR NNNN](NNNN-....md) | <complements / superseded-by / related> |
+| Implementation PRs | <#NNN ...> |

--- a/.claude/skills/adr-governance/preflight-checklist.md
+++ b/.claude/skills/adr-governance/preflight-checklist.md
@@ -1,0 +1,41 @@
+# adr-governance — pre-flight checklist
+
+Tick every box (or mark N/A with a reason) before opening a PR that embeds a
+material decision.
+
+## Discovery
+- [ ] Judged materiality against the Step 1 criteria (cross-cutting / contract /
+      boundary / long-lived constraint / expensive-to-reverse).
+- [ ] Searched `docs/src/adr/` (+ `docs/architecture/`, `docs/security/`,
+      `docs/decisions/` where present).
+- [ ] Searched `SECURITY.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `.claude/` rules.
+- [ ] Searched relevant Jira issues and merged PRs.
+- [ ] Emitted an **Existing Decision Summary** before editing.
+
+## Decision
+- [ ] Chose exactly ONE ADR action (none / follow / amend / create / supersede /
+      record-accepted-risk).
+- [ ] Any **conflict** with a recorded decision was **surfaced/escalated**, not
+      silently overridden.
+- [ ] If `supersede`: the old ADR's status was set to `Superseded by NNNN` and the
+      new ADR links back.
+- [ ] If `record-accepted-risk`: assumptions **and** reconsideration triggers are
+      written down.
+
+## Record
+- [ ] ADR written from the template with all required sections (Context/threat
+      models, Decision, Accepted risks, Forbidden designs, Consequences,
+      Operational guidance, Validation requirements, Reconsideration triggers,
+      Traceability).
+- [ ] Sequential number; no shipped ADR's history rewritten (amended/superseded
+      instead).
+- [ ] ADR added to `docs/src/adr/README.md` index **and** `docs/src/SUMMARY.md`
+      TOC.
+
+## Linkage (Jira → ADR → PR → evidence)
+- [ ] PR description references the applicable ADR.
+- [ ] ADR Traceability table references the Jira ticket(s) and the implementation
+      PR(s).
+- [ ] Jira ticket references the ADR.
+- [ ] Validation requirements in the ADR are backed by real tests/checks in the PR
+      (or the ADR says why not yet).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,6 +65,32 @@ Honest boundary: per-endpoint authentication is endpoint hygiene, not an
 absolute control. The sidecar proxy and eBPF layers remain the authoritative
 backstop for bypass attempts.
 
+## Deployment posture — `aa-api` HTTP surface & operator dashboard
+
+The `aa-api` REST/HTTP surface and the bundled React **operator dashboard**
+(including its WebSocket live-ops, approvals, and alert streams) are designed for
+a **local / self-hosted / operator-controlled** deployment — a single process on
+the operator's own host or private network. Treat them accordingly:
+
+1. **Do not expose the dashboard / `aa-api` HTTP surface directly to the public
+   internet** without a trusted authenticating layer in front of it (a VPN, a
+   private network, or an authenticated reverse proxy). `aa-api` binds to loopback
+   by default; binding to a routable interface (e.g. `--mode remote`) puts the API
+   and dashboard on the network.
+2. **Browser session auth is a scoped trade-off.** The dashboard keeps its session
+   JWT in `sessionStorage` under a strict CSP. This is an **intentional, accepted
+   trade-off for the OSS local threat model** — it is *not* hardened against a
+   same-origin XSS, and it is not the design the SaaS edition uses. See
+   [ADR 0012](docs/src/adr/0012-websocket-and-browser-credential-handling.md).
+3. **WebSocket streams carry no credential in the URL.** Browser WS connections
+   authenticate with a short-lived, single-use ticket minted over an authenticated
+   REST call (AAASM-4861), so no long-lived token appears in a URL that
+   proxy/CDN/LB access logs would capture. The application logs the request path
+   only, not the query string; operators who front `aa-api` with their own
+   reverse proxy / CDN should still configure edge redaction of `token` / `ticket`
+   query parameters — infrastructure outside this repo is not automatically
+   protected.
+
 ## Disclosure Policy
 
 We follow coordinated disclosure. Once a fix is available, we will:

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -145,3 +145,4 @@
   - [0009 - Versioned Base-Image Tags & SDK Pinning](adr/0009-versioned-base-image-tags-and-sdk-pinning.md)
   - [0010 - Gateway Distribution for Self-Host & Examples](adr/0010-gateway-distribution-self-host-examples.md)
   - [0011 - Cross-Process Op-Control via NATS Subject (durable JetStream)](adr/0011-cross-process-op-control-nats-subject.md)
+  - [0012 - WebSocket & Browser Credential Handling](adr/0012-websocket-and-browser-credential-handling.md)

--- a/docs/src/adr/0012-websocket-and-browser-credential-handling.md
+++ b/docs/src/adr/0012-websocket-and-browser-credential-handling.md
@@ -1,0 +1,215 @@
+# ADR 0012: WebSocket & Browser Credential Handling (OSS vs SaaS)
+
+**Status**: Accepted
+**Date**: 2026-07
+**Ticket**: [AAASM-4861](https://lightning-dust-mite.atlassian.net/browse/AAASM-4861)
+(WebSocket ticket auth — implementation),
+[AAASM-4860](https://lightning-dust-mite.atlassian.net/browse/AAASM-4860)
+(OSS dashboard token storage — accepted risk)
+
+This ADR records **how browser-held credentials and WebSocket upgrades are
+authenticated** across the two editions of the product — the open-source (OSS)
+operator dashboard shipped in this repo, and the future SaaS dashboard. It exists
+because the two editions have **different threat models** and therefore make
+**different, deliberate** trade-offs, and because a browser API limitation (a WS
+handshake cannot carry an `Authorization` header) forced a specific credential
+design that must not be reinvented ad hoc each time a new stream is added.
+
+It complements [ADR 0008](0008-saas-host-routing-auth-cookie-boundaries.md)
+(SaaS host routing, auth & cookie boundaries) and does not contradict it: 0008
+governs *SaaS cookie scoping across hosts*; this ADR governs *where a browser
+credential may live* and *how a WebSocket authenticates* in each edition.
+
+---
+
+## Context
+
+### Threat model A — OSS operator dashboard (this repo)
+
+The OSS dashboard (`dashboard/`, served by `aa-api`) is a **single-process,
+local / self-hosted, operator-controlled** surface. It ships in the
+limited-function OSS stack an operator runs on their own host or private network.
+Its session credential is a JWT the dashboard obtains from `POST
+/api/v1/auth/token` and stores in the browser. Under this threat model the
+adversary of concern is a network observer or a curious co-tenant on the same
+box — **not** a multi-tenant public-internet attacker.
+
+The token was historically kept in `localStorage`; it was moved to
+`sessionStorage` ([AAASM-4322](https://lightning-dust-mite.atlassian.net/browse/AAASM-4322))
+so an XSS on the dashboard origin is confined to the current tab and the token is
+dropped when the tab closes. `sessionStorage` is still **JS-readable**: it is not
+a defence against same-origin XSS. A server-managed `HttpOnly` cookie surface
+would be stronger, but no such backend surface exists in the OSS edition, and
+building one is out of scope for a local/self-hosted operator tool.
+
+### Threat model B — SaaS dashboard (future)
+
+The SaaS dashboard is **multi-tenant** and served over the **public internet**
+(`app.agent-assembly.com`, per ADR 0008). Its adversary includes remote attackers
+and cross-tenant actors. A JS-readable long-lived credential is **not acceptable**
+here: an XSS or a malicious dependency could exfiltrate a live session.
+
+### Threat model C — WebSocket authentication (both editions)
+
+The dashboard opens WebSocket streams for live governance events
+(`GET /api/v1/ws/events` — live-ops + approvals) and alerts
+(`GET /api/v1/alerts/ws`, [AAASM-1389](https://lightning-dust-mite.atlassian.net/browse/AAASM-1389)).
+The **browser WebSocket API cannot set request headers**, so a bearer token
+cannot travel in an `Authorization` header on the upgrade. The original
+workaround put the long-lived JWT in the query string
+(`?token=<jwt>`,
+[AAASM-4861](https://lightning-dust-mite.atlassian.net/browse/AAASM-4861)).
+Request URLs are logged by every intermediary — reverse proxies, CDNs, load
+balancers — so this leaked a **live, long-lived credential** into
+infrastructure logs, an exposure channel entirely distinct from XSS and
+unaffected by any `sessionStorage`/CSP hardening. Per-connection tenant gating
+already exists ([AAASM-3980](https://lightning-dust-mite.atlassian.net/browse/AAASM-3980));
+the defect was purely *how the connection authenticates*.
+
+---
+
+## Decision
+
+### 1. OSS dashboard auth — `sessionStorage` + strict CSP (accepted trade-off)
+
+The OSS dashboard keeps its session JWT in **`sessionStorage`**, hardened by a
+strict Content-Security-Policy, and treats this as an **intentional, accepted
+trade-off** under threat model A. It is **not** considered secure against a
+same-origin XSS, and this is stated plainly rather than papered over. There is no
+`HttpOnly`-cookie backend in the OSS edition and none is added by this decision.
+The OSS dashboard **must not be exposed directly to the public internet** without
+a trusted authenticating layer in front of it (VPN, private network, or an
+authenticated reverse proxy). Recorded as an accepted risk in
+[AAASM-4860](https://lightning-dust-mite.atlassian.net/browse/AAASM-4860); the
+storage tier is [AAASM-4322](https://lightning-dust-mite.atlassian.net/browse/AAASM-4322).
+
+### 2. SaaS dashboard auth — server-managed cookies (must not copy OSS)
+
+The SaaS dashboard **must not** store a long-lived credential in `localStorage`
+or `sessionStorage`. It uses **server-managed `HttpOnly` + `Secure` +
+`SameSite`** cookies (host-only, per ADR 0008) with CSRF defence, plus token
+expiry / refresh / logout / server-side revocation. The SaaS edition **must not
+copy the OSS `sessionStorage` design** — that design is an accepted compromise
+scoped to the OSS local threat model only, and inheriting it into a multi-tenant
+public surface would be a regression.
+
+### 3. WebSocket auth — short-lived, single-use, purpose-bound tickets
+
+No long-lived credential — JWT, API key, or session cookie value — may appear in
+a WebSocket URL, in **either** edition. Instead:
+
+- The client authenticates a normal **REST** call to
+  `POST /api/v1/auth/ws-ticket` (Bearer header, which a `fetch`/`XHR` *can*
+  set) and receives a **short-lived (30–60 s), single-use, opaque** ticket.
+- The client opens the socket with `?ticket=<opaque>`; the upgrade handler
+  **atomically consumes** the ticket (replay-safe) and rebuilds the caller from
+  the server-side record.
+- The ticket is **bound to the minting caller's identity, tenant, scopes, and a
+  single stream purpose** (`events` vs `alerts`); it is **not** accepted as a
+  REST credential and is **not** refreshable. Every connect and **every
+  reconnect mints a fresh ticket**.
+
+CLI and non-browser clients — which *can* set an `Authorization` header — keep
+using bearer-header auth on the WS upgrade unchanged; the ticket is the
+browser-only path. Implemented in
+[AAASM-4861](https://lightning-dust-mite.atlassian.net/browse/AAASM-4861).
+
+---
+
+## Accepted risks
+
+- **OSS JS-readable token.** The OSS session JWT is readable by same-origin
+  JavaScript (`sessionStorage`). Accepted under threat model A (local /
+  self-hosted / operator-controlled). Mitigations: strict CSP, `sessionStorage`
+  (tab-scoped, dropped on close), and the operational guidance not to expose the
+  dashboard publicly.
+- **OSS ticket store is in-memory / single-node.** The OSS `aa-api` is a single
+  process; there is no Redis / shared KV in the OSS stack, so the WS-ticket store
+  is **in-process**. Tickets do not survive a restart and are not valid across a
+  hypothetical multi-instance deployment. Accepted because tickets are
+  short-lived and single-use — the worst case is a failed upgrade the client
+  simply re-mints.
+- **Infrastructure outside the repo is not automatically protected.** We do not
+  claim that a reverse proxy / CDN / load balancer an operator runs is safe. The
+  repo's own request-logging layer logs the request **path only, not the query
+  string**, so a ticket is not written to app logs; but operators must configure
+  their **own** edge log redaction of `token` / `ticket` query parameters. This
+  is documented, not asserted as automatic.
+
+---
+
+## Explicitly forbidden designs
+
+- Any long-lived credential (JWT, API key, session value) in a URL — including a
+  WebSocket query string — in either edition.
+- Reusing a WS ticket as a REST credential, or minting a refreshable / long-TTL
+  ticket.
+- Storing a long-lived credential in `localStorage` or `sessionStorage` in the
+  **SaaS** edition.
+- Copying the OSS `sessionStorage` design into the SaaS dashboard.
+- Adding a new browser-facing WebSocket stream that authenticates by any means
+  other than the ticket flow in Decision §3.
+
+---
+
+## Consequences
+
+- **OSS operators**: unchanged login; the dashboard now mints a ticket before each
+  stream connect, so no credential is ever in a WS URL or infra log. The
+  exposure caveat is documented in `SECURITY.md` and the CLI `start`/`dashboard`
+  docs.
+- **SaaS**: a hard constraint is on record before the SaaS dashboard is built —
+  cookies, not web storage; it cannot silently inherit the OSS compromise.
+- **SDK / CLI**: **unchanged.** Bearer-token auth for programmatic and CLI clients
+  (including on the WS upgrade, via the `Authorization` header) is untouched.
+- **New streams**: adding one is now a well-defined recipe — add a
+  `WsTicketPurpose`, mint with that purpose, consume it on the upgrade.
+
+## Operational guidance
+
+- Do **not** expose the OSS dashboard / `aa-api` HTTP surface to the public
+  internet. Front it with a VPN, a private network, or an authenticated reverse
+  proxy.
+- Configure edge (reverse-proxy / CDN / LB) access-log redaction of `token` and
+  `ticket` query parameters. The application already logs path-only.
+- Bind `aa-api` to loopback unless a trusted authenticating layer sits in front
+  (see `SECURITY.md` and `docs/src/cli/start-stop.md`).
+
+## Validation requirements
+
+The WS-ticket flow ([AAASM-4861](https://lightning-dust-mite.atlassian.net/browse/AAASM-4861))
+must be covered by tests asserting: mint requires authentication; mint is
+scope/tenant-bound; the ticket is single-use (replay rejected); an expired ticket
+is rejected; a wrong-purpose / wrong-tenant / malformed ticket is rejected; the
+ticket is **not** valid for REST auth; a concurrent double-consume resolves for
+exactly one caller; application logs contain no raw JWT or ticket; and a reconnect
+mints a fresh ticket. The browser clients must be covered by tests asserting the
+WS URL carries a ticket (never the JWT) and that a reconnect re-mints.
+
+## Reconsideration triggers
+
+Re-open this ADR if any of the following change:
+
+- The OSS edition ships an `HttpOnly`-cookie auth backend (then OSS §1 can be
+  hardened).
+- `aa-api` is ever run **multi-instance** (the in-memory ticket store must move to
+  a shared KV or a signed stateless ticket).
+- A reachable XSS sink is found in the OSS dashboard (re-weigh the accepted
+  `sessionStorage` risk).
+- SaaS dashboard work begins (§2 becomes an implementation contract, aligned with
+  ADR 0008).
+
+## Traceability
+
+| Reference | Relation |
+| --- | --- |
+| [AAASM-4322](https://lightning-dust-mite.atlassian.net/browse/AAASM-4322) | OSS dashboard token → `sessionStorage` (the storage tier this ADR accepts) |
+| [AAASM-4860](https://lightning-dust-mite.atlassian.net/browse/AAASM-4860) | OSS `sessionStorage` token — accepted-risk decision (Decision §1) |
+| [AAASM-4861](https://lightning-dust-mite.atlassian.net/browse/AAASM-4861) | WebSocket ticket auth — implementation (Decision §3) |
+| [AAASM-245](https://lightning-dust-mite.atlassian.net/browse/AAASM-245) | Dashboard authentication surface (related) |
+| [AAASM-1331](https://lightning-dust-mite.atlassian.net/browse/AAASM-1331) | Live-ops WebSocket stream (related) |
+| [AAASM-1389](https://lightning-dust-mite.atlassian.net/browse/AAASM-1389) | Alerts WebSocket stream (`/alerts/ws`) (related) |
+| [AAASM-297](https://lightning-dust-mite.atlassian.net/browse/AAASM-297) | Approvals stream (related) |
+| [AAASM-3980](https://lightning-dust-mite.atlassian.net/browse/AAASM-3980) | Per-connection WebSocket tenant gating (related) |
+| [ADR 0008](0008-saas-host-routing-auth-cookie-boundaries.md) | SaaS cookie / host boundary (complements Decision §2) |
+| Implementation PRs | PR-A `#TBD` (this ADR + exposure docs, AAASM-4860); PR-B `#TBD` (WS-ticket code + tests, AAASM-4861) |

--- a/docs/src/adr/0012-websocket-and-browser-credential-handling.md
+++ b/docs/src/adr/0012-websocket-and-browser-credential-handling.md
@@ -212,4 +212,4 @@ Re-open this ADR if any of the following change:
 | [AAASM-297](https://lightning-dust-mite.atlassian.net/browse/AAASM-297) | Approvals stream (related) |
 | [AAASM-3980](https://lightning-dust-mite.atlassian.net/browse/AAASM-3980) | Per-connection WebSocket tenant gating (related) |
 | [ADR 0008](0008-saas-host-routing-auth-cookie-boundaries.md) | SaaS cookie / host boundary (complements Decision §2) |
-| Implementation PRs | PR-A `#TBD` (this ADR + exposure docs, AAASM-4860); PR-B `#TBD` (WS-ticket code + tests, AAASM-4861) |
+| Implementation PRs | [#1582](https://github.com/ai-agent-assembly/agent-assembly/pull/1582) (this ADR + exposure docs, AAASM-4860); [#1583](https://github.com/ai-agent-assembly/agent-assembly/pull/1583) (WS-ticket code + tests, AAASM-4861) |

--- a/docs/src/adr/README.md
+++ b/docs/src/adr/README.md
@@ -18,3 +18,4 @@ The format follows a lightweight variant of [Michael Nygard's template](https://
 | [0009](0009-versioned-base-image-tags-and-sdk-pinning.md) | Versioned Base-Image Tags & Reproducible SDK Pinning | Proposed |
 | [0010](0010-gateway-distribution-self-host-examples.md) | Gateway Distribution for Self-Host & Examples | Proposed |
 | [0011](0011-cross-process-op-control-nats-subject.md) | Cross-Process Op-Control Delivery via a NATS Subject (durable JetStream) | Accepted |
+| [0012](0012-websocket-and-browser-credential-handling.md) | WebSocket & Browser Credential Handling (OSS vs SaaS) | Accepted |

--- a/docs/src/cli/dashboard.md
+++ b/docs/src/cli/dashboard.md
@@ -34,6 +34,16 @@ var → `--port` flag → `dashboard.port` in `~/.aa/config.yaml` (default
 Serve the embedded SPA at `http://127.0.0.1:<port>`. Blocks until Ctrl-C.
 Reverse-proxies `/api/*` to the configured gateway.
 
+> **Exposure caution.** The dashboard is designed for local / self-hosted /
+> operator-controlled use and binds loopback by default. Do not put it directly on
+> the public internet without a trusted authenticating layer (VPN, private network,
+> or an authenticated reverse proxy) in front. Browser session auth uses
+> `sessionStorage` + CSP (an accepted OSS trade-off, not hardened against
+> same-origin XSS), and WebSocket streams authenticate with short-lived single-use
+> tickets so no credential rides the URL. See
+> [`SECURITY.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/SECURITY.md)
+> and [ADR 0012](../adr/0012-websocket-and-browser-credential-handling.md).
+
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--port <PORT>` | integer | `3000` (config) | Port to listen on. Overrides config; also reads `AASM_DASHBOARD_PORT`. |

--- a/docs/src/cli/start-stop.md
+++ b/docs/src/cli/start-stop.md
@@ -29,6 +29,14 @@ aasm start [OPTIONS]
 | `--foreground` | flag | off | Stay in the foreground; do not daemonize. |
 | `--no-dashboard` | flag | off | Accepted for a stable operator surface but **not yet wired** — currently a no-op. Dashboard serving is determined by the mode: local mode runs `aa-api-server`, which always serves the dashboard. |
 
+> **Exposure caution.** `--mode remote` binds `0.0.0.0`, putting the API and the
+> operator dashboard on the network. The dashboard is designed for local /
+> self-hosted / operator-controlled use — **do not expose it directly to the
+> public internet** without a trusted authenticating layer (VPN, private network,
+> or an authenticated reverse proxy) in front. See
+> [`SECURITY.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/SECURITY.md)
+> and [ADR 0012](../adr/0012-websocket-and-browser-credential-handling.md).
+
 ### Behavior
 
 1. Resolve the listen address from `mode` + `port`.


### PR DESCRIPTION
## Description

Governance + docs companion to the WebSocket-ticket implementation (PR for AAASM-4861). This PR records the **decision** and adds the **operator-facing exposure warnings** that were missing; it does **not** change the OSS dashboard's browser auth.

- **ADR 0012 — WebSocket & Browser Credential Handling (OSS vs SaaS)** (`docs/src/adr/0012-...md`, registered in the index + book TOC). Explicit Threat models / Decision / Accepted risks / Explicitly-forbidden-designs / Consequences / Operational-guidance / Validation-requirements / Reconsideration-triggers sections:
  - **OSS dashboard** keeps its JWT in `sessionStorage` + strict CSP — an intentional, **accepted** trade-off under the local/self-hosted threat model (not hardened vs same-origin XSS; no HttpOnly-cookie backend in OSS). Ties to AAASM-4322 / AAASM-4860.
  - **SaaS dashboard** must use server-managed `HttpOnly`/`Secure`/`SameSite` cookies (+ CSRF, expiry/refresh/logout/revocation) and **must not copy** the OSS design. Cross-references ADR 0008.
  - **WebSocket auth**: no long-lived credential in any WS URL; short-lived, single-use, purpose/identity/tenant-bound tickets minted over an authenticated REST call, atomically consumed, reconnects re-mint (implemented in AAASM-4861).
- **`SECURITY.md`** — new exposure section for the aa-api HTTP surface + operator dashboard: don't put the dashboard on the public internet without a trusted authenticating layer; the token-storage trade-off; WS streams carry no URL credential; operators must configure their own edge log redaction (infra outside the repo isn't automatically protected).
- **CLI docs** (`start-stop.md`, `dashboard.md`) — exposure cautions where `--mode remote` binds `0.0.0.0` / the dashboard serves.
- **`adr-governance` skill** (`.claude/skills/adr-governance/`) — SKILL.md + ADR template + pre-flight checklist: search existing decisions first, emit an "Existing Decision Summary", pick exactly one ADR action, surface conflicts instead of silently overriding, link Jira → ADR → PR → evidence.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4860](https://lightning-dust-mite.atlassian.net/browse/AAASM-4860)
- Stacked with the AAASM-4861 code PR (this PR carries the ADR the code references; file-disjoint, either can merge first).

## Testing

- [x] Manual testing performed — `mdbook build` passes (ADR renders, TOC + index link resolve).
- [x] No code tests required (docs + skill only).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated (this PR *is* the docs)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-4860]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ