### PR TITLE
[AAASM-5253] 🔒 (teams): Derive team-admin from verified scopes, not localStorage

### DIFF
--- a/dashboard/src/features/teams/permissions.test.tsx
+++ b/dashboard/src/features/teams/permissions.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { AuthContext, type AuthContextValue, type Scope } from '../../auth/AuthContext'
+import { useCanManageTeam } from './permissions'
+
+function providerWith(scopes: Scope[]) {
+  const value: AuthContextValue = {
+    token: 'tok',
+    scopes,
+    login: async () => {},
+    logout: () => {},
+  }
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  }
+}
+
+afterEach(() => {
+  globalThis.localStorage.clear()
+})
+
+describe('useCanManageTeam', () => {
+  it('ignores the client-writable aa_team_admin localStorage flag', () => {
+    // The pre-fix implementation granted admin whenever this flag was set.
+    globalThis.localStorage.setItem('aa_team_admin', '1')
+    const { result } = renderHook(() => useCanManageTeam(), { wrapper: providerWith(['read']) })
+    expect(result.current).toBe(false)
+  })
+
+  it('grants management only when the verified token carries the admin scope', () => {
+    const { result } = renderHook(() => useCanManageTeam(), { wrapper: providerWith(['admin']) })
+    expect(result.current).toBe(true)
+  })
+
+  it('denies a write-only caller even with the flag set', () => {
+    globalThis.localStorage.setItem('aa_team_admin', '1')
+    const { result } = renderHook(() => useCanManageTeam(), { wrapper: providerWith(['write']) })
+    expect(result.current).toBe(false)
+  })
+
+  it('denies a caller whose token carries no scopes (fail-closed)', () => {
+    const { result } = renderHook(() => useCanManageTeam(), { wrapper: providerWith([]) })
+    expect(result.current).toBe(false)
+  })
+})

--- a/dashboard/src/features/teams/permissions.ts
+++ b/dashboard/src/features/teams/permissions.ts
@@ -1,10 +1,16 @@
-const TEAM_ADMIN_FLAG_KEY = 'aa_team_admin'
+import { useCan } from '../../auth/usePermissions'
 
-export function isTeamAdmin(): boolean {
-  if (typeof globalThis === 'undefined') return false
-  return globalThis.localStorage.getItem(TEAM_ADMIN_FLAG_KEY) === '1'
-}
-
+/**
+ * Whether the current caller may manage a team (suspend/resume its members).
+ *
+ * Team management is an administrative, team-wide mutation. The token exposes
+ * no dedicated team-admin scope (`Scope` is `read | write | admin`), so — per
+ * AAASM-5253 — we do NOT synthesize one; we route the check through the same
+ * verified scope machinery as every other gated control and require the
+ * existing `admin` scope. This derives from the token/context (fail-closed:
+ * absent or scope-less tokens yield no admin), never from client-writable
+ * storage.
+ */
 export function useCanManageTeam(): boolean {
-  return isTeamAdmin()
+  return useCan('admin')
 }

--- a/dashboard/tests/e2e/review-aaasm-5044.spec.ts
+++ b/dashboard/tests/e2e/review-aaasm-5044.spec.ts
@@ -48,7 +48,6 @@ const DATA_PLATFORM_TEAM = {
 async function seed(page: Page, theme: Theme) {
   await page.addInitScript((opts: { key: string; theme: string }) => {
     sessionStorage.setItem('aa_token', 'teams-e2e-token')
-    localStorage.setItem('aa_team_admin', '1')
     localStorage.setItem(opts.key, opts.theme)
   }, { key: THEME_KEY, theme })
 }

--- a/dashboard/tests/e2e/teams.spec.ts
+++ b/dashboard/tests/e2e/teams.spec.ts
@@ -1,10 +1,19 @@
 import { test, expect, type Page } from '@playwright/test'
 
+// A real 3-part JWT carrying an admin-scoped `scope` claim. Team management
+// (the ActionBar Suspend/Resume controls) is gated on `useCanManageTeam()` →
+// `useCan('admin')` since AAASM-5253, and scopes are recovered from the token's
+// `scope` claim via `parseScopesFromJwt`. This grants team-admin through the
+// same verified-scope machinery as production — never the removed
+// client-writable `aa_team_admin` flag.
+const b64url = (o: object) =>
+  Buffer.from(JSON.stringify(o)).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+const ADMIN_JWT = `${b64url({ alg: 'none' })}.${b64url({ sub: 'e2e-admin', scope: ['read', 'write', 'admin'] })}.sig`
+
 async function injectAuth(page: Page) {
-  await page.addInitScript(() => {
-    sessionStorage.setItem('aa_token', 'e2e-test-token')
-    localStorage.setItem('aa_team_admin', '1')
-  })
+  await page.addInitScript((token) => {
+    sessionStorage.setItem('aa_token', token)
+  }, ADMIN_JWT)
 }
 
 const TEAM_MEMBERS = [

--- a/dashboard/tests/e2e/verify-aaasm-5044.spec.ts
+++ b/dashboard/tests/e2e/verify-aaasm-5044.spec.ts
@@ -67,7 +67,6 @@ async function seed(page: Page, theme: Theme) {
   await page.addInitScript(
     (opts: { key: string; theme: string }) => {
       sessionStorage.setItem('aa_token', 'teams-e2e-token')
-      localStorage.setItem('aa_team_admin', '1')
       localStorage.setItem(opts.key, opts.theme)
     },
     { key: THEME_KEY, theme },

--- a/dashboard/tests/e2e/verify-aaasm-5080.spec.ts
+++ b/dashboard/tests/e2e/verify-aaasm-5080.spec.ts
@@ -53,7 +53,6 @@ const DATA_PLATFORM_TEAM = {
 async function seed(page: Page, theme: Theme) {
   await page.addInitScript((opts: { key: string; theme: string }) => {
     sessionStorage.setItem('aa_token', 'teams-e2e-token')
-    localStorage.setItem('aa_team_admin', '1')
     localStorage.setItem(opts.key, opts.theme)
   }, { key: THEME_KEY, theme })
 }


### PR DESCRIPTION
## Description

`isTeamAdmin()` in `dashboard/src/features/teams/permissions.ts` derived an authorization decision from the **client-writable** `aa_team_admin` localStorage flag. Any user could grant themselves the team-admin UI affordance from the browser console (`localStorage.setItem('aa_team_admin', '1')`).

**Trust-boundary root cause.** localStorage is client-controlled storage — reading a permission decision from it means the client asserts its own privilege. This contradicts the direction AAASM-5180 established: permission state must come from the verified auth context and default to *no* scopes when absent. The flag reader is indistinguishable, to a reader of the code, from a genuine authorization check.

**The fix.** `useCanManageTeam()` now routes through the same verified scope machinery as every other gated control — `useCan('admin')` — and the localStorage flag reader (`isTeamAdmin`) is removed entirely. The decision now derives from the token/`AuthContext` scopes and is fail-closed: an absent, malformed, or scope-less token yields no admin (per AAASM-5180 / `parseScopesFromJwt` → `[]`).

**Does a team-admin scope exist in the token?** No. The token `Scope` enum is exactly `read | write | admin` (`dashboard/src/api/generated/schema.d.ts`). There is **no dedicated team-admin scope**. Per the ticket, we do **not** synthesize one from client storage. Team management is a team-wide administrative mutation, so it maps to the existing verified `admin` scope — the natural home for such an action — rather than a fabricated capability. Callers without `admin` correctly see the capability as unavailable (the Suspend/Resume action bar is hidden).

**Footprint finding (deviation from ticket).** The ticket's footprint audit stated `isTeamAdmin`/`useCanManageTeam` have ZERO callers in-repo. That is **incorrect**: `useCanManageTeam` IS consumed by `ActionBar` in `dashboard/src/pages/TeamDetailPage.tsx:126`, which gates the "Suspend Team" / "Resume Team" buttons, and is mocked in `TeamDetailPage.actions.test.tsx`. `isTeamAdmin` had no callers beyond `useCanManageTeam` and was removed. Because a real consuming component exists, returning a hardcoded `false` would break the action bar for legitimate admins and diverge from "route through the same scope machinery as every other gated control" — hence the `useCan('admin')` mapping.

**Severity — UI honesty, not a server-side gap.** The gated buttons POST to `/api/v1/agents/{id}/suspend` and `/resume`, which the gateway authorizes independently on every request. So the realistic impact was UI affordances appearing that the backend would then reject — a UI-honesty bug — not privilege escalation. It is still fixed as a real trust-boundary finding, not cosmetics.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Public API surface (`useCanManageTeam`) is unchanged; only its implementation changed. The now-unused `isTeamAdmin` export (no in-repo callers) was removed.

## Related Issues

- Related Jira ticket: AAASM-5253
- Related: AAASM-5180 (fail-closed scope machinery)

## Testing

- [x] Unit tests added / updated

New co-located `dashboard/src/features/teams/permissions.test.tsx`:
- The `aa_team_admin` flag no longer grants management (set flag + `read` scope → `false`).
- Management granted only when the verified token carries `admin`.
- `write`-only caller denied even with the flag set.
- Empty scope set → denied (fail-closed).

**Load-bearing verification:** run against the pre-fix localStorage implementation, 3 of the 4 assertions fail (the flag grants `true` regardless of scope). Against the fix, all pass.

### Acceptance criteria

- [x] Team-admin decision no longer derives from client-writable storage
- [x] Decision routed through verified `useCan`/`useScopes` machinery
- [x] Fail-closed (no permissive default; empty/absent scopes → unavailable)
- [x] No synthesized team-admin scope — mapped to the existing verified `admin` scope; finding documented (no team-admin scope in the token)
- [x] Regression test asserts the flag is ignored and the value derives from scopes

## Gate results

- `pnpm type-check` — PASS (tsc --noEmit, 0 errors)
- `pnpm lint` — PASS (eslint, 0 warnings, `--max-warnings 0`)
- Affected tests — PASS (17/17: permissions.test.tsx, TeamDetailPage.actions.test.tsx, usePermissions.test.tsx)
- Full suite — pre-existing `Test timed out in 5000ms` flakes in unrelated files (AgentDetailPage, AlertRuleForm, approvals, liveOps, OverviewPage) that do not import `teams/permissions`; reproduce independently of this change under local resource load. CI is authoritative for the full suite.

## Checklist

- [x] Self-review of the diff completed
- [x] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)