### PR TITLE
[AAASM-4947] 🐛 (aa-gateway): Fail-closed graph-context resolution failures with audit evidence

### DIFF
--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -57,6 +57,7 @@ pub(crate) fn evaluate_single_doc(
     ctx: &aa_core::AgentContext,
     action: &aa_core::GovernanceAction,
     policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
+    failures: &mut Vec<crate::policy::expr::ResolutionFailure>,
 ) -> PolicyDecision {
     if let Some(d) = stage_network(doc, action) {
         return d;
@@ -67,7 +68,7 @@ pub(crate) fn evaluate_single_doc(
     if let Some(d) = stage_capability(doc, action) {
         return d;
     }
-    if let Some(d) = stage_approval(doc, ctx, action, policy_ctx) {
+    if let Some(d) = stage_approval(doc, ctx, action, policy_ctx, failures) {
         return d;
     }
 
@@ -228,6 +229,7 @@ fn stage_approval(
     ctx: &aa_core::AgentContext,
     action: &aa_core::GovernanceAction,
     policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
+    failures: &mut Vec<crate::policy::expr::ResolutionFailure>,
 ) -> Option<PolicyDecision> {
     match action {
         // AAASM-4164: fall back to the `"*"` wildcard entry (exact entry wins) so a
@@ -240,6 +242,7 @@ fn stage_approval(
                 ctx,
                 action,
                 policy_ctx,
+                failures,
             ) =>
         {
             Some(PolicyDecision::RequireApproval {
@@ -251,7 +254,7 @@ fn stage_approval(
         // expression evaluator resolves source/target team and channel ids from
         // the SendMessage action fields directly.
         aa_core::GovernanceAction::SendMessage { .. }
-            if approval_condition_met(doc.tools.get("message"), ctx, action, policy_ctx) =>
+            if approval_condition_met(doc.tools.get("message"), ctx, action, policy_ctx, failures) =>
         {
             Some(PolicyDecision::RequireApproval {
                 reason: "approval required: cross-team channel policy".into(),
@@ -264,16 +267,29 @@ fn stage_approval(
 
 /// Whether a tool/channel policy has a non-empty `requires_approval_if`
 /// expression that evaluates true for `action`.
+///
+/// `requires_approval_if` is a guard clause, so any graph-context resolution
+/// failure fails closed (fires) per ADR 0015 §4 and is appended to `failures`
+/// as audit evidence.
 fn approval_condition_met(
     tool_policy: Option<&crate::policy::document::ToolPolicy>,
     ctx: &aa_core::AgentContext,
     action: &aa_core::GovernanceAction,
     policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
+    failures: &mut Vec<crate::policy::expr::ResolutionFailure>,
 ) -> bool {
     let Some(expr) = tool_policy.and_then(|tp| tp.requires_approval_if.as_ref()) else {
         return false;
     };
-    !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), policy_ctx)
+    !expr.is_empty()
+        && crate::policy::expr::evaluate_clause(
+            expr,
+            action,
+            Some(ctx.governance_level),
+            policy_ctx,
+            crate::policy::expr::ClauseKind::RequireApproval,
+            failures,
+        )
 }
 
 /// Merge a cascade of policy documents into a single `PolicyDecision` using
@@ -295,6 +311,26 @@ pub fn merge_decisions(
     action: &aa_core::GovernanceAction,
     policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
 ) -> PolicyDecision {
+    // Callers that do not consume the resolution-failure audit evidence discard
+    // it here; the engine uses [`merge_decisions_audited`] to surface it.
+    let mut failures = Vec::new();
+    merge_decisions_audited(cascade, ctx, action, policy_ctx, &mut failures)
+}
+
+/// Like [`merge_decisions`], but appends every graph-context **resolution
+/// failure** encountered during evaluation to `failures` (ADR 0015 §4 rule 5).
+///
+/// Each record identifies the unresolved variable, the clause that referenced
+/// it, and — via [`crate::policy::expr::ResolutionFailure::fail_safe_action`] —
+/// the fail-safe action taken. The engine drains this into the audit trail so a
+/// decision made on degraded context is never invisible to an operator.
+pub fn merge_decisions_audited(
+    cascade: &[Arc<PolicyDocument>],
+    ctx: &aa_core::AgentContext,
+    action: &aa_core::GovernanceAction,
+    policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
+    failures: &mut Vec<crate::policy::expr::ResolutionFailure>,
+) -> PolicyDecision {
     if cascade.is_empty() {
         return PolicyDecision::Deny {
             reason: "no policy — fail-closed".into(),
@@ -305,7 +341,7 @@ pub fn merge_decisions(
     let mut running = PolicyDecision::Allow;
 
     for doc in cascade {
-        let verdict = evaluate_single_doc(doc, ctx, action, policy_ctx);
+        let verdict = evaluate_single_doc(doc, ctx, action, policy_ctx, failures);
         match verdict {
             // Short-circuit: Deny always wins.
             PolicyDecision::Deny { .. } => return verdict,
@@ -382,7 +418,7 @@ mod tests {
             path: "/tmp/f".into(),
             mode: FileMode::Read,
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action, None);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None, &mut Vec::new());
         assert_eq!(
             result,
             PolicyDecision::Deny {
@@ -401,7 +437,7 @@ mod tests {
             path: "/tmp/f".into(),
             mode: FileMode::Write,
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action, None);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None, &mut Vec::new());
         assert_eq!(
             result,
             PolicyDecision::Deny {
@@ -420,7 +456,7 @@ mod tests {
             path: "/tmp/f".into(),
             mode: FileMode::Read,
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action, None);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None, &mut Vec::new());
         assert_eq!(result, PolicyDecision::Allow);
     }
 
@@ -433,7 +469,7 @@ mod tests {
             path: "/tmp/f".into(),
             mode: FileMode::Write,
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action, None);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None, &mut Vec::new());
         assert_eq!(result, PolicyDecision::Allow);
     }
 
@@ -445,7 +481,7 @@ mod tests {
             name: "bash".into(),
             args: "{}".into(),
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action, None);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None, &mut Vec::new());
         assert_eq!(
             result,
             PolicyDecision::Deny {
@@ -463,7 +499,7 @@ mod tests {
             name: "bash".into(),
             args: "{}".into(),
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action, None);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None, &mut Vec::new());
         assert_eq!(result, PolicyDecision::Allow);
     }
 

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -991,7 +991,19 @@ impl PolicyEngine {
             )
         });
         let pctx_dyn: Option<&dyn crate::policy::context::PolicyContext> = pctx.as_ref().map(|c| c as _);
-        if crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), pctx_dyn) {
+        // ADR 0015 §4: `requires_approval_if` is a guard clause; a graph-context
+        // resolution failure fails closed (fires) and is recorded for audit.
+        let mut failures = Vec::new();
+        let fired = crate::policy::expr::evaluate_clause(
+            expr,
+            action,
+            Some(ctx.governance_level),
+            pctx_dyn,
+            crate::policy::expr::ClauseKind::RequireApproval,
+            &mut failures,
+        );
+        Self::emit_resolution_failures(&failures);
+        if fired {
             return Some(EvaluationResult {
                 decision: aa_core::PolicyResult::RequiresApproval {
                     timeout_secs: policy.approval_timeout_secs,
@@ -1002,6 +1014,25 @@ impl PolicyEngine {
             });
         }
         None
+    }
+
+    /// Emit audit evidence for every graph-context variable that failed to
+    /// resolve during evaluation (ADR 0015 §4 rule 5), so a decision made on
+    /// degraded context is never invisible to an operator.
+    ///
+    /// Emitted on the `audit` tracing target — the same log-based audit-visibility
+    /// path the engine uses for other audit-only side effects. The variable name
+    /// and fail-safe verdict are safe to log; the underlying error detail (which
+    /// could reference secret-adjacent state) is deliberately not surfaced here.
+    fn emit_resolution_failures(failures: &[crate::policy::expr::ResolutionFailure]) {
+        for f in failures {
+            tracing::warn!(
+                target: "audit",
+                variable = %f.variable,
+                fail_safe_action = %f.fail_safe_action(),
+                "graph-context resolution failure — policy clause failed closed"
+            );
+        }
     }
 
     /// Map a budget policy's `action_on_exceed` to the [`DenyAction`] the
@@ -1385,7 +1416,13 @@ impl PolicyEngine {
     ) -> PolicyDecision {
         let context_dependent = Self::cascade_has_live_context_approval(cascade);
         if context_dependent {
-            merge_decisions(cascade, ctx, action, pctx_dyn)
+            // ADR 0015 §4: surface any graph-context resolution failures for audit
+            // on the fresh-evaluation path (context-dependent verdicts are never
+            // cached, so this is the only place they can arise).
+            let mut failures = Vec::new();
+            let v = decision::merge_decisions_audited(cascade, ctx, action, pctx_dyn, &mut failures);
+            Self::emit_resolution_failures(&failures);
+            v
         } else if let Some(cached) = self.decision_cache.get(&cache_key) {
             cached
         } else {

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -43,26 +43,37 @@ impl<'a> ProductionPolicyContext<'a> {
 }
 
 impl<'a> PolicyContext for ProductionPolicyContext<'a> {
-    fn agent_depth(&self) -> Option<u32> {
-        self.registry.get(&self.agent_key).map(|r| r.depth)
+    // The in-memory [`AgentRegistry`] / [`BudgetTracker`] lookups cannot fail —
+    // an unknown agent/team is a legitimate `Ok(None)` (null-as-no-match), not a
+    // resolution failure. These methods therefore never return `Err`; the
+    // `Result` return type exists so a future backend-backed context (registry
+    // over a remote store) can surface a genuine lookup error as `Err`, which the
+    // evaluator then fails **closed** per ADR 0015 §4.
+    fn agent_depth(&self) -> Result<Option<u32>, ContextError> {
+        Ok(self.registry.get(&self.agent_key).map(|r| r.depth))
     }
 
-    fn team_active_agents(&self) -> Option<u64> {
-        let team_id = self.team_id.as_deref()?;
-        Some(self.registry.team_members(team_id).len() as u64)
+    fn team_active_agents(&self) -> Result<Option<u64>, ContextError> {
+        Ok(self
+            .team_id
+            .as_deref()
+            .map(|team_id| self.registry.team_members(team_id).len() as u64))
     }
 
-    fn team_budget_remaining(&self) -> Option<f64> {
-        let team_id = self.team_id.as_deref()?;
-        let state = self.budget.team_state(team_id)?;
-        let limit = self.budget.monthly_limit_usd()?;
-        let spent = state.monthly_spent_usd.unwrap_or(state.spent_usd);
-        let remaining = (limit - spent).max(rust_decimal::Decimal::ZERO);
-        remaining.to_f64()
+    fn team_budget_remaining(&self) -> Result<Option<f64>, ContextError> {
+        Ok((|| {
+            let team_id = self.team_id.as_deref()?;
+            let state = self.budget.team_state(team_id)?;
+            let limit = self.budget.monthly_limit_usd()?;
+            let spent = state.monthly_spent_usd.unwrap_or(state.spent_usd);
+            let remaining = (limit - spent).max(rust_decimal::Decimal::ZERO);
+            remaining.to_f64()
+        })())
     }
 
-    fn child_tools(&self) -> Vec<String> {
-        self.registry
+    fn child_tools(&self) -> Result<Vec<String>, ContextError> {
+        Ok(self
+            .registry
             .children_of(&self.agent_key)
             .into_iter()
             .flat_map(|key| {
@@ -71,42 +82,52 @@ impl<'a> PolicyContext for ProductionPolicyContext<'a> {
                     .map(|r| r.tool_names.clone())
                     .unwrap_or_default()
             })
-            .collect()
+            .collect())
     }
 
-    fn agent_risk_tier(&self) -> Option<aa_core::RiskTier> {
-        let record = self.registry.get(&self.agent_key)?;
-        aa_core::RiskTier::from_proto_i32(record.risk_tier)
+    fn agent_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError> {
+        Ok(self
+            .registry
+            .get(&self.agent_key)
+            .and_then(|record| aa_core::RiskTier::from_proto_i32(record.risk_tier)))
     }
 
-    fn parent_risk_tier(&self) -> Option<aa_core::RiskTier> {
-        let record = self.registry.get(&self.agent_key)?;
-        let parent_key = record.parent_key?;
-        let parent = self.registry.get(&parent_key)?;
-        aa_core::RiskTier::from_proto_i32(parent.risk_tier)
+    fn parent_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError> {
+        Ok((|| {
+            let record = self.registry.get(&self.agent_key)?;
+            let parent_key = record.parent_key?;
+            let parent = self.registry.get(&parent_key)?;
+            aa_core::RiskTier::from_proto_i32(parent.risk_tier)
+        })())
     }
 
-    fn child_risk_tier(&self) -> Option<aa_core::RiskTier> {
-        self.proposed_child_risk_tier
+    fn child_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError> {
+        Ok(self.proposed_child_risk_tier)
     }
 
-    fn agent_age_secs(&self) -> Option<u64> {
-        let record = self.registry.get(&self.agent_key)?;
-        let registered_unix = record.registered_at.timestamp() as u64;
-        Some(self.now_secs.saturating_sub(registered_unix))
+    fn agent_age_secs(&self) -> Result<Option<u64>, ContextError> {
+        Ok(self.registry.get(&self.agent_key).map(|record| {
+            let registered_unix = record.registered_at.timestamp() as u64;
+            self.now_secs.saturating_sub(registered_unix)
+        }))
     }
 
-    fn agent_parent_id(&self) -> Option<String> {
-        self.registry.get(&self.agent_key)?.parent_agent_id.clone()
+    fn agent_parent_id(&self) -> Result<Option<String>, ContextError> {
+        Ok(self
+            .registry
+            .get(&self.agent_key)
+            .and_then(|record| record.parent_agent_id.clone()))
     }
 
-    fn agent_team_id(&self) -> Option<String> {
-        self.team_id.clone()
+    fn agent_team_id(&self) -> Result<Option<String>, ContextError> {
+        Ok(self.team_id.clone())
     }
 
-    fn agent_children_count(&self) -> Option<u32> {
-        let record = self.registry.get(&self.agent_key)?;
-        Some(record.children.len() as u32)
+    fn agent_children_count(&self) -> Result<Option<u32>, ContextError> {
+        Ok(self
+            .registry
+            .get(&self.agent_key)
+            .map(|record| record.children.len() as u32))
     }
 }
 
@@ -211,23 +232,23 @@ mod production_context_tests {
         let budget = BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC);
         let ctx = ProductionPolicyContext::new(&reg, &budget, PARENT, Some("eng".into()), (T0 + 500) as u64);
 
-        assert_eq!(ctx.agent_depth(), Some(0));
+        assert_eq!(ctx.agent_depth(), Ok(Some(0)));
         // Both agents share team "eng".
-        assert_eq!(ctx.team_active_agents(), Some(2));
+        assert_eq!(ctx.team_active_agents(), Ok(Some(2)));
         // Parent's sole child contributes its declared tools.
-        let mut tools = ctx.child_tools();
+        let mut tools = ctx.child_tools().unwrap();
         tools.sort();
         assert_eq!(tools, vec!["exec".to_string(), "write".to_string()]);
-        assert_eq!(ctx.agent_risk_tier(), Some(aa_core::RiskTier::High));
+        assert_eq!(ctx.agent_risk_tier(), Ok(Some(aa_core::RiskTier::High)));
         // A root has no parent, so parent_risk_tier is absent.
-        assert_eq!(ctx.parent_risk_tier(), None);
+        assert_eq!(ctx.parent_risk_tier(), Ok(None));
         // child_risk_tier is the proposed-spawn tier, unset on a plain context.
-        assert_eq!(ctx.child_risk_tier(), None);
+        assert_eq!(ctx.child_risk_tier(), Ok(None));
         // now_secs - registered_at = 500.
-        assert_eq!(ctx.agent_age_secs(), Some(500));
-        assert_eq!(ctx.agent_parent_id(), None);
-        assert_eq!(ctx.agent_team_id(), Some("eng".to_string()));
-        assert_eq!(ctx.agent_children_count(), Some(1));
+        assert_eq!(ctx.agent_age_secs(), Ok(Some(500)));
+        assert_eq!(ctx.agent_parent_id(), Ok(None));
+        assert_eq!(ctx.agent_team_id(), Ok(Some("eng".to_string())));
+        assert_eq!(ctx.agent_children_count(), Ok(Some(1)));
     }
 
     #[test]
@@ -236,13 +257,13 @@ mod production_context_tests {
         let budget = BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC);
         let ctx = ProductionPolicyContext::new(&reg, &budget, CHILD, Some("eng".into()), (T0 + 10) as u64);
 
-        assert_eq!(ctx.agent_depth(), Some(1));
-        assert_eq!(ctx.agent_risk_tier(), Some(aa_core::RiskTier::Medium));
+        assert_eq!(ctx.agent_depth(), Ok(Some(1)));
+        assert_eq!(ctx.agent_risk_tier(), Ok(Some(aa_core::RiskTier::Medium)));
         // The child's parent is the High-tier root.
-        assert_eq!(ctx.parent_risk_tier(), Some(aa_core::RiskTier::High));
-        assert_eq!(ctx.agent_parent_id(), Some("parent-str".to_string()));
-        assert_eq!(ctx.agent_children_count(), Some(0));
-        assert_eq!(ctx.agent_age_secs(), Some(10));
+        assert_eq!(ctx.parent_risk_tier(), Ok(Some(aa_core::RiskTier::High)));
+        assert_eq!(ctx.agent_parent_id(), Ok(Some("parent-str".to_string())));
+        assert_eq!(ctx.agent_children_count(), Ok(Some(0)));
+        assert_eq!(ctx.agent_age_secs(), Ok(Some(10)));
     }
 
     #[test]
@@ -253,7 +274,7 @@ mod production_context_tests {
         budget.record_raw_spend(aa_core::AgentId::from_bytes(PARENT), Some("eng"), None, dec("30"));
 
         let ctx = ProductionPolicyContext::new(&reg, &budget, PARENT, Some("eng".into()), T0 as u64);
-        assert_eq!(ctx.team_budget_remaining(), Some(70.0));
+        assert_eq!(ctx.team_budget_remaining(), Ok(Some(70.0)));
     }
 
     #[test]
@@ -265,7 +286,7 @@ mod production_context_tests {
 
         let ctx = ProductionPolicyContext::new(&reg, &budget, PARENT, Some("eng".into()), T0 as u64);
         // `monthly_limit_usd()` is None → the whole getter short-circuits.
-        assert_eq!(ctx.team_budget_remaining(), None);
+        assert_eq!(ctx.team_budget_remaining(), Ok(None));
     }
 
     #[test]
@@ -277,17 +298,17 @@ mod production_context_tests {
         let budget = BudgetTracker::new(PricingTable::default_table(), None, Some(dec("100")), chrono_tz::UTC);
         let ctx = ProductionPolicyContext::new(&reg, &budget, [9u8; 16], None, T0 as u64);
 
-        assert_eq!(ctx.agent_depth(), None);
-        assert_eq!(ctx.agent_risk_tier(), None);
-        assert_eq!(ctx.parent_risk_tier(), None);
-        assert_eq!(ctx.agent_age_secs(), None);
-        assert_eq!(ctx.agent_parent_id(), None);
-        assert_eq!(ctx.agent_children_count(), None);
-        assert!(ctx.child_tools().is_empty());
+        assert_eq!(ctx.agent_depth(), Ok(None));
+        assert_eq!(ctx.agent_risk_tier(), Ok(None));
+        assert_eq!(ctx.parent_risk_tier(), Ok(None));
+        assert_eq!(ctx.agent_age_secs(), Ok(None));
+        assert_eq!(ctx.agent_parent_id(), Ok(None));
+        assert_eq!(ctx.agent_children_count(), Ok(None));
+        assert!(ctx.child_tools().unwrap().is_empty());
         // No team on the context → the team-scoped getters are all None.
-        assert_eq!(ctx.team_active_agents(), None);
-        assert_eq!(ctx.team_budget_remaining(), None);
-        assert_eq!(ctx.agent_team_id(), None);
+        assert_eq!(ctx.team_active_agents(), Ok(None));
+        assert_eq!(ctx.team_budget_remaining(), Ok(None));
+        assert_eq!(ctx.agent_team_id(), Ok(None));
     }
 
     #[test]
@@ -299,7 +320,7 @@ mod production_context_tests {
             .unwrap();
         let budget = BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC);
         let ctx = ProductionPolicyContext::new(&reg, &budget, [7u8; 16], None, T0 as u64);
-        assert_eq!(ctx.agent_risk_tier(), None);
+        assert_eq!(ctx.agent_risk_tier(), Ok(None));
     }
 }
 
@@ -322,109 +343,139 @@ pub struct FakePolicyContext {
 
 #[cfg(test)]
 impl PolicyContext for FakePolicyContext {
-    fn agent_depth(&self) -> Option<u32> {
-        self.depth
+    fn agent_depth(&self) -> Result<Option<u32>, ContextError> {
+        Ok(self.depth)
     }
 
-    fn team_active_agents(&self) -> Option<u64> {
-        self.team_active
+    fn team_active_agents(&self) -> Result<Option<u64>, ContextError> {
+        Ok(self.team_active)
     }
 
-    fn team_budget_remaining(&self) -> Option<f64> {
-        self.team_budget
+    fn team_budget_remaining(&self) -> Result<Option<f64>, ContextError> {
+        Ok(self.team_budget)
     }
 
-    fn child_tools(&self) -> Vec<String> {
-        self.child_tools.clone()
+    fn child_tools(&self) -> Result<Vec<String>, ContextError> {
+        Ok(self.child_tools.clone())
     }
 
-    fn agent_risk_tier(&self) -> Option<aa_core::RiskTier> {
-        self.agent_risk_tier
+    fn agent_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError> {
+        Ok(self.agent_risk_tier)
     }
 
-    fn parent_risk_tier(&self) -> Option<aa_core::RiskTier> {
-        self.parent_risk_tier
+    fn parent_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError> {
+        Ok(self.parent_risk_tier)
     }
 
-    fn child_risk_tier(&self) -> Option<aa_core::RiskTier> {
-        self.child_risk_tier
+    fn child_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError> {
+        Ok(self.child_risk_tier)
     }
 
-    fn agent_age_secs(&self) -> Option<u64> {
-        self.agent_age_secs
+    fn agent_age_secs(&self) -> Result<Option<u64>, ContextError> {
+        Ok(self.agent_age_secs)
     }
 
-    fn agent_parent_id(&self) -> Option<String> {
-        self.agent_parent_id.clone()
+    fn agent_parent_id(&self) -> Result<Option<String>, ContextError> {
+        Ok(self.agent_parent_id.clone())
     }
 
-    fn agent_team_id(&self) -> Option<String> {
-        self.agent_team_id.clone()
+    fn agent_team_id(&self) -> Result<Option<String>, ContextError> {
+        Ok(self.agent_team_id.clone())
     }
 
-    fn agent_children_count(&self) -> Option<u32> {
-        self.agent_children_count
+    fn agent_children_count(&self) -> Result<Option<u32>, ContextError> {
+        Ok(self.agent_children_count)
     }
 }
+
+/// A graph-context variable could not be resolved because of a
+/// registry/backend/lookup error — as distinct from the variable being
+/// *legitimately absent* (which the getters express as `Ok(None)`).
+///
+/// ADR 0015 §4 requires the evaluator to tell these two causes apart: a
+/// legitimate absence is `null-as-no-match` (unchanged behavior), whereas a
+/// resolution failure fails **closed** — `deny` ⇒ deny, `requires_approval_if`
+/// ⇒ require approval, conditional `allow` ⇒ never grant — and emits audit
+/// evidence. This error type is the "failure" arm the getters return.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextError {
+    /// Human-readable detail of what failed (which backend / lookup). Must never
+    /// contain secret material — it is surfaced in audit evidence.
+    pub detail: String,
+}
+
+impl ContextError {
+    /// Construct a resolution failure with a human-readable `detail`.
+    pub fn new(detail: impl Into<String>) -> Self {
+        Self { detail: detail.into() }
+    }
+}
+
+impl std::fmt::Display for ContextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "graph-context resolution failure: {}", self.detail)
+    }
+}
+
+impl std::error::Error for ContextError {}
 
 /// Provides runtime values for graph-aware policy condition variables.
 ///
 /// Production code wires this to `AgentRegistry` and `BudgetTracker` via
-/// [`super::super::engine::ProductionPolicyContext`]. Unit tests inject a
-/// `FakePolicyContext` that returns canned values.
+/// [`ProductionPolicyContext`]. Unit tests inject a `FakePolicyContext` that
+/// returns canned values.
 ///
-/// # Null-safety semantics
+/// # Absence vs. resolution failure (ADR 0015 §4)
 ///
-/// Every getter returns `Option<T>`. When a variable cannot be resolved (the
-/// getter returns `None`), the expression clause that references it
-/// short-circuits to `false`. The effect on the overall policy decision is:
+/// Every getter returns `Result<Option<T>, ContextError>`, encoding **three**
+/// outcomes the evaluator treats differently:
 ///
-/// | Clause type          | Variable resolves `Some(_)` | Variable is `None`     |
-/// |----------------------|-----------------------------|------------------------|
-/// | `requires_approval_if` | fires when expression is `true` | **does not fire** |
-/// | `deny` condition     | denies when expression is `true` | **does not deny**  |
-/// | `allow`              | always allows               | always allows          |
+/// | Getter outcome | Meaning | Evaluator behavior |
+/// |----------------|---------|--------------------|
+/// | `Ok(Some(v))`  | resolved value | clause compares against `v` |
+/// | `Ok(None)`     | **legitimate absence** (no team, root agent, unknown-but-valid) | `null-as-no-match` — unchanged from prior behavior |
+/// | `Err(_)`       | **resolution failure** (backend/lookup error) | fails **closed** per clause polarity + emits audit evidence |
 ///
-/// In every case an unresolvable variable contributes **nothing** to the
-/// decision: it neither allows nor denies. A request that references an absent
-/// graph-variable is evaluated as if the condition clause were absent from the
-/// policy. This is sometimes called *null-as-no-match* or *fail-open on
-/// missing context*.
-///
-/// The fixture tests in `tests/graph_vars_fixture_test.rs` snapshot the
-/// `PolicyDecision` produced for each variable in both the null and non-null
-/// paths to guard against accidental semantics changes.
+/// The `Ok(None)` path is the historical *null-as-no-match* contract and is
+/// preserved byte-for-byte (its snapshots in `tests/graph_vars_fixture_test.rs`
+/// are frozen). The `Err(_)` path is the ADR 0015 §4 addition: a variable that
+/// *fails to resolve* must never silently no-match a `deny`/approval clause or
+/// be laundered into an `allow` grant. The in-memory production context never
+/// returns `Err` (its registry lookups cannot fail); the arm exists so a
+/// backend-backed context can surface a genuine outage and have it fail closed.
 pub trait PolicyContext: Send + Sync {
     /// Delegation depth of the current agent (0 = root).
-    fn agent_depth(&self) -> Option<u32>;
+    fn agent_depth(&self) -> Result<Option<u32>, ContextError>;
     /// Number of currently registered agents that belong to the current agent's
-    /// team. Returns `None` when the agent has no team.
-    fn team_active_agents(&self) -> Option<u64>;
-    /// Remaining monthly budget in USD for the current agent's team. Returns
-    /// `None` when the agent has no team, no budget entry, or no monthly limit
-    /// is configured.
-    fn team_budget_remaining(&self) -> Option<f64>;
+    /// team. `Ok(None)` when the agent has no team.
+    fn team_active_agents(&self) -> Result<Option<u64>, ContextError>;
+    /// Remaining monthly budget in USD for the current agent's team. `Ok(None)`
+    /// when the agent has no team, no budget entry, or no monthly limit is
+    /// configured.
+    fn team_budget_remaining(&self) -> Result<Option<f64>, ContextError>;
     /// Union of `tool_names` across all direct children of the current agent.
-    fn child_tools(&self) -> Vec<String>;
-    /// Risk tier of the current agent. Returns `None` when the agent is not
-    /// found in the registry or has an unspecified (0) risk tier.
-    fn agent_risk_tier(&self) -> Option<aa_core::RiskTier>;
-    /// Risk tier of the current agent's parent. Returns `None` when the agent
-    /// has no parent or the parent is not in the registry.
-    fn parent_risk_tier(&self) -> Option<aa_core::RiskTier>;
+    /// An agent with no children resolves to `Ok(vec![])` (legitimate absence);
+    /// `Err` is a lookup failure.
+    fn child_tools(&self) -> Result<Vec<String>, ContextError>;
+    /// Risk tier of the current agent. `Ok(None)` when the agent is not found in
+    /// the registry or has an unspecified (0) risk tier.
+    fn agent_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError>;
+    /// Risk tier of the current agent's parent. `Ok(None)` when the agent has no
+    /// parent or the parent is not in the registry.
+    fn parent_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError>;
     /// Proposed risk tier of the child agent being spawned, supplied in the
-    /// spawn action payload. Returns `None` when the evaluation is not for a
-    /// spawn action or no tier was specified.
-    fn child_risk_tier(&self) -> Option<aa_core::RiskTier>;
+    /// spawn action payload. `Ok(None)` when the evaluation is not for a spawn
+    /// action or no tier was specified.
+    fn child_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError>;
     /// Age of the current agent in seconds, computed as `now_secs - registered_at`.
-    /// Returns `None` when the agent is not found in the registry.
-    fn agent_age_secs(&self) -> Option<u64>;
-    /// Parent agent ID string of the current agent. Returns `None` when the agent
+    /// `Ok(None)` when the agent is not found in the registry.
+    fn agent_age_secs(&self) -> Result<Option<u64>, ContextError>;
+    /// Parent agent ID string of the current agent. `Ok(None)` when the agent
     /// has no parent (i.e. it is a root agent).
-    fn agent_parent_id(&self) -> Option<String>;
-    /// Team ID of the current agent. Returns `None` when the agent has no team.
-    fn agent_team_id(&self) -> Option<String>;
-    /// Number of direct children of the current agent. Returns `None` when the
-    /// agent is not found in the registry.
-    fn agent_children_count(&self) -> Option<u32>;
+    fn agent_parent_id(&self) -> Result<Option<String>, ContextError>;
+    /// Team ID of the current agent. `Ok(None)` when the agent has no team.
+    fn agent_team_id(&self) -> Result<Option<String>, ContextError>;
+    /// Number of direct children of the current agent. `Ok(None)` when the agent
+    /// is not found in the registry.
+    fn agent_children_count(&self) -> Result<Option<u32>, ContextError>;
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -53,7 +53,7 @@
 
 use aa_core::{GovernanceAction, GovernanceLevel};
 
-use crate::policy::context::PolicyContext;
+use crate::policy::context::{ContextError, PolicyContext};
 
 use strsim;
 
@@ -428,6 +428,117 @@ fn field_value<'a>(field: &FieldRef, action: &'a GovernanceAction) -> &'a str {
 }
 
 // ---------------------------------------------------------------------------
+// Graph-context resolution fail-safety (ADR 0015 §4)
+// ---------------------------------------------------------------------------
+
+/// Clause polarity that determines the fail-safe direction when a graph-context
+/// variable cannot be *resolved* (ADR 0015 §4). The evaluator returns a plain
+/// "does this clause fire?" boolean, so the caller declares which kind of clause
+/// the expression drives:
+///
+/// * `Deny` / `RequireApproval` are **guard** clauses — a resolution failure
+///   makes the clause *fire* (fail closed): the action is denied / escalated.
+/// * `Allow` is a **permit** clause — a resolution failure makes the clause *not
+///   fire*: a failure can never be laundered into a grant.
+///
+/// Note this governs *resolution failures* (`Err`), not legitimate absence
+/// (`Ok(None)`), which keeps its historical null-as-no-match behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClauseKind {
+    /// A conditional `deny` clause.
+    Deny,
+    /// A `requires_approval_if` clause.
+    RequireApproval,
+    /// A conditional `allow` clause.
+    Allow,
+}
+
+impl ClauseKind {
+    /// Whether a *resolution failure* makes a clause of this kind fire. Guards
+    /// (`Deny`/`RequireApproval`) fail closed by firing; a conditional `Allow`
+    /// fails closed by NOT firing (never granting).
+    fn fail_safe_fires(self) -> bool {
+        matches!(self, ClauseKind::Deny | ClauseKind::RequireApproval)
+    }
+
+    /// The fail-safe action label recorded in audit evidence.
+    fn fail_safe_action(self) -> &'static str {
+        match self {
+            ClauseKind::Deny => "deny",
+            ClauseKind::RequireApproval => "require_approval",
+            ClauseKind::Allow => "no_grant",
+        }
+    }
+}
+
+/// Audit evidence for a single graph-context variable that failed to resolve
+/// during policy evaluation (ADR 0015 §4 rule 5). Identifies the unresolved
+/// variable, the clause polarity that referenced it, and — derived from that —
+/// the fail-safe action taken. Never carries the underlying error detail into a
+/// value that could leak secrets; only the variable name and verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolutionFailure {
+    /// Canonical name of the variable that could not be resolved (e.g.
+    /// `"team.active_agents"`).
+    pub variable: String,
+    /// The clause polarity that referenced the variable.
+    pub clause: ClauseKind,
+}
+
+impl ResolutionFailure {
+    /// The fail-safe action taken for this failure: `"deny"`,
+    /// `"require_approval"`, or `"no_grant"`.
+    pub fn fail_safe_action(&self) -> &'static str {
+        self.clause.fail_safe_action()
+    }
+}
+
+/// Per-evaluation fail-safe state threaded to the context-backed field handlers:
+/// the clause polarity plus the audit sink that collects every resolution
+/// failure. Uses a shared `RefCell` so it can be passed by `&` across the nested
+/// `any`/`all` closures without `&mut` aliasing.
+struct FailSafe<'a> {
+    clause: ClauseKind,
+    failures: &'a std::cell::RefCell<Vec<ResolutionFailure>>,
+}
+
+impl FailSafe<'_> {
+    /// Resolve a context getter into an optional value, or short-circuit with the
+    /// clause's fail-safe verdict on a resolution failure (ADR 0015 §4):
+    ///
+    /// * `policy_ctx == None` (whole context absent) → `Ok(None)`: the historical
+    ///   null-as-no-match path, byte-identical to pre-ADR behavior.
+    /// * getter `Ok(opt)` → `Ok(opt)`: a resolved value or a legitimate absence.
+    /// * getter `Err(_)` → record an audit failure for `var` and return
+    ///   `Err(fail_safe_fires)` — the verdict the caller returns directly.
+    fn resolve<'c, T>(
+        &self,
+        policy_ctx: Option<&'c dyn PolicyContext>,
+        var: &str,
+        getter: impl FnOnce(&'c dyn PolicyContext) -> Result<Option<T>, ContextError>,
+    ) -> Result<Option<T>, bool> {
+        match policy_ctx {
+            None => Ok(None),
+            Some(c) => match getter(c) {
+                Ok(opt) => Ok(opt),
+                Err(_) => Err(self.record(var)),
+            },
+        }
+    }
+
+    /// Record a resolution failure for `var` and return the clause's fail-safe
+    /// verdict (whether the clause fires). Used by handlers whose getter is not
+    /// `Result<Option<T>, _>` (e.g. `child_tools` → `Result<Vec<_>, _>`).
+    fn record(&self, var: &str) -> bool {
+        self.failures.borrow_mut().push(ResolutionFailure {
+            variable: var.to_string(),
+            clause: self.clause,
+        });
+        self.clause.fail_safe_fires()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Clause evaluation
 // ---------------------------------------------------------------------------
 
@@ -438,15 +549,16 @@ fn eval_clause_safe(
     action: &GovernanceAction,
     agent_level: Option<GovernanceLevel>,
     policy_ctx: Option<&dyn PolicyContext>,
+    fs: &FailSafe,
 ) -> bool {
     // Each `eval_*` helper owns one field group and returns `Some(verdict)` when
     // it recognises `field`, or `None` to fall through to the next group. The
     // final string-field path is the catch-all. This dispatch chain preserves
     // the original evaluation order and per-group null-safety contracts exactly.
-    if let Some(v) = eval_numeric_ctx_field(field, op, literal, policy_ctx) {
+    if let Some(v) = eval_numeric_ctx_field(field, op, literal, policy_ctx, fs) {
         return v;
     }
-    if let Some(v) = eval_child_tool_field(field, op, literal, policy_ctx) {
+    if let Some(v) = eval_child_tool_field(field, op, literal, policy_ctx, fs) {
         return v;
     }
     if let Some(v) = eval_tool_result_field(field, op, literal, action) {
@@ -455,13 +567,13 @@ fn eval_clause_safe(
     if let Some(v) = eval_tool_arg_field(field, op, literal, action) {
         return v;
     }
-    if let Some(v) = eval_risk_tier_field(field, op, literal, policy_ctx) {
+    if let Some(v) = eval_risk_tier_field(field, op, literal, policy_ctx, fs) {
         return v;
     }
-    if let Some(v) = eval_agent_identity_field(field, op, literal, policy_ctx) {
+    if let Some(v) = eval_agent_identity_field(field, op, literal, policy_ctx, fs) {
         return v;
     }
-    if let Some(v) = eval_topology_flag_field(field, op, literal, policy_ctx) {
+    if let Some(v) = eval_topology_flag_field(field, op, literal, policy_ctx, fs) {
         return v;
     }
     if let Some(v) = eval_send_message_field(field, op, literal, action) {
@@ -484,26 +596,57 @@ fn eval_numeric_ctx_field(
     op: &OpKind,
     literal: &LiteralVal,
     policy_ctx: Option<&dyn PolicyContext>,
+    fs: &FailSafe,
 ) -> Option<bool> {
+    // AAASM-4947 / ADR 0015 §4: a `resolve` `Err(fired)` is a *resolution
+    // failure* (the getter reported a backend/lookup error). The failure has
+    // been recorded for audit; return the clause's fail-safe verdict directly.
+    // `Ok(None)` (legitimate absence, or an absent context) falls through to the
+    // preserved numeric no-match handling below.
     let numeric_ctx_value: Option<f64> = match field {
-        FieldRef::AgentDepth => policy_ctx.and_then(|c| c.agent_depth()).map(|d| d as f64),
+        FieldRef::AgentDepth => match fs.resolve(policy_ctx, "agent.depth", |c| c.agent_depth()) {
+            Ok(o) => o.map(|d| d as f64),
+            Err(fired) => return Some(fired),
+        },
         FieldRef::TeamActiveAgents | FieldRef::TeamParallelAgents => {
-            policy_ctx.and_then(|c| c.team_active_agents()).map(|n| n as f64)
+            let var = if matches!(field, FieldRef::TeamParallelAgents) {
+                "team.parallel_agents"
+            } else {
+                "team.active_agents"
+            };
+            match fs.resolve(policy_ctx, var, |c| c.team_active_agents()) {
+                Ok(o) => o.map(|n| n as f64),
+                Err(fired) => return Some(fired),
+            }
         }
-        FieldRef::TeamBudgetRemaining => policy_ctx.and_then(|c| c.team_budget_remaining()),
-        FieldRef::AgentAge => policy_ctx.and_then(|c| c.agent_age_secs()).map(|a| a as f64),
-        FieldRef::AgentChildrenCount => policy_ctx.and_then(|c| c.agent_children_count()).map(|n| n as f64),
+        FieldRef::TeamBudgetRemaining => {
+            match fs.resolve(policy_ctx, "team.budget_remaining", |c| c.team_budget_remaining()) {
+                Ok(o) => o,
+                Err(fired) => return Some(fired),
+            }
+        }
+        FieldRef::AgentAge => match fs.resolve(policy_ctx, "agent.age", |c| c.agent_age_secs()) {
+            Ok(o) => o.map(|a| a as f64),
+            Err(fired) => return Some(fired),
+        },
+        FieldRef::AgentChildrenCount => {
+            match fs.resolve(policy_ctx, "agent.children_count", |c| c.agent_children_count()) {
+                Ok(o) => o.map(|n| n as f64),
+                Err(fired) => return Some(fired),
+            }
+        }
         _ => return None,
     };
     Some(match numeric_ctx_value {
         Some(lhs) => compare_numeric(lhs, op, literal),
         // AAASM-3995(b): this evaluator drives `requires_approval_if`, where a
         // `false` result means "no approval required". When a context field
-        // (agent.depth / team.*) cannot be resolved, silently returning `false`
-        // lets a sole-clause approval guard never fire — the action runs
-        // unguarded (fail-open). An unresolvable guard condition must fail
-        // CLOSED: fire the predicate (require approval), mirroring the
+        // (agent.depth / team.*) is legitimately absent, silently returning
+        // `false` let a sole-clause approval guard never fire — the action ran
+        // unguarded (fail-open). A legitimately-absent numeric guard condition
+        // fails CLOSED here: fire the predicate (require approval), mirroring the
         // fail-closed handling of unparseable ordered comparisons (AAASM-3893).
+        // (A resolution *failure* is handled above, per ADR 0015 §4.)
         None => true,
     })
 }
@@ -515,12 +658,20 @@ fn eval_child_tool_field(
     op: &OpKind,
     literal: &LiteralVal,
     policy_ctx: Option<&dyn PolicyContext>,
+    fs: &FailSafe,
 ) -> Option<bool> {
     let FieldRef::ChildTool = field else {
         return None;
     };
     let tools = match policy_ctx {
-        Some(c) => c.child_tools(),
+        // ADR 0015 §4: a resolution failure fails closed (record + fail-safe
+        // verdict) instead of the historical fail-open no-match. `Ok` (including
+        // an empty child set — legitimate absence) keeps the null-as-no-match
+        // behavior below.
+        Some(c) => match c.child_tools() {
+            Ok(t) => t,
+            Err(_) => return Some(fs.record("child.tool")),
+        },
         None => return Some(false),
     };
     let rhs = match literal {
@@ -585,12 +736,20 @@ fn eval_risk_tier_field(
     op: &OpKind,
     literal: &LiteralVal,
     policy_ctx: Option<&dyn PolicyContext>,
+    fs: &FailSafe,
 ) -> Option<bool> {
+    // ADR 0015 §4: `Err(fired)` is a resolution failure (recorded + fail-safe);
+    // `Ok(None)` (legitimate absence — no parent/child/tier) keeps the historical
+    // no-match (`false`).
     let tier = match field {
-        FieldRef::AgentRiskTier => policy_ctx.and_then(|c| c.agent_risk_tier()),
-        FieldRef::ParentRiskTier => policy_ctx.and_then(|c| c.parent_risk_tier()),
-        FieldRef::ChildRiskTier => policy_ctx.and_then(|c| c.child_risk_tier()),
+        FieldRef::AgentRiskTier => fs.resolve(policy_ctx, "agent.risk_tier", |c| c.agent_risk_tier()),
+        FieldRef::ParentRiskTier => fs.resolve(policy_ctx, "parent.risk_tier", |c| c.parent_risk_tier()),
+        FieldRef::ChildRiskTier => fs.resolve(policy_ctx, "child.risk_tier", |c| c.child_risk_tier()),
         _ => return None,
+    };
+    let tier = match tier {
+        Ok(o) => o,
+        Err(fired) => return Some(fired),
     };
     let (Some(lhs), LiteralVal::Tier(rhs)) = (tier, literal) else {
         return Some(false);
@@ -605,11 +764,19 @@ fn eval_agent_identity_field(
     op: &OpKind,
     literal: &LiteralVal,
     policy_ctx: Option<&dyn PolicyContext>,
+    fs: &FailSafe,
 ) -> Option<bool> {
+    // ADR 0015 §4: `Err(fired)` is a resolution failure (recorded + fail-safe);
+    // `Ok(None)` (legitimate absence — root agent / no team) keeps the historical
+    // no-match (`false`).
     let val = match field {
-        FieldRef::AgentParentId => policy_ctx.and_then(|c| c.agent_parent_id()),
-        FieldRef::AgentTeamId => policy_ctx.and_then(|c| c.agent_team_id()),
+        FieldRef::AgentParentId => fs.resolve(policy_ctx, "agent.parent_agent_id", |c| c.agent_parent_id()),
+        FieldRef::AgentTeamId => fs.resolve(policy_ctx, "agent.team_id", |c| c.agent_team_id()),
         _ => return None,
+    };
+    let val = match val {
+        Ok(o) => o,
+        Err(fired) => return Some(fired),
     };
     let id = match val {
         Some(v) => v,
@@ -630,10 +797,19 @@ fn eval_topology_flag_field(
     op: &OpKind,
     literal: &LiteralVal,
     policy_ctx: Option<&dyn PolicyContext>,
+    fs: &FailSafe,
 ) -> Option<bool> {
+    // ADR 0015 §4: `Err(fired)` is a resolution failure (recorded + fail-safe);
+    // `Ok(None)` (legitimate absence) keeps the historical no-match (`false`).
     let flag: Option<bool> = match field {
-        FieldRef::AgentIsRoot => policy_ctx.and_then(|c| c.agent_depth()).map(|d| d == 0),
-        FieldRef::AgentIsLeaf => policy_ctx.and_then(|c| c.agent_children_count()).map(|n| n == 0),
+        FieldRef::AgentIsRoot => match fs.resolve(policy_ctx, "agent.is_root", |c| c.agent_depth()) {
+            Ok(o) => o.map(|d| d == 0),
+            Err(fired) => return Some(fired),
+        },
+        FieldRef::AgentIsLeaf => match fs.resolve(policy_ctx, "agent.is_leaf", |c| c.agent_children_count()) {
+            Ok(o) => o.map(|n| n == 0),
+            Err(fired) => return Some(fired),
+        },
         _ => return None,
     };
     let lhs = match flag {
@@ -909,6 +1085,7 @@ fn eval_tokens(
     action: &GovernanceAction,
     agent_level: Option<GovernanceLevel>,
     policy_ctx: Option<&dyn PolicyContext>,
+    fs: &FailSafe,
 ) -> bool {
     // Parse tokens into OR-groups of AND-connected clauses, then evaluate:
     // OR across groups, AND within each group. Any parse anomaly is fail-safe
@@ -926,7 +1103,7 @@ fn eval_tokens(
     or_groups.iter().any(|group| {
         group
             .iter()
-            .all(|c| eval_clause_safe(c.field, c.op, c.literal, action, agent_level, policy_ctx))
+            .all(|c| eval_clause_safe(c.field, c.op, c.literal, action, agent_level, policy_ctx, fs))
     })
 }
 
@@ -1193,17 +1370,59 @@ fn validate_level_word(word: &str) -> Result<(), String> {
 ///
 /// Returns `true` if the expression matches (approval required).
 /// Returns `true` on ANY parse/tokenization error (fail-safe).
+///
+/// Thin wrapper over [`evaluate_clause`] for the common `requires_approval_if`
+/// caller: fixes the clause polarity to [`ClauseKind::RequireApproval`] and
+/// discards the resolution-failure audit records. Use [`evaluate_clause`]
+/// directly when the caller needs the audit evidence or a different polarity.
 pub(crate) fn evaluate(
     expr: &str,
     action: &GovernanceAction,
     agent_level: Option<GovernanceLevel>,
     policy_ctx: Option<&dyn PolicyContext>,
 ) -> bool {
+    let mut failures = Vec::new();
+    evaluate_clause(
+        expr,
+        action,
+        agent_level,
+        policy_ctx,
+        ClauseKind::RequireApproval,
+        &mut failures,
+    )
+}
+
+/// Evaluate a flat boolean expression, applying the ADR 0015 §4 graph-context
+/// resolution fail-safety for the given clause polarity.
+///
+/// Behaves like [`evaluate`] for resolved / legitimately-absent variables, but
+/// additionally: on a graph-context **resolution failure** the referencing
+/// clause fails closed according to `clause` (a `Deny`/`RequireApproval` guard
+/// fires; a conditional `Allow` does not fire, so a failure can never grant),
+/// and every such failure is appended to `failures` as audit evidence.
+///
+/// Returns `true` when the expression matches (the clause fires); `true` on any
+/// parse/tokenization anomaly (fail-safe).
+pub fn evaluate_clause(
+    expr: &str,
+    action: &GovernanceAction,
+    agent_level: Option<GovernanceLevel>,
+    policy_ctx: Option<&dyn PolicyContext>,
+    clause: ClauseKind,
+    failures: &mut Vec<ResolutionFailure>,
+) -> bool {
     let tokens = match tokenize(expr) {
         Some(t) if !t.is_empty() => t,
         _ => return true, // fail-safe
     };
-    eval_tokens(&tokens, action, agent_level, policy_ctx)
+    let sink = std::cell::RefCell::new(Vec::new());
+    let fs = FailSafe {
+        clause,
+        failures: &sink,
+    };
+    let fired = eval_tokens(&tokens, action, agent_level, policy_ctx, &fs);
+    failures.append(&mut sink.into_inner());
+    fired
 }
 
 /// AAASM-3995(c) — whether `expr` references any field whose value is resolved

--- a/aa-gateway/src/policy/mod.rs
+++ b/aa-gateway/src/policy/mod.rs
@@ -25,8 +25,10 @@ pub mod rbac;
 pub mod scope;
 pub mod validator;
 
+pub use context::{ContextError, PolicyContext};
 pub use document::{ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy, ToolPolicy};
 pub use error::{PolicyParseError, ValidationError, ValidationWarning};
+pub use expr::{evaluate_clause, ClauseKind, ResolutionFailure};
 pub use network::{check_network_egress, EgressDecision};
 pub use rbac::{required_role_for, CallerRole, MutationKind, PolicyScopeKind};
 pub use scope::{OrgId, PolicyScope, TeamId};

--- a/aa-gateway/tests/graph_vars_fixture_test.rs
+++ b/aa-gateway/tests/graph_vars_fixture_test.rs
@@ -10,8 +10,9 @@ use std::sync::Arc;
 
 use aa_core::identity::{AgentId, SessionId};
 use aa_core::{AgentContext, GovernanceAction, GovernanceLevel};
-use aa_gateway::engine::decision::{merge_decisions, PolicyDecision};
+use aa_gateway::engine::decision::{merge_decisions, merge_decisions_audited, PolicyDecision};
 use aa_gateway::policy::validator::PolicyValidator;
+use aa_gateway::policy::{evaluate_clause, ClauseKind, ContextError, PolicyContext, ResolutionFailure};
 
 fn make_ctx() -> AgentContext {
     AgentContext {
@@ -202,4 +203,157 @@ fn snapshot_null_ctx_agent_depth_fixture_requires_approval() {
     let action = tool_action("deploy");
     let result = merge_decisions(&[doc], &ctx, &action, None);
     insta::assert_debug_snapshot!(result);
+}
+
+// ── ADR 0015 §4: resolution failure vs. legitimate absence (AAASM-4947) ───────
+//
+// These fixtures exercise the deterministic §4 table: a graph-context variable
+// that *fails to resolve* (registry/backend/lookup error, modelled here by
+// `FailingCtx`) fails **closed** according to the clause polarity, whereas a
+// *legitimate absence* keeps the historical null-as-no-match behavior (its
+// snapshots above stay byte-identical). Every resolution failure is recorded as
+// audit evidence; legitimate absence records nothing.
+
+/// A `PolicyContext` whose every getter reports a resolution failure — the
+/// backend/lookup-error case ADR 0015 §4 distinguishes from `Ok(None)`.
+struct FailingCtx;
+
+impl PolicyContext for FailingCtx {
+    fn agent_depth(&self) -> Result<Option<u32>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+    fn team_active_agents(&self) -> Result<Option<u64>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+    fn team_budget_remaining(&self) -> Result<Option<f64>, ContextError> {
+        Err(ContextError::new("budget backend unavailable"))
+    }
+    fn child_tools(&self) -> Result<Vec<String>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+    fn agent_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+    fn parent_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+    fn child_risk_tier(&self) -> Result<Option<aa_core::RiskTier>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+    fn agent_age_secs(&self) -> Result<Option<u64>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+    fn agent_parent_id(&self) -> Result<Option<String>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+    fn agent_team_id(&self) -> Result<Option<String>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+    fn agent_children_count(&self) -> Result<Option<u32>, ContextError> {
+        Err(ContextError::new("registry unavailable"))
+    }
+}
+
+// (1) Legitimate absence — no context object at all — is null-as-no-match and,
+// crucially, is NOT a resolution failure: it records zero audit evidence. This
+// is the invariant that separates "absent" from "failed" (and the frozen
+// snapshots above prove the decision itself is unchanged).
+#[test]
+fn legitimate_absence_is_not_a_resolution_failure() {
+    let action = tool_action("deploy");
+    let mut failures = Vec::new();
+    // Numeric legit-absence still fails closed (fires) as before AAASM-4947...
+    let fired = evaluate_clause(
+        "agent.depth >= 2",
+        &action,
+        None,
+        None,
+        ClauseKind::RequireApproval,
+        &mut failures,
+    );
+    assert!(fired, "legitimate absence of a numeric guard still fires (unchanged)");
+    // ...but it emits NO audit record, because nothing failed to resolve.
+    assert!(
+        failures.is_empty(),
+        "legitimate absence must not record a resolution failure"
+    );
+}
+
+// (2) Resolution failure + `deny` (conditional) ⇒ DENY (clause fires).
+#[test]
+fn resolution_failure_denies_for_deny_clause() {
+    let action = tool_action("deploy");
+    let mut failures = Vec::new();
+    let fired = evaluate_clause(
+        "agent.depth >= 2",
+        &action,
+        None,
+        Some(&FailingCtx),
+        ClauseKind::Deny,
+        &mut failures,
+    );
+    assert!(fired, "a deny clause must fire (deny) on resolution failure");
+    // (5) audit evidence for this failure.
+    assert_eq!(
+        failures,
+        vec![ResolutionFailure {
+            variable: "agent.depth".to_string(),
+            clause: ClauseKind::Deny,
+        }]
+    );
+    assert_eq!(failures[0].fail_safe_action(), "deny");
+}
+
+// (3) Resolution failure + `requires_approval_if` ⇒ REQUIRE APPROVAL, end-to-end
+// through the merge layer, with audit evidence surfaced.
+#[test]
+fn resolution_failure_requires_approval_end_to_end() {
+    // Fixture guard: `requires_approval_if: "team.active_agents > 10"`.
+    let doc = load_fixture("team_active_agents_allow.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("spawn");
+    let mut failures = Vec::new();
+    let result = merge_decisions_audited(&[doc], &ctx, &action, Some(&FailingCtx), &mut failures);
+    assert!(
+        matches!(result, PolicyDecision::RequireApproval { .. }),
+        "resolution failure on an approval guard must escalate, got {result:?}"
+    );
+    // (5) audit evidence for this failure.
+    assert_eq!(
+        failures,
+        vec![ResolutionFailure {
+            variable: "team.active_agents".to_string(),
+            clause: ClauseKind::RequireApproval,
+        }]
+    );
+    assert_eq!(failures[0].fail_safe_action(), "require_approval");
+}
+
+// (4) Resolution failure + conditional `allow` ⇒ no match, MUST NEVER grant
+// (clause does NOT fire), with audit evidence.
+#[test]
+fn resolution_failure_never_grants_for_allow_clause() {
+    let action = tool_action("spawn");
+    let mut failures = Vec::new();
+    let fired = evaluate_clause(
+        "team.active_agents > 10",
+        &action,
+        None,
+        Some(&FailingCtx),
+        ClauseKind::Allow,
+        &mut failures,
+    );
+    assert!(
+        !fired,
+        "a conditional allow must NOT fire on resolution failure — a failure can never grant"
+    );
+    // (5) audit evidence: the failure is recorded even though the clause did not fire.
+    assert_eq!(
+        failures,
+        vec![ResolutionFailure {
+            variable: "team.active_agents".to_string(),
+            clause: ClauseKind::Allow,
+        }]
+    );
+    assert_eq!(failures[0].fail_safe_action(), "no_grant");
 }


### PR DESCRIPTION
## Description

Implements ADR 0015 §4/§5.3 (workstream 3): the graph-context policy layer now
distinguishes a **legitimate absence** of a variable from a **resolution
failure** (registry/backend/lookup error), and makes failures fail **closed**
with audit evidence — instead of silently no-matching a `deny`/approval clause
or laundering a failure into an `allow` grant.

`PolicyContext` getters changed from `Option<T>` to `Result<Option<T>, ContextError>`:
`Ok(Some)` = value, `Ok(None)` = legitimate absence (**unchanged** null-as-no-match),
`Err` = resolution failure. Both impls (`ProductionPolicyContext`, `FakePolicyContext`)
were migrated; the in-memory production context never returns `Err` (its registry
lookups cannot fail), so **there is no behavioral change for well-formed policies
today** — the `Err` arm exists so a future backend-backed context fails closed.

The expression evaluator applies the deterministic §4 table by clause polarity
(`ClauseKind`), and records every resolution failure as a `ResolutionFailure`
(variable, clause, fail-safe action) that the engine drains to the `audit`
tracing target.

### ADR 0015 §4 table (implemented)

| Clause | `Some(_)` | Legitimate absence (`Ok(None)`) | Resolution failure (`Err`) |
|---|---|---|---|
| `deny` (conditional) | denies iff `true` | no-match — **unchanged** | **DENY** (fail-closed) |
| `requires_approval_if` | fires iff `true` | no-match — **unchanged** | **REQUIRE APPROVAL** (fail-closed) |
| conditional `allow` | grants iff `true` | no-match — **unchanged** | no-match — **NEVER grants** |

Every resolution failure is audit-visible (variable + affected clause +
fail-safe action). See ADR `docs/src/adr/0015-dlp-trust-boundary-and-redaction-semantics.md` §4/§5.3.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] Yes (describe below)

**Behavioural change** (not an API break for well-formed policies): a policy
whose `deny`/`requires_approval_if` clause references a graph variable that
*fails to resolve* now denies / requires approval (and a conditional `allow`
will not grant) instead of silently allowing — a stricter, safer default, and
every such failure is now audit-visible. **Legitimate absence is unchanged**, so
existing well-formed policies see no behavioral difference and the frozen
null-as-no-match snapshots remain byte-identical. The `PolicyContext` trait
signature changed (`Option<T>` → `Result<Option<T>, ContextError>`); the trait
is internal to `aa-gateway`, so no SDK/CLI/HTTP surface is affected.

## Related Issues

- Related Jira ticket: [AAASM-4947](https://lightning-dust-mite.atlassian.net/browse/AAASM-4947) (subtask of AAASM-4945)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Fixtures in `tests/graph_vars_fixture_test.rs` cover all five §4 paths:
(1) legitimate absence records **zero** audit evidence, (2) failure+`deny` ⇒ deny,
(3) failure+`requires_approval_if` ⇒ require approval (end-to-end via
`merge_decisions_audited`), (4) failure+conditional `allow` ⇒ never grants,
(5) each failure asserts the expected `ResolutionFailure` audit record.

- `cargo nextest run -p aa-gateway -p aa-api` → **2357 passed, 0 failed**
- The 5 existing legitimate-absence snapshots remain **byte-identical** (no `.snap.new` generated)
- `cargo fmt` clean; `cargo clippy -p aa-gateway --all-targets -- -D warnings` clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (trait doc + code comments cite ADR 0015 §4)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-4947]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ