### PR TITLE
[AAASM-5210] 🐛 (audit): Key audit-log wire lookups by Map (DETAIL_SUMMARISERS, DECISION_BY_NAME)

### DIFF
--- a/dashboard/src/features/audit/logs.test.tsx
+++ b/dashboard/src/features/audit/logs.test.tsx
@@ -112,6 +112,26 @@ describe('extractVerdict — proto enum wire shape', () => {
   it('ignores an empty-string decision and falls through', () => {
     expect(extractVerdict('{"decision":""}').enforced).toMatchObject({ known: false })
   })
+
+  // ── AAASM-5225: an inherited decision-name key must never resolve ────────────
+  // `decision` / `shadow_decision` are strings straight out of `JSON.parse` of an
+  // untrusted audit blob, looked up in DECISION_BY_NAME. With a plain object that
+  // table inherited `Object.prototype`, so a prototype-member name in the wire
+  // value could resolve to a truthy inherited value and be coerced into a
+  // fabricated verdict on the governance surface. A Map holds only its own four
+  // keys, so an inherited name resolves to nothing and the value is reported as
+  // an explicit `unknown` — never one of the four verdicts.
+  it.each(['__proto__', 'constructor', 'toString', 'valueOf', 'hasOwnProperty'])(
+    'refuses to turn the inherited-member name %j into a verdict',
+    (name) => {
+      const enforced = extractVerdict(JSON.stringify({ decision: name })).enforced
+      expect(isKnown(enforced)).toBe(false)
+      expect(enforced).toMatchObject({ state: 'unknown' })
+      const suppressed = extractVerdict(JSON.stringify({ shadow_decision: name })).suppressed
+      // Either null (not read) or an explicit unknown — never a resolved verdict.
+      expect(suppressed === null || isKnown(suppressed) === false).toBe(true)
+    },
+  )
 })
 
 // ── AAASM-5117 review blocker: observe mode ────────────────────────────────
@@ -315,6 +335,28 @@ describe('payloadSummary — real payload shapes', () => {
   it('reports an absence for a JSON array payload', () => {
     expect(payloadSummary('[1,2,3]')).toMatchObject({ known: false })
   })
+
+  // ── AAASM-5223: an inherited `detail.kind` must never resolve to a summariser ──
+  // The summariser table was a plain object, so `detail.kind` — a value straight
+  // out of `JSON.parse` of an untrusted audit blob — could name an
+  // `Object.prototype` member and be *invoked* as a summariser: `constructor`
+  // fabricates a summary from the detail object, `toString` returns
+  // `[object Undefined]`, and `valueOf` / `__proto__` throw. A Map has no
+  // inherited keys, so each of these misses and the caller reports an absence
+  // rather than fabricating or crashing.
+  it.each(['constructor', 'toString', 'valueOf', '__proto__', 'hasOwnProperty'])(
+    'does not invoke an inherited member for detail.kind %j — reports an absence',
+    (kind) => {
+      let summary: ReturnType<typeof payloadSummary>
+      // The read must not throw (valueOf / __proto__ would, if invoked).
+      expect(() => {
+        summary = payloadSummary(JSON.stringify({ detail: { kind, tool_name: 'x' } }))
+      }).not.toThrow()
+      // ...and it must not fabricate a summary (constructor / toString would).
+      expect(isKnown(summary!)).toBe(false)
+      expect(summary!).toMatchObject({ known: false })
+    },
+  )
 })
 
 describe('extractTraceId', () => {

--- a/dashboard/src/features/audit/logs.ts
+++ b/dashboard/src/features/audit/logs.ts
@@ -71,13 +71,23 @@ const DECISION_BY_DISCRIMINANT: Readonly<Record<number, AuditDecision>> = {
   4: 'REDACT',
 }
 
-/** Accepted spellings of the string form, which only the shadow path emits. */
-const DECISION_BY_NAME: Readonly<Record<string, AuditDecision>> = {
-  ALLOW: 'ALLOW',
-  DENY: 'DENY',
-  PENDING: 'PENDING',
-  REDACT: 'REDACT',
-}
+/**
+ * Accepted spellings of the string form, which only the shadow path emits.
+ *
+ * A `Map` rather than a plain object because the key is `raw.toUpperCase()`,
+ * derived from a `JSON.parse` of an untrusted audit blob. A plain-object lookup
+ * inherits `Object.prototype`, so `"__proto__"` (or any prototype member name)
+ * would resolve to a truthy inherited value and be coerced into a fabricated
+ * verdict on a governance surface. A `Map` only holds its own keys, so an
+ * inherited name misses and the value is reported as an explicit `unknown`
+ * (AAASM-5225).
+ */
+const DECISION_BY_NAME: ReadonlyMap<string, AuditDecision> = new Map([
+  ['ALLOW', 'ALLOW'],
+  ['DENY', 'DENY'],
+  ['PENDING', 'PENDING'],
+  ['REDACT', 'REDACT'],
+])
 
 /**
  * Interpret one raw `decision`-shaped JSON value.
@@ -103,7 +113,7 @@ function readDecisionValue(raw: unknown): Certain<AuditDecision> | null {
     )
   }
   if (typeof raw === 'string' && raw.length > 0) {
-    const mapped = DECISION_BY_NAME[raw.toUpperCase()]
+    const mapped = DECISION_BY_NAME.get(raw.toUpperCase())
     if (mapped) return known(mapped)
     return absent('unknown', `Unrecognised decision value "${raw}"`)
   }

--- a/dashboard/src/features/audit/logs.ts
+++ b/dashboard/src/features/audit/logs.ts
@@ -370,51 +370,80 @@ function boolLabel(value: unknown, whenTrue: string, whenFalse: string): string 
  * One summariser per `detail.kind`, keyed exactly as
  * `aa-runtime/src/audit_publisher/conversion.rs::detail_summary` emits them.
  *
+ * A `Map` rather than a plain object because the key comes straight from
+ * `detail.kind` — a `JSON.parse` of an untrusted audit blob. A plain-object
+ * lookup inherits `Object.prototype`, so a blob whose `kind` is `constructor`,
+ * `toString`, `valueOf` or `__proto__` would resolve to a *prototype* member and
+ * then be **invoked** as though it were a summariser: `constructor` returns the
+ * detail object stringified, `toString` returns `[object Undefined]`, and
+ * `valueOf` throws — every one of them either fabricates a summary or crashes
+ * the reader on a governance surface. A `Map` only ever contains its own keys,
+ * so an inherited name misses and the caller reports an honest absence
+ * (AAASM-5223).
+ *
  * A table rather than a `switch` so each kind is an independently readable unit
  * and adding a producer-side kind is a one-line change here.
  */
-const DETAIL_SUMMARISERS: Readonly<
-  Record<string, (detail: Record<string, unknown>) => string | null>
-> = {
-  llm_call: (d) => joinParts([str(d, 'model'), str(d, 'provider')]),
+const DETAIL_SUMMARISERS: ReadonlyMap<
+  string,
+  (detail: Record<string, unknown>) => string | null
+> = new Map([
+  ['llm_call', (d) => joinParts([str(d, 'model'), str(d, 'provider')])],
 
-  tool_call: (d) => {
-    const name = str(d, 'tool_name')
-    const source = str(d, 'tool_source')
-    const named = name && source ? `${name} (${source})` : (name ?? source)
-    return joinParts([named, boolLabel(d['succeeded'], '✓ ok', '✕ error')])
-  },
+  [
+    'tool_call',
+    (d) => {
+      const name = str(d, 'tool_name')
+      const source = str(d, 'tool_source')
+      const named = name && source ? `${name} (${source})` : (name ?? source)
+      return joinParts([named, boolLabel(d['succeeded'], '✓ ok', '✕ error')])
+    },
+  ],
 
-  file_op: (d) => {
-    const operation = str(d, 'operation')
-    const verb = operation ? operation.toUpperCase() : null
-    return joinParts([joinParts([verb, str(d, 'path')], ' '), str(d, 'source')])
-  },
+  [
+    'file_op',
+    (d) => {
+      const operation = str(d, 'operation')
+      const verb = operation ? operation.toUpperCase() : null
+      return joinParts([joinParts([verb, str(d, 'path')], ' '), str(d, 'source')])
+    },
+  ],
 
-  network_call: (d) => {
-    const protocol = str(d, 'protocol')
-    const host = str(d, 'host')
-    if (!host) return protocol
-    const port = typeof d['port'] === 'number' ? String(d['port']) : null
-    const authority = port ? `${host}:${port}` : host
-    return protocol ? `${protocol}://${authority}` : authority
-  },
+  [
+    'network_call',
+    (d) => {
+      const protocol = str(d, 'protocol')
+      const host = str(d, 'host')
+      if (!host) return protocol
+      const port = typeof d['port'] === 'number' ? String(d['port']) : null
+      const authority = port ? `${host}:${port}` : host
+      return protocol ? `${protocol}://${authority}` : authority
+    },
+  ],
 
-  process_exec: (d) => {
-    const exitCode = d['exit_code']
-    const exit = typeof exitCode === 'number' ? `exit ${exitCode}` : null
-    return joinParts([str(d, 'command'), exit])
-  },
+  [
+    'process_exec',
+    (d) => {
+      const exitCode = d['exit_code']
+      const exit = typeof exitCode === 'number' ? `exit ${exitCode}` : null
+      return joinParts([str(d, 'command'), exit])
+    },
+  ],
 
-  policy_violation: (d) => {
-    const head = joinParts([str(d, 'blocked_action'), str(d, 'reason')], ' — ')
-    const rule = str(d, 'policy_rule')
-    return joinParts([head, rule ? `rule ${rule}` : null])
-  },
+  [
+    'policy_violation',
+    (d) => {
+      const head = joinParts([str(d, 'blocked_action'), str(d, 'reason')], ' — ')
+      const rule = str(d, 'policy_rule')
+      return joinParts([head, rule ? `rule ${rule}` : null])
+    },
+  ],
 
-  approval: (d) =>
-    joinParts([str(d, 'approval_id'), boolLabel(d['approved'], 'approved', 'denied')], ' '),
-}
+  [
+    'approval',
+    (d) => joinParts([str(d, 'approval_id'), boolLabel(d['approved'], 'approved', 'denied')], ' '),
+  ],
+])
 
 /**
  * Summarise the runtime's `detail` object.
@@ -428,7 +457,7 @@ const DETAIL_SUMMARISERS: Readonly<
  */
 function summariseDetail(detail: Record<string, unknown>): string | null {
   const kind = str(detail, 'kind')
-  const summarise = kind === null ? undefined : DETAIL_SUMMARISERS[kind]
+  const summarise = kind === null ? undefined : DETAIL_SUMMARISERS.get(kind)
   return summarise ? summarise(detail) : null
 }
 


### PR DESCRIPTION
## Description

The audit-log data layer (`dashboard/src/features/audit/logs.ts`) resolves two lookups with keys taken **straight from `JSON.parse` of an untrusted audit blob**. Both tables were plain objects, so a key that names an `Object.prototype` member resolved to an inherited value.

**Root cause — invoked function (highest-severity in Epic AAASM-5208):** `DETAIL_SUMMARISERS` (site 1) is indexed by `detail.kind`, and the resolved value is **invoked** as a summariser. When `kind` is an inherited member the reader either fabricates a summary or crashes, silently, on the system-of-record surface:

| `detail.kind` | pre-fix behaviour |
|---|---|
| `constructor` | invoked → returns the detail object stringified (a fabricated summary) |
| `toString` | invoked → returns `[object Undefined]` |
| `valueOf` | invoked → **throws** |
| `__proto__` | resolves to `Object.prototype` (non-callable) → **throws** `summarise is not a function` |

Fabricating a summary — or throwing — on a governance/audit surface is exactly the silent-fabrication class this Epic exists to remove.

Both sites are converted to `Map`, which contains only its own keys, so an inherited name misses and the caller reports an honest absence / explicit `unknown`.

### Sites changed (`dashboard/src/features/audit/logs.ts`)

- **AAASM-5223** — `DETAIL_SUMMARISERS` (`~:376`) → `ReadonlyMap`; lookup in `summariseDetail` (`~:431`) now uses `.get(kind)`. This is the invoked-function fix.
- **AAASM-5225** — `DECISION_BY_NAME` (`~:75`) → `ReadonlyMap`; lookup in `readDecisionValue` (`~:106`) now uses `.get(...)`.

### Downstream verification — `export.ts:203` (`suppressedCounts[label]`)

The Story flagged `export.ts:203` as a downstream amplifier of 5225. Verified: `label = csvCertain(verdict.suppressed)`, reached only when `isSuppressedDenial(verdict)` (i.e. `isKnown(verdict.suppressed)`), so `label = String(verdict.suppressed.value)`. `verdict.suppressed` is produced by `readDecisionValue`, whose value is strictly one of the four `AuditDecision` literals (`ALLOW`/`DENY`/`PENDING`/`REDACT`). None is a prototype-member name, so even though `suppressedCounts` is a plain object it can never take a `__proto__` key. **Label provenance corrects it — confirmed corrected by the 5225 fix; not filed separately, not touched.**

Note: `DECISION_BY_NAME` was already un-exploitable via a wire literal because `readDecisionValue` uppercases the key first (`raw.toUpperCase()`), and every prototype-member name uppercases to a non-existent key (`__proto__` → `__PROTO__` misses). The 5225 Map conversion is therefore a structural/defence-in-depth consistency change with **no behaviour change for real inputs**; the guarantee is now inherent in the data structure.

## Type of Change

- [x] 🐛 Bug fix
- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5210 (Story), AAASM-5223, AAASM-5225 (subtasks)

## Testing

- [x] Unit tests added / updated
- [x] No integration tests required (pure client-side data layer)

New parametrised guards in `logs.test.tsx`:
- `payloadSummary` — inherited `detail.kind` (`constructor`, `toString`, `valueOf`, `__proto__`, `hasOwnProperty`) must neither throw nor fabricate; reports an absence. **Verified RED pre-fix** (throws / fabrication against the plain object), green post-fix.
- `extractVerdict` — inherited decision-name via `decision` / `shadow_decision` must never resolve to a verdict, only an explicit `unknown`. (Green both pre- and post-fix, per the `toUpperCase()` note above; documents the structural guarantee.)

Gate results (dashboard):
- `pnpm type-check` — clean
- `pnpm lint` — clean (0 warnings, `--max-warnings 0`)
- `pnpm exec vitest run src/features/audit/logs.test.tsx` — 67 passed

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

Resolves AAASM-5223, AAASM-5225.