### PR TITLE
[AAASM-4957] 🔧 (release): Point homebrew-tap bot-PR base at main + guard drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -740,7 +740,11 @@ jobs:
           path: tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           branch: bot/aasm-${{ steps.version.outputs.version }}
-          base: master
+          # AAASM-4955: homebrew-tap migrated master → main (AAASM-4957); the SDK
+          # bot-PR steps below stay `master` until their repos migrate. The
+          # downstream-base check in scripts/check-release-completeness.sh guards
+          # each of these against silently going stale.
+          base: main
           delete-branch: true
           commit-message: "🤖 (formula): Update tap to ${{ steps.version.outputs.version }}"
           title: "🤖 (formula): aasm ${{ steps.version.outputs.version }}"

--- a/scripts/check-release-completeness.sh
+++ b/scripts/check-release-completeness.sh
@@ -85,6 +85,41 @@ for b in $RELEASE_BINARIES; do
   esac
 done
 
+# 4. Downstream bot-PR base-branch drift (AAASM-4955 / AAASM-4957).
+#    release.yml opens a bot PR into each downstream repo (homebrew-tap + the
+#    three SDKs) via peter-evans/create-pull-request, each with a hardcoded
+#    `base:`. When a downstream repo's default branch is renamed (master → main),
+#    a stale `base:` here silently breaks that repo's release PR — the
+#    homebrew-tap migration hit exactly this. Pin each downstream's expected base
+#    to its CURRENT default branch; a mismatch in either direction fails the gate,
+#    so release.yml and this map must be updated together, in lockstep with each
+#    repo's migration.
+expected_base_for() {
+  # bot-token secret name -> that repo's current default branch
+  case "$1" in
+    HOMEBREW_TAP_TOKEN)   echo main ;;    # migrated (AAASM-4957)
+    NODE_SDK_BOT_TOKEN)   echo master ;;  # migrates under AAASM-4960
+    PYTHON_SDK_BOT_TOKEN) echo master ;;  # migrates under AAASM-4959
+    GO_SDK_BOT_TOKEN)     echo master ;;  # migrates under AAASM-4961
+    *) echo "" ;;
+  esac
+}
+
+# Pair each create-pull-request `base:` with the bot token most recently seen in
+# the same step (portable awk — no gawk match(s,re,arr)).
+while IFS="$(printf '\t')" read -r tok base; do
+  [ -n "${base:-}" ] || continue
+  exp="$(expected_base_for "$tok")"
+  if [ -z "$exp" ]; then
+    err "release.yml opens a bot PR (token '$tok') with base '$base' but check-release-completeness.sh has no expected-base mapping for it — add one so its target branch can't silently go stale (AAASM-4955)."
+  elif [ "$base" != "$exp" ]; then
+    err "downstream bot-PR base for '$tok' is '$base' but that repo's default branch is '$exp' — a release would open the PR against a non-existent branch. Update $RELEASE_YML 'base:' and this map together, in lockstep with the repo's master→main migration (AAASM-4955)."
+  fi
+done < <(awk '
+  /token: \$\{\{ secrets\./ { line=$0; sub(/.*secrets\./,"",line); sub(/[[:space:]]*\}\}.*/,"",line); tok=line }
+  /^[[:space:]]*base:[[:space:]]*[A-Za-z]/ { b=$0; sub(/^[[:space:]]*base:[[:space:]]*/,"",b); sub(/[[:space:]].*$/,"",b); print tok"\t"b }
+' "$RELEASE_YML")
+
 if [ "$fail" -ne 0 ]; then
   echo "release-artifact completeness gate: FAILED" >&2
   exit 1


### PR DESCRIPTION
## Description

Surgical fix from the **homebrew-tap migration pilot** (AAASM-4957, under the master→main Epic AAASM-4955). The tap's default branch was renamed `master → main`; `release.yml` opens the tap version-bump bot PR with a hardcoded `base:`, so the stale `base: master` would make the **next release fail to open the tap PR** (base branch gone).

Two commits, tightly scoped:
1. **`release.yml`** — point **only** the homebrew-tap bot-PR step (`bot/aasm-*`, `HOMEBREW_TAP_TOKEN`) at `base: main`. The three SDK bot-PR steps (`bot/aa-ffi-pin-*`) **stay `master`** — those repos are still on `master`.
2. **`scripts/check-release-completeness.sh`** — extend the existing release gate (already run on any `release.yml` change) with a **downstream-base drift guard**: each bot-PR `base:` is pinned to its repo's current default branch; a mismatch fails CI, so `release.yml` + the expected-base map must move together in lockstep with each migration. This is the "not silently stale" check — it would have caught this bug.

**Explicitly NOT in scope** (per the pilot guardrails):
- agent-assembly's own default branch is **not** renamed.
- The SDK `base: master` lines (846/941/1054) are untouched.
- No other repo migration touched.
- Skill docs that still reference the tap's `master` (`homebrew-tap-merge`, `release-validate-channels`) are non-breaking operator guidance — tracked on AAASM-4958, not fixed here to keep this narrow.

## Type of Change
- [x] 🔧 Configuration / CI change

## Related Issues
- AAASM-4957 (pilot) · AAASM-4958 (agent-assembly migration) · Epic AAASM-4955

## Testing
- **Positive:** `bash scripts/check-release-completeness.sh` → gate **OK** (tap `base: main` matches; SDKs `base: master` match).
- **Negative:** reverting the tap to `base: master` in a temp copy → gate **FAILS** with the exact drift error. Guard verified in both directions.

## Checklist
- [x] Self-review completed
- [x] Focused check added + verified (positive + negative)
- [x] Confirmed no other agent-assembly homebrew-tap ref breaks (only non-breaking skill docs, tracked on 4958)
- [ ] CI green (release-completeness gate runs on this `release.yml` change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)