### PR TITLE
[AAASM-5209] ✨ (aa-api): Constrain agent/decision/verdict/event wire vocabularies in OpenAPI

### DIFF
--- a/aa-api/src/models/topology.rs
+++ b/aa-api/src/models/topology.rs
@@ -27,6 +27,36 @@ pub(crate) fn status_str(status: &AgentStatus) -> &'static str {
     }
 }
 
+/// Runtime status of an agent node in the topology projection.
+///
+/// AAASM-5218 — constrains the wire vocabulary of [`AgentNode::status`] at the
+/// OpenAPI derive to exactly the three values `status_str` can emit, so the
+/// generated spec (and the TypeScript client) advertises a closed enum instead
+/// of an unconstrained `string`. Serializes lowercase, matching the strings the
+/// registry's [`AgentStatus`] mapped to before this was a free-form field.
+///
+/// Deliberately distinct from the runtime registry [`AgentStatus`], whose
+/// `Suspended(_)` variant carries a parameterised reason an enum cannot express,
+/// and from the capability-view `AgentStatus` — the three agent-status
+/// vocabularies are not reconciled here (that is an ADR question, see AAASM-5209).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentNodeStatus {
+    Active,
+    Suspended,
+    Deregistered,
+}
+
+impl From<&AgentStatus> for AgentNodeStatus {
+    fn from(status: &AgentStatus) -> Self {
+        match status {
+            AgentStatus::Active => AgentNodeStatus::Active,
+            AgentStatus::Suspended(_) => AgentNodeStatus::Suspended,
+            AgentStatus::Deregistered => AgentNodeStatus::Deregistered,
+        }
+    }
+}
+
 /// Policy-violation count at or above which a node is surfaced as "flagged"
 /// (danger-tinted card + ⚑ marker) in the topology graph.
 ///
@@ -257,7 +287,7 @@ pub struct AgentNode {
     /// Delegation depth — 0 for root agents.
     pub depth: u32,
     /// Runtime status: `active`, `suspended`, or `deregistered`.
-    pub status: String,
+    pub status: AgentNodeStatus,
     /// Team this agent belongs to, if any.
     pub team_id: Option<String>,
     /// Governance level — included only when `show_budget=true`.
@@ -315,7 +345,7 @@ impl From<&AgentRecord> for AgentNode {
             id: format_id(&r.agent_id),
             name: r.name.clone(),
             depth: r.depth,
-            status: status_str(&r.status).to_owned(),
+            status: AgentNodeStatus::from(&r.status),
             team_id: r.team_id.clone(),
             governance_level: None,
             mode: agent_mode(r),
@@ -667,7 +697,7 @@ mod tests {
             id: "0102030405060708090a0b0c0d0e0f10".to_string(),
             name: "agent-x".to_string(),
             depth: 1,
-            status: "active".to_string(),
+            status: AgentNodeStatus::Active,
             team_id: Some("team-alpha".to_string()),
             governance_level: None,
             mode: "enforce".to_string(),

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -222,6 +222,7 @@ use crate::routes::{
         topology::TopologyGraphEdge,
         topology::TeamSummary,
         topology::AgentNode,
+        topology::AgentNodeStatus,
         topology::NodeBudget,
         topology::NodeEffectivePermissions,
         topology::PolicyChainTier,

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -182,6 +182,7 @@ use crate::routes::{
         policies::PolicyResponse,
         policies::CreatePolicyRequest,
         policies::SimulatePolicyRequest,
+        policies::SimulateVerdict,
         policies::SimulatePolicyResponse,
         policies::TeamPolicyResponse,
         policies::TeamPoliciesResponse,

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -176,6 +176,7 @@ use crate::routes::{
         agents::ChildSpendResponse,
         agents::DailyBurnPointResponse,
         agents::SubtreeBurnResponse,
+        logs::LogEventType,
         logs::LogEntry,
         TraceResponse,
         TraceSpan,

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -168,6 +168,7 @@ use crate::routes::{
         agents::PermissionSourceResponse,
         agents::EffectivePermissionsResponse,
         crate::models::verdict::RuntimeVerdict,
+        agents::DecisionLabel,
         agents::AgentDecisionResponse,
         agents::AgentDecisionsResponse,
         agents::BudgetRowResponse,

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -1018,7 +1018,7 @@ pub struct AgentDecisionResponse {
     /// Lowercase label derived from `decision` (`allow` / `deny` / `pending` /
     /// `redact` / `unspecified`) so the UI can map to its verdict styling
     /// without re-deriving the enum. Derived, not a separate audit field.
-    pub decision_label: String,
+    pub decision_label: DecisionLabel,
     /// The canonical 5-way runtime verdict (`allow` / `narrow` / `scrub` /
     /// `pending` / `deny`, AAASM-5086) for this action — the vocabulary the
     /// dashboard renders. Distinct from `decision`/`decisionLabel`, which are the
@@ -1071,16 +1071,33 @@ const MAX_DECISIONS_LIMIT: usize = 500;
 /// do (AAASM-4145); a caller that wants more history pages via `limit`.
 const MAX_DECISIONS_SCAN: usize = 10_000;
 
+/// Wire vocabulary for [`AgentDecisionResponse::decision_label`].
+///
+/// AAASM-5219 — constrains the `decisionLabel` field to the closed set of
+/// lowercase labels [`decision_label`] can emit, one per proto
+/// [`Decision`](aa_proto::assembly::common::v1::Decision) discriminant plus the
+/// `unspecified` fallback, so the generated OpenAPI spec advertises an enum
+/// rather than a free-form `string`. Serializes lowercase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum DecisionLabel {
+    Allow,
+    Deny,
+    Pending,
+    Redact,
+    Unspecified,
+}
+
 /// Lowercase label for a [`Decision`](aa_proto::assembly::common::v1::Decision)
 /// discriminant, used for `decisionLabel`.
-fn decision_label(discriminant: i64) -> &'static str {
+fn decision_label(discriminant: i64) -> DecisionLabel {
     use aa_proto::assembly::common::v1::Decision;
     match discriminant {
-        d if d == Decision::Allow as i64 => "allow",
-        d if d == Decision::Deny as i64 => "deny",
-        d if d == Decision::Pending as i64 => "pending",
-        d if d == Decision::Redact as i64 => "redact",
-        _ => "unspecified",
+        d if d == Decision::Allow as i64 => DecisionLabel::Allow,
+        d if d == Decision::Deny as i64 => DecisionLabel::Deny,
+        d if d == Decision::Pending as i64 => DecisionLabel::Pending,
+        d if d == Decision::Redact as i64 => DecisionLabel::Redact,
+        _ => DecisionLabel::Unspecified,
     }
 }
 
@@ -1143,7 +1160,7 @@ fn entry_to_decision_row(entry: &AuditEntry) -> Option<AgentDecisionResponse> {
         verb,
         resource,
         decision,
-        decision_label: decision_label(decision).to_string(),
+        decision_label: decision_label(decision),
         // The 5-way runtime verdict is not captured at decision time yet;
         // deriving it is the ADR-0018-gated hot-path follow-up. Surface null
         // rather than lossily mapping the coarse proto `decision` onto it.
@@ -1270,12 +1287,12 @@ mod tests {
 
     #[test]
     fn decision_label_maps_each_discriminant() {
-        assert_eq!(decision_label(1), "allow");
-        assert_eq!(decision_label(2), "deny");
-        assert_eq!(decision_label(3), "pending");
-        assert_eq!(decision_label(4), "redact");
-        assert_eq!(decision_label(0), "unspecified");
-        assert_eq!(decision_label(99), "unspecified");
+        assert_eq!(decision_label(1), DecisionLabel::Allow);
+        assert_eq!(decision_label(2), DecisionLabel::Deny);
+        assert_eq!(decision_label(3), DecisionLabel::Pending);
+        assert_eq!(decision_label(4), DecisionLabel::Redact);
+        assert_eq!(decision_label(0), DecisionLabel::Unspecified);
+        assert_eq!(decision_label(99), DecisionLabel::Unspecified);
     }
 
     #[test]
@@ -1308,7 +1325,7 @@ mod tests {
         );
         let row = entry_to_decision_row(&entry).expect("tool_call carries a decision");
         assert_eq!(row.decision, 1);
-        assert_eq!(row.decision_label, "allow");
+        assert_eq!(row.decision_label, DecisionLabel::Allow);
         assert_eq!(row.verb.as_deref(), Some("TOOL_CALL"));
         assert_eq!(row.resource.as_deref(), Some("pg.users"));
         assert_eq!(row.matched_policy, None);
@@ -1335,7 +1352,7 @@ mod tests {
             r#"{"action_type":"TOOL_CALL","decision":2,"detail":{"kind":"policy_violation","policy_rule":"P-066","blocked_action":"gmail.send"}}"#,
         );
         let row = entry_to_decision_row(&nested).unwrap();
-        assert_eq!(row.decision_label, "deny");
+        assert_eq!(row.decision_label, DecisionLabel::Deny);
         assert_eq!(row.matched_policy.as_deref(), Some("P-066"));
         assert_eq!(row.resource.as_deref(), Some("gmail.send"));
 

--- a/aa-api/src/routes/logs.rs
+++ b/aa-api/src/routes/logs.rs
@@ -1,5 +1,6 @@
 //! Audit log query endpoints.
 
+use aa_core::AuditEventType;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
@@ -9,6 +10,71 @@ use utoipa::{IntoParams, ToSchema};
 use crate::auth::scope::{RequireRead, Scope};
 use crate::pagination::PaginationParams;
 use crate::state::AppState;
+
+/// Category of an audit log entry, mirroring [`aa_core::AuditEventType`].
+///
+/// AAASM-5221 — constrains the [`LogEntry::event_type`] wire vocabulary to the
+/// closed set of labels [`AuditEventType::as_str`] emits, so the generated
+/// OpenAPI spec advertises an enum rather than a free-form `string`. Variants
+/// serialize verbatim (PascalCase), matching the strings the audit log has
+/// always written, so the wire shape is unchanged.
+///
+/// Kept in lock-step with `AuditEventType`: the [`From`] impl is exhaustive, so
+/// adding an audit variant without extending this enum is a compile error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub enum LogEventType {
+    ToolCallIntercepted,
+    PolicyViolation,
+    CredentialLeakBlocked,
+    ApprovalRequested,
+    ApprovalGranted,
+    ApprovalDenied,
+    BudgetLimitApproached,
+    BudgetLimitExceeded,
+    ApprovalTimedOut,
+    ApprovalRouted,
+    ApprovalEscalated,
+    AgentForceDeregistered,
+    MessageBlocked,
+    ToolDispatched,
+    A2ACallIntercepted,
+    A2AImpersonationAttempted,
+    SandboxStarted,
+    SandboxFilesystemBlocked,
+    SandboxCpuTimeout,
+    SandboxOomKilled,
+    SandboxTerminated,
+    SandboxHostFnRateLimited,
+}
+
+impl From<AuditEventType> for LogEventType {
+    fn from(t: AuditEventType) -> Self {
+        match t {
+            AuditEventType::ToolCallIntercepted => LogEventType::ToolCallIntercepted,
+            AuditEventType::PolicyViolation => LogEventType::PolicyViolation,
+            AuditEventType::CredentialLeakBlocked => LogEventType::CredentialLeakBlocked,
+            AuditEventType::ApprovalRequested => LogEventType::ApprovalRequested,
+            AuditEventType::ApprovalGranted => LogEventType::ApprovalGranted,
+            AuditEventType::ApprovalDenied => LogEventType::ApprovalDenied,
+            AuditEventType::BudgetLimitApproached => LogEventType::BudgetLimitApproached,
+            AuditEventType::BudgetLimitExceeded => LogEventType::BudgetLimitExceeded,
+            AuditEventType::ApprovalTimedOut => LogEventType::ApprovalTimedOut,
+            AuditEventType::ApprovalRouted => LogEventType::ApprovalRouted,
+            AuditEventType::ApprovalEscalated => LogEventType::ApprovalEscalated,
+            AuditEventType::AgentForceDeregistered => LogEventType::AgentForceDeregistered,
+            AuditEventType::MessageBlocked => LogEventType::MessageBlocked,
+            AuditEventType::ToolDispatched => LogEventType::ToolDispatched,
+            AuditEventType::A2ACallIntercepted => LogEventType::A2ACallIntercepted,
+            AuditEventType::A2AImpersonationAttempted => LogEventType::A2AImpersonationAttempted,
+            AuditEventType::SandboxStarted => LogEventType::SandboxStarted,
+            AuditEventType::SandboxFilesystemBlocked => LogEventType::SandboxFilesystemBlocked,
+            AuditEventType::SandboxCpuTimeout => LogEventType::SandboxCpuTimeout,
+            AuditEventType::SandboxOomKilled => LogEventType::SandboxOomKilled,
+            AuditEventType::SandboxTerminated => LogEventType::SandboxTerminated,
+            AuditEventType::SandboxHostFnRateLimited => LogEventType::SandboxHostFnRateLimited,
+        }
+    }
+}
 
 /// JSON representation of an audit log entry.
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -22,7 +88,7 @@ pub struct LogEntry {
     /// Hex-encoded session ID for the agent run.
     pub session_id: String,
     /// Type of audit event.
-    pub event_type: String,
+    pub event_type: LogEventType,
     /// Pre-serialized JSON payload.
     pub payload: String,
 }
@@ -127,7 +193,7 @@ pub async fn list_logs(
                 timestamp,
                 agent_id: hex::encode(e.agent_id().as_bytes()),
                 session_id: hex::encode(e.session_id().as_bytes()),
-                event_type: e.event_type().as_str().to_string(),
+                event_type: LogEventType::from(e.event_type()),
                 payload: e.payload().to_string(),
             }
         })

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -751,11 +751,26 @@ pub struct SimulatePolicyRequest {
     pub team_id: Option<String>,
 }
 
+/// Dry-run verdict returned by `POST /api/v1/policies/simulate`.
+///
+/// AAASM-5220 — constrains the [`SimulatePolicyResponse::verdict`] wire
+/// vocabulary to the closed set the simulate handler emits, so the generated
+/// OpenAPI spec advertises an enum rather than a free-form `string`. Serializes
+/// lowercase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SimulateVerdict {
+    Allow,
+    Narrow,
+    Approval,
+    Deny,
+}
+
 /// Response body for `POST /api/v1/policies/simulate` (AAASM-5037).
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct SimulatePolicyResponse {
-    /// Dry-run verdict: `"allow"`, `"narrow"`, `"approval"`, or `"deny"`.
-    pub verdict: String,
+    /// Dry-run verdict: `allow`, `narrow`, `approval`, or `deny`.
+    pub verdict: SimulateVerdict,
     /// Label of the policy rule / reason that produced the verdict. `null` for a
     /// clean allow with no matched narrowing or deny rule.
     pub matched_rule: Option<String>,
@@ -845,14 +860,14 @@ pub async fn simulate_policy(
         // Allowed, but the scanner would scrub sensitive content first — the
         // request is narrowed rather than passed through verbatim.
         aa_core::PolicyResult::Allow if redacted => (
-            "narrow",
+            SimulateVerdict::Narrow,
             Some("sensitive content scrubbed".to_string()),
             "allowed after redacting sensitive content".to_string(),
         ),
-        aa_core::PolicyResult::Allow => ("allow", None, "allowed by policy".to_string()),
-        aa_core::PolicyResult::Deny { reason } => ("deny", Some(reason.clone()), reason.clone()),
+        aa_core::PolicyResult::Allow => (SimulateVerdict::Allow, None, "allowed by policy".to_string()),
+        aa_core::PolicyResult::Deny { reason } => (SimulateVerdict::Deny, Some(reason.clone()), reason.clone()),
         aa_core::PolicyResult::RequiresApproval { timeout_secs } => (
-            "approval",
+            SimulateVerdict::Approval,
             Some("requires_approval".to_string()),
             format!("human approval required (timeout {timeout_secs}s)"),
         ),
@@ -861,7 +876,7 @@ pub async fn simulate_policy(
     Ok((
         StatusCode::OK,
         Json(SimulatePolicyResponse {
-            verdict: verdict.to_string(),
+            verdict,
             matched_rule,
             reason,
             redacted,

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -25,8 +25,9 @@ use crate::auth::AuthenticatedCaller;
 use crate::error::ProblemDetail;
 use crate::models::topology::{agent_flagged, agent_mode, format_id, status_str};
 pub use crate::models::topology::{
-    AgentLineage, AgentNode, AgentTree, LineageStep, NodeBudget, NodeEffectivePermissions, PolicyChainTier,
-    TeamSummary, TeamTopology, TopologyGraphEdge, TopologyGraphResponse, TopologyOverview, TopologyStats,
+    AgentLineage, AgentNode, AgentNodeStatus, AgentTree, LineageStep, NodeBudget, NodeEffectivePermissions,
+    PolicyChainTier, TeamSummary, TeamTopology, TopologyGraphEdge, TopologyGraphResponse, TopologyOverview,
+    TopologyStats,
 };
 use crate::routes::enforcement_mirror::{agent_tool_ids, cascade_denies_all_egress, cascade_denies_tool};
 use crate::state::AppState;

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1964,7 +1964,7 @@ export interface components {
              *     `redact` / `unspecified`) so the UI can map to its verdict styling
              *     without re-deriving the enum. Derived, not a separate audit field.
              */
-            decisionLabel: string;
+            decisionLabel: components["schemas"]["DecisionLabel"];
             /**
              * Format: int64
              * @description The design's `latency` column. **Always `null`: the audit log records no
@@ -2177,7 +2177,7 @@ export interface components {
              */
             policy_count?: number | null;
             /** @description Runtime status: `active`, `suspended`, or `deregistered`. */
-            status: string;
+            status: components["schemas"]["AgentNodeStatus"];
             /** @description Team this agent belongs to, if any. */
             team_id?: string | null;
             /**
@@ -2191,6 +2191,22 @@ export interface components {
              */
             trust: number | null;
         };
+        /**
+         * @description Runtime status of an agent node in the topology projection.
+         *
+         *     AAASM-5218 — constrains the wire vocabulary of [`AgentNode::status`] at the
+         *     OpenAPI derive to exactly the three values `status_str` can emit, so the
+         *     generated spec (and the TypeScript client) advertises a closed enum instead
+         *     of an unconstrained `string`. Serializes lowercase, matching the strings the
+         *     registry's [`AgentStatus`] mapped to before this was a free-form field.
+         *
+         *     Deliberately distinct from the runtime registry [`AgentStatus`], whose
+         *     `Suspended(_)` variant carries a parameterised reason an enum cannot express,
+         *     and from the capability-view `AgentStatus` — the three agent-status
+         *     vocabularies are not reconciled here (that is an ADR question, see AAASM-5209).
+         * @enum {string}
+         */
+        AgentNodeStatus: "active" | "suspended" | "deregistered";
         /** @description JSON representation of an agent returned by the API. */
         AgentResponse: {
             /** @description Currently active sessions for this agent. */
@@ -3018,6 +3034,17 @@ export interface components {
          */
         Decision: "allow" | "narrow" | "approval" | "deny" | "na";
         /**
+         * @description Wire vocabulary for [`AgentDecisionResponse::decision_label`].
+         *
+         *     AAASM-5219 — constrains the `decisionLabel` field to the closed set of
+         *     lowercase labels [`decision_label`] can emit, one per proto
+         *     [`Decision`](aa_proto::assembly::common::v1::Decision) discriminant plus the
+         *     `unspecified` fallback, so the generated OpenAPI spec advertises an enum
+         *     rather than a free-form `string`. Serializes lowercase.
+         * @enum {string}
+         */
+        DecisionLabel: "allow" | "deny" | "pending" | "redact" | "unspecified";
+        /**
          * @description Per-kind configuration payload for a `Destination`.
          *
          *     Serialised as `{ "kind": "...", "config": { ... } }` so that the API
@@ -3401,7 +3428,7 @@ export interface components {
             /** @description Hex-encoded agent ID that produced this log entry. */
             agent_id: string;
             /** @description Type of audit event. */
-            event_type: string;
+            event_type: components["schemas"]["LogEventType"];
             /** @description Pre-serialized JSON payload. */
             payload: string;
             /**
@@ -3414,6 +3441,20 @@ export interface components {
             /** @description ISO 8601 timestamp of the event. */
             timestamp: string;
         };
+        /**
+         * @description Category of an audit log entry, mirroring [`aa_core::AuditEventType`].
+         *
+         *     AAASM-5221 — constrains the [`LogEntry::event_type`] wire vocabulary to the
+         *     closed set of labels [`AuditEventType::as_str`] emits, so the generated
+         *     OpenAPI spec advertises an enum rather than a free-form `string`. Variants
+         *     serialize verbatim (PascalCase), matching the strings the audit log has
+         *     always written, so the wire shape is unchanged.
+         *
+         *     Kept in lock-step with `AuditEventType`: the [`From`] impl is exhaustive, so
+         *     adding an audit variant without extending this enum is a compile error.
+         * @enum {string}
+         */
+        LogEventType: "ToolCallIntercepted" | "PolicyViolation" | "CredentialLeakBlocked" | "ApprovalRequested" | "ApprovalGranted" | "ApprovalDenied" | "BudgetLimitApproached" | "BudgetLimitExceeded" | "ApprovalTimedOut" | "ApprovalRouted" | "ApprovalEscalated" | "AgentForceDeregistered" | "MessageBlocked" | "ToolDispatched" | "A2ACallIntercepted" | "A2AImpersonationAttempted" | "SandboxStarted" | "SandboxFilesystemBlocked" | "SandboxCpuTimeout" | "SandboxOomKilled" | "SandboxTerminated" | "SandboxHostFnRateLimited";
         /**
          * @description Per-agent daily budget projection for a topology node (AAASM-5045).
          *
@@ -4478,9 +4519,19 @@ export interface components {
              *     credential/PII content was detected (drives the `"narrow"` verdict).
              */
             redacted: boolean;
-            /** @description Dry-run verdict: `"allow"`, `"narrow"`, `"approval"`, or `"deny"`. */
-            verdict: string;
+            /** @description Dry-run verdict: `allow`, `narrow`, `approval`, or `deny`. */
+            verdict: components["schemas"]["SimulateVerdict"];
         };
+        /**
+         * @description Dry-run verdict returned by `POST /api/v1/policies/simulate`.
+         *
+         *     AAASM-5220 — constrains the [`SimulatePolicyResponse::verdict`] wire
+         *     vocabulary to the closed set the simulate handler emits, so the generated
+         *     OpenAPI spec advertises an enum rather than a free-form `string`. Serializes
+         *     lowercase.
+         * @enum {string}
+         */
+        SimulateVerdict: "allow" | "narrow" | "approval" | "deny";
         /** @description Response for `GET /api/v1/agents/{id}/subtree-burn`. */
         SubtreeBurnResponse: {
             /** @description Hex-encoded root agent ID. */

--- a/dashboard/src/pages/AuditLogPage.test.tsx
+++ b/dashboard/src/pages/AuditLogPage.test.tsx
@@ -173,7 +173,12 @@ describe('AuditLogPage', () => {
 
   it('routes an unrecognised event type into the Unrecognised tile', async () => {
     get.mockResolvedValue({
-      data: page([entry({ seq: 901, event_type: 'SomeFutureVariant', payload: '{}' })]),
+      // A variant outside the closed `LogEventType` enum — deliberately cast to
+      // exercise the UI's runtime fallback for a value a future backend could
+      // emit before the generated schema catches up (the "Unrecognised" tile).
+      data: page([
+        entry({ seq: 901, event_type: 'SomeFutureVariant' as LogEntry['event_type'], payload: '{}' }),
+      ]),
     })
     renderPage()
     const row = await screen.findByTestId('audit-row-901')
@@ -399,14 +404,17 @@ describe('AuditLogPage', () => {
 // ── AAASM-5120 ─────────────────────────────────────────────────────────────
 describe('AuditLogPage — window coverage', () => {
   function fullPage(pageNumber: number, total: number): { data: ReturnType<typeof page> } {
-    const items = Array.from({ length: AUDIT_PAGE_SIZE }, (_, i) => ({
-      seq: (pageNumber - 1) * AUDIT_PAGE_SIZE + i,
-      timestamp: '2026-05-11T14:02:11Z',
-      agent_id: RESEARCH_AGENT,
-      session_id: 'sess-9a4f',
-      event_type: 'ToolCallIntercepted',
-      payload: '{"decision":1}',
-    }))
+    const items = Array.from(
+      { length: AUDIT_PAGE_SIZE },
+      (_, i): LogEntry => ({
+        seq: (pageNumber - 1) * AUDIT_PAGE_SIZE + i,
+        timestamp: '2026-05-11T14:02:11Z',
+        agent_id: RESEARCH_AGENT,
+        session_id: 'sess-9a4f',
+        event_type: 'ToolCallIntercepted',
+        payload: '{"decision":1}',
+      }),
+    )
     return { data: page(items, total, pageNumber) }
   }
 

--- a/dashboard/src/pages/TeamsPage.test.tsx
+++ b/dashboard/src/pages/TeamsPage.test.tsx
@@ -95,10 +95,10 @@ const APPROVALS: Approval[] = [
 
 function topologyFor(teamId: string): TeamTopology {
   const members = teamId === 'team-000'
-    ? [{ id: 'a1', name: 'orchestrator', status: 'active', depth: 0, flagged: false, mode: 'enforce', trust: null }]
+    ? [{ id: 'a1', name: 'orchestrator', status: 'active' as const, depth: 0, flagged: false, mode: 'enforce', trust: null }]
     : [
-        { id: 'b1', name: 'router', status: 'active', depth: 0, flagged: false, mode: 'enforce', trust: null },
-        { id: 'b2', name: 'scraper', status: 'suspended', depth: 1, flagged: true, mode: 'shadow', trust: null },
+        { id: 'b1', name: 'router', status: 'active' as const, depth: 0, flagged: false, mode: 'enforce', trust: null },
+        { id: 'b2', name: 'scraper', status: 'suspended' as const, depth: 1, flagged: true, mode: 'shadow', trust: null },
       ]
   return { team_id: teamId, agent_count: members.length, members }
 }

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -3374,7 +3374,7 @@ components:
             the AAASM-5035 note in `analytics::decision_is_error`): `1` = Allow,
             `2` = Deny, `3` = Pending, `4` = Redact, `0` = Unspecified.
         decisionLabel:
-          type: string
+          $ref: '#/components/schemas/DecisionLabel'
           description: |-
             Lowercase label derived from `decision` (`allow` / `deny` / `pending` /
             `redact` / `unspecified`) so the UI can map to its verdict styling
@@ -3663,7 +3663,7 @@ components:
             leave it `null` rather than emitting a misleading `0`.
           minimum: 0
         status:
-          type: string
+          $ref: '#/components/schemas/AgentNodeStatus'
           description: 'Runtime status: `active`, `suspended`, or `deregistered`.'
         team_id:
           type:
@@ -3698,6 +3698,25 @@ components:
         status: active
         team_id: team-alpha
         trust: null
+    AgentNodeStatus:
+      type: string
+      description: |-
+        Runtime status of an agent node in the topology projection.
+
+        AAASM-5218 — constrains the wire vocabulary of [`AgentNode::status`] at the
+        OpenAPI derive to exactly the three values `status_str` can emit, so the
+        generated spec (and the TypeScript client) advertises a closed enum instead
+        of an unconstrained `string`. Serializes lowercase, matching the strings the
+        registry's [`AgentStatus`] mapped to before this was a free-form field.
+
+        Deliberately distinct from the runtime registry [`AgentStatus`], whose
+        `Suspended(_)` variant carries a parameterised reason an enum cannot express,
+        and from the capability-view `AgentStatus` — the three agent-status
+        vocabularies are not reconciled here (that is an ADR question, see AAASM-5209).
+      enum:
+      - active
+      - suspended
+      - deregistered
     AgentResponse:
       type: object
       description: JSON representation of an agent returned by the API.
@@ -5118,6 +5137,22 @@ components:
       - approval
       - deny
       - na
+    DecisionLabel:
+      type: string
+      description: |-
+        Wire vocabulary for [`AgentDecisionResponse::decision_label`].
+
+        AAASM-5219 — constrains the `decisionLabel` field to the closed set of
+        lowercase labels [`decision_label`] can emit, one per proto
+        [`Decision`](aa_proto::assembly::common::v1::Decision) discriminant plus the
+        `unspecified` fallback, so the generated OpenAPI spec advertises an enum
+        rather than a free-form `string`. Serializes lowercase.
+      enum:
+      - allow
+      - deny
+      - pending
+      - redact
+      - unspecified
     DestinationConfig:
       oneOf:
       - type: object
@@ -5758,7 +5793,7 @@ components:
           type: string
           description: Hex-encoded agent ID that produced this log entry.
         event_type:
-          type: string
+          $ref: '#/components/schemas/LogEventType'
           description: Type of audit event.
         payload:
           type: string
@@ -5774,6 +5809,42 @@ components:
         timestamp:
           type: string
           description: ISO 8601 timestamp of the event.
+    LogEventType:
+      type: string
+      description: |-
+        Category of an audit log entry, mirroring [`aa_core::AuditEventType`].
+
+        AAASM-5221 — constrains the [`LogEntry::event_type`] wire vocabulary to the
+        closed set of labels [`AuditEventType::as_str`] emits, so the generated
+        OpenAPI spec advertises an enum rather than a free-form `string`. Variants
+        serialize verbatim (PascalCase), matching the strings the audit log has
+        always written, so the wire shape is unchanged.
+
+        Kept in lock-step with `AuditEventType`: the [`From`] impl is exhaustive, so
+        adding an audit variant without extending this enum is a compile error.
+      enum:
+      - ToolCallIntercepted
+      - PolicyViolation
+      - CredentialLeakBlocked
+      - ApprovalRequested
+      - ApprovalGranted
+      - ApprovalDenied
+      - BudgetLimitApproached
+      - BudgetLimitExceeded
+      - ApprovalTimedOut
+      - ApprovalRouted
+      - ApprovalEscalated
+      - AgentForceDeregistered
+      - MessageBlocked
+      - ToolDispatched
+      - A2ACallIntercepted
+      - A2AImpersonationAttempted
+      - SandboxStarted
+      - SandboxFilesystemBlocked
+      - SandboxCpuTimeout
+      - SandboxOomKilled
+      - SandboxTerminated
+      - SandboxHostFnRateLimited
     NodeBudget:
       type: object
       description: |-
@@ -7308,8 +7379,22 @@ components:
             Whether the payload would be scrubbed before reaching the model because
             credential/PII content was detected (drives the `"narrow"` verdict).
         verdict:
-          type: string
-          description: 'Dry-run verdict: `"allow"`, `"narrow"`, `"approval"`, or `"deny"`.'
+          $ref: '#/components/schemas/SimulateVerdict'
+          description: 'Dry-run verdict: `allow`, `narrow`, `approval`, or `deny`.'
+    SimulateVerdict:
+      type: string
+      description: |-
+        Dry-run verdict returned by `POST /api/v1/policies/simulate`.
+
+        AAASM-5220 — constrains the [`SimulatePolicyResponse::verdict`] wire
+        vocabulary to the closed set the simulate handler emits, so the generated
+        OpenAPI spec advertises an enum rather than a free-form `string`. Serializes
+        lowercase.
+      enum:
+      - allow
+      - narrow
+      - approval
+      - deny
     SubtreeBurnResponse:
       type: object
       description: Response for `GET /api/v1/agents/{id}/subtree-burn`.


### PR DESCRIPTION
## Description

`openapi/v1.yaml` is generated from the `utoipa` derives in the Rust crates — it is never hand-edited. This PR constrains four wire vocabularies **at the derive** (each was a free-form `string`) and then regenerates both the spec and the dashboard TypeScript schema from those derives. The four fields now `$ref` dedicated closed enums:

| Subtask | Field | New enum | Values |
|---|---|---|---|
| AAASM-5218 | `AgentNode.status` (`aa-api/src/models/topology.rs`) | `AgentNodeStatus` | `active` / `suspended` / `deregistered` |
| AAASM-5219 | `AgentDecisionResponse.decisionLabel` (`routes/agents.rs`) | `DecisionLabel` | `allow` / `deny` / `pending` / `redact` / `unspecified` |
| AAASM-5220 | `SimulatePolicyResponse.verdict` (`routes/policies.rs`) | `SimulateVerdict` | `allow` / `narrow` / `approval` / `deny` |
| AAASM-5221 | `LogEntry.event_type` (`routes/logs.rs`) | `LogEventType` | the 22 `AuditEventType::as_str` PascalCase labels |

Each new enum is registered in `aa-api/src/openapi.rs` `components(schemas(...))` so it resolves as a `$ref`. `LogEventType` mirrors `aa_core::AuditEventType` via an exhaustive `From` impl, so adding an audit variant without extending the enum becomes a compile error.

The wire strings are identical to what the handlers already emitted — each new enum's serde representation matches the exact values the pre-existing helper functions produced (`status_str`, `decision_label`, the simulate match arms, `AuditEventType::as_str`), so this is a **schema-tightening only** change with no runtime wire-shape change.

### Explicit exclusions (per the Story)

- **`AgentResponse.status` is deliberately NOT touched** — it emits parameterised Rust variants like `Suspended(Manual)` that a flat enum cannot express.
- **The three differing agent-status vocabularies are NOT reconciled** — the topology `AgentNodeStatus`, the runtime registry `AgentStatus`, and the capability-view `AgentStatus` remain distinct; unifying them is an ADR question outside this Story's scope. `AgentTree.status` was left as `String` for the same reason (only `AgentNode.status` was in scope).

### Generation-only, no dashboard behaviour change

`openapi/v1.yaml` and `dashboard/src/api/generated/schema.d.ts` were regenerated via `cargo run -p aa-api --bin generate_openapi` and `pnpm generate:api` — no hand edits. No dashboard runtime code changed. The only dashboard-side edits are three **test fixtures** narrowed to the now-closed enum types (the regenerated schema tightened `event_type` / `status` from `string` to the enum); the unrecognised-event-type test keeps its out-of-vocabulary value via an explicit cast to preserve its runtime-fallback intent.

## Type of Change

- [x] ♻️ Refactoring (schema-tightening; no behaviour change)

## Breaking Changes

- [x] No

The wire values are unchanged; the spec merely advertises the closed set the API already emitted.

## Related Issues

- Related Jira tickets: AAASM-5209 (Story), AAASM-5218, AAASM-5219, AAASM-5220, AAASM-5221 (subtasks)

## Testing

- [x] Unit tests updated (Rust `decision_label` assertions now compare enum variants; dashboard fixtures narrowed)

Gate results (run in the worktree):

- `cargo build -p aa-api` — pass
- `cargo clippy -p aa-api --all-targets -- -D warnings` — pass (exit 0)
- `cargo fmt --check -p aa-api` — pass
- `cargo test -p aa-api --lib` — **465 passed / 0 failed** (includes all changed code + the `openapi.rs` schema-contract test)
- `cd dashboard && pnpm type-check` (`tsc --noEmit`) — pass (exit 0)
- **Regenerated-artifact drift**: the `v1.yaml` and `schema.d.ts` diffs contain exactly the four `type: string` → `$ref` field flips plus the four new enum schemas, and nothing else — no unexpected drift.

**Pre-existing unrelated failures:** `aa-api/tests/destinations.rs` has 3 failing webhook/SSRF-guard tests (`test_webhook_*`). These are network-sandbox artifacts (outbound/loopback connections return 502 instead of the expected app-level rejection) and were confirmed failing on the pristine base as well. They do not touch any code in this PR (no wire-vocabulary field is involved) and are left for CI, which runs in a network environment where they pass.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention (one per field + one codegen commit + one test-fixture commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
