### PR TITLE
[AAASM-5019] ✨ (dashboard): draw topology edges (relationships)

### DIFF
--- a/dashboard/src/components/topology/TopologyGraph.css
+++ b/dashboard/src/components/topology/TopologyGraph.css
@@ -73,6 +73,42 @@
   fill: var(--ink-3);
 }
 
+/* ── Relationship edges (AAASM-5019) ────────────────────────────
+   Mirrors design/v1/hi-fi/topology.jsx TOPO_EC. The data model exposes
+   two kinds; each maps to a token so lines re-theme in light/dark:
+     delegation → --ink-3  (primary solid line)
+     call       → --info   (secondary dashed line)
+   Arrowheads reuse the same token via fill so head + line match. */
+
+.topology-edge {
+  fill: none;
+  stroke-linecap: round;
+}
+
+.topology-edge--delegation {
+  stroke: var(--ink-3);
+  opacity: 0.75;
+}
+
+.topology-edge--call {
+  stroke: var(--info);
+  opacity: 0.7;
+}
+
+/* Long-range cross-team relationships read slightly lighter so the curved
+   connectors don't dominate the intra-team structure. */
+.topology-edge[data-cross-team='true'] {
+  opacity: 0.55;
+}
+
+.topology-edge__arrow--delegation {
+  fill: var(--ink-3);
+}
+
+.topology-edge__arrow--call {
+  fill: var(--info);
+}
+
 /* ── Team clusters (AAASM-1339) ─────────────────────────────── */
 
 .topology-cluster__outline {

--- a/dashboard/src/components/topology/TopologyGraph.test.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { TopologyGraph } from './TopologyGraph'
-import type { TopologyNode } from '../../features/topology/types'
+import type { TopologyEdge, TopologyNode } from '../../features/topology/types'
 
 const NODES: TopologyNode[] = [
   // ratio 0.1 → small
@@ -155,6 +155,65 @@ describe('TopologyGraph', () => {
       expect(labels).toHaveLength(2)
       const texts = labels.map(l => l.textContent).sort()
       expect(texts).toEqual(['analytics', 'support'])
+    })
+  })
+
+  // ── Relationship edges (AAASM-5019) ────────────────────────────────────────
+  // The graph must actually draw the edges between agents: one <path> per edge,
+  // styled per kind, with cross-team edges flagged so they render as curves.
+  describe('edges', () => {
+    const EDGE_NODES: TopologyNode[] = [
+      { id: 'p1', name: 'planner', status: 'active', team: 'alpha', owner: 'a', policyCount: 1, budgetSpend: 1, budgetLimit: 10 },
+      { id: 'w1', name: 'worker-1', status: 'active', team: 'alpha', owner: 'a', policyCount: 1, budgetSpend: 2, budgetLimit: 10 },
+      { id: 'w2', name: 'worker-2', status: 'idle', team: 'alpha', owner: 'a', policyCount: 1, budgetSpend: 3, budgetLimit: 10 },
+      { id: 'x1', name: 'x-caller', status: 'active', team: 'beta', owner: 'b', policyCount: 1, budgetSpend: 1, budgetLimit: 10 },
+    ]
+    // 3 intra-team delegations + 1 cross-team call.
+    const EDGE_EDGES: TopologyEdge[] = [
+      { source: 'p1', target: 'w1', kind: 'delegation' },
+      { source: 'p1', target: 'w2', kind: 'delegation' },
+      { source: 'w1', target: 'w2', kind: 'call' },
+      { source: 'p1', target: 'x1', kind: 'call' },
+    ]
+
+    it('renders one <path data-testid="topology-edge"> per edge', () => {
+      render(<TopologyGraph nodes={EDGE_NODES} edges={EDGE_EDGES} />)
+      expect(screen.getAllByTestId('topology-edge')).toHaveLength(EDGE_EDGES.length)
+    })
+
+    it('mirrors each edge kind onto data-kind and a per-kind class', () => {
+      render(<TopologyGraph nodes={EDGE_NODES} edges={EDGE_EDGES} />)
+      const paths = screen.getAllByTestId('topology-edge')
+      const kinds = paths.map(p => p.getAttribute('data-kind'))
+      expect(kinds).toEqual(['delegation', 'delegation', 'call', 'call'])
+      // Per-kind styling hook is present so the CSS token can colour each line.
+      expect(paths[0]).toHaveClass('topology-edge--delegation')
+      expect(paths[2]).toHaveClass('topology-edge--call')
+    })
+
+    it('flags only cross-team edges and draws them as curves', () => {
+      render(<TopologyGraph nodes={EDGE_NODES} edges={EDGE_EDGES} />)
+      const paths = screen.getAllByTestId('topology-edge')
+      // p1→x1 (alpha→beta) is the only cross-team edge.
+      const cross = paths.filter(p => p.getAttribute('data-cross-team') === 'true')
+      expect(cross).toHaveLength(1)
+      // Cross-team edges bow out along a quadratic curve (command "Q");
+      // intra-team edges are straight lines (command "L").
+      expect(cross[0].getAttribute('d')).toContain('Q')
+      const intra = paths.filter(p => p.getAttribute('data-cross-team') !== 'true')
+      for (const p of intra) expect(p.getAttribute('d')).toContain('L')
+    })
+
+    it('attaches a per-kind arrowhead marker to each edge', () => {
+      render(<TopologyGraph nodes={EDGE_NODES} edges={EDGE_EDGES} />)
+      const paths = screen.getAllByTestId('topology-edge')
+      expect(paths[0]).toHaveAttribute('marker-end', 'url(#topo-arrow-delegation)')
+      expect(paths[2]).toHaveAttribute('marker-end', 'url(#topo-arrow-call)')
+    })
+
+    it('renders no edge paths when there are no edges', () => {
+      render(<TopologyGraph nodes={EDGE_NODES} edges={[]} />)
+      expect(screen.queryByTestId('topology-edge')).toBeNull()
     })
   })
 

--- a/dashboard/src/components/topology/TopologyGraph.test.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { TopologyGraph } from './TopologyGraph'
@@ -155,6 +155,54 @@ describe('TopologyGraph', () => {
       expect(labels).toHaveLength(2)
       const texts = labels.map(l => l.textContent).sort()
       expect(texts).toEqual(['analytics', 'support'])
+    })
+  })
+
+  // ── Collision (AAASM-5018) ─────────────────────────────────────────────────
+  // The per-team forceX/forceY pull every same-team card toward one center, so
+  // without a collision force the cards stack on top of each other. Assert the
+  // simulation settles with no two same-team cards overlapping.
+  describe('collision', () => {
+    // Card dims by size bucket (mirrors SIZE_VARIANT in TopologyGraph.tsx).
+    const CARD = { small: { w: 76, h: 44 }, medium: { w: 96, h: 56 }, large: { w: 116, h: 68 } }
+
+    function cardRect(node: Element) {
+      const m = /translate\(([-\d.]+),\s*([-\d.]+)\)/.exec(node.getAttribute('transform') ?? '')
+      const x = Number(m?.[1] ?? 0)
+      const y = Number(m?.[2] ?? 0)
+      const bucket = node.getAttribute('data-size-bucket') as keyof typeof CARD
+      const { w, h } = CARD[bucket]
+      return { x, y, w, h }
+    }
+
+    function overlaps(a: ReturnType<typeof cardRect>, b: ReturnType<typeof cardRect>) {
+      return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y
+    }
+
+    const SAME_TEAM: TopologyNode[] = Array.from({ length: 6 }, (_, i) => ({
+      id: `t${i}`,
+      name: `agent-${i}`,
+      status: 'active',
+      team: 'clustered',
+      owner: 'alice',
+      policyCount: 1,
+      budgetSpend: 1,
+      budgetLimit: 10,
+    }))
+
+    it('settles with no two same-team cards overlapping', async () => {
+      render(<TopologyGraph nodes={SAME_TEAM} edges={[]} width={800} height={500} />)
+      await waitFor(
+        () => {
+          const rects = screen.getAllByTestId('topology-node').map(cardRect)
+          for (let i = 0; i < rects.length; i++) {
+            for (let j = i + 1; j < rects.length; j++) {
+              expect(overlaps(rects[i], rects[j])).toBe(false)
+            }
+          }
+        },
+        { timeout: 4000, interval: 100 },
+      )
     })
   })
 })

--- a/dashboard/src/components/topology/TopologyGraph.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type KeyboardEvent } from 'react'
 import {
   forceCenter,
+  forceCollide,
   forceLink,
   forceManyBody,
   forceSimulation,
@@ -122,8 +123,15 @@ export function TopologyGraph({
       .force('link', forceLink<PositionedNode, PositionedEdge>(links).id(d => d.id).distance(120))
       .force('charge', forceManyBody().strength(-220))
       .force('center', forceCenter(width / 2, height / 2).strength(0.05))
-      .force('teamX', forceX<PositionedNode>(d => teamCenterById.get(d.source.team)?.cx ?? width / 2).strength(0.18))
-      .force('teamY', forceY<PositionedNode>(d => teamCenterById.get(d.source.team)?.cy ?? height / 2).strength(0.18))
+      .force('teamX', forceX<PositionedNode>(d => teamCenterById.get(d.source.team)?.cx ?? width / 2).strength(0.12))
+      .force('teamY', forceY<PositionedNode>(d => teamCenterById.get(d.source.team)?.cy ?? height / 2).strength(0.12))
+      // Keep same-team cards from stacking: the teamX/teamY centers pull all
+      // members to one point, so without a collision force they overlap. Size
+      // the collision circle to the card's half-width (widest dimension) plus a
+      // gap so neither the card nor its inside-the-card labels visually clash.
+      .force('collide', forceCollide<PositionedNode>()
+        .radius(d => SIZE_VARIANT[bucketForRatio(d.source.budgetSpend, d.source.budgetLimit)].w / 2 + 10)
+        .strength(0.85))
       .stop()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [identityKey, width, height, teamCenterById])

--- a/dashboard/src/components/topology/TopologyGraph.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.tsx
@@ -26,6 +26,54 @@ const CLUSTER_PADDING = 18
 const TEAM_LABEL_HEIGHT = 36
 const TEAM_BUDGET_BAR_HEIGHT = 32
 
+/**
+ * Per-kind edge styling, mirroring the hi-fi reference edge config
+ * (`design/v1/hi-fi/topology.jsx` TOPO_EC). The design defines six relation
+ * kinds; the frontend data model (`features/topology/types.ts`) currently
+ * exposes only `delegation` and `call`, so exactly those two are styled here —
+ * `delegation` as the primary solid line, `call` as a lighter dashed line.
+ *
+ * `strokeWidth` is inlined; colour comes from CSS variables via the
+ * `.topology-edge--<kind>` class so edges re-theme in light/dark like the rest
+ * of the graph (the design's raw hex would not).
+ */
+const EDGE_STYLE: Record<TopologyEdge['kind'], { width: number; dash?: string }> = {
+  delegation: { width: 1.75 },
+  call: { width: 1.5, dash: '6 4' },
+}
+
+const EDGE_KINDS = Object.keys(EDGE_STYLE) as ReadonlyArray<TopologyEdge['kind']>
+
+interface EdgeGeometry {
+  readonly key: string
+  readonly kind: TopologyEdge['kind']
+  readonly crossTeam: boolean
+  readonly d: string
+}
+
+/**
+ * Point where the ray from a node centre toward `(towardX, towardY)` exits the
+ * node's rectangular card. Used so an edge starts/ends flush against the card
+ * border — the arrowhead then sits on the target card edge instead of being
+ * hidden underneath it.
+ */
+function rectBorderPoint(
+  cx: number,
+  cy: number,
+  w: number,
+  h: number,
+  towardX: number,
+  towardY: number,
+): { x: number; y: number } {
+  const dx = towardX - cx
+  const dy = towardY - cy
+  if (dx === 0 && dy === 0) return { x: cx, y: cy }
+  const scaleX = dx !== 0 ? w / 2 / Math.abs(dx) : Infinity
+  const scaleY = dy !== 0 ? h / 2 / Math.abs(dy) : Infinity
+  const scale = Math.min(scaleX, scaleY)
+  return { x: cx + dx * scale, y: cy + dy * scale }
+}
+
 interface PositionedNode extends SimulationNodeDatum {
   id: string
   source: TopologyNode
@@ -188,6 +236,53 @@ export function TopologyGraph({
     })
   }, [positions, teamLayout])
 
+  // Edge geometry derived from settled node positions. Intra-team edges are
+  // straight lines; cross-team edges bow out along a quadratic curve so they
+  // read as distinct long-range relationships rather than crossing clutter.
+  // Endpoints are trimmed to each card's border so arrowheads land on the
+  // target card edge. Drawn under the node cards (see render order below).
+  const edgeGeometries = useMemo<readonly EdgeGeometry[]>(() => {
+    const posById = new Map<string, PositionedNode>()
+    for (const p of positions) posById.set(p.id, p)
+
+    const geoms: EdgeGeometry[] = []
+    edges.forEach((edge, i) => {
+      const src = posById.get(String(edge.source))
+      const tgt = posById.get(String(edge.target))
+      if (!src || !tgt || src === tgt) return
+
+      const sDims = SIZE_VARIANT[bucketForRatio(src.source.budgetSpend, src.source.budgetLimit)]
+      const tDims = SIZE_VARIANT[bucketForRatio(tgt.source.budgetSpend, tgt.source.budgetLimit)]
+      const scx = src.x ?? width / 2
+      const scy = src.y ?? height / 2
+      const tcx = tgt.x ?? width / 2
+      const tcy = tgt.y ?? height / 2
+
+      const start = rectBorderPoint(scx, scy, sDims.w, sDims.h, tcx, tcy)
+      const end = rectBorderPoint(tcx, tcy, tDims.w, tDims.h, scx, scy)
+      const crossTeam = src.source.team !== tgt.source.team
+
+      let d: string
+      if (crossTeam) {
+        // Perpendicular offset at the midpoint gives the bowed control point.
+        const mx = (start.x + end.x) / 2
+        const my = (start.y + end.y) / 2
+        const vx = end.x - start.x
+        const vy = end.y - start.y
+        const len = Math.hypot(vx, vy) || 1
+        const off = Math.min(60, len * 0.25)
+        const ctrlX = mx + (-vy / len) * off
+        const ctrlY = my + (vx / len) * off
+        d = `M${start.x} ${start.y} Q${ctrlX} ${ctrlY} ${end.x} ${end.y}`
+      } else {
+        d = `M${start.x} ${start.y} L${end.x} ${end.y}`
+      }
+
+      geoms.push({ key: `${edge.source}->${edge.target}-${edge.kind}-${i}`, kind: edge.kind, crossTeam, d })
+    })
+    return geoms
+  }, [edges, positions, width, height])
+
   return (
     <svg
       className="topology-graph"
@@ -196,6 +291,29 @@ export function TopologyGraph({
       role="img"
       aria-label="Agent topology graph"
     >
+      {/* Per-kind arrowhead markers. Fill is set from the same CSS variable as
+          the matching edge stroke (via .topology-edge__arrow--<kind>) so the
+          head colour tracks the line in both themes. */}
+      <defs>
+        {EDGE_KINDS.map(kind => (
+          <marker
+            key={kind}
+            id={`topo-arrow-${kind}`}
+            markerWidth="8"
+            markerHeight="8"
+            refX="6.5"
+            refY="3"
+            orient="auto"
+            markerUnits="userSpaceOnUse"
+          >
+            <path
+              className={`topology-edge__arrow topology-edge__arrow--${kind}`}
+              d="M0 0 L0 6 L7 3 z"
+            />
+          </marker>
+        ))}
+      </defs>
+
       {/* Team clusters (drawn under nodes) */}
       {clusters.map(c => (
         <g
@@ -228,6 +346,23 @@ export function TopologyGraph({
             </div>
           </foreignObject>
         </g>
+      ))}
+
+      {/* Relationship edges — above the cluster fills, under the node cards so
+          nodes sit on top and arrowheads land on the target card border. */}
+      {edgeGeometries.map(e => (
+        <path
+          key={e.key}
+          className={`topology-edge topology-edge--${e.kind}`}
+          data-testid="topology-edge"
+          data-kind={e.kind}
+          data-cross-team={e.crossTeam ? 'true' : undefined}
+          d={e.d}
+          fill="none"
+          strokeWidth={EDGE_STYLE[e.kind].width}
+          strokeDasharray={EDGE_STYLE[e.kind].dash}
+          markerEnd={`url(#topo-arrow-${e.kind})`}
+        />
       ))}
 
       {positions.map(pos => {


### PR DESCRIPTION
## Description

The dashboard Topology graph rendered nodes and team clusters but **never drew the edges between agents** — the single biggest design-fidelity gap versus `design/v1/hi-fi/topology.jsx`. This PR renders the relationships.

Each `TopologyEdge` is drawn as an SVG `<path>` between the settled force-simulation node positions, layered above the cluster fills but under the node cards so nodes sit on top:

- **Per-kind styling** mirroring the hi-fi `TOPO_EC` config — the data model (`features/topology/types.ts`) exposes exactly two kinds, so only those are styled: `delegation` → solid `--ink-3` line, `call` → dashed `--info` line. Colours come from CSS tokens so edges re-theme in light/dark like the rest of the graph.
- **Arrowhead markers** per kind (`<marker>` in `<defs>`), fill tracking the same token as the stroke.
- **Cross-team edges** (endpoints in different teams) bow out along a quadratic curve so long-range relationships read as distinct instead of crossing clutter; intra-team edges are straight lines.
- Endpoints are **trimmed to each card's rectangular border** so the arrowhead lands on the target card edge rather than being hidden underneath it.

**Stacked on #1647 (AAASM-5018 topology collide fix).** This branch is cut from that branch so the two land together; the diff will also show the collide commit until #1647 merges. Base is `main` per convention.

Scope is **edges only** — the other AAASM-5019 gaps (node badges, teams filter, edge legend, stat bar, pan/zoom) remain tracked on the ticket and are intentionally out of scope here.

## Type of Change

- [x] 🐛 Bug fix (design-fidelity gap)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-5019](https://lightning-dust-mite.atlassian.net/browse/AAASM-5019)
- Depends on / stacked on: #1647 (AAASM-5018)

## Testing

- [x] Unit tests added / updated — new `edges` suite in `TopologyGraph.test.tsx`: one `<path>` per edge, `data-kind` + per-kind class, cross-team edges flagged and drawn as curves (`Q`) vs straight (`L`), per-kind arrowhead marker, and no paths when `edges=[]`.
- [x] Manual testing performed — rendered the Topology page via a fixture harness (Playwright, 1440x900, both themes) and visually confirmed edges are drawn with correct arrowheads, cross-team curves, legible labels, and nodes still separated (collide).
- `pnpm test` (1507 pass), `pnpm build`, `pnpm type-check`, `pnpm lint` all green.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — behaviour-only)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention


[AAASM-5019]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ