### PR TITLE
[AAASM-5234] ♻️ (audit): Key AuditLogPage EVENT_META by Map

### DIFF
--- a/dashboard/src/pages/AuditLogPage.test.tsx
+++ b/dashboard/src/pages/AuditLogPage.test.tsx
@@ -181,6 +181,39 @@ describe('AuditLogPage', () => {
     expect(screen.getByTestId('audit-stat-other')).toHaveTextContent('1')
   })
 
+  // ── AAASM-5234: event_type is raw wire (`type: string`), so a value that
+  // collides with a prototype member (`constructor`, `__proto__`) must fall to
+  // the default meta, not resolve to an inherited object member. A plain-object
+  // lookup with `?? default` fails this because the inherited member is truthy;
+  // keying by Map makes the lookup own-keys only.
+  it.each(['constructor', '__proto__', 'toString', 'hasOwnProperty'])(
+    'falls to the default meta for the prototype-member event type %s',
+    async (inherited) => {
+      get.mockResolvedValue({
+        data: page([entry({ seq: 950, event_type: inherited, payload: '{}' })]),
+      })
+      renderPage()
+      const row = await screen.findByTestId('audit-row-950')
+      // The default meta labels the chip with the raw event type verbatim; a
+      // leaked inherited member would render `[object Object]`/`function ...`.
+      expect(within(row).getByText(new RegExp(inherited))).toBeInTheDocument()
+      const chip = within(row).getByText(new RegExp(inherited))
+      expect(chip.textContent).not.toContain('[object')
+      expect(chip.textContent).not.toContain('function')
+      expect(screen.getByTestId('audit-stat-other')).toHaveTextContent('1')
+    },
+  )
+
+  it('still maps a real event type to its declared meta', async () => {
+    get.mockResolvedValue({
+      data: page([entry({ seq: 951, event_type: 'PolicyViolation', payload: '{}' })]),
+    })
+    renderPage()
+    const row = await screen.findByTestId('audit-row-951')
+    expect(within(row).getByText(/Policy Violation/)).toBeInTheDocument()
+    expect(within(row).getByText(/⚑/)).toBeInTheDocument()
+  })
+
   it('filters by event family when a stats tile is clicked', async () => {
     renderPage()
     await screen.findByTestId('audit-row-1048')

--- a/dashboard/src/pages/AuditLogPage.tsx
+++ b/dashboard/src/pages/AuditLogPage.tsx
@@ -29,30 +29,30 @@ import './AuditLogPage.css'
  * previous table listed six names invented by the hi-fi fixture, of which only
  * `PolicyViolation` exists on the backend.
  */
-const EVENT_META: Record<string, { label: string; chip: string; icon: string }> = {
-  ToolCallIntercepted: { label: 'Tool Call', chip: 'info', icon: '⚙' },
-  ToolDispatched: { label: 'Tool Dispatched', chip: 'info', icon: '⚙' },
-  PolicyViolation: { label: 'Policy Violation', chip: 'danger', icon: '⚑' },
-  MessageBlocked: { label: 'Message Blocked', chip: 'danger', icon: '⊘' },
-  CredentialLeakBlocked: { label: 'Credential Blocked', chip: 'danger', icon: '⊘' },
-  ApprovalRequested: { label: 'Approval Requested', chip: 'info', icon: '◷' },
-  ApprovalGranted: { label: 'Approval Granted', chip: 'ok', icon: '✓' },
-  ApprovalDenied: { label: 'Approval Denied', chip: 'danger', icon: '✕' },
-  ApprovalTimedOut: { label: 'Approval Timed Out', chip: 'warn', icon: '◷' },
-  ApprovalRouted: { label: 'Approval Routed', chip: 'info', icon: '⇄' },
-  ApprovalEscalated: { label: 'Approval Escalated', chip: 'warn', icon: '⇄' },
-  BudgetLimitApproached: { label: 'Budget Warning', chip: 'warn', icon: '◈' },
-  BudgetLimitExceeded: { label: 'Budget Exceeded', chip: 'danger', icon: '◈' },
-  AgentForceDeregistered: { label: 'Agent Deregistered', chip: 'warn', icon: '⊘' },
-  A2ACallIntercepted: { label: 'A2A Call', chip: 'info', icon: '⇥' },
-  A2AImpersonationAttempted: { label: 'A2A Impersonation', chip: 'danger', icon: '⚑' },
-  SandboxStarted: { label: 'Sandbox Started', chip: '', icon: '▣' },
-  SandboxFilesystemBlocked: { label: 'Sandbox FS Blocked', chip: 'danger', icon: '▣' },
-  SandboxCpuTimeout: { label: 'Sandbox CPU Timeout', chip: 'warn', icon: '▣' },
-  SandboxOomKilled: { label: 'Sandbox OOM Killed', chip: 'warn', icon: '▣' },
-  SandboxTerminated: { label: 'Sandbox Terminated', chip: '', icon: '▣' },
-  SandboxHostFnRateLimited: { label: 'Sandbox Rate Limited', chip: 'warn', icon: '▣' },
-}
+const EVENT_META = new Map<string, { label: string; chip: string; icon: string }>([
+  ['ToolCallIntercepted', { label: 'Tool Call', chip: 'info', icon: '⚙' }],
+  ['ToolDispatched', { label: 'Tool Dispatched', chip: 'info', icon: '⚙' }],
+  ['PolicyViolation', { label: 'Policy Violation', chip: 'danger', icon: '⚑' }],
+  ['MessageBlocked', { label: 'Message Blocked', chip: 'danger', icon: '⊘' }],
+  ['CredentialLeakBlocked', { label: 'Credential Blocked', chip: 'danger', icon: '⊘' }],
+  ['ApprovalRequested', { label: 'Approval Requested', chip: 'info', icon: '◷' }],
+  ['ApprovalGranted', { label: 'Approval Granted', chip: 'ok', icon: '✓' }],
+  ['ApprovalDenied', { label: 'Approval Denied', chip: 'danger', icon: '✕' }],
+  ['ApprovalTimedOut', { label: 'Approval Timed Out', chip: 'warn', icon: '◷' }],
+  ['ApprovalRouted', { label: 'Approval Routed', chip: 'info', icon: '⇄' }],
+  ['ApprovalEscalated', { label: 'Approval Escalated', chip: 'warn', icon: '⇄' }],
+  ['BudgetLimitApproached', { label: 'Budget Warning', chip: 'warn', icon: '◈' }],
+  ['BudgetLimitExceeded', { label: 'Budget Exceeded', chip: 'danger', icon: '◈' }],
+  ['AgentForceDeregistered', { label: 'Agent Deregistered', chip: 'warn', icon: '⊘' }],
+  ['A2ACallIntercepted', { label: 'A2A Call', chip: 'info', icon: '⇥' }],
+  ['A2AImpersonationAttempted', { label: 'A2A Impersonation', chip: 'danger', icon: '⚑' }],
+  ['SandboxStarted', { label: 'Sandbox Started', chip: '', icon: '▣' }],
+  ['SandboxFilesystemBlocked', { label: 'Sandbox FS Blocked', chip: 'danger', icon: '▣' }],
+  ['SandboxCpuTimeout', { label: 'Sandbox CPU Timeout', chip: 'warn', icon: '▣' }],
+  ['SandboxOomKilled', { label: 'Sandbox OOM Killed', chip: 'warn', icon: '▣' }],
+  ['SandboxTerminated', { label: 'Sandbox Terminated', chip: '', icon: '▣' }],
+  ['SandboxHostFnRateLimited', { label: 'Sandbox Rate Limited', chip: 'warn', icon: '▣' }],
+])
 
 /**
  * Chip variant + lowercased label for the decision verdict carried in the
@@ -284,7 +284,7 @@ export function AuditLogPage() {
               </tr>
             ) : (
               filtered.map((e) => {
-                const meta = EVENT_META[e.event_type] ?? {
+                const meta = EVENT_META.get(e.event_type) ?? {
                   label: e.event_type,
                   chip: '',
                   icon: '·',


### PR DESCRIPTION
## What changed

`EVENT_META` in `dashboard/src/pages/AuditLogPage.tsx` was a plain object
(`Record<string, …>`) indexed at the row-render site (`:287`) by
`e.event_type`. It is now a `Map`, looked up with `.get()`.

## Why (root cause)

`LogEntry.event_type` is raw wire data typed `type: string` — it is not
constrained to the declared variant names. When the value collides with an
inherited prototype member (`constructor`, `__proto__`, `toString`,
`hasOwnProperty`), a plain-object lookup returns the **inherited** member,
which is truthy, so the `?? { label, chip, icon }` default never fires. The
cell then renders a leaked function/object instead of the raw type. Keying by
`Map` makes the lookup own-keys only, so unknown values (including
prototype-member names) fall through to the default meta as intended.

## Scope note — already-safe sites left untouched

Per the ticket, the following lookups in the same file were **not** changed
because their keys resolve through a Map-with-default or are pre-canonicalised
and are already safe:
- `:62` / `:103` — `DECISION_META`, keyed by the canonicalised `AuditDecision`.
- `:183` / `:186` / `:212` — `counts` keyed via `eventGroupOf(...)` (canonicalised group key).

Only `EVENT_META` (`:32` definition, `:287` lookup) was converted.

## The fix

- `:32` — `const EVENT_META = new Map<string, {…}>([ [key, meta], … ])`
- `:287` — `EVENT_META.get(e.event_type) ?? { label: e.event_type, chip: '', icon: '·' }`

## How to verify / gate results

- `pnpm type-check` — clean (tsc --noEmit, exit 0)
- `pnpm lint` — clean (eslint, --max-warnings 0, exit 0)
- `pnpm test` (scoped to `AuditLogPage`) — 53 passed (53)

**Test red pre-fix:** with the source reverted to the plain-object form, the 4
new prototype-member cases fail (`constructor`, `__proto__`, `toString`,
`hasOwnProperty` each resolve to an inherited member and never reach the
default meta); with the Map fix they pass. Confirmed load-bearing.

## Acceptance criteria

- [x] `EVENT_META` is a `Map`; lookup uses `.get()`.
- [x] An inherited-prototype `event_type` falls to the default meta (not an inherited member).
- [x] Real event types still map to their declared label/icon.
- [x] Already-safe sites (`:62/:103`, `:183/:186/:212`) untouched.
- [x] type-check, lint, and scoped tests green.

Refs AAASM-5234

🤖 Generated with [Claude Code](https://claude.com/claude-code)