### PR TITLE
[AAASM-5137] ♻️ (topology): Dim non-neighbour nodes and edges on node select

### DIFF
--- a/dashboard/src/components/topology/TopologyGraph.css
+++ b/dashboard/src/components/topology/TopologyGraph.css
@@ -84,6 +84,19 @@
   opacity: 1;
 }
 
+/* Neighbour focus on node select (AAASM-5137): a selected node keeps itself and
+   its immediate neighbours at full opacity while everything unconnected recedes,
+   mirroring design/v2/hi-fi/topology.jsx (nodes → 0.2, edges → 0.07). The
+   `data-dimmed` attribute is only present while a node is selected, so with no
+   selection nothing dims. */
+.topology-node[data-dimmed='true'] {
+  opacity: 0.2;
+}
+
+.topology-edge[data-dimmed='true'] {
+  opacity: 0.07;
+}
+
 .topology-node__card {
   fill: var(--paper);
   stroke: var(--line);

--- a/dashboard/src/components/topology/TopologyGraph.test.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.test.tsx
@@ -853,4 +853,14 @@ describe('TopologyGraph — neighbour focus on node select', () => {
     // Only the lone→lone-two edge is dimmed; the two edges incident to p1 are lit.
     expect(dimmed).toHaveLength(1)
   })
+
+  it('dims nothing when no node is selected', () => {
+    render(<TopologyGraph nodes={NODES} edges={EDGES} />)
+    for (const g of screen.getAllByTestId('topology-node')) {
+      expect(g).not.toHaveAttribute('data-dimmed')
+    }
+    for (const p of screen.getAllByTestId('topology-edge')) {
+      expect(p).not.toHaveAttribute('data-dimmed')
+    }
+  })
 })

--- a/dashboard/src/components/topology/TopologyGraph.test.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.test.tsx
@@ -840,4 +840,17 @@ describe('TopologyGraph — neighbour focus on node select', () => {
     render(<TopologyGraph nodes={NODES} edges={EDGES} selectedNodeId="p1" />)
     expect(nodeNamed('lone')).toHaveAttribute('data-dimmed', 'true')
   })
+
+  it('dims edges touching neither the selection nor a neighbour', () => {
+    // Add an edge whose endpoints are both outside p1's neighbourhood
+    // (lone ↔ lone-two). p1's own two edges must stay lit; the outside edge
+    // must dim.
+    const edges: TopologyEdge[] = [...EDGES, { source: 'lone', target: 'lone2', kind: 'call' }]
+    render(<TopologyGraph nodes={NODES} edges={edges} selectedNodeId="p1" />)
+    const dimmed = screen
+      .getAllByTestId('topology-edge')
+      .filter(p => p.getAttribute('data-dimmed') === 'true')
+    // Only the lone→lone-two edge is dimmed; the two edges incident to p1 are lit.
+    expect(dimmed).toHaveLength(1)
+  })
 })

--- a/dashboard/src/components/topology/TopologyGraph.test.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.test.tsx
@@ -835,4 +835,9 @@ describe('TopologyGraph — neighbour focus on node select', () => {
     expect(nodeNamed('worker')).not.toHaveAttribute('data-dimmed')
     expect(nodeNamed('x-caller')).not.toHaveAttribute('data-dimmed')
   })
+
+  it('dims a node connected to neither the selection nor its neighbours', () => {
+    render(<TopologyGraph nodes={NODES} edges={EDGES} selectedNodeId="p1" />)
+    expect(nodeNamed('lone')).toHaveAttribute('data-dimmed', 'true')
+  })
 })

--- a/dashboard/src/components/topology/TopologyGraph.test.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.test.tsx
@@ -805,3 +805,34 @@ describe('TopologyGraph — cluster for agents with no team', () => {
     expect(onTeamClick).toHaveBeenCalledWith('support')
   })
 })
+
+// ── Neighbour focus on node select (AAASM-5137) ──────────────────────────────
+// Selecting a node keeps it and its immediate neighbours lit while everything
+// unconnected recedes (data-dimmed → CSS opacity 0.2 / 0.07), mirroring the
+// `connectedIds` focus treatment in design/v2/hi-fi/topology.jsx:392.
+describe('TopologyGraph — neighbour focus on node select', () => {
+  const NODES: TopologyNode[] = [
+    { id: 'p1', name: 'planner', status: 'active', team: 'alpha', owner: 'a', policyCount: 1, budgetSpend: 1, budgetLimit: 10 },
+    { id: 'w1', name: 'worker', status: 'active', team: 'alpha', owner: 'a', policyCount: 1, budgetSpend: 1, budgetLimit: 10 },
+    { id: 'x1', name: 'x-caller', status: 'active', team: 'beta', owner: 'b', policyCount: 1, budgetSpend: 1, budgetLimit: 10 },
+    // Outside p1's neighbourhood — these must dim when p1 is selected.
+    { id: 'lone', name: 'lone', status: 'active', team: 'beta', owner: 'b', policyCount: 1, budgetSpend: 1, budgetLimit: 10 },
+    { id: 'lone2', name: 'lone-two', status: 'active', team: 'beta', owner: 'b', policyCount: 1, budgetSpend: 1, budgetLimit: 10 },
+  ]
+  const EDGES: TopologyEdge[] = [
+    { source: 'p1', target: 'w1', kind: 'delegation' }, // p1 ↔ w1
+    { source: 'x1', target: 'p1', kind: 'call' },        // p1 ↔ x1 (target side)
+  ]
+
+  const nodeNamed = (name: string) =>
+    screen.getAllByTestId('topology-node').find(
+      g => g.querySelector('.topology-node__name')?.textContent?.includes(name),
+    )!
+
+  it('keeps the selected node and its neighbours undimmed', () => {
+    render(<TopologyGraph nodes={NODES} edges={EDGES} selectedNodeId="p1" />)
+    expect(nodeNamed('planner')).not.toHaveAttribute('data-dimmed')
+    expect(nodeNamed('worker')).not.toHaveAttribute('data-dimmed')
+    expect(nodeNamed('x-caller')).not.toHaveAttribute('data-dimmed')
+  })
+})

--- a/dashboard/src/components/topology/TopologyGraph.test.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.test.tsx
@@ -863,4 +863,11 @@ describe('TopologyGraph — neighbour focus on node select', () => {
       expect(p).not.toHaveAttribute('data-dimmed')
     }
   })
+
+  it('re-lights everything when the selection is cleared', () => {
+    const { rerender } = render(<TopologyGraph nodes={NODES} edges={EDGES} selectedNodeId="p1" />)
+    expect(nodeNamed('lone')).toHaveAttribute('data-dimmed', 'true')
+    rerender(<TopologyGraph nodes={NODES} edges={EDGES} selectedNodeId={null} />)
+    expect(nodeNamed('lone')).not.toHaveAttribute('data-dimmed')
+  })
 })

--- a/dashboard/src/components/topology/TopologyGraph.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.tsx
@@ -361,6 +361,31 @@ export function TopologyGraph({
   /** Team lookup for edge classification. Hoisted so it is not rebuilt per tick. */
   const nodeTeams = useMemo(() => teamById(nodes), [nodes])
 
+  /**
+   * The selected node plus every node sharing an edge with it, or `null` when
+   * nothing is selected (AAASM-5137).
+   *
+   * When a node is selected the canvas dims everything outside this set so the
+   * operator sees the selection's immediate neighbourhood without the rest of
+   * the mesh competing for attention — the `connectedIds` focus treatment from
+   * `design/v2/hi-fi/topology.jsx:392`. `null` (nothing selected) is distinct
+   * from an empty set: it means "dim nothing", so every node and edge renders at
+   * full opacity.
+   *
+   * Derived from the *drawable* `edges` — the same set the canvas draws — so a
+   * neighbour reachable only through a filtered-out edge kind is not counted as
+   * connected on a view that isn't showing that connection.
+   */
+  const connectedIds = useMemo<ReadonlySet<string> | null>(() => {
+    if (selectedNodeId == null) return null
+    const ids = new Set<string>([selectedNodeId])
+    for (const e of edges) {
+      if (e.source === selectedNodeId) ids.add(e.target)
+      if (e.target === selectedNodeId) ids.add(e.source)
+    }
+    return ids
+  }, [selectedNodeId, edges])
+
   // Cluster centers: a grid laid out left-to-right, top-to-bottom. Depends only
   // on *which* teams exist and the canvas size — never on their budgets — so it
   // stays referentially stable across a metrics-only payload update.

--- a/dashboard/src/components/topology/TopologyGraph.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.tsx
@@ -181,6 +181,10 @@ interface EdgeGeometry {
   readonly kind: TopologyEdge['kind']
   readonly crossTeam: boolean
   readonly d: string
+  /** Endpoint ids, kept so the node-select dim state can be read at render time
+   *  without recomputing geometry (AAASM-5137). */
+  readonly source: string
+  readonly target: string
 }
 
 /**
@@ -578,7 +582,14 @@ export function TopologyGraph({
         d = `M${start.x} ${start.y} L${end.x} ${end.y}`
       }
 
-      geoms.push({ key: `${edge.source}->${edge.target}-${edge.kind}-${i}`, kind: edge.kind, crossTeam, d })
+      geoms.push({
+        key: `${edge.source}->${edge.target}-${edge.kind}-${i}`,
+        kind: edge.kind,
+        crossTeam,
+        d,
+        source: String(edge.source),
+        target: String(edge.target),
+      })
     })
     return geoms
   }, [edges, positions, width, height, visibleKinds, showCrossTeam, nodeTeams, nodeById])
@@ -706,6 +717,9 @@ export function TopologyGraph({
           data-testid="topology-edge"
           data-kind={e.kind}
           data-cross-team={e.crossTeam ? 'true' : undefined}
+          // Dimmed when a node is selected and neither endpoint is it or a
+          // neighbour (AAASM-5137). `null` connectedIds = nothing selected.
+          data-dimmed={connectedIds && !connectedIds.has(e.source) && !connectedIds.has(e.target) ? 'true' : undefined}
           d={e.d}
           fill="none"
           strokeWidth={EDGE_STYLE[e.kind].width}

--- a/dashboard/src/components/topology/TopologyGraph.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.tsx
@@ -730,6 +730,10 @@ export function TopologyGraph({
         // (AAASM-5138). Only meaningful while a team filter is narrowing the
         // view — see the `teamFilterActive` prop.
         const crossTeamCount = teamFilterActive ? (crossTeamDegree.get(node.id) ?? 0) : 0
+        // Dimmed when a node is selected and this one is neither it nor a
+        // neighbour (AAASM-5137). `null` connectedIds means nothing is selected,
+        // so nothing dims.
+        const dimmed = connectedIds ? !connectedIds.has(node.id) : false
 
         const handleClick = onNodeClick ? () => onNodeClick(node) : undefined
         const handleKeyDown = onNodeClick
@@ -749,6 +753,7 @@ export function TopologyGraph({
             data-status={node.status}
             data-size-bucket={bucket}
             data-selected={selectedNodeId === node.id ? 'true' : undefined}
+            data-dimmed={dimmed ? 'true' : undefined}
             data-depth={depth}
             data-root={isRoot ? 'true' : undefined}
             data-in-cycle={inCycle ? 'true' : undefined}


### PR DESCRIPTION
## Description

Selecting a Topology node now dims everything outside its immediate neighbourhood, so the operator sees the selection's connections without the rest of the mesh competing for attention. Previously a selected node only got a `data-selected` border; the rest of the graph stayed at full opacity.

The change derives a `connectedIds` set — the selected node plus every node sharing an edge with it — from the drawable `edges`, then marks unconnected nodes and edges with a `data-dimmed` attribute. Two CSS rules fade them (nodes → opacity 0.2, edges → 0.07), mirroring the `connectedIds` focus treatment in `design/v2/hi-fi/topology.jsx:392` (nodes `:220`, edges `:272`). `connectedIds` is `null` when nothing is selected, which means "dim nothing", so with no selection the graph renders exactly as before.

## Type of Change

- [x] ♻️ Refactoring
- [x] ✨ New feature (adds the neighbour-focus dimming behaviour)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5137

## Testing

- [x] Unit tests added / updated

Added a `TopologyGraph — neighbour focus on node select` describe block (5 tests) in `dashboard/src/components/topology/TopologyGraph.test.tsx`:
- selected node + neighbours stay undimmed
- a node connected to neither the selection nor its neighbours is dimmed
- an edge touching neither is dimmed (while the selection's own edges stay lit)
- nothing is dimmed when no node is selected
- clearing the selection re-lights the graph

Local gate (run from `dashboard/`, all clean):
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm exec eslint .` — 0 problems
- `pnpm exec vitest run` — 276 files, 3078 tests passed

**Manual/DOM verification:** not performed. The Topology surface fetches from the live `GET /api/v1/topology` backend (no MSW mocks, no Storybook story for this component), so a screenshot would require standing up the seeded Rust backend — disproportionate for this change. Verified instead by the DOM-contract unit tests above (asserting the exact `data-dimmed` attribute wiring) plus code inspection: `TopologyPage.tsx:242` already passes `selectedNodeId` into `TopologyGraph`, so the feature is fully wired end to end.

## Checklist

- [x] Self-review of the diff completed
- [x] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention

## Notes on the sibling ticket AAASM-5139

While picking up this chain I confirmed AAASM-5139 (label unclaimed agents as a sentinel cluster) is **already implemented on `main`** via AAASM-5184/5140 — `features/topology/unclaimed.ts` (`UNCLAIMED_TEAM = '__orphan__'`, `teamLabel`, `countUnclaimed`), the `⚠ N unclaimed` sidebar stat (`TopologySidebar.tsx:105-114`), and the labelled/`data-unclaimed` cluster (`TopologyGraph.tsx`). No further work was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
