### PR TITLE
[AAASM-5224] 🐛 (alerts): Key parseAlert wire lookups by Map to restore fail-closed

### DIFF
--- a/dashboard/src/features/alerts/parseAlert.test.ts
+++ b/dashboard/src/features/alerts/parseAlert.test.ts
@@ -59,6 +59,20 @@ describe('canonicalStatus / canonicalSeverity — the live wire vocabulary', () 
     expect(() => canonicalStatus(undefined)).toThrow(AlertShapeError)
     expect(() => canonicalSeverity(3)).toThrow(AlertShapeError)
   })
+
+  it.each(['constructor', '__proto__', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'throws on the inherited object member %s instead of returning it',
+    (inherited) => {
+      // A plain-object lookup keyed by `WIRE_STATUS[value]` would resolve these
+      // names to a truthy Object.prototype member and slip past the `if (mapped)`
+      // guard — a payload we cannot read silently becoming a well-typed Alert.
+      // That is the exact route by which "a suppressed alert starts counting as
+      // firing". Keyed by a Map, `.get()` returns undefined for inherited names
+      // and the documented fail-closed throw fires as designed.
+      expect(() => canonicalStatus(inherited)).toThrow(AlertShapeError)
+      expect(() => canonicalSeverity(inherited)).toThrow(AlertShapeError)
+    },
+  )
 })
 
 describe('normaliseAlert', () => {

--- a/dashboard/src/features/alerts/parseAlert.ts
+++ b/dashboard/src/features/alerts/parseAlert.ts
@@ -48,11 +48,11 @@ export class AlertShapeError extends Error {
  * active silence covers it (AAASM-1645). The three map 1:1 onto the dashboard's
  * ladder with no judgement call.
  */
-const WIRE_STATUS: Readonly<Record<string, AlertStatus>> = {
-  unresolved: 'FIRING',
-  resolved: 'RESOLVED',
-  suppressed: 'SUPPRESSED',
-}
+const WIRE_STATUS: ReadonlyMap<string, AlertStatus> = new Map([
+  ['unresolved', 'FIRING'],
+  ['resolved', 'RESOLVED'],
+  ['suppressed', 'SUPPRESSED'],
+])
 
 /**
  * Severity vocabulary as `aa-api` actually serialises it.
@@ -108,7 +108,7 @@ export function canonicalStatus(raw: unknown): AlertStatus {
   const value = str(raw)
   if (value === null) throw new AlertShapeError('alert.status is not a string')
   if (CANONICAL_STATUS.has(value)) return value as AlertStatus
-  const mapped = WIRE_STATUS[value.toLowerCase()]
+  const mapped = WIRE_STATUS.get(value.toLowerCase())
   if (mapped) return mapped
   throw new AlertShapeError(`unrecognised alert status: ${JSON.stringify(value)}`)
 }

--- a/dashboard/src/features/alerts/parseAlert.ts
+++ b/dashboard/src/features/alerts/parseAlert.ts
@@ -68,11 +68,11 @@ const WIRE_STATUS: ReadonlyMap<string, AlertStatus> = new Map([
  * Stories (AAASM-1385…1389) settle on a different ladder, this table is the one
  * place that changes.
  */
-const WIRE_SEVERITY: Readonly<Record<string, Severity>> = {
-  critical: 'CRITICAL',
-  warning: 'HIGH',
-  info: 'LOW',
-}
+const WIRE_SEVERITY: ReadonlyMap<string, Severity> = new Map([
+  ['critical', 'CRITICAL'],
+  ['warning', 'HIGH'],
+  ['info', 'LOW'],
+])
 
 /** The dashboard's own vocabulary, accepted unchanged. */
 const CANONICAL_STATUS: ReadonlySet<string> = new Set<AlertStatus>([
@@ -118,7 +118,7 @@ export function canonicalSeverity(raw: unknown): Severity {
   const value = str(raw)
   if (value === null) throw new AlertShapeError('alert.severity is not a string')
   if (CANONICAL_SEVERITY.has(value)) return value as Severity
-  const mapped = WIRE_SEVERITY[value.toLowerCase()]
+  const mapped = WIRE_SEVERITY.get(value.toLowerCase())
   if (mapped) return mapped
   throw new AlertShapeError(`unrecognised alert severity: ${JSON.stringify(value)}`)
 }


### PR DESCRIPTION
## Description

`dashboard/src/features/alerts/parseAlert.ts` canonicalises the wire vocabulary through two object literals indexed by the untrusted `AlertResponse.status` / `.severity` (both `type: string`, no enum):

```ts
const mapped = WIRE_STATUS[value.toLowerCase()]
if (mapped) return mapped
throw new AlertShapeError(...)
```

**Root cause — the documented fail-closed throw is bypassed.** A plain object inherits its members from `Object.prototype`. A status/severity of `"constructor"` or `"__proto__"` survives `.toLowerCase()`, and `WIRE_STATUS["constructor"]` resolves to the inherited constructor function — a *truthy* value. `if (mapped) return mapped` therefore returns it and the `throw` never fires. The module's own docblock names exactly this harm: guessing at an unrecognised status is *"how a suppressed alert starts counting as firing"* — an unreadable payload silently becomes a well-typed `Alert` instead of being rejected, defeating the fail-closed contract this module exists to enforce (AAASM-5149).

**Fix.** Convert both `WIRE_STATUS` and `WIRE_SEVERITY` to `ReadonlyMap`. `Map.get()` returns `undefined` for inherited names, so `if (mapped)` is false and the documented `AlertShapeError` fires as designed. No behaviour change for any real status/severity — all three statuses and three severities still map identically.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Real wire values (`unresolved`/`resolved`/`suppressed`, `critical`/`warning`/`info`) and the canonical upper-case forms map unchanged. Only previously-bypassing inherited-member inputs change: they now correctly throw.

## Related Issues

- Related Jira ticket: AAASM-5224 (Subtask of Story AAASM-5210, Epic AAASM-5208)

## Testing

- [x] Unit tests added / updated

Extended `parseAlert.test.ts` with a parametrised case asserting `canonicalStatus` and `canonicalSeverity` throw `AlertShapeError` for `constructor`, `__proto__`, `toString`, `hasOwnProperty`, `valueOf`. The existing wire-vocabulary maps and the AAASM-5149 nav-badge regression guard continue to assert every real status/severity still maps.

**Test verified load-bearing (red pre-fix):** ran the new assertions against the pre-fix object-literal lookup — the `constructor` and `__proto__` cases FAIL (`expected function to throw an error, but it didn't`), reproducing the bypass. With the Map, all 23 tests pass. (`toString`/`hasOwnProperty`/`valueOf` pass against both versions because `.toLowerCase()` mangles them out of prototype-name form; `constructor`/`__proto__` are the load-bearing pair the ticket calls out.)

### Gate results (dashboard/, Node 22)

- `pnpm type-check` — clean (tsc --noEmit, 0 errors)
- `pnpm lint` — clean (eslint --max-warnings 0, 0 violations)
- `pnpm test parseAlert` — 23 passed (1 file)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (existing docblock already documents the exact failure mode this closes; no wording change needed)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)