### PR TITLE
[AAASM-5230] ♻️ (iam): Key AgentRegistryList STATUS_CLASS by Map

### DIFF
--- a/dashboard/src/features/iam/AgentRegistryList.test.tsx
+++ b/dashboard/src/features/iam/AgentRegistryList.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tone-lookup guard for AAASM-5230.
+ *
+ * The status tone was resolved through a plain object literal keyed by a
+ * wire-derived value: `STATUS_CLASS[agentStatusVariant(status)]`. Because the
+ * gateway emits the status verbatim, a status whose outer variant happens to
+ * name an inherited `Object.prototype` member (`constructor`, `toString`,
+ * `valueOf`, `__proto__`, `hasOwnProperty`) resolved to that inherited member
+ * instead of `undefined`, so the `?? 'iam-agent-status--other'` fallback was
+ * dead for those names. A `Map.get()` returns `undefined` for non-own keys,
+ * which restores the fallback. These tests render the list and assert the tone
+ * class on the status chip, so they fail against the object-literal version.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { AgentRegistryList } from './AgentRegistryList'
+import { api } from '../../api/client'
+
+interface FetchResult {
+  data?: unknown
+  error?: unknown
+}
+
+function renderList() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <AgentRegistryList selectedAgentId={null} onSelect={() => {}} />
+    </QueryClientProvider>,
+  )
+}
+
+function rawAgent(id: string, status: string) {
+  return {
+    id,
+    name: `agent-${id}`,
+    framework: 'langgraph',
+    version: '1.0.0',
+    status,
+    tool_names: [],
+    metadata: {},
+    session_count: 0,
+    policy_violations_count: 0,
+    active_sessions: [],
+    recent_events: [],
+    recent_traces: [],
+    last_event: '2026-07-26T09:00:00Z',
+  }
+}
+
+let get: Mock
+
+beforeEach(() => {
+  get = vi.spyOn(api, 'GET') as unknown as Mock
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/** Read the status chip's className for a given agent row. */
+async function statusChipClass(agentId: string): Promise<string> {
+  const chip = await screen.findByTestId(`agent-status-${agentId}`)
+  // TruthfulValue renders the status chip span inside the cell.
+  const span = chip.querySelector('.iam-agent-status')
+  if (!span) throw new Error(`no status chip rendered for ${agentId}`)
+  return span.className
+}
+
+describe('AgentRegistryList status tone', () => {
+  it('maps the three real registry variants to their own tone', async () => {
+    get.mockResolvedValue({
+      data: {
+        items: [
+          rawAgent('active', 'Active'),
+          rawAgent('suspended', 'Suspended(Manual)'),
+          rawAgent('deregistered', 'Deregistered'),
+        ],
+        page: 1,
+        per_page: 100,
+        total: 3,
+      },
+    } satisfies FetchResult)
+
+    renderList()
+    await waitFor(() => expect(get).toHaveBeenCalled())
+
+    expect(await statusChipClass('active')).toContain('iam-agent-status--active')
+    expect(await statusChipClass('suspended')).toContain('iam-agent-status--suspended')
+    expect(await statusChipClass('deregistered')).toContain('iam-agent-status--deregistered')
+  })
+
+  // Each of these is an inherited `Object.prototype` member. Keyed into a plain
+  // object literal it resolves to the inherited value (a function or the
+  // prototype), so the `?? '--other'` fallback never fired and the chip
+  // borrowed a non-string tone. `Map.get()` returns `undefined` for them.
+  it.each(['constructor', 'toString', 'valueOf', '__proto__', 'hasOwnProperty'])(
+    'falls a %s status through to the --other tone, never an inherited member',
+    async (inheritedName) => {
+      get.mockResolvedValue({
+        data: {
+          items: [rawAgent('inherited', inheritedName)],
+          page: 1,
+          per_page: 100,
+          total: 1,
+        },
+      } satisfies FetchResult)
+
+      renderList()
+      await waitFor(() => expect(get).toHaveBeenCalled())
+
+      const className = await statusChipClass('inherited')
+      // The only tone applied is the neutral fallback.
+      expect(className).toContain('iam-agent-status--other')
+      expect(className).not.toContain('iam-agent-status--active')
+      expect(className).not.toContain('iam-agent-status--suspended')
+      expect(className).not.toContain('iam-agent-status--deregistered')
+      // No inherited member ever leaks in as a tone class (e.g. `[object ...]`
+      // or a stringified function).
+      expect(className).not.toMatch(/function|\[object/i)
+    },
+  )
+})

--- a/dashboard/src/features/iam/AgentRegistryList.tsx
+++ b/dashboard/src/features/iam/AgentRegistryList.tsx
@@ -9,11 +9,11 @@ import './AgentRegistryList.css'
  * emits — see `agentStatusVariant` for why these are capitalised Rust variant
  * names and not the lowercase capability-matrix enum.
  */
-const STATUS_CLASS: Record<string, string> = {
-  Active: 'iam-agent-status--active',
-  Suspended: 'iam-agent-status--suspended',
-  Deregistered: 'iam-agent-status--deregistered',
-}
+const STATUS_CLASS = new Map<string, string>([
+  ['Active', 'iam-agent-status--active'],
+  ['Suspended', 'iam-agent-status--suspended'],
+  ['Deregistered', 'iam-agent-status--deregistered'],
+])
 
 /**
  * Render the registry's own word for the agent's status.
@@ -26,7 +26,7 @@ const STATUS_CLASS: Record<string, string> = {
  * the outer variant, so a payload cannot cost a suspended agent its colour.
  */
 function StatusChip({ status }: Readonly<{ status: string }>) {
-  const toneClass = STATUS_CLASS[agentStatusVariant(status)] ?? 'iam-agent-status--other'
+  const toneClass = STATUS_CLASS.get(agentStatusVariant(status)) ?? 'iam-agent-status--other'
   return (
     <span className={`iam-agent-status ${toneClass}`} data-status={status} title={status}>
       {status}


### PR DESCRIPTION
## Description

`AgentRegistryList.tsx` resolved the status chip's tone through a plain object
literal keyed by a wire-derived value:

```ts
const STATUS_CLASS: Record<string, string> = { Active, Suspended, Deregistered }
const toneClass = STATUS_CLASS[agentStatusVariant(status)] ?? 'iam-agent-status--other'
```

**Root cause (prototype pollution of the lookup):** `agentStatusVariant(status)`
returns whatever outer variant the gateway emitted, verbatim. When that value
names an inherited `Object.prototype` member — `constructor`, `toString`,
`valueOf`, `__proto__`, `hasOwnProperty` — the bracket index resolves to the
*inherited* member (a function, or the prototype object) rather than `undefined`,
so the `?? 'iam-agent-status--other'` fallback is dead for those names. The chip
then gets a non-tone `className` such as `[object Object]` or a stringified
native function instead of the neutral `--other` tone.

**Fix:** convert `STATUS_CLASS` to a `Map<string, string>` and index it with
`.get()`, which returns `undefined` for any non-own key, restoring the fallback.

**Preserved capitalisation:** the keys `Active` / `Suspended` / `Deregistered`
are the Rust `Debug` variant names the registry actually emits (`AgentRegistryList.tsx:8-10`,
`agents.ts:agentStatusVariant`). This casing is deliberate and left exactly as-is.

Scope note: this is the crash-prone copy only. The separate `ROLE_BADGE_TONE`
in `RoleCapabilityCards.tsx` is a different ticket (AAASM-5229) and is untouched.
No OpenAPI/schema change is involved — this is a pure TS conversion.

## Type of Change

- [x] ♻️ Refactoring
- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Behaviour is unchanged for every value the gateway actually emits; the only
change is that statuses colliding with inherited prototype names now correctly
fall through to `--other` instead of receiving a garbage tone class.

## Related Issues

- Related Jira ticket: AAASM-5230 (subtask of Story AAASM-5211, Epic AAASM-5208)

## Acceptance criteria

- [x] `STATUS_CLASS` is a `Map<string, string>` with the capitalised keys preserved
- [x] Index site uses `STATUS_CLASS.get(agentStatusVariant(status)) ?? 'iam-agent-status--other'`
- [x] The three real variants (`Active`, `Suspended(...)`, `Deregistered`) still map to their own tone
- [x] Inherited prototype names no longer resolve to a class — they fall to `--other`
- [x] `RoleCapabilityCards.tsx` untouched; no schema change

## Testing

- [x] Unit tests added / updated

Added `dashboard/src/features/iam/AgentRegistryList.test.tsx`: renders the list
(mocking `api.GET`) and asserts the status chip's tone class. Covers the three
real variants and each of the five inherited prototype names, asserting they
fall through to `--other` and never leak an inherited member (no `function` /
`[object ...]` in the class).

**Load-bearing verification:** reverting the source to the object-literal
version turns the five inherited-key cases red (`__proto__` →
`iam-agent-status [object Object]`, `hasOwnProperty` →
`iam-agent-status function hasOwnProperty() { [native code] }`), while the
three-real-variant case stays green. The Map fix makes all six pass.

### Gate results (Node 22, pnpm 10.9.0)

- `pnpm type-check` — clean (tsc --noEmit, no errors)
- `pnpm lint` — clean (eslint, `--max-warnings 0`)
- `pnpm test AgentRegistryList` — 6 passed / 6

No build or Playwright run: this is a logic + unit-test change with no visual delta.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed (n/a — no behaviour doc affected)
- [x] All CI checks passing (local gates green; CI pending)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)