### PR TITLE
[AAASM-5241] 🐛 (components): Keep __proto__ child ids in subtree-burn chart rows

### DIFF
--- a/dashboard/src/components/SubtreeBurnChart.test.tsx
+++ b/dashboard/src/components/SubtreeBurnChart.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import type { UseQueryResult } from '@tanstack/react-query'
-import { SubtreeBurnChart, BurnTooltip } from './SubtreeBurnChart'
+import { SubtreeBurnChart, BurnTooltip, transform } from './SubtreeBurnChart'
 import * as agentsApi from '../features/agents/api'
 import type { SubtreeBurn } from '../features/agents/api'
 
@@ -93,6 +93,47 @@ describe('SubtreeBurnChart — populated', () => {
     renderChart()
     expect(screen.getByTestId('subtree-burn-period-7d')).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByTestId('subtree-burn-period-30d')).toHaveAttribute('aria-pressed', 'false')
+  })
+})
+
+// AAASM-5241 regression: a child agent id equal to `__proto__` must be retained
+// as an own property on the chart row. On a plain `{}` row, `row['__proto__'] = n`
+// is a silent no-op prototype assignment, so that child's burn vanishes from the
+// stacked chart. Rows are built on a null-prototype object to prevent that.
+describe('SubtreeBurnChart — __proto__ child id (AAASM-5241)', () => {
+  const data: SubtreeBurn = {
+    agent_id: 'aabbccdd00112233aabbccdd00112233',
+    period: '7d',
+    points: [
+      {
+        date: '2026-05-16',
+        per_child: [
+          { child_agent_id: '__proto__', child_name: 'proto-bot', spent_usd: '9.00' },
+          { child_agent_id: 'child-1', child_name: 'analyst-bot', spent_usd: '3.00' },
+        ],
+        total_usd: '12.00',
+      },
+    ],
+  }
+
+  it('keeps a __proto__ child id as an own row property carrying its burn', () => {
+    const { rows, childIds } = transform(data)
+
+    expect(childIds).toContain('__proto__')
+
+    const row = rows[0]
+    // Own property, not the object prototype — a plain `{}` row would drop this.
+    expect(Object.prototype.hasOwnProperty.call(row, '__proto__')).toBe(true)
+    expect(row['__proto__']).toBe(9)
+  })
+
+  it('still populates real child ids alongside the __proto__ child', () => {
+    const { rows, childIds } = transform(data)
+
+    expect(childIds).toContain('child-1')
+    expect(rows[0]['child-1']).toBe(3)
+    expect(rows[0].total).toBe(12)
+    expect(rows[0].date).toBe('2026-05-16')
   })
 })
 

--- a/dashboard/src/components/SubtreeBurnChart.tsx
+++ b/dashboard/src/components/SubtreeBurnChart.tsx
@@ -132,7 +132,13 @@ export function SubtreeBurnChart({ agentId }: Readonly<{ agentId: string }>) {
   )
 }
 
-function transform(data: SubtreeBurn | undefined): {
+// Exported for tests: recharts does not render `<Area>` paths under jsdom, so the
+// per-child row contract (including retaining a `__proto__` child id) is exercised
+// directly against the transformed rows rather than the mounted SVG. This pure
+// helper is not a component, so react-refresh's component-only-export rule is
+// disabled for this single export.
+// eslint-disable-next-line react-refresh/only-export-components
+export function transform(data: SubtreeBurn | undefined): {
   rows: ChartRow[]
   childIds: string[]
   childName: Map<string, string>
@@ -151,7 +157,13 @@ function transform(data: SubtreeBurn | undefined): {
   const sortedChildIds = Array.from(childIds).sort((a, b) => a.localeCompare(b))
 
   const rows: ChartRow[] = (data?.points ?? []).map((point) => {
-    const row: ChartRow = { date: point.date, total: Number.parseFloat(point.total_usd) || 0 }
+    // Build on a null-prototype object so a `__proto__` child agent id is stored
+    // as a real own property. A plain `{}` would treat `row['__proto__'] = n` as a
+    // no-op prototype assignment, silently dropping that child's burn from the row.
+    const row = Object.assign(Object.create(null) as ChartRow, {
+      date: point.date,
+      total: Number.parseFloat(point.total_usd) || 0,
+    })
     for (const cid of sortedChildIds) {
       const match = point.per_child.find((c) => c.child_agent_id === cid)
       row[cid] = match ? Number.parseFloat(match.spent_usd) || 0 : 0


### PR DESCRIPTION
## What changed
`SubtreeBurnChart.tsx`'s `transform()` built each chart row as a plain object literal and then wrote per-child burn with `row[cid] = ...`, where `cid` is the `child_agent_id` from `GET /api/v1/agents/{id}/subtree-burn`. Rows are now built with `Object.create(null)` (via `Object.assign(Object.create(null) as ChartRow, { date, total })`) so every child id — including `__proto__` — is stored as a real own property.

## Why (root cause)
On a normal object, `row['__proto__'] = number` does not create an own property; it is a **silent no-op** prototype assignment (the JS engine ignores a non-object/null value). So a child whose `child_agent_id` is exactly `__proto__` had no data key on the row, its `<Area>` dataKey resolved to nothing, and that child's burn silently vanished from the stacked chart with no error. A null-prototype object has no `__proto__` accessor, so the assignment lands as an ordinary own property that Recharts picks up like any other child.

## How to verify
`transform()` is exported (recharts renders no `<Area>` SVG under jsdom, so the row contract is asserted directly) with a scoped, commented `react-refresh/only-export-components` disable, matching the existing test-only `BurnTooltip` export precedent.

New tests in `SubtreeBurnChart.test.tsx`:
- a `__proto__` child id is retained as an **own** row property carrying its burn (`hasOwnProperty` true, value `9`);
- real child ids still populate (`child-1` = 3), and `date`/`total` are unaffected.

**Test is load-bearing:** reverting the row to the plain-object literal makes the `__proto__` test fail red (`hasOwnProperty('__proto__')` → false — the child was dropped); the fix turns it green.

## Acceptance criteria
- [x] A `__proto__` child id is retained instead of being a silent no-op — its burn row no longer vanishes.
- [x] Real (non-`__proto__`) child ids still populate the chart rows.
- [x] Row `date` and `total` fields unchanged.

## Gate results (Node 22.23.1, pnpm 10.9.0)
- `pnpm type-check` — pass (0 errors)
- `pnpm lint` — pass (0 errors, 0 warnings)
- `pnpm test SubtreeBurnChart` — 10 passed (was 8; +2 regression tests)

Closes AAASM-5241

🤖 Generated with [Claude Code](https://claude.com/claude-code)