### PR TITLE
[AAASM-4960] 🔧 (release): node-sdk bot-PR base → main + guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -847,7 +847,7 @@ jobs:
           path: sdk
           token: ${{ secrets.NODE_SDK_BOT_TOKEN }}
           branch: bot/aa-ffi-pin-${{ github.ref_name }}
-          base: master
+          base: main
           delete-branch: true
           commit-message: "🤖 (aa-ffi-node): Bump agent-assembly git pins to ${{ github.ref_name }}"
           title: "🤖 (aa-ffi-node): Bump agent-assembly git pins to ${{ github.ref_name }}"

--- a/scripts/check-release-completeness.sh
+++ b/scripts/check-release-completeness.sh
@@ -98,7 +98,7 @@ expected_base_for() {
   # bot-token secret name -> that repo's current default branch
   case "$1" in
     HOMEBREW_TAP_TOKEN)   echo main ;;    # migrated (AAASM-4957)
-    NODE_SDK_BOT_TOKEN)   echo master ;;  # migrates under AAASM-4960
+    NODE_SDK_BOT_TOKEN)   echo main ;;    # migrated (AAASM-4960)
     PYTHON_SDK_BOT_TOKEN) echo main ;;    # migrated (AAASM-4959)
     GO_SDK_BOT_TOKEN)     echo master ;;  # migrates under AAASM-4961
     *) echo "" ;;


### PR DESCRIPTION
## Description

Lockstep half of the **node-sdk** default-branch rename `master → main` (AAASM-4960, ADR 0016). The `node-sdk` repo default was renamed to `main`; this repo's release fan-out opens the `aa-ffi-node` pin-bump bot PR **into** node-sdk with a hardcoded `base:`, so that base must flip in the same window or the next release opens the PR against a non-existent branch.

Two one-line changes:

- `.github/workflows/release.yml` — the `update-node-sdk-ffi-pin` step (`peter-evans/create-pull-request`, token `NODE_SDK_BOT_TOKEN`, branch `bot/aa-ffi-pin-*`): `base: master` → `base: main`.
- `scripts/check-release-completeness.sh` — the downstream-base drift guard map: `NODE_SDK_BOT_TOKEN) echo master` → `echo main` (comment updated to "migrated (AAASM-4960)").

`python-sdk` (AAASM-4959) is already `main`; `go-sdk` stays `master` until AAASM-4961; `homebrew-tap` already `main` (AAASM-4957).

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-4960](https://lightning-dust-mite.atlassian.net/browse/AAASM-4960) (Epic AAASM-4955)

## Testing

- [x] Manual testing performed

Ran the drift guard locally after the change — exit 0:

```
$ bash scripts/check-release-completeness.sh
release-artifact completeness gate: OK
```

The guard now pins the node-sdk downstream bot-PR base to `main` and compares it against `release.yml`; both are `main`, so it passes. (Positive case; a mismatch would fail the gate, as designed.)

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (guard comment)
- [x] Commits are small and follow the Gitmoji convention

---

Depends on / pairs with the node-sdk rename + outbound-ref PR (AAASM-4960). The rename itself is already applied (node-sdk default = `main`); this PR keeps the release fan-out consistent with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-4960]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ