### PR TITLE
[AAASM-4934] 🐛 (aa-proxy): Force single-request scan on plain-HTTP keep-alive connections

### DIFF
--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -1201,9 +1201,10 @@ impl ProxyServer {
         }
 
         let content_length = plain_http_content_length(&headers)?;
-        // Only requests that carry a body are buffered+scanned. A bodyless
-        // request (GET, or a plain-HTTP upgrade) keeps the original full-duplex
-        // streaming copy below, so keep-alive / upgrade behaviour is unchanged.
+        // Only requests that carry a body are buffered+scanned; a bodyless
+        // request (GET) has nothing to scan. Either way the forward path below
+        // now forces `Connection: close` and relays only the upstream response,
+        // so exactly one request/response crosses this connection (AAASM-4934).
         let scanned_body: Option<Vec<u8>> = if content_length > 0 {
             let mut body = vec![0u8; content_length];
             reader.read_exact(&mut body).await?;
@@ -1260,33 +1261,44 @@ impl ProxyServer {
             None => self.connect_revalidated(&upstream_addr).await?,
         };
 
-        // Re-serialise and forward the original request.
+        // Re-serialise and forward the request, forcing `Connection: close`.
+        //
+        // AAASM-4934: the DLP scan above inspects only the *first* request on
+        // this connection. Historically the request was forwarded with the
+        // client's own headers (often `Connection: keep-alive`) and the exchange
+        // finished with a *bidirectional* copy — so a second request pipelined on
+        // the same keep-alive connection was relayed client→upstream with no
+        // scan, re-opening the exfiltration hole AAASM-4897 closed for request
+        // one. Mirror the MitM path (`serialize_http_request_with_auth`): drop
+        // any inbound `Connection` header and emit a single `Connection: close`,
+        // then relay only the upstream→client direction below. Together these
+        // enforce one inspected request/response per connection — a second,
+        // un-scanned request can never reach upstream.
         upstream.write_all(request_line.as_bytes()).await?;
         upstream.write_all(b"\r\n").await?;
         for h in &headers {
+            if h.to_ascii_lowercase().starts_with("connection:") {
+                continue;
+            }
             upstream.write_all(h.as_bytes()).await?;
         }
+        upstream.write_all(b"Connection: close\r\n").await?;
         upstream.write_all(b"\r\n").await?;
 
-        // Forward the buffered, DLP-scanned request body (AAASM-4897). When a
-        // body was scanned the client→upstream direction below only carries any
-        // pipelined trailing bytes; the response relay completes the exchange.
+        // Forward the buffered, DLP-scanned request body (AAASM-4897).
         if let Some(body) = scanned_body.as_deref() {
             upstream.write_all(body).await?;
         }
 
-        // Bidirectional copy between client and upstream.
-        let stream = reader.into_inner();
-        let (mut client_read, mut client_write) = tokio::io::split(stream);
-        let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream);
-
-        let c2u = tokio::io::copy(&mut client_read, &mut upstream_write);
-        let u2c = tokio::io::copy(&mut upstream_read, &mut client_write);
-
-        tokio::select! {
-            r = c2u => { r?; }
-            r = u2c => { r?; }
-        }
+        // AAASM-4934: relay only the upstream response back to the client, then
+        // tear the connection down — mirroring the MitM path's single-exchange
+        // relay. We never copy further client bytes upstream, so a second request
+        // pipelined on this connection cannot reach upstream un-inspected. The
+        // forced `Connection: close` makes upstream close after one response,
+        // bounding this copy.
+        let mut client_stream = reader.into_inner();
+        tokio::io::copy(&mut upstream, &mut client_stream).await?;
+        let _ = client_stream.shutdown().await;
 
         Ok(())
     }
@@ -1383,10 +1395,22 @@ fn plain_http_header_value(headers: &[String], name: &str) -> Option<String> {
 /// Parse and validate the plain-HTTP `Content-Length`. Absent → `0` (empty
 /// body). Rejects a length above [`MAX_BODY_LEN`] fail-closed so a buffered
 /// body cannot OOM the proxy (AAASM-4897, mirroring the MitM path's cap).
+///
+/// AAASM-4934: a header that is *present but unparseable* (`Content-Length: abc`,
+/// a negative, a duplicated/comma-joined value) fails closed rather than
+/// silently collapsing to `0`. The old `unwrap_or(0)` treated such a request as
+/// bodyless, so its actual body bytes skipped the DLP scan and were relayed
+/// upstream un-inspected — the same class of exfiltration hole this ticket
+/// closes for keep-alive. An absent header still legitimately means no body.
 fn plain_http_content_length(headers: &[String]) -> Result<usize, ProxyError> {
-    let content_length = plain_http_header_value(headers, "content-length")
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(0);
+    let content_length = match plain_http_header_value(headers, "content-length") {
+        None => 0,
+        Some(v) => v.parse::<usize>().map_err(|_| {
+            ProxyError::Config(format!(
+                "plain-HTTP Content-Length {v:?} is not a valid length; refusing (fail-closed)"
+            ))
+        })?,
+    };
     if content_length > MAX_BODY_LEN {
         return Err(ProxyError::Config(format!(
             "plain-HTTP Content-Length {content_length} exceeds maximum {MAX_BODY_LEN}; refusing (fail-closed)"
@@ -1557,6 +1581,20 @@ mod tests {
         assert_eq!(canonical_host("evil.com."), "evil.com");
         assert_eq!(canonical_host("Evil.Com.:443"), "evil.com");
         assert_eq!(canonical_host("evil.com"), "evil.com");
+    }
+
+    #[test]
+    fn plain_http_content_length_fails_closed_on_unparseable_value() {
+        // AAASM-4934: an absent header means no body (Ok(0)), but a present but
+        // unparseable value must fail closed rather than collapse to 0 — a `0`
+        // would skip the DLP scan on the real body and relay it un-inspected.
+        assert_eq!(plain_http_content_length(&[]).unwrap(), 0);
+        assert_eq!(
+            plain_http_content_length(&["Content-Length: 5\r\n".to_string()]).unwrap(),
+            5
+        );
+        assert!(plain_http_content_length(&["Content-Length: abc\r\n".to_string()]).is_err());
+        assert!(plain_http_content_length(&["Content-Length: -1\r\n".to_string()]).is_err());
     }
 
     #[test]

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -206,6 +206,108 @@ async fn plain_http_request_to_denied_host_is_rejected_with_403() {
     );
 }
 
+/// Start a mock HTTP upstream that records *every* byte it receives on the first
+/// accepted connection, so a test can assert whether a second, pipelined request
+/// was relayed upstream. It responds once the request head is seen, then keeps
+/// reading (to capture any wrongly-forwarded follow-up) until the connection
+/// falls quiet, then closes.
+async fn start_recording_upstream() -> (SocketAddr, std::sync::Arc<std::sync::Mutex<Vec<u8>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let received = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+    let received_task = std::sync::Arc::clone(&received);
+
+    tokio::spawn(async move {
+        let Ok((mut stream, _)) = listener.accept().await else {
+            return;
+        };
+        let mut buf = vec![0u8; 16384];
+        let mut responded = false;
+        loop {
+            match tokio::time::timeout(std::time::Duration::from_millis(200), stream.read(&mut buf)).await {
+                // EOF or read error: connection done.
+                Ok(Ok(0)) | Ok(Err(_)) => break,
+                Ok(Ok(n)) => {
+                    received_task.lock().unwrap().extend_from_slice(&buf[..n]);
+                    // Respond as soon as the request head is complete so the
+                    // proxy's response relay (and the client) can make progress.
+                    if !responded && received_task.lock().unwrap().windows(4).any(|w| w == b"\r\n\r\n") {
+                        let resp = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK";
+                        let _ = stream.write_all(resp).await;
+                        responded = true;
+                    }
+                }
+                // Quiet period: no further bytes are coming — stop recording.
+                Err(_) => break,
+            }
+        }
+        let _ = stream.shutdown().await;
+    });
+
+    (addr, received)
+}
+
+#[tokio::test]
+async fn plain_http_second_keepalive_request_is_not_forwarded_uninspected() {
+    // AAASM-4934: the plain-HTTP path scans only the first request body. It must
+    // force `Connection: close` and relay a single request/response, so a second
+    // request pipelined on the same keep-alive connection can never reach
+    // upstream un-inspected. Before the fix, the bidirectional copy forwarded the
+    // pipelined request #2 (carrying a secret) straight upstream with no scan.
+    let dir = tempfile::TempDir::new().unwrap();
+    let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+    let config = test_config(dir.path());
+    let (proxy_addr, _handle) = start_proxy(config, ca).await;
+
+    let (upstream_addr, received) = start_recording_upstream().await;
+
+    // The secret rides in request #2, placed at the end of a large body so its
+    // bytes are NOT swallowed by the proxy's BufReader read-ahead on the buggy
+    // path — they sit in the socket and (pre-fix) get copied upstream verbatim.
+    const SECRET: &str = "SECOND-REQUEST-SECRET-sk-live-DEADBEEFCAFE";
+    let padding = "x".repeat(64 * 1024);
+    let body2 = format!("{padding}{SECRET}");
+
+    let req1 = format!(
+        "POST http://{upstream_addr}/one HTTP/1.1\r\nHost: {upstream_addr}\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nHELLO"
+    );
+    let req2 = format!(
+        "POST http://{upstream_addr}/two HTTP/1.1\r\nHost: {upstream_addr}\r\nContent-Length: {}\r\n\r\n{}",
+        body2.len(),
+        body2
+    );
+
+    // Pipeline both requests in one write on a single connection.
+    let mut stream = TcpStream::connect(proxy_addr).await.unwrap();
+    stream.write_all(format!("{req1}{req2}").as_bytes()).await.unwrap();
+
+    // Read the (single) response the proxy relays for request #1.
+    let mut response = String::new();
+    let mut reader = BufReader::new(stream);
+    reader.read_line(&mut response).await.unwrap();
+    assert!(response.contains("200"), "expected 200 for request #1, got: {response}");
+
+    // Let the recording upstream reach its quiet-period cutoff.
+    tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+
+    let got = received.lock().unwrap().clone();
+    let got_str = String::from_utf8_lossy(&got);
+
+    // Request #1 must have been forwarded (proves the path still works)...
+    assert!(got_str.contains("HELLO"), "request #1 body should reach upstream");
+    // ...with `Connection: close` forced, not the client's `keep-alive`.
+    assert!(
+        got_str.contains("Connection: close"),
+        "forwarded request must force Connection: close, got head:\n{}",
+        got_str.get(..got_str.find("\r\n\r\n").unwrap_or(0)).unwrap_or("")
+    );
+    // The pipelined request #2's secret must NEVER reach upstream un-inspected.
+    assert!(
+        !got_str.contains(SECRET),
+        "request #2 secret was forwarded upstream un-inspected (keep-alive DLP bypass)"
+    );
+}
+
 #[tokio::test]
 async fn connect_to_llm_host_triggers_interception_without_crash() {
     // This test verifies that a CONNECT to a known LLM API host


### PR DESCRIPTION
## Description

The `aa-proxy` plain-HTTP forward path (`handle_plain_http`) DLP-scans only the **first** request body on a connection (AAASM-4897), then forwarded the client's request headers verbatim and completed the exchange with a **bidirectional** `tokio::io::copy`. Two residual holes let a secret leave over cleartext `http://` un-inspected:

1. **Keep-alive pipelining** — the forwarded request carried the client's own `Connection: keep-alive`, and the bidirectional copy relayed a *second* request pipelined on the same connection straight client→upstream with **no scan** — a steered agent could exfiltrate a secret in request #2 to a non-LLM host with zero inspection. The HTTPS MitM path already forces `Connection: close` + a single-direction relay for exactly this reason; the plain path did not.
2. **Unparseable Content-Length** — a present-but-unparseable `Content-Length` (`abc`, negative) collapsed to `0` via `unwrap_or(0)`, so the request's real body was treated as empty and skipped the scan.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Plain-HTTP connections are now single request/response (one inspected exchange, then `Connection: close`), matching the MitM path. Keep-alive reuse and `http://` upgrade tunnels on the plain path are intentionally not preserved — an un-inspected full-duplex tunnel is itself a DLP bypass, so failing closed here is the intended security posture.

## Related Issues

- Related Jira ticket: [AAASM-4934](https://lightning-dust-mite.atlassian.net/browse/AAASM-4934)

## Fix

Mirror the MitM path (`serialize_http_request_with_auth`): drop any inbound `Connection` header, force a single `Connection: close`, and relay **only** the upstream→client direction so a second (un-scanned) request can never reach upstream. Fail closed on an unparseable `Content-Length` instead of treating the request as bodyless.

## Testing

- [x] Unit tests added / updated — `plain_http_content_length_fails_closed_on_unparseable_value` (absent → `Ok(0)`; `abc`/`-1` → `Err`).
- [x] Integration tests added / updated — `plain_http_second_keepalive_request_is_not_forwarded_uninspected`: pipelines two requests on one plain-HTTP connection with a secret in request #2 (placed past the proxy's BufReader read-ahead), asserts the forwarded request #1 carries `Connection: close` and that request #2's secret **never** reaches the recording upstream. **Verified this test FAILS on the pre-fix code** (caught the forwarded `Connection: keep-alive`) and passes with the fix.
- [x] Local validation: `cargo nextest run -p aa-proxy` → **230 passed, 3 skipped**; `cargo fmt -p aa-proxy` clean; `cargo clippy -p aa-proxy --all-targets -- -D warnings` → 0 warnings on aa-proxy.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (why-comments on the forward path + CL helper)
- [ ] All CI checks passing (org Actions may be billing-blocked; validated locally)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-4934]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ