### PR TITLE
[AAASM-5233] ♻️ (teams): Key TeamDetailPage STATUS_COLOR by Map

### DIFF
--- a/dashboard/src/pages/TeamDetailPage.test.tsx
+++ b/dashboard/src/pages/TeamDetailPage.test.tsx
@@ -139,6 +139,35 @@ describe('TeamDetailPage', () => {
     expect(screen.getByTestId('location')).toHaveTextContent(`/topology?root=${rootId}`)
   })
 
+  it('colors known statuses from the map and unknown statuses fall to the muted color', async () => {
+    // 'constructor' and 'toString' are inherited Object.prototype members: a
+    // plain-object lookup returns the inherited function for these key names and
+    // defeats the `?? var(--text-muted)` fallback. A Map returns only the
+    // explicitly-set entries, so both fall through to the muted color.
+    const team: TeamTopology = {
+      team_id: 'team-proto',
+      agent_count: 4,
+      members: [
+        { id: 'a'.repeat(32), name: 'known-active', status: 'active', depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
+        { id: 'b'.repeat(32), name: 'known-suspended', status: 'suspended', depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
+        { id: 'c'.repeat(32), name: 'proto-constructor', status: 'constructor', depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
+        { id: 'd'.repeat(32), name: 'proto-tostring', status: 'toString', depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
+      ],
+    }
+    mockTeam({ data: team })
+    mockCosts()
+    mockLineage('a'.repeat(32))
+    render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/team-proto']}>{children}</Wrapper> })
+    const badges = await screen.findAllByTestId('team-member-status')
+    expect(badges).toHaveLength(4)
+    // Known statuses resolve to their mapped colors.
+    expect(badges[0]).toHaveStyle({ background: 'var(--status-success-solid)' })
+    expect(badges[1]).toHaveStyle({ background: 'var(--status-warning-solid)' })
+    // Inherited prototype member names must fall to the muted color, not a function.
+    expect(badges[2]).toHaveStyle({ background: 'var(--text-muted)' })
+    expect(badges[3]).toHaveStyle({ background: 'var(--text-muted)' })
+  })
+
   it('falls back to the member id when lineage is unavailable', async () => {
     const user = userEvent.setup()
     mockTeam({ data: FIVE_MEMBER_TEAM })

--- a/dashboard/src/pages/TeamDetailPage.tsx
+++ b/dashboard/src/pages/TeamDetailPage.tsx
@@ -13,14 +13,14 @@ import {
 import { useCanManageTeam } from '../features/teams/permissions'
 import { NotFoundPage } from './NotFoundPage'
 
-const STATUS_COLOR: Record<string, string> = {
-  active: 'var(--status-success-solid)',
-  suspended: 'var(--status-warning-solid)',
-  deregistered: 'var(--text-muted)',
-}
+const STATUS_COLOR = new Map<string, string>([
+  ['active', 'var(--status-success-solid)'],
+  ['suspended', 'var(--status-warning-solid)'],
+  ['deregistered', 'var(--text-muted)'],
+])
 
 function StatusBadge({ status }: Readonly<{ status: string }>) {
-  const color = STATUS_COLOR[status] ?? 'var(--text-muted)'
+  const color = STATUS_COLOR.get(status) ?? 'var(--text-muted)'
   return (
     <span
       data-testid="team-member-status"


### PR DESCRIPTION
## What changed
Converts the module-level `STATUS_COLOR` lookup in `dashboard/src/pages/TeamDetailPage.tsx` from a plain object (`Record<string, string>`) to a `Map<string, string>`, and updates the `StatusBadge` lookup from `STATUS_COLOR[status] ?? …` to `STATUS_COLOR.get(status) ?? …`.

## Why (root cause)
`StatusBadge` receives `member.status`, which is the raw wire value from `AgentNode.status` — an unbounded string with no enum guard. The old code indexed a plain object with that value:

```ts
const color = STATUS_COLOR[status] ?? 'var(--text-muted)'
```

When `status` collides with an inherited `Object.prototype` member name (e.g. `constructor`, `toString`, `hasOwnProperty`), the object lookup returns the inherited **function** rather than `undefined`. The `?? 'var(--text-muted)'` fallback therefore never fires, and `color` becomes a function reference that is then spread into the badge's `background` style. A `Map` only returns entries that were explicitly set, so unknown / prototype-named statuses now correctly fall through to the muted color.

## The fix
- `STATUS_COLOR` is now `new Map<string, string>([...])` with the same three entries (`active`, `suspended`, `deregistered`).
- Lookup uses `STATUS_COLOR.get(status) ?? 'var(--text-muted)'`.
- No behavior change for the three known statuses; only the fallback path for unknown/inherited names is corrected.

## Acceptance checklist
- [x] `STATUS_COLOR` is a `Map`, keyed by status string.
- [x] Lookup uses `.get()` with the `var(--text-muted)` fallback preserved.
- [x] Known statuses (`active`, `suspended`, `deregistered`) map to their original colors.
- [x] Inherited-prototype status names fall to `var(--text-muted)`.
- [x] Test added asserting both the mapped and the muted-fallback paths.

## How to verify / gate results
Run from `dashboard/` with Node 22:
- `pnpm exec vitest run src/pages/TeamDetailPage.test.tsx` → **7 passed**
- `pnpm type-check` (`tsc --noEmit`) → **clean, exit 0**
- `pnpm lint` (eslint, `--max-warnings 0`) → **clean, exit 0**

## Test red pre-fix (load-bearing confirmation)
The new test `colors known statuses from the map and unknown statuses fall to the muted color` was run against the pre-fix plain-object version and **failed** at the `constructor`-status assertion:

```
FAIL … > colors known statuses from the map and unknown statuses fall to the muted color
expect(element).toHaveStyle()
- background: var(--text-muted);
  at src/pages/TeamDetailPage.test.tsx:167  // badges[2], status "constructor"
```

With the Map fix in place the same test passes, confirming it exercises the exact defect.

Closes AAASM-5233

🤖 Generated with [Claude Code](https://claude.com/claude-code)