### PR TITLE
[AAASM-4933] 🐛 (aa-api): Enforce policy-mutation RBAC against the document scope

### DIFF
--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -8,6 +8,7 @@ use utoipa::{IntoParams, ToSchema};
 
 use aa_gateway::policy::rbac::MutationKind;
 use aa_gateway::policy::scope::PolicyScope;
+use aa_gateway::policy::PolicyValidator;
 
 use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
 use crate::auth::scope::{RequireRead, Scope};
@@ -147,22 +148,14 @@ pub struct CreatePolicyRequest {
     pub policy_yaml: String,
     /// Governance scope this policy targets (e.g. `"global"`, `"team:platform"`).
     ///
-    /// Used for RBAC authorization — the caller must hold the role required
-    /// to mutate policies at this scope. Defaults to `"global"` when absent.
+    /// Optional client-declared RBAC scope. **Advisory only** (AAASM-4933): the
+    /// authorization scope is derived from the policy *document's own* declared
+    /// scope, never this field. When present it must equal the document's scope
+    /// — a value that disagrees is rejected (`400`) rather than trusted, closing
+    /// the pre-fix path where a caller under-claimed a narrow scope (e.g.
+    /// `tool:x`) to satisfy a lower role while installing a global-effect policy.
     #[serde(default)]
     pub scope: Option<String>,
-}
-
-impl CreatePolicyRequest {
-    /// Parse `scope` into a [`PolicyScope`], defaulting to `Global`.
-    pub fn policy_scope(&self) -> Result<PolicyScope, String> {
-        match &self.scope {
-            None => Ok(PolicyScope::Global),
-            Some(s) => s
-                .parse()
-                .map_err(|e: aa_gateway::policy::error::PolicyParseError| e.to_string()),
-        }
-    }
 }
 
 /// `POST /api/v1/policies` — apply a new governance policy.
@@ -186,14 +179,63 @@ pub async fn create_policy(
     Extension(state): Extension<AppState>,
     Json(body): Json<CreatePolicyRequest>,
 ) -> Result<(StatusCode, Json<PolicyResponse>), PolicyCreateError> {
-    let scope = body.policy_scope().map_err(|e| {
+    // Parse the (advisory) client-declared scope for input validation only.
+    let requested_scope = body
+        .scope
+        .as_deref()
+        .map(str::parse::<PolicyScope>)
+        .transpose()
+        .map_err(|e: aa_gateway::policy::error::PolicyParseError| {
+            PolicyCreateError::BadRequest(
+                ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid scope: {e}")),
+            )
+        })?;
+
+    // AAASM-4933: authorize against the policy DOCUMENT's own declared scope,
+    // never the client-asserted `body.scope`. Validate the YAML up front so the
+    // real scope is known before the RBAC gate. `apply_yaml` re-validates below;
+    // the duplication is deliberate — it keeps this security fix contained to the
+    // handler (no change to the engine's evaluate/install path) on a cold,
+    // low-frequency write endpoint.
+    let validated = PolicyValidator::from_yaml(&body.policy_yaml).map_err(|errs| {
         PolicyCreateError::BadRequest(
-            ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid scope: {e}")),
+            ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid policy: {errs:?}")),
         )
     })?;
+    let doc_scope = validated.document.scope;
 
+    // The client may annotate the request with a scope, but it must agree with
+    // the document — a divergent claim is rejected, not trusted. This is the
+    // pre-fix privilege-escalation vector: a Write/Developer caller declared
+    // `scope: tool:x` (Developer-authorized) while submitting a scope-less
+    // (global) policy, installing a global-effect policy with a Developer role.
+    if let Some(requested) = &requested_scope {
+        if requested != &doc_scope {
+            return Err(PolicyCreateError::BadRequest(
+                ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!(
+                    "scope mismatch: request scope '{requested}' does not match policy document scope '{doc_scope}'"
+                )),
+            ));
+        }
+    }
+
+    // This endpoint hot-swaps the single GLOBAL primary policy slot (see
+    // `PolicyEngine::apply_yaml`), so it can only honor a Global-scoped document.
+    // A narrower declared scope would be silently globalised — installed for
+    // every agent — so it is rejected until scoped installation is wired into the
+    // `scope_index` cascade (AAASM-4933 follow-up).
+    if doc_scope != PolicyScope::Global {
+        return Err(PolicyCreateError::BadRequest(
+            ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!(
+                "scoped policy installation is not supported via this endpoint; only global \
+                 policies may be applied (policy declared scope '{doc_scope}')"
+            )),
+        ));
+    }
+
+    // Gate on the document's true scope: a global install requires OrgAdmin.
     policy_auth
-        .check_mutation(&scope, MutationKind::Create)
+        .check_mutation(&doc_scope, MutationKind::Create)
         .map_err(PolicyCreateError::Forbidden)?;
 
     let meta = state

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -146,14 +146,18 @@ pub async fn list_policies(
 pub struct CreatePolicyRequest {
     /// Raw YAML content of the governance policy.
     pub policy_yaml: String,
-    /// Governance scope this policy targets (e.g. `"global"`, `"team:platform"`).
-    ///
-    /// Optional client-declared RBAC scope. **Advisory only** (AAASM-4933): the
-    /// authorization scope is derived from the policy *document's own* declared
-    /// scope, never this field. When present it must equal the document's scope
-    /// — a value that disagrees is rejected (`400`) rather than trusted, closing
-    /// the pre-fix path where a caller under-claimed a narrow scope (e.g.
-    /// `tool:x`) to satisfy a lower role while installing a global-effect policy.
+    /// Optional client-declared governance scope (e.g. `"global"`,
+    /// `"team:platform"`). Advisory: authorization is derived from the policy
+    /// document's own declared scope, and a value that disagrees with the
+    /// document is rejected.
+    //
+    // AAASM-4933: this field must NOT lower the RBAC gate. `create_policy`
+    // authorizes against the *validated document's* declared scope; a
+    // `body.scope` that disagrees is rejected (400), closing the pre-fix
+    // privilege-escalation path where a caller under-claimed a narrow scope
+    // (e.g. `tool:x`) to satisfy a lower role while installing a global-effect
+    // policy. The rationale is an inline `//` comment, not `///`, so it does not
+    // fold into the OpenAPI schema description (utoipa folds `///` into the spec).
     #[serde(default)]
     pub scope: Option<String>,
 }

--- a/aa-api/tests/policy_rbac_integration.rs
+++ b/aa-api/tests/policy_rbac_integration.rs
@@ -23,9 +23,30 @@ spec:
     daily_limit_usd: 1000.0
 "#;
 
-/// Build an authenticated POST /api/v1/policies request.
+/// A policy YAML that declares a non-global (`tool:`) scope in its `spec`.
+/// The create endpoint installs the single global primary policy slot, so it
+/// cannot honor a scoped document and must reject it (AAASM-4933).
+const TOOL_SCOPED_POLICY_YAML: &str = r#"
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: rbac-test-scoped-policy
+  version: "1.0.0"
+spec:
+  scope: tool:slack-mcp
+  budget:
+    daily_limit_usd: 1000.0
+"#;
+
+/// Build an authenticated POST /api/v1/policies request with `VALID_POLICY_YAML`
+/// (a scope-less, i.e. global, document) and an optional advisory `body.scope`.
 fn post_policy_request(token: &str, scope: Option<&str>) -> Request<Body> {
-    let mut body = serde_json::json!({ "policy_yaml": VALID_POLICY_YAML });
+    post_policy_request_yaml(token, scope, VALID_POLICY_YAML)
+}
+
+/// Variant that lets the caller supply the policy YAML body.
+fn post_policy_request_yaml(token: &str, scope: Option<&str>, yaml: &str) -> Request<Body> {
+    let mut body = serde_json::json!({ "policy_yaml": yaml });
     if let Some(s) = scope {
         body["scope"] = serde_json::Value::String(s.to_string());
     }
@@ -38,81 +59,121 @@ fn post_policy_request(token: &str, scope: Option<&str>) -> Request<Body> {
         .unwrap()
 }
 
-// ── Admin scope (→ OrgAdmin) — allowed at every scope level ─────────────────
+// The endpoint installs the single GLOBAL primary policy, so authorization is
+// derived from the policy document's own scope (global here), NOT the advisory
+// `body.scope`. Contract (AAASM-4933):
+//   - body.scope omitted or "global"  → gated by role (OrgAdmin installs; lower
+//     roles are 403).
+//   - body.scope a non-global scope   → 400, because it disagrees with the
+//     global document (the old privilege-escalation claim vector).
+
+// ── Admin (→ OrgAdmin) — installs the global policy; scope mismatch is 400 ──
 
 #[rstest]
-#[case(None)] // global (default)
-#[case(Some("global"))]
-#[case(Some("org:acme"))]
-#[case(Some("team:platform"))]
-#[case(Some("tool:slack-mcp"))]
+#[case(None, StatusCode::CREATED)] // global (default)
+#[case(Some("global"), StatusCode::CREATED)]
+#[case(Some("org:acme"), StatusCode::BAD_REQUEST)]
+#[case(Some("team:platform"), StatusCode::BAD_REQUEST)]
+#[case(Some("tool:slack-mcp"), StatusCode::BAD_REQUEST)]
 #[tokio::test]
-async fn admin_scope_allowed_at_all_policy_scopes(#[case] scope: Option<&str>) {
+async fn admin_installs_global_and_rejects_scope_mismatch(#[case] scope: Option<&str>, #[case] expected: StatusCode) {
     let (token, entry) = common::generate_test_api_key("admin-key", vec![Scope::Read, Scope::Write, Scope::Admin]);
     let app = common::test_app_with_auth(&[entry], 1000);
 
     let response = app.oneshot(post_policy_request(&token, scope)).await.unwrap();
-    assert_eq!(
-        response.status(),
-        StatusCode::CREATED,
-        "OrgAdmin should be allowed for scope={scope:?}"
-    );
+    assert_eq!(response.status(), expected, "admin scope={scope:?}");
 }
 
-// ── Write scope (→ Developer) — allowed only at agent/tool scopes ────────────
+// ── Write (→ Developer) — may NEVER install the global policy ────────────────
+// A global body (None / "global") is a role denial (403); a scoped body is a
+// document mismatch (400). Either way the developer cannot create the policy —
+// this is the AAASM-4933 privilege-escalation fix.
 
 #[rstest]
-#[case(Some("tool:slack-mcp"))]
+#[case(None, StatusCode::FORBIDDEN)] // global (default) → role denied
+#[case(Some("global"), StatusCode::FORBIDDEN)]
+#[case(Some("org:acme"), StatusCode::BAD_REQUEST)] // mismatch vs global document
+#[case(Some("team:platform"), StatusCode::BAD_REQUEST)]
+#[case(Some("tool:slack-mcp"), StatusCode::BAD_REQUEST)]
 #[tokio::test]
-async fn write_scope_allowed_at_tool_scope(#[case] scope: Option<&str>) {
+async fn developer_cannot_install_global_policy(#[case] scope: Option<&str>, #[case] expected: StatusCode) {
     let (token, entry) = common::generate_test_api_key("dev-key", vec![Scope::Read, Scope::Write]);
     let app = common::test_app_with_auth(&[entry], 1000);
 
     let response = app.oneshot(post_policy_request(&token, scope)).await.unwrap();
-    assert_eq!(
+    assert_ne!(
         response.status(),
         StatusCode::CREATED,
-        "Developer should be allowed for scope={scope:?}"
+        "Developer must never install a global-effect policy (scope={scope:?})"
     );
+    assert_eq!(response.status(), expected, "developer scope={scope:?}");
 }
 
-#[rstest]
-#[case(None)] // global (default)
-#[case(Some("global"))]
-#[case(Some("org:acme"))]
-#[case(Some("team:platform"))]
+/// AAASM-4933 regression (the exact exploit): a Write/Developer caller submits a
+/// scope-less (global) policy but claims `body.scope: tool:slack-mcp` to satisfy
+/// the Developer role. Pre-fix this returned 201 and installed a global policy;
+/// it must now be rejected.
 #[tokio::test]
-async fn write_scope_denied_at_global_org_team_scopes(#[case] scope: Option<&str>) {
+async fn developer_cannot_launder_global_policy_via_tool_scope_claim() {
     let (token, entry) = common::generate_test_api_key("dev-key", vec![Scope::Read, Scope::Write]);
     let app = common::test_app_with_auth(&[entry], 1000);
 
-    let response = app.oneshot(post_policy_request(&token, scope)).await.unwrap();
+    let response = app
+        .oneshot(post_policy_request(&token, Some("tool:slack-mcp")))
+        .await
+        .unwrap();
+    assert_ne!(
+        response.status(),
+        StatusCode::CREATED,
+        "privilege escalation must be closed"
+    );
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+/// A document that itself declares a non-global scope cannot be installed via
+/// this endpoint (it would be silently globalised). Even an OrgAdmin is rejected
+/// with 400 until scoped installation is wired into the cascade.
+#[tokio::test]
+async fn scoped_document_yaml_is_rejected() {
+    let (token, entry) = common::generate_test_api_key("admin-key", vec![Scope::Read, Scope::Write, Scope::Admin]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(post_policy_request_yaml(
+            &token,
+            Some("tool:slack-mcp"),
+            TOOL_SCOPED_POLICY_YAML,
+        ))
+        .await
+        .unwrap();
     assert_eq!(
         response.status(),
-        StatusCode::FORBIDDEN,
-        "Developer should be denied for scope={scope:?}"
+        StatusCode::BAD_REQUEST,
+        "scoped install must be rejected"
     );
 }
 
-// ── Read scope (→ Viewer) — denied at all scopes ────────────────────────────
+// ── Read scope (→ Viewer) — denied everywhere ───────────────────────────────
+// Global body → role denial (403); scoped body → document mismatch (400).
 
 #[rstest]
-#[case(None)]
-#[case(Some("global"))]
-#[case(Some("org:acme"))]
-#[case(Some("team:platform"))]
-#[case(Some("tool:slack-mcp"))]
+#[case(None, StatusCode::FORBIDDEN)]
+#[case(Some("global"), StatusCode::FORBIDDEN)]
+#[case(Some("org:acme"), StatusCode::BAD_REQUEST)]
+#[case(Some("team:platform"), StatusCode::BAD_REQUEST)]
+#[case(Some("tool:slack-mcp"), StatusCode::BAD_REQUEST)]
 #[tokio::test]
-async fn read_scope_denied_at_all_policy_scopes(#[case] scope: Option<&str>) {
+async fn read_scope_never_creates_a_policy(#[case] scope: Option<&str>, #[case] expected: StatusCode) {
     let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
     let app = common::test_app_with_auth(&[entry], 1000);
 
     let response = app.oneshot(post_policy_request(&token, scope)).await.unwrap();
-    assert_eq!(
+    assert_ne!(
         response.status(),
-        StatusCode::FORBIDDEN,
-        "Viewer should be denied for scope={scope:?}"
+        StatusCode::CREATED,
+        "Viewer must never create (scope={scope:?})"
     );
+    assert_eq!(response.status(), expected, "viewer scope={scope:?}");
 }
 
 // ── No auth — unauthenticated request returns 401 ───────────────────────────

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -2442,10 +2442,10 @@ export interface components {
             /** @description Raw YAML content of the governance policy. */
             policy_yaml: string;
             /**
-             * @description Governance scope this policy targets (e.g. `"global"`, `"team:platform"`).
-             *
-             *     Used for RBAC authorization — the caller must hold the role required
-             *     to mutate policies at this scope. Defaults to `"global"` when absent.
+             * @description Optional client-declared governance scope (e.g. `"global"`,
+             *     `"team:platform"`). Advisory: authorization is derived from the policy
+             *     document's own declared scope, and a value that disagrees with the
+             *     document is rejected.
              */
             scope?: string | null;
         };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -4343,10 +4343,10 @@ components:
           - string
           - 'null'
           description: |-
-            Governance scope this policy targets (e.g. `"global"`, `"team:platform"`).
-
-            Used for RBAC authorization — the caller must hold the role required
-            to mutate policies at this scope. Defaults to `"global"` when absent.
+            Optional client-declared governance scope (e.g. `"global"`,
+            `"team:platform"`). Advisory: authorization is derived from the policy
+            document's own declared scope, and a value that disagrees with the
+            document is rejected.
     DailyBurnPointResponse:
       type: object
       description: One point in the subtree-burn time series.


### PR DESCRIPTION
## Description

`POST /api/v1/policies` (`create_policy`) authorized the caller against a **client-asserted `body.scope`** but installed a policy whose real effect is the document's own scope — and `PolicyEngine::apply_yaml` always hot-swaps the single **global primary policy slot**. A `Write`/`Developer`-scoped caller could POST a scope-less (global) policy while claiming `scope: tool:x` (which only requires the `Developer` role for a `tool` scope) and thereby install an arbitrary **global-effect** policy governing every agent — a vertical privilege escalation (an `OrgAdmin`-only operation performed by a `Developer`) whenever auth is enabled.

This PR authorizes against the **policy document's own declared scope** instead of the client claim:
- validate the YAML up front and read `document.scope`;
- reject a `body.scope` that disagrees with the document (`400`) — the laundering vector;
- reject a non-`Global` document scope outright (`400`) — the endpoint can only install the global primary slot, so a narrower scope would be silently globalised;
- the RBAC gate then runs against the document's true scope, so a global install correctly requires `OrgAdmin`.

Wiring genuine scoped installation (routing a non-global document into the `scope_index` cascade rather than the primary slot) is deferred to an AAASM-4933 follow-up, because doing it safely touches the engine evaluate path (the cascade reads its Global base from `scope_index`, so a naive scoped insert would drop the global deny baseline for that scope). This fix is deliberately **contained to the `aa-api` handler** — no change to the engine evaluate/install path — so it carries zero enforcement-regression risk.

## Type of Change

- [x] 🐛 Bug fix (security — privilege escalation)

## Breaking Changes

- [x] Yes (describe below)

Behavioural change to `POST /api/v1/policies`:
- a `body.scope` that disagrees with the policy document is now `400` (previously trusted);
- a document declaring a non-global scope is now `400` (previously installed globally);
- consequently every accepted install requires `OrgAdmin`. Callers that relied on a `Developer` role installing via a `tool:` scope claim will now receive `403`/`400`. This closes the vulnerability; genuine per-tool policies await the scoped-install follow-up.

## Related Issues

- Related Jira ticket: AAASM-4933 (Epic AAASM-4932 — 20th security + QA sweep)

## Testing

- [x] Integration tests added / updated

`policy_rbac_integration.rs` rewritten to the fixed contract, plus:
- `developer_cannot_launder_global_policy_via_tool_scope_claim` — the exact-exploit regression (Developer + global YAML + `scope: tool:slack-mcp` → no longer `201`);
- `scoped_document_yaml_is_rejected` — a document declaring `scope: tool:x` is `400` even for `OrgAdmin`.

Full `aa-api` suite green locally: **920/920** (`cargo nextest run -p aa-api`); `policy_rbac_integration` 21/21. `cargo fmt` + `cargo clippy -p aa-api --all-targets -- -D warnings` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (handler + `scope` field docstrings)
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)