### PR TITLE
[AAASM-5227] 🐛 (agentDetail): Key decision-verdict lookup by Map

### DIFF
--- a/dashboard/src/components/agentDetail/AgentDecisionStream.test.tsx
+++ b/dashboard/src/components/agentDetail/AgentDecisionStream.test.tsx
@@ -4,6 +4,7 @@ import type { UseQueryResult } from '@tanstack/react-query'
 import { AgentDecisionStream } from './AgentDecisionStream'
 import * as agentsApi from '../../features/agents/api'
 import type { AgentDecision } from '../../features/agents/api'
+import { VERDICT_META } from '../../features/trace/decision'
 
 function mockQuery<T>(partial: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, Error> {
   return partial as unknown as UseQueryResult<T, Error>
@@ -133,6 +134,41 @@ describe('AgentDecisionStream', () => {
     render(<AgentDecisionStream agentId="a1" />)
     const verdict = within(screen.getByTestId('agent-decision-row')).getByText(/unspecified/)
     expect(verdict).toHaveStyle({ color: 'var(--ink-3)' })
+  })
+
+  it.each(['constructor', 'toString', '__proto__', 'hasOwnProperty'])(
+    'renders an inherited-name decision label (%s) with the neutral absence colour rather than crashing',
+    (label) => {
+      vi.spyOn(agentsApi, 'useAgentDecisionsQuery').mockReturnValue(
+        mockQuery<AgentDecision[]>({
+          data: [decision({ decision: 0, decisionLabel: label })],
+          isLoading: false,
+          isError: false,
+          refetch: vi.fn(),
+        }),
+      )
+      // With an object-literal lookup this throws (the inherited function value is
+      // truthy, so `VERDICT_META[<function>].colorVar` reads `.colorVar` of undefined)
+      // and unmounts the Traffic tab. The Map lookup must return undefined and render
+      // the absence colour instead.
+      render(<AgentDecisionStream agentId="a1" />)
+      const verdict = within(screen.getByTestId('agent-decision-row')).getByText(new RegExp(label))
+      expect(verdict).toHaveStyle({ color: 'var(--ink-3)' })
+    },
+  )
+
+  it('still maps real decision labels to their verdict colour', () => {
+    vi.spyOn(agentsApi, 'useAgentDecisionsQuery').mockReturnValue(
+      mockQuery<AgentDecision[]>({
+        data: [decision({ decision: 2, decisionLabel: 'deny' })],
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    render(<AgentDecisionStream agentId="a1" />)
+    const verdict = within(screen.getByTestId('agent-decision-row')).getByText(/deny/)
+    expect(verdict).toHaveStyle({ color: VERDICT_META.denied.colorVar })
   })
 
   it('falls back to the raw timestamp when it is not a valid date', () => {

--- a/dashboard/src/components/agentDetail/AgentDecisionStream.tsx
+++ b/dashboard/src/components/agentDetail/AgentDecisionStream.tsx
@@ -23,12 +23,12 @@ import { ErrorState } from '../ErrorState'
  * as the trace decision-explainer. `unspecified` / unknown labels fall through
  * to a neutral render (no verdict colour) rather than a guessed one.
  */
-const VERDICT_BY_LABEL: Record<string, Verdict> = {
-  allow: 'allowed',
-  deny: 'denied',
-  pending: 'pending',
-  redact: 'scrubbed',
-}
+const VERDICT_BY_LABEL = new Map<string, Verdict>([
+  ['allow', 'allowed'],
+  ['deny', 'denied'],
+  ['pending', 'pending'],
+  ['redact', 'scrubbed'],
+])
 
 /** Format an RFC 3339 timestamp as `HH:MM:SS`, matching the design's ts column. */
 function formatTime(ts: string): string {
@@ -39,7 +39,7 @@ function formatTime(ts: string): string {
 }
 
 function DecisionCell({ row }: Readonly<{ row: AgentDecision }>) {
-  const verdict = VERDICT_BY_LABEL[row.decisionLabel]
+  const verdict = VERDICT_BY_LABEL.get(row.decisionLabel)
   const color = verdict ? VERDICT_META[verdict].colorVar : 'var(--ink-3)'
   return (
     <span className="adt-verdict" style={{ color }}>


### PR DESCRIPTION
## What changed
`VERDICT_BY_LABEL` in `dashboard/src/components/agentDetail/AgentDecisionStream.tsx` is converted from an object-literal `Record<string, Verdict>` to a `Map<string, Verdict>`, and the per-row lookup uses `.get()` instead of bracket indexing.

## Why it changed
The decision cell resolved a verdict with a **truthiness** check (`const verdict = VERDICT_BY_LABEL[row.decisionLabel]; const color = verdict ? VERDICT_META[verdict].colorVar : 'var(--ink-3)'`), not `??`. `decisionLabel` is a free-form `string` (proto `Decision` enum lowercased, no TS enum). When the backend emits — or a fuzzed/crafted payload contains — a label matching an **inherited** object property name (e.g. `constructor`, `toString`, `__proto__`, `hasOwnProperty`), the bracket lookup returns the truthy inherited function value from `Object.prototype`. The truthiness branch is then taken and `VERDICT_META[<function>].colorVar` reads `.colorVar` of `undefined`, throwing `TypeError` and unmounting the entire agent-detail **Traffic tab**.

A `Map` has no prototype-chain string keys, so `.get()` returns `undefined` for any inherited name. The absence branch (`var(--ink-3)`) then renders correctly, and real labels (`allow`/`deny`/`pending`/`redact`) still map to their verdict colour.

## Acceptance criteria
- [x] `VERDICT_BY_LABEL` is a `Map`, looked up with `.get()`
- [x] An inherited `decisionLabel` (`constructor`/`toString`/`__proto__`/`hasOwnProperty`) no longer crashes and renders the `var(--ink-3)` absence colour
- [x] Real labels still map to the correct verdict colour
- [x] Traffic tab no longer unmounts on such input

## How to verify
`AgentDecisionStream.test.tsx` extended with a parametrised regression test asserting inherited-name labels render the absence colour without throwing, plus a test that real labels still map. **Verified load-bearing:** against the pre-fix object-literal version those 4 inherited-name cases fail with `TypeError: Cannot read properties of undefined (reading 'colorVar')` at the exact crash site; they pass on the `Map` version.

## Gate results
- `pnpm type-check` — clean
- `pnpm lint` — clean (`--max-warnings 0`)
- `pnpm test` (scoped to `AgentDecisionStream`) — 14 passed

Closes AAASM-5227

🤖 Generated with [Claude Code](https://claude.com/claude-code)