### PR TITLE
[AAASM-5170] ♻️ (agent-detail): Restore full Capability snapshot and Recent traffic tab labels

### DIFF
--- a/dashboard/src/pages/AgentDetailDrawer.css
+++ b/dashboard/src/pages/AgentDetailDrawer.css
@@ -58,6 +58,13 @@
   color: var(--danger);
 }
 
+.ad-head__note {
+  margin-top: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--danger);
+}
+
 .ad-head__chip {
   display: inline-flex;
   align-items: center;

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -258,6 +258,13 @@ describe('AgentDetailPage drawer head flag note (AAASM-5163)', () => {
     const note = await screen.findByTestId('agent-detail-note')
     expect(note).toHaveTextContent('⚠ quarantined pending review')
   })
+
+  it('omits the note sub-line when metadata carries no note', async () => {
+    mockAgentDetail({ ...MOCK_AGENT, metadata: { owner: 'alice' } })
+    renderApp('/agents/abc123')
+    await screen.findByTestId('agent-detail')
+    expect(screen.queryByTestId('agent-detail-note')).not.toBeInTheDocument()
+  })
 })
 
 describe('AgentDetailPage close behavior', () => {

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -187,6 +187,26 @@ function mockSuspendedAgent() {
   )
 }
 
+// AAASM-5163: mount the drawer for one specific agent (custom metadata /
+// last_event) so the flag-note and last-seen assertions control their inputs.
+function mockAgentDetail(agent: Agent) {
+  mockCapabilityMatrix()
+  vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+    mockQuery<Agent[]>({ data: [agent], isLoading: false, isError: false, refetch: vi.fn() }),
+  )
+  vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+    mockQuery<Agent | undefined>({ data: agent, isLoading: false, isError: false, refetch: vi.fn() }),
+  )
+  vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+    mockQuery<LogEntry[]>({ data: [MOCK_LOG], isLoading: false, isError: false }),
+  )
+  vi.spyOn(agentsApi, 'useAgentCapabilitiesQuery').mockReturnValue(
+    mockQuery<agentsApi.EffectivePermissions>({
+      data: { allow: [], deny: [], sources: [] }, isLoading: false, isError: false,
+    }),
+  )
+}
+
 afterEach(() => { vi.restoreAllMocks() })
 
 describe('AgentDetailPage deep link', () => {
@@ -228,6 +248,15 @@ describe('AgentDetailPage deep link', () => {
     mockCapabilityMatrix()
     renderApp('/agents/abc123')
     expect(await screen.findByTestId('agent-detail-did')).toHaveTextContent('did:agent:agent-assembly:abc123')
+  })
+})
+
+describe('AgentDetailPage drawer head flag note (AAASM-5163)', () => {
+  it('renders the ⚠-prefixed note when metadata carries one', async () => {
+    mockAgentDetail({ ...MOCK_AGENT, metadata: { owner: 'alice', note: 'quarantined pending review' } })
+    renderApp('/agents/abc123')
+    const note = await screen.findByTestId('agent-detail-note')
+    expect(note).toHaveTextContent('⚠ quarantined pending review')
   })
 })
 

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -294,6 +294,17 @@ describe('AgentDetailPage decision-mix empty state (AAASM-5164)', () => {
   })
 })
 
+describe('AgentDetailPage tab labels (AAASM-5170)', () => {
+  it('renders the full Capability snapshot and Recent traffic tab labels', async () => {
+    mockHappyPath()
+    renderApp('/agents/abc123')
+    expect(await screen.findByTestId('agent-detail-tab-capability')).toHaveTextContent(
+      'Capability snapshot',
+    )
+    expect(screen.getByTestId('agent-detail-tab-traffic')).toHaveTextContent('Recent traffic')
+  })
+})
+
 describe('AgentDetailPage close behavior', () => {
   it('closes back to /agents when the breadcrumb button is clicked', async () => {
     mockHappyPath()

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -275,6 +275,13 @@ describe('AgentDetailPage identity last-seen (AAASM-5163)', () => {
     expect(lastSeen).toHaveTextContent(/last seen \d+[smhd] ago/)
     expect(lastSeen).not.toHaveTextContent('2026-05-12T00:00:00Z')
   })
+
+  it('renders an em-dash for last-seen when the agent has no last event', async () => {
+    mockAgentDetail({ ...MOCK_AGENT, last_event: null })
+    renderApp('/agents/abc123')
+    const lastSeen = await screen.findByTestId('agent-detail-last-seen')
+    expect(lastSeen).toHaveTextContent('last seen —')
+  })
 })
 
 describe('AgentDetailPage close behavior', () => {

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -284,6 +284,16 @@ describe('AgentDetailPage identity last-seen (AAASM-5163)', () => {
   })
 })
 
+describe('AgentDetailPage decision-mix empty state (AAASM-5164)', () => {
+  it('shows an honest empty state and not the internal placeholder shorthand', async () => {
+    mockHappyPath()
+    renderApp('/agents/abc123')
+    const empty = await screen.findByTestId('agent-detail-traffic-mix-empty')
+    expect(empty).toHaveTextContent('Decision mix is not available yet')
+    expect(screen.queryByText(/wired in a follow-up sub-task/i)).not.toBeInTheDocument()
+  })
+})
+
 describe('AgentDetailPage close behavior', () => {
   it('closes back to /agents when the breadcrumb button is clicked', async () => {
     mockHappyPath()

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -267,6 +267,16 @@ describe('AgentDetailPage drawer head flag note (AAASM-5163)', () => {
   })
 })
 
+describe('AgentDetailPage identity last-seen (AAASM-5163)', () => {
+  it('humanizes the last-seen ISO timestamp rather than printing it raw', async () => {
+    mockAgentDetail({ ...MOCK_AGENT, last_event: '2026-05-12T00:00:00Z' })
+    renderApp('/agents/abc123')
+    const lastSeen = await screen.findByTestId('agent-detail-last-seen')
+    expect(lastSeen).toHaveTextContent(/last seen \d+[smhd] ago/)
+    expect(lastSeen).not.toHaveTextContent('2026-05-12T00:00:00Z')
+  })
+})
+
 describe('AgentDetailPage close behavior', () => {
   it('closes back to /agents when the breadcrumb button is clicked', async () => {
     mockHappyPath()

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useAgentQuery, useAgentEventsQuery, useAgentEnforcementQuery, type Agent } from '../features/agents/api'
 import { extractSandboxInfo } from '../features/audit/api'
 import { useSuspendAgent, useResumeAgent } from '../features/agents/mutations'
-import { toFleetAgent } from '../features/agents/fleetTypes'
+import { toFleetAgent, formatLastSeen } from '../features/agents/fleetTypes'
 import { Drawer } from '../components/Drawer'
 import { SuspendReasonDialog } from '../components/SuspendReasonDialog'
 import { StatusChip } from '../components/fleet/StatusChip'
@@ -86,9 +86,9 @@ function IdentityStrip({ agent }: Readonly<{ agent: Agent }>) {
         <p className="ad-identity__did" data-testid="agent-detail-did">
           did:agent:{ownerSlug}:{agent.id}
         </p>
-        {fleetAgent.lastSeen && (
-          <p className="ad-identity__did-meta">last seen {fleetAgent.lastSeen}</p>
-        )}
+        <p className="ad-identity__did-meta" data-testid="agent-detail-last-seen">
+          last seen {formatLastSeen(fleetAgent.lastSeen)}
+        </p>
       </div>
 
       <TrustGauge score={fleetAgent.trust} />

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -262,6 +262,11 @@ export function AgentDetailPage() {
                     <span className="ad-head__owner">@{toFleetAgent(agent).owner}</span>
                   )}
                 </h1>
+                {toFleetAgent(agent).note && (
+                  <p className="ad-head__note" data-testid="agent-detail-note">
+                    ⚠ {toFleetAgent(agent).note}
+                  </p>
+                )}
               </div>
               <div className="ad-head__actions">
                 <button

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -133,8 +133,8 @@ type AgentDetailTab = 'overview' | 'capability' | 'traffic' | 'policies' | 'line
 
 const TABS: ReadonlyArray<{ id: AgentDetailTab; label: string }> = [
   { id: 'overview',   label: 'Overview' },
-  { id: 'capability', label: 'Capability' },
-  { id: 'traffic',    label: 'Traffic' },
+  { id: 'capability', label: 'Capability snapshot' },
+  { id: 'traffic',    label: 'Recent traffic' },
   { id: 'policies',   label: 'Policies' },
   { id: 'lineage',    label: 'Lineage' },
   { id: 'config',     label: 'Config' },

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -338,8 +338,11 @@ export function AgentDetailPage() {
                   <section className="ad-card">
                     <h2 className="ad-card__title">traffic mix · last 24h</h2>
                     <div className="ad-traffic-mix" data-testid="agent-detail-traffic-mix">
-                      <div className="ad-traffic-mix__seg ad-traffic-mix__seg--placeholder">
-                        wired in a follow-up sub-task
+                      <div
+                        className="ad-traffic-mix__seg ad-traffic-mix__seg--placeholder"
+                        data-testid="agent-detail-traffic-mix-empty"
+                      >
+                        Decision mix is not available yet
                       </div>
                     </div>
                   </section>


### PR DESCRIPTION
## Description

The agent-detail drawer's tab strip rendered the abbreviated labels `Capability` and `Traffic`, but the hi-fi spec `design/v1/hi-fi/agent-detail.jsx` (`:272-273`) specifies the full labels `Capability snapshot` and `Recent traffic`. The abbreviation also created an internal inconsistency: the Overview card at `:380` already reads "capability snapshot", so the tab and the card disagreed.

This PR restores the two spec label strings. Tab order and the other four labels (Overview / Policies / Lineage / Config) already matched, so they are untouched. No `id`, routing, or `data-testid` changed — only the two display strings.

> **Stacked on** #1787 (AAASM-5164), which is itself stacked on #1785 (AAASM-5163). Merge in order 5163 → 5164 → 5170; this branch's diff collapses once its parents land on `main`.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5170

## Testing

- [x] Unit tests added / updated
- [ ] No tests required

New regression test in `dashboard/src/pages/AgentDetailPage.test.tsx`:
- `renders the full Capability snapshot and Recent traffic tab labels` — asserts both tabs carry their full spec label text (guards against the same abbreviation regressing again).

No existing test asserted the old `Capability` / `Traffic` label text (the tab tests key off `data-testid` + `aria-selected`), so none needed adjusting.

Local gate (from `dashboard/`), all clean:
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm exec eslint .` — 0 problems
- `pnpm exec vitest run` — 276 files / 3079 tests passed

**Verification method:** DOM-level unit-test assertion + code inspection against the design spec. No live-app/Playwright screenshot was captured in this run, so there is no `dashboard/verify/AAASM-5170/` artifact.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
- [x] All CI checks passing (pending CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
