### PR TITLE
🔧 deps(dashboard): fix brace-expansion DoS alerts (#41, #42, #43)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -69,7 +69,10 @@
       "dompurify": "^3.4.11",
       "esbuild": "^0.28.1",
       "js-yaml": "^4.3.0",
-      "undici": "^7.28.0"
+      "undici": "^7.28.0",
+      "brace-expansion@1": "^1.1.16",
+      "brace-expansion@2": "^2.1.2",
+      "brace-expansion@5": "^5.0.7"
     }
   }
 }

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   esbuild: ^0.28.1
   js-yaml: ^4.3.0
   undici: ^7.28.0
+  brace-expansion@1: ^1.1.16
+  brace-expansion@2: ^2.1.2
+  brace-expansion@5: ^5.0.7
 
 importers:
 
@@ -1352,14 +1355,14 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3815,16 +3818,16 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4478,19 +4481,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- Closes Dependabot alerts #41, #42, and #43 for the transitive `brace-expansion` package in `dashboard/pnpm-lock.yaml` (regex DoS via exponential-time expansion, GHSA).
- `brace-expansion` is pulled in transitively (via `minimatch`/`glob` chains), not a direct dependency, so it is not added to `package.json`'s `dependencies`.
- Added version-scoped `pnpm.overrides` entries in `dashboard/package.json` so each vulnerable major line resolves to its own patched release:
  - `brace-expansion@1` -> `^1.1.16` (fixes alert #42, was `< 1.1.16`)
  - `brace-expansion@2` -> `^2.1.2` (fixes alert #43, was `>= 2.0.0, < 2.1.2`)
  - `brace-expansion@5` -> `^5.0.7` (fixes alert #41, was `>= 3.0.0, < 5.0.7`; brace-expansion skipped 3.x/4.x version numbers)
- No direct dependency versions changed; `dashboard/pnpm-lock.yaml` regenerated via `pnpm install`.

## Verification
- `grep "brace-expansion@" pnpm-lock.yaml` confirms only `1.1.16`, `2.1.2`, and `5.0.7` remain resolved — no vulnerable ranges left.
- `pnpm run type-check` — clean
- `pnpm run build` — succeeds (pre-existing chunk-size/dynamic-import warnings only, unrelated to this change)
- `pnpm run lint` — clean
- `pnpm run test` — 1501/1501 tests passed (168 test files)

## Test plan
- [x] Confirm all 3 alerts resolved in regenerated lockfile
- [x] `pnpm run type-check` passes
- [x] `pnpm run build` succeeds
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (1501/1501)

Closes #41, #42, #43