### PR TITLE
[AAASM-4959] 🔧 (release): python-sdk bot-PR base → main + guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -942,7 +942,7 @@ jobs:
           path: sdk
           token: ${{ secrets.PYTHON_SDK_BOT_TOKEN }}
           branch: bot/aa-ffi-pin-${{ github.ref_name }}
-          base: master
+          base: main
           delete-branch: true
           commit-message: "🤖 (aa-ffi-python): Bump aa-core/aa-proto/aa-sdk-client pin to ${{ github.ref_name }}"
           title: "🤖 (aa-ffi-python): Bump aa-core/aa-proto/aa-sdk-client pin to ${{ github.ref_name }}"

--- a/scripts/check-release-completeness.sh
+++ b/scripts/check-release-completeness.sh
@@ -99,7 +99,7 @@ expected_base_for() {
   case "$1" in
     HOMEBREW_TAP_TOKEN)   echo main ;;    # migrated (AAASM-4957)
     NODE_SDK_BOT_TOKEN)   echo master ;;  # migrates under AAASM-4960
-    PYTHON_SDK_BOT_TOKEN) echo master ;;  # migrates under AAASM-4959
+    PYTHON_SDK_BOT_TOKEN) echo main ;;    # migrated (AAASM-4959)
     GO_SDK_BOT_TOKEN)     echo master ;;  # migrates under AAASM-4961
     *) echo "" ;;
   esac


### PR DESCRIPTION
## Description

Lockstep companion to **python-sdk#293** for its default-branch migration (`master` → `main`, [ADR 0016](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/docs/src/adr/0016-default-branch-master-to-main-migration.md) / AAASM-4959). python-sdk has been renamed to `main`, so the release fan-out must open its aa-ffi pin-bump PR against `main`:

- `.github/workflows/release.yml` — the `update-python-sdk-ffi-pin` job's `peter-evans/create-pull-request` step (`PYTHON_SDK_BOT_TOKEN`, branch `bot/aa-ffi-pin-*`): `base: master` → `base: main`. **Only this step** — the node-sdk and go-sdk steps stay `base: master` (those repos migrate under AAASM-4960 / AAASM-4961).
- `scripts/check-release-completeness.sh` — the downstream-base drift guard's `expected_base_for PYTHON_SDK_BOT_TOKEN` → `main`, in lockstep, so the guard stays green.

Without this, the next `agent-assembly` release would fail to open the python-sdk pin PR (base `master` no longer exists as a branch).

## Type of Change

- [x] 🔧 Bug fix (release automation — config)

## Breaking Changes

- [x] No — keeps the release fan-out targeting python-sdk's new default branch.

## Related Issues

- Related JIRA ticket: AAASM-4959 (Epic AAASM-4955)
- Stacked with: python-sdk#293 (the outbound rename sweep). This PR must land in the same window as the python-sdk rename.

## Note on base branch

This PR targets `master` because `agent-assembly` itself is **not** migrated yet (it migrates LAST per ADR 0016 §8, after the SDK/tap base lockstep is proven).

## Testing

- [x] `bash scripts/check-release-completeness.sh` → `OK` (exit 0) with python-sdk expected base = `main` and release.yml python step base = `main` (consistent). node/go remain `master` and stay consistent.

## Checklist

- [x] Self-review completed
- [x] Only the python-sdk step changed; node/go untouched
