### PR TITLE
[AAASM-5239] 🐛 (analytics): Keep __proto__ segments in cost-breakdown chart rows

### DIFF
--- a/dashboard/src/features/analytics/CostBreakdownPanel.test.tsx
+++ b/dashboard/src/features/analytics/CostBreakdownPanel.test.tsx
@@ -101,6 +101,20 @@ describe('transformBuckets', () => {
     expect(rows[0]).toEqual({ label: 'Jan', 'agent-a': 120, 'agent-b': 80 })
     expect(rows[1]).toEqual({ label: 'Feb', 'agent-a': 200, 'agent-b': 60 })
   })
+
+  it('retains a "__proto__" segment as an own property instead of silently dropping it', () => {
+    // With a plain-object row, `row['__proto__'] = value` is a silent no-op:
+    // it reassigns the prototype slot rather than creating an own property, so
+    // the segment vanishes from the chart with no crash and no wrong value.
+    const rows = transformBuckets([
+      {
+        label: 'Jan',
+        segments: [{ key: '__proto__', name: 'Sneaky', value: 42 }],
+      },
+    ])
+    expect(Object.prototype.hasOwnProperty.call(rows[0], '__proto__')).toBe(true)
+    expect(rows[0]['__proto__']).toBe(42)
+  })
 })
 
 describe('formatUsd', () => {

--- a/dashboard/src/features/analytics/costBreakdownUtils.ts
+++ b/dashboard/src/features/analytics/costBreakdownUtils.ts
@@ -29,7 +29,12 @@ export function computeSegmentTotals(buckets: CostBucket[]): Map<string, number>
 
 export function transformBuckets(buckets: CostBucket[]): Record<string, string | number>[] {
   return buckets.map(b => {
-    const row: Record<string, string | number> = { label: b.label }
+    // Build on a null-prototype object so a segment keyed "__proto__" is stored
+    // as an own property rather than silently reassigning the prototype slot (a
+    // no-op that drops the segment from the chart with no crash, wrong value, or
+    // log). Segment keys come from an unvalidated API response.
+    const row: Record<string, string | number> = Object.create(null)
+    row.label = b.label
     for (const s of b.segments) {
       row[s.key] = clampChartValue(s.value)
     }


### PR DESCRIPTION
## What changed
`transformBuckets` in `dashboard/src/features/analytics/costBreakdownUtils.ts` now builds each chart row on a null-prototype object (`Object.create(null)`) instead of a plain object literal, then sets `row.label` and each segment key as own properties.

## Why (root cause — the quietest failure in the Epic)
Segment keys come from `GET /api/v1/analytics/cost-breakdown` through an unvalidated `res.json() as T` cast. On a plain object literal, `row["__proto__"] = numericValue` is a **silent no-op**: JavaScript treats `__proto__` as the prototype accessor, and assigning a number to it is ignored rather than creating an own property. The result is a segment that **vanishes from the chart with no crash, no wrong value, and no log** — the quietest failure mode in Story 5214 / Epic 5208. A null-prototype object has no `__proto__` accessor, so the key is stored as an ordinary own property and the segment is retained.

Downstream consumers are unaffected: recharts reads row data via bracketed `dataKey` lookups, which work identically on a null-proto object, and `label` is still present for the X axis.

## How to verify
- Automated regression added in `dashboard/src/features/analytics/CostBreakdownPanel.test.tsx` (`transformBuckets` describe block). Note: there is **no** `costBreakdownUtils.test.ts` sibling — coverage for these utils lives in the panel test file.
- The new test asserts `Object.prototype.hasOwnProperty.call(row, '__proto__') === true` and `row['__proto__'] === 42`.
- **Verified load-bearing**: reverting the fix to the plain-object row turns the new test red with `expected false to be true` on the `hasOwnProperty('__proto__')` assertion — the exact silent-drop symptom.

## Acceptance criteria
- [x] A cost segment keyed `__proto__` is retained in the transformed chart row instead of silently disappearing.
- [x] No crash, and existing segments/label behaviour unchanged.
- [x] Regression test added and confirmed to fail before the fix, pass after.

## Gate results (Node 22 via nvm, pnpm 10.9.0)
- `pnpm type-check`: pass (tsc --noEmit, 0 errors)
- `pnpm lint`: pass (eslint, exit 0, --max-warnings 0)
- `pnpm test`: pass (268 files, 2942 tests)

Refs AAASM-5239

🤖 Generated with [Claude Code](https://claude.com/claude-code)