### PR TITLE
[AAASM-5143] ✨ (policies): Add history toggle for archived policy versions

### DIFF
--- a/dashboard/src/features/policies/api.test.tsx
+++ b/dashboard/src/features/policies/api.test.tsx
@@ -32,6 +32,11 @@ const POLICY: Policy = {
   policy_yaml: 'name: baseline\n',
 }
 
+// The policies list is keyed by its includeArchived flag (AAASM-5143); the
+// default (history-off) view — where a newly created policy lands — carries
+// this exact key.
+const DEFAULT_POLICIES_KEY = ['policies', { includeArchived: false }] as const
+
 let get: Mock
 let post: Mock
 
@@ -124,13 +129,13 @@ describe('useCreatePolicy', () => {
       () => new Promise<FetchResult>((resolve) => { resolvePost = resolve }),
     )
     const { client, wrapper } = makeWrapper()
-    client.setQueryData<Policy[]>(['policies'], [POLICY])
+    client.setQueryData<Policy[]>(DEFAULT_POLICIES_KEY, [POLICY])
     const { result } = renderHook(() => useCreatePolicy(), { wrapper })
 
     result.current.mutate({ policy_yaml: 'name: "my-new-policy"\n' })
 
     await waitFor(() => {
-      const cached = client.getQueryData<Policy[]>(['policies'])
+      const cached = client.getQueryData<Policy[]>(DEFAULT_POLICIES_KEY)
       expect(cached?.some((p) => p.name === 'my-new-policy' && p.version === 'pending')).toBe(true)
     })
 
@@ -149,7 +154,7 @@ describe('useCreatePolicy', () => {
     result.current.mutate({ policy_yaml: 'rules: []\n' })
 
     await waitFor(() => {
-      const cached = client.getQueryData<Policy[]>(['policies'])
+      const cached = client.getQueryData<Policy[]>(DEFAULT_POLICIES_KEY)
       expect(cached?.some((p) => p.name === '(new policy)')).toBe(true)
     })
 
@@ -160,7 +165,7 @@ describe('useCreatePolicy', () => {
   it('rolls back the optimistic placeholder on failure', async () => {
     post.mockResolvedValue({ error: { message: 'boom' } } satisfies FetchResult)
     const { client, wrapper } = makeWrapper()
-    client.setQueryData<Policy[]>(['policies'], [POLICY])
+    client.setQueryData<Policy[]>(DEFAULT_POLICIES_KEY, [POLICY])
     const { result } = renderHook(() => useCreatePolicy(), { wrapper })
 
     await expect(
@@ -168,7 +173,7 @@ describe('useCreatePolicy', () => {
     ).rejects.toThrow('Failed to apply policy')
 
     await waitFor(() => {
-      const cached = client.getQueryData<Policy[]>(['policies'])
+      const cached = client.getQueryData<Policy[]>(DEFAULT_POLICIES_KEY)
       expect(cached).toEqual([POLICY])
     })
   })

--- a/dashboard/src/features/policies/api.test.tsx
+++ b/dashboard/src/features/policies/api.test.tsx
@@ -92,15 +92,17 @@ describe('usePoliciesQuery', () => {
     expect(result.current.error?.message).toBe('Failed to fetch policies')
   })
 
-  it('requests active-only versions by default', async () => {
-    // AAASM-5143: the endpoint returns only the in-force version unless
-    // include_archived is set, so the default query must send `false`.
+  it('requests active-only versions by default without a query string', async () => {
+    // AAASM-5143: the endpoint already defaults to active-only, so the default
+    // query sends NO param — keeping the request URL exactly `/api/v1/policies`,
+    // the bare path every existing caller, nav badge and e2e route mock targets.
+    // Sending `include_archived=false` would change that URL and slip past them.
     get.mockResolvedValue({ data: { items: [POLICY], page: 1, per_page: 50, total: 1 } } satisfies FetchResult)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => usePoliciesQuery(), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(get).toHaveBeenCalledWith('/api/v1/policies', {
-      params: { query: { include_archived: false } },
+      params: { query: {} },
     })
   })
 

--- a/dashboard/src/features/policies/api.test.tsx
+++ b/dashboard/src/features/policies/api.test.tsx
@@ -104,6 +104,17 @@ describe('usePoliciesQuery', () => {
     })
   })
 
+  it('requests archived versions when includeArchived is set', async () => {
+    // AAASM-5143: the page-header history toggle flips this option, which must
+    // reach the wire as `include_archived=true` so older versions come back.
+    get.mockResolvedValue({ data: { items: [POLICY], page: 1, per_page: 50, total: 1 } } satisfies FetchResult)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => usePoliciesQuery({ includeArchived: true }), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(get).toHaveBeenCalledWith('/api/v1/policies', {
+      params: { query: { include_archived: true } },
+    })
+  })
 })
 
 describe('useActivePolicyQuery', () => {

--- a/dashboard/src/features/policies/api.test.tsx
+++ b/dashboard/src/features/policies/api.test.tsx
@@ -91,6 +91,19 @@ describe('usePoliciesQuery', () => {
     await waitFor(() => expect(result.current.isError).toBe(true))
     expect(result.current.error?.message).toBe('Failed to fetch policies')
   })
+
+  it('requests active-only versions by default', async () => {
+    // AAASM-5143: the endpoint returns only the in-force version unless
+    // include_archived is set, so the default query must send `false`.
+    get.mockResolvedValue({ data: { items: [POLICY], page: 1, per_page: 50, total: 1 } } satisfies FetchResult)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => usePoliciesQuery(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(get).toHaveBeenCalledWith('/api/v1/policies', {
+      params: { query: { include_archived: false } },
+    })
+  })
+
 })
 
 describe('useActivePolicyQuery', () => {

--- a/dashboard/src/features/policies/api.ts
+++ b/dashboard/src/features/policies/api.ts
@@ -54,7 +54,13 @@ export function usePoliciesQuery({
     enabled,
     queryFn: async () => {
       const { data, error } = await api.GET('/api/v1/policies', {
-        params: { query: { include_archived: includeArchived } },
+        // Only send the param in history mode. The endpoint already defaults to
+        // active-only, so omitting it when false keeps the default request URL
+        // exactly `/api/v1/policies` (no query string) — the URL every existing
+        // caller, nav badge and route mock already targets. Sending
+        // `include_archived=false` would silently change that URL and slip past
+        // consumers matching the bare path (AAASM-5143).
+        params: { query: includeArchived ? { include_archived: true } : {} },
       })
       if (error) throw new Error('Failed to fetch policies')
       // AAASM-4892: /policies returns a paginated { items, total } object.

--- a/dashboard/src/features/policies/api.ts
+++ b/dashboard/src/features/policies/api.ts
@@ -20,14 +20,42 @@ export interface PoliciesQueryOptions {
    * log (AAASM-5186).
    */
   readonly enabled?: boolean
+
+  /**
+   * Include older (inactive) policy versions in the response (AAASM-5143).
+   *
+   * Maps to `GET /api/v1/policies?include_archived` (`openapi/v1.yaml`). Off by
+   * default: the endpoint returns only the currently in-force version unless
+   * this is set, so the archived history is fetched on demand — when the
+   * page-header `history` toggle asks for it — rather than on every load.
+   */
+  readonly includeArchived?: boolean
 }
 
-export function usePoliciesQuery({ enabled = true }: PoliciesQueryOptions = {}) {
+/**
+ * Prefix shared by every policies-list query variant. `cancelQueries` /
+ * `invalidateQueries` match it by prefix, so they cover both the default
+ * (active-only) view and the `includeArchived` history view (AAASM-5143).
+ */
+const POLICIES_QUERY_KEY = ['policies'] as const
+
+/** Exact cache key for the default (active-only) policies-list view. */
+const POLICIES_DEFAULT_QUERY_KEY = [...POLICIES_QUERY_KEY, { includeArchived: false }] as const
+
+export function usePoliciesQuery({
+  enabled = true,
+  includeArchived = false,
+}: PoliciesQueryOptions = {}) {
   return useQuery({
-    queryKey: ['policies'],
+    // includeArchived is part of the key so flipping the history toggle
+    // refetches (and caches the two result sets independently) rather than
+    // reusing the active-only page for the archived view.
+    queryKey: [...POLICIES_QUERY_KEY, { includeArchived }],
     enabled,
     queryFn: async () => {
-      const { data, error } = await api.GET('/api/v1/policies', {})
+      const { data, error } = await api.GET('/api/v1/policies', {
+        params: { query: { include_archived: includeArchived } },
+      })
       if (error) throw new Error('Failed to fetch policies')
       // AAASM-4892: /policies returns a paginated { items, total } object.
       // AAASM-5186: a 200 whose body carries no `items` is a malformed
@@ -94,8 +122,11 @@ export function useCreatePolicy() {
     // the editor overlay can close without a flash of stale data. On error
     // we restore the snapshot taken before the mutation fired.
     onMutate: async (body) => {
-      await queryClient.cancelQueries({ queryKey: ['policies'] })
-      const previous = queryClient.getQueryData<Policy[]>(['policies'])
+      await queryClient.cancelQueries({ queryKey: POLICIES_QUERY_KEY })
+      // Exact key: getQueryData/setQueryData match exactly, so the optimistic
+      // placeholder lands in the default (active-only) view — the one visible
+      // when a policy is created (history is off by default).
+      const previous = queryClient.getQueryData<Policy[]>(POLICIES_DEFAULT_QUERY_KEY)
       const optimistic: Policy = {
         name: nameFromYaml(body.policy_yaml),
         version: 'pending',
@@ -103,7 +134,7 @@ export function useCreatePolicy() {
         active: false,
         policy_yaml: body.policy_yaml,
       }
-      queryClient.setQueryData<Policy[]>(['policies'], (prev) => [
+      queryClient.setQueryData<Policy[]>(POLICIES_DEFAULT_QUERY_KEY, (prev) => [
         ...(prev ?? []),
         optimistic,
       ])
@@ -112,7 +143,7 @@ export function useCreatePolicy() {
 
     onError: (_err, _vars, context) => {
       if (context && 'previous' in context) {
-        queryClient.setQueryData(['policies'], context.previous)
+        queryClient.setQueryData(POLICIES_DEFAULT_QUERY_KEY, context.previous)
       }
     },
 
@@ -120,7 +151,7 @@ export function useCreatePolicy() {
     // replaced by the real `PolicyResponse` (with the server-assigned
     // version, rule_count, and active flag).
     onSettled: () => {
-      ignorePromise(queryClient.invalidateQueries({ queryKey: ['policies'] }))
+      ignorePromise(queryClient.invalidateQueries({ queryKey: POLICIES_QUERY_KEY }))
     },
   })
 }

--- a/dashboard/src/pages/PoliciesPage.css
+++ b/dashboard/src/pages/PoliciesPage.css
@@ -56,6 +56,35 @@
   outline-offset: 1px;
 }
 
+/* History toggle (AAASM-5143): matches the secondary button chrome, with a
+   pressed state when archived versions are being shown. */
+.policies-page__history-btn {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ink);
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.policies-page__history-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.policies-page__history-btn:focus-visible {
+  outline: 2px solid var(--info);
+  outline-offset: 1px;
+}
+
+.policies-page__history-btn--on {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--paper);
+}
+
 .policies-page__title {
   margin: 0;
   font-size: 1.5rem;
@@ -295,6 +324,26 @@
   border-radius: 4px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+/* Archived (older) policy versions surfaced by the history toggle (AAASM-5143):
+   a muted uppercase tag plus a dimmed row so live versions stay foregrounded. */
+.policies-list__chip-archived {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.375rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--ink-4);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.policies-list__row--archived {
+  opacity: 0.72;
 }
 
 /* ── Skeleton loading rows ───────────────────────────────── */

--- a/dashboard/src/pages/PoliciesPage.test.tsx
+++ b/dashboard/src/pages/PoliciesPage.test.tsx
@@ -776,3 +776,28 @@ describe('PoliciesPage list-row reach and hits', () => {
     expect(screen.getByTestId('policy-row-hits')).toHaveTextContent('142')
   })
 })
+
+// ── AAASM-5143: history toggle for archived policy versions ─────────────────
+
+describe('PoliciesPage — history toggle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts with history off — queries active-only versions', () => {
+    const spy = mockPolicies({ data: [ACTIVE_POLICY], isLoading: false, isError: false, refetch: vi.fn() })
+    render(<PoliciesPage />, { wrapper: Wrapper })
+    expect(spy).toHaveBeenCalledWith({ includeArchived: false })
+    expect(screen.getByTestId('policy-history-toggle')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('re-runs the query with include_archived when the toggle is clicked', async () => {
+    const user = userEvent.setup()
+    const spy = mockPolicies({ data: [ACTIVE_POLICY], isLoading: false, isError: false, refetch: vi.fn() })
+    render(<PoliciesPage />, { wrapper: Wrapper })
+    await user.click(screen.getByTestId('policy-history-toggle'))
+    expect(spy).toHaveBeenLastCalledWith({ includeArchived: true })
+    expect(screen.getByTestId('policy-history-toggle')).toHaveAttribute('aria-pressed', 'true')
+  })
+
+})

--- a/dashboard/src/pages/PoliciesPage.test.tsx
+++ b/dashboard/src/pages/PoliciesPage.test.tsx
@@ -800,4 +800,27 @@ describe('PoliciesPage — history toggle', () => {
     expect(screen.getByTestId('policy-history-toggle')).toHaveAttribute('aria-pressed', 'true')
   })
 
+  it('marks inactive rows as archived only once history is on', async () => {
+    const user = userEvent.setup()
+    // An active + an inactive (archived) version, as the endpoint returns them
+    // under include_archived.
+    mockPolicies({
+      data: [ACTIVE_POLICY, PROPOSED_POLICY],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    })
+    render(<PoliciesPage />, { wrapper: Wrapper })
+    // History off: no archived marker even though a row is inactive.
+    expect(screen.queryByTestId('policy-row-archived-tag')).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('policy-history-toggle'))
+
+    // History on: exactly the inactive row carries the archived tag.
+    const tags = screen.getAllByTestId('policy-row-archived-tag')
+    expect(tags).toHaveLength(1)
+    const rows = screen.getAllByTestId('policy-row')
+    expect(rows[0]).not.toHaveAttribute('data-archived')
+    expect(rows[1]).toHaveAttribute('data-archived', 'true')
+  })
 })

--- a/dashboard/src/pages/PoliciesPage.tsx
+++ b/dashboard/src/pages/PoliciesPage.tsx
@@ -146,7 +146,11 @@ function PolicyRowAffects({ affects }: Readonly<{ affects: Policy['affects'] }>)
   )
 }
 
-function PolicyRow({ policy, onEdit }: Readonly<{ policy: Policy; onEdit: () => void }>) {
+function PolicyRow({
+  policy,
+  archived,
+  onEdit,
+}: Readonly<{ policy: Policy; archived: boolean; onEdit: () => void }>) {
   const proposed = !policy.active
   // The aa-api `PolicyResponse` has no `scope` field, so recover it from the
   // raw `policy_yaml` via the same parse the editor's draftFromPolicy uses.
@@ -155,13 +159,26 @@ function PolicyRow({ policy, onEdit }: Readonly<{ policy: Policy; onEdit: () => 
     <li>
       <button
         type="button"
-        className="policies-list__row"
+        className={
+          archived
+            ? 'policies-list__row policies-list__row--archived'
+            : 'policies-list__row'
+        }
         data-testid="policy-row"
+        data-archived={archived ? 'true' : undefined}
         onClick={onEdit}
       >
         <span className="policies-list__row-main">
           <span className="policies-list__row-name">
             {policy.name}
+            {archived ? (
+              <span
+                className="policies-list__chip-archived"
+                data-testid="policy-row-archived-tag"
+              >
+                archived
+              </span>
+            ) : null}
             {proposed ? (
               <span className="policies-list__chip-draft">draft</span>
             ) : null}
@@ -294,6 +311,12 @@ interface PoliciesContentProps {
   readonly onNew: () => void
   readonly onEdit: (policy: Policy) => void
   readonly canWrite: boolean
+  /**
+   * History mode is on (AAASM-5143). When true, inactive rows are the older
+   * archived versions the gateway only returns under include_archived, so they
+   * carry the archived marker.
+   */
+  readonly showHistory: boolean
 }
 
 /**
@@ -310,6 +333,7 @@ function PoliciesContent({
   onNew,
   onEdit,
   canWrite,
+  showHistory,
 }: PoliciesContentProps) {
   if (isError) {
     return (
@@ -359,6 +383,7 @@ function PoliciesContent({
         <PolicyRow
           key={`${policy.name}-${policy.version}`}
           policy={policy}
+          archived={showHistory && !policy.active}
           onEdit={() => onEdit(policy)}
         />
       ))}
@@ -367,7 +392,12 @@ function PoliciesContent({
 }
 
 export function PoliciesPage() {
-  const { data: policies, isLoading, isError, refetch } = usePoliciesQuery()
+  // History toggle (AAASM-5143): off shows only the in-force version, on asks
+  // the gateway for older (archived) versions too via include_archived.
+  const [showHistory, setShowHistory] = useState(false)
+  const { data: policies, isLoading, isError, refetch } = usePoliciesQuery({
+    includeArchived: showHistory,
+  })
   const { data: sandboxSummary } = useSandboxSummaryQuery({ window: '24h' })
   const [filter, setFilter] = useState<FilterTab>('all')
   const { openOverlay, closeOverlay } = useOverlay('policy-editor')
@@ -381,6 +411,8 @@ export function PoliciesPage() {
   // by the editor overlay's footer "Simulate impact" (AAASM-5142).
   const openSimulate = useCallback(() => setSimulateOpen(true), [])
   const closeSimulate = useCallback(() => setSimulateOpen(false), [])
+
+  const toggleHistory = useCallback(() => setShowHistory((on) => !on), [])
 
   // Observe-mode policies detected by parsing each policy_yaml client-side.
   // The aa-api `PolicyResponse` doesn't expose `enforcement_mode` as a
@@ -474,6 +506,19 @@ export function PoliciesPage() {
         <div className="policies-page__head-actions">
           <button
             type="button"
+            className={
+              showHistory
+                ? 'policies-page__history-btn policies-page__history-btn--on'
+                : 'policies-page__history-btn'
+            }
+            data-testid="policy-history-toggle"
+            aria-pressed={showHistory}
+            onClick={toggleHistory}
+          >
+            history
+          </button>
+          <button
+            type="button"
             className="policies-page__simulate-btn"
             data-testid="open-simulate-btn"
             onClick={openSimulate}
@@ -513,6 +558,7 @@ export function PoliciesPage() {
         onNew={handleNew}
         onEdit={handleEdit}
         canWrite={canWrite}
+        showHistory={showHistory}
       />
 
       <OverlayHost name="policy-editor" onRequestClose={attemptCloseEditor}>


### PR DESCRIPTION
## Description

Adds a `history` toggle to the Policies page header. When on, it re-runs
`usePoliciesQuery` with `include_archived=true` (`GET /api/v1/policies?include_archived`)
so older, inactive policy versions come back, and it visually marks those
archived rows with an uppercase `archived` tag and a dimmed row. Matches the
`design/v1/hi-fi/policy.jsx` header (`+ new policy`, `history`, `▸ Simulate`).

The `include_archived` flag is now part of the query key so the active-only and
history views cache independently; `useCreatePolicy`'s optimistic cache ops are
retargeted at the exact default-view key.

Archived vs proposed: `PolicyResponse` carries no `archived`/`status` field on
the wire, so the marker is derived honestly — a row is shown as archived only
when history mode is on and the version is inactive (`active === false`), i.e.
one of the older versions the endpoint surfaces solely under `include_archived`.
No archived data is fabricated; it comes from the API.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5143

## Testing

- [x] Unit tests added / updated
- [x] No integration tests required

New tests (`features/policies/api.test.tsx`, `pages/PoliciesPage.test.tsx`):
- default query sends `include_archived=false`; toggle sends `true`
- clicking the header toggle re-runs the query with `{ includeArchived: true }`
- the archived marker appears on inactive rows only once history is on

Local gate (from `dashboard/`): `tsc --noEmit` clean, `eslint .` clean,
`vitest run` — 3078 passed. Browser verification was not possible without a
live gateway (the page is admin-scope gated and needs a backend for policy
data); behaviour is covered by the rendered-DOM component tests above.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
