### PR TITLE
[AAASM-4958] 🔧 (config): Migrate default branch master → main

### DIFF
--- a/.ci/check-compatibility-matrix.sh
+++ b/.ci/check-compatibility-matrix.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-BASE="${GITHUB_BASE_REF:-master}"
+BASE="${GITHUB_BASE_REF:-main}"
 MERGE_BASE=$(git merge-base HEAD "origin/${BASE}")
 CHANGED=$(git diff --name-only "${MERGE_BASE}"...HEAD)
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -79,12 +79,12 @@ cargo doc --workspace --no-deps        # checked on push by hooks
   (`<type>` = feat/fix/refactor/test/docs/config/deps/remove/lint;
   e.g. `v0.0.1/AAASM-42/feat/add_agent_registry`).
 - **PR title:** `[<ticket>] <emoji> (<scope>): <summary>`; base branch **always
-  `master`**; body follows the repo PR template; ≥1 Pioneer-team approval.
+  `main`**; body follows the repo PR template; ≥1 Pioneer-team approval.
 
 ## Repo-specific gotchas
 
 - **Push remote is `remote`** (→ `ai-agent-assembly/agent-assembly`, canonical), not
-  `origin` (a personal fork). Scope changes against `remote/master`, which is often
+  `origin` (a personal fork). Scope changes against `remote/main`, which is often
   far ahead of a fork checkout.
 - **Pre-push runs `cargo doc` with no path glob**, so it fails on eBPF/macOS even for
   docs-only changes. For Markdown/`.claude`-only branches that can't satisfy it,

--- a/.claude/skills/release-docs-sync/SKILL.md
+++ b/.claude/skills/release-docs-sync/SKILL.md
@@ -104,7 +104,7 @@ not on `X`.
 
 ## Procedure
 
-Work in a worktree off fresh `remote/master` (see the project worktree rules).
+Work in a worktree off fresh `remote/main` (see the project worktree rules).
 Edit each file below, then run the verifier. Granular GitEmoji commits.
 
 ### Step 1 — agent-assembly `docs/` + README (the verifier covers these)

--- a/.claude/skills/release-tag-cut/REFERENCE.md
+++ b/.claude/skills/release-tag-cut/REFERENCE.md
@@ -25,13 +25,13 @@ All of the following MUST hold before any step below runs. If any fails,
 stop and report — do not attempt to remediate from inside this skill.
 
 1. **Working tree clean** — `git status --porcelain` returns no output.
-2. **On `master`, up to date with `remote/master`** —
-   `git rev-parse --abbrev-ref HEAD` is `master`, and
-   `git rev-list --count remote/master..HEAD` and
-   `git rev-list --count HEAD..remote/master` both return `0`.
+2. **On `main`, up to date with `remote/main`** —
+   `git rev-parse --abbrev-ref HEAD` is `main`, and
+   `git rev-list --count remote/main..HEAD` and
+   `git rev-list --count HEAD..remote/main` both return `0`.
    (Run `git fetch remote` first.)
-3. **Most recent CI run on master is green** — query via
-   `gh run list --branch master --limit 1 --json conclusion,status`
+3. **Most recent CI run on main is green** — query via
+   `gh run list --branch main --limit 1 --json conclusion,status`
    and confirm `status=completed` and `conclusion=success`.
 4. **Target version provided** — the operator supplies `<X>` (e.g.
    `0.0.1-alpha.10`). The skill does not invent or bump version numbers.
@@ -116,7 +116,7 @@ git tag -a "v<X>" -m "Release v<X>
 See docs/release/v<X>.md for details."
 ```
 
-Do not push intermediate commits to master from inside this skill — the
+Do not push intermediate commits to main from inside this skill — the
 bump PR (RUNBOOK section 1) should already be merged before invocation.
 This skill's only push is the tag itself.
 

--- a/.claude/skills/release-tag-cut/SKILL.md
+++ b/.claude/skills/release-tag-cut/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: release-tag-cut
-description: Cut a coordinated agent-assembly release tag: bump every workspace Cargo version literal, regenerate Cargo.lock, create the annotated tag, and push it to trigger release.yml. Use when an operator is ready to cut a new pre-release agent-assembly tag (the current cadence is the 0.0.1-beta.N series; earlier cuts were 0.0.1-alpha.N) on a green master and wants the version bump, tag, release-notes, and downstream fan-out handled in the correct order.
+description: Cut a coordinated agent-assembly release tag: bump every workspace Cargo version literal, regenerate Cargo.lock, create the annotated tag, and push it to trigger release.yml. Use when an operator is ready to cut a new pre-release agent-assembly tag (the current cadence is the 0.0.1-beta.N series; earlier cuts were 0.0.1-alpha.N) on a green main and wants the version bump, tag, release-notes, and downstream fan-out handled in the correct order.
 ---
 
 # release-tag-cut
 
 Executable contract for cutting an agent-assembly release tag from a clean
-`master`. This SKILL.md is a lean overview; the per-step detail lives in
+`main`. This SKILL.md is a lean overview; the per-step detail lives in
 [REFERENCE.md](REFERENCE.md) and a concrete walk-through in
 [EXAMPLES.md](EXAMPLES.md). The canonical prose, recovery procedure, manual
 gates, and downstream channel matrix live in
@@ -55,10 +55,10 @@ Pick this skill when **all** of the following hold:
 - The operator has decided agent-assembly is ready for a new pre-release tag
   (current cadence: the beta series, e.g. cutting `0.0.1-beta.3` after
   `0.0.1-beta.2`; the same path served the earlier `0.0.1-alpha.N` cuts).
-- The most recent CI run on `master` is green.
+- The most recent CI run on `main` is green.
 - Draft release notes exist (or the operator is prepared to write them inline
   during step 5).
-- The working tree is clean and `master` is up to date with `remote/master`.
+- The working tree is clean and `main` is up to date with `remote/main`.
 
 The triggering operator phrasing is typically:
 
@@ -78,7 +78,7 @@ specific. Pick a different path in any of the following cases:
   review, not this autopilot path.
 - **Hotfix to an already-tagged release** — use the SDK-only path or a
   follow-up patch tag coordinated via the RUNBOOK; do not re-cut the same tag.
-- **Pre-conditions not met** — if `master` is dirty, behind `remote/master`,
+- **Pre-conditions not met** — if `main` is dirty, behind `remote/main`,
   or has a red CI run, stop and surface the gap to the operator.
 - **No PASS security sign-off for `<X>`** — if
   `docs/release/security-signoff/v<X>.md` is missing or its verdict is not
@@ -90,7 +90,7 @@ specific. Pick a different path in any of the following cases:
 After this skill ends (`git push remote v<X>`), agent-assembly's `release.yml` will publish the GitHub Release and fire two automation jobs:
 
 - `notify-downstream` — `repository_dispatch` so node-sdk and python-sdk know `aasm-*` binaries are downloadable (AAASM-2336).
-- `update-{node|python|go}-sdk-ffi-pin` — opens an auto-bump PR on each SDK that aligns the `aa-sdk-client` git-SHA pin on master with this tag's commit (AAASM-2883 + AAASM-3006).
+- `update-{node|python|go}-sdk-ffi-pin` — opens an auto-bump PR on each SDK that aligns the `aa-sdk-client` git-SHA pin on main with this tag's commit (AAASM-2883 + AAASM-3006).
 
 ### Operator rule for the SDK side (codified in each SDK's `sdk-only-release` skill — AAASM-3007)
 
@@ -129,8 +129,8 @@ remediate from inside this skill. Full detail in
 [REFERENCE.md → Pre-conditions](REFERENCE.md#pre-conditions).
 
 1. **Working tree clean** (`git status --porcelain` empty).
-2. **On `master`, in sync with `remote/master`** (fetch first; zero ahead/behind).
-3. **Most recent CI run on master is green** (`gh run list --branch master …`).
+2. **On `main`, in sync with `remote/main`** (fetch first; zero ahead/behind).
+3. **Most recent CI run on main is green** (`gh run list --branch main …`).
 4. **Target version `<X>` provided** — the skill does not invent or bump it.
 5. **Security sign-off PASS for `<X>`** — `docs/release/security-signoff/v<X>.md`
    exists and contains `Verdict: PASS` (stage 0, `/release-security-gate <X>`).

--- a/.claude/skills/release-validate-channels/REFERENCE.md
+++ b/.claude/skills/release-validate-channels/REFERENCE.md
@@ -255,7 +255,7 @@ the missing-package list.
 ```bash
 # agent-assembly main docs site
 gh run list --repo ai-agent-assembly/agent-assembly \
-  --workflow "Docs" --branch master --limit 1 \
+  --workflow "Docs" --branch main --limit 1 \
   --json status,conclusion,createdAt,url
 
 # python-sdk and node-sdk publish docs via GitHub Pages directly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-*/**"
       - "proto/**"
@@ -28,7 +28,7 @@ on:
       - "!**/*.webp"
       - "!**/*.ico"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-*/**"
       - "proto/**"
@@ -53,7 +53,7 @@ on:
   # AAASM-3446: the per-PR / per-push path-filter above gates the slow eBPF
   # jobs (ebpf-build, e2e-ebpf-linux) to aa-ebpf*/** changes for cost control,
   # which means the Layer 3 (eBPF) / three-layer suite is normally SKIPPED on
-  # master. A weekly schedule + on-demand dispatch restores standing master
+  # main. A weekly schedule + on-demand dispatch restores standing main
   # coverage for the AAASM-1520/1522/1523 suites at ~1 run/week without
   # adding per-PR eBPF cost. The eBPF jobs' `if:` opt in to these events.
   schedule:
@@ -504,7 +504,7 @@ jobs:
           name: rust-coverage-lcov
           path: lcov.info
           # AAASM-3829: 14d (not 1d) so the AAASM-3197 cross-run backfill in the
-          # `sonar` job reliably finds this artifact when a Rust-less master push
+          # `sonar` job reliably finds this artifact when a Rust-less main push
           # (dashboard-only / dep bump) path-skips the `coverage` job — otherwise
           # the scan silently runs without Rust LCOV (dashboard-only, ~5k lines).
           retention-days: 14
@@ -744,7 +744,7 @@ jobs:
     needs: [changes]
     # AAASM-2580: per-PR/push, only run when aa-ebpf* (or this workflow) changed.
     # AAASM-3446: also run on the weekly schedule and on manual dispatch so the
-    # Layer 3 suite keeps standing master coverage despite the path-filter.
+    # Layer 3 suite keeps standing main coverage despite the path-filter.
     if: needs.changes.outputs.ebpf == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: eBPF probes build (Linux nightly)
     runs-on: ubuntu-latest
@@ -833,7 +833,7 @@ jobs:
     needs: [changes]
     # AAASM-2580: per-PR/push, only run when aa-ebpf* (or this workflow) changed.
     # AAASM-3446: also run on the weekly schedule and on manual dispatch so the
-    # Layer 3 e2e suite keeps standing master coverage despite the path-filter.
+    # Layer 3 e2e suite keeps standing main coverage despite the path-filter.
     if: needs.changes.outputs.ebpf == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     # AAASM-1520 / F116 ST-H — Layer 3 (eBPF) end-to-end interception suite.
     # Linux-only, runs as root for CAP_BPF + CAP_PERFMON; the test source is
@@ -1217,11 +1217,11 @@ jobs:
   # only when `coverage` succeeded and the TS download only when `dashboard-test`
   # succeeded. Runs in the pull_request context so PR decoration works (AAASM-2542).
   #
-  # AAASM-3197: SonarCloud treats every master-branch analysis as a FULL snapshot
+  # AAASM-3197: SonarCloud treats every main-branch analysis as a FULL snapshot
   # that REPLACES the project's coverage. A push that touches only one side (e.g.
   # dashboard-only → `coverage` skipped) would otherwise publish a partial report
   # that wipes the other side's coverage to 0. On pushes, whichever producer was
-  # skipped/failed is backfilled from the last successful master run so the
+  # skipped/failed is backfilled from the last successful main run so the
   # snapshot is always complete. PR analysis (new-code-only) is left unchanged.
   sonar:
     name: SonarCloud analysis
@@ -1229,7 +1229,7 @@ jobs:
     if: ${{ !cancelled() && needs.changes.result == 'success' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-coverage') || needs.changes.outputs.dashboard == 'true') }}
     runs-on: ubuntu-latest
     # AAASM-3197: actions:read lets `gh run download` pull the last successful
-    # master LCOV when a coverage producer was skipped this run (see fallback
+    # main LCOV when a coverage producer was skipped this run (see fallback
     # steps below). contents:read mirrors the workflow default for checkout.
     permissions:
       contents: read
@@ -1257,25 +1257,25 @@ jobs:
         with:
           name: rust-coverage-lcov
           path: .
-      # AAASM-3197: master-branch analysis is a FULL snapshot — a partial report
+      # AAASM-3197: main-branch analysis is a FULL snapshot — a partial report
       # wipes the other side's coverage to 0. When the `coverage` job was skipped
       # or failed on a push (non-Rust change), backfill `lcov.info` from the most
-      # recent successful master CI run so the snapshot stays complete. PR runs are
+      # recent successful main CI run so the snapshot stays complete. PR runs are
       # new-code-decorated and intentionally left untouched.
-      - name: Backfill Rust coverage (LCOV) from last successful master run
+      - name: Backfill Rust coverage (LCOV) from last successful main run
         if: ${{ github.event_name == 'push' && needs.coverage.result != 'success' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          run_id="$(gh run list --workflow ci.yml --branch master \
+          run_id="$(gh run list --workflow ci.yml --branch main \
             --status success --limit 1 --json databaseId \
             --jq '.[0].databaseId')"
           if [ -z "$run_id" ]; then
-            echo "::warning::No prior successful master CI run found; scanning without backfilled Rust LCOV."
+            echo "::warning::No prior successful main CI run found; scanning without backfilled Rust LCOV."
             exit 0
           fi
-          echo "Backfilling rust-coverage-lcov from master run ${run_id}."
+          echo "Backfilling rust-coverage-lcov from main run ${run_id}."
           gh run download "$run_id" --name rust-coverage-lcov --dir . \
             || echo "::warning::rust-coverage-lcov artifact unavailable on run ${run_id} (expired/absent); scanning without it."
       # ---- TypeScript coverage ---------------------------------------------
@@ -1287,7 +1287,7 @@ jobs:
       # billing-throttled scan), letting Sonar scan with 0.0% dashboard coverage.
       # This avoids re-running the dashboard tests on the common path (a dashboard
       # PR, where `dashboard-test` already ran) while still guaranteeing coverage
-      # on a Rust-only master push (where `dashboard-test` is path-skipped but the
+      # on a Rust-only main push (where `dashboard-test` is path-skipped but the
       # AAASM-3197 full-snapshot invariant still requires dashboard coverage).
       - name: Download TypeScript coverage (LCOV) from the Dashboard test job
         if: needs.dashboard-test.result == 'success'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ name: CodeQL
 # recorded ZERO CodeQL analyses (code-scanning/analyses -> 404, default-setup
 # not-configured). Code scanning only updates the repo's security tab when an
 # analysis is uploaded from a `push` to the default branch, so this workflow
-# triggers on push to master (not just pull_request) plus a weekly schedule.
+# triggers on push to main (not just pull_request) plus a weekly schedule.
 # Mirrors the known-good go-sdk codeql.yml, adapted for this Rust + TS/JS repo.
 
 on:
@@ -18,7 +18,7 @@ on:
       - "**/*.md"
       - "LICENSE"
     branches:
-      - master
+      - main
   schedule:
     - cron: "0 3 * * 1"
 

--- a/.github/workflows/crate-pinnability-smoke.yml
+++ b/.github/workflows/crate-pinnability-smoke.yml
@@ -14,7 +14,7 @@ permissions:
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-core/**"
       - "aa-proto/**"
@@ -26,7 +26,7 @@ on:
       - "scripts/standalone-build-smoke.sh"
       - ".github/workflows/crate-pinnability-smoke.yml"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-core/**"
       - "aa-proto/**"

--- a/.github/workflows/dev-verify.yml
+++ b/.github/workflows/dev-verify.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "Makefile"
       - "scripts/**"
@@ -19,7 +19,7 @@ on:
       - "!**/*.webp"
       - "!**/*.ico"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "Makefile"
       - "scripts/**"

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -10,13 +10,13 @@ permissions:
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - 'README.md'
       - 'scripts/check-doc-links.sh'
       - '.github/workflows/doc-links.yml'
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - 'README.md'
       - 'scripts/check-doc-links.sh'

--- a/.github/workflows/docker-image-smoke.yml
+++ b/.github/workflows/docker-image-smoke.yml
@@ -20,7 +20,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-runtime/**"
       - "docker/**"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-runtime/**"
       - "aa-gateway/**"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: Docs
 
-# Least-privilege default for every job. The PR/master-push `build` and
+# Least-privilege default for every job. The PR/main-push `build` and
 # `verify-commands` jobs only read the repo; the elevated `pages: write` +
 # `id-token: write` scopes are granted to the `deploy` job alone (AAASM-3877).
 permissions:
@@ -8,7 +8,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - 'docs/**'
       - 'README.md'
@@ -26,7 +26,7 @@ on:
       # AAASM-4922: the metadata-drift lint (ADR 0014); re-run it when it changes.
       - '.ci/check-metadata-drift.sh'
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - 'docs/**'
       - 'README.md'
@@ -50,7 +50,7 @@ jobs:
   build:
     name: Build mdBook
     runs-on: ubuntu-latest
-    # PR + master-push always build. A workflow_run only proceeds when the
+    # PR + main-push always build. A workflow_run only proceeds when the
     # upstream Release succeeded, was a TAG PUSH (not a pull_request / dispatch
     # dry-run — AAASM-3714; our branch names also start with 'v', so the
     # head_branch check alone is insufficient), and the tag looks like a release
@@ -66,7 +66,7 @@ jobs:
           # Full history so the last-changed preprocessor can read per-page
           # git dates; a shallow clone would collapse every page to one commit.
           fetch-depth: 0
-          # For a release cut, build the docs from the tagged commit, not master.
+          # For a release cut, build the docs from the tagged commit, not main.
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
 
       - name: Install Rust toolchain
@@ -121,19 +121,19 @@ jobs:
       # The Pages site is laid out as per-version subpaths under `_site/`:
       #   _site/index.html      -> root redirect (stable -> pre-release -> latest)
       #   _site/versions.json   -> manifest read by the selector + warning banner
-      #   _site/latest/         -> live docs tracking master
+      #   _site/latest/         -> live docs tracking main
       #   _site/<vX.Y.Z[-pre]>/ -> frozen, immutable release snapshots
       #
       # versions.json describes moving CHANNELS that point at a concrete
       # subpath, plus immutable ARCHIVED concrete versions:
       #   { "channels": [ {id,title,target}, ... ],
       #     "archived": [ {id,title}, ... ] }
-      # Channels: latest (master), pre-release (newest vX.Y.Z-pre tag),
+      # Channels: latest (main), pre-release (newest vX.Y.Z-pre tag),
       #           stable (newest vX.Y.Z tag). Channel id classification:
       #   ^v\d+\.\d+\.\d+$    -> stable
       #   ^v\d+\.\d+\.\d+-.+  -> pre-release
       #
-      # On master push we publish into latest/. On a *successful* Release
+      # On main push we publish into latest/. On a *successful* Release
       # (workflow_run) we publish into <tag>/, archive it, and repoint the
       # stable or pre-release channel to it.
       - name: Resolve target version subpath
@@ -280,11 +280,11 @@ jobs:
           # 1b. Always materialise the `latest/` channel directory (AAASM-3733).
           #     `latest` is a guaranteed channel in versions.json and the root
           #     redirect's final fallback target, but it was only written on a
-          #     master-push cut (VERSION=latest). A release-only deploy (the only
+          #     main-push cut (VERSION=latest). A release-only deploy (the only
           #     kind this site has had) left `latest/` as a dangling target, so
           #     the documented entry point /latest/ 404'd. On a release cut the
           #     freshly built book is the newest live docs, so it is the correct
-          #     content for `latest/` too; on a master cut this is a no-op copy.
+          #     content for `latest/` too; on a main cut this is a no-op copy.
           if [ "$VERSION" != "latest" ]; then
             rm -rf "_site/latest"
             mkdir -p "_site/latest"
@@ -329,7 +329,7 @@ jobs:
 
   verify-commands:
     name: Verify documented commands (Linux)
-    # Only on PR / master push; a release cut re-verifies nothing new.
+    # Only on PR / main push; a release cut re-verifies nothing new.
     if: github.event_name != 'workflow_run'
     runs-on: ubuntu-latest
     steps:
@@ -364,7 +364,7 @@ jobs:
   # signal is fast and independent of the heavy book build.
   version-drift:
     name: Version-drift gate (propagate_versions --check)
-    # PR + master push only; a release-cut workflow_run rebuilds no sources.
+    # PR + main push only; a release-cut workflow_run rebuilds no sources.
     if: github.event_name != 'workflow_run'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration-bypass-permissions.yml
+++ b/.github/workflows/integration-bypass-permissions.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-devtool-claude-code/**"
       - "aa-proxy/**"
@@ -20,7 +20,7 @@ on:
       - "!**/*.webp"
       - "!**/*.ico"
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-devtool-claude-code/**"
       - "aa-proxy/**"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ permissions:
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-integration-tests/**"
       - "aa-api/**"
@@ -31,7 +31,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/integration-tests.yml"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "aa-integration-tests/**"
       - "aa-api/**"

--- a/.github/workflows/release-completeness.yml
+++ b/.github/workflows/release-completeness.yml
@@ -10,7 +10,7 @@ permissions:
 # AAASM-4449 aa-api-server gap went undetected across every rc).
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "Cargo.toml"
       - "Cargo.lock"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -740,8 +740,8 @@ jobs:
           path: tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           branch: bot/aasm-${{ steps.version.outputs.version }}
-          # AAASM-4955: homebrew-tap migrated master → main (AAASM-4957); the SDK
-          # bot-PR steps below stay `master` until their repos migrate. The
+          # AAASM-4955: every downstream repo (homebrew-tap + the three SDKs) has
+          # migrated master → main, so every bot-PR `base:` below is `main`. The
           # downstream-base check in scripts/check-release-completeness.sh guards
           # each of these against silently going stale.
           base: main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ To add a new crate to the workspace:
 
 ## Pull Requests
 
-- Open a PR against `master`.
+- Open a PR against `main`.
 - Title format: `[<ticket>] <emoji> (<scope>): <summary>` — external contributors
   without Jira access may use a GitHub issue reference (e.g. `[#123]`) or `[N/A]`
   in place of the `AAASM-NN` ticket; the Jira field in the PR template is

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 > Governance-native runtime for AI agents — open-source core.
 
-[![CI](https://img.shields.io/github/actions/workflow/status/ai-agent-assembly/agent-assembly/ci.yml?branch=master&logo=githubactions&logoColor=white&label=CI)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/ci.yml)
-[![Docs](https://img.shields.io/github/actions/workflow/status/ai-agent-assembly/agent-assembly/docs.yml?branch=master&logo=githubactions&logoColor=white&label=docs)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/docs.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/ai-agent-assembly/agent-assembly/ci.yml?branch=main&logo=githubactions&logoColor=white&label=CI)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/github/actions/workflow/status/ai-agent-assembly/agent-assembly/docs.yml?branch=main&logo=githubactions&logoColor=white&label=docs)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/docs.yml)
 [![GitHub release](https://img.shields.io/github/v/release/ai-agent-assembly/agent-assembly?include_prereleases&sort=semver&logo=github&label=release)](https://github.com/ai-agent-assembly/agent-assembly/releases)
 [![crates.io](https://img.shields.io/crates/v/aa-cli?logo=rust&label=crates.io)](https://crates.io/crates/aa-cli)
 [![Coverage](https://img.shields.io/codecov/c/github/ai-agent-assembly/agent-assembly?logo=codecov&logoColor=white)](https://codecov.io/gh/ai-agent-assembly/agent-assembly)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing `aasm`
 
 This document describes how to cut a release of the `aasm` binary.
-Releases are tagged from `master`; the release workflow handles binary
+Releases are tagged from `main`; the release workflow handles binary
 compilation, packaging, and GitHub Release publication automatically.
 
 ## Prerequisites
@@ -21,8 +21,8 @@ Run these steps locally before pushing the release tag. All checks must
 pass with a clean exit code.
 
 ```bash
-# 1. Ensure local master is up to date
-git fetch remote && git checkout master && git merge remote/master --ff-only
+# 1. Ensure local main is up to date
+git fetch remote && git checkout main && git merge remote/main --ff-only
 
 # 2. Build the dashboard — REQUIRED; aa-cli embeds dashboard/dist/
 cd dashboard

--- a/aa-auth/README.md
+++ b/aa-auth/README.md
@@ -5,7 +5,7 @@ credential-token checks, and the fail-closed auth posture the gateway enforces.
 
 [![crates.io](https://img.shields.io/crates/v/aa-auth?logo=rust&label=crates.io)](https://crates.io/crates/aa-auth)
 [![docs.rs](https://img.shields.io/docsrs/aa-auth?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-auth)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 Owns the shared authentication types and verification logic so the gateway can
 guard privileged surfaces (e.g. `/admin/status`) without pulling the full

--- a/aa-cache/README.md
+++ b/aa-cache/README.md
@@ -5,7 +5,7 @@ Assembly storage traits.
 
 [![crates.io](https://img.shields.io/crates/v/aa-cache?logo=rust&label=crates.io)](https://crates.io/crates/aa-cache)
 [![docs.rs](https://img.shields.io/docsrs/aa-cache?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-cache)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 Wraps any storage backend behind an in-process `DashMap` with a configurable TTL
 and per-key stampede protection, so policy lookups on the tool-call critical path

--- a/aa-ebpf-common/README.md
+++ b/aa-ebpf-common/README.md
@@ -4,7 +4,7 @@ Shared `no_std` types between eBPF kernel probes and userspace loader.
 
 [![crates.io](https://img.shields.io/crates/v/aa-ebpf-common?logo=rust&label=crates.io)](https://crates.io/crates/aa-ebpf-common)
 [![docs.rs](https://img.shields.io/docsrs/aa-ebpf-common?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-ebpf-common)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 The shared event types for Layer 3 (eBPF) of the interception model. This `no_std`
 crate is compiled twice — for the host target by `aa-ebpf` (userspace consumer)

--- a/aa-proto/README.md
+++ b/aa-proto/README.md
@@ -4,7 +4,7 @@ Generated protobuf/gRPC types for Agent Assembly (prost + tonic).
 
 [![crates.io](https://img.shields.io/crates/v/aa-proto?logo=rust&label=crates.io)](https://crates.io/crates/aa-proto)
 [![docs.rs](https://img.shields.io/docsrs/aa-proto?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-proto)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 The single code-generation entrypoint for every proto definition under `proto/`,
 and the single source of truth for the wire format. Other crates (`aa-runtime`,

--- a/aa-proxy/README.md
+++ b/aa-proxy/README.md
@@ -4,7 +4,7 @@ Sidecar traffic interception proxy for Agent Assembly.
 
 [![crates.io](https://img.shields.io/crates/v/aa-proxy?logo=rust&label=crates.io)](https://crates.io/crates/aa-proxy)
 [![docs.rs](https://img.shields.io/docsrs/aa-proxy?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-proxy)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 Implements Layer 2 of the three-layer interception model: a sidecar proxy that
 sits alongside each AI agent process, intercepting outbound HTTPS traffic and

--- a/aa-runtime/README.md
+++ b/aa-runtime/README.md
@@ -4,7 +4,7 @@ Tokio async runtime wrapper and lifecycle management for Agent Assembly.
 
 [![crates.io](https://img.shields.io/crates/v/aa-runtime?logo=rust&label=crates.io)](https://crates.io/crates/aa-runtime)
 [![docs.rs](https://img.shields.io/docsrs/aa-runtime?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-runtime)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 Wraps `tokio` to give Agent Assembly components a consistent async execution
 environment — runtime initialization, shutdown coordination, and agent lifecycle

--- a/aa-sandbox/README.md
+++ b/aa-sandbox/README.md
@@ -4,7 +4,7 @@ WebAssembly/WASI sandbox runtime for Agent Assembly tool execution.
 
 [![crates.io](https://img.shields.io/crates/v/aa-sandbox?logo=rust&label=crates.io)](https://crates.io/crates/aa-sandbox)
 [![docs.rs](https://img.shields.io/docsrs/aa-sandbox?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-sandbox)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 Hosts a `wasmtime`-based runtime that executes WASM-marked tools registered with
 the gateway, enforcing three independent isolation surfaces — filesystem allowlist

--- a/aa-security/README.md
+++ b/aa-security/README.md
@@ -5,7 +5,7 @@ audit-normalization.
 
 [![crates.io](https://img.shields.io/crates/v/aa-security?logo=rust&label=crates.io)](https://crates.io/crates/aa-security)
 [![docs.rs](https://img.shields.io/docsrs/aa-security?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-security)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 Owns the credential-detection scanner, redaction primitives, audit-normalization
 types, and the canonical policy AST relied on by the trusted enforcement layers

--- a/aa-storage-memory/README.md
+++ b/aa-storage-memory/README.md
@@ -4,7 +4,7 @@ In-memory `aa-storage` driver (DashMap-backed) for tests and local development.
 
 [![crates.io](https://img.shields.io/crates/v/aa-storage-memory?logo=rust&label=crates.io)](https://crates.io/crates/aa-storage-memory)
 [![docs.rs](https://img.shields.io/docsrs/aa-storage-memory?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-storage-memory)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 `DashMap`- and `parking_lot`-backed implementations of the six `aa-storage` traits
 for unit/integration tests and local development without a real database. State is

--- a/aa-storage-redis/README.md
+++ b/aa-storage-redis/README.md
@@ -4,7 +4,7 @@ Redis L2 shared-cache storage driver for Agent Assembly.
 
 [![crates.io](https://img.shields.io/crates/v/aa-storage-redis?logo=rust&label=crates.io)](https://crates.io/crates/aa-storage-redis)
 [![docs.rs](https://img.shields.io/docsrs/aa-storage-redis?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-storage-redis)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 Implements the high-frequency `aa-storage` traits (`SessionStore`,
 `RateLimitCounter`, and a read-through `PolicyStore`) against a Redis or Valkey

--- a/aa-storage-sqlite-buffer/README.md
+++ b/aa-storage-sqlite-buffer/README.md
@@ -5,7 +5,7 @@ flushes audit events on reconnect.
 
 [![crates.io](https://img.shields.io/crates/v/aa-storage-sqlite-buffer?logo=rust&label=crates.io)](https://crates.io/crates/aa-storage-sqlite-buffer)
 [![docs.rs](https://img.shields.io/docsrs/aa-storage-sqlite-buffer?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-storage-sqlite-buffer)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 A single WAL-mode SQLite file that buffers governance `AuditEntry` records when the
 upstream NATS/gateway is briefly unreachable, then flushes the backlog in insertion

--- a/aa-storage/README.md
+++ b/aa-storage/README.md
@@ -4,7 +4,7 @@ Storage trait abstraction (pure interface) for the Agent Assembly persistence la
 
 [![crates.io](https://img.shields.io/crates/v/aa-storage?logo=rust&label=crates.io)](https://crates.io/crates/aa-storage)
 [![docs.rs](https://img.shields.io/docsrs/aa-storage?logo=docsdotrs&label=docs.rs)](https://docs.rs/aa-storage)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/LICENSE)
 
 A thin facade over `aa_core::storage` that re-exports the storage trait contract
 (`PolicyStore`, `AuditSink`, `SessionStore`, `CredentialStore`, `RateLimitCounter`,

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,8 +18,8 @@
 # aa-sdk-client/…) on both dashboards.
 codecov:
   token: $CODECOV_TOKEN
-  branch: master
-  strict_yaml_branch: master
+  branch: main
+  strict_yaml_branch: main
 
 coverage:
   precision: 2

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -9,7 +9,7 @@ src = "src"
 default-theme = "light"
 preferred-dark-theme = "navy"
 git-repository-url = "https://github.com/ai-agent-assembly/agent-assembly"
-edit-url-template = "https://github.com/ai-agent-assembly/agent-assembly/edit/master/docs/{path}"
+edit-url-template = "https://github.com/ai-agent-assembly/agent-assembly/edit/main/docs/{path}"
 additional-css = ["theme/aaasm-brand.css", "theme/tabs.css"]
 additional-js = ["mermaid.min.js", "mermaid-init.js", "theme/tabs.js"]
 

--- a/docs/devtools/plugins.md
+++ b/docs/devtools/plugins.md
@@ -6,7 +6,7 @@ implementation is the in-repo sample at
 [`examples/aa-devtool-sample-myeditor/`][sample-crate] — copy and
 adapt.
 
-[sample-crate]: https://github.com/ai-agent-assembly/agent-assembly/tree/master/examples/aa-devtool-sample-myeditor
+[sample-crate]: https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/examples/aa-devtool-sample-myeditor
 
 ---
 
@@ -121,7 +121,7 @@ The sample's [`tests/contract.rs`][sample-tests] is the **reference
 test suite** every adapter should mirror. Adapt each test to your
 tool's specifics:
 
-[sample-tests]: https://github.com/ai-agent-assembly/agent-assembly/blob/master/examples/aa-devtool-sample-myeditor/tests/contract.rs
+[sample-tests]: https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/examples/aa-devtool-sample-myeditor/tests/contract.rs
 
 | Sample test | What it verifies | What you change |
 |---|---|---|

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -40,8 +40,8 @@ This book targets contributors and operators of `agent-assembly`. SDK users (Pyt
 
 ## See also
 
-- [README](https://github.com/ai-agent-assembly/agent-assembly/blob/master/README.md) — top-level project overview, prerequisites, quickstart
-- [CONTRIBUTING](https://github.com/ai-agent-assembly/agent-assembly/blob/master/CONTRIBUTING.md) — development workflow, branch naming, PR rules
+- [README](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/README.md) — top-level project overview, prerequisites, quickstart
+- [CONTRIBUTING](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/CONTRIBUTING.md) — development workflow, branch naming, PR rules
 - API reference — generate locally with `cargo doc --workspace --no-deps --open`
 
 ## Diagram rendering

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -36,18 +36,18 @@ Once rustdoc is built (`target/doc/<crate>/index.html`), the most-frequented ent
 
 | Crate | rustdoc entry | Highlights |
 |---|---|---|
-| [`aa-core`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-core) | `target/doc/aa_core/index.html` | Domain newtypes (`AgentId`, `TeamId`), `ActionType` enum, common traits |
-| [`aa-proto`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-proto) | `target/doc/aa_proto/index.html` | Generated protobuf message types — wire format source of truth |
-| [`aa-runtime`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-runtime) | `target/doc/aa_runtime/index.html` | Tokio runtime wrapper, agent lifecycle hooks |
-| [`aa-proxy`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-proxy) | `target/doc/aa_proxy/index.html` | MitM HTTPS proxy primitives |
-| [`aa-gateway`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-gateway) | `target/doc/aa_gateway/index.html` | Policy engine, agent registry, budget tracker |
-| [`aa-api`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-api) | `target/doc/aa_api/index.html` | HTTP layer with `utoipa`-generated OpenAPI spec |
-| [`aa-cli`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-cli) | `target/doc/aa_cli/index.html` | `aasm` operator binary surface (clap commands) |
-| [`aa-sdk-client`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-sdk-client) | `target/doc/aa_sdk_client/index.html` | Shared SDK runtime-client (UDS transport, codec, lifecycle) the Python/Node/Go shims wrap |
-| [`aa-wasm`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-wasm) | `target/doc/aa_wasm/index.html` | wasm-bindgen surface for in-browser embedding |
-| [`conformance`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/conformance) | `target/doc/conformance/index.html` | Cross-SDK protocol vector harness |
+| [`aa-core`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-core) | `target/doc/aa_core/index.html` | Domain newtypes (`AgentId`, `TeamId`), `ActionType` enum, common traits |
+| [`aa-proto`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-proto) | `target/doc/aa_proto/index.html` | Generated protobuf message types — wire format source of truth |
+| [`aa-runtime`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-runtime) | `target/doc/aa_runtime/index.html` | Tokio runtime wrapper, agent lifecycle hooks |
+| [`aa-proxy`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-proxy) | `target/doc/aa_proxy/index.html` | MitM HTTPS proxy primitives |
+| [`aa-gateway`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-gateway) | `target/doc/aa_gateway/index.html` | Policy engine, agent registry, budget tracker |
+| [`aa-api`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-api) | `target/doc/aa_api/index.html` | HTTP layer with `utoipa`-generated OpenAPI spec |
+| [`aa-cli`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-cli) | `target/doc/aa_cli/index.html` | `aasm` operator binary surface (clap commands) |
+| [`aa-sdk-client`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-sdk-client) | `target/doc/aa_sdk_client/index.html` | Shared SDK runtime-client (UDS transport, codec, lifecycle) the Python/Node/Go shims wrap |
+| [`aa-wasm`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-wasm) | `target/doc/aa_wasm/index.html` | wasm-bindgen surface for in-browser embedding |
+| [`conformance`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/conformance) | `target/doc/conformance/index.html` | Cross-SDK protocol vector harness |
 
-The HTTP API (served by `aa-api`) additionally publishes a generated [OpenAPI v1 spec](https://github.com/ai-agent-assembly/agent-assembly/tree/master/openapi). Validate the spec with `npx @stoplight/spectral-cli lint openapi/v1.yaml`.
+The HTTP API (served by `aa-api`) additionally publishes a generated [OpenAPI v1 spec](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/openapi). Validate the spec with `npx @stoplight/spectral-cli lint openapi/v1.yaml`.
 
 ## Hosted documentation (deferred)
 

--- a/docs/src/architecture/building.md
+++ b/docs/src/architecture/building.md
@@ -2,7 +2,7 @@
 
 This page is the short version of building, testing, and linting the workspace.
 The authoritative source is
-[`CONTRIBUTING.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/CONTRIBUTING.md)
+[`CONTRIBUTING.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/CONTRIBUTING.md)
 at the repo root; read it before opening a pull request.
 
 ## Prerequisites
@@ -13,7 +13,7 @@ at the repo root; read it before opening a pull request.
 - **Lefthook** — `brew install lefthook` (macOS) or see the
   [Lefthook install guide](https://github.com/evilmartians/lefthook/blob/master/docs/install.md).
   The hook configuration lives in
-  [`lefthook.toml`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/lefthook.toml).
+  [`lefthook.toml`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/lefthook.toml).
 
 ## Setup
 
@@ -59,7 +59,7 @@ The dev profile already builds dependencies at `opt-level = 1` with
 `line-tables-only` debuginfo, so warm rebuilds link faster while backtraces stay
 readable — no setup needed. A faster **linker** is opt-in: install it and
 uncomment the block for your platform in
-[`.cargo/config.toml`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/.cargo/config.toml)
+[`.cargo/config.toml`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/.cargo/config.toml)
 (mold + clang on Linux, lld via `brew install llvm` on macOS).
 
 ## Commit & branch conventions

--- a/docs/src/architecture/components.md
+++ b/docs/src/architecture/components.md
@@ -5,7 +5,7 @@ who it depends on. For the bird's-eye map and the dependency diagram, start with
 [System architecture](system-architecture.md).
 
 All paths link into the
-[`master` tree on GitHub](https://github.com/ai-agent-assembly/agent-assembly/tree/master).
+[`master` tree on GitHub](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD).
 
 ---
 
@@ -30,7 +30,7 @@ sub-modules are:
 | `server.rs` | Registers all seven services and serves over TCP (`serve_tcp`) or UDS (`serve_uds`). |
 
 **Key types:** `AgentRecord`, `AgentRegistry`, `AgentStatus`
-([`registry/store.rs`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/aa-gateway/src/registry/store.rs)).
+([`registry/store.rs`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/aa-gateway/src/registry/store.rs)).
 **Depends on:** `aa-core`, `aa-proto`, `aa-runtime`, `aa-storage`, `aa-cache`.
 **Serves:** gRPC on `127.0.0.1:50051`.
 

--- a/docs/src/architecture/system-architecture.md
+++ b/docs/src/architecture/system-architecture.md
@@ -23,7 +23,7 @@ protobuf wire format defined in `aa-proto` and the same `PolicyService` RPC.
 ## Workspace at a glance
 
 The Cargo workspace declares **28 member crates** in the top-level
-[`Cargo.toml`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/Cargo.toml).
+[`Cargo.toml`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/Cargo.toml).
 They group into a handful of architectural roles:
 
 | Role | Crates | What they own |
@@ -194,11 +194,11 @@ flowchart LR
 | **Unix domain socket (UDS)** | per-agent socket | `IpcFrame` events from the in-process SDK | SDK shim → `aa-runtime` |
 
 The seven gRPC services are registered together in
-[`aa-gateway/src/server.rs`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/aa-gateway/src/server.rs);
+[`aa-gateway/src/server.rs`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/aa-gateway/src/server.rs);
 the gateway can serve them over either TCP (`serve_tcp`) or a Unix socket
 (`serve_uds`). The default gRPC listen address is `127.0.0.1:50051`; the HTTP API
 default bind is `127.0.0.1:7700` (constant `DEFAULT_ADDR` in
-[`aa-api/src/config.rs`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/aa-api/src/config.rs),
+[`aa-api/src/config.rs`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/aa-api/src/config.rs),
 overridable via `AA_API_ADDR`).
 
 ## Where to go next

--- a/docs/src/architecture/workflows.md
+++ b/docs/src/architecture/workflows.md
@@ -17,7 +17,7 @@ For component-level detail behind each box, see
 ## Policy evaluation
 
 When `aa-gateway` receives a `PolicyService.CheckAction` RPC, the policy engine
-under [`aa-gateway/src/policy/`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-gateway/src/policy)
+under [`aa-gateway/src/policy/`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/aa-gateway/src/policy)
 walks parse → compile → scope cascade → budget → decision, then audits the
 result. The decision type (`engine/decision.rs`) is one of **Allow**, **Deny**,
 or **RequireApproval**.
@@ -65,7 +65,7 @@ Latency targets and current p99 measurements live in
 ## Agent registration
 
 Registration flows through `AgentLifecycleService.Register`
-([`aa-gateway/src/service/lifecycle_service.rs`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/aa-gateway/src/service/lifecycle_service.rs)),
+([`aa-gateway/src/service/lifecycle_service.rs`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/aa-gateway/src/service/lifecycle_service.rs)),
 which validates delegation depth and writes into the `DashMap`-backed
 `AgentRegistry`. Agents then keep their record live with periodic `Heartbeat`s.
 

--- a/docs/src/cli/dashboard.md
+++ b/docs/src/cli/dashboard.md
@@ -41,7 +41,7 @@ Reverse-proxies `/api/*` to the configured gateway.
 > `sessionStorage` + CSP (an accepted OSS trade-off, not hardened against
 > same-origin XSS), and WebSocket streams authenticate with short-lived single-use
 > tickets so no credential rides the URL. See
-> [`SECURITY.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/SECURITY.md)
+> [`SECURITY.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/SECURITY.md)
 > and [ADR 0012](../adr/0012-websocket-and-browser-credential-handling.md).
 
 | Flag | Type | Default | Description |

--- a/docs/src/cli/start-stop.md
+++ b/docs/src/cli/start-stop.md
@@ -34,7 +34,7 @@ aasm start [OPTIONS]
 > self-hosted / operator-controlled use — **do not expose it directly to the
 > public internet** without a trusted authenticating layer (VPN, private network,
 > or an authenticated reverse proxy) in front. See
-> [`SECURITY.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/SECURITY.md)
+> [`SECURITY.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/SECURITY.md)
 > and [ADR 0012](../adr/0012-websocket-and-browser-credential-handling.md).
 
 ### Behavior

--- a/docs/src/development/local-development.md
+++ b/docs/src/development/local-development.md
@@ -2,7 +2,7 @@
 
 This page covers the from-clone development loop for the `agent-assembly`
 monorepo. For contribution conventions (commit style, PR process) see
-[`CONTRIBUTING.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/CONTRIBUTING.md).
+[`CONTRIBUTING.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/CONTRIBUTING.md).
 
 ## Prerequisites
 

--- a/docs/src/development/shared-docs-metadata.md
+++ b/docs/src/development/shared-docs-metadata.md
@@ -16,7 +16,7 @@ existing one, without introducing docs drift.
 | Rendered snippets for pages to include | `docs/src/generated/*.md` | Checked in so `mdbook build docs` needs no Python at build time. |
 
 The generator that ties them together lives at
-[`scripts/generate_docs_metadata.py`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/scripts/generate_docs_metadata.py).
+[`scripts/generate_docs_metadata.py`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/scripts/generate_docs_metadata.py).
 
 ## How pages consume a snippet
 

--- a/docs/src/policy-reference.md
+++ b/docs/src/policy-reference.md
@@ -543,7 +543,7 @@ These ship under `policy-examples/` and all pass `aasm policy validate`.
 ### Strict
 
 Deny all unknown tools, $5/day budget, block all sensitive data. See
-[`policy-examples/strict.yaml`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/policy-examples/strict.yaml).
+[`policy-examples/strict.yaml`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/policy-examples/strict.yaml).
 
 ```yaml
 apiVersion: agent-assembly/v1
@@ -602,7 +602,7 @@ spec:
 ### Balanced
 
 Allowlist common tools, $20/day budget, PII detection on (redact). See
-[`policy-examples/balanced.yaml`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/policy-examples/balanced.yaml).
+[`policy-examples/balanced.yaml`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/policy-examples/balanced.yaml).
 
 ```yaml
 apiVersion: agent-assembly/v1
@@ -666,7 +666,7 @@ spec:
 ### Audit-only
 
 Log everything, enforce nothing. See
-[`policy-examples/audit-only.yaml`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/policy-examples/audit-only.yaml).
+[`policy-examples/audit-only.yaml`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/policy-examples/audit-only.yaml).
 
 ```yaml
 apiVersion: agent-assembly/v1

--- a/docs/src/quick-start/configuration.md
+++ b/docs/src/quick-start/configuration.md
@@ -138,7 +138,7 @@ $ aasm version --output json
 The CLI config above is about *how the CLI connects*. The **gateway** itself
 reads a separate runtime config — `agent-assembly.toml` — that selects its
 persistence backends. A starter file ships at the repo root as
-[`agent-assembly.toml.example`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/agent-assembly.toml.example):
+[`agent-assembly.toml.example`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/agent-assembly.toml.example):
 
 ```toml
 # agent-assembly.toml — example runtime configuration

--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -29,14 +29,14 @@ curl -sSf https://agent-assembly.com/install.sh | sh
 By default the binary is installed to `/usr/local/bin` if that directory is
 writable, otherwise to `~/.local/bin` (always user-writable, no `sudo` needed).
 The installer script lives in the repo at
-[`scripts/install-cli.sh`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/scripts/install-cli.sh).
+[`scripts/install-cli.sh`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/scripts/install-cli.sh).
 
 > **Hosted installer endpoint.** The one-liner above fetches from the canonical
 > `https://agent-assembly.com/install.sh` (served by the official website — see
 > [ADR 0007](../adr/0007-public-domain-and-url-contract.md)); `https://tool.agent-assembly.dev`
 > is a kept alternate that serves the same script. Prefer to fetch the installer
 > straight from GitHub? The
-> [`raw.githubusercontent.com`](https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh)
+> [`raw.githubusercontent.com`](https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/HEAD/scripts/install-cli.sh)
 > URL serves the identical script.
 
 If the install directory is not on your `PATH`, the script prints the line to add

--- a/docs/src/quick-start/requirements.md
+++ b/docs/src/quick-start/requirements.md
@@ -26,7 +26,7 @@ eBPF interception is Linux-only.
 | Windows | ⚠️ via WSL2 | ⚠️ via WSL2 | ⚠️ via WSL2 |
 
 On macOS, governance is enforced through the **SDK** and **proxy** layers; the
-eBPF layer is unavailable. See [`aa-ebpf/README.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/aa-ebpf/README.md)
+eBPF layer is unavailable. See [`aa-ebpf/README.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/aa-ebpf/README.md)
 for kernel requirements.
 
 ## Installing the CLI only

--- a/docs/src/releases.md
+++ b/docs/src/releases.md
@@ -17,7 +17,7 @@ and wire protocol are not yet stable.
   GitHub Releases page for the exact publish date and per-tag notes.
 - **Per-tag notes:** the source-controlled release notes live under
   `docs/release/` (one file per tag, e.g. `docs/release/v0.0.1-beta.4.md`).
-- **Top-level changelog:** [`CHANGELOG.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/CHANGELOG.md).
+- **Top-level changelog:** [`CHANGELOG.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/CHANGELOG.md).
 
 ## Distribution channels
 

--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -20,10 +20,10 @@ brain, at least one interception layer (SDK shim, `aa-proxy` sidecar, or eBPF),
 and a policy. Pick the language you are integrating, or browse the cross-cutting
 scenarios:
 
-- **Node** — [examples-repo/node](https://github.com/ai-agent-assembly/examples/tree/master/node)
-- **Python** — [examples-repo/python](https://github.com/ai-agent-assembly/examples/tree/master/python)
-- **Go** — [examples-repo/go](https://github.com/ai-agent-assembly/examples/tree/master/go)
-- **Scenarios** (cross-cutting: approval-gates, audit-trace, budget-limits, policy-enforcement, sidecar-runtime) — [examples-repo/scenarios](https://github.com/ai-agent-assembly/examples/tree/master/scenarios)
+- **Node** — [examples-repo/node](https://github.com/ai-agent-assembly/examples/tree/HEAD/node)
+- **Python** — [examples-repo/python](https://github.com/ai-agent-assembly/examples/tree/HEAD/python)
+- **Go** — [examples-repo/go](https://github.com/ai-agent-assembly/examples/tree/HEAD/go)
+- **Scenarios** (cross-cutting: approval-gates, audit-trace, budget-limits, policy-enforcement, sidecar-runtime) — [examples-repo/scenarios](https://github.com/ai-agent-assembly/examples/tree/HEAD/scenarios)
 
 ## Per-SDK example docs
 

--- a/docs/src/usage-guide/self-hosting.md
+++ b/docs/src/usage-guide/self-hosting.md
@@ -2,7 +2,7 @@
 
 Agent Assembly is open source. You can **self-host it yourself** — stand the
 infrastructure up, run it, and maintain it — using the sample Docker Compose stack
-in [`examples/docker-compose/`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/examples/docker-compose).
+in [`examples/docker-compose/`](https://github.com/ai-agent-assembly/agent-assembly/tree/HEAD/examples/docker-compose).
 This page is the quick path for developers: it shows the **infrastructure
 architecture** (which containers exist, who each is for, and what each does), the
 exact configuration, and how to bring it up.
@@ -190,7 +190,7 @@ docker compose --profile proxy down
 tracked in AAASM-55). To run a real agent, replace its `image:` with your agent
 image, keep `AA_AGENT_ID` identical to `aa-runtime`, and keep the
 `aa-runtime-socket` volume mounted at `/tmp`. See the example's
-[README](https://github.com/ai-agent-assembly/agent-assembly/blob/master/examples/docker-compose/README.md)
+[README](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/examples/docker-compose/README.md)
 for details.
 
 ## When you want it fully managed

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -510,10 +510,10 @@
 
                 if (currentChannel && currentChannel.id === "latest") {
                     if (stable) {
-                        html = '⚠️ You’re viewing the in-development docs (master) — content may change. '
+                        html = '⚠️ You’re viewing the in-development docs (main) — content may change. '
                              + '<a href="' + stableHref + '">Go to the latest stable release →</a>';
                     } else {
-                        html = 'ℹ️ You’re viewing the in-development docs (master). '
+                        html = 'ℹ️ You’re viewing the in-development docs (main). '
                              + 'There is no stable release yet.';
                     }
                 } else if (stable) {

--- a/infra/install-endpoint/wrangler.toml
+++ b/infra/install-endpoint/wrangler.toml
@@ -18,9 +18,12 @@ routes = [
 
 [vars]
 # Source repo + ref the install script is served from.
-#   SCRIPT_REF = "master"   → always serves the latest reviewed installer.
+#   SCRIPT_REF = "HEAD"     → always serves the latest reviewed installer from the
+#                             default branch (rename-safe: tracks the default branch
+#                             rather than a literal name, so a master→main rename
+#                             does not 404 the raw fetch — AAASM-4958).
 #   SCRIPT_REF = "v0.0.1"   → freeze the installer to a release tag (recommended
 #                             once releases are cut, so the served script is
 #                             immutable and auditable).
 SCRIPT_REPO = "ai-agent-assembly/agent-assembly"
-SCRIPT_REF = "master"
+SCRIPT_REF = "HEAD"

--- a/metadata/docs.yaml
+++ b/metadata/docs.yaml
@@ -55,7 +55,7 @@ docs_url: "https://docs.agent-assembly.com/"
 # installer — AAASM-4931 retired the legacy hosted installer alternate. The
 # GitHub raw URL is the fallback for users who want to fetch the script directly.
 install_script_url: "https://agent-assembly.com/install.sh"
-install_script_url_raw: "https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh"
+install_script_url_raw: "https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/HEAD/scripts/install-cli.sh"
 
 # mdBook / mdbook-mermaid toolchain pins — the SoT for the docs-build tool
 # versions (ADR 0013). These were duplicated by hand in .github/workflows/docs.yml

--- a/scripts/release-readiness.sh
+++ b/scripts/release-readiness.sh
@@ -28,22 +28,22 @@ else
   fail "Working tree has uncommitted changes" "commit or stash before tagging"
 fi
 
-# 2. On master
+# 2. On main
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$BRANCH" = "master" ]; then
-  pass "On master branch"
+if [ "$BRANCH" = "main" ]; then
+  pass "On main branch"
 else
-  fail "Not on master (current: $BRANCH)" "git checkout master"
+  fail "Not on main (current: $BRANCH)" "git checkout main"
 fi
 
-# 3. Local master up-to-date with remote/master
-git fetch remote master --quiet 2>/dev/null || true
-LOCAL="$(git rev-parse master 2>/dev/null || echo missing)"
-REMOTE="$(git rev-parse remote/master 2>/dev/null || echo missing)"
+# 3. Local main up-to-date with remote/main
+git fetch remote main --quiet 2>/dev/null || true
+LOCAL="$(git rev-parse main 2>/dev/null || echo missing)"
+REMOTE="$(git rev-parse remote/main 2>/dev/null || echo missing)"
 if [ "$LOCAL" = "$REMOTE" ] && [ "$LOCAL" != "missing" ]; then
-  pass "Local master matches remote/master"
+  pass "Local main matches remote/main"
 else
-  fail "Local master diverges from remote/master" "git pull --ff-only remote master"
+  fail "Local main diverges from remote/main" "git pull --ff-only remote main"
 fi
 
 # 4. Cargo.toml [workspace.package].version


### PR DESCRIPTION
## What

Completes the org-wide default-branch migration (Epic AAASM-4955, ADR 0016) for **agent-assembly** — the last repo on `master`. The GitHub branch rename (`master` → `main`) has already been executed via the rename API; this PR repoints every in-repo reference so nothing depends on the retired `master` name.

Changes (granular commits):
- **CI**: every workflow `on.{push,pull_request}.branches` filter (`ci.yml`, `codeql.yml`, `docs.yml`, `docker*.yml`, `dev-verify.yml`, `doc-links.yml`, `crate-pinnability-smoke.yml`, `integration*.yml`, `release-completeness.yml`) → `main`; the `ci.yml` master-coverage backfill (`gh run list --branch`, snapshot comments).
- **Config/scripts**: `codecov.yml`, `.ci/check-compatibility-matrix.sh` buf-breaking base default, `scripts/release-readiness.sh`.
- **Infra (functional)**: the install-endpoint Worker `SCRIPT_REF` and `metadata/docs.yaml` raw install URL → `HEAD` (raw URLs do not follow the rename; `HEAD` tracks the default branch and is rename-safe).
- **Docs**: README CI/docs badges → `?branch=main`; per-crate LICENSE badges and all `docs/src` self blob/tree links → `/HEAD/`; raw `install-cli` link, `book.toml` edit-url, in-dev docs banner, examples-repo links, `CONTRIBUTING` PR-base line.
- **Conventions/runbooks**: `.claude/CLAUDE.md`, `RELEASING.md`, and the agent-assembly release skills (`release-tag-cut`, `release-docs-sync`, `release-validate-channels` Docs query).
- **release.yml**: refreshed the now-stale comment (all downstream bot-PR `base:` are already `main`).

## Why

Per ADR 0016 the rename API moves the default pointer + branch protection + open-PR targets + a redirect, but does **not** touch workflow filters, raw URLs, badges, or runbook prose — those are swept here. The public installer was de-risked ahead of the rename (consumer raw URLs already on `/HEAD/`).

## Not touched (intentional)
- The registry-canonical `.github/blob/master` link (owned by the `.github` migration; the metadata-drift gate enforces it) and third-party links (lefthook, jquery).
- Historical artifacts (verification-reports, CHANGELOG, release notes, ADR examples, `docs/ci/channels.py` tested display label) — cosmetic per ADR §6, `github.com` web links are redirect-covered.
- Homebrew-tap branch references in tap-focused skills — the tap's own migration residual.

## Verify
- `bash scripts/check-release-completeness.sh` → exit 0 (downstream-base guard green).
- `bash .ci/check-metadata-drift.sh` → passes.
- Default branch = `main`; protection re-verified on `main` (1 approval + code-owner); all 8 open PRs auto-retargeted.

Refs: https://lightning-dust-mite.atlassian.net/browse/AAASM-4958

🤖 Generated with [Claude Code](https://claude.com/claude-code)