### PR TITLE
[AAASM-5236] 🐛 (audit): Tally export typeCounts in a Map

### DIFF
--- a/dashboard/src/features/audit/export.test.ts
+++ b/dashboard/src/features/audit/export.test.ts
@@ -284,6 +284,38 @@ describe('buildAuditCsv — observe mode', () => {
   })
 })
 
+// ── AAASM-5236: `event_type` is raw wire input, so the type-count tally must ──
+// survive an attacker- or client-supplied key that collides with `Object.prototype`.
+// With a plain-object accumulator, `constructor` reads back `Object` (yielding a
+// fabricated string count) and `__proto__` writes through the prototype setter
+// (the tally silently vanishes). A Map treats both as ordinary keys.
+describe('buildComplianceReport — prototype-polluting event types', () => {
+  const ctx = { typeFilter: 'all', agentFilter: 'all', search: '' }
+  const now = new Date('2026-05-11T15:00:00Z')
+
+  it('tallies a __proto__ event_type instead of silently dropping it', () => {
+    const rows = [
+      entry({ seq: 1, event_type: '__proto__', payload: '{"event_id":"a"}' }),
+      entry({ seq: 2, event_type: '__proto__', payload: '{"event_id":"b"}' }),
+    ]
+    const report = buildComplianceReport(rows, ctx, COMPLETE, now)
+    expect(report).toContain('- __proto__: 2')
+  })
+
+  it('gives a constructor event_type a real numeric count, not a fabricated string', () => {
+    const rows = [
+      entry({ seq: 1, event_type: 'constructor', payload: '{"event_id":"a"}' }),
+      entry({ seq: 2, event_type: 'constructor', payload: '{"event_id":"b"}' }),
+    ]
+    const report = buildComplianceReport(rows, ctx, COMPLETE, now)
+    expect(report).toMatch(/^- constructor: 2$/m)
+    // The old object accumulator produced `(Object ?? 0) + 1` = a string like
+    // `function Object() { [native code] }1`. Guard against that regression.
+    expect(report).not.toContain('native code')
+    expect(report).not.toContain('constructor: function')
+  })
+})
+
 describe('buildComplianceReport — observe mode', () => {
   const ctx = { typeFilter: 'all', agentFilter: 'all', search: '' }
   const now = new Date('2026-05-11T15:00:00Z')

--- a/dashboard/src/features/audit/export.ts
+++ b/dashboard/src/features/audit/export.ts
@@ -159,7 +159,11 @@ export interface AuditExportContext {
  * suppressed denials would be a worse failure than either number alone.
  */
 interface ReportTally {
-  readonly typeCounts: Record<string, number>
+  // A Map, not a plain object: `event_type` is raw wire input, so a value of
+  // `__proto__` or `constructor` must be tallied as an ordinary key rather than
+  // hitting the prototype setter (silent data loss) or colliding with an
+  // inherited method (a bogus non-numeric count).
+  readonly typeCounts: ReadonlyMap<string, number>
   readonly decisionCounts: Record<string, number>
   readonly noVerdictCounts: Record<string, number>
   readonly suppressedCounts: Record<string, number>
@@ -178,7 +182,7 @@ function verdictTallyKey(verdict: AuditVerdict, enforced: string): string {
 }
 
 function tallyRows(rows: readonly LogEntry[]): ReportTally {
-  const typeCounts: Record<string, number> = {}
+  const typeCounts = new Map<string, number>()
   const decisionCounts: Record<string, number> = {}
   const noVerdictCounts: Record<string, number> = {}
   const suppressedCounts: Record<string, number> = {}
@@ -186,7 +190,7 @@ function tallyRows(rows: readonly LogEntry[]): ReportTally {
   const suppressed: { entry: LogEntry; verdict: AuditVerdict }[] = []
 
   for (const e of rows) {
-    typeCounts[e.event_type] = (typeCounts[e.event_type] ?? 0) + 1
+    typeCounts.set(e.event_type, (typeCounts.get(e.event_type) ?? 0) + 1)
     const verdict = extractVerdict(e.payload)
     const wasSuppressed = isSuppressedDenial(verdict)
 
@@ -226,8 +230,9 @@ function tallyRows(rows: readonly LogEntry[]): ReportTally {
 }
 
 /** Descending by count — the order every tally table in the report uses. */
-function byCountDesc(counts: Record<string, number>): [string, number][] {
-  return Object.entries(counts).sort((a, b) => b[1] - a[1])
+function byCountDesc(counts: ReadonlyMap<string, number> | Record<string, number>): [string, number][] {
+  const entries = counts instanceof Map ? [...counts.entries()] : Object.entries(counts)
+  return entries.sort((a, b) => b[1] - a[1])
 }
 
 /**


### PR DESCRIPTION
## What changed

`tallyRows()` in `dashboard/src/features/audit/export.ts` accumulated the per-event-type tally (`typeCounts`) into a plain object (`Record<string, number> = {}`), keyed by `LogEntry.event_type` — raw wire input. This PR converts `typeCounts` to a `Map<string, number>` and widens the shared `byCountDesc()` consumer to accept either a `ReadonlyMap` or a `Record`, normalizing entries.

## Why (silent-data-loss root cause)

With a plain object keyed on untrusted input:

- A `__proto__` `event_type` wrote **through the prototype setter** — the assignment never created an own property, so the tally **silently vanished** from the report.
- A `constructor` `event_type` read back the inherited `Object` constructor, so `(typeCounts[e.event_type] ?? 0) + 1` evaluated to `(Object ?? 0) + 1` = a **fabricated string count**. Verified against the pre-fix code: the report literally rendered `- constructor: function Object() { [native code] }11`.

Both corrupt an exported audit compliance report. A `Map` treats `__proto__` and `constructor` as ordinary keys.

## Scope note (do NOT touch the safe / other-ticket sites)

Only `typeCounts` is converted. Deliberately left unchanged:

- `decisionCounts` — key from `verdictTallyKey()`, locally computed, safe.
- `noVerdictCounts` — label from `TRUTH_STATE_META`, locally computed, safe.
- `suppressedCounts` — covered by a **different** ticket (AAASM-5225).

`byCountDesc()` is the single shared consumer for all four tallies; it was widened (not narrowed) so the three untouched object tallies behave exactly as before.

## Acceptance criteria

- [x] `typeCounts` accumulator is a `Map`, not a plain object.
- [x] A `__proto__` `event_type` is tallied rather than silently lost.
- [x] A `constructor` `event_type` produces a real numeric count, not a fabricated string.
- [x] `decisionCounts`, `noVerdictCounts`, `suppressedCounts` untouched.

## How to verify

Regression tests added in `dashboard/src/features/audit/export.test.ts` (`buildComplianceReport — prototype-polluting event types`): asserts `- __proto__: 2` appears, asserts `- constructor: 2` (via `/^- constructor: 2$/m`), and guards against `native code` / `constructor: function` regressions.

**Tests are red pre-fix**: against the old object accumulator both new tests fail (report rendered `- constructor: function Object() { [native code] }11`; `__proto__` was dropped). Green after the Map fix.

## Gate results

- `pnpm type-check` (`tsc --noEmit`): pass
- `pnpm lint` (`eslint … --max-warnings 0`): pass
- `pnpm test src/features/audit/export.test.ts`: 33 passed (2 new)

Closes AAASM-5236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
