### PR TITLE
⬆ Bump recharts from 3.9.2 to 3.10.1 in /dashboard (rebased)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.17.0",
-    "recharts": "^3.9.2",
+    "recharts": "^3.10.1",
     "use-debounce": "^10.1.1",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         specifier: ^7.17.0
         version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       recharts:
-        specifier: ^3.9.2
+        specifier: ^3.10.1
         version: 3.10.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-is@17.0.2)(react@19.2.8)(redux@5.0.1)
       use-debounce:
         specifier: ^10.1.1


### PR DESCRIPTION
Rebases dependabot #1758 onto current main after Cargo.lock/dashboard churn from other merged dependency PRs left it conflicting.

Verified locally: `tsc --noEmit` clean, `eslint` clean, full test suite (3016 tests) passing, `pnpm run build` succeeds.

Closes the need for #1758.