### PR TITLE
[AAASM-4936] 🐛 (aa-cli): Redact _URI connection strings + fail-closed DLP hardening

### DIFF
--- a/aa-api/src/routes/dispatch.rs
+++ b/aa-api/src/routes/dispatch.rs
@@ -198,8 +198,12 @@ async fn dispatch_wasm(
     let outcome = tokio::task::spawn_blocking(move || dispatch_wasm_tool(&tool_name, &args_bytes, &registry))
         .await
         .map_err(|e| {
+            // AAASM-4936 (L3): a JoinError carries the panic payload, which can
+            // expose internal state. Log it server-side and return a generic
+            // 500 body so the detail never crosses the API boundary.
+            tracing::error!(error = %e, "sandbox dispatch task panicked");
             ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
-                .with_detail(format!("sandbox dispatch task panicked: {e}"))
+                .with_detail("Internal error during tool dispatch".to_string())
         })?;
 
     let (result, audit_events) = match outcome {

--- a/aa-api/src/routes/traces.rs
+++ b/aa-api/src/routes/traces.rs
@@ -58,10 +58,14 @@ pub async fn get_trace(
             .with_detail("This operation requires admin scope or a team scope".to_string()));
     }
 
-    let trace = state
-        .trace_store
-        .get_trace(&session_id)
-        .map_err(|e| ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(e.to_string()))?;
+    // AAASM-4936 (L3): log the underlying store error server-side, but return a
+    // generic 500 body — the internal error string may reveal storage paths or
+    // implementation detail and must not cross the API boundary to the caller.
+    let trace = state.trace_store.get_trace(&session_id).map_err(|e| {
+        tracing::error!(error = %e, session_id = %session_id, "failed to read session trace");
+        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_detail("Failed to retrieve session trace".to_string())
+    })?;
 
     // AAASM-3376 — the in-memory `TraceStore` is only populated by live span
     // recording; fall back to reconstructing the trace from the persisted audit

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -374,26 +374,34 @@ fn load_policy() -> PolicyDocument {
 /// (`AA_JWT_SECRET`, `DB_PASSWORD`, connection URLs, …) in cleartext.
 ///
 /// Two masking strategies, by key name (case-insensitive):
-/// * keys naming a connection string (`*_URL` / `*_DSN`) keep their structure
-///   but have the password redacted via [`redact_database_url`], matching how
-///   `aasm status` displays a `database_url`;
+/// * keys naming a connection string (`*_URL` / `*_DSN` / `*_URI`) keep their
+///   structure but have the password redacted via [`redact_database_url`],
+///   matching how `aasm status` displays a `database_url`. `*_URI` covers the
+///   common `MONGODB_URI` / `DATABASE_URI` / `REDIS_URI` / `AMQP_URI` shapes
+///   that carry `user:pass@host` userinfo (AAASM-4936, sibling of AAASM-4894);
 /// * keys whose name signals an opaque secret (token, key, password, secret,
 ///   credential, auth) have the entire value replaced — the value has no
 ///   structure worth preserving.
+///
+/// As a final fail-closed backstop, any value not caught by the rules above is
+/// still routed through [`redact_database_url`]: a value in an unrecognised key
+/// may itself be a `scheme://user:pass@host` connection string, and the
+/// redactor returns the value unchanged unless it finds userinfo credentials to
+/// strip — so ordinary values are untouched while an embedded credential is not
+/// printed verbatim.
 ///
 /// The denylist is intentionally broad and errs toward over-masking: a masked
 /// non-secret in a diagnostic preview is harmless, a leaked secret is not.
 fn mask_value(key: &str, value: &str) -> String {
     let upper = key.to_uppercase();
-    if upper.ends_with("_URL") || upper.ends_with("_DSN") {
+    if upper.ends_with("_URL") || upper.ends_with("_DSN") || upper.ends_with("_URI") {
         return redact_database_url(value);
     }
     const SECRET_SUBSTRINGS: [&str; 7] = ["TOKEN", "KEY", "SECRET", "PASSWORD", "PASS", "CREDENTIAL", "AUTH"];
     if SECRET_SUBSTRINGS.iter().any(|needle| upper.contains(needle)) {
-        "***MASKED***".into()
-    } else {
-        value.to_string()
+        return "***MASKED***".into();
     }
+    redact_database_url(value)
 }
 
 /// Build the structured dry-run output string.
@@ -1391,6 +1399,61 @@ mod tests {
         assert!(
             output.contains("DATABASE_URL=postgresql://aasm:***@db:5432/aasm"),
             "DATABASE_URL password should be redacted while preserving structure: {output}"
+        );
+    }
+
+    /// AAASM-4936 (sibling of AAASM-4894): `*_URI` connection strings —
+    /// `MONGODB_URI` / `REDIS_URI` / `AMQP_URI` / `DATABASE_URI` — carry
+    /// `user:pass@host` userinfo just like `*_URL`, but the previous denylist
+    /// only matched `_URL` / `_DSN`, so a `MONGODB_URI` password printed in the
+    /// clear in the dry-run preview. It must be redacted like a `_URL`.
+    #[test]
+    fn dry_run_redacts_uri_connection_strings() {
+        let handle = RegistrationHandle {
+            agent_id: "agent-xyz".into(),
+            registration_id: "reg-xyz".into(),
+            trace_id: "trace-xyz".into(),
+            session_id: "session-xyz".into(),
+            proxy_addr: None,
+            team_id: None,
+        };
+        let cmd = std::process::Command::new("mock-tool");
+        let mut env = HashMap::new();
+        env.insert("MONGODB_URI".into(), "mongodb://user:p4ss@host:27017/db".into());
+
+        let output = format_dry_run_output(&handle, "{}", &cmd, &env);
+
+        assert!(
+            !output.contains("p4ss"),
+            "MONGODB_URI password must not appear in cleartext: {output}"
+        );
+        assert!(
+            output.contains("MONGODB_URI=mongodb://user:***@host:27017/db"),
+            "MONGODB_URI password should be redacted while preserving structure: {output}"
+        );
+    }
+
+    /// The fail-closed backstop: a value carrying `user:pass@` userinfo must be
+    /// redacted even when its key name matches none of the connection-string
+    /// suffixes or secret substrings, since the value is itself a credential.
+    #[test]
+    fn mask_value_redacts_connection_string_in_unrecognised_key() {
+        let masked = mask_value("PRIMARY_BROKER", "amqp://svc:s3cr3t@rabbit:5672/vhost");
+        assert!(
+            !masked.contains("s3cr3t"),
+            "userinfo password must be redacted: {masked}"
+        );
+        assert_eq!(masked, "amqp://svc:***@rabbit:5672/vhost");
+    }
+
+    /// The backstop must not mangle an ordinary non-credential value: a plain
+    /// value with no `scheme://user:pass@` shape passes through untouched.
+    #[test]
+    fn mask_value_leaves_plain_value_unchanged() {
+        assert_eq!(mask_value("LOG_LEVEL", "debug"), "debug");
+        assert_eq!(
+            mask_value("ENDPOINT", "https://api.example.com/v1"),
+            "https://api.example.com/v1"
         );
     }
 }

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -106,6 +106,21 @@ impl CaStore {
             tokio::fs::read_to_string(&key_path).await,
         ) {
             (Ok(ca_cert_pem), Ok(ca_key_pem)) => {
+                // AAASM-4936 (L4): 0600 is enforced only at creation time, so a
+                // key written by an older build, restored from a backup, or
+                // copied in with loose perms would be served group/other-
+                // readable. Re-assert 0600 on every load so the private key can
+                // never be left world-readable across a proxy restart.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let key_path_clone = key_path.clone();
+                    tokio::task::spawn_blocking(move || {
+                        std::fs::set_permissions(&key_path_clone, std::fs::Permissions::from_mode(0o600))
+                    })
+                    .await
+                    .map_err(|e| ProxyError::Io(std::io::Error::other(e)))??;
+                }
                 return Ok(Self {
                     ca_dir: ca_dir.to_path_buf(),
                     ca_cert_pem,
@@ -264,6 +279,32 @@ mod tests {
         CaStore::load_or_create(dir.path()).await.unwrap();
         let perms = std::fs::metadata(dir.path().join("ca-key.pem")).unwrap().permissions();
         assert_eq!(perms.mode() & 0o777, 0o600, "ca-key.pem must be owner-read-write only");
+    }
+
+    /// AAASM-4936 (L4): perms are enforced only at creation, so a key that
+    /// already exists with loose perms (older build, restored backup, manual
+    /// copy) must be re-tightened to 0600 when it is loaded.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn load_or_create_reasserts_600_on_loose_existing_key() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        // First create a valid CA, then loosen the key perms to world-readable.
+        CaStore::load_or_create(dir.path()).await.unwrap();
+        let key_path = dir.path().join("ca-key.pem");
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+
+        // Loading the existing CA must re-tighten the key to 0600.
+        CaStore::load_or_create(dir.path()).await.unwrap();
+        assert_eq!(
+            std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "load must re-assert 0600 on an existing loose key"
+        );
     }
 
     #[tokio::test]

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -196,17 +196,6 @@ impl CredentialKind {
         }
     }
 
-    /// Whether this kind is a PEM private-key block detected by its
-    /// `-----BEGIN … PRIVATE KEY-----` header. Used to extend the finding span
-    /// through the block's `-----END …-----` marker so a short trailing base64
-    /// line cannot slip past the length-gated entropy pass (AAASM-4936).
-    fn is_pem_private_key(&self) -> bool {
-        matches!(
-            self,
-            Self::EcPrivateKey | Self::OpensshPrivateKey | Self::PgpPrivateKey | Self::PrivateKey | Self::RsaPrivateKey
-        )
-    }
-
     /// Relative confidence of this kind when two overlapping findings are
     /// coalesced into one span.
     ///
@@ -447,18 +436,7 @@ impl CredentialScanner {
         for mat in self.patterns.find_iter(text) {
             let kind = self.kinds[mat.pattern()].clone();
             let offset = mat.start();
-            let mut end = token_end(text, mat.end());
-            // AAASM-4936 (L2): the literal detector only matches a PEM key's
-            // `-----BEGIN … PRIVATE KEY-----` header line. The base64 body is
-            // normally caught by the entropy pass, but a short final base64 line
-            // (below the run-length gate) slips through and leaks key material.
-            // Extend the finding through the matching `-----END …-----` marker so
-            // the whole block — including any short trailing line — is redacted.
-            if kind.is_pem_private_key() {
-                if let Some(block_end) = pem_block_end(text, mat.end()) {
-                    end = end.max(block_end);
-                }
-            }
+            let end = token_end(text, mat.end());
             findings.push(CredentialFinding::new(kind, offset, end));
         }
 
@@ -616,19 +594,6 @@ fn token_end(text: &str, from: usize) -> usize {
         .find(|c: char| c.is_whitespace() || matches!(c, '"' | '\'' | ',' | ';' | ')' | ']' | '}'))
         .map(|i| from + i)
         .unwrap_or(text.len())
-}
-
-/// Byte index just past the closing dashes of the `-----END …-----` marker that
-/// terminates the PEM block whose header ended at `from`, or `None` when no END
-/// marker follows (a truncated block — the entropy pass still covers the body
-/// lines that meet the run-length gate).
-fn pem_block_end(text: &str, from: usize) -> Option<usize> {
-    let end_rel = text[from..].find("-----END")?;
-    let after_end_keyword = from + end_rel + "-----END".len();
-    // The END line closes with `-----`; consume through it so the whole marker
-    // (and thus the whole block) is inside the redaction span.
-    let closing = text[after_end_keyword..].find("-----")?;
-    Some(after_end_keyword + closing + "-----".len())
 }
 
 /// Returns `true` if `s` matches the SSN format `DDD-DD-DDDD` exactly.
@@ -1237,34 +1202,6 @@ mod tests {
         let redacted = result.redact(text);
         assert!(!redacted.contains("xoxr-"));
         assert!(redacted.contains("[REDACTED:SlackRefreshToken]"));
-    }
-
-    /// AAASM-4936 (L2): a PEM private key whose final base64 line is shorter
-    /// than the entropy pass's run-length gate must still be fully redacted. The
-    /// literal detector only matches the BEGIN header, so before the block-end
-    /// extension the short trailing line (`wJ8=`) leaked. The whole block —
-    /// header through the END marker — must be covered.
-    #[test]
-    fn redacts_pem_private_key_with_short_final_line() {
-        let scanner = CredentialScanner::new();
-        let text = "-----BEGIN RSA PRIVATE KEY-----\n\
-                    MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu\n\
-                    wJ8=\n\
-                    -----END RSA PRIVATE KEY-----";
-        let result = scanner.scan(text);
-        let redacted = result.redact(text);
-        assert!(
-            !redacted.contains("wJ8="),
-            "short final base64 line must be redacted: {redacted}"
-        );
-        assert!(
-            !redacted.contains("MIIBOgIBAAJBAKj"),
-            "key body must be redacted: {redacted}"
-        );
-        assert!(
-            !redacted.contains("-----END RSA PRIVATE KEY-----"),
-            "END marker must fall inside the redaction span: {redacted}"
-        );
     }
 
     /// AAASM-4936 (L1): `redact` must fail closed when a finding's span cannot

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -196,6 +196,17 @@ impl CredentialKind {
         }
     }
 
+    /// Whether this kind is a PEM private-key block detected by its
+    /// `-----BEGIN … PRIVATE KEY-----` header. Used to extend the finding span
+    /// through the block's `-----END …-----` marker so a short trailing base64
+    /// line cannot slip past the length-gated entropy pass (AAASM-4936).
+    fn is_pem_private_key(&self) -> bool {
+        matches!(
+            self,
+            Self::EcPrivateKey | Self::OpensshPrivateKey | Self::PgpPrivateKey | Self::PrivateKey | Self::RsaPrivateKey
+        )
+    }
+
     /// Relative confidence of this kind when two overlapping findings are
     /// coalesced into one span.
     ///
@@ -304,9 +315,17 @@ impl ScanResult {
     /// no region is ever partially redacted (which previously left raw secret
     /// fragments and mangled labels in the output). The merged spans are then
     /// spliced in reverse offset order so earlier byte positions remain valid
-    /// after each replacement. Spans whose boundaries do not fall on UTF-8
-    /// character boundaries are skipped rather than spliced, making the former
-    /// mid-codepoint panic structurally impossible.
+    /// after each replacement.
+    ///
+    /// A span whose bounds are out of range or do not fall on UTF-8 character
+    /// boundaries cannot be spliced without panicking, but it still marks a
+    /// region the scanner flagged as a secret. Rather than skip it — which would
+    /// emit that region's raw bytes and leak the secret (fail-open) — the whole
+    /// value is replaced with a single opaque redaction label (fail-closed).
+    /// This branch is unreachable for spans the scanner produces over `text`
+    /// (offsets are always valid char boundaries of the scanned text); it exists
+    /// so a caller that ever pairs mismatched spans with `text` cannot leak a
+    /// secret through this path.
     pub fn redact(&self, text: &str) -> String {
         let merged = coalesce_findings(&self.findings);
         let mut result = text.to_string();
@@ -318,6 +337,10 @@ impl ScanResult {
                 && result.is_char_boundary(span.end)
             {
                 result.replace_range(span.offset..span.end, &span.label);
+            } else {
+                // Fail closed: we cannot prove this flagged region has been
+                // removed, so never return the raw text with a secret intact.
+                return "[REDACTED]".to_string();
             }
         }
         result
@@ -424,7 +447,18 @@ impl CredentialScanner {
         for mat in self.patterns.find_iter(text) {
             let kind = self.kinds[mat.pattern()].clone();
             let offset = mat.start();
-            let end = token_end(text, mat.end());
+            let mut end = token_end(text, mat.end());
+            // AAASM-4936 (L2): the literal detector only matches a PEM key's
+            // `-----BEGIN … PRIVATE KEY-----` header line. The base64 body is
+            // normally caught by the entropy pass, but a short final base64 line
+            // (below the run-length gate) slips through and leaks key material.
+            // Extend the finding through the matching `-----END …-----` marker so
+            // the whole block — including any short trailing line — is redacted.
+            if kind.is_pem_private_key() {
+                if let Some(block_end) = pem_block_end(text, mat.end()) {
+                    end = end.max(block_end);
+                }
+            }
             findings.push(CredentialFinding::new(kind, offset, end));
         }
 
@@ -582,6 +616,19 @@ fn token_end(text: &str, from: usize) -> usize {
         .find(|c: char| c.is_whitespace() || matches!(c, '"' | '\'' | ',' | ';' | ')' | ']' | '}'))
         .map(|i| from + i)
         .unwrap_or(text.len())
+}
+
+/// Byte index just past the closing dashes of the `-----END …-----` marker that
+/// terminates the PEM block whose header ended at `from`, or `None` when no END
+/// marker follows (a truncated block — the entropy pass still covers the body
+/// lines that meet the run-length gate).
+fn pem_block_end(text: &str, from: usize) -> Option<usize> {
+    let end_rel = text[from..].find("-----END")?;
+    let after_end_keyword = from + end_rel + "-----END".len();
+    // The END line closes with `-----`; consume through it so the whole marker
+    // (and thus the whole block) is inside the redaction span.
+    let closing = text[after_end_keyword..].find("-----")?;
+    Some(after_end_keyword + closing + "-----".len())
 }
 
 /// Returns `true` if `s` matches the SSN format `DDD-DD-DDDD` exactly.
@@ -1190,6 +1237,63 @@ mod tests {
         let redacted = result.redact(text);
         assert!(!redacted.contains("xoxr-"));
         assert!(redacted.contains("[REDACTED:SlackRefreshToken]"));
+    }
+
+    /// AAASM-4936 (L2): a PEM private key whose final base64 line is shorter
+    /// than the entropy pass's run-length gate must still be fully redacted. The
+    /// literal detector only matches the BEGIN header, so before the block-end
+    /// extension the short trailing line (`wJ8=`) leaked. The whole block —
+    /// header through the END marker — must be covered.
+    #[test]
+    fn redacts_pem_private_key_with_short_final_line() {
+        let scanner = CredentialScanner::new();
+        let text = "-----BEGIN RSA PRIVATE KEY-----\n\
+                    MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu\n\
+                    wJ8=\n\
+                    -----END RSA PRIVATE KEY-----";
+        let result = scanner.scan(text);
+        let redacted = result.redact(text);
+        assert!(
+            !redacted.contains("wJ8="),
+            "short final base64 line must be redacted: {redacted}"
+        );
+        assert!(
+            !redacted.contains("MIIBOgIBAAJBAKj"),
+            "key body must be redacted: {redacted}"
+        );
+        assert!(
+            !redacted.contains("-----END RSA PRIVATE KEY-----"),
+            "END marker must fall inside the redaction span: {redacted}"
+        );
+    }
+
+    /// AAASM-4936 (L1): `redact` must fail closed when a finding's span cannot
+    /// be spliced. An out-of-range `end` previously hit the implicit skip and
+    /// returned the raw text with the flagged secret intact; it must instead
+    /// return an opaque redaction so no secret bytes escape.
+    #[test]
+    fn redact_fails_closed_on_out_of_bounds_span() {
+        let text = "the secret is hunter2";
+        let result = ScanResult {
+            findings: vec![CredentialFinding::from_regex_match(14, 999)],
+        };
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("hunter2"), "raw secret must not leak: {redacted}");
+        assert_eq!(redacted, "[REDACTED]");
+    }
+
+    /// AAASM-4936 (L1): a span whose bound lands mid-codepoint (not on a UTF-8
+    /// char boundary) must also fail closed rather than leave the secret raw.
+    #[test]
+    fn redact_fails_closed_on_non_char_boundary_span() {
+        // "é" occupies bytes 6..8; a span ending at byte 7 is mid-codepoint.
+        let text = "secretémore";
+        let result = ScanResult {
+            findings: vec![CredentialFinding::from_regex_match(0, 7)],
+        };
+        let redacted = result.redact(text);
+        assert!(!redacted.contains("secret"), "raw secret must not leak: {redacted}");
+        assert_eq!(redacted, "[REDACTED]");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes the AAASM-4936 LOW cluster: one dry-run secret leak plus defense-in-depth
fail-open hardenings. Every change is surgical and biases toward fail-closed.

**Landed (PRIMARY + L1 + L3 + L4):**

- **PRIMARY — aa-cli `_URI` dry-run leak** (sibling of AAASM-4894).
  `mask_value` in `aa-cli/src/commands/run.rs` routed `*_URL` / `*_DSN`
  through `redact_database_url` but missed `*_URI`, so `MONGODB_URI`,
  `DATABASE_URI`, `REDIS_URI`, `AMQP_URI` (e.g. `mongodb://user:p4ss@host`)
  printed verbatim in `aasm run --dry-run`. Now `*_URI` is redacted like a
  connection URL, and a fail-closed backstop routes any otherwise-unrecognised
  value through `redact_database_url` (strips `user:pass@` userinfo, leaves
  plain values untouched). Regression tests added.

- **L1 — aa-security fail-open redaction.** `ScanResult::redact` skipped a
  finding whose span was out of range or off a UTF-8 char boundary, emitting
  the raw secret (fail-open). It now returns an opaque `[REDACTED]` when a span
  can't be spliced. Tests added for out-of-bounds and mid-codepoint spans.

- **L3 — aa-api internal error leakage.** `GET /traces/:session_id` and the
  WASM dispatch path put internal error strings (store error / `JoinError`
  panic payload) into 500 bodies. Detail is now logged via `tracing::error!`
  and the caller gets a generic message. The `#[utoipa::path]` responses list
  only 200/404, so `openapi/v1.yaml` is unaffected (no regeneration needed).

- **L4 — aa-proxy CA key perms.** `ca-key.pem`'s 0600 mode was set only at
  creation. It is now re-asserted on every load so a key from an older build,
  a backup, or a manual copy can never be served world-readable. Test added.

**Deferred (all of L2 + L5):**

- **L2 — DLP heuristic hardening (all deferred).** A PEM full-block-coverage
  attempt (extend a PEM finding through its `-----END …-----` marker) was tried
  and then **reverted** (commit `♻️ Revert L2 PEM full-block extension`): it
  regressed the conformance golden vector
  `conformance::credential_detection all_vectors_redact_correctly` — for an EC
  private key the output became
  `[REDACTED:EcPrivateKey]\n[REDACTED:GenericHighEntropy]\n-----END EC PRIVATE KEY-----`
  instead of the clean `[REDACTED:EcPrivateKey]`, i.e. worse (it left the END
  marker + a stray fragment in the clear). The golden vector was intentionally
  **not** updated. The remaining L2 evasions (entropy dilution, credit-card
  multi-space separators, SSN adjacent-digit) each need false-positive analysis
  or a broader heuristic redesign — no surgical, clearly-correct fix. All of L2
  is therefore deferred.

- **L5 — aa-gateway graph-context fail-open.** An unresolved graph variable
  (`None`) short-circuits its clause to `false`, so a `deny` rule referencing
  an absent graph var silently no-ops. This is *documented, intentional*
  `null-as-no-match` / "fail-open on missing context" semantics
  (`PolicyContext` doc comment) guarded by snapshot fixtures in
  `tests/graph_vars_fixture_test.rs` covering every variable in both the null
  and non-null paths. The `expr.rs` approval evaluator fail-safes only for a
  whole-expression *parse* error — a different case from a value-level `None`.
  Making graph-context deny-on-missing would flip a documented invariant across
  every graph variable and both clause types (deny *and* requires_approval),
  breaking the snapshot contract. Deferred pending an explicit semantics
  decision (ADR).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4936
- Related GitHub issues: N/A

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Validation (local, on this branch, after the L2 PEM revert):

- `cargo nextest run -p aa-security -p conformance -p aa-cli -p aa-api -p aa-proxy` — 2160 passed, 3 skipped. `conformance::credential_detection all_vectors_redact_correctly` passes.
- `cargo nextest run -p aa-gateway` — green (2347 in earlier full run).
- `cargo clippy -p aa-security -p conformance -p aa-cli -p aa-api -p aa-proxy -p aa-gateway --all-targets -- -D warnings` — clean (exit 0).
- `cargo fmt` — clean. Pre-commit (fmt + clippy) and pre-push (`cargo doc`) hooks passed.

New tests: `dry_run_redacts_uri_connection_strings`,
`mask_value_redacts_connection_string_in_unrecognised_key`,
`mask_value_leaves_plain_value_unchanged` (aa-cli);
`redact_fails_closed_on_out_of_bounds_span`,
`redact_fails_closed_on_non_char_boundary_span` (aa-security);
`load_or_create_reasserts_600_on_loose_existing_key` (aa-proxy).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
