### PR TITLE
🚨 fix(dashboard): cast intentionally-invalid wire values in prototype-pollution tests

### DIFF
--- a/dashboard/src/components/agentDetail/AgentDecisionStream.test.tsx
+++ b/dashboard/src/components/agentDetail/AgentDecisionStream.test.tsx
@@ -141,7 +141,7 @@ describe('AgentDecisionStream', () => {
     (label) => {
       vi.spyOn(agentsApi, 'useAgentDecisionsQuery').mockReturnValue(
         mockQuery<AgentDecision[]>({
-          data: [decision({ decision: 0, decisionLabel: label })],
+          data: [decision({ decision: 0, decisionLabel: label as never })],
           isLoading: false,
           isError: false,
           refetch: vi.fn(),

--- a/dashboard/src/features/audit/export.test.ts
+++ b/dashboard/src/features/audit/export.test.ts
@@ -295,8 +295,8 @@ describe('buildComplianceReport — prototype-polluting event types', () => {
 
   it('tallies a __proto__ event_type instead of silently dropping it', () => {
     const rows = [
-      entry({ seq: 1, event_type: '__proto__', payload: '{"event_id":"a"}' }),
-      entry({ seq: 2, event_type: '__proto__', payload: '{"event_id":"b"}' }),
+      entry({ seq: 1, event_type: '__proto__' as never, payload: '{"event_id":"a"}' }),
+      entry({ seq: 2, event_type: '__proto__' as never, payload: '{"event_id":"b"}' }),
     ]
     const report = buildComplianceReport(rows, ctx, COMPLETE, now)
     expect(report).toContain('- __proto__: 2')
@@ -304,8 +304,8 @@ describe('buildComplianceReport — prototype-polluting event types', () => {
 
   it('gives a constructor event_type a real numeric count, not a fabricated string', () => {
     const rows = [
-      entry({ seq: 1, event_type: 'constructor', payload: '{"event_id":"a"}' }),
-      entry({ seq: 2, event_type: 'constructor', payload: '{"event_id":"b"}' }),
+      entry({ seq: 1, event_type: 'constructor' as never, payload: '{"event_id":"a"}' }),
+      entry({ seq: 2, event_type: 'constructor' as never, payload: '{"event_id":"b"}' }),
     ]
     const report = buildComplianceReport(rows, ctx, COMPLETE, now)
     expect(report).toMatch(/^- constructor: 2$/m)

--- a/dashboard/src/features/teams/TeamMembersCard.test.tsx
+++ b/dashboard/src/features/teams/TeamMembersCard.test.tsx
@@ -63,7 +63,7 @@ describe('TeamMembersCard', () => {
   it('renders an unrecognised status with no chip modifier', () => {
     // `status` is a raw wire string: an unmapped value must fall back to the bare
     // `teams-chip` class (the `?? ''` at the call site), never leak a stray token.
-    renderCard({ members: [member({ status: 'retired' })], isLoading: false, isError: false })
+    renderCard({ members: [member({ status: 'retired' as never })], isLoading: false, isError: false })
     const chip = screen.getByTestId('team-member-status')
     expect(chip).toHaveTextContent('retired')
     expect(chip).toHaveAttribute('class', 'teams-chip ')

--- a/dashboard/src/features/teams/TeamOrphanDetail.test.tsx
+++ b/dashboard/src/features/teams/TeamOrphanDetail.test.tsx
@@ -72,7 +72,7 @@ describe('TeamOrphanDetail', () => {
   it('renders an unrecognised agent status with no chip modifier', () => {
     // `status` is a raw wire string: an unmapped value must fall back to the bare
     // `teams-chip` class (the `?? ''` at the call site), never leak a stray token.
-    renderOrphan(known([agent({ id: 'a1', status: 'retired' })]))
+    renderOrphan(known([agent({ id: 'a1', status: 'retired' as never })]))
     const chip = screen.getByTestId('orphan-agent-status')
     expect(chip).toHaveTextContent('retired')
     expect(chip).toHaveAttribute('class', 'teams-chip ')

--- a/dashboard/src/pages/AuditLogPage.test.tsx
+++ b/dashboard/src/pages/AuditLogPage.test.tsx
@@ -195,7 +195,7 @@ describe('AuditLogPage', () => {
     'falls to the default meta for the prototype-member event type %s',
     async (inherited) => {
       get.mockResolvedValue({
-        data: page([entry({ seq: 950, event_type: inherited, payload: '{}' })]),
+        data: page([entry({ seq: 950, event_type: inherited as never, payload: '{}' })]),
       })
       renderPage()
       const row = await screen.findByTestId('audit-row-950')

--- a/dashboard/src/pages/TeamDetailPage.test.tsx
+++ b/dashboard/src/pages/TeamDetailPage.test.tsx
@@ -150,8 +150,8 @@ describe('TeamDetailPage', () => {
       members: [
         { id: 'a'.repeat(32), name: 'known-active', status: 'active', depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
         { id: 'b'.repeat(32), name: 'known-suspended', status: 'suspended', depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
-        { id: 'c'.repeat(32), name: 'proto-constructor', status: 'constructor', depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
-        { id: 'd'.repeat(32), name: 'proto-tostring', status: 'toString', depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
+        { id: 'c'.repeat(32), name: 'proto-constructor', status: 'constructor' as never, depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
+        { id: 'd'.repeat(32), name: 'proto-tostring', status: 'toString' as never, depth: 0, team_id: 'team-proto', mode: 'enforce', flagged: false, trust: null },
       ],
     }
     mockTeam({ data: team })


### PR DESCRIPTION
`tsc --noEmit` was broken on `main` (introduced by #1749), blocking every open PR's "Dashboard (type-check + lint)" and "Build" checks regardless of what they touch — currently blocking all 12 open agent-assembly dependency-upgrade PRs.

Six test files pass deliberately out-of-union wire values (`'retired'`, `'constructor'`, `'__proto__'`, `'toString'`, `'hasOwnProperty'`) to verify the UI degrades gracefully on an unrecognised or prototype-colliding `status`/`event_type`/`decisionLabel` — the whole point of each test is that these values are NOT part of the schema-generated union type, so a literal assignment correctly trips `tsc`.

Applied the `as never` cast already established for this exact scenario in `agents.test.tsx` (`toRegistryAgent(rawAgent({ status: 'Quarantined' }) as never)`) to each new call site — no application or schema type was widened.

Verified locally: `tsc --noEmit` clean, `eslint` clean, full test suite (3014 tests) passing, `pnpm run build` succeeds.