### PR TITLE
[AAASM-5050] 🐛 (deps): Target main in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
   # The workspace resolver means a single Cargo.lock at "/" tracks them all.
   - package-ecosystem: "cargo"
     directory: "/"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "daily"
     labels: ["dependencies", "rust"]
@@ -58,7 +58,7 @@ updates:
   # Covers: react, react-dom, vite, typescript, @vitejs/plugin-react, @types/*.
   - package-ecosystem: "npm"
     directory: "/dashboard"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "daily"
     labels: ["dependencies", "dashboard", "pnpm"]
@@ -76,7 +76,7 @@ updates:
   #         EmbarkStudios/cargo-deny-action, SonarSource/sonarqube-scan-action.
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "daily"
     labels: ["dependencies", "github-actions"]


### PR DESCRIPTION
## What

Change `target-branch` from `"master"` to `"main"` in all three ecosystem blocks (cargo, npm, github-actions) of `.github/dependabot.yml`.

## Why

Since the 2026-07-23 branch migration this repo has only a `main` branch — no `master` exists. The Dependabot config still targeted `master`, so every Dependabot PR was silently failing to land (opened against a non-existent branch). Verified there is no `master` on the canonical remote:

```
$ git ls-remote --heads remote 'refs/heads/(main|master)'
<sha>  refs/heads/main      # only main; no master
```

## How verified

- `ruby -ryaml -e "YAML.load_file('.github/dependabot.yml')"` → valid YAML
- `grep` confirms zero `target-branch: "master"` remain; all three now `"main"`
- Diff is scoped to exactly the three `target-branch` lines (3 additions / 3 deletions), nothing else.

## Operator action required (cannot be done from this PR)

There are currently **9 stale open `dependabot/*/master/*` branches** (and their PRs) still targeting the now-defunct `master`. Once this merges, Dependabot will re-open fresh PRs against `main` on its next run. The stale `*/master/*` branches/PRs will **need manual closing** — merging this config change does not retroactively retarget or clean them up.

Stale branches observed:
- `dependabot/cargo/master/hmac-0.13.0`
- `dependabot/npm_and_yarn/dashboard/master/hookform/resolvers-5.4.0`
- `dependabot/npm_and_yarn/dashboard/master/react-dom-19.2.6`
- `dependabot/npm_and_yarn/dashboard/master/storybook/react-10.4.6`
- `dependabot/npm_and_yarn/dashboard/master/storybook/react-vite-10.4.1`
- `dependabot/npm_and_yarn/dashboard/master/tanstack/react-query-5.100.11`
- `dependabot/npm_and_yarn/dashboard/master/vite-8.1.2`
- `dependabot/npm_and_yarn/dashboard/master/vitest-4.1.7`
- `dependabot/npm_and_yarn/dashboard/master/vitest/coverage-v8-4.1.8`

## Jira

https://lightning-dust-mite.atlassian.net/browse/AAASM-5050