### PR TITLE
[AAASM-5086] ✨ (aa-api): Canonical verdict enum + enriched decision record (schema + ADR)

### DIFF
--- a/aa-api/src/models/mod.rs
+++ b/aa-api/src/models/mod.rs
@@ -7,6 +7,7 @@ pub mod event_type;
 pub mod retention;
 pub mod topology;
 pub mod trace;
+pub mod verdict;
 pub mod ws_payloads;
 
 pub use alert_ws_payloads::AlertWsFrame;

--- a/aa-api/src/models/verdict.rs
+++ b/aa-api/src/models/verdict.rs
@@ -1,0 +1,94 @@
+//! Canonical runtime verdict vocabulary (AAASM-5086, ADR 0018).
+//!
+//! [`RuntimeVerdict`] is the single source of truth for the **5-way** runtime
+//! decision the dashboard renders per enforced action: `allow` / `narrow` /
+//! `scrub` / `pending` / `deny` (`design/v1/hi-fi/agent-detail.jsx`,
+//! `scrub.jsx`). It is deliberately distinct from two pre-existing 3-to-4-state
+//! vocabularies and must not be conflated with either:
+//!
+//! - the proto wire enum [`Decision`](aa_proto::assembly::common::v1::Decision)
+//!   (`allow` / `deny` / `pending` / `redact`) that the gateway writes to the
+//!   audit log — the coarse enforcement outcome, blind to whether a `deny` was a
+//!   full block or a scoped narrowing, or whether an `allow` passed clean or was
+//!   scrubbed en route; and
+//! - the capability-matrix [`Decision`](crate::models::capability::Decision)
+//!   (`allow` / `narrow` / `approval` / `deny` / `na`) that describes a *static*
+//!   (agent × resource × verb) permission cell, not a *runtime* per-action
+//!   outcome.
+//!
+//! This enum freezes the vocabulary now so the read-side contract (the enriched
+//! per-decision record on `GET /api/v1/agents/{id}/decisions`) is stable for the
+//! Bucket-B backend program. **Deriving a `RuntimeVerdict` at decision time is
+//! not implemented here** — it requires instrumenting the enforcement hot path
+//! and is the ADR-0018-gated follow-up (AAASM-5086 follow-up); until then the
+//! field is surfaced as `null`. See ADR 0018 for the decision-capture plan.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// The canonical 5-way runtime verdict for a single enforced action.
+///
+/// Wire form is lowercase (`"allow"`, `"narrow"`, `"scrub"`, `"pending"`,
+/// `"deny"`) to match the dashboard's verdict styling keys. The variants are
+/// ordered least-to-most restrictive; do not reorder for wire stability, but the
+/// order carries no serialized meaning (each variant serializes by name).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum RuntimeVerdict {
+    /// Action permitted unchanged.
+    Allow,
+    /// Action permitted but scoped down (e.g. a broad write narrowed to specific
+    /// paths) — distinct from a full `deny` so the UI can show partial success.
+    Narrow,
+    /// Action permitted, but its payload had secrets/PII stripped (L3 scrubbing)
+    /// before reaching the destination — distinct from `allow` so scrubbed
+    /// traffic is visible.
+    Scrub,
+    /// Action held awaiting human approval (maps to proto `Decision::PENDING`).
+    Pending,
+    /// Action blocked outright.
+    Deny,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_lowercase_five_way_vocabulary() {
+        assert_eq!(serde_json::to_string(&RuntimeVerdict::Allow).unwrap(), r#""allow""#);
+        assert_eq!(serde_json::to_string(&RuntimeVerdict::Narrow).unwrap(), r#""narrow""#);
+        assert_eq!(serde_json::to_string(&RuntimeVerdict::Scrub).unwrap(), r#""scrub""#);
+        assert_eq!(serde_json::to_string(&RuntimeVerdict::Pending).unwrap(), r#""pending""#);
+        assert_eq!(serde_json::to_string(&RuntimeVerdict::Deny).unwrap(), r#""deny""#);
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        for v in [
+            RuntimeVerdict::Allow,
+            RuntimeVerdict::Narrow,
+            RuntimeVerdict::Scrub,
+            RuntimeVerdict::Pending,
+            RuntimeVerdict::Deny,
+        ] {
+            let s = serde_json::to_string(&v).unwrap();
+            let back: RuntimeVerdict = serde_json::from_str(&s).unwrap();
+            assert_eq!(v, back);
+        }
+    }
+
+    /// The runtime verdict is a distinct vocabulary from the capability-matrix
+    /// `Decision`: it has a `scrub`/`pending` where the matrix has
+    /// `approval`/`na`. Guards against a future accidental merge of the two.
+    #[test]
+    fn scrub_is_not_a_capability_decision_variant() {
+        // `scrub` must deserialize as a runtime verdict...
+        assert_eq!(
+            serde_json::from_str::<RuntimeVerdict>(r#""scrub""#).unwrap(),
+            RuntimeVerdict::Scrub
+        );
+        // ...but is not a member of the capability `Decision` enum.
+        assert!(serde_json::from_str::<crate::models::capability::Decision>(r#""scrub""#).is_err());
+    }
+}

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -165,6 +165,7 @@ use crate::routes::{
         agents::ResumeResponse,
         agents::PermissionSourceResponse,
         agents::EffectivePermissionsResponse,
+        crate::models::verdict::RuntimeVerdict,
         agents::AgentDecisionResponse,
         agents::AgentDecisionsResponse,
         agents::BudgetRowResponse,

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -14,6 +14,7 @@ use aa_gateway::registry::{AgentStatus, OrphanMode};
 use crate::auth::scope::{RequireRead, RequireWrite, Scope};
 use crate::auth::AuthenticatedCaller;
 use crate::error::ProblemDetail;
+use crate::models::verdict::RuntimeVerdict;
 use crate::pagination::PaginationParams;
 use crate::state::AppState;
 
@@ -1018,6 +1019,22 @@ pub struct AgentDecisionResponse {
     /// `redact` / `unspecified`) so the UI can map to its verdict styling
     /// without re-deriving the enum. Derived, not a separate audit field.
     pub decision_label: String,
+    /// The canonical 5-way runtime verdict (`allow` / `narrow` / `scrub` /
+    /// `pending` / `deny`, AAASM-5086) for this action — the vocabulary the
+    /// dashboard renders. Distinct from `decision`/`decisionLabel`, which are the
+    /// coarse proto enforcement outcome: a proto `deny` cannot tell a full block
+    /// from a scoped `narrow`, nor a proto `allow` from a `scrub`. **Always
+    /// `null` today**: deriving the verdict requires capturing it at decision
+    /// time on the enforcement hot path, which is the ADR-0018-gated follow-up
+    /// (populated once decision-capture lands — ADR 0018 / AAASM-5086 follow-up).
+    /// Wired through now so the column lands without another contract change.
+    pub verdict: Option<RuntimeVerdict>,
+    /// Distributed-trace id linking this decision to its session trace
+    /// (`/api/v1/traces/...`). **Always `null` today**: the audit log records no
+    /// per-decision trace id, so it is surfaced nullable rather than fabricated.
+    /// Populated once trace-id propagation lands on the runtime — the
+    /// ADR-0018-gated follow-up (ADR 0018 / AAASM-5086 follow-up).
+    pub trace_id: Option<String>,
     /// The matched policy rule id (audit `policy_rule`, top-level or under
     /// `detail`). The design's `policy` column. `null` when the decision
     /// recorded no rule (e.g. a baseline allow with no matching rule).
@@ -1127,10 +1144,19 @@ fn entry_to_decision_row(entry: &AuditEntry) -> Option<AgentDecisionResponse> {
         resource,
         decision,
         decision_label: decision_label(decision).to_string(),
+        // The 5-way runtime verdict is not captured at decision time yet;
+        // deriving it is the ADR-0018-gated hot-path follow-up. Surface null
+        // rather than lossily mapping the coarse proto `decision` onto it.
+        // populated once decision-capture lands (ADR 0018 / AAASM-5086 follow-up)
+        verdict: None,
         matched_policy,
         // No per-decision latency source exists in the audit log (AAASM-5058);
         // report it honestly as absent rather than inventing a value.
         latency_ms: None,
+        // No per-decision trace id is recorded on the audit write path yet;
+        // trace-id propagation is the ADR-0018-gated hot-path follow-up.
+        // populated once decision-capture lands (ADR 0018 / AAASM-5086 follow-up)
+        trace_id: None,
     })
 }
 
@@ -1288,6 +1314,10 @@ mod tests {
         assert_eq!(row.matched_policy, None);
         // No per-decision latency source exists — it must be reported as absent.
         assert_eq!(row.latency_ms, None);
+        // The verdict + trace id are frozen in the schema but not yet captured
+        // at decision time (ADR-0018 hot-path follow-up); they must read null.
+        assert_eq!(row.verdict, None);
+        assert_eq!(row.trace_id, None);
         assert_eq!(row.seq, 7);
         assert_eq!(row.session_id, "ee".repeat(16));
     }

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1929,12 +1929,21 @@ export interface components {
             /** @description Decision timestamp as an RFC 3339 UTC string (audit `timestamp_ns`). */
             timestamp: string;
             /**
+             * @description Distributed-trace id linking this decision to its session trace
+             *     (`/api/v1/traces/...`). **Always `null` today**: the audit log records no
+             *     per-decision trace id, so it is surfaced nullable rather than fabricated.
+             *     Populated once trace-id propagation lands on the runtime — the
+             *     ADR-0018-gated follow-up (ADR 0018 / AAASM-5086 follow-up).
+             */
+            traceId?: string | null;
+            /**
              * @description The recorded action category (audit payload `action_type`, e.g.
              *     `TOOL_CALL` / `FILE_OPERATION`). The design's `verb` column: the audit
              *     log records the action *category*, not a fine-grained read/write verb,
              *     so this is the closest recorded source. `null` when unrecorded.
              */
             verb?: string | null;
+            verdict?: null | components["schemas"]["RuntimeVerdict"];
         };
         /** @description Recent per-agent decision stream (AAASM-5058). */
         AgentDecisionsResponse: {
@@ -3956,6 +3965,16 @@ export interface components {
              */
             dry_run?: boolean;
         };
+        /**
+         * @description The canonical 5-way runtime verdict for a single enforced action.
+         *
+         *     Wire form is lowercase (`"allow"`, `"narrow"`, `"scrub"`, `"pending"`,
+         *     `"deny"`) to match the dashboard's verdict styling keys. The variants are
+         *     ordered least-to-most restrictive; do not reorder for wire stability, but the
+         *     order carries no serialized meaning (each variant serializes by name).
+         * @enum {string}
+         */
+        RuntimeVerdict: "allow" | "narrow" | "scrub" | "pending" | "deny";
         /**
          * @description A representative call sample shown alongside the matrix to explain the
          *     effect of the current (and any proposed) policy.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -151,3 +151,4 @@
   - [0015 - DLP Trust Boundary, Redaction Fail-Safety & Heuristic Detection Limits](adr/0015-dlp-trust-boundary-and-redaction-semantics.md)
   - [0016 - Organization-wide Default Branch — master → main](adr/0016-default-branch-master-to-main-migration.md)
   - [0017 - Dashboard Design-Parity — Ratified Evolutions](adr/0017-dashboard-design-parity-ratified-evolutions.md)
+  - [0018 - Canonical Runtime Verdict & Enriched Decision Record](adr/0018-canonical-runtime-verdict-and-enriched-decision-record.md)

--- a/docs/src/adr/0018-canonical-runtime-verdict-and-enriched-decision-record.md
+++ b/docs/src/adr/0018-canonical-runtime-verdict-and-enriched-decision-record.md
@@ -1,0 +1,223 @@
+# ADR 0018: Canonical Runtime Verdict & Enriched Decision Record
+
+**Status**: Accepted (schema freeze) — decision-capture plan **requires product/architecture sign-off before implementation**
+**Date**: 2026-07
+**Ticket**: [AAASM-5086](https://lightning-dust-mite.atlassian.net/browse/AAASM-5086) (Epic [AAASM-5082](https://lightning-dust-mite.atlassian.net/browse/AAASM-5082))
+
+This ADR freezes the **canonical runtime verdict vocabulary** and the **enriched
+per-decision record** shape that the Bucket-B backend program
+([AAASM-5082](https://lightning-dust-mite.atlassian.net/browse/AAASM-5082)) builds
+on. It is the *gating* contract: downstream tickets
+([AAASM-5085](https://lightning-dust-mite.atlassian.net/browse/AAASM-5085),
+[AAASM-5089](https://lightning-dust-mite.atlassian.net/browse/AAASM-5089)) depend on
+this vocabulary being fixed before they can proceed. It scopes the freeze
+deliberately narrowly: it defines the **types + read-side wire contract** and
+**does not** change any enforcement/audit-write hot-path behavior. The hot-path
+instrumentation that would actually *populate* the new fields is captured here as a
+**decision-capture plan** and explicitly flagged as requiring sign-off — it is not
+implemented by the freeze.
+
+It complements ADR 0004 (governance enforcement flow), ADR 0015 (DLP trust boundary
+/ redaction semantics — the source of the `scrub` verdict), and ADR 0017 (dashboard
+design-parity, which ratified the agent-detail Traffic tab this record backs).
+
+---
+
+## Context
+
+**Three verdict vocabularies exist, at different layers, and they are not the
+same.** Conflating them loses information the dashboard needs:
+
+1. **Proto wire enum** —
+   [`Decision`](https://github.com/AI-agent-assembly/agent-assembly/blob/main/proto)
+   (`aa_proto::assembly::common::v1::Decision`): `ALLOW` / `DENY` / `PENDING` /
+   `REDACT`. This is what the gateway writes into the audit log per action. It is a
+   **3-to-4-state enforcement outcome** and is intentionally coarse — it cannot
+   distinguish a full block from a *scoped narrowing* (both are `DENY`-adjacent in
+   practice), nor an untouched `ALLOW` from one whose payload was scrubbed en route.
+
+2. **Capability-matrix `Decision`** (`aa-api` `models::capability::Decision`):
+   `allow` / `narrow` / `approval` / `deny` / `na`. This describes a **static**
+   `(agent × resource × verb)` permission cell in the Capability Matrix page — a
+   *policy posture*, not a runtime per-action result. Its `na` means "no such cell";
+   its `approval` is a matrix-cell state.
+
+3. **The UI's runtime verdict** — what `design/v1/hi-fi/agent-detail.jsx` (Traffic
+   tab) and `design/v1/hi-fi/scrub.jsx` actually render per enforced action:
+   `allow` / `narrow` / `scrub` / `pending` / `deny`. This is a **5-way runtime
+   outcome**. `narrow` (action permitted but scoped down) and `scrub` (action
+   permitted but secrets/PII stripped — the L3 sanitization of ADR 0015) are
+   first-class outcomes the coarse proto enum folds away.
+
+**The read-side already exists but is under-specified.** AAASM-5058 added
+`GET /api/v1/agents/{id}/decisions`, projecting the audit log into a per-decision
+table. It surfaces `decision` (the proto integer) + a derived `decisionLabel`, and
+already carries `matchedPolicy` and a nullable `latencyMs` placeholder. But:
+
+- there is **no canonical 5-way verdict** on the record — the UI is left to
+  re-derive one from the coarse proto label, which cannot represent `narrow`/`scrub`;
+- **per-decision latency is not recorded** anywhere on the write path (`latencyMs`
+  is always null today);
+- **no trace id** links a decision row to its distributed-trace/session trace;
+- `matchedPolicy` is present but only opportunistically populated from whatever the
+  audit payload happened to carry.
+
+**Why freeze now, ahead of capture.** The downstream Bucket-B tickets need a stable
+vocabulary and record shape to build against. If each consumer invented its own
+verdict strings or field names, they would drift. Freezing the contract — with the
+not-yet-captured fields present and honestly `null` — lets consumers integrate
+against the final shape immediately, and lets the capture work land later without a
+second breaking contract change. The alternative (waiting until the hot path is
+instrumented) would block 5085/5089 on sign-off-gated work.
+
+---
+
+## Decision
+
+### 1. Freeze a canonical 5-way `RuntimeVerdict`
+
+Introduce `aa-api` `models::verdict::RuntimeVerdict` — the single source of truth
+for the runtime verdict vocabulary:
+
+| Variant | Wire | Meaning |
+|---|---|---|
+| `Allow`   | `"allow"`   | Action permitted unchanged. |
+| `Narrow`  | `"narrow"`  | Permitted but scoped down (e.g. a broad write narrowed to specific paths). Distinct from `deny` so the UI shows partial success. |
+| `Scrub`   | `"scrub"`   | Permitted, but payload had secrets/PII stripped (L3 scrubbing, ADR 0015) before reaching the destination. Distinct from `allow`. |
+| `Pending` | `"pending"` | Held awaiting human approval (maps to proto `Decision::PENDING`). |
+| `Deny`    | `"deny"`    | Blocked outright. |
+
+It is deliberately **separate** from both `Decision` enums above and must not be
+merged with, renamed onto, or derived-by-default from either. The existing proto and
+capability enums are left **unchanged**.
+
+### 2. Enrich the per-decision record — as **nullable** fields
+
+Extend the existing `AgentDecisionResponse` (the `GET /api/v1/agents/{id}/decisions`
+row) with the enriched vocabulary, all **nullable**, present in the schema but
+defaulting to `null` until capture lands:
+
+- `verdict: RuntimeVerdict | null` — the canonical 5-way verdict (new).
+- `traceId: string | null` — distributed-trace id linking the row to its session
+  trace (new).
+- `latencyMs: integer | null` — per-decision latency (already present from
+  AAASM-5058; remains null).
+- `matchedPolicy: string | null` — matched policy rule id (already present).
+
+This is a **schema extension of an existing path** — it adds **0 new OpenAPI paths**
+(the contract path count stays 71). The generated `openapi/v1.yaml` and the
+dashboard codegen (`schema.d.ts`) are regenerated so the drift gate stays green.
+
+### 3. Read-side / schema **only** — no hot-path change
+
+The freeze touches **only** the type definitions, the response schema, and the
+read-side projection. It does **not** measure latency, propagate a trace id, or
+derive a `RuntimeVerdict` at decision time. The read handler continues to project
+the audit log exactly as before; the three not-yet-sourced fields are returned
+`null`. No enforcement, audit-write, or runtime path is modified. This keeps the
+freeze free of enforcement-behavior risk and therefore mergeable without the
+product/architecture sign-off that the capture work needs.
+
+---
+
+## Decision-capture plan (FOLLOW-UP — requires sign-off before implementation)
+
+This section describes what a follow-up would need to actually *populate* the frozen
+fields. **It is not implemented by this ADR's freeze and must not be** — each item
+below alters behavior on the enforcement/audit-write hot path, so it requires
+explicit product + architecture sign-off before any implementation ticket is opened.
+It is documented here so the shape of that work is visible and can be scoped against
+a stated baseline.
+
+### A. Where the 5-way verdict is derived
+
+- **Point of derivation:** the authoritative enforcement pipeline in `aa-runtime`
+  (`RuntimeScanner`), which is where an action's outcome is actually decided. It
+  already knows, per action, whether the action was allowed, blocked, held for
+  approval, scoped/narrowed by a policy match, or scrubbed by the `aa-security` DLP
+  layer (ADR 0015). The proto `Decision` collapses `narrow`→`deny`-ish and
+  `scrub`→`allow`; the runtime has the finer signal *before* it collapses it.
+- **What must change:** the runtime would compute a `RuntimeVerdict` alongside the
+  proto `Decision` and thread it into the audit event payload (a new optional field
+  on the audit record), rather than reconstructing it after the fact. `scrub` comes
+  from "the DLP layer rewrote the payload"; `narrow` from "a policy match scoped the
+  action rather than blocking it".
+- **Sign-off concern:** this changes what the enforcement path emits and records per
+  decision — an audit-write schema change on the hot path. Must be reviewed for
+  latency budget, audit-log size, and backward-compatibility of existing audit
+  consumers.
+
+### B. Where per-decision latency is measured
+
+- **Point of measurement:** the enforcement pipeline boundary in `aa-runtime` —
+  start a monotonic timer when an action enters the scanner, stop it when the verdict
+  is produced, and record the elapsed milliseconds on the audit event.
+- **What must change:** a new `latency_ms` field on the audit write path, populated
+  by the runtime. The read-side field already exists; only the *source* is missing.
+- **Sign-off concern:** adds per-action measurement + a field to every audit write —
+  a hot-path cost (however small) and an audit-schema change. Needs a decision on
+  whether latency is measured for *all* actions or sampled, and where the timer
+  boundaries sit relative to DLP scrubbing and approval waits (an approval `pending`
+  can block for minutes — latency semantics for held actions must be defined).
+
+### C. How trace_id propagates
+
+- **Point of origin:** a trace/span id is established when a session begins (or is
+  carried in from the SDK/proxy layer) and must be propagated through the runtime so
+  each decision can stamp the *current* span id onto its audit event.
+- **What must change:** trace-context propagation through `aa-runtime` (and the
+  SDK/proxy entry points) plus a `trace_id` field on the audit write path. This is
+  the largest of the three — it is distributed-tracing plumbing, not a local field.
+- **Sign-off concern:** touches the SDK→runtime→gateway enforcement path (ADR 0004)
+  and the audit-write schema; needs a decision on trace-context format
+  (W3C traceparent vs internal) and whether the existing `/api/v1/traces` span model
+  (`models::trace`) is the join target.
+
+**Explicitly out of scope of the freeze** (and gated on the above sign-off): any
+change to `aa-runtime`, the audit-write schema, the proto `Decision` enum, or the
+gateway enforcement path. If a future consumer finds the frozen *read-side* shape
+cannot be satisfied without one of these, that is a signal to open the sign-off
+conversation — not to instrument the hot path under this ticket.
+
+---
+
+## Consequences
+
+- **Positive:** the Bucket-B vocabulary is fixed; 5085/5089 can integrate against the
+  final record shape now. The capture work can land later with no further breaking
+  contract change (fields go from always-null to populated). The three verdict
+  vocabularies are documented as distinct, reducing the risk of a future accidental
+  merge.
+- **Negative / accepted:** `verdict`, `traceId`, and `latencyMs` read `null` until
+  the sign-off-gated capture work lands — consumers must treat them as optional and
+  not assume presence. The dashboard renders the coarse `decisionLabel` in the
+  interim.
+- **Neutral:** `RuntimeVerdict` lives in `aa-api` (not `aa-core`) because it needs a
+  `utoipa::ToSchema` derive for the OpenAPI contract and `aa-core` is a
+  `no_std`-compatible leaf without a `utoipa` dependency; adding one there would be a
+  larger, riskier change than this freeze warrants. If a non-API consumer later needs
+  the vocabulary, promoting it to `aa-core` is a mechanical follow-up.
+
+## Validation requirements
+
+- Unit tests assert the `RuntimeVerdict` wire form (5 lowercase variants) and that it
+  is distinct from the capability `Decision` (e.g. `scrub` is not a `Decision`).
+- The read-side test asserts `verdict` and `traceId` are `null` on a projected row.
+- The OpenAPI contract test still counts exactly **71 paths** (0 new paths); the
+  dashboard `schema.d.ts` regenerates cleanly (drift gate green).
+
+## Reconsideration triggers
+
+- A fourth verdict distinction the UI needs that the 5-way vocabulary can't express.
+- Product/architecture sign-off on the decision-capture plan — at which point the
+  follow-up tickets are opened against Sections A/B/C above.
+
+## Traceability
+
+- Freezes the vocabulary for Epic
+  [AAASM-5082](https://lightning-dust-mite.atlassian.net/browse/AAASM-5082); gates
+  [AAASM-5085](https://lightning-dust-mite.atlassian.net/browse/AAASM-5085) /
+  [AAASM-5089](https://lightning-dust-mite.atlassian.net/browse/AAASM-5089).
+- Extends the AAASM-5058 decision-stream endpoint.
+- `scrub` semantics inherit from ADR 0015 (DLP redaction); the Traffic-tab surface
+  was ratified in ADR 0017; enforcement flow context is ADR 0004.

--- a/docs/src/adr/README.md
+++ b/docs/src/adr/README.md
@@ -24,3 +24,4 @@ The format follows a lightweight variant of [Michael Nygard's template](https://
 | [0015](0015-dlp-trust-boundary-and-redaction-semantics.md) | DLP Trust Boundary, Redaction Fail-Safety & Heuristic Detection Limits | Accepted |
 | [0016](0016-default-branch-master-to-main-migration.md) | Organization-wide Default Branch — `master` → `main` | Accepted |
 | [0017](0017-dashboard-design-parity-ratified-evolutions.md) | Dashboard Design-Parity — Ratified Evolutions | Accepted |
+| [0018](0018-canonical-runtime-verdict-and-enriched-decision-record.md) | Canonical Runtime Verdict & Enriched Decision Record | Accepted |

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -3336,6 +3336,16 @@ components:
         timestamp:
           type: string
           description: Decision timestamp as an RFC 3339 UTC string (audit `timestamp_ns`).
+        traceId:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Distributed-trace id linking this decision to its session trace
+            (`/api/v1/traces/...`). **Always `null` today**: the audit log records no
+            per-decision trace id, so it is surfaced nullable rather than fabricated.
+            Populated once trace-id propagation lands on the runtime — the
+            ADR-0018-gated follow-up (ADR 0018 / AAASM-5086 follow-up).
         verb:
           type:
           - string
@@ -3345,6 +3355,20 @@ components:
             `TOOL_CALL` / `FILE_OPERATION`). The design's `verb` column: the audit
             log records the action *category*, not a fine-grained read/write verb,
             so this is the closest recorded source. `null` when unrecorded.
+        verdict:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/RuntimeVerdict'
+            description: |-
+              The canonical 5-way runtime verdict (`allow` / `narrow` / `scrub` /
+              `pending` / `deny`, AAASM-5086) for this action — the vocabulary the
+              dashboard renders. Distinct from `decision`/`decisionLabel`, which are the
+              coarse proto enforcement outcome: a proto `deny` cannot tell a full block
+              from a scoped `narrow`, nor a proto `allow` from a `scrub`. **Always
+              `null` today**: deriving the verdict requires capturing it at decision
+              time on the enforcement hot path, which is the ADR-0018-gated follow-up
+              (populated once decision-capture lands — ADR 0018 / AAASM-5086 follow-up).
+              Wired through now so the column lands without another contract change.
     AgentDecisionsResponse:
       type: object
       description: Recent per-agent decision stream (AAASM-5058).
@@ -6590,6 +6614,21 @@ components:
           description: |-
             When true, the run logs the work it *would* perform without
             taking action. Defaults to `false`.
+    RuntimeVerdict:
+      type: string
+      description: |-
+        The canonical 5-way runtime verdict for a single enforced action.
+
+        Wire form is lowercase (`"allow"`, `"narrow"`, `"scrub"`, `"pending"`,
+        `"deny"`) to match the dashboard's verdict styling keys. The variants are
+        ordered least-to-most restrictive; do not reorder for wire stability, but the
+        order carries no serialized meaning (each variant serializes by name).
+      enum:
+      - allow
+      - narrow
+      - scrub
+      - pending
+      - deny
     SampleCall:
       type: object
       description: |-


### PR DESCRIPTION
## Description

Freezes the **gating contract** for the Bucket-B backend program (Epic AAASM-5082): the canonical **5-way runtime verdict** vocabulary and the enriched per-decision record shape that AAASM-5085/5089 depend on. Schema + read-side only — **no enforcement/hot-path behavior change**.

- **ADR 0018** (`docs/src/adr/0018-…md`, registered in `README.md` + `SUMMARY.md`): records the 5-way vocabulary, the enriched record, and a **decision-capture plan** describing exactly what hot-path instrumentation a follow-up would need (where the verdict is derived in `aa-runtime`, where per-decision latency is measured, how `trace_id` propagates) — explicitly flagged as requiring product/architecture sign-off before implementation.
- **`RuntimeVerdict` enum** (`aa-api` `models::verdict`): `allow` / `narrow` / `scrub` / `pending` / `deny`. Deliberately distinct from the proto `Decision` wire enum (allow/deny/pending/redact) and the capability-matrix `Decision` (allow/narrow/approval/deny/na) — neither can express `narrow`/`scrub`. The existing enums are left unchanged.
- **Enriched decision record**: `GET /api/v1/agents/{id}/decisions` (AAASM-5058) gains nullable `verdict` + `traceId`, joining the already-present nullable `latencyMs` + `matchedPolicy`. Both new fields return **null** — capturing them is the ADR-0018-gated hot-path follow-up.

Schema extension of an existing path: **0 new OpenAPI paths** (count stays 71). `openapi/v1.yaml` and the dashboard `schema.d.ts` codegen are regenerated so the drift gate stays green.

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation update

## Breaking Changes

- [x] No — additive, nullable fields on an existing response; no path added; existing enums untouched; no enforcement/audit-write path modified.

## Related Issues

- Related Jira ticket: [AAASM-5086](https://lightning-dust-mite.atlassian.net/browse/AAASM-5086) (Epic [AAASM-5082](https://lightning-dust-mite.atlassian.net/browse/AAASM-5082))

## Testing

- [x] Unit tests added / updated — `RuntimeVerdict` wire form + distinctness from capability `Decision`; decision-row test asserts `verdict`/`traceId` read null.
- [x] Integration tests — OpenAPI contract (`openapi_spec`, 71 paths) passes; live-response schema validation passes.

Validated locally (org CI billing-blocked): `cargo nextest -p aa-api -p aa-integration-tests` (verdict + decision-row + contract green), `clippy --all-targets -D warnings` clean, `fmt --check` clean, `cargo deny check` clean, `cargo doc` clean. Dashboard: `type-check` + `lint` + `test` (1940 pass) + `build` all green.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — org CI is billing-blocked; validated locally instead
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-5086]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ