### PR TITLE
[AAASM-4950] 🐛 (aa-api,aa-gateway): Generic 500 bodies + polarity-correct clause fail-safe

### DIFF
--- a/aa-api/src/routes/edges.rs
+++ b/aa-api/src/routes/edges.rs
@@ -267,7 +267,13 @@ pub async fn report_edge(
         })
         .await
         .map_err(|e| {
-            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
+            // AAASM-4950 (L3): log the underlying store error server-side, but
+            // return a generic 500 body — the internal error string may reveal
+            // storage paths or implementation detail and must not cross the API
+            // boundary to the caller.
+            tracing::error!(error = %e, "failed to insert topology edge");
+            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_detail("Failed to record topology edge".to_string())
         })?;
 
     Ok((StatusCode::CREATED, Json(ReportEdgeResponse { id })))
@@ -357,7 +363,11 @@ pub async fn list_agent_edges(
         _ => state.edge_repo.list_outgoing(agent_id, edge_type, limit).await,
     }
     .map_err(|e| {
-        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
+        // AAASM-4950 (L3): log server-side, return a generic 500 body so the
+        // internal store error never crosses the API boundary.
+        tracing::error!(error = %e, "failed to list agent edges");
+        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_detail("Failed to list topology edges".to_string())
     })?;
 
     // Apply optional `before` cursor (best-effort for in-memory store)
@@ -421,7 +431,11 @@ pub struct GraphResponse {
 /// error-mapping site instead of duplicating it.
 async fn list_outgoing_or_500(state: &AppState, node: AgentId) -> Result<Vec<Edge>, ProblemDetail> {
     state.edge_repo.list_outgoing(node, None, 1000).await.map_err(|e| {
-        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
+        // AAASM-4950 (L3): log server-side, return a generic 500 body so the
+        // internal store error never crosses the API boundary.
+        tracing::error!(error = %e, "failed to list outgoing edges");
+        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_detail("Failed to list topology edges".to_string())
     })
 }
 
@@ -595,7 +609,11 @@ pub async fn list_topology_edges(
     let mut all_edges: Vec<Edge> = Vec::new();
     for &et in EdgeType::ALL {
         let batch = state.edge_repo.list_by_type(et, epoch, 1000).await.map_err(|e| {
-            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
+            // AAASM-4950 (L3): log server-side, return a generic 500 body so the
+            // internal store error never crosses the API boundary.
+            tracing::error!(error = %e, "failed to list topology edges by type");
+            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_detail("Failed to list topology edges".to_string())
         })?;
         all_edges.extend(batch);
     }

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -89,11 +89,14 @@ pub async fn list_policies(
             .with_detail("listing policy versions requires admin scope".to_string()));
     }
 
-    let all = state
-        .policy_history
-        .list(usize::MAX)
-        .await
-        .map_err(|e| ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("{e:?}")))?;
+    let all = state.policy_history.list(usize::MAX).await.map_err(|e| {
+        // AAASM-4950 (L3): log the underlying store error server-side, but return
+        // a generic 500 body — the internal error string may reveal storage paths
+        // or implementation detail and must not cross the API boundary.
+        tracing::error!(error = ?e, "failed to list policy history");
+        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_detail("Failed to list policy versions".to_string())
+    })?;
 
     // Without include_archived only the most-recent (active) version is visible.
     let visible: Vec<_> = if filter.include_archived {

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -454,7 +454,8 @@ pub enum ClauseKind {
 }
 
 impl ClauseKind {
-    /// Whether a *resolution failure* makes a clause of this kind fire. Guards
+    /// Whether a fail-safe condition (a graph-context *resolution failure*, or a
+    /// tokenize/parse anomaly) makes a clause of this kind fire. Guards
     /// (`Deny`/`RequireApproval`) fail closed by firing; a conditional `Allow`
     /// fails closed by NOT firing (never granting).
     fn fail_safe_fires(self) -> bool {
@@ -1088,16 +1089,18 @@ fn eval_tokens(
     fs: &FailSafe,
 ) -> bool {
     // Parse tokens into OR-groups of AND-connected clauses, then evaluate:
-    // OR across groups, AND within each group. Any parse anomaly is fail-safe
-    // (returns `true` — the condition fires).
+    // OR across groups, AND within each group. A parse anomaly is fail-safe
+    // per the clause polarity (ADR 0015 §4): a `Deny`/`RequireApproval` guard
+    // fires, but a conditional `Allow` does NOT fire — an anomaly can never
+    // grant. `fs.clause.fail_safe_fires()` encodes that direction.
     let or_groups = match parse_or_groups(tokens) {
         Some(g) => g,
-        None => return true, // unexpected structure → fail-safe
+        None => return fs.clause.fail_safe_fires(), // unexpected structure → fail-safe
     };
 
     // If nothing was parsed, that's a fail-safe trigger (empty expr)
     if or_groups.is_empty() || or_groups.iter().all(|g| g.is_empty()) {
-        return true;
+        return fs.clause.fail_safe_fires();
     }
 
     or_groups.iter().any(|group| {
@@ -1401,8 +1404,10 @@ pub(crate) fn evaluate(
 /// fires; a conditional `Allow` does not fire, so a failure can never grant),
 /// and every such failure is appended to `failures` as audit evidence.
 ///
-/// Returns `true` when the expression matches (the clause fires); `true` on any
-/// parse/tokenization anomaly (fail-safe).
+/// Returns `true` when the expression matches (the clause fires). A
+/// parse/tokenization anomaly is fail-safe **per clause polarity** (ADR 0015
+/// §4): a `Deny`/`RequireApproval` guard fires (fail-closed), but a conditional
+/// `Allow` does **not** fire — an anomaly can never be laundered into a grant.
 pub fn evaluate_clause(
     expr: &str,
     action: &GovernanceAction,
@@ -1413,7 +1418,10 @@ pub fn evaluate_clause(
 ) -> bool {
     let tokens = match tokenize(expr) {
         Some(t) if !t.is_empty() => t,
-        _ => return true, // fail-safe
+        // AAASM-4950 / ADR 0015 §4: a tokenize anomaly follows the clause's
+        // fail-safe polarity. Firing unconditionally would GRANT on an `Allow`
+        // clause — the exact fail-open §4 forbids ("allow + failure ⇒ never grant").
+        _ => return clause.fail_safe_fires(),
     };
     let sink = std::cell::RefCell::new(Vec::new());
     let fs = FailSafe {

--- a/aa-gateway/tests/graph_vars_fixture_test.rs
+++ b/aa-gateway/tests/graph_vars_fixture_test.rs
@@ -357,3 +357,48 @@ fn resolution_failure_never_grants_for_allow_clause() {
     );
     assert_eq!(failures[0].fail_safe_action(), "no_grant");
 }
+
+// AAASM-4950 / ADR 0015 §4 (forward-conformance): a tokenize/parse anomaly must
+// follow the SAME clause polarity as a resolution failure. Firing unconditionally
+// on an anomaly would GRANT a conditional `Allow` — the exact fail-open §4 forbids
+// ("allow + failure ⇒ never grant"). A guard (`Deny`/`RequireApproval`) still fires.
+#[test]
+fn parse_anomaly_never_grants_for_allow_clause() {
+    let action = tool_action("spawn");
+
+    // Both a tokenize anomaly (unknown char) and a structural anomaly (a bare
+    // field with no operator/literal) must never fire an `Allow` clause.
+    for bad_expr in ["not valid @@@ expr", "tool"] {
+        let mut failures = Vec::new();
+        let fired = evaluate_clause(bad_expr, &action, None, None, ClauseKind::Allow, &mut failures);
+        assert!(
+            !fired,
+            "a conditional allow must NOT fire on a parse anomaly ({bad_expr:?}) — an anomaly can never grant"
+        );
+        // A parse anomaly is not a graph-variable resolution failure, so it
+        // records no ResolutionFailure audit evidence.
+        assert!(
+            failures.is_empty(),
+            "a parse anomaly records no resolution-failure evidence"
+        );
+
+        // The guard polarities still fail closed by firing.
+        let mut deny_failures = Vec::new();
+        assert!(
+            evaluate_clause(bad_expr, &action, None, None, ClauseKind::Deny, &mut deny_failures),
+            "a deny clause must fire (deny) on a parse anomaly ({bad_expr:?})"
+        );
+        let mut approval_failures = Vec::new();
+        assert!(
+            evaluate_clause(
+                bad_expr,
+                &action,
+                None,
+                None,
+                ClauseKind::RequireApproval,
+                &mut approval_failures,
+            ),
+            "a requires_approval clause must fire on a parse anomaly ({bad_expr:?})"
+        );
+    }
+}


### PR DESCRIPTION
## Description

Two small LOW-severity forward-conformance fixes (AAASM-4950).

**Item 1 — 500-body internal-error leak (completes AAASM-4936 L3).** Five 500-error
handlers still put the raw store error string into the `ProblemDetail` body:
`aa-api/src/routes/edges.rs` (`report_edge`, `list_agent_edges`, `get_agent_graph`,
`list_topology_edges`) and `aa-api/src/routes/policies.rs` (`list_policies` policy-history
list). The raw error can reveal storage paths / implementation detail across the API
boundary. Each now mirrors the L3 pattern already used in `dispatch.rs` / `traces.rs`:
log the detail server-side via `tracing::error!` and return a generic `with_detail`
string.

**Item 2 — parse-anomaly fail-safe ignored clause polarity (ADR 0015 §4).** In
`aa-gateway/src/policy/expr.rs`, `evaluate_clause` returned `true` (fires) on a
tokenize/parse anomaly for **every** `ClauseKind`. For `Deny`/`RequireApproval` that
is fail-safe, but a `ClauseKind::Allow` would then GRANT on an anomaly — violating
[ADR 0015 §4](docs/src/adr/0015-dlp-trust-boundary-and-redaction-semantics.md)
("conditional allow + failure ⇒ never grant"). Both the tokenize anomaly and the
structural parse anomaly now route through `ClauseKind::fail_safe_fires()`, so `Allow`
does not fire while the guard polarities still fail closed. Unreachable today (only
`RequireApproval` is wired) but a latent trap; fixed for forward-conformance.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

500 response bodies now carry a generic detail instead of the raw store-error string;
the underlying error is preserved in server logs. No public-API shape change.

## Related Issues

- Related Jira ticket: [AAASM-4950](https://lightning-dust-mite.atlassian.net/browse/AAASM-4950)

## Testing

- [x] Unit tests added / updated

Added `parse_anomaly_never_grants_for_allow_clause` to
`aa-gateway/tests/graph_vars_fixture_test.rs`: a tokenize anomaly and a structural
parse anomaly must not fire a conditional `Allow` (no grant), while `Deny` and
`RequireApproval` still fire per §4.

Local validation (macOS):
- `cargo nextest run -p aa-api -p aa-gateway` — 2358 passed, 0 failed
- `cargo fmt` clean; `cargo clippy -p aa-api -p aa-gateway --all-targets -- -D warnings` clean
- `openapi/v1.yaml` unchanged (only 500 bodies changed, no utoipa annotations)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-4950]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ