### PR TITLE
[AAASM-5228] ♻️ (policies): Key PolicySimulatePanel VERDICT_CLASS by Map

### DIFF
--- a/dashboard/src/features/policies/PolicySimulatePanel.test.tsx
+++ b/dashboard/src/features/policies/PolicySimulatePanel.test.tsx
@@ -150,6 +150,46 @@ describe('PolicySimulatePanel', () => {
     expect(screen.getByTestId('simulate-redacted')).toBeInTheDocument()
   })
 
+  // The schema types `verdict` as a bare `string`, so a value that collides
+  // with an inherited Object.prototype member ("toString", "constructor", …)
+  // used to resolve against the plain-object lookup and defeat the `?? --na`
+  // fallback. Keyed by a Map, only the four real verdicts resolve; anything
+  // else — including prototype-member names — falls through to `--na`.
+  it.each(['toString', 'constructor', 'hasOwnProperty', '__proto__', 'valueOf'])(
+    'falls to the --na class for the inherited "%s" verdict key',
+    async (verdict) => {
+      const user = userEvent.setup()
+      post.mockResolvedValue({
+        data: { verdict, matched_rule: null, reason: 'unknown', redacted: false },
+      })
+      renderPanel()
+      await user.type(screen.getByTestId('simulate-tool-input'), 'shell')
+      await user.click(screen.getByTestId('simulate-run-btn'))
+
+      const el = await screen.findByTestId('simulate-verdict')
+      expect(el).toHaveClass('policy-simulate__verdict--na')
+    },
+  )
+
+  it.each([
+    ['allow', 'policy-simulate__verdict--allow'],
+    ['narrow', 'policy-simulate__verdict--narrow'],
+    ['approval', 'policy-simulate__verdict--approval'],
+    ['deny', 'policy-simulate__verdict--deny'],
+  ])('maps the real "%s" verdict to its modifier class', async (verdict, expectedClass) => {
+    const user = userEvent.setup()
+    post.mockResolvedValue({
+      data: { verdict, matched_rule: null, reason: 'ok', redacted: false },
+    })
+    renderPanel()
+    await user.type(screen.getByTestId('simulate-tool-input'), 'shell')
+    await user.click(screen.getByTestId('simulate-run-btn'))
+
+    const el = await screen.findByTestId('simulate-verdict')
+    expect(el).toHaveClass(expectedClass)
+    expect(el).not.toHaveClass('policy-simulate__verdict--na')
+  })
+
   it('surfaces an error banner when the request fails', async () => {
     const user = userEvent.setup()
     post.mockResolvedValue({ error: { detail: 'boom' } })

--- a/dashboard/src/features/policies/PolicySimulatePanel.tsx
+++ b/dashboard/src/features/policies/PolicySimulatePanel.tsx
@@ -8,16 +8,21 @@ interface PolicySimulatePanelProps {
   readonly onClose: () => void
 }
 
-/** Verdict → design-token modifier, matching the hi-fi policy simulator. */
-const VERDICT_CLASS: Record<string, string> = {
-  allow: 'policy-simulate__verdict--allow',
-  narrow: 'policy-simulate__verdict--narrow',
-  approval: 'policy-simulate__verdict--approval',
-  deny: 'policy-simulate__verdict--deny',
-}
+/**
+ * Verdict → design-token modifier, matching the hi-fi policy simulator.
+ * A Map (not a plain object) so an arbitrary string verdict — its schema type
+ * is `string`, not an enum — cannot resolve to an inherited prototype member
+ * (`toString`, `constructor`, …) and defeat the `?? --na` fallback below.
+ */
+const VERDICT_CLASS = new Map<string, string>([
+  ['allow', 'policy-simulate__verdict--allow'],
+  ['narrow', 'policy-simulate__verdict--narrow'],
+  ['approval', 'policy-simulate__verdict--approval'],
+  ['deny', 'policy-simulate__verdict--deny'],
+])
 
 function VerdictResult({ result }: Readonly<{ result: SimulatePolicyResponse }>) {
-  const verdictClass = VERDICT_CLASS[result.verdict] ?? 'policy-simulate__verdict--na'
+  const verdictClass = VERDICT_CLASS.get(result.verdict) ?? 'policy-simulate__verdict--na'
   return (
     <div className="policy-simulate__result" data-testid="simulate-result" aria-live="polite">
       <div className="policy-simulate__verdict-row">


### PR DESCRIPTION
## What changed
`PolicySimulatePanel`'s `VERDICT_CLASS` verdict→CSS-modifier lookup was a plain
object (`Record<string, string>`) indexed as `VERDICT_CLASS[result.verdict] ?? '…--na'`.
It is now a `Map<string, string>` read with `.get(result.verdict) ?? '…--na'`.

## Why (root cause — prototype pollution / inherited members)
`SimulatePolicyResponse.verdict` is typed as a bare `string` (no enum in the
OpenAPI schema), so the runtime value is not constrained to the four real
verdicts. When it collided with an inherited `Object.prototype` member —
`toString`, `valueOf`, `constructor`, `hasOwnProperty`, `__proto__` — the
object index returned the inherited member (a truthy function / object), so the
`??` fallback never fired and the component rendered a garbage class such as
`policy-simulate__verdict [object Object]` or
`…verdict function valueOf() { [native code] }`.

A `Map` has no such inherited string keys: `.get()` returns `undefined` for any
key that is not an own entry, so unknown verdicts now correctly fall through to
`policy-simulate__verdict--na`.

### Decoy note
`AgentDecisionResponse.verdict` (openapi ~:3443, "always null today") is a
**different** field and was intentionally left untouched. Only
`SimulatePolicyResponse.verdict` in this component was changed.

## How to verify
`dashboard/src/features/policies/PolicySimulatePanel.test.tsx` adds two
parametrised regression suites:
- five inherited-member verdict keys must resolve to `--na`;
- the four real verdicts must still map to their own modifier class.

Against the old plain-object lookup these five inherited-key cases fail
(verified by stashing the source fix: `5 failed | 12 passed`); with the Map
fix all 17 pass.

## Acceptance criteria
- [x] `VERDICT_CLASS` is a `Map`, looked up via `.get()`
- [x] Inherited prototype-member verdict keys resolve to `--na`
- [x] The four real verdicts still map to their modifier class
- [x] `AgentDecisionResponse.verdict` decoy field untouched
- [x] Regression test added and load-bearing (red pre-fix)

## Gate results
- `pnpm type-check` — pass (exit 0)
- `pnpm lint` — pass (exit 0, `--max-warnings 0`)
- `pnpm test` (scoped to `PolicySimulatePanel`) — 17 passed; the 5 new
  inherited-key cases fail without the source fix

Closes AAASM-5228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
