### PR TITLE
⬆ Bump @hookform/resolvers from 5.2.2 to 5.5.7 in /dashboard (rebased)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -23,7 +23,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.2.2",
+    "@hookform/resolvers": "^5.5.7",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^8.21.3",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
   .:
     dependencies:
       '@hookform/resolvers':
-        specifier: ^5.2.2
+        specifier: ^5.5.7
         version: 5.5.7(@standard-schema/spec@1.1.0)(react-hook-form@7.83.0(react@19.2.8))(zod@4.4.3)
       '@monaco-editor/react':
         specifier: ^4.7.0


### PR DESCRIPTION
Rebases dependabot #1753 onto current main after Cargo.lock/dashboard churn from other merged dependency PRs left it conflicting.

Verified locally: `tsc --noEmit` clean, `eslint` clean, full test suite (3016 tests) passing.

Closes the need for #1753.