### PR TITLE
⬆ Bump @playwright/test from 1.61.1 to 1.62.0 in /dashboard (rebased)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.0",
+    "@playwright/test": "^1.62.0",
     "@storybook/react": "^10.5.5",
     "@storybook/react-vite": "^10.4.6",
     "@testing-library/jest-dom": "^7.0.0",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.61.0
+        specifier: ^1.62.0
         version: 1.62.0
       '@storybook/react':
         specifier: ^10.5.5


### PR DESCRIPTION
Rebases dependabot #1760 onto current main after Cargo.lock/dashboard churn from other merged dependency PRs left it conflicting.

Verified locally: `tsc --noEmit` clean, `eslint` clean, full unit test suite (3016 tests) passing, and `playwright test --list` discovers all 481 e2e specs with the new version.

Closes the need for #1760.