### PR TITLE
⬆ Bump react-hook-form from 7.80.0 to 7.83.0 in /dashboard (rebased)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -34,7 +34,7 @@
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.5",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.83.0",
     "react-router-dom": "^7.17.0",
     "recharts": "^3.9.2",
     "use-debounce": "^10.1.1",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         specifier: ^19.2.5
         version: 19.2.8(react@19.2.8)
       react-hook-form:
-        specifier: ^7.80.0
+        specifier: ^7.83.0
         version: 7.83.0(react@19.2.8)
       react-router-dom:
         specifier: ^7.17.0


### PR DESCRIPTION
Rebases dependabot #1761 onto current main after Cargo.lock/dashboard churn from other merged dependency PRs left it conflicting.

Verified locally: `tsc --noEmit` clean, `eslint` clean, full test suite (3016 tests) passing (exercises the @hookform/resolvers integration too), `pnpm run build` succeeds.

Closes the need for #1761.