### PR TITLE
⬆ Sync @storybook/react-vite and storybook to 10.5.5

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@playwright/test": "^1.61.0",
     "@storybook/react": "^10.5.5",
-    "@storybook/react-vite": "^10.4.6",
+    "@storybook/react-vite": "^10.5.5",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -60,7 +60,7 @@
     "eslint-plugin-react-refresh": "^0.4.12",
     "jsdom": "^29.1.1",
     "openapi-typescript": "^7.13.0",
-    "storybook": "^10.5.0",
+    "storybook": "^10.5.5",
     "typescript": "^5.5.3",
     "vite": "^8.1.5",
     "vitest": "^4.1.5"

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         specifier: ^10.5.5
         version: 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(react@19.2.8))(typescript@5.9.3)
       '@storybook/react-vite':
-        specifier: ^10.4.6
+        specifier: ^10.5.5
         version: 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(react@19.2.8))(typescript@5.9.3)(vite@8.1.5(esbuild@0.28.1)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^7.0.0
@@ -125,7 +125,7 @@ importers:
         specifier: ^7.13.0
         version: 7.13.0(typescript@5.9.3)
       storybook:
-        specifier: ^10.5.0
+        specifier: ^10.5.5
         version: 10.5.5(@types/react@19.2.17)(react@19.2.8)
       typescript:
         specifier: ^5.5.3


### PR DESCRIPTION
Combines dependabot #1752 (@storybook/react-vite) and #1755 (storybook) — both conflicted with #1763's @storybook/react bump, which already landed on main. Storybook's own packages are released in lockstep and must stay on the same minor/patch version; leaving react-vite/storybook behind at 10.4.6/10.5.0 while react moved to 10.5.5 would reintroduce the same conflict on the next bump.

Verified locally: `tsc --noEmit` clean, `eslint` clean, full test suite (3016 tests) passing, `pnpm run build` succeeds, `pnpm run build-storybook` succeeds.

Closes the need for #1752 and #1755.