### PR TITLE
[AAASM-5051] 📝 (docs): Update stale master refs to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,7 +93,7 @@ lefthook.toml @Chisanan232
 # lead, backing the mandatory 2-reviewer policy ("at least one with a
 # security background"). The @ai-agent-assembly/security team is the
 # security owner; the ≥2-approval + require-code-owner-review enforcement
-# itself is a server-side branch-protection setting on `master` (it cannot
+# itself is a server-side branch-protection setting on `main` (it cannot
 # be committed in this file — see verification-reports/AAASM-3565.md).
 #
 # Placed AFTER the catch-all and the broad Rust-root rules so last-match

--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -16,19 +16,19 @@ The bump PR sets the workspace version, refreshes path-dep version literals,
 adds the `CHANGELOG.md` section, and creates `docs/release/v<version>.md`.
 
 ```bash
-# in a feature worktree off master
+# in a feature worktree off main
 $EDITOR Cargo.toml                 # workspace.package.version
 $EDITOR aa-*/Cargo.toml            # all path-dep `version = "..."` literals
 $EDITOR CHANGELOG.md               # prepend ## [<version>] section
 $EDITOR docs/release/v<version>.md # release notes (copy structure from previous)
 ```
 
-Open the bump PR, wait for green CI, merge to master. **Then run the
-readiness check from a fresh master checkout:**
+Open the bump PR, wait for green CI, merge to main. **Then run the
+readiness check from a fresh main checkout:**
 
 ```bash
-git checkout master
-git pull --ff-only remote master
+git checkout main
+git pull --ff-only remote main
 bash scripts/release-readiness.sh <version>      # e.g. 0.0.1-alpha.5
 ```
 
@@ -143,7 +143,7 @@ re-trigger command. The workflow:
 
 1. Open a ticket describing the failure (link the failed workflow run).
 2. Open a fix PR against the affected repo (sources, not just CI config).
-3. Merge the fix to master.
+3. Merge the fix to main.
 4. Re-trigger the relevant workflow via `workflow_dispatch` with the
    `release_tag` input. Each `release-*.yml` accepts this for re-trigger.
 5. Re-run `check-release.sh v<version>` to verify.

--- a/infra/install-endpoint/README.md
+++ b/infra/install-endpoint/README.md
@@ -81,4 +81,4 @@ release tag and re-deploy:
 SCRIPT_REF = "v0.0.1"
 ```
 
-`master` (the default) always serves the latest reviewed installer.
+`main` (the default) always serves the latest reviewed installer.


### PR DESCRIPTION
## What

Replace stale `master` default-branch references with `main` in three
operator-facing files, left over from the master→main default-branch migration:

- `docs/release/RUNBOOK.md` — release instructions: worktree-off, merge-to,
  `git checkout` / `git pull remote`, and the recovery "merge the fix to" step
  (6 refs).
- `infra/install-endpoint/README.md` — prose describing the default branch that
  serves the latest reviewed installer (the sibling `wrangler.toml` already uses
  `SCRIPT_REF = "HEAD"`, which is rename-safe).
- `.github/CODEOWNERS` — comment describing where the ≥2-approval enforcement
  lives (a server-side branch-protection setting).

## Why

The repository's default branch was renamed `master` → `main`. These operator
docs still told operators to check out / merge to / branch off `master`, which
no longer exists — following them verbatim would fail.

## How verified

- `grep -in master` across the 3 files: no remaining default-branch `master`
  references. (One match remains at `RUNBOOK.md:117` — "the tap's `master`
  branch" — which refers to the **separate** `ai-agent-assembly/homebrew-tap`
  repo, not this repo's default branch, so it is intentionally out of scope for
  this migration.)
- `git diff` reviewed: only the intended one-word/branch-name substitutions;
  no code, config, or unrelated prose touched.
- Docs-only change; no build/test surface.

## Operator action required (cannot be verified from source)

The `.github/CODEOWNERS` comment references a **live GitHub branch-protection
rule**. This PR only updates the comment text to say `main`. An operator must
confirm the actual server-side branch-protection rule now targets `main` — if
it is still bound to `master` server-side, it may have silently stopped
enforcing the ≥2-approval + require-code-owner-review policy after the rename.
Please verify the branch-protection rule on `main` in repo settings.

## Jira Ticket

https://lightning-dust-mite.atlassian.net/browse/AAASM-5051