### PR TITLE
[AAASM-5217] 🐛 (dashboard): Validate or document fetch-boundary casts

### DIFF
--- a/dashboard/src/api/capability.ts
+++ b/dashboard/src/api/capability.ts
@@ -18,8 +18,22 @@ export interface CapabilityClient {
  * agent registry and the policy capability cascade, so there is no mock client
  * left to fall back to. The hand-written feature-side types in
  * `features/capability/types` and the codegen'd types in `api/generated/schema`
- * are structurally identical for these payloads, so the response body casts at
- * the API boundary are safe.
+ * are structurally identical for these payloads, but that is a compile-time
+ * claim about shape, not a runtime guarantee about content — "structurally
+ * identical" was previously (mis)cited here as making the response body casts
+ * below "safe" outright (AAASM-5217 audit). It doesn't: `data as
+ * CapabilityMatrix` still hands every consumer raw wire values wearing
+ * unenforced `Decision` / `Verb` / `AgentStatus` annotations.
+ *
+ * The cast is accepted-risk only because every field it produces that is ever
+ * used as an object/Map lookup key is validated downstream before that lookup
+ * happens: `Decision` values read off `caps[...]` go through
+ * `decisionMeta()`/`decisionWeight()` (`features/capability/types.ts`,
+ * `features/capability/sort.ts`), which check membership in the `Decision`
+ * union before indexing. Every other field on this payload (ids, names,
+ * timestamps, trust scores) is rendered as opaque display value, never used as
+ * a key, so an unrecognised or prototype-inherited value there is a display
+ * glitch, not a lookup hazard.
  */
 export function createApiCapabilityClient(): CapabilityClient {
   return {

--- a/dashboard/src/auth/AuthProvider.test.tsx
+++ b/dashboard/src/auth/AuthProvider.test.tsx
@@ -60,6 +60,28 @@ describe('AuthProvider', () => {
     )
   })
 
+  // AAASM-5217: the login response's `scopes` field reaches this provider
+  // through a bare cast in `login()` and is later used as a `SCOPE_RANK`
+  // lookup key (`usePermissions.ts::scopesSatisfy`). A hostile scope like
+  // `"__proto__"` must be filtered out here, not carried into state and
+  // resolved to an inherited `Object.prototype` member on the first
+  // permission check.
+  it('drops a hostile scope from the login response rather than trusting it', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ token: 'new-token', scopes: ['read', '__proto__'] }), {
+        status: 200,
+      }),
+    )
+    const { result } = renderHook(() => useAuth(), { wrapper })
+
+    await act(async () => {
+      await result.current.login('my-api-key')
+    })
+
+    await waitFor(() => expect(result.current.token).toBe('new-token'))
+    expect(result.current.scopes).toEqual(['read'])
+  })
+
   it('login throws and leaves the token unset on a non-OK response', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 401 }))
     const { result } = renderHook(() => useAuth(), { wrapper })

--- a/dashboard/src/auth/AuthProvider.tsx
+++ b/dashboard/src/auth/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { AuthContext, type Scope } from './AuthContext'
-import { parseScopesFromJwt } from './jwtScopes'
+import { isScope, parseScopesFromJwt } from './jwtScopes'
 import { clearToken, getToken, setToken } from './tokenStorage'
 
 export function AuthProvider({ children }: Readonly<{ children: React.ReactNode }>) {
@@ -26,11 +26,21 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
     if (!res.ok) {
       throw new Error(`Authentication failed (${res.status})`)
     }
-    const data = (await res.json()) as { token: string; scopes?: Scope[] }
+    // `as { token: string; scopes?: Scope[] }` is a bare cast (AAASM-5217
+    // audit): `data.scopes` wears a `Scope[]` annotation over raw wire data,
+    // and every granted scope is later used as a `SCOPE_RANK` lookup key
+    // (`usePermissions.ts::scopesSatisfy`) — the exact hazard this ticket
+    // covers. Filtered through `isScope` before use, same allow-list
+    // `parseScopesFromJwt` applies to the JWT-claim fallback, so a value like
+    // `"__proto__"` is dropped rather than resolving an inherited member.
+    const data = (await res.json()) as { token: string; scopes?: unknown }
     setToken(data.token)
     setTokenState(data.token)
-    // Prefer the response's explicit scopes; fall back to the JWT claim.
-    setScopes(data.scopes ?? parseScopesFromJwt(data.token))
+    // Prefer the response's explicit scopes; fall back to the JWT claim only
+    // when the response carried none at all.
+    setScopes(
+      Array.isArray(data.scopes) ? data.scopes.filter(isScope) : parseScopesFromJwt(data.token),
+    )
   }, [])
 
   const logout = useCallback(() => {

--- a/dashboard/src/auth/jwtScopes.test.ts
+++ b/dashboard/src/auth/jwtScopes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getSubject } from './jwtScopes'
+import { getSubject, isScope, parseScopesFromJwt } from './jwtScopes'
 
 /** Build a real 3-part JWT with the given payload (unpadded base64url). */
 function makeJwt(payload: Record<string, unknown>): string {
@@ -7,6 +7,53 @@ function makeJwt(payload: Record<string, unknown>): string {
     btoa(JSON.stringify(o)).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
   return `${b64url({ alg: 'none' })}.${b64url(payload)}.sig`
 }
+
+// AAASM-5217: `parseScopesFromJwt` reaches an unverified JWT claim through a
+// bare `as { scope?: unknown }` cast, and every element that survives is later
+// used as a `SCOPE_RANK` lookup key (`usePermissions.ts`). A claim of
+// `"__proto__"` or `"constructor"` must be rejected here — before it becomes a
+// `Scope` — not resolve to an inherited `Object.prototype` member downstream.
+describe('isScope', () => {
+  it('accepts the three known scopes', () => {
+    expect(isScope('read')).toBe(true)
+    expect(isScope('write')).toBe(true)
+    expect(isScope('admin')).toBe(true)
+  })
+
+  it.each([
+    ['a plain unknown scope', 'superadmin'],
+    ['the inherited "__proto__" key', '__proto__'],
+    ['the inherited "constructor" key', 'constructor'],
+    ['the inherited "toString" key', 'toString'],
+    ['the inherited "hasOwnProperty" key', 'hasOwnProperty'],
+  ])('rejects %s', (_label, value) => {
+    expect(isScope(value)).toBe(false)
+  })
+
+  it('rejects non-string values without throwing', () => {
+    expect(isScope(42)).toBe(false)
+    expect(isScope(null)).toBe(false)
+    expect(isScope(undefined)).toBe(false)
+    expect(isScope({})).toBe(false)
+  })
+})
+
+describe('parseScopesFromJwt', () => {
+  it('returns the valid scopes from the `scope` claim', () => {
+    expect(parseScopesFromJwt(makeJwt({ scope: ['read', 'write'] }))).toEqual(['read', 'write'])
+  })
+
+  it.each([
+    ['a hostile "__proto__" entry', ['read', '__proto__']],
+    ['a hostile "constructor" entry', ['constructor', 'admin']],
+    ['a non-string entry', [42, 'write']],
+  ])('drops %s rather than trusting it as a Scope', (_label, scope) => {
+    const result = parseScopesFromJwt(makeJwt({ scope }))
+    for (const s of result) {
+      expect(['read', 'write', 'admin']).toContain(s)
+    }
+  })
+})
 
 describe('getSubject', () => {
   it('returns the `sub` claim when present', () => {

--- a/dashboard/src/auth/jwtScopes.ts
+++ b/dashboard/src/auth/jwtScopes.ts
@@ -3,6 +3,18 @@ import type { Scope } from './AuthContext'
 const VALID_SCOPES: ReadonlySet<Scope> = new Set(['read', 'write', 'admin'])
 
 /**
+ * Validate an unknown value against the `Scope` union (AAASM-5217). Shared by
+ * every path that turns raw wire/claim data into a `Scope` — the JWT-claim
+ * path below and the login-response path in `AuthProvider.tsx` — so a scope
+ * is never trusted as a `SCOPE_RANK` lookup key
+ * (`usePermissions.ts::scopesSatisfy`) without first passing this allow-list
+ * membership check.
+ */
+export function isScope(value: unknown): value is Scope {
+  return typeof value === 'string' && VALID_SCOPES.has(value as Scope)
+}
+
+/**
  * Extract the `scope` claim from an unverified JWT payload.
  *
  * The dashboard only persists the token string in sessionStorage, so after a
@@ -11,6 +23,13 @@ const VALID_SCOPES: ReadonlySet<Scope> = new Set(['read', 'write', 'admin'])
  * them. The signature is deliberately NOT verified here: the gateway validates
  * the token on every request and is the sole authority. A missing, malformed,
  * or scope-less token yields `[]`, which reflects as "no mutating controls".
+ *
+ * `as { scope?: unknown }` is a bare cast (AAASM-5217 audit); accepted-risk
+ * because the field it exposes is typed `unknown`, not `Scope`, and every
+ * element is filtered through `VALID_SCOPES.has()` — an allow-list membership
+ * check, not an indexed lookup — before it is trusted as a `Scope`. A
+ * malicious claim like `"__proto__"` fails that check and is dropped, never
+ * resolves an inherited member.
  */
 export function parseScopesFromJwt(token: string | null): Scope[] {
   if (!token) return []
@@ -19,7 +38,7 @@ export function parseScopesFromJwt(token: string | null): Scope[] {
   try {
     const payload = JSON.parse(base64UrlDecode(parts[1])) as { scope?: unknown }
     if (!Array.isArray(payload.scope)) return []
-    return payload.scope.filter((s): s is Scope => VALID_SCOPES.has(s as Scope))
+    return payload.scope.filter(isScope)
   } catch {
     return []
   }
@@ -34,6 +53,12 @@ export function parseScopesFromJwt(token: string | null): Scope[] {
  * signature is deliberately NOT verified — same rationale as
  * `parseScopesFromJwt`: the gateway is the sole authority. Returns `null` for a
  * missing, malformed, or identity-less token, which the caller renders as blank.
+ *
+ * `as Record<string, unknown>` is a bare cast (AAASM-5217 audit); accepted-risk
+ * because `payload` is only ever probed with four fixed string literals
+ * (`'sub'`, `'username'`, `'email'`, `'preferred_username'`) — never a dynamic
+ * key derived from the wire — so a claim named `"__proto__"` simply isn't one
+ * of the four keys checked and is ignored.
  */
 export function getSubject(token: string | null): string | null {
   if (!token) return null

--- a/dashboard/src/components/agentDetail/AgentCapabilityInspectDrawer.tsx
+++ b/dashboard/src/components/agentDetail/AgentCapabilityInspectDrawer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import type { CellSelection } from '../../features/capability/CapabilityMatrixGrid'
-import { DECISIONS, type Policy, type Verb } from '../../features/capability/types'
+import { decisionMeta, type Policy, type Verb } from '../../features/capability/types'
 import type { EffectivePermissions, PermissionSource } from '../../features/agents/api'
 // Reuse the shared cell-inspect drawer shell (scrim / aside / header / section
 // tokens) so the agent-detail drawer stays visually identical to the Capability
@@ -82,7 +82,7 @@ export function AgentCapabilityInspectDrawer({
 
   if (!cell) return null
   const { agent, resource, verb, decision } = cell
-  const decMeta = DECISIONS[decision]
+  const decMeta = decisionMeta(decision)
   const respPolicies = policiesFor(policies, agent.id, resource.id, verb)
 
   return (

--- a/dashboard/src/features/alerts/SeverityBadge.test.tsx
+++ b/dashboard/src/features/alerts/SeverityBadge.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { SeverityBadge } from './SeverityBadge'
+import type { Severity } from './types'
+
+// AAASM-5217: `severity` reaches this component from the single-alert-detail
+// path (`useAlertQuery` in `api.ts`) through a bare `as T` cast with no
+// canonicalisation, unlike the `/alerts` list path's `canonicalSeverity`. A
+// hostile or malformed value must not resolve `SEVERITY_BG[severity]` to
+// `undefined` (a silently blank badge) or an inherited `Object.prototype`
+// member.
+describe('SeverityBadge', () => {
+  it.each(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as const)('renders the %s badge', (severity) => {
+    render(<SeverityBadge severity={severity} />)
+    expect(screen.getByTestId(`severity-badge-${severity}`)).toHaveTextContent(severity)
+  })
+
+  it.each([
+    ['a plain unknown severity', 'EXTREME'],
+    ['the inherited "__proto__" key', '__proto__'],
+    ['the inherited "constructor" key', 'constructor'],
+  ])('renders %s as the unknown badge with a real background, not undefined', (_label, value) => {
+    render(<SeverityBadge severity={value as unknown as Severity} />)
+    const badge = screen.getByTestId('severity-badge-unknown')
+    expect(badge).toHaveTextContent(value)
+    expect(badge.style.background).not.toBe('')
+  })
+})

--- a/dashboard/src/features/alerts/SeverityBadge.tsx
+++ b/dashboard/src/features/alerts/SeverityBadge.tsx
@@ -18,10 +18,35 @@ const SEVERITY_BG: Record<Severity, string> = {
   LOW: 'var(--severity-low)',
 }
 
+const KNOWN_SEVERITIES: ReadonlySet<string> = new Set<Severity>([
+  'CRITICAL',
+  'HIGH',
+  'MEDIUM',
+  'LOW',
+])
+
+/**
+ * Validate a severity before it is trusted as a `SEVERITY_BG` lookup key
+ * (AAASM-5217). `severity` reaches this component from two paths: the
+ * `/alerts` list, which canonicalises it via `parseAlert.ts`'s
+ * `canonicalSeverity` before it ever becomes an `Alert`, and the single-alert
+ * detail / rules endpoints (`useAlertQuery`, `useAlertRulesQuery`), which fetch
+ * through the bare `as T` cast in `api.ts` with no equivalent validation. This
+ * component is the shared lookup boundary for both, so it — not the fetch — is
+ * where an unrecognised or prototype-inherited value (`"__proto__"`,
+ * `"constructor"`) must be caught, rather than resolving to `undefined`
+ * (`background: undefined`, a silently blank badge) or an inherited
+ * `Object.prototype` member.
+ */
+function isSeverity(value: string): value is Severity {
+  return KNOWN_SEVERITIES.has(value)
+}
+
 export function SeverityBadge({ severity }: Readonly<{ severity: Severity }>) {
+  const known = isSeverity(severity)
   return (
     <span
-      data-testid={`severity-badge-${severity}`}
+      data-testid={`severity-badge-${known ? severity : 'unknown'}`}
       style={{
         display: 'inline-block',
         padding: '2px 8px',
@@ -30,7 +55,7 @@ export function SeverityBadge({ severity }: Readonly<{ severity: Severity }>) {
         fontWeight: 700,
         letterSpacing: '0.04em',
         color: 'var(--text-on-accent)',
-        background: SEVERITY_BG[severity],
+        background: known ? SEVERITY_BG[severity] : 'var(--severity-low)',
       }}
     >
       {severity}

--- a/dashboard/src/features/alerts/StatusBadge.test.tsx
+++ b/dashboard/src/features/alerts/StatusBadge.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { StatusBadge } from './StatusBadge'
+import type { AlertStatus } from './types'
+
+// AAASM-5217: `status` reaches this component from the single-alert-detail
+// path (`useAlertQuery` in `api.ts`) through a bare `as T` cast with no
+// canonicalisation. `STATUS_STYLE[status]` on an unrecognised or
+// prototype-inherited key would previously throw on destructuring
+// `undefined`, crashing the whole alert detail drawer instead of rendering a
+// badge.
+describe('StatusBadge', () => {
+  it.each(['FIRING', 'RESOLVED', 'SUPPRESSED'] as const)('renders the %s badge', (status) => {
+    render(<StatusBadge status={status} />)
+    expect(screen.getByTestId(`status-badge-${status}`)).toHaveTextContent(status)
+  })
+
+  it.each([
+    ['a plain unknown status', 'ARCHIVED'],
+    ['the inherited "__proto__" key', '__proto__'],
+    ['the inherited "constructor" key', 'constructor'],
+  ])('renders %s as the unknown badge instead of throwing', (_label, value) => {
+    expect(() =>
+      render(<StatusBadge status={value as unknown as AlertStatus} />),
+    ).not.toThrow()
+    const badge = screen.getByTestId('status-badge-unknown')
+    expect(badge).toHaveTextContent(value)
+  })
+})

--- a/dashboard/src/features/alerts/StatusBadge.tsx
+++ b/dashboard/src/features/alerts/StatusBadge.tsx
@@ -6,11 +6,33 @@ const STATUS_STYLE: Record<AlertStatus, { bg: string; fg: string }> = {
   SUPPRESSED: { bg: 'var(--surface-card-border)', fg: 'var(--text-secondary)' },
 }
 
+const KNOWN_STATUSES: ReadonlySet<string> = new Set<AlertStatus>([
+  'FIRING',
+  'RESOLVED',
+  'SUPPRESSED',
+])
+
+/**
+ * Validate a status before it is trusted as a `STATUS_STYLE` lookup key
+ * (AAASM-5217). Same rationale as `SeverityBadge.isSeverity`: the single-alert
+ * detail path (`useAlertQuery` in `api.ts`) reaches this component through a
+ * bare `as T` cast with no canonicalisation, unlike the `/alerts` list path.
+ * `STATUS_STYLE[status]` on an unrecognised or prototype-inherited key
+ * (`"__proto__"`) would throw on destructuring `undefined`, crashing the whole
+ * alert detail drawer instead of rendering a badge.
+ */
+function isAlertStatus(value: string): value is AlertStatus {
+  return KNOWN_STATUSES.has(value)
+}
+
 export function StatusBadge({ status }: Readonly<{ status: AlertStatus }>) {
-  const { bg, fg } = STATUS_STYLE[status]
+  const known = isAlertStatus(status)
+  const { bg, fg } = known
+    ? STATUS_STYLE[status]
+    : { bg: 'var(--surface-card-border)', fg: 'var(--text-secondary)' }
   return (
     <span
-      data-testid={`status-badge-${status}`}
+      data-testid={`status-badge-${known ? status : 'unknown'}`}
       style={{
         display: 'inline-block',
         padding: '2px 8px',

--- a/dashboard/src/features/alerts/api.ts
+++ b/dashboard/src/features/alerts/api.ts
@@ -37,6 +37,24 @@ function authHeader(): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
+/**
+ * Generic fetch helper shared by every alerts endpoint. `return (await
+ * response.json()) as T` (AAASM-5217 audit) is a bare cast: nothing here
+ * canonicalises the body against `T`.
+ *
+ * Accepted-risk, not blanket-safe: the list path (`fetchAlertsPage` below)
+ * pipes its response through `readAlertsPage` → `parseAlertList`, which
+ * validates `severity`/`status` before an `Alert` exists (AAASM-5149). The
+ * single-alert-detail and rules/destinations/silence paths that also call
+ * this helper (`useAlertQuery`, `useAlertRulesQuery`, `useDestinationsQuery`,
+ * etc.) do not get that same normalisation — but every place their
+ * `severity`/`status` fields are used as an object-lookup key
+ * (`SeverityBadge`, `StatusBadge`) validates the value itself immediately
+ * before indexing, rather than trusting the annotation this cast asserts. No
+ * other field this helper's callers return is ever used as a lookup key —
+ * `metric`, `operator`, ids, and timestamps are all rendered as opaque
+ * display values.
+ */
 export async function alertsFetch<T>(
   path: string,
   init: RequestInit = {},

--- a/dashboard/src/features/alerts/useAlertsStream.ts
+++ b/dashboard/src/features/alerts/useAlertsStream.ts
@@ -106,6 +106,13 @@ export function useAlertsStream(
 
       socket.onmessage = (event) => {
         if (cancelled) return
+        // `JSON.parse(...) as AlertsStreamFrame` is a bare cast (AAASM-5217
+        // audit). Accepted-risk: `frame.type` is only ever compared with `===`
+        // against fixed string literals below, never used as an object-lookup
+        // key, and `frame.alert` is validated by `normaliseAlert` two lines
+        // down before any of its fields (including `severity`/`status`, the
+        // ones that do become lookup keys via `SeverityBadge`/`StatusBadge`)
+        // are trusted.
         let frame: AlertsStreamFrame
         try {
           frame = JSON.parse(event.data) as AlertsStreamFrame

--- a/dashboard/src/features/analytics/analyticsFetch.ts
+++ b/dashboard/src/features/analytics/analyticsFetch.ts
@@ -11,6 +11,17 @@ import { getToken } from '../../auth/tokenStorage'
  * targets the API origin the same way the rest of the app does (see also
  * `features/trace/api.ts`, `features/alerts/api.ts`). These hooks can be
  * migrated to the typed `api.GET` client now that the schema covers them.
+ *
+ * `return res.json() as Promise<T>` is a bare cast (AAASM-5217 audit).
+ * Accepted-risk: the one place a response field from this path is used as a
+ * lookup key is `CostSegment.key` / `ActionVolumeSeries.key`, and both
+ * `transformBuckets` (`costBreakdownUtils.ts`) and `transformSeries`
+ * (`ActionVolumePanel.tsx`) already build their row objects on
+ * `Object.create(null)` specifically because that key is unvalidated wire
+ * data — a segment/series keyed `"__proto__"` becomes an ordinary own
+ * property instead of reassigning the row's prototype. Every other field this
+ * helper's callers consume (tool names, dates, cost buckets' numeric values)
+ * is rendered as opaque display value or a plain number, never a lookup key.
  */
 export async function analyticsFetch<T>(path: string): Promise<T> {
   const base = import.meta.env.VITE_API_BASE_URL ?? ''

--- a/dashboard/src/features/approvals/useApprovalsStream.ts
+++ b/dashboard/src/features/approvals/useApprovalsStream.ts
@@ -58,6 +58,14 @@ export function useApprovalsStream({
 
   // Hoisted out of the WebSocket `onmessage` handler to keep the effect's
   // callback nesting shallow.
+  //
+  // `JSON.parse(...) as GovernanceEvent` and `event.payload as
+  // ApprovalPayload` are bare casts (AAASM-5217 audit). Accepted-risk:
+  // `event.event_type` and `payload.status` are only ever compared with
+  // `===` against fixed string literals (never used as an object-lookup
+  // key), and `payload.action` — the field carried into `Approval.action` —
+  // is rendered as opaque display text and added to a `Set` for the filter
+  // dropdown (`filter.ts`), never indexed into a `Record`/object literal.
   const handleMessage = useCallback(
     (evt: MessageEvent) => {
       try {

--- a/dashboard/src/features/audit/api.ts
+++ b/dashboard/src/features/audit/api.ts
@@ -68,6 +68,14 @@ export interface SandboxPayloadInfo {
  * observe-mode signal. Tolerates malformed payloads and missing fields by
  * returning a `dryRun: false` value, matching the gateway's contract that
  * absence of the field means live enforcement.
+ *
+ * `JSON.parse(payload) as Record<string, unknown>` is a bare cast
+ * (AAASM-5217 audit); accepted-risk because `parsed` is only ever probed with
+ * two fixed string literals (`'dry_run'`, `'shadow_decision'`) — ordinary own
+ * keys on the union type, never a dynamic value read off the wire — so a
+ * payload keyed `"__proto__"` or `"constructor"` simply fails both checks and
+ * falls to the tolerant default, the same as a payload missing the field
+ * entirely.
  */
 export function extractSandboxInfo(payload: string): SandboxPayloadInfo {
   try {

--- a/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
+++ b/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
@@ -1,5 +1,5 @@
 import type { CapabilityAgent, Decision, Resource, Verb } from './types'
-import { DECISIONS } from './types'
+import { DECISIONS, decisionMeta } from './types'
 import type { SortState } from './sort'
 import './CapabilityMatrixGrid.css'
 import { orNoData } from './display'
@@ -231,7 +231,7 @@ function RowGroup({
               }
             }}
           >
-            {DECISIONS[decision].label}
+            {decisionMeta(decision).label}
             {flagged && <span className="cap-mx-cell-flag" aria-label="recent flag" />}
           </div>
         )

--- a/dashboard/src/features/capability/CellInspectDrawer.tsx
+++ b/dashboard/src/features/capability/CellInspectDrawer.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import type { CapabilityAgent, Policy, Resource, SampleCall, Verb } from './types'
-import { DECISIONS } from './types'
+import { decisionMeta } from './types'
 import type { CellSelection } from './CapabilityMatrixGrid'
 import './CellInspectDrawer.css'
 
@@ -56,7 +56,7 @@ export function CellInspectDrawer({
 
   if (!cell) return null
   const { agent, resource, verb, decision } = cell
-  const decMeta = DECISIONS[decision]
+  const decMeta = decisionMeta(decision)
   const respPolicies = policiesFor(policies, agent, resource, verb)
   const recentCalls = callsFor(sampleCalls, agent, verb)
 

--- a/dashboard/src/features/capability/PerAgentTab.tsx
+++ b/dashboard/src/features/capability/PerAgentTab.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import type { CapabilityAgent, Decision, Resource } from './types'
-import { DECISIONS, VERBS } from './types'
+import { decisionMeta, VERBS } from './types'
 import type { CellSelection } from './CapabilityMatrixGrid'
 import './PerAgentTab.css'
 import { orNoData } from './display'
@@ -137,7 +137,7 @@ export function PerAgentTab({
                           }
                         >
                           <span className="cap-pat-cell-label">
-                            {DECISIONS[decision].label}
+                            {decisionMeta(decision).label}
                           </span>
                         </td>
                       )

--- a/dashboard/src/features/capability/PerResourceTab.tsx
+++ b/dashboard/src/features/capability/PerResourceTab.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import type { CapabilityAgent, Resource, Verb } from './types'
-import { DECISIONS } from './types'
+import { decisionMeta } from './types'
 import type { CellSelection } from './CapabilityMatrixGrid'
 import './PerResourceTab.css'
 import { orNoData, relativeTime } from './display'
@@ -145,7 +145,7 @@ export function PerResourceTab({
                           className={`cap-prt-decision cap-prt-decision--${decision}`}
                           data-decision={decision}
                         >
-                          {DECISIONS[decision].label}
+                          {decisionMeta(decision).label}
                         </span>
                       </td>
                       <td className="cap-prt-last-seen">{relativeTime(a.lastSeen)}</td>

--- a/dashboard/src/features/capability/__tests__/sort.test.ts
+++ b/dashboard/src/features/capability/__tests__/sort.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { NO_SORT, nextSortState, sortAgents } from '../sort'
 import { AGENTS, RESOURCES } from '../fixtures'
+import type { CapabilityAgent, Decision } from '../types'
 
 describe('nextSortState', () => {
   it('cycles desc → asc → none on the same column', () => {
@@ -34,5 +35,39 @@ describe('sortAgents', () => {
     // desc puts deny first.
     expect(sorted[0].caps.gmail.write).toBe('deny')
     expect(sorted.at(-1)!.caps.gmail.write).toBe('allow')
+  })
+
+  // AAASM-5217: `a.caps[id]?.[verb]` is raw wire data wearing an unenforced
+  // `Decision` annotation — the capability matrix is cast wholesale at the API
+  // boundary (`api/capability.ts`). A hostile payload can set a cell's
+  // decision to an inherited-prototype key (`"__proto__"`/`"constructor"`) or
+  // an unrecognised string; the sort must not throw, produce `NaN` comparisons,
+  // or resolve an inherited `Object.prototype` member as if it were a real
+  // weight.
+  it('does not throw or misorder when a cell carries a hostile decision value', () => {
+    const hostile: CapabilityAgent = {
+      ...AGENTS[0],
+      id: 'hostile-agent',
+      caps: {
+        ...AGENTS[0].caps,
+        gmail: { read: 'allow', write: '__proto__' as unknown as Decision, delete: 'na', exec: 'na' },
+      },
+    }
+    const agents = [...AGENTS, hostile]
+    expect(() =>
+      sortAgents(agents, RESOURCES, 'write', { resourceId: 'gmail', direction: 'desc' }),
+    ).not.toThrow()
+    const sorted = sortAgents(agents, RESOURCES, 'write', {
+      resourceId: 'gmail',
+      direction: 'desc',
+    })
+    expect(sorted).toHaveLength(agents.length)
+    // A hostile/unrecognised value weighs the same as `na`, so it must not
+    // rank ahead of every real decision (which an inherited prototype member
+    // like an unbound function could otherwise coerce to NaN and place
+    // unpredictably via `Array.prototype.sort`'s undefined-NaN handling).
+    const hostileIdx = sorted.findIndex((a) => a.id === 'hostile-agent')
+    const denyIdx = sorted.findIndex((a) => a.caps.gmail.write === 'deny')
+    expect(hostileIdx).toBeGreaterThan(denyIdx)
   })
 })

--- a/dashboard/src/features/capability/__tests__/types.test.ts
+++ b/dashboard/src/features/capability/__tests__/types.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { DECISIONS, decisionMeta, isDecision, type Decision } from '../types'
+
+// AAASM-5217: `GET /api/v1/capability/matrix` is cast wholesale to
+// `CapabilityMatrix` at the API boundary (`api/capability.ts`), so a cell's
+// `Decision` carries an unenforced annotation over raw wire data. Every
+// consumer that indexes `DECISIONS[decision]` must validate first — an
+// unrecognised or prototype-inherited value must fold to the `na` metadata,
+// never resolve `undefined` or an inherited `Object.prototype` member.
+describe('isDecision', () => {
+  it('accepts every member of the Decision union', () => {
+    for (const d of ['allow', 'narrow', 'approval', 'deny', 'na'] as const) {
+      expect(isDecision(d)).toBe(true)
+    }
+  })
+
+  it.each([
+    ['a plain unknown decision', 'partial'],
+    ['the inherited "__proto__" key', '__proto__'],
+    ['the inherited "constructor" key', 'constructor'],
+    ['the inherited "toString" key', 'toString'],
+    ['the inherited "hasOwnProperty" key', 'hasOwnProperty'],
+  ])('rejects %s', (_label, value) => {
+    expect(isDecision(value)).toBe(false)
+  })
+
+  it('rejects non-string values without throwing', () => {
+    expect(isDecision(42)).toBe(false)
+    expect(isDecision(null)).toBe(false)
+    expect(isDecision(undefined)).toBe(false)
+    expect(isDecision({})).toBe(false)
+  })
+})
+
+describe('decisionMeta', () => {
+  it('returns the real metadata for every known decision', () => {
+    for (const d of ['allow', 'narrow', 'approval', 'deny', 'na'] as const) {
+      expect(decisionMeta(d)).toBe(DECISIONS[d])
+    }
+  })
+
+  it.each([
+    ['the inherited "__proto__" key', '__proto__'],
+    ['the inherited "constructor" key', 'constructor'],
+    ['a plain unknown decision', 'partial'],
+  ])('folds %s to the na metadata rather than an inherited member', (_label, value) => {
+    expect(decisionMeta(value as unknown as Decision)).toBe(DECISIONS.na)
+  })
+})

--- a/dashboard/src/features/capability/sort.ts
+++ b/dashboard/src/features/capability/sort.ts
@@ -1,4 +1,4 @@
-import type { CapabilityAgent, Decision, Resource, Verb } from './types'
+import { isDecision, type CapabilityAgent, type Decision, type Resource, type Verb } from './types'
 
 export type SortDirection = 'asc' | 'desc' | null
 
@@ -15,6 +15,19 @@ const DECISION_WEIGHT: Record<Decision, number> = {
   narrow: 2,
   approval: 3,
   deny: 4,
+}
+
+/**
+ * Weight for a sort comparison, validating the wire-derived decision first
+ * (AAASM-5217). `a.caps[id]?.[verb]` is raw wire data wearing an unenforced
+ * `Decision` annotation — the capability matrix is cast wholesale at the API
+ * boundary (`api/capability.ts`) — so a hostile or malformed payload can send
+ * `"__proto__"` or `"constructor"` here. An unrecognised value weighs the same
+ * as `na` rather than resolving to `undefined` (making every comparison
+ * `NaN`) or an inherited `Object.prototype` member.
+ */
+function decisionWeight(decision: Decision): number {
+  return isDecision(decision) ? DECISION_WEIGHT[decision] : DECISION_WEIGHT.na
 }
 
 export function nextSortState(prev: SortState, resourceId: string): SortState {
@@ -36,6 +49,6 @@ export function sortAgents(
   return [...agents].sort((a, b) => {
     const da = a.caps[sort.resourceId as string]?.[verb] ?? 'na'
     const db = b.caps[sort.resourceId as string]?.[verb] ?? 'na'
-    return factor * (DECISION_WEIGHT[da] - DECISION_WEIGHT[db])
+    return factor * (decisionWeight(da) - decisionWeight(db))
   })
 }

--- a/dashboard/src/features/capability/types.ts
+++ b/dashboard/src/features/capability/types.ts
@@ -137,3 +137,33 @@ export const DECISIONS: Record<Decision, DecisionMeta> = {
   deny: { label: 'deny', color: '--danger', bg: '--danger-bg' },
   na: { label: 'n/a', color: '--ink-5', bg: '--paper-3' },
 }
+
+const KNOWN_DECISIONS: ReadonlySet<string> = new Set<Decision>([
+  'allow',
+  'narrow',
+  'approval',
+  'deny',
+  'na',
+])
+
+/**
+ * Validate an unknown value against the `Decision` union before it is trusted
+ * as a `DECISIONS` lookup key (AAASM-5217). `GET /api/v1/capability/matrix` is
+ * cast wholesale to `CapabilityMatrix` at the API boundary
+ * (`api/capability.ts`), so a cell's decision carries an unenforced `Decision`
+ * annotation over raw wire data — a hostile or malformed payload can send
+ * `"__proto__"` or `"constructor"` here.
+ */
+export function isDecision(value: unknown): value is Decision {
+  return typeof value === 'string' && KNOWN_DECISIONS.has(value)
+}
+
+/**
+ * Look up display metadata for a decision, validating the wire value first.
+ * An unrecognised or prototype-inherited key folds to the `na` metadata
+ * rather than resolving to `undefined` or an inherited `Object.prototype`
+ * member the way `DECISIONS[decision]` would for a key like `"__proto__"`.
+ */
+export function decisionMeta(decision: Decision): DecisionMeta {
+  return isDecision(decision) ? DECISIONS[decision] : DECISIONS.na
+}

--- a/dashboard/src/features/iam/apiKeys.ts
+++ b/dashboard/src/features/iam/apiKeys.ts
@@ -74,6 +74,12 @@ let _revokeOverride: ((id: string) => Promise<void>) | null = null
 let _rotateOverride: ((id: string) => Promise<GeneratedApiKey>) | null = null
 let _testSeed: readonly ApiKey[] = SEED_API_KEYS
 
+// `as ApiKey[]` / `as GeneratedApiKey` (below and in `rotateApiKey`) are bare
+// casts (AAASM-5217 audit). Accepted-risk: none of `ApiKey`'s fields —
+// `status`, `role`, `scopes`, `recent_activity[].action` — are ever used as an
+// object/Map lookup key anywhere in `features/iam`. `ApiKeyList.tsx` compares
+// `status`/`role` with `===` and renders them as text; `GenerateKeyDialog.tsx`
+// checks `scopes` membership with `Array.includes`, not indexing.
 async function fetchApiKeys(): Promise<ApiKey[]> {
   if (_listOverride) return _listOverride()
   const { data, error } = await api.GET('/api/v1/iam/api-keys')

--- a/dashboard/src/features/liveOps/useLiveOpsStream.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.ts
@@ -268,6 +268,17 @@ export function useLiveOpsStream({
 
   // Hoisted out of the WebSocket `onmessage` handler to keep the effect's
   // callback nesting shallow (mapEvent + mergeOp already isolate the logic).
+  //
+  // `JSON.parse(...) as GovernanceEvent` is a bare cast (AAASM-5217 audit).
+  // Accepted-risk: every field of `parsed` that ends up used as an
+  // object-lookup key is validated before that lookup, not trusted from the
+  // annotation — `mapEvent` runs the wire `audit.status` / `ops_change.state`
+  // through `coerceStatus`/`opStateToStatus` (allow-listed against
+  // `OPERATION_STATUSES`) before it becomes the `LiveOperation.status` that
+  // `STATUS_LABEL[op.status]` (`OperationRow.tsx`) indexes, and
+  // `mapCallStackNode` runs `node.kind` through `coerceCallStackKind`
+  // (allow-listed against `CALL_STACK_KINDS`). `event.id` / `agent_id` /
+  // `resource` / `op_type` are rendered as opaque display values, never keys.
   const handleMessage = useCallback(
     (evt: MessageEvent) => {
       try {

--- a/dashboard/src/features/onboarding/api.ts
+++ b/dashboard/src/features/onboarding/api.ts
@@ -41,6 +41,14 @@ function isChecksMap(value: unknown): value is Record<string, string> {
  *
  * Declining matters as much as accepting: reading a health report out of a body
  * that is not one would be a fabrication of exactly the kind this lane removes.
+ *
+ * The two casts below (AAASM-5217 audit) are accepted-risk: `candidate.checks`
+ * (validated as a string-valued map by `isChecksMap`, but not against a
+ * closed key set — the gateway's subsystem list is open-ended) is only ever
+ * iterated with `Object.entries` in `probeLines.ts`, which reads `[name,
+ * status]` pairs and renders both as opaque text; it is never used as an
+ * object-lookup key itself. `status` / `version` / `api_version` are likewise
+ * rendered as plain text, not indexed into a `Record`.
  */
 function asHealthResponse(body: unknown): GatewayHealth | null {
   if (typeof body !== 'object' || body === null) return null

--- a/dashboard/src/features/teams/api.ts
+++ b/dashboard/src/features/teams/api.ts
@@ -33,6 +33,15 @@ export interface TeamListRow {
   burn_pct: number | null
 }
 
+// The four response casts in this file (`TopologyOverview`, `CostSummary`,
+// `TeamTopology`, `AgentLineage` below) are bare casts (AAASM-5217 audit).
+// Accepted-risk: no field any of them expose — team/agent ids, spend figures,
+// member `status` (`'active' | 'suspended'`), lineage `tier` — is ever used
+// as an object/Map lookup key in `features/teams` or its consumers.
+// `joinTeamRows` keys `costByTeam` by `team_id`, but that id is opaque
+// (looked up with `.get()` on a real `Map`, which treats every key as an
+// ordinary key regardless of value); every status/tier field is rendered as
+// display text or compared with `===`.
 export function useTopologyOverviewQuery() {
   return useQuery({
     queryKey: ['topology', 'overview'],

--- a/dashboard/src/features/topology/api.ts
+++ b/dashboard/src/features/topology/api.ts
@@ -61,6 +61,13 @@ export function useTopologyQuery() {
 
       const res = await fetch(`${base}/api/v1/topology`, { headers })
       if (!res.ok) throw new Error('Failed to fetch topology')
+      // `as components['schemas']['TopologyGraphResponse']` is a bare cast
+      // (AAASM-5217 audit). Accepted-risk: `mapTopologyGraph` runs every
+      // node's wire `status`/`mode` through `toStatus`/`toMode`
+      // (`mapGraph.ts`), each an allow-list check against
+      // `RUNTIME_STATUSES`/`MODES`, before either becomes part of the
+      // `TopologyNode` the view renders — no field of this cast's target is
+      // used as a lookup key before that validation happens.
       const raw = (await res.json()) as components['schemas']['TopologyGraphResponse']
       return mapTopologyGraph(raw)
     },
@@ -91,6 +98,10 @@ export function useTopologyNodeRecentEvents(nodeId: string) {
         { headers },
       )
       if (!res.ok) throw new Error('Failed to fetch recent events')
+      // `as readonly RecentEvent[]` is a bare cast (AAASM-5217 audit).
+      // Accepted-risk: `RecentEvent.type` (`NodeDetailPanel.tsx`) is rendered
+      // as opaque display text, never used as a lookup key — the minimal
+      // shared shape this type declares has no field that is.
       return (await res.json()) as readonly RecentEvent[]
     },
   })

--- a/dashboard/src/pages/ViolationHeatmapPage.tsx
+++ b/dashboard/src/pages/ViolationHeatmapPage.tsx
@@ -58,6 +58,11 @@ export function ViolationHeatmapPage() {
     const headers: Record<string, string> = {};
     if (token) headers.Authorization = `Bearer ${token}`;
 
+    // `r.json() as Promise<ApiResponse>` is a bare cast (AAASM-5217 audit).
+    // Accepted-risk: `ApiResponse.nodes[].agent_id` is used as a React list
+    // `key` and a d3 hierarchy id (`ViolationHeatmap.tsx`), never as an
+    // object/Map lookup key, and `violation_count`/`window_secs` are plain
+    // numbers consumed arithmetically, not as keys.
     fetch(`${base}/api/v1/audit/violations-by-lineage?${params}`, { headers })
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);


### PR DESCRIPTION
## Description

AAASM-5217 audit: enumerates every bare `as T` / `as Promise<T>` cast at a dashboard fetch/WebSocket/JWT deserialization boundary, and for each site either (a) adds runtime validation where a cast-derived value is used as an object/Map lookup key, or (b) documents why the cast is accepted-risk when it isn't.

This closes the gap AAASM-5245's AST lint rule cannot catch: a lookup can be declared with a correctly-constrained union key type and still receive raw, unvalidated wire data if the fetch boundary feeding it uses a bare cast. Two of the fixes below are genuine defects the original 18-site AAASM-5208 sweep missed because they're one hop removed from the cast site itself (`capability/types.ts`'s `DECISIONS`, `capability/sort.ts`'s `DECISION_WEIGHT`) — both named explicitly in the ticket. Two more (`SeverityBadge`/`StatusBadge`, `AuthProvider`'s login scopes) are new findings surfaced during this audit's enumeration pass.

`features/alerts/api.ts`'s cast site itself was re-examined per the ticket: AAASM-5215's `isAlertMetric()` fix (merged via PR #1748) already guards `alertCategory.ts`'s `METRIC_CATEGORY` Map downstream of that cast using a `Map` (not object), so that specific lookup is validated. However, the audit found the *same* cast feeds `SeverityBadge`/`StatusBadge` through the unvalidated single-alert-detail and rules paths (`useAlertQuery`, `useAlertRulesQuery`), which bypass the list path's `parseAlertList`/`canonicalSeverity`/`canonicalStatus` normalisation — fixed at the shared badge boundary since both paths render through the same components.

`api/capability.ts`'s doc comment claimed the boundary cast was "safe" because the hand-written and codegen'd types are "structurally identical" — that's a compile-time claim about shape, not a runtime guarantee about content, and was corrected to state the actual (now-enforced) justification.

## Enumeration (AAASM-5247)

| # | File:Line | Cast target | Used as lookup key? | Decision |
|---|---|---|---|---|
| 1 | `features/capability/types.ts:133` (`DECISIONS`) | `Decision` (one hop from `api/capability.ts:31`) | **Yes** — `DECISIONS[decision]` | **Fixed** — `isDecision`/`decisionMeta()` |
| 2 | `features/capability/sort.ts:12` (`DECISION_WEIGHT`) | `Decision` (one hop from `api/capability.ts:31`) | **Yes** — `DECISION_WEIGHT[da/db]` | **Fixed** — `decisionWeight()` |
| 3 | `features/alerts/SeverityBadge.tsx` (`SEVERITY_BG`) | `Severity` (one hop from `alerts/api.ts:57` via unvalidated detail/rules paths) | **Yes** — `SEVERITY_BG[severity]` | **Fixed** — `isSeverity()` |
| 4 | `features/alerts/StatusBadge.tsx` (`STATUS_STYLE`) | `AlertStatus` (same paths) | **Yes** — `STATUS_STYLE[status]` | **Fixed** — `isAlertStatus()` |
| 5 | `auth/AuthProvider.tsx:29` (`login()`) | `Scope[]` (feeds `SCOPE_RANK[s]` in `usePermissions.ts`) | **Yes** — unfiltered, unlike the JWT-claim fallback | **Fixed** — reuse `isScope()` |
| 6 | `features/alerts/api.ts:57` (`alertsFetch`) | generic `T` | No, at guarded call sites (see #3/#4) | Accepted-risk (documented) |
| 7 | `features/analytics/analyticsFetch.ts:23` | generic `T` | No — segment/series keys already build on `Object.create(null)` | Accepted-risk (documented) |
| 8 | `api/capability.ts:31` (`getMatrix`) | `CapabilityMatrix` | No, downstream of fixes #1/#2 | Accepted-risk (doc corrected) |
| 9 | `features/onboarding/api.ts:47,54` | `GatewayHealth` | No — rendered as text | Accepted-risk (documented) |
| 10 | `features/audit/api.ts:74` | `Record<string, unknown>` | No — fixed literal keys only | Accepted-risk (documented) |
| 11 | `auth/jwtScopes.ts:43` (`getSubject`) | `Record<string, unknown>` | No — fixed literal keys only | Accepted-risk (documented) |
| 12 | `features/liveOps/useLiveOpsStream.ts:274` | `GovernanceEvent` | No — `mapEvent` allow-list-validates before lookup | Accepted-risk (documented) |
| 13 | `features/alerts/useAlertsStream.ts:111` | `AlertsStreamFrame` | No — `frame.alert` goes through `normaliseAlert` | Accepted-risk (documented) |
| 14 | `features/approvals/useApprovalsStream.ts:64` | `GovernanceEvent`/`ApprovalPayload` | No — `===` comparisons / text / Set membership | Accepted-risk (documented) |
| 15 | `features/topology/api.ts:64` | `TopologyGraphResponse` | No — `mapGraph.ts` allow-list-validates | Accepted-risk (documented) |
| 16 | `features/topology/api.ts:94` | `RecentEvent[]` | No — rendered as text | Accepted-risk (documented) |
| 17 | `features/iam/apiKeys.ts:83,94,115` | `ApiKey[]`/`GeneratedApiKey` | No — `===`/text/`Array.includes` only | Accepted-risk (documented) |
| 18 | `features/teams/api.ts:42,89,144,165` | `TopologyOverview`/`CostSummary`/`TeamTopology`/`AgentLineage` | No — Map keyed by opaque id; status/tier as text | Accepted-risk (documented) |
| 19 | `components/ViolationHeatmap.tsx:172` | `ViolationNode` (d3 datum, not wire) | No | Accepted-risk (pre-existing, not wire-facing) |
| 20 | `pages/ViolationHeatmapPage.tsx:64` | `ApiResponse` | No — `agent_id` is a React/d3 key, not object index | Accepted-risk (documented) |

5 sites required runtime validation; 15 documented as accepted-risk.

## Type of Change

- [x] 🐛 Bug fix
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5217 (subtasks AAASM-5247, AAASM-5248)

## Testing

- [x] Unit tests added / updated — regression tests for every runtime-validated site (`capability/__tests__/types.test.ts`, `capability/__tests__/sort.test.ts`, `alerts/SeverityBadge.test.tsx`, `alerts/StatusBadge.test.tsx`, `auth/jwtScopes.test.ts`, `auth/AuthProvider.test.tsx`), each proving an inherited-prototype-member wire value (`"__proto__"`, `"constructor"`) is rejected or safely handled.
- [x] `pnpm exec tsc --noEmit`, `pnpm exec eslint .`, `pnpm exec vitest run` all clean (275 test files, 3053 tests passing).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated where behaviour changed
- [x] Commits are small and follow the Gitmoji convention