### PR TITLE
[AAASM-5232] ♻️ (teams): Share a Map-based status-chip lookup across the two cards

### DIFF
--- a/dashboard/src/features/teams/TeamMembersCard.test.tsx
+++ b/dashboard/src/features/teams/TeamMembersCard.test.tsx
@@ -59,4 +59,13 @@ describe('TeamMembersCard', () => {
     renderCard({ members: [member({ flagged: true })], isLoading: false, isError: false })
     expect(screen.getByTestId('team-member-flagged')).toBeInTheDocument()
   })
+
+  it('renders an unrecognised status with no chip modifier', () => {
+    // `status` is a raw wire string: an unmapped value must fall back to the bare
+    // `teams-chip` class (the `?? ''` at the call site), never leak a stray token.
+    renderCard({ members: [member({ status: 'retired' })], isLoading: false, isError: false })
+    const chip = screen.getByTestId('team-member-status')
+    expect(chip).toHaveTextContent('retired')
+    expect(chip).toHaveAttribute('class', 'teams-chip ')
+  })
 })

--- a/dashboard/src/features/teams/TeamMembersCard.tsx
+++ b/dashboard/src/features/teams/TeamMembersCard.tsx
@@ -1,11 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { AgentNode } from './api'
-
-const STATUS_CHIP: Record<string, string> = {
-  active: 'is-ok',
-  suspended: 'is-warn',
-  deregistered: '',
-}
+import { statusChip } from './statusChip'
 
 interface TeamMembersCardProps {
   members: AgentNode[]
@@ -52,7 +47,7 @@ export function TeamMembersCard({ members, isLoading, isError }: Readonly<TeamMe
                 <span className="teams-chip is-danger" data-testid="team-member-flagged">flagged</span>
               )}
               <span
-                className={`teams-chip ${STATUS_CHIP[member.status] ?? ''}`}
+                className={`teams-chip ${statusChip(member.status) ?? ''}`}
                 data-testid="team-member-status"
               >
                 {member.status}

--- a/dashboard/src/features/teams/TeamOrphanDetail.test.tsx
+++ b/dashboard/src/features/teams/TeamOrphanDetail.test.tsx
@@ -69,6 +69,15 @@ describe('TeamOrphanDetail', () => {
     expect(screen.getByTestId('orphan-detail-header')).toHaveTextContent('1 flagged')
   })
 
+  it('renders an unrecognised agent status with no chip modifier', () => {
+    // `status` is a raw wire string: an unmapped value must fall back to the bare
+    // `teams-chip` class (the `?? ''` at the call site), never leak a stray token.
+    renderOrphan(known([agent({ id: 'a1', status: 'retired' })]))
+    const chip = screen.getByTestId('orphan-agent-status')
+    expect(chip).toHaveTextContent('retired')
+    expect(chip).toHaveAttribute('class', 'teams-chip ')
+  })
+
   it('renders an absent set as its state, never as an empty roster', () => {
     renderOrphan(absent<readonly AgentNode[]>('unavailable', 'HTTP 503'), absent('unknown'))
     expect(screen.getByTestId('orphan-detail-agent-count-value')).toHaveAttribute(

--- a/dashboard/src/features/teams/TeamOrphanDetail.tsx
+++ b/dashboard/src/features/teams/TeamOrphanDetail.tsx
@@ -4,12 +4,7 @@ import { TruthfulValue } from '../../components/truthfulness/TruthfulValue'
 import { isKnown, mapCertain, type Certain } from '../../lib/truthfulness'
 import type { AgentNode } from './api'
 import type { AgentCensus } from './orphans'
-
-const STATUS_CHIP: Record<string, string> = {
-  active: 'is-ok',
-  suspended: 'is-warn',
-  deregistered: '',
-}
+import { statusChip } from './statusChip'
 
 interface TeamOrphanDetailProps {
   /**
@@ -151,7 +146,7 @@ export function TeamOrphanDetail({ orphans, census }: Readonly<TeamOrphanDetailP
                   {agent.flagged && (
                     <span className="teams-chip is-danger" data-testid="orphan-agent-flagged">flagged</span>
                   )}
-                  <span className={`teams-chip ${STATUS_CHIP[agent.status] ?? ''}`} data-testid="orphan-agent-status">
+                  <span className={`teams-chip ${statusChip(agent.status) ?? ''}`} data-testid="orphan-agent-status">
                     {agent.status}
                   </span>
                 </div>

--- a/dashboard/src/features/teams/statusChip.test.ts
+++ b/dashboard/src/features/teams/statusChip.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { statusChip } from './statusChip'
+
+describe('statusChip', () => {
+  it('maps known agent statuses to their chip modifier token', () => {
+    expect(statusChip('active')).toBe('is-ok')
+    expect(statusChip('suspended')).toBe('is-warn')
+    expect(statusChip('deregistered')).toBe('')
+  })
+
+  it('returns undefined for an unrecognised status so the caller falls back', () => {
+    expect(statusChip('retired')).toBeUndefined()
+    // The `?? ''` at each call site collapses that undefined to no modifier.
+    expect(statusChip('retired') ?? '').toBe('')
+  })
+
+  // Load-bearing: the raw wire `status` is an untrusted string, so a value that
+  // collides with an inherited Object.prototype name must miss. An object-literal
+  // lookup would return the prototype member (a function) instead of undefined,
+  // leaking it into the chip's className; the Map-backed helper misses cleanly.
+  it('misses inherited prototype keys instead of leaking a prototype member', () => {
+    for (const proto of ['toString', 'constructor', 'hasOwnProperty', '__proto__']) {
+      expect(statusChip(proto)).toBeUndefined()
+      expect(statusChip(proto) ?? '').toBe('')
+    }
+  })
+})

--- a/dashboard/src/features/teams/statusChip.ts
+++ b/dashboard/src/features/teams/statusChip.ts
@@ -1,0 +1,22 @@
+/**
+ * Agent-status → chip modifier token, keyed by the raw wire `AgentNode.status`
+ * (no enum). Shared by the member row in {@link TeamMembersCard} and the orphan
+ * row in {@link TeamOrphanDetail}, which carried byte-identical copies of this
+ * table (AAASM-5232). Kept in its own module (not a card) so each card file
+ * exports only its component (satisfies `react-refresh/only-export-components`).
+ *
+ * A `Map` rather than an object literal so a status that collides with an
+ * inherited `Object.prototype` name (e.g. `"toString"`, `"constructor"`) misses
+ * cleanly — `.get()` returns `undefined`, restoring the caller's `?? ''`
+ * fallback rather than leaking a prototype member as a class name.
+ */
+const STATUS_CHIP = new Map<string, string>([
+  ['active', 'is-ok'],
+  ['suspended', 'is-warn'],
+  ['deregistered', ''],
+])
+
+/** Chip modifier token for an agent status, or `undefined` for an unknown status. */
+export function statusChip(status: string): string | undefined {
+  return STATUS_CHIP.get(status)
+}


### PR DESCRIPTION
## Description

`TeamMembersCard` and `TeamOrphanDetail` each carried a **byte-identical**
object-literal `STATUS_CHIP` lookup table keyed by the raw wire `AgentNode.status`
(`active → is-ok`, `suspended → is-warn`, `deregistered → ''`), each read as
`STATUS_CHIP[status] ?? ''` to build the row's status-chip className.

**Root cause / dedup decision.** Two copies of the same table drift independently
— a token added to one card silently diverges from the other. Because the tables
were literally identical, they were extracted into **one** shared helper,
`dashboard/src/features/teams/statusChip.ts`, and both cards now route through it.
No second copy remains. The helper lives in its own module (not a card component)
so each card file still exports only its component, satisfying
`react-refresh/only-export-components` — the same convention as the sibling
`budgetColor.ts`.

**The Map fix.** `AgentNode.status` is an untrusted raw-wire string. An
object-literal lookup keyed by such a string returns *inherited* `Object.prototype`
members for keys like `"toString"` or `"constructor"` — leaking a function into
the chip's `className` rather than missing. The shared helper is backed by a
`Map`, so `.get()` returns `undefined` for any unknown or prototype-collision key,
which each call site's existing `?? ''` collapses to no modifier. Behaviour for
the three real statuses is unchanged.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5232 (Subtask of Story AAASM-5212, Epic AAASM-5208)

## Testing

- [x] Unit tests added / updated

Added `dashboard/src/features/teams/statusChip.test.ts`:
- known statuses map to their token (`active`/`suspended`/`deregistered`),
- an unknown status returns `undefined` and collapses to `''`,
- **load-bearing**: inherited prototype keys (`toString`, `constructor`,
  `hasOwnProperty`, `__proto__`) miss instead of leaking a prototype member.

The prototype test is red against the pre-fix object-literal version — verified by
temporarily reverting the helper to `Record<string,string>`; the run reported
`expected [Function toString] to be undefined`. It passes with the Map-backed helper.

### Gate results (Node 22.23.1, pnpm 10.9.0)

- `pnpm type-check` — pass (exit 0)
- `pnpm lint` — pass (exit 0, `--max-warnings 0`)
- `pnpm test` scoped to `statusChip`, `TeamMembersCard`, `TeamOrphanDetail` — 3 files, 18 tests passed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (helper JSDoc explains the Map choice)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)