### PR TITLE
[AAASM-5102] 🐛 (aa-api): Wire the agent registry into the policy engine

### DIFF
--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -1378,4 +1378,136 @@ mod tests {
         let err = parse_agent_id("aabb").unwrap_err();
         assert_eq!(err.status, StatusCode::BAD_REQUEST.as_u16());
     }
+
+    // ── AAASM-5102: the cascade this endpoint reports must be tenancy-aware ──
+
+    fn admin() -> RequireRead {
+        RequireRead(AuthenticatedCaller {
+            key_id: "k".to_string(),
+            scopes: vec![Scope::Admin],
+            tenant: crate::auth::Tenant {
+                org_id: None,
+                team_id: None,
+            },
+        })
+    }
+
+    /// Minimal registered agent owned by `team_id`. Only the fields the
+    /// capabilities path reads (id, tenancy) carry meaningful values.
+    fn record(id_byte: u8, team_id: Option<&str>) -> aa_gateway::registry::AgentRecord {
+        aa_gateway::registry::AgentRecord {
+            agent_id: [id_byte; 16],
+            name: "a".to_string(),
+            framework: "langgraph".to_string(),
+            version: "0.1.0".to_string(),
+            risk_tier: 1,
+            tool_names: Vec::new(),
+            public_key: "pk".to_string(),
+            credential_token: "tok".to_string(),
+            metadata: BTreeMap::new(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: Vec::new(),
+            recent_events: std::collections::VecDeque::new(),
+            recent_traces: Vec::new(),
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: team_id.map(str::to_string),
+            org_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: Some([id_byte; 16]),
+            children: Vec::new(),
+            parent_key: None,
+            enforcement_mode: None,
+        }
+    }
+
+    /// A policy document carrying only the capability block the cascade reads.
+    fn policy_doc(
+        name: &str,
+        scope: aa_gateway::policy::PolicyScope,
+        capabilities: aa_core::CapabilitySet,
+    ) -> aa_gateway::policy::PolicyDocument {
+        aa_gateway::policy::PolicyDocument {
+            name: Some(name.to_string()),
+            policy_version: Some("1".to_string()),
+            version: None,
+            scope,
+            network: None,
+            schedule: None,
+            budget: None,
+            data: None,
+            approval_timeout_secs: 300,
+            approval_policy: None,
+            tools: Default::default(),
+            capabilities: Some(capabilities),
+        }
+    }
+
+    /// `AppState::local_in_memory` loads a budget-only policy file, so the
+    /// documents under test have to be pushed into the engine directly.
+    fn state_with_policies(
+        records: Vec<aa_gateway::registry::AgentRecord>,
+        docs: Vec<aa_gateway::policy::PolicyDocument>,
+    ) -> AppState {
+        let mut state = AppState::local_in_memory().expect("state builds");
+        for r in records {
+            state.agent_registry.register(r).expect("register");
+        }
+        let engine =
+            std::sync::Arc::get_mut(&mut state.policy_engine).expect("engine is unshared until the state is cloned");
+        for doc in docs {
+            engine.load_policy(doc);
+        }
+        state
+    }
+
+    /// Regression guard for AAASM-5102. `AppState::local_in_memory` never called
+    /// `PolicyEngine::with_registry`, so `effective_permissions` resolved
+    /// `Lineage::default()` and walked only Global and Agent — this endpoint
+    /// dropped every Org- and Team-scoped allow *and* deny, reporting a
+    /// team-denied capability as permitted (a reporting fail-open). Enforcement
+    /// was never affected; it resolves tenancy itself (AAASM-3729).
+    #[tokio::test]
+    async fn a_team_scoped_deny_reaches_the_capabilities_response() {
+        let mut caps = aa_core::CapabilitySet::default();
+        caps.deny.insert(aa_core::Capability::TerminalExec);
+
+        let state = state_with_policies(
+            vec![record(0x01, Some("team-alpha"))],
+            vec![policy_doc(
+                "team-rules",
+                aa_gateway::policy::PolicyScope::Team("team-alpha".to_string()),
+                caps,
+            )],
+        );
+
+        let (status, Json(body)) = get_agent_capabilities(
+            admin(),
+            Extension(state),
+            axum::extract::Path(hex::encode([0x01u8; 16])),
+        )
+        .await
+        .expect("admin may read a registered agent's capabilities");
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body.deny.iter().any(|c| c == "terminal_exec"),
+            "a Team-scoped deny must reach the merged set: {:?}",
+            body.deny
+        );
+        assert!(
+            body.sources.iter().any(|s| s.scope == "team:team-alpha"),
+            "the Team tier must appear in the cascade provenance: {:?}",
+            body.sources.iter().map(|s| &s.scope).collect::<Vec<_>>()
+        );
+    }
 }

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -583,9 +583,13 @@ fn collect_policy_rows(
 /// boundary.
 ///
 /// The cascade is collected with an explicit lineage rather than via
-/// `PolicyEngine::effective_permissions`, because the engine `aa-api` builds is
-/// not registry-wired: without a lineage it resolves only the Global and Agent
-/// tiers and would silently drop every Org- and Team-scoped policy.
+/// `PolicyEngine::effective_permissions`: without a lineage the engine falls
+/// back to `Lineage::default()` and resolves only the Global and Agent tiers,
+/// silently dropping every Org- and Team-scoped policy. AAASM-5102 wired the
+/// registry into the engine `AppState::local_in_memory` builds, so that
+/// fallback no longer fires in the shipped composition root — this projection
+/// keeps the explicit lineage anyway so it stays correct under any engine,
+/// registry-wired or not.
 fn project_matrix(records: &[aa_gateway::registry::AgentRecord], state: &AppState) -> CapabilityMatrix {
     use aa_core::Capability as C;
 
@@ -1071,10 +1075,12 @@ mod tests {
         assert!(!m.agents[0].caps.contains_key(TOOL_WILDCARD));
     }
 
-    /// Guards the explicit lineage at the top of [`project_matrix`]: the engine
-    /// `aa-api` builds is not registry-wired, so resolving the cascade without a
-    /// lineage silently drops every Org- and Team-scoped document. Regressing
-    /// that call would leave this the only failing test.
+    /// Guards the explicit lineage at the top of [`project_matrix`]: resolving
+    /// the cascade without a lineage silently drops every Org- and Team-scoped
+    /// document. Since AAASM-5102 the engine is registry-wired too, so this now
+    /// guards the projection against a *second* regression rather than the only
+    /// one — see `agents::tests::a_team_scoped_deny_reaches_the_capabilities_response`
+    /// for the composition-root guard.
     #[tokio::test]
     async fn a_team_scoped_deny_reaches_the_projection() {
         use aa_core::Capability as C;

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -395,10 +395,12 @@ fn project_effective_permissions(
 /// policy cascade, effective permissions, and daily budget.
 ///
 /// The cascade is collected with an **explicitly resolved** lineage rather than
-/// via `PolicyEngine::collect_cascade` / `effective_permissions`: the engine
-/// `aa-api` builds is not registry-wired (AAASM-5102), so those resolve
-/// `Lineage::default()` and silently walk only the Global and Agent tiers,
-/// dropping every Org- and Team-scoped allow *and* deny. Same guard as
+/// via `PolicyEngine::collect_cascade` / `effective_permissions`: an engine with
+/// no registry attached resolves `Lineage::default()` and silently walks only
+/// the Global and Agent tiers, dropping every Org- and Team-scoped allow *and*
+/// deny. AAASM-5102 attached the registry in `AppState::local_in_memory`, so the
+/// shipped engine no longer takes that fallback — the explicit lineage stays as
+/// the guard that keeps this projection correct under any engine. Same guard as
 /// `capability::project_matrix` (AAASM-5090).
 fn project_graph_nodes(records: &[AgentRecord], state: &AppState) -> Vec<AgentNode> {
     // Budget: snapshot once (not per node) and index today's per-agent spend by
@@ -1369,12 +1371,14 @@ mod graph_tests {
 
     // ── Effective permissions ──────────────────────────────────────────────
 
-    /// Guards the explicit lineage in [`project_graph_nodes`]: the engine
-    /// `aa-api` builds is not registry-wired (AAASM-5102), so resolving the
-    /// cascade without a lineage silently walks only Global and Agent and drops
-    /// every Org- and Team-scoped allow AND deny. Regressing that call back to
-    /// `collect_cascade` / `effective_permissions` would leave this the only
-    /// failing test.
+    /// Guards the explicit lineage in [`project_graph_nodes`]: resolving the
+    /// cascade without a lineage walks only Global and Agent and drops every
+    /// Org- and Team-scoped allow AND deny. Since AAASM-5102 registry-wired the
+    /// engine, regressing that call to `collect_cascade` /
+    /// `effective_permissions` would no longer break this test on its own — it
+    /// guards the projection, and
+    /// `agents::tests::a_team_scoped_deny_reaches_the_capabilities_response`
+    /// guards the composition root that makes the unlineaged path safe.
     #[tokio::test]
     async fn a_team_scoped_policy_reaches_the_permission_chain() {
         let mut caps = aa_core::CapabilitySet::default();

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -674,6 +674,89 @@ mod tests {
         assert_eq!(state.key_store.len(), 1, "exactly the seeded admin key is present");
     }
 
+    /// AAASM-5102 — the shipped `serve_local` entrypoint goes through
+    /// `local_hardened_at`, which swaps in a durable SQLite-backed registry.
+    /// The engine has to end up holding *that* registry: if it keeps the
+    /// throwaway one `local_in_memory` would otherwise have created, every
+    /// lineage lookup misses and the cascade silently degrades to Global+Agent
+    /// again — the wiring fix would then never reach production.
+    #[tokio::test]
+    async fn local_hardened_engine_resolves_lineage_from_the_durable_registry() {
+        let mut state = AppState::local_hardened(LocalAuth::Off)
+            .await
+            .expect("hardened state builds");
+
+        let mut caps = aa_core::CapabilitySet::default();
+        caps.deny.insert(aa_core::Capability::TerminalExec);
+        let engine = Arc::get_mut(&mut state.policy_engine).expect("engine is unshared right after construction");
+        engine.load_policy(aa_gateway::policy::PolicyDocument {
+            name: Some("team-rules".to_string()),
+            policy_version: Some("1".to_string()),
+            version: None,
+            scope: aa_gateway::policy::PolicyScope::Team("team-alpha".to_string()),
+            network: None,
+            schedule: None,
+            budget: None,
+            data: None,
+            approval_timeout_secs: 300,
+            approval_policy: None,
+            tools: Default::default(),
+            capabilities: Some(caps),
+        });
+
+        state
+            .agent_registry
+            .register(test_record([0x01; 16], "team-alpha"))
+            .expect("register");
+
+        let merged = state
+            .policy_engine
+            .effective_permissions(&aa_core::identity::AgentId::from_bytes([0x01; 16]))
+            .merged;
+        assert!(
+            merged.deny.contains(&aa_core::Capability::TerminalExec),
+            "the engine must resolve the durable registry's lineage: {:?}",
+            merged.deny
+        );
+    }
+
+    /// Minimal registered agent owned by `team_id`.
+    fn test_record(agent_id: [u8; 16], team_id: &str) -> aa_gateway::registry::AgentRecord {
+        aa_gateway::registry::AgentRecord {
+            agent_id,
+            name: "a".to_string(),
+            framework: "langgraph".to_string(),
+            version: "0.1.0".to_string(),
+            risk_tier: 1,
+            tool_names: Vec::new(),
+            public_key: "pk".to_string(),
+            credential_token: "tok".to_string(),
+            metadata: std::collections::BTreeMap::new(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: aa_gateway::registry::AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: Vec::new(),
+            recent_events: std::collections::VecDeque::new(),
+            recent_traces: Vec::new(),
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: Some(team_id.to_string()),
+            org_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: Some(agent_id),
+            children: Vec::new(),
+            parent_key: None,
+            enforcement_mode: None,
+        }
+    }
+
     #[test]
     fn local_state_error_messages_are_descriptive() {
         let load = LocalStateError::PolicyLoad("bad policy".to_string());

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -242,6 +242,19 @@ impl AppState {
     /// with a daily budget limit) written to a per-process temp file because
     /// [`PolicyEngine::load_from_file`] is the only public loader.
     pub fn local_in_memory() -> Result<Self, LocalStateError> {
+        Self::local_in_memory_with_registry(Arc::new(AgentRegistry::new()))
+    }
+
+    /// [`local_in_memory`](Self::local_in_memory) over a caller-supplied agent
+    /// registry.
+    ///
+    /// AAASM-5102 — the engine has to adopt the *same* `Arc<AgentRegistry>` the
+    /// `AppState` exposes, and [`local_hardened_at`](Self::local_hardened_at)
+    /// needs a durable SQLite-backed registry rather than the throwaway
+    /// in-memory one. Threading it in here is what lets both entrypoints share
+    /// one registry instance; replacing `state.agent_registry` after the fact
+    /// would leave the engine holding the discarded registry.
+    fn local_in_memory_with_registry(agent_registry: Arc<AgentRegistry>) -> Result<Self, LocalStateError> {
         use std::sync::atomic::AtomicUsize;
 
         // Unique temp paths per call so concurrent processes / tests do not
@@ -277,9 +290,18 @@ impl AppState {
 
         let events = Arc::new(EventBroadcast::default());
         let budget_alert_tx = events.budget_sender();
+        // AAASM-5102: the engine adopts the *same* registry the AppState
+        // exposes. Without `with_registry`, `PolicyEngine::registry` stays
+        // `None`, and every lineage-less cascade read (`collect_cascade` →
+        // `effective_permissions`, behind `GET /agents/{id}/capabilities`)
+        // resolves `Lineage::default()` and walks only Global and Agent —
+        // silently dropping every Org- and Team-scoped allow *and* deny.
+        // Enforcement was never affected: it resolves tenancy itself via
+        // `authoritative_lineage` (AAASM-3729).
         let policy_engine = Arc::new(
             aa_gateway::engine::PolicyEngine::load_from_file(&policy_path, budget_alert_tx)
                 .map_err(|e| LocalStateError::PolicyLoad(format!("{e:?}")))?
+                .with_registry(Arc::clone(&agent_registry))
                 .with_invalidation_hub(aa_gateway::invalidation::InvalidationHub::new()),
         );
 
@@ -326,7 +348,7 @@ impl AppState {
         let audit_reader = Arc::new(AuditReader::new(audit_dir));
 
         Ok(AppState {
-            agent_registry: Arc::new(AgentRegistry::new()),
+            agent_registry,
             policy_engine,
             budget_tracker,
             approval_queue: ApprovalQueue::new(),
@@ -435,7 +457,43 @@ impl AppState {
     ) -> Result<Self, LocalStateError> {
         use std::sync::atomic::AtomicUsize;
 
-        let mut state = Self::local_in_memory()?;
+        // --- Durable agent registry (AAASM-4447 / AAASM-4459). ---
+        // Built *before* the base wiring (AAASM-5102): `local_in_memory` attaches
+        // whatever registry it is given to the policy engine, so the durable one
+        // has to exist first. Assigning `state.agent_registry` afterwards would
+        // leave the engine resolving lineage against the discarded throwaway
+        // registry — i.e. against an always-empty registry, which is exactly the
+        // `Lineage::default()` fallback this ticket removes.
+        //
+        // The embedded gRPC `AgentLifecycleService` (AAASM-4460) and the
+        // REST/dashboard surface share this SAME `Arc<AgentRegistry>`, so an
+        // SDK-registered agent is immediately visible to the dashboard and
+        // persists across restarts (mirrors aa-gateway/src/main.rs).
+        if let Some(parent) = registry_db_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(|source| LocalStateError::PolicyWrite {
+                    path: registry_db_path.clone(),
+                    source,
+                })?;
+            }
+        }
+        let registry_storage = aa_gateway::storage::open_sqlite_backend(&registry_db_path)
+            .await
+            .map_err(|e| LocalStateError::Storage(format!("{e}")))?;
+        let registry = Arc::new(AgentRegistry::new().with_storage(registry_storage));
+        let restored = registry
+            .rehydrate_from_storage()
+            .await
+            .map_err(|e| LocalStateError::Storage(format!("registry rehydrate failed: {e}")))?;
+        if restored > 0 {
+            tracing::info!(
+                restored,
+                path = %registry_db_path.display(),
+                "rehydrated agents from durable registry store"
+            );
+        }
+
+        let mut state = Self::local_in_memory_with_registry(registry)?;
 
         // --- Rate limiting: honour AA_RATE_LIMIT_RPM in the live limiter. ---
         // `local_in_memory` hard-codes 1000; the shipped binary resolves the
@@ -548,39 +606,6 @@ impl AppState {
                 }
             }
         }
-
-        // --- Durable agent registry (AAASM-4447 / AAASM-4459). ---
-        // `local_in_memory` seeds a throwaway in-memory `AgentRegistry`. Replace
-        // it with one backed by a durable SQLite store and rehydrated on boot,
-        // mirroring the aa-gateway legacy-grpc path (aa-gateway/src/main.rs). The
-        // embedded gRPC `AgentLifecycleService` (AAASM-4460) and the
-        // REST/dashboard surface then share this SAME `Arc<AgentRegistry>`, so an
-        // SDK-registered agent is immediately visible to the dashboard and
-        // persists across restarts.
-        if let Some(parent) = registry_db_path.parent() {
-            if !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent).map_err(|source| LocalStateError::PolicyWrite {
-                    path: registry_db_path.clone(),
-                    source,
-                })?;
-            }
-        }
-        let registry_storage = aa_gateway::storage::open_sqlite_backend(&registry_db_path)
-            .await
-            .map_err(|e| LocalStateError::Storage(format!("{e}")))?;
-        let registry = Arc::new(AgentRegistry::new().with_storage(registry_storage));
-        let restored = registry
-            .rehydrate_from_storage()
-            .await
-            .map_err(|e| LocalStateError::Storage(format!("registry rehydrate failed: {e}")))?;
-        if restored > 0 {
-            tracing::info!(
-                restored,
-                path = %registry_db_path.display(),
-                "rehydrated agents from durable registry store"
-            );
-        }
-        state.agent_registry = registry;
 
         Ok(state)
     }


### PR DESCRIPTION
## Description

`AppState` never called `PolicyEngine::with_registry`, so `PolicyEngine.registry` was permanently `None` in the aa-api process. `collect_cascade` then fell back to `Lineage::default()` and walked **only the Global and Agent tiers**, so `GET /api/v1/agents/{id}/capabilities` (which goes through `effective_permissions` → `collect_cascade`) silently omitted every **Org- and Team-scoped allow *and* deny**. Because the denies were dropped too, the endpoint could report a capability as permitted while a team policy denied it — a **reporting fail-open**. It surfaced in `aasm policy show --show-permissions`, `aasm topology lineage --show-permissions`, and the dashboard's inherited-permissions panel, and it made `/agents/{id}/capabilities` disagree with `/topology` about the same agent.

**Enforcement was never affected.** `PolicyEngine::evaluate` deliberately avoids `collect_cascade`: it resolves tenancy itself via `authoritative_lineage(ctx)` and calls `collect_cascade_with_lineage` (AAASM-3729). Real verdicts always saw Org/Team policy. This PR changes reporting only — no response schema changed, only the data inside the existing shape.

### The fix

`AppState::local_in_memory` now attaches the registry: `.with_registry(Arc::clone(&agent_registry))`.

**A second, load-bearing detail:** the shipped `serve_local` entrypoint goes through `local_hardened_at`, which *replaces* `state.agent_registry` with a durable SQLite-backed registry **after** the base wiring. Wiring `local_in_memory` alone would have left the engine holding the discarded throwaway registry — an always-empty registry, i.e. exactly the `Lineage::default()` fallback this ticket removes — so the fix would never have reached production. The durable registry is therefore built *first* and threaded into the base wiring via a new private `local_in_memory_with_registry`, and the trailing `state.agent_registry = registry` assignment is gone. Nothing else about how state is assembled changed.

### Blast radius

aa-api calls exactly four `policy_engine` methods: `effective_permissions` (1×, `agents.rs:633` — the bug), `collect_cascade_with_lineage` (2×, already lineage-explicit), `active_policy_info` (2×), `simulate` (1×). Only the first changes behaviour. `simulate` shares the engine's registry, so a dry-run of a *registered* agent now resolves its cascade from the registered owner instead of the client-supplied context — that is the designed behaviour (AAASM-3729/3138) and matches what a real evaluation does; unregistered agents still fall back to the request context, unchanged.

No enforcement crate was touched — `git diff --name-only remote/main..HEAD` is four files, all under `aa-api/src/`.

**No existing test asserted the old (broken, Org/Team-dropped) numbers** — the full `aa-api` package (1014 tests, lib + integration) is green with no expectation edits. The only pre-existing tests in this area (`capability::project_matrix`, `topology::project_graph_nodes` and their guards) deliberately pass an *explicit* lineage to sidestep this bug, so they were already asserting the corrected numbers and keep passing untouched. Their doc comments, which asserted "the engine `aa-api` builds is not registry-wired", were refreshed in a separate comment-only commit — the explicit lineage stays as the guard that keeps those projections correct under any engine.

### Other construction sites checked

- `aa-gateway/src/server.rs` `serve_tcp` / `serve_uds` also build the engine without `.with_registry(..)` even though a registry is in scope. **Left as-is, out of scope:** aa-gateway has no production caller of `effective_permissions` / unlineaged `collect_cascade`, and enforcement resolves lineage itself, so it is latent rather than live. Worth a follow-up ticket.
- `aa-api/tests/common/mod.rs` builds its own unwired engine, but it constructs `AppState` by hand rather than through `local_in_memory`, so it is unaffected by this change. Left alone.
- `aa-cli/src/commands/policy/simulate.rs` builds a standalone engine for offline simulation with no registry available — correct as-is.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No

No schema change. `GET /api/v1/agents/{id}/capabilities` keeps its exact response shape; it now returns the Org- and Team-scoped rows it was dropping. A consumer that had (incorrectly) treated the endpoint as authoritative will now see additional `deny` entries and additional `sources` rows — which is the endpoint finally agreeing with enforcement and with `/topology`.

## Related Issues

- Related Jira ticket: [AAASM-5102](https://lightning-dust-mite.atlassian.net/browse/AAASM-5102)
- Related GitHub issues: N/A

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Two regression guards, both verified red without the wiring by reverting `.with_registry(..)` and re-running:

`aa-api routes::agents::tests::a_team_scoped_deny_reaches_the_capabilities_response`

```
thread 'routes::agents::tests::a_team_scoped_deny_reaches_the_capabilities_response' panicked at aa-api/src/routes/agents.rs:1502:9:
a Team-scoped deny must reach the merged set: []
```

`aa-api state::tests::local_hardened_engine_resolves_lineage_from_the_durable_registry`

```
thread 'state::tests::local_hardened_engine_resolves_lineage_from_the_durable_registry' panicked at aa-api/src/state.rs:716:9:
the engine must resolve the durable registry's lineage: {}
```

Both pass with the fix restored. Gates run locally:

```
cargo nextest run -p aa-api --lib   → 439 tests run: 439 passed, 0 skipped
cargo nextest run -p aa-api         → 1014 tests run: 1014 passed (1 leaky), 0 skipped
cargo fmt --all                     → clean
cargo clippy -p aa-api --all-targets -- -D warnings → exit 0
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced


[AAASM-5102]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ