### PR TITLE
[AAASM-5229] ♻️ (iam): Key MemberList ROLE_BADGE_TONE by Map

### DIFF
--- a/dashboard/src/features/iam/MemberList.test.tsx
+++ b/dashboard/src/features/iam/MemberList.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { RoleBadge } from './MemberList'
+
+const DEFAULT_TONE = 'iam-role-badge--viewer'
+
+function toneClass(role: string): string {
+  render(<RoleBadge role={role} />)
+  // The badge span carries the base class plus exactly one tone class.
+  const badge = screen.getByText(role)
+  const tone = [...badge.classList].find((c) => c !== 'iam-role-badge')
+  return tone ?? ''
+}
+
+describe('MemberList RoleBadge tone', () => {
+  it.each([
+    ['org_admin', 'iam-role-badge--owner'],
+    ['team_admin', 'iam-role-badge--admin'],
+    ['developer', 'iam-role-badge--member'],
+    ['viewer', 'iam-role-badge--viewer'],
+    ['auditor', 'iam-role-badge--viewer'],
+  ])('maps the real role %s to its tone class', (role, expected) => {
+    expect(toneClass(role)).toBe(expected)
+  })
+
+  // Load-bearing: an object literal indexed as ROLE_BADGE_TONE[role] resolves
+  // inherited Object.prototype keys, so a crafted role id like `constructor`
+  // reaches a prototype method's class name instead of falling to the default
+  // tone. A Map `.get()` returns undefined for these names, so they hit the
+  // default. Against the pre-fix object literal these cases fail.
+  it.each(['constructor', 'toString', '__proto__', 'hasOwnProperty', 'valueOf'])(
+    'falls back to the default tone for the inherited key %s',
+    (role) => {
+      expect(toneClass(role)).toBe(DEFAULT_TONE)
+    },
+  )
+
+  it('falls back to the default tone for any unknown role', () => {
+    expect(toneClass('not-a-role')).toBe(DEFAULT_TONE)
+  })
+})

--- a/dashboard/src/features/iam/MemberList.tsx
+++ b/dashboard/src/features/iam/MemberList.tsx
@@ -4,12 +4,22 @@ import { RoleSelect } from './RoleSelect'
 import type { Member, Role } from './types'
 import './MemberList.css'
 
-const ROLE_BADGE_TONE: Record<Role, string> = {
-  org_admin: 'iam-role-badge--owner',
-  team_admin: 'iam-role-badge--admin',
-  developer: 'iam-role-badge--member',
-  viewer: 'iam-role-badge--viewer',
-  auditor: 'iam-role-badge--viewer',
+// A Map, not an object literal: `.get()` returns undefined for inherited
+// names like `constructor`/`toString`/`__proto__`, so an attacker-controlled
+// role id can never resolve to a prototype method's class name. An object
+// literal indexed as `ROLE_BADGE_TONE[role]` would resolve those inherited
+// keys and let a crafted role reach a value that is not a real tone class.
+const ROLE_BADGE_TONE = new Map<string, string>([
+  ['org_admin', 'iam-role-badge--owner'],
+  ['team_admin', 'iam-role-badge--admin'],
+  ['developer', 'iam-role-badge--member'],
+  ['viewer', 'iam-role-badge--viewer'],
+  ['auditor', 'iam-role-badge--viewer'],
+])
+
+/** Badge tone class for a role id, defaulting when the role is unrecognised. */
+function badgeTone(role: string): string {
+  return ROLE_BADGE_TONE.get(role) ?? 'iam-role-badge--viewer'
 }
 
 function Avatar({ name }: Readonly<{ name: string }>) {
@@ -17,8 +27,11 @@ function Avatar({ name }: Readonly<{ name: string }>) {
   return <div className="iam-avatar" aria-hidden="true">{initial}</div>
 }
 
-function RoleBadge({ role }: Readonly<{ role: Role }>) {
-  return <span className={`iam-role-badge ${ROLE_BADGE_TONE[role]}`}>{role}</span>
+// `role` is typed as `string`, not `Role`: the tone lookup must be safe for
+// any role id the API might send, including one that collides with an
+// inherited object key. `badgeTone` defaults unrecognised ids to a real tone.
+export function RoleBadge({ role }: Readonly<{ role: string }>) {
+  return <span className={`iam-role-badge ${badgeTone(role)}`}>{role}</span>
 }
 
 function StatusCell({ status }: Readonly<{ status: Member['status'] }>) {


### PR DESCRIPTION
## Description

`MemberList.tsx` looked up role badge tones through an object literal typed
`Record<Role, string>` and indexed as `ROLE_BADGE_TONE[role]` inside `RoleBadge`
— with **no default guard**. Object-literal indexing walks the prototype chain,
so a role id that collides with an inherited `Object.prototype` key
(`constructor`, `toString`, `__proto__`, `hasOwnProperty`, `valueOf`) resolves
to that prototype member (e.g. a function) instead of falling through to a real
tone class. That is a prototype-pollution-adjacent lookup crash/mis-render: an
attacker-influenced or malformed role id from the API reaches a value that is
not a valid CSS tone class.

**Fix:** convert `ROLE_BADGE_TONE` to a `Map<string, string>`. `Map.get()`
returns `undefined` for inherited names, and a small `badgeTone()` helper
defaults any unrecognised id to the real `iam-role-badge--viewer` tone.
`RoleBadge`'s `role` prop is widened from `Role` to `string` to reflect that
untrusted ids can reach the lookup — the lookup is now safe for any of them.

**Scope note:** there is a *separate* copy of `ROLE_BADGE_TONE` in
`RoleCapabilityCards.tsx`. That copy already routes through a `badgeTone()`
guard with a default, so it is not crash-prone and is a **different concern** —
it is intentionally **left untouched** by this PR. Only the crash-prone
`MemberList.tsx` copy is changed.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

`RoleBadge` is an internal component of the IAM feature; widening its `role`
prop to `string` does not affect any public API.

## Related Issues

- Related Jira ticket: AAASM-5229 (subtask of Story AAASM-5211, Epic AAASM-5208)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

New `dashboard/src/features/iam/MemberList.test.tsx` renders `RoleBadge` and
asserts the resolved tone class:

- **Acceptance criteria**
  - [x] The five real roles (`org_admin`, `team_admin`, `developer`, `viewer`,
        `auditor`) still map to their correct tone class.
  - [x] Inherited object keys (`constructor`, `toString`, `__proto__`,
        `hasOwnProperty`, `valueOf`) fall to the default tone instead of
        resolving a prototype member.
  - [x] Unknown role ids fall to the default tone.
  - [x] `RoleCapabilityCards.tsx` left unchanged.

- **Load-bearing check (test fails before the fix):** running the new test
  against a temporary revert to the object-literal `ROLE_BADGE_TONE[role]`
  version produces **6 failed | 5 passed** — the inherited-key and unknown-role
  cases fail (they resolve prototype members / `undefined`), the five real-role
  cases pass. After the Map fix: **11 passed**.

- **Gate results (Node 22.23.1, pnpm 10.9.0):**
  - `pnpm type-check` — pass (exit 0)
  - `pnpm lint` — pass (0 errors, 0 warnings)
  - `pnpm test MemberList` — pass (11/11)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)