### PR TITLE
[AAASM-4937] ✅ (dashboard): Remove dead e2e fixtures, widen lint, note tools.rs kind

### DIFF
--- a/aa-api/src/routes/tools.rs
+++ b/aa-api/src/routes/tools.rs
@@ -20,6 +20,15 @@ type ToolsList = Vec<ToolInfoSchema>;
 #[allow(dead_code)] // fields are only used by utoipa's macro for OpenAPI schema generation
 #[derive(ToSchema)]
 pub struct ToolInfoSchema {
+    // Mirrors `DevToolInfo::kind` (`aa_core::DevToolKind`, an externally-tagged
+    // enum). The four built-in unit variants (ClaudeCode/Codex/GitHubCopilot/
+    // WindsurfCascade) serialize as plain strings, so `String` is accurate for
+    // every adapter that ships today. `DevToolKind::Custom(name)` would instead
+    // serialize as an object (`{"Custom": "…"}`), which this `String` schema
+    // would not describe — but no out-of-tree/Custom adapter is exposed yet, so
+    // it is unreachable.
+    // TODO(AAASM-4937): when a Custom adapter ships, widen this to a oneOf (or a
+    // dedicated schema) so the OpenAPI contract stays accurate.
     kind: String,
     version: Option<String>,
     install_path: String,

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --noEmit && vite build",
     "serve": "vite preview --port 3000 --strictPort",
     "preview": "vite preview",
-    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint src tests --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",
     "generate:api": "openapi-typescript ../openapi/v1.yaml -o src/api/generated/schema.d.ts",
     "test": "vitest run",

--- a/dashboard/tests/e2e/alerts.spec.ts
+++ b/dashboard/tests/e2e/alerts.spec.ts
@@ -38,8 +38,6 @@ const FIRING_ALERT = {
   destinationIds: ['dst-slack-ops'],
 }
 
-const SUPPRESSED_ALERT = { ...FIRING_ALERT, status: 'SUPPRESSED' }
-
 const RULE = {
   id: 'rule-001',
   name: 'Budget guardrail',

--- a/dashboard/tests/e2e/governance-dashboard.spec.ts
+++ b/dashboard/tests/e2e/governance-dashboard.spec.ts
@@ -20,13 +20,6 @@ const APPROVAL = {
   team_id: null,
 }
 
-const POLICY = {
-  name: 'e2e-policy',
-  version: '1.0.0',
-  rule_count: 2,
-  active: true,
-}
-
 const AGENT = {
   id: 'agent-e2e-001',
   name: 'E2E Test Agent',


### PR DESCRIPTION
## Description

Housekeeping fixes for AAASM-4937 (LOW): dashboard e2e dead fixtures + a lint blind spot, plus a latent schema-accuracy note in `aa-api`.

1. **Dead e2e fixtures removed.** `SUPPRESSED_ALERT` (`tests/e2e/alerts.spec.ts`) and `POLICY` (`tests/e2e/governance-dashboard.spec.ts`) were assigned-but-never-used (`@typescript-eslint/no-unused-vars`). The SUPPRESSED path is exercised via the live `silence` route mock; the POLICY fixture had no consumer. Both deleted.
2. **Lint blind spot closed.** The `pnpm lint` script was scoped `eslint src`, so `tests/e2e/` was never linted — which is how the two dead consts slipped past CI. Widened to `eslint src tests …`. No pre-existing violations surfaced under `tests/` beyond the two above; lint is clean.
3. **`tools.rs` `kind` schema note.** `ToolInfoSchema.kind: String` mirrors `DevToolInfo.kind: DevToolKind` (externally-tagged enum). The four built-in unit variants serialize as plain strings (accurate); `DevToolKind::Custom(String)` would serialize as an object and is **not currently reachable** (no Custom adapter ships). Added an inline `//` note documenting the limitation + a `TODO(AAASM-4937)` for when a Custom adapter lands. Inline `//` only — no schema-bearing `///` changed, so **OpenAPI is unchanged** (verified: no diff in `openapi/v1.yaml` or the generated dashboard schema).

## Type of Change

- [x] 🔧 Configuration / CI change
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4937](https://lightning-dust-mite.atlassian.net/browse/AAASM-4937)

## Testing

Front-end change is **test-only** (deleting dead test consts + a lint-script glob) — no runtime UI change, so Playwright is not required. Non-breaking proven via type-check + lint + unit tests.

- dashboard: `pnpm type-check` clean; `pnpm lint` clean (widening verified to catch dead code in `tests/` via an injected unused const); `pnpm test` → **168 files, 1501 tests passed**.
- rust: `cargo nextest run -p aa-api` → **920 passed, 0 skipped**; `cargo fmt` clean; `cargo clippy -p aa-api --all-targets -- -D warnings` → exit 0.

- [x] Unit tests added / updated (dead fixtures removed)
- [x] Manual testing performed (lint-catch proof)
- [x] No tests required for the doc-note / lint-glob parts

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention


[AAASM-4937]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ