### PR TITLE
[AAASM-5237] 🐛 (agents): Key the enforcement lookup accumulator by Map

### DIFF
--- a/dashboard/src/features/agents/api.ts
+++ b/dashboard/src/features/agents/api.ts
@@ -46,9 +46,13 @@ export function useAgentEnforcementQuery(window: EnforcementWindow = '24h') {
         params: { query: { window } },
       })
       if (error) throw new Error('Failed to fetch agent enforcement metrics')
-      const lookup: Record<string, { blocked: number; scrubbed: number }> = {}
+      // `agent_id` is raw wire input, so a plain object accumulator would let a
+      // value of `constructor`/`__proto__`/etc. write through to (or read back)
+      // an inherited prototype member instead of being stored as an ordinary
+      // entry. A Map treats every key as an ordinary key.
+      const lookup = new Map<string, { blocked: number; scrubbed: number }>()
       for (const row of data ?? []) {
-        lookup[row.agent_id] = { blocked: row.blocked, scrubbed: row.scrubbed }
+        lookup.set(row.agent_id, { blocked: row.blocked, scrubbed: row.scrubbed })
       }
       return lookup
     },

--- a/dashboard/src/features/agents/apiHooks.test.tsx
+++ b/dashboard/src/features/agents/apiHooks.test.tsx
@@ -69,10 +69,12 @@ describe('useAgentEnforcementQuery', () => {
     } satisfies FetchResult)
     const { result } = renderHook(() => useAgentEnforcementQuery(), { wrapper: makeWrapper() })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data).toEqual({
-      a1: { blocked: 3, scrubbed: 1 },
-      a2: { blocked: 0, scrubbed: 5 },
-    })
+    expect(result.current.data).toEqual(
+      new Map([
+        ['a1', { blocked: 3, scrubbed: 1 }],
+        ['a2', { blocked: 0, scrubbed: 5 }],
+      ]),
+    )
     expect(get).toHaveBeenCalledWith('/api/v1/analytics/agent-enforcement', {
       params: { query: { window: '24h' } },
     })
@@ -91,7 +93,26 @@ describe('useAgentEnforcementQuery', () => {
     get.mockResolvedValue({ data: undefined } satisfies FetchResult)
     const { result } = renderHook(() => useAgentEnforcementQuery(), { wrapper: makeWrapper() })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data).toEqual({})
+    expect(result.current.data).toEqual(new Map())
+  })
+
+  it('retrieves an inherited-prototype agent_id via .get() instead of colliding with it', async () => {
+    // AAASM-5237: agent_id is raw wire input. With the old plain-object
+    // accumulator, `constructor` would read back `Object` and `__proto__`
+    // would write through the prototype setter instead of storing an ordinary
+    // entry. A Map treats both as ordinary keys.
+    get.mockResolvedValue({
+      data: [
+        { agent_id: 'constructor', blocked: 9, scrubbed: 2 },
+        { agent_id: '__proto__', blocked: 4, scrubbed: 1 },
+      ],
+    } satisfies FetchResult)
+    const { result } = renderHook(() => useAgentEnforcementQuery(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const lookup = result.current.data
+    expect(lookup?.get('constructor')).toEqual({ blocked: 9, scrubbed: 2 })
+    expect(lookup?.get('__proto__')).toEqual({ blocked: 4, scrubbed: 1 })
+    expect(lookup?.size).toBe(2)
   })
 
   it('throws on failure', async () => {

--- a/dashboard/src/features/agents/fleetTypes.test.ts
+++ b/dashboard/src/features/agents/fleetTypes.test.ts
@@ -71,9 +71,7 @@ describe('toFleetAgent', () => {
   })
 
   it('fills blocked24h / scrubbed24h from the enforcement lookup when present', () => {
-    const fa = toFleetAgent(makeAgent({ id: 'id-1' }), {
-      'id-1': { blocked: 7, scrubbed: 3 },
-    })
+    const fa = toFleetAgent(makeAgent({ id: 'id-1' }), new Map([['id-1', { blocked: 7, scrubbed: 3 }]]))
     expect(fa.blocked24h).toBe(7)
     expect(fa.scrubbed24h).toBe(3)
   })
@@ -81,11 +79,30 @@ describe('toFleetAgent', () => {
   it('leaves blocked24h / scrubbed24h null when the agent is absent from the lookup', () => {
     // An agent with no blocked/scrubbed decisions in the window is omitted from
     // the endpoint response, so it must render `—`, not a fabricated 0.
-    const fa = toFleetAgent(makeAgent({ id: 'id-1' }), {
-      'other-agent': { blocked: 2, scrubbed: 1 },
-    })
+    const fa = toFleetAgent(makeAgent({ id: 'id-1' }), new Map([['other-agent', { blocked: 2, scrubbed: 1 }]]))
     expect(fa.blocked24h).toBeNull()
     expect(fa.scrubbed24h).toBeNull()
+  })
+
+  it('retrieves an inherited-prototype agent id via .get() instead of colliding with it', () => {
+    // AAASM-5237: agent_id is raw wire input. With a plain-object accumulator,
+    // a `constructor` key would read back `Object` and a `__proto__` key would
+    // write through the prototype setter instead of storing an ordinary entry.
+    // A Map treats both as ordinary keys.
+    const ctorLookup = new Map([['constructor', { blocked: 9, scrubbed: 2 }]])
+    const ctorAgent = toFleetAgent(makeAgent({ id: 'constructor' }), ctorLookup)
+    expect(ctorAgent.blocked24h).toBe(9)
+    expect(ctorAgent.scrubbed24h).toBe(2)
+
+    const protoLookup = new Map([['__proto__', { blocked: 4, scrubbed: 1 }]])
+    const protoAgent = toFleetAgent(makeAgent({ id: '__proto__' }), protoLookup)
+    expect(protoAgent.blocked24h).toBe(4)
+    expect(protoAgent.scrubbed24h).toBe(1)
+
+    // A real, unrelated agent id must still resolve normally.
+    const realAgent = toFleetAgent(makeAgent({ id: 'id-1' }), new Map([['id-1', { blocked: 7, scrubbed: 3 }]]))
+    expect(realAgent.blocked24h).toBe(7)
+    expect(realAgent.scrubbed24h).toBe(3)
   })
 })
 

--- a/dashboard/src/features/agents/fleetTypes.ts
+++ b/dashboard/src/features/agents/fleetTypes.ts
@@ -18,8 +18,12 @@ export interface AgentEnforcementCount {
  * lookup) by `GET /api/v1/analytics/agent-enforcement` (AAASM-5084). Absence of
  * a key means the agent recorded no blocked/scrubbed decisions in the window,
  * which the Fleet view renders as `—` rather than `0`.
+ *
+ * A Map, not a plain object: `agent_id` is raw wire input, so a value of
+ * `constructor`/`__proto__`/etc. must be an ordinary key rather than hitting
+ * the prototype setter or colliding with an inherited member (AAASM-5237).
  */
-export type AgentEnforcementLookup = Readonly<Record<string, AgentEnforcementCount>>
+export type AgentEnforcementLookup = ReadonlyMap<string, AgentEnforcementCount>
 
 /** Enforcement modes rendered by `ModeChip`. */
 export type FleetMode = 'enforce' | 'shadow' | 'off'
@@ -91,7 +95,7 @@ function parseMode(raw: string | undefined): FleetMode {
  */
 export function toFleetAgent(agent: Agent, enforcement?: AgentEnforcementLookup): FleetAgent {
   const metadata = agent.metadata ?? {}
-  const counts = enforcement?.[agent.id]
+  const counts = enforcement?.get(agent.id)
   return {
     source: agent,
     id: agent.id,

--- a/dashboard/src/pages/OverviewPage.test.tsx
+++ b/dashboard/src/pages/OverviewPage.test.tsx
@@ -74,7 +74,7 @@ function makeAlert(overrides: Partial<Alert> = {}): Alert {
 }
 
 /** Enforcement counts for the default single-agent fleet. */
-const FULL_ENFORCEMENT: AgentEnforcementLookup = { 'agent-1': { blocked: 4, scrubbed: 12 } }
+const FULL_ENFORCEMENT: AgentEnforcementLookup = new Map([['agent-1', { blocked: 4, scrubbed: 12 }]])
 
 function setup({
   agents = [makeAgent()],


### PR DESCRIPTION
## Description

Closes a gap left by the AAASM-5208 sweep. That sweep converted every plain-object accumulator keyed by raw wire input to a `Map`, closing a prototype-pollution shape across the codebase — but `useAgentEnforcementQuery` in `dashboard/src/features/agents/api.ts` was never done. Its sibling site, `typeCounts` in `dashboard/src/features/audit/export.ts` (AAASM-5236), was already fixed and merged (#1737).

**Root cause:** `useAgentEnforcementQuery` folded `GET /api/v1/analytics/agent-enforcement` rows into a plain object keyed by `row.agent_id` — raw wire data. An `agent_id` of `constructor`, `__proto__`, `toString`, `hasOwnProperty`, or `valueOf` would read back an inherited prototype member or write through the prototype setter instead of being stored as an ordinary entry, matching the pattern fixed at every other site in Epic AAASM-5208.

**Fix:** `AgentEnforcementLookup` (`dashboard/src/features/agents/fleetTypes.ts`) is now `ReadonlyMap<string, AgentEnforcementCount>` instead of `Readonly<Record<string, AgentEnforcementCount>>`. `useAgentEnforcementQuery` builds a `Map` via `.set()` instead of object-literal assignment.

**Read side (`fleetTypes.ts` — `toFleetAgent`):** The parent Story (AAASM-5213) originally scoped this call site as *not* needing a change when AAASM-5236 was fixed. Re-verified that claim while doing this conversion: it was only true because the lookup stayed a `Record` at the time. Now that this ticket converts the type `toFleetAgent` reads, the read side does need to change — `enforcement?.[agent.id]` became `enforcement?.get(agent.id)`.

No other call site in `dashboard/src` indexes into, spreads, or iterates the lookup as a plain object (`AgentDetailPage.tsx`, `OverviewPage.tsx`, `FleetPage.tsx` all pass the value through opaquely into `toFleetAgent`), so no further production call sites needed updating.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No (internal type only; no public API surface changes — `AgentEnforcementLookup` is not exported outside the dashboard package)

## Related Issues

- Related Jira ticket: AAASM-5237 (subtask of Story AAASM-5213, Epic AAASM-5208)

## Testing

- [x] Unit tests added / updated
  - `dashboard/src/features/agents/apiHooks.test.tsx`: updated the two `useAgentEnforcementQuery` fixtures from object literals to `Map` literals, and added a regression test asserting a `constructor`/`__proto__` `agent_id` round-trips through `.get()` without colliding.
  - `dashboard/src/features/agents/fleetTypes.test.ts`: updated the two `toFleetAgent` enforcement fixtures to `Map` literals, and added a regression test asserting a `constructor`/`__proto__` agent id resolves correctly via `toFleetAgent`, alongside a real agent id.
  - `dashboard/src/pages/OverviewPage.test.tsx`: updated the `FULL_ENFORCEMENT` fixture to a `Map` literal (existing `OverviewPage` tests exercise the sum path against it).
- [x] No integration tests required — this is an internal accumulator/type change with unit coverage at the construction site (`api.ts`) and the sole read site (`fleetTypes.ts`).

**Load-bearing confirmation:** stashed the two source-file fixes (`api.ts`, `fleetTypes.ts`) and reran the updated test suite against the prior `Record`-based implementation — 6 tests failed as expected (the 3 new/updated regression tests in `apiHooks.test.tsx`/`fleetTypes.test.ts`, plus the two `fleetTypes.test.ts` fixture-based tests, plus an existing `OverviewPage.test.tsx` sum test that also caught the regression). All 71 tests pass with the fix restored.

## Gate results

- `pnpm type-check`: 9 pre-existing errors, all in files untouched by this PR (`AgentDecisionStream.test.tsx`, `export.test.ts`, `TeamMembersCard.test.tsx`, `TeamOrphanDetail.test.tsx`, `AuditLogPage.test.tsx`, `TeamDetailPage.test.tsx`) — confirmed identical on `origin/main` before this change; no new errors introduced.
- `pnpm lint`: clean, zero violations.
- `pnpm exec vitest run` (full suite): 272 test files / 3016 tests passed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (updated the `AgentEnforcementLookup` doc comment)
- [x] All CI checks passing (locally: type-check clean of new errors, lint clean, full test suite green)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
