### PR TITLE
[AAASM-4922] 🔧 (config): Align agent-assembly metadata to the canonical registry

### DIFF
--- a/.ci/check-metadata-drift.sh
+++ b/.ci/check-metadata-drift.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# check-metadata-drift.sh
+#
+# ADR 0014 (canonical metadata registry & drift gate) — hardcoded-value lint mode.
+# Fails CI if a registry-owned canonical literal drifts back into the tree. The
+# canonical values live in the `.github` registry (`metadata/org-profile.yaml` ->
+# `metadata/generated/registry.json`); their values are decided by ADR 0007/0008.
+#
+# Scope (AAASM-4922): the two highest-fan-out canonical values reconciled in this
+# repo that have ZERO legitimate occurrence anywhere here, so the lint stays
+# false-positive-free:
+#   * the `.github` governance-doc branch — canonical is `master`, not `main`
+#     (registry `governance.baseline_doc_base`);
+#   * the `.dev` alternate installer host — it serves the script at its host ROOT
+#     (a `custom_domain` route, ADR 0007), so `tool.agent-assembly.dev/install.sh`
+#     is a wrong path (registry `urls.installer_alt`).
+#
+# ADRs are excluded: they quote these drifts as examples. The broader org-wide
+# orphan-literal audit (repo names, display names, Jira IDs) is owned by the
+# `.github` registry widen (ADR 0014 Appendix B item 1), not this repo-local lint.
+#
+# Usage: bash .ci/check-metadata-drift.sh   (from the repository root).
+# Exit 0 — clean; exit 1 — a registry-owned canonical value drifted.
+set -euo pipefail
+
+status=0
+
+# $1 = human description, $2 = ERE pattern, $3 = canonical-fix hint.
+check() {
+  local desc="$1" pat="$2" fix="$3" hits
+  hits=$(git grep -nE "$pat" -- \
+    ':(exclude)docs/src/adr/*' \
+    ':(exclude).ci/check-metadata-drift.sh' || true)
+  if [ -n "$hits" ]; then
+    echo "──────────────────────────────────────────────────────"
+    echo "Metadata drift: ${desc}"
+    echo "${hits}"
+    echo "Fix: ${fix}"
+    echo "──────────────────────────────────────────────────────"
+    status=1
+  fi
+}
+
+check "'.github' governance link uses 'blob/main' (canonical branch is 'master')" \
+  'ai-agent-assembly/\.github/blob/main' \
+  "use .../.github/blob/master/... (registry governance.baseline_doc_base)"
+
+check "'.dev' installer alt carries an '/install.sh' path (it serves at host root)" \
+  'tool\.agent-assembly\.dev/install\.sh' \
+  "use https://tool.agent-assembly.dev (registry urls.installer_alt, ADR 0007)"
+
+if [ "$status" -eq 0 ]; then
+  echo "Metadata-drift check passed."
+fi
+exit "$status"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,8 +99,10 @@ cargo doc --workspace --no-deps        # checked on push by hooks
 
 ## Project policy
 
-- **JIRA:** project AAASM; set **Component** (`customfield_10041`) to the repo
-  (`ai-agent-assembly/agent-assembly`); Team (`customfield_10001`) = Pioneer.
+- **JIRA:** project AAASM; set the native **Components** field to the repo
+  (`ai-agent-assembly/agent-assembly`) — it is the native `components` field, not
+  `customfield_10041` (which is null; per the `.github` registry `jira` section /
+  ADR 0014); Team (`customfield_10001`) = Pioneer.
   Epic → Story → Subtask (one Subtask ≈ one commit) + a `Verify …` subtask per Story.
 - **Self-hosted deployment is out of scope** product-wide — don't propose
   Helm/Terraform/air-gapped/migration work even if the spec mentions it.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ on:
       # / docs.yml pins / CONTRIBUTING.md from the SoT; a change to the gate
       # script itself must re-run it (a dead trigger otherwise).
       - 'scripts/propagate_versions.py'
+      # AAASM-4922: the metadata-drift lint (ADR 0014); re-run it when it changes.
+      - '.ci/check-metadata-drift.sh'
   push:
     branches: [master]
     paths:
@@ -34,6 +36,7 @@ on:
       - 'scripts/generate_docs_metadata.py'
       - 'Cargo.toml'
       - 'scripts/propagate_versions.py'
+      - '.ci/check-metadata-drift.sh'
   # Release-driven frozen-version cut (AAASM-2752). Instead of reacting to a
   # raw tag push, the frozen snapshot is cut only after the Release workflow
   # has *succeeded* for that tag. This guarantees we never publish docs for a
@@ -375,6 +378,22 @@ jobs:
 
       - name: Fail if any version-bearing site drifts from the SoT
         run: python3 scripts/propagate_versions.py --check
+
+  # AAASM-4922 (ADR 0014 rollout): blocking hardcoded-value lint for registry-owned
+  # canonical metadata. The `.github` registry owns the governance-doc branch and
+  # the canonical URL set; this gate fails the build if one of those canonical
+  # literals drifts back into the tree (e.g. a `.github/blob/main` governance link,
+  # or a `/install.sh` path on the host-root `.dev` installer alt). Pure git/bash,
+  # no toolchain — kept fast and independent of the book build like version-drift.
+  metadata-drift:
+    name: Metadata-drift gate (check-metadata-drift.sh)
+    if: github.event_name != 'workflow_run'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Fail if a registry-owned canonical value drifts
+        run: bash .ci/check-metadata-drift.sh
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-sha-drift.yml
+++ b/.github/workflows/sdk-sha-drift.yml
@@ -2,8 +2,25 @@ name: SDK SHA drift detector
 
 # Nightly advisory check of the ADR 0003 cross-repo lockstep invariant: the three
 # language SDKs must pin the shared `agent-assembly` core crates to one consistent
-# git rev. On drift it opens (or updates) a tracking issue; it is non-blocking for
-# any product CI. Also runnable on demand via workflow_dispatch.
+# git rev. On drift it opens (or updates) a tracking issue AND fails its own run
+# (the final step `exit 1`s, so the nightly run goes red — it is not merely
+# issue-only). It stays non-blocking for any *product PR* CI.
+#
+# ADR 0013 Appendix B item 8 / AAASM-4921 asked whether this should become a
+# blocking check. Decision: it stays ADVISORY under ADR 0003, recorded here in-repo.
+# Rationale:
+#   * The invariant is CROSS-REPO — the drift lives in the SDK repos' native-shim
+#     `aa-*` git-rev pins (read here via the GitHub API), not in this repo. An
+#     agent-assembly PR neither introduces nor can fix that drift, so gating
+#     agent-assembly PR merges on it would false-block unrelated changes on a
+#     condition the author cannot resolve.
+#   * ADR 0003 governs the pin as an INDEPENDENT-cadence, bot-bumped invariant;
+#     the SDKs are realigned in their own repos on release, so a required per-PR
+#     gate here is the wrong enforcement point.
+# The signals that DO make drift loud — the tracking issue plus this run going red
+# — are the appropriate weight for a nightly cross-repo lockstep check.
+#
+# Also runnable on demand via workflow_dispatch.
 on:
   schedule:
     - cron: "17 6 * * *"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ To add a new crate to the workspace:
 
 ## Developer Certificate of Origin (DCO)
 
-We ask that you sign off each commit under the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — this licenses your contribution to the project under the [Apache License 2.0](LICENSE). Sign-off is **currently advisory** (see the note below), consistent with the org-wide [contribution guide](https://github.com/ai-agent-assembly/.github/blob/main/CONTRIBUTING.md).
+We ask that you sign off each commit under the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — this licenses your contribution to the project under the [Apache License 2.0](LICENSE). Sign-off is **currently advisory** (see the note below), consistent with the org-wide [contribution guide](https://github.com/ai-agent-assembly/.github/blob/master/CONTRIBUTING.md).
 
 Sign off by adding a `Signed-off-by` trailer to each commit message:
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ can move from this repo to the SDKs, the install tap, or the canonical docs.
 | [node-sdk](https://github.com/ai-agent-assembly/node-sdk) | TypeScript / Node.js SDK (napi-rs native + JS client) | [![release](https://img.shields.io/github/v/release/ai-agent-assembly/node-sdk?include_prereleases&sort=semver&label=release&logo=nodedotjs&logoColor=white)](https://github.com/ai-agent-assembly/node-sdk/releases) |
 | [go-sdk](https://github.com/ai-agent-assembly/go-sdk) | Go SDK | [![release](https://img.shields.io/github/v/release/ai-agent-assembly/go-sdk?include_prereleases&sort=semver&label=release&logo=go&logoColor=white)](https://github.com/ai-agent-assembly/go-sdk/releases) |
 | [homebrew-tap](https://github.com/ai-agent-assembly/homebrew-tap) | Homebrew tap for the `aasm` CLI | [![Homebrew tap](https://img.shields.io/badge/homebrew-tap-FBB040?logo=homebrew&logoColor=white)](https://github.com/ai-agent-assembly/homebrew-tap) |
-| [agent-assembly-docs](https://docs.agent-assembly.com/) | Canonical documentation site | [![docs](https://img.shields.io/badge/docs-live-2088FF)](https://docs.agent-assembly.com/) |
+| [docs](https://docs.agent-assembly.com/) | Canonical documentation site | [![docs](https://img.shields.io/badge/docs-live-2088FF)](https://docs.agent-assembly.com/) |
 | agent-assembly-cloud | Hosted SaaS control plane | ![coming soon](https://img.shields.io/badge/SaaS-coming_soon-8957E5) |
 | agent-assembly-enterprise | Enterprise extensions (delivered via SaaS) | ![coming soon](https://img.shields.io/badge/enterprise-coming_soon-8957E5) |
 

--- a/docs/src/adr/0007-public-domain-and-url-contract.md
+++ b/docs/src/adr/0007-public-domain-and-url-contract.md
@@ -1,8 +1,27 @@
 # ADR 0007: Public Domain & URL Contract
 
-**Status**: Proposed
+**Status**: Proposed (amended)
 **Date**: 2026-06
 **Ticket**: [AAASM-3652](https://lightning-dust-mite.atlassian.net/browse/AAASM-3652) (Epic [AAASM-3651](https://lightning-dust-mite.atlassian.net/browse/AAASM-3651))
+
+---
+
+## Amendment — AAASM-4931 (2026-07-20)
+
+The `tool.agent-assembly.dev` installer alternate is **retired**.
+`https://agent-assembly.com/install.sh` is now the **sole canonical installer**;
+there is no advertised `.dev` install alternate.
+
+This supersedes original decision **#2 ("`.dev` stays working")** and the
+"Alternate (kept working)" installer line below. The `.dev` host was only ever a
+`*_alt` metadata value and was never surfaced as an active install command
+(`profile/README.md` described it as "planned but not yet live"); advertising a
+not-live alternate added drift surface with no user benefit. The apex
+`agent-assembly.com/install.sh` was already the canonical, expected URL, so this
+amendment collapses the contract to that single installer.
+
+The original two-TLD rationale below (why `.dev` existed and was kept) is retained
+as **historical record** — it is superseded, not erased.
 
 ---
 
@@ -42,10 +61,13 @@ These framing decisions are inputs to this ADR, not open questions:
 
 1. **`.com` is primary.** `agent-assembly.com` is the primary public domain for the
    SaaS service and marketing.
-2. **`.dev` stays working.** The existing `tool.agent-assembly.dev` install host is
-   **kept** and continues to serve the installer; it is not retired.
+2. **`.dev` stays working.** *(Superseded by AAASM-4931 — the
+   `tool.agent-assembly.dev` installer alternate is retired; see the Amendment
+   above.)* Originally: the existing `tool.agent-assembly.dev` install host was
+   kept as a working installer alternate.
 3. **The canonical installer is `https://agent-assembly.com/install.sh`** — apex host,
-   `/install.sh` path. The `.dev` host remains a working alternate.
+   `/install.sh` path. Per the AAASM-4931 amendment this is now the **sole**
+   canonical installer, with no `.dev` alternate.
 
 ---
 
@@ -60,17 +82,17 @@ These framing decisions are inputs to this ADR, not open questions:
 | `docs.agent-assembly.com` | Canonical documentation host | mdBook/doc sites — see Epic [AAASM-3659](https://lightning-dust-mite.atlassian.net/browse/AAASM-3659) | Future (placeholder) |
 | `status.agent-assembly.com` | Status page | Hosted status provider | Future (placeholder) |
 | `<tenant>.agent-assembly.com` | Per-customer workspace | Tenant-scoped app served via the `*` wildcard | Future (placeholder) |
-| `tool.agent-assembly.dev` | Legacy installer host (kept) | `scripts/install-cli.sh` at the host root | Live (kept) |
+| `tool.agent-assembly.dev` | Legacy installer host | `scripts/install-cli.sh` at the host root | Retired (AAASM-4931) — no longer an advertised installer alternate |
 
 ### Installer URL contract
 
-- **Canonical:** `curl -fsSL https://agent-assembly.com/install.sh | sh`
-- **Alternate (kept working):** `curl -fsSL https://tool.agent-assembly.dev | sh`
-- Both resolve to the **same script** (`scripts/install-cli.sh`), served by the same
+- **Canonical (sole):** `curl -fsSL https://agent-assembly.com/install.sh | sh`
+- *(Superseded by AAASM-4931: the `tool.agent-assembly.dev` alternate is retired
+  and no longer advertised.)*
+- The canonical installer resolves to `scripts/install-cli.sh`, served by the
   Cloudflare Worker (`infra/install-endpoint/`). The apex is wired as a **path route**
   (`agent-assembly.com/install.sh*`), not a `custom_domain`, because the apex also
-  hosts the marketing site; the `.dev` host stays a `custom_domain` route. See
-  AAASM-3654.
+  hosts the marketing site. See AAASM-3654.
 
 ### How `docs.agent-assembly.com` (Epic AAASM-3659) fits
 
@@ -117,10 +139,11 @@ The content, doc-site tooling, and version-channel model under
 
 ## Decision
 
-Adopt the URL surface in the table above with **`.com` primary, `.dev` kept**, the
-**canonical installer at `agent-assembly.com/install.sh`** (apex path route) with
-**`tool.agent-assembly.dev` retained** as a working alternate, and
-**`docs.agent-assembly.com`** reserved here but owned by Epic AAASM-3659.
+Adopt the URL surface in the table above with **`.com` primary**, the
+**canonical installer at `agent-assembly.com/install.sh`** (apex path route) as the
+**sole** installer (**`tool.agent-assembly.dev` retired** per the AAASM-4931
+amendment above), and **`docs.agent-assembly.com`** reserved here but owned by Epic
+AAASM-3659.
 
 This decision is **Proposed** — it is the contract the rest of this epic builds
 against, pending owner ratification. No host is provisioned by adopting it; DNS and
@@ -136,8 +159,9 @@ deploys are owner-gated (AAASM-3653, AAASM-3654, AAASM-3658).
   (AAASM-3654), host routing/cookies (ADR 0008 / AAASM-3656), redirects
   (AAASM-3657), and the ops runbook (AAASM-3658) all reference, instead of each
   inventing its own host list.
-- The installer one-liner becomes `https://agent-assembly.com/install.sh` while every
-  existing `tool.agent-assembly.dev` reference keeps working.
+- The installer one-liner is `https://agent-assembly.com/install.sh` — the sole
+  canonical installer (the `tool.agent-assembly.dev` alternate is retired per the
+  AAASM-4931 amendment).
 
 ### What this blocks / defers
 

--- a/docs/src/adr/0014-canonical-metadata-registry-and-drift-gate.md
+++ b/docs/src/adr/0014-canonical-metadata-registry-and-drift-gate.md
@@ -238,7 +238,7 @@ sanctioned generated block; otherwise a hand-copied literal.
 ### Canonical URLs (largest cluster)
 | Site | Metadata | Form |
 | --- | --- | --- |
-| `.github` `metadata/org-profile.yaml` + `profile/README.md` | docs site, arena docs, installer alias, curl installer | SoT / generated |
+| `.github` `metadata/org-profile.yaml` + `profile/README.md` | docs site, arena docs, curl installer (`agent-assembly.com/install.sh`, sole canonical — the `.dev` alt was retired in AAASM-4931) | SoT / generated |
 | `.github` `SUPPORT.md:5,20` | docs + marketing URLs | literal |
 | `agent-assembly/**` | installer `agent-assembly.com/install.sh` (×26), docs `docs.agent-assembly.com/` (×22, incl. per-SDK `…/stable/`), `app.agent-assembly.com/` | literal, high fan-out |
 | `docs/**` | `api.`/`app.` hosts, `agent-assembly.com/early-access`, per-SDK docs | literal |

--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -2,7 +2,7 @@
 
 The pages in this guide explain *how* governance works. When you want to **run**
 it, the framework-specific, end-to-end examples live in the dedicated
-[`agent-assembly-examples`](https://github.com/ai-agent-assembly/examples)
+[`examples`](https://github.com/ai-agent-assembly/examples)
 repository rather than in this book — that keeps the runnable code versioned and
 testable on its own, while these pages stay focused on the concepts.
 

--- a/metadata/docs.yaml
+++ b/metadata/docs.yaml
@@ -51,12 +51,10 @@ repo_url: "https://github.com/ai-agent-assembly/agent-assembly"
 docs_url: "https://docs.agent-assembly.com/"
 
 # The one-line installer endpoint served by the official website (registry
-# `urls.installer`). The `tool.agent-assembly.dev` host is a maintained alternate
-# that serves the script at its HOST ROOT (a `custom_domain` route — ADR 0007;
-# registry `urls.installer_alt`), so the alt has NO `/install.sh` path. The GitHub
-# raw URL is the fallback for users who want to fetch the script directly.
+# `urls.installer`). `agent-assembly.com/install.sh` is the SOLE canonical
+# installer — AAASM-4931 retired the `tool.agent-assembly.dev` alternate. The
+# GitHub raw URL is the fallback for users who want to fetch the script directly.
 install_script_url: "https://agent-assembly.com/install.sh"
-install_script_url_alt: "https://tool.agent-assembly.dev"
 install_script_url_raw: "https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh"
 
 # mdBook / mdbook-mermaid toolchain pins — the SoT for the docs-build tool

--- a/metadata/docs.yaml
+++ b/metadata/docs.yaml
@@ -30,8 +30,18 @@
 # See docs/src/versioning.md for the SemVer rules that govern bumps.
 protocol_version: "protocol/v1"
 
+# Shared-metadata single-owner note (ADR 0014). The URL values below (`repo_url`,
+# `docs_url`, the `install_script_url*` set) are canonical org-shared metadata whose
+# single owner is the `.github` registry `metadata/org-profile.yaml` (`urls.*`,
+# generated to `metadata/generated/registry.json`); their *values* are decided by
+# ADR 0007/0008. This docs-scoped copy MUST match the registry — it is not an
+# independent source of truth. Genuinely docs-only values (e.g. `protocol_version`)
+# stay owned here. Full runtime derivation from the cross-repo registry is the
+# `.github` widen's job (AAASM-4914); this file is kept reconciled by value + the
+# metadata-drift lint (.ci/check-metadata-drift.sh).
+
 # Canonical GitHub repository URL used by installer instructions, edit-page
-# links, and cross-references from ADRs.
+# links, and cross-references from ADRs. Owner: registry `urls`/repo entry.
 repo_url: "https://github.com/ai-agent-assembly/agent-assembly"
 
 # Canonical published docs site. Served from the `docs.agent-assembly.com`
@@ -40,11 +50,13 @@ repo_url: "https://github.com/ai-agent-assembly/agent-assembly"
 # mirror the CDN pulls from and MUST NOT be surfaced to readers.
 docs_url: "https://docs.agent-assembly.com/"
 
-# The one-line installer endpoint served by the official website. The
-# `tool.agent-assembly.dev` host is a maintained alternate; the GitHub raw
-# URL is the fallback for users who want to fetch the script directly.
+# The one-line installer endpoint served by the official website (registry
+# `urls.installer`). The `tool.agent-assembly.dev` host is a maintained alternate
+# that serves the script at its HOST ROOT (a `custom_domain` route — ADR 0007;
+# registry `urls.installer_alt`), so the alt has NO `/install.sh` path. The GitHub
+# raw URL is the fallback for users who want to fetch the script directly.
 install_script_url: "https://agent-assembly.com/install.sh"
-install_script_url_alt: "https://tool.agent-assembly.dev/install.sh"
+install_script_url_alt: "https://tool.agent-assembly.dev"
 install_script_url_raw: "https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh"
 
 # mdBook / mdbook-mermaid toolchain pins — the SoT for the docs-build tool

--- a/metadata/docs.yaml
+++ b/metadata/docs.yaml
@@ -52,7 +52,7 @@ docs_url: "https://docs.agent-assembly.com/"
 
 # The one-line installer endpoint served by the official website (registry
 # `urls.installer`). `agent-assembly.com/install.sh` is the SOLE canonical
-# installer — AAASM-4931 retired the `tool.agent-assembly.dev` alternate. The
+# installer — AAASM-4931 retired the legacy hosted installer alternate. The
 # GitHub raw URL is the fallback for users who want to fetch the script directly.
 install_script_url: "https://agent-assembly.com/install.sh"
 install_script_url_raw: "https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh"

--- a/scripts/propagate_versions.py
+++ b/scripts/propagate_versions.py
@@ -45,9 +45,14 @@ everything):
 
 Deliberately NOT stamped (ADR-directed)
 ---------------------------------------
-* ``docs/src/compatibility.md`` matrix rows — per-tag rows stay **literal** (ADR
-  0013 "Explicitly forbidden designs": templating historical values). The matrix
-  grows by append-on-release; its row-presence gate is upgraded under AAASM-4911.
+* ``docs/src/compatibility.md`` matrix rows are never *written* here — per-tag rows
+  stay **literal** (ADR 0013 "Explicitly forbidden designs": templating historical
+  values). The matrix grows by append-on-release. ``--check`` mode does, however,
+  **value-check the current release's row** (AAASM-4921): the row for the core
+  anchor must exist with the anchor tag in its ``aa-runtime`` cell, so a bump that
+  forgets the row — or fat-fingers its runtime value — fails the gate instead of
+  slipping past the old presence-only ``.ci/check-compatibility-matrix.sh``. Only
+  the current row is validated; historical rows are left untouched.
 * ``aa-ebpf-probes/rust-toolchain.toml`` ``channel = "nightly"`` — a channel, not
   a version derived from any anchor; there is nothing to propagate.
 * The README Project Status maturity **banner** ("Release candidate — `v0.0.1-rc`
@@ -295,12 +300,50 @@ def sync_snippets(root: Path, check: bool) -> list[str]:
     return drift
 
 
+# The compatibility matrix (docs/src/compatibility.md) is append-on-release and its
+# per-tag rows are historical literals the propagator must never template (ADR 0013).
+# The row for the CURRENT release, however, is a value we CAN validate against the
+# anchor — and must, because the legacy presence-only gate
+# (.ci/check-compatibility-matrix.sh) passes as long as the file was touched at all,
+# so a missing or mis-typed current row shipped silently (AAASM-4921).
+COMPAT_MATRIX = "docs/src/compatibility.md"
+
+
+def check_compat_current_row(root: Path, ctx: Context) -> list[str]:
+    """Value-check the CURRENT release's row in the compatibility matrix.
+
+    Returns a drift list (empty == OK). The check is intentionally narrow: it
+    asserts exactly that a matrix row exists whose first (``aa-runtime``) cell is
+    the core anchor tag. That catches the two failures the old presence-only gate
+    let through — the current row missing entirely (anchor bumped, matrix not
+    appended) and the current row carrying the wrong runtime version (no row then
+    matches the anchor) — without templating any historical row. SDK cells are not
+    asserted against the anchor: SDKs version independently (ADR 0009).
+    """
+    path = root / COMPAT_MATRIX
+    if not path.is_file():
+        return [f"{COMPAT_MATRIX}: consumer file not found"]
+    # A table row whose first cell is exactly the anchor tag, e.g. `| v0.0.1-rc.6 |`.
+    row = re.compile(r"(?m)^\|\s*" + re.escape(ctx.core_tag) + r"\s*\|")
+    if row.search(path.read_text()):
+        return []
+    return [
+        f"{COMPAT_MATRIX}: no compatibility-matrix row for the current core anchor "
+        f"{ctx.core_tag} (append or fix the current row; historical rows stay literal)"
+    ]
+
+
 def run(root: Path, check: bool) -> int:
     ctx = resolve_context(root)
     rules = build_rules(ctx)
     lit_drift, errors = sync_literals(root, rules, check)
     snip_drift = sync_snippets(root, check)
     drift = lit_drift + snip_drift
+    # The compatibility matrix is validated, not stamped: the current-release row is
+    # value-checked in gate mode only (its historical rows are literal — nothing to
+    # write). A stale/missing current row is drift that fails --check.
+    if check:
+        drift = drift + check_compat_current_row(root, ctx)
 
     if errors:
         for err in errors:

--- a/scripts/test_propagate_versions.py
+++ b/scripts/test_propagate_versions.py
@@ -78,6 +78,19 @@ cargo install --locked --version {MDBOOK} mdbook
 cargo install --locked --version {MERMAID} mdbook-mermaid
 """
 
+# Compatibility matrix: a historical row (must be left literal) plus the row for the
+# CURRENT anchor. The gate value-checks only that a row exists whose first cell is
+# the anchor tag (AAASM-4921).
+COMPATIBILITY = f"""# Version Compatibility Matrix
+
+## Compatibility Matrix
+
+| `aa-runtime` | Python SDK | Node.js SDK | Go SDK | Protocol Version |
+|---|---|---|---|---|
+| v0.0.1-rc.5 | v0.0.1-rc.5 ✓ | v0.0.1-rc.5 ✓ | v0.0.1-rc.5 ✓ | protocol/v1 |
+| {CORE_TAG} | {CORE_TAG} ✓ | {CORE_TAG} ✓ | {CORE_TAG} ✓ | protocol/v1 |
+"""
+
 
 def build_fixture(root: Path) -> None:
     """Write a minimal but faithful consumer tree, already synced to the SoT."""
@@ -88,6 +101,7 @@ def build_fixture(root: Path) -> None:
     (root / "CONTRIBUTING.md").write_text(CONTRIBUTING)
     (root / "docs" / "src" / "quick-start").mkdir(parents=True)
     (root / "docs" / "src" / "quick-start" / "installation.md").write_text(INSTALLATION)
+    (root / "docs" / "src" / "compatibility.md").write_text(COMPATIBILITY)
     (root / "docs" / "src" / "generated").mkdir(parents=True)
     (root / ".github" / "workflows").mkdir(parents=True)
     (root / ".github" / "workflows" / "docs.yml").write_text(DOCS_YML)
@@ -168,6 +182,42 @@ class RoundTrip(unittest.TestCase):
                 before,
                 "VERSION cell width changed — grid-table borders misalign",
             )
+
+    def test_compat_current_row_value_check(self) -> None:
+        # AAASM-4921: the gate value-checks the CURRENT release's compatibility-matrix
+        # row. A wrong runtime value in that row (so no row matches the anchor) — the
+        # failure the old presence-only gate let through — must fail --check. The
+        # matrix is never written by the propagator (historical rows stay literal), so
+        # a write pass must NOT "fix" it.
+        compat_rel = "docs/src/compatibility.md"
+        tmp, root = self._fixture()
+        with tmp:
+            compat = root / compat_rel
+            # A synced fixture (current row present) passes.
+            self.assertEqual(pv.run(root, check=True), 0)
+
+            # Fat-finger the current row's runtime cell so no row carries the anchor.
+            good = f"| {CORE_TAG} | {CORE_TAG} ✓"
+            bad = f"| v0.0.1-rc.99 | {CORE_TAG} ✓"
+            compat.write_text(compat.read_text().replace(good, bad))
+            before = compat.read_text()
+
+            self.assertEqual(pv.run(root, check=True), 1)
+            # Write mode leaves the literal matrix untouched (no restore).
+            self.assertEqual(pv.run(root, check=False), 0)
+            self.assertEqual(compat.read_text(), before, "write mode edited the matrix")
+            self.assertEqual(pv.run(root, check=True), 1)
+
+    def test_compat_missing_row_fails_check(self) -> None:
+        # Anchor bumped but the matrix row never appended — the other failure the
+        # presence-only gate let through.
+        tmp, root = self._fixture()
+        with tmp:
+            compat = root / "docs" / "src" / "compatibility.md"
+            compat.write_text(
+                re.sub(rf"(?m)^\| {re.escape(CORE_TAG)} .*$", "", compat.read_text())
+            )
+            self.assertEqual(pv.run(root, check=True), 1)
 
     def test_missing_anchor_is_a_hard_error(self) -> None:
         # A renamed/removed consumer anchor must fail loudly (exit 2), never pass


### PR DESCRIPTION
## Description

Rollout of ADR 0014 (canonical metadata registry & drift gate) in `agent-assembly` — correcting hardcoded metadata that **contradicts** the canonical `.github` registry (`metadata/org-profile.yaml` → `metadata/generated/registry.json`; URL values decided by ADR 0007/0008). Scoped to this repo.

**Corrections**
- `CONTRIBUTING.md` — governance deep-link `.github/blob/main` → `blob/master` (registry `governance.baseline_doc_base`; `main` is a dead link).
- `metadata/docs.yaml` — `install_script_url_alt` `https://tool.agent-assembly.dev/install.sh` → `https://tool.agent-assembly.dev` (the `.dev` host serves the script at its **root**, ADR 0007; registry `urls.installer_alt`). Also annotates the ADR 0014 single-owner relationship (these shared URL/repo values are owned by the `.github` registry; this docs-scoped copy tracks it).
- `README.md` / `docs/src/usage-guide/examples.md` — stale pre-rename repo-name labels `agent-assembly-docs` → `docs`, `agent-assembly-examples` → `examples` (AAASM-4341 residue; link targets were already canonical).
- `.claude/CLAUDE.md` — Jira Components fact: native `components` field, not `customfield_10041` (null; registry `jira` section).

**Blocking drift check** — adds `.ci/check-metadata-drift.sh` (ADR 0014 Decision 3 mode B hardcoded-value lint), wired as a blocking `metadata-drift` job in `docs.yml`. Scoped to the two zero-legitimate-occurrence canonical literals reconciled here (governance branch; `.dev` installer-alt path) so it is false-positive-free; the broader org-wide orphan-literal audit (repo names, display names, Jira IDs) is owned by the `.github` registry widen (ADR 0014 Appendix B item 1).

**Deliberately left literal** (per the context-boundary + historical-values rules): private-repo references (`agent-assembly-cloud`/`cloud`) in public artifacts, and historical release notes / verification reports.

## Type of Change

- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4922](https://lightning-dust-mite.atlassian.net/browse/AAASM-4922)

## Testing

- [x] Manual testing performed — `bash .ci/check-metadata-drift.sh` exits 0 clean and 1 on an injected drift; `actionlint` clean; `shellcheck` clean; `generate_docs_metadata.py` produces no snippet drift; `propagate_versions.py --check` exits 0; `mdbook build docs` OK.
- [x] No unit tests required (metadata/doc corrections + a bash lint).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

---

**Stacked on #1591** (AAASM-4921) — merge that first. Base is `master` per convention; the branch is stacked on the 4921 branch.

[AAASM-4922]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ