### PR TITLE
[AAASM-4911] 👷 (ci): Gate version drift with propagate_versions --check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,10 @@ on:
       - 'metadata/**'
       - 'scripts/generate_docs_metadata.py'
       - 'Cargo.toml'
+      # AAASM-4911: the version-drift gate below stamps README / installation.md
+      # / docs.yml pins / CONTRIBUTING.md from the SoT; a change to the gate
+      # script itself must re-run it (a dead trigger otherwise).
+      - 'scripts/propagate_versions.py'
   push:
     branches: [master]
     paths:
@@ -29,6 +33,7 @@ on:
       - 'metadata/**'
       - 'scripts/generate_docs_metadata.py'
       - 'Cargo.toml'
+      - 'scripts/propagate_versions.py'
   # Release-driven frozen-version cut (AAASM-2752). Instead of reacting to a
   # raw tag push, the frozen snapshot is cut only after the Release workflow
   # has *succeeded* for that tag. This guarantees we never publish docs for a
@@ -343,6 +348,33 @@ jobs:
 
       - name: Verify api-reference.md rustdoc command
         run: cargo doc --workspace --no-deps --exclude aa-ebpf
+
+  # AAASM-4911 (ADR 0013 rollout): the blocking version-drift gate. The `build`
+  # job above already fails on stale `docs/src/generated/` snippets, but that
+  # only covers the generated tier. `propagate_versions.py --check` extends the
+  # SoT → consumer contract to the hand-maintained literal tier the ADR audit
+  # flagged (README install/Project-Status lines, docs/src/quick-start/
+  # installation.md, this workflow's mdBook pins, CONTRIBUTING.md) plus a
+  # re-check of the snippet tier — so a version literal that drifts from the
+  # Cargo.toml / metadata/docs.yaml SoT fails the build instead of shipping.
+  # Kept as its own lightweight job (no Rust/mdBook toolchain) so the drift
+  # signal is fast and independent of the heavy book build.
+  version-drift:
+    name: Version-drift gate (propagate_versions --check)
+    # PR + master push only; a release-cut workflow_run rebuilds no sources.
+    if: github.event_name != 'workflow_run'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # The propagator uses `tomllib` (Python 3.11+); pin 3.12 rather than rely
+      # on the runner's default `python3`, which is not guaranteed to be ≥3.11.
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Fail if any version-bearing site drifts from the SoT
+        run: python3 scripts/propagate_versions.py --check
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,14 @@ mdbook serve docs --open
 
 Mermaid diagrams use the `mdbook-mermaid` preprocessor, which is wired in `docs/book.toml`. The `Docs` GitHub Actions workflow runs `mdbook build docs` on every PR that touches `docs/**`, `README.md`, or `CONTRIBUTING.md` and fails the build on errors.
 
+## Version metadata: single source of truth & drift gate
+
+Per [ADR 0013](docs/src/adr/0013-version-metadata-source-of-truth-and-drift-gate.md), every version-bearing value in this repo has exactly one source of truth (SoT) and propagates one direction only — SoT → generator → checked-in consumer. Nothing outside a SoT (or its generated output) may carry a version literal.
+
+- **Anchors (the SoT):** the core/runtime version is `Cargo.toml [workspace.package].version`; the mdBook/tool pins live in `metadata/docs.yaml`. The mdBook install commands just above are *stamped from that SoT* — edit the SoT, not these lines.
+- **To change a version-bearing value:** edit the anchor, then run `python3 scripts/propagate_versions.py` (Python 3.11+) to restamp every consumer (README install/status lines, `docs/src/quick-start/installation.md`, the `Docs` workflow pins, these CONTRIBUTING commands, and the `docs/src/generated/` snippets). Commit the SoT edit and the regenerated files together.
+- **The gate:** the `Docs` workflow's `version-drift` job runs `python3 scripts/propagate_versions.py --check` on every PR/push touching a version-bearing path and **fails the build** if any consumer is stale (mirrors `examples`' `example-metadata-check.yml`). Never hand-edit a stamped line or restate a version literal in prose.
+
 ## Reporting Issues
 
 Use the GitHub issue templates:


### PR DESCRIPTION
## Description

Wires `scripts/propagate_versions.py --check` into the **Docs** workflow as a blocking `version-drift` job, so a version literal that drifts from the source-of-truth (SoT) fails the build at PR time instead of being caught by a later security sweep. This is the `agent-assembly` slice of the **[ADR 0013](https://github.com/ai-agent-assembly/agent-assembly/blob/master/docs/src/adr/0013-version-metadata-source-of-truth-and-drift-gate.md)** rollout (Epic AAASM-4907).

- **New `version-drift` job** in `.github/workflows/docs.yml`: checkout → `setup-python` 3.12 (the propagator needs `tomllib`, 3.11+) → `python3 scripts/propagate_versions.py --check`. Kept as its own lightweight job (no Rust/mdBook toolchain) so the drift signal is fast and independent of the heavy book build.
- The existing `build` job already fails on stale `docs/src/generated/` snippets (the *generated* tier). This extends the SoT→consumer contract to the **hand-maintained literal tier** the ADR audit flagged: README install/Project-Status lines, `docs/src/quick-start/installation.md`, this workflow's mdBook pins, and `CONTRIBUTING.md`.
- Adds `scripts/propagate_versions.py` to both `on.*.paths` lists so a change to the gate script itself re-runs it (per the repo's two-layer trigger convention — every trigger needs a matching `on.*.paths` entry or it's a dead trigger).
- Does **not** re-implement the propagator (shipped by AAASM-4910); it only gates on it.
- Documents the gate + the edit-anchor-then-propagate workflow in `CONTRIBUTING.md`.

## Type of Change

- [x] 🔧 Configuration / CI change
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4911](https://lightning-dust-mite.atlassian.net/browse/AAASM-4911)
- Governing spec: ADR 0013 — Version Metadata Source-of-Truth & Drift Gate

### Cross-repo tail (per ADR 0013 Appendix B) — subtasks filed under AAASM-4911

The remaining version-bearing repos each get their own `--check` gate; one subtask per repo:

- [AAASM-4917](https://lightning-dust-mite.atlassian.net/browse/AAASM-4917) — **docs**: wire `generate_compatibility.py --check` (currently unwired)
- [AAASM-4918](https://lightning-dust-mite.atlassian.net/browse/AAASM-4918) — **python-sdk**: gate the README sample-output line
- [AAASM-4919](https://lightning-dust-mite.atlassian.net/browse/AAASM-4919) — **node-sdk**: fold README prose into the generated install block
- [AAASM-4920](https://lightning-dust-mite.atlassian.net/browse/AAASM-4920) — **go-sdk**: bring README protocol prose under `gen-metadata.go`
- [AAASM-4921](https://lightning-dust-mite.atlassian.net/browse/AAASM-4921) — **agent-assembly**: residual local gaps (compatibility.md presence→value; sdk-sha-drift issue-only→blocking)

`examples` / `e2e-public` are already conformant (the reference gate shape). `homebrew-agent-assembly` is named by the ADR but has **no matching Jira component** — flagged to the maintainer rather than filed as a mis-componented ticket.

## Testing

- [x] Manual testing performed

Validated locally with `python3.12`:
- Clean tree: `python3 scripts/propagate_versions.py --check` → `OK … match the SoT`, exit **0**.
- Deliberately staling a README version literal → `DRIFT: 1 … site(s) are stale`, exit **1**; restoring returns to exit 0.
- `actionlint .github/workflows/docs.yml` → clean.

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention


[AAASM-4911]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ