### PR TITLE
[AAASM-5035] 🐛 (aa-api): Fix decision_is_error type mismatch

### DIFF
--- a/aa-api/src/routes/analytics.rs
+++ b/aa-api/src/routes/analytics.rs
@@ -697,9 +697,16 @@ fn extract_tool_name(payload: &serde_json::Value) -> Option<String> {
 /// Whether an audit payload's policy `decision` represents a blocked/denied
 /// outcome (anything other than an explicit allow). A missing decision is
 /// treated as a success.
+///
+/// The gateway writes `decision` as the proto [`Decision`] enum's **integer**
+/// discriminant (see `record_audit` in `aa-gateway` and `build_payload` in
+/// `aa-runtime`), not a string — so this reads it as an integer and compares
+/// against `Decision::Allow` rather than a case-insensitive `"allow"` string,
+/// which never matched the emitted payload (AAASM-5035).
 fn decision_is_error(payload: &serde_json::Value) -> bool {
-    match payload.get("decision").and_then(|v| v.as_str()) {
-        Some(d) => !d.eq_ignore_ascii_case("allow"),
+    use aa_proto::assembly::common::v1::Decision;
+    match payload.get("decision").and_then(|v| v.as_i64()) {
+        Some(d) => d != Decision::Allow as i64,
         None => false,
     }
 }

--- a/aa-api/src/routes/analytics.rs
+++ b/aa-api/src/routes/analytics.rs
@@ -1797,4 +1797,100 @@ mod tests {
 
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    /// End-to-end regression through `get_policy_effectiveness`: the non-dry-run
+    /// `blocks`-vs-`passes` split reads the audit `decision` field, which the
+    /// gateway writes as the proto `Decision` integer discriminant (AAASM-5035).
+    /// A non-`PolicyViolation` event carrying a non-allow decision (here a
+    /// `Redact`) must land in `blocks`; under the pre-fix string reader its
+    /// integer decision never matched and it was silently counted as a `pass`.
+    #[tokio::test]
+    async fn get_policy_effectiveness_classifies_blocks_from_integer_decision() {
+        use aa_core::audit::Lineage;
+        use aa_core::{AgentId, SessionId};
+        use aa_gateway::AuditReader;
+        use aa_proto::assembly::common::v1::Decision;
+        use std::sync::Arc;
+
+        // Audit entry shaped as the gateway writes it: a `policy_rule` string and
+        // an integer `decision`. `dry_run` is only emitted on shadow evaluations.
+        fn event(seq: u64, ts: u64, ev: AuditEventType, decision: Decision, dry_run: bool) -> AuditEntry {
+            let mut payload = serde_json::json!({
+                "action_type": "shell",
+                "decision": decision as i32,
+                "policy_rule": "rule-x",
+            });
+            if dry_run {
+                payload["dry_run"] = serde_json::Value::Bool(true);
+            }
+            AuditEntry::new_with_lineage(
+                seq,
+                ts,
+                ev,
+                AgentId::from_bytes([0xAB; 16]),
+                SessionId::from_bytes([0xEE; 16]),
+                payload.to_string(),
+                [0u8; 32],
+                Lineage::default(),
+            )
+        }
+
+        // Same UTC day so all three land in one `PolicyDay` bucket.
+        let now = now_ns();
+        let entries = [
+            // Allow, non-dry-run -> pass.
+            event(0, now, AuditEventType::ToolCallIntercepted, Decision::Allow, false),
+            // Redact, non-dry-run, NOT a PolicyViolation -> block *only* via the
+            // integer decision comparison (the crux of this regression).
+            event(1, now, AuditEventType::CredentialLeakBlocked, Decision::Redact, false),
+            // Dry-run -> warn, regardless of decision.
+            event(2, now, AuditEventType::ToolCallIntercepted, Decision::Allow, true),
+        ];
+
+        let dir = std::env::temp_dir().join(format!("aa-5035-policyeff-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create audit dir");
+        let mut contents = String::new();
+        for e in &entries {
+            contents.push_str(&serde_json::to_string(e).unwrap());
+            contents.push('\n');
+        }
+        std::fs::write(dir.join("audit.jsonl"), contents).expect("write jsonl");
+
+        let mut state = AppState::local_in_memory().expect("state builds");
+        state.audit_reader = Arc::new(AuditReader::new(dir.clone()));
+
+        let caller = AuthenticatedCaller {
+            key_id: "k".to_string(),
+            scopes: vec![Scope::Admin],
+            tenant: crate::auth::Tenant {
+                team_id: None,
+                org_id: None,
+            },
+        };
+
+        let (status, Json(resp)) = get_policy_effectiveness(
+            RequireRead(caller),
+            Extension(state),
+            Query(AnalyticsParams {
+                range: None,
+                agents: None,
+                teams: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(resp.rules.len(), 1, "single rule aggregated");
+        let rule = &resp.rules[0];
+        assert_eq!(rule.id, "rule-x");
+        assert_eq!(rule.days.len(), 1, "all events share one UTC day");
+        let day = &rule.days[0];
+        // block from the Redact decision, pass from the Allow, warn from dry-run.
+        // The pre-fix string reader would have yielded blocks=0, passes=2.
+        assert_eq!(day.blocks, 1, "non-allow decision counted as a block");
+        assert_eq!(day.passes, 1, "the allow decision counted as a pass");
+        assert_eq!(day.warns, 1, "the dry-run evaluation counted as a warn");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/aa-api/src/routes/analytics.rs
+++ b/aa-api/src/routes/analytics.rs
@@ -1674,4 +1674,121 @@ mod tests {
         assert_eq!(total_deny, 1, "pre-window entry dropped, post-window entry clamped in");
         assert_eq!(buckets[SERIES_BUCKETS - 1].deny, 1);
     }
+
+    // --- tool-usage error classification (AAASM-5035) ----------------------
+
+    /// AAASM-5035: the gateway writes the audit `decision` field as the proto
+    /// `Decision` enum's integer discriminant, not a string. `decision_is_error`
+    /// must read that integer — the old `as_str()` reader never matched, so every
+    /// tool call was silently classified as a success.
+    #[test]
+    fn decision_is_error_reads_integer_discriminant() {
+        use aa_proto::assembly::common::v1::Decision;
+        // Payload shaped exactly as the gateway emits it (integer decision).
+        let allow = serde_json::json!({ "action_type": "shell", "decision": Decision::Allow as i32 });
+        let deny = serde_json::json!({ "action_type": "shell", "decision": Decision::Deny as i32 });
+        let pending = serde_json::json!({ "action_type": "shell", "decision": Decision::Pending as i32 });
+        let redact = serde_json::json!({ "action_type": "shell", "decision": Decision::Redact as i32 });
+        assert!(!decision_is_error(&allow), "an allow is not an error");
+        assert!(decision_is_error(&deny), "a deny is an error");
+        assert!(decision_is_error(&pending), "a held decision is an error");
+        assert!(decision_is_error(&redact), "a redact is an error");
+        // A missing decision stays a success (unchanged contract).
+        assert!(!decision_is_error(&serde_json::json!({ "action_type": "shell" })));
+        // Regression guard: a *string* "allow" (the old on-wire assumption) is
+        // not what the gateway writes and must not be silently treated as allow.
+        let stringy = serde_json::json!({ "action_type": "shell", "decision": "allow" });
+        assert!(
+            !decision_is_error(&stringy),
+            "a non-integer decision is absent -> treated as success, not a false allow-match"
+        );
+    }
+
+    /// End-to-end regression through `get_tool_usage`: seed audit events exactly
+    /// as the gateway writes them (integer `decision`) and assert the per-tool
+    /// error rate reflects the denied calls. Under the pre-fix string reader the
+    /// error rate collapsed to `0.0` regardless of the real decisions.
+    #[tokio::test]
+    async fn get_tool_usage_classifies_errors_from_integer_decision() {
+        use aa_core::audit::Lineage;
+        use aa_core::{AgentId, SessionId};
+        use aa_gateway::AuditReader;
+        use aa_proto::assembly::common::v1::Decision;
+        use std::sync::Arc;
+
+        // One dispatched tool event, payload shaped as the gateway emits it: a
+        // string `action_type` (the tool-name fallback) and an integer `decision`.
+        fn event(seq: u64, ts: u64, decision: Decision) -> AuditEntry {
+            let payload = serde_json::json!({
+                "action_type": "shell",
+                "decision": decision as i32,
+                "reason": "",
+                "policy_rule": "",
+                "latency_us": 0,
+            })
+            .to_string();
+            AuditEntry::new_with_lineage(
+                seq,
+                ts,
+                AuditEventType::ToolDispatched,
+                AgentId::from_bytes([0xAB; 16]),
+                SessionId::from_bytes([0xEE; 16]),
+                payload,
+                [0u8; 32],
+                Lineage::default(),
+            )
+        }
+
+        // Stamp events at "now" so they land inside the default 7d window.
+        let now = now_ns();
+        let entries = [
+            event(0, now, Decision::Allow),
+            event(1, now, Decision::Deny),
+            event(2, now, Decision::Allow),
+            event(3, now, Decision::Deny),
+        ];
+
+        let dir = std::env::temp_dir().join(format!("aa-5035-toolusage-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create audit dir");
+        let mut contents = String::new();
+        for e in &entries {
+            contents.push_str(&serde_json::to_string(e).unwrap());
+            contents.push('\n');
+        }
+        std::fs::write(dir.join("audit.jsonl"), contents).expect("write jsonl");
+
+        let mut state = AppState::local_in_memory().expect("state builds");
+        state.audit_reader = Arc::new(AuditReader::new(dir.clone()));
+
+        let caller = AuthenticatedCaller {
+            key_id: "k".to_string(),
+            scopes: vec![Scope::Admin],
+            tenant: crate::auth::Tenant {
+                team_id: None,
+                org_id: None,
+            },
+        };
+
+        let (status, Json(resp)) = get_tool_usage(
+            RequireRead(caller),
+            Extension(state),
+            Query(AnalyticsParams {
+                range: None,
+                agents: None,
+                teams: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(resp.tools.len(), 1, "single tool aggregated");
+        let tool = &resp.tools[0];
+        assert_eq!(tool.name, "shell");
+        assert_eq!(tool.calls, 4);
+        // Two of four decisions were a Deny -> error_rate 0.5. The pre-fix string
+        // reader would have produced 0.0 here.
+        assert_eq!(tool.error_rate, 0.5, "denied calls are counted as errors");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/aa-api/src/routes/analytics.rs
+++ b/aa-api/src/routes/analytics.rs
@@ -840,8 +840,14 @@ pub async fn get_policy_effectiveness(
         } else if matches!(e.event_type(), AuditEventType::PolicyViolation) {
             day.0 += 1;
         } else {
-            match payload.get("decision").and_then(|v| v.as_str()) {
-                Some(d) if !d.eq_ignore_ascii_case("allow") => day.0 += 1,
+            // The gateway writes `decision` as the proto `Decision` enum's
+            // integer discriminant, not a string (AAASM-5035) — read it as an
+            // integer and compare against `Decision::Allow`, so a non-allow
+            // outcome is counted as a block instead of silently passing (the
+            // old `as_str()` reader never matched the emitted payload).
+            let allow = aa_proto::assembly::common::v1::Decision::Allow as i64;
+            match payload.get("decision").and_then(|v| v.as_i64()) {
+                Some(d) if d != allow => day.0 += 1,
                 _ => day.2 += 1,
             }
         }


### PR DESCRIPTION
## Description

`aa-api`'s analytics `decision_is_error` (used by `GET /api/v1/analytics/tool-usage`) read the audit payload's `decision` field with `.as_str()` and compared it to the string `"allow"`. The gateway, however, writes `decision` as the proto `Decision` enum's **integer** discriminant — confirmed on both authoritative write paths:

- `aa-gateway/src/service/policy_service.rs` `record_audit` → `"decision": response.decision` (`response.decision` is `i32`).
- `aa-runtime/src/audit_publisher/conversion.rs` `build_payload` → `"decision": proto.decision` (`i32`).

Because the string match never matched the emitted integer, `decision_is_error` always returned `false` and the per-tool `errorRate` silently misfired (every call counted as a success). The write side is authoritative and correct, so the fix is entirely on the read side.

The reader now parses the field as an integer (`as_i64`) and compares against `Decision::Allow`'s discriminant (referencing the enum, not a magic number). A missing/non-integer decision is still treated as a success, unchanged. Read-only analytics path — no enforcement or gateway behaviour is touched, and no OpenAPI path is added.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-5035](https://lightning-dust-mite.atlassian.net/browse/AAASM-5035)
- Related GitHub issues: N/A

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Added two regression tests in `aa-api/src/routes/analytics.rs`:

- `decision_is_error_reads_integer_discriminant` — pins the integer-vs-string contract across Allow/Deny/Pending/Redact, a missing decision, and a stray string decision (which must not be treated as a false allow-match).
- `get_tool_usage_classifies_errors_from_integer_decision` — seeds audit events shaped exactly as the gateway writes them (integer `decision`) and asserts the aggregated per-tool `errorRate` is `0.5` for 2-of-4 denied calls. Under the pre-fix string reader this collapsed to `0.0`.

Local validation (org CI is billing-blocked): `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo deny check` (ok), `cargo doc --workspace --no-deps` (ok), `cargo nextest run -p aa-api` (all pass, incl. both new tests). The full `-p aa-gateway` run had one unrelated failure — `policy_latency_test::sustained_load_p99_under_5ms`, a known load/timing-sensitive flake on a busy dev box, in code this PR does not touch.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-5035]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ