### PR TITLE
[AAASM-5240] 🐛 (analytics): Keep __proto__ series in action-volume chart rows

### DIFF
--- a/dashboard/src/features/analytics/ActionVolumePanel.test.tsx
+++ b/dashboard/src/features/analytics/ActionVolumePanel.test.tsx
@@ -104,6 +104,27 @@ describe('transformSeries', () => {
     expect(row['agent-b']).toBe(8)
   })
 
+  it('retains a "__proto__" series key as an own property instead of dropping it (AAASM-5240)', () => {
+    // The series key comes from an unvalidated fetch response. When rows were
+    // plain object literals, `row['__proto__'] = value` was a silent no-op, so a
+    // "__proto__" series vanished from the chart data. Rows built on a null-proto
+    // object keep it as a real own property that Recharts can plot.
+    const withProtoKey: ActionVolumeSeries[] = [
+      {
+        key: '__proto__',
+        name: 'Proto',
+        points: [
+          { t: 1000, value: 7 },
+          { t: 2000, value: 9 },
+        ],
+      },
+    ]
+    const rows = transformSeries(withProtoKey)
+    const row = rows.find(r => r['t'] === 1000)!
+    expect(Object.prototype.hasOwnProperty.call(row, '__proto__')).toBe(true)
+    expect(row['__proto__']).toBe(7)
+  })
+
   it('clamps out-of-range values so the axis domain stays finite (AAASM-4334)', () => {
     // A malformed 200 can carry the schema-boundary value -Number.MAX_VALUE,
     // which previously collapsed the Recharts Y axis and spawned duplicate tick

--- a/dashboard/src/features/analytics/actionVolumeUtils.ts
+++ b/dashboard/src/features/analytics/actionVolumeUtils.ts
@@ -34,7 +34,10 @@ export function transformSeries(series: ActionVolumeSeries[]): ChartRow[] {
   const rowMap = new Map<number, ChartRow>()
   for (const s of series) {
     for (const pt of s.points) {
-      if (!rowMap.has(pt.t)) rowMap.set(pt.t, { t: pt.t })
+      // Row values are built on a null-prototype object so a series whose key is
+      // "__proto__" (from the unvalidated fetch response) becomes an own property
+      // instead of a silent no-op that would drop the series from the chart.
+      if (!rowMap.has(pt.t)) rowMap.set(pt.t, Object.assign(Object.create(null), { t: pt.t }))
       rowMap.get(pt.t)![s.key] = clampChartValue(pt.value)
     }
   }


### PR DESCRIPTION
## What changed
`transformSeries` in `dashboard/src/features/analytics/actionVolumeUtils.ts` now builds each row's **value object** with `Object.create(null)` (via `Object.assign(Object.create(null), { t: pt.t })`) instead of a plain object literal. The outer row `Map` is unchanged.

## Why
The series key (`ActionVolumeSeries.key`) comes straight from an unvalidated `res.json() as T` fetch response. With a plain object literal as the row value, `row['__proto__'] = clampChartValue(pt.value)` is a **silent no-op** — it targets the object's prototype accessor rather than creating an own property. A series whose key is `__proto__` therefore carried no data into the chart and silently vanished. A null-prototype object has no `__proto__` accessor, so the assignment becomes a real own property and the series is retained and plotted.

## How to verify
- Regression test in `dashboard/src/features/analytics/ActionVolumePanel.test.tsx` (test id "retains a \"__proto__\" series key ... (AAASM-5240)"): asserts the transformed row has `__proto__` as an own property with the expected value.
- Test-location note: `actionVolumeUtils.ts` has **no** sibling `actionVolumeUtils.test.ts`; coverage lives in `ActionVolumePanel.test.tsx`, so the regression was added there.
- **Red pre-fix, green post-fix (load-bearing):** against the original plain-literal rows the test fails with `expected false to be true` on `hasOwnProperty('__proto__')`; with the fix the analytics suite is 16/16.

## Acceptance criteria
- [x] A `__proto__` series key is no longer a silent no-op — it is retained as an own property on the row.
- [x] The outer row `Map` is kept as-is; only the value object is null-prototyped.
- [x] Regression test asserts a `__proto__` series survives `transformSeries`.

## Gate results
- `pnpm type-check`: pass (exit 0, no errors)
- `pnpm lint`: pass (exit 0, no violations)
- `pnpm test`: analytics suite 16/16 green in isolation. The full-suite run showed 11 unrelated 5000ms timeouts (in `PolicyEditorOverlay.test.tsx` and `ServiceIdentitiesPanel.test.tsx`) caused by running 29 vitest workers concurrently with tsc+eslint on a loaded machine — both files pass 39/39 in isolation. No analytics failures.

Refs AAASM-5240

🤖 Generated with [Claude Code](https://claude.com/claude-code)