### PR TITLE
[AAASM-5012] 🐛 (aa-runtime): fix --help panic

### DIFF
--- a/aa-runtime/src/main.rs
+++ b/aa-runtime/src/main.rs
@@ -9,7 +9,86 @@ fn init_tracing() {
         .init();
 }
 
+/// Meta-flag the binary handles before doing any real work.
+///
+/// `aa-runtime` takes no positional arguments and is configured entirely through
+/// environment variables, but `--help`/`--version` must still short-circuit
+/// *before* config load — otherwise an operator inspecting the image gets a Rust
+/// panic on the required `AA_AGENT_ID` instead of documented usage (AAASM-5012).
+enum CliAction {
+    Help,
+    Version,
+    Run,
+}
+
+/// Scan CLI args for `--help`/`--version` meta-flags.
+///
+/// `--help` wins over `--version` when both are present, matching the convention
+/// of clap and most CLIs. Unknown flags are ignored here so normal startup
+/// proceeds to env-based configuration.
+fn parse_cli_action(args: impl IntoIterator<Item = String>) -> CliAction {
+    let mut version = false;
+    for arg in args {
+        match arg.as_str() {
+            "--help" | "-h" => return CliAction::Help,
+            "--version" | "-V" => version = true,
+            _ => {}
+        }
+    }
+    if version {
+        CliAction::Version
+    } else {
+        CliAction::Run
+    }
+}
+
+fn print_usage() {
+    let bin = env!("CARGO_PKG_NAME");
+    let version = env!("CARGO_PKG_VERSION");
+    println!(
+        "{bin} {version}
+Authoritative enforcement sidecar for Agent Assembly.
+
+USAGE:
+    {bin} [OPTIONS]
+
+OPTIONS:
+    -h, --help       Print this help and exit
+    -V, --version    Print version and exit
+
+CONFIGURATION:
+    aa-runtime takes no positional arguments; it is configured entirely through
+    environment variables.
+
+    Required:
+      AA_AGENT_ID              Unique agent identifier (must not contain '/' or '..')
+
+    Common:
+      AA_GATEWAY_ENDPOINT      Gateway URL for policy/event RPCs (e.g. http://gateway:50051)
+      AA_POLICY_PATH           Path to policy.toml (default: /etc/aa/policy.toml)
+      AA_METRICS_ADDR          Prometheus metrics bind address (default: 0.0.0.0:8080)
+      AA_GATEWAY_FAIL_CLOSED   Deny when the gateway is unreachable (default: true)
+
+    See the aa-runtime documentation for the full list of AA_* variables."
+    );
+}
+
 fn main() {
+    // Handle meta-flags before tracing init, privilege enforcement, or config
+    // load so `--help`/`--version` always print and exit 0 — even in an
+    // unconfigured image where `AA_AGENT_ID` is unset (AAASM-5012).
+    match parse_cli_action(std::env::args().skip(1)) {
+        CliAction::Help => {
+            print_usage();
+            return;
+        }
+        CliAction::Version => {
+            println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+            return;
+        }
+        CliAction::Run => {}
+    }
+
     init_tracing();
 
     // AAASM-3605: the runtime must hold NO BPF-class capabilities — probe
@@ -40,4 +119,37 @@ fn main() {
         .build()
         .expect("failed to build Tokio runtime")
         .block_on(aa_runtime::run(config));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn action(args: &[&str]) -> CliAction {
+        parse_cli_action(args.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn no_flags_runs() {
+        assert!(matches!(action(&[]), CliAction::Run));
+        assert!(matches!(action(&["--unknown", "positional"]), CliAction::Run));
+    }
+
+    #[test]
+    fn help_flags_detected() {
+        assert!(matches!(action(&["--help"]), CliAction::Help));
+        assert!(matches!(action(&["-h"]), CliAction::Help));
+    }
+
+    #[test]
+    fn version_flags_detected() {
+        assert!(matches!(action(&["--version"]), CliAction::Version));
+        assert!(matches!(action(&["-V"]), CliAction::Version));
+    }
+
+    #[test]
+    fn help_takes_precedence_over_version() {
+        assert!(matches!(action(&["--version", "--help"]), CliAction::Help));
+        assert!(matches!(action(&["--help", "--version"]), CliAction::Help));
+    }
 }


### PR DESCRIPTION
## Description

`aa-runtime --help` (and any invocation without `AA_AGENT_ID`) panicked instead of printing usage:

```
thread 'main' panicked at aa-runtime/src/main.rs:22:64:
failed to load runtime configuration: AA_AGENT_ID is required but not set
```

Root cause: `aa-runtime` has no argument parsing — `main()` read config purely from the environment and never inspected `argv`, so `--help` fell straight through to `RuntimeConfig::from_env()`, which errors (and is `.expect()`-ed → panics) when `AA_AGENT_ID` is unset. An operator inspecting the runtime image got a Rust panic + backtrace hint rather than documented usage.

Fix: intercept `--help`/`-h` and `--version`/`-V` at the top of `main()`, *before* tracing init, privilege enforcement, and config load. `--help` prints usage plus the required (`AA_AGENT_ID`) and common (`AA_GATEWAY_ENDPOINT`, `AA_POLICY_PATH`, `AA_METRICS_ADDR`, `AA_GATEWAY_FAIL_CLOSED`) env vars and exits 0; `--version` prints `aa-runtime <version>` and exits 0. `--help` takes precedence over `--version` when both are present (matching clap). Scope limited to `aa-runtime/src/main.rs`.

Before:
```
$ aa-runtime --help
thread 'main' panicked at aa-runtime/src/main.rs:22:64: failed to load runtime configuration: AA_AGENT_ID is required but not set
```
After:
```
$ aa-runtime --help
aa-runtime 0.0.1-rc.6
Authoritative enforcement sidecar for Agent Assembly.

USAGE:
    aa-runtime [OPTIONS]
...
    Required:
      AA_AGENT_ID              Unique agent identifier (must not contain '/' or '..')
...
$ echo $?
0
```

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-5012](https://lightning-dust-mite.atlassian.net/browse/AAASM-5012)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated — `parse_cli_action` unit tests (help/version/`-h`/`-V`/precedence/no-flags) in `aa-runtime/src/main.rs`
- [x] Manual testing performed — `./target/debug/aa-runtime --help`, `--version`, `-h` all print and exit 0 with `AA_AGENT_ID` unset

Local results: `cargo nextest run -p aa-runtime` → 381 passed; `cargo clippy -p aa-runtime --all-targets -- -D warnings` clean; `cargo fmt -p aa-runtime -- --check` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-5012]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ