### PR TITLE
[AAASM-4961] 🔧 (release): go-sdk bot-PR base → main + guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1055,7 +1055,7 @@ jobs:
           path: sdk
           token: ${{ secrets.GO_SDK_BOT_TOKEN }}
           branch: bot/aa-ffi-pin-${{ github.ref_name }}
-          base: master
+          base: main
           delete-branch: true
           commit-message: "🤖 (aa-ffi-go): Bump agent-assembly git pins to ${{ github.ref_name }}"
           title: "🤖 (aa-ffi-go): Bump agent-assembly git pins to ${{ github.ref_name }}"

--- a/scripts/check-release-completeness.sh
+++ b/scripts/check-release-completeness.sh
@@ -100,7 +100,7 @@ expected_base_for() {
     HOMEBREW_TAP_TOKEN)   echo main ;;    # migrated (AAASM-4957)
     NODE_SDK_BOT_TOKEN)   echo main ;;    # migrated (AAASM-4960)
     PYTHON_SDK_BOT_TOKEN) echo main ;;    # migrated (AAASM-4959)
-    GO_SDK_BOT_TOKEN)     echo master ;;  # migrates under AAASM-4961
+    GO_SDK_BOT_TOKEN)     echo main ;;    # migrated (AAASM-4961)
     *) echo "" ;;
   esac
 }


### PR DESCRIPTION
## Description

Lockstep companion to the go-sdk default-branch rename ([AAASM-4961](https://lightning-dust-mite.atlassian.net/browse/AAASM-4961), Epic [AAASM-4955](https://lightning-dust-mite.atlassian.net/browse/AAASM-4955), ADR 0016). go-sdk's default branch was renamed `master` → `main`; the release fan-out opens a `native/aa-ffi-go` pin-bump bot PR into go-sdk with a hardcoded `base:`, which must flip in the same window or the next release opens the PR against a non-existent branch (ADR 0016 §3 — the exact class of break the homebrew-tap pilot hit).

Two changes, one logical unit:
- `.github/workflows/release.yml` — the `GO_SDK_BOT_TOKEN` `peter-evans/create-pull-request` step's `base: master` → `base: main` (only that step; homebrew/python/node were already `main`).
- `scripts/check-release-completeness.sh` — drift-guard map entry `GO_SDK_BOT_TOKEN` now expects `main`.

With this, **all four** downstream bot-PR bases (homebrew, python, node, go) are `main`. The guard passes **exit 0** run from the repo root:

```
release-artifact completeness gate: OK
```

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-4961

## Testing

- [x] Manual testing performed — `bash scripts/check-release-completeness.sh` from repo root → exit 0 / OK (positive check: go-sdk base now matches its `main` default). No Rust sources touched.
- [x] No tests required (explain why) — refs-only config change; the drift guard itself is the regression check and is green.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

[AAASM-4961]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-4955]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ