### PR TITLE
[AAASM-5211] 🐛 (iam): Key RoleCapabilityCards ROLE_BADGE_TONE by Map

### DIFF
--- a/dashboard/src/features/iam/RoleCapabilityCards.test.tsx
+++ b/dashboard/src/features/iam/RoleCapabilityCards.test.tsx
@@ -220,3 +220,31 @@ describe('RoleCapabilityCard — null-safe rendering', () => {
     expect(screen.getByTestId('role-card-count-viewer')).toHaveTextContent('0 members')
   })
 })
+
+describe('RoleCapabilityCard — badge tone', () => {
+  const DEFAULT_TONE = 'iam-role-badge--viewer'
+
+  function toneClass(role: string): string {
+    const card: RoleCard = { role, description: null, capabilities: [], memberCount: 0, assignees: [] }
+    render(<RoleCapabilityCard card={card} />)
+    const badge = screen.getByText(role)
+    const tone = [...badge.classList].find((c) => c !== 'iam-role-badge')
+    return tone ?? ''
+  }
+
+  // Load-bearing: an object literal indexed as ROLE_BADGE_TONE[role] resolves
+  // inherited Object.prototype keys, so a crafted role id like `constructor`
+  // reaches a prototype method's class name instead of falling to the default
+  // tone. A Map `.get()` returns undefined for these names, so they hit the
+  // default. Against a pre-fix object literal these cases fail.
+  it.each(['constructor', 'toString', '__proto__', 'hasOwnProperty', 'valueOf'])(
+    'falls back to the default tone for the inherited key %s',
+    (role) => {
+      expect(toneClass(role)).toBe(DEFAULT_TONE)
+    },
+  )
+
+  it('falls back to the default tone for any unknown role', () => {
+    expect(toneClass('not-a-role')).toBe(DEFAULT_TONE)
+  })
+})

--- a/dashboard/src/features/iam/RoleCapabilityCards.tsx
+++ b/dashboard/src/features/iam/RoleCapabilityCards.tsx
@@ -3,17 +3,22 @@ import { buildRoleCards, type RoleCard } from './roleCapabilities'
 import type { Member } from './types'
 import './RoleCapabilityCards.css'
 
-const ROLE_BADGE_TONE: Record<string, string> = {
-  org_admin: 'iam-role-badge--owner',
-  team_admin: 'iam-role-badge--admin',
-  developer: 'iam-role-badge--member',
-  viewer: 'iam-role-badge--viewer',
-  auditor: 'iam-role-badge--viewer',
-}
+// A Map, not an object literal: `.get()` returns undefined for inherited
+// names like `constructor`/`toString`/`__proto__`, so an attacker-controlled
+// role id can never resolve to a prototype method's class name. An object
+// literal indexed as `ROLE_BADGE_TONE[role]` would resolve those inherited
+// keys and let a crafted role reach a value that is not a real tone class.
+const ROLE_BADGE_TONE = new Map<string, string>([
+  ['org_admin', 'iam-role-badge--owner'],
+  ['team_admin', 'iam-role-badge--admin'],
+  ['developer', 'iam-role-badge--member'],
+  ['viewer', 'iam-role-badge--viewer'],
+  ['auditor', 'iam-role-badge--viewer'],
+])
 
 /** Badge tone class for a role id, defaulting when the role is unrecognised. */
 function badgeTone(role: string): string {
-  return ROLE_BADGE_TONE[role] ?? 'iam-role-badge--viewer'
+  return ROLE_BADGE_TONE.get(role) ?? 'iam-role-badge--viewer'
 }
 
 function firstName(name: string): string {


### PR DESCRIPTION
## Description

While verifying AAASM-5211's acceptance criteria (subtask AAASM-5231), found that one of the Story's four target sites was never actually fixed despite the Story/Epic being tracked as complete: `dashboard/src/features/iam/RoleCapabilityCards.tsx`'s `ROLE_BADGE_TONE` was still a plain `Record<string, string>` object literal, indexed with bracket notation (`ROLE_BADGE_TONE[role] ?? 'iam-role-badge--viewer'`).

This is the same wire-data-keyed object-literal lookup pattern the rest of Epic AAASM-5208 eradicated — a role id equal to an inherited `Object.prototype` member name (`constructor`, `toString`, `__proto__`, `hasOwnProperty`, `valueOf`) would resolve to that inherited value instead of falling through to the default tone class, defeating the `?? 'iam-role-badge--viewer'` fallback.

Note: this file/variable is distinct from the byte-identical-looking `ROLE_BADGE_TONE` in `features/iam/MemberList.tsx`, which AAASM-5229's PR #1744 already converted to a `Map` — that PR's own description explicitly noted `RoleCapabilityCards.tsx` was left untouched, out of scope for that ticket. This PR closes that gap for `RoleCapabilityCards.tsx`'s own `ROLE_BADGE_TONE`, following the identical `Map` pattern already established in `MemberList.tsx`.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5211

## Testing

- [x] Unit tests added / updated — new `RoleCapabilityCard — badge tone` describe block in `RoleCapabilityCards.test.tsx` asserting inherited-prototype-key role ids (`constructor`, `toString`, `__proto__`, `hasOwnProperty`, `valueOf`) and unknown roles fall back to the default tone class. These assertions fail against the pre-fix object-literal lookup.
- [x] No integration tests required — component-level unit coverage is sufficient for this lookup-safety fix.

Locally verified in `dashboard/`:
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint .` — clean
- `pnpm exec vitest run` — 272 files / 3022 tests passed (full suite)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — internal lookup only)
- [ ] All CI checks passing (pending CI run)
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off (`git commit -s`) — advisory only per CONTRIBUTING.md
