### PR TITLE
[AAASM-5172] ♻️ (dashboard): Small parity + truthfulness fixes across Costs, Teams, Topology, sessions, audit

### DIFF
--- a/dashboard/src/components/costs/BudgetTree.css
+++ b/dashboard/src/components/costs/BudgetTree.css
@@ -150,6 +150,12 @@
   color: var(--ink-4);
 }
 
+/* No limit configured → no burn fraction. Neutral ink, matching the em-dash
+   tone of the sibling "Limit" and "% parent" cells (AAASM-5172). */
+.budget-tree__burn-absent {
+  color: var(--ink-4);
+}
+
 .budget-tree__burn-track {
   position: relative;
   height: 5px;

--- a/dashboard/src/components/costs/BudgetTree.test.tsx
+++ b/dashboard/src/components/costs/BudgetTree.test.tsx
@@ -72,9 +72,36 @@ describe('BudgetTree', () => {
     expect(screen.getByTestId('budget-node-team-a')).toBeInTheDocument()
     expect(screen.getByTestId('budget-node-root-a')).toBeInTheDocument()
     expect(screen.queryByTestId('budget-node-child-a')).not.toBeInTheDocument()
-    // Kind badge and governance level surface on the agent row.
+    // Kind badge and governance level surface on the agent row. The level is
+    // shown in its two-char form (L0), with the full enum in the chip title
+    // (AAASM-5172).
     expect(screen.getByTestId('budget-node-root-a')).toHaveAttribute('data-kind', 'agent')
-    expect(screen.getAllByText('L0Discover').length).toBeGreaterThan(0)
+    const govChips = screen.getAllByText('L0')
+    expect(govChips.length).toBeGreaterThan(0)
+    expect(govChips[0]).toHaveAttribute('title', 'L0Discover')
+  })
+
+  it('renders each governance level as its two-char tag', () => {
+    const levels: BudgetTreeData = {
+      root: {
+        id: 'org',
+        label: 'org',
+        kind: 'org',
+        depth: 0,
+        budget_limit_usd: '100',
+        own_spend_usd: '0',
+        subtree_spend_usd: '0',
+        children: [
+          { id: 'e', label: 'e', kind: 'agent', depth: 1, budget_limit_usd: '10', own_spend_usd: '1', subtree_spend_usd: '1', governance_level: 'L2Enforce', children: [] },
+          { id: 'n', label: 'n', kind: 'agent', depth: 1, budget_limit_usd: '10', own_spend_usd: '1', subtree_spend_usd: '1', governance_level: 'L3Native', children: [] },
+        ],
+      },
+    }
+    render(<BudgetTree data={levels} isLoading={false} isError={false} />)
+
+    expect(screen.getByText('L2')).toHaveAttribute('title', 'L2Enforce')
+    expect(screen.getByText('L3')).toHaveAttribute('title', 'L3Native')
+    expect(screen.queryByText('L2Enforce')).not.toBeInTheDocument()
   })
 
   it('expands and collapses a node with children on click', async () => {

--- a/dashboard/src/components/costs/BudgetTree.test.tsx
+++ b/dashboard/src/components/costs/BudgetTree.test.tsx
@@ -153,4 +153,27 @@ describe('BudgetTree', () => {
     expect(screen.getByTestId('budget-tree-empty')).toBeInTheDocument()
     expect(screen.queryByTestId('budget-tree-grid')).not.toBeInTheDocument()
   })
+
+  it('dashes the subtree burn for a node with no configured limit', () => {
+    // A node that has spent money but has no ceiling has no burn fraction to
+    // report. It must read as an em-dash, never a fabricated 0.0% that scans as
+    // a measured zero burn (AAASM-5172).
+    const noLimit: BudgetTreeData = {
+      root: {
+        id: 'acme',
+        label: 'acme',
+        kind: 'org',
+        depth: 0,
+        budget_limit_usd: null,
+        own_spend_usd: '12.00',
+        subtree_spend_usd: '12.00',
+        children: [],
+      },
+    }
+    render(<BudgetTree data={noLimit} isLoading={false} isError={false} />)
+
+    const row = screen.getByTestId('budget-node-acme')
+    expect(row).toHaveTextContent('—')
+    expect(row).not.toHaveTextContent('0.0%')
+  })
 })

--- a/dashboard/src/components/costs/BudgetTree.tsx
+++ b/dashboard/src/components/costs/BudgetTree.tsx
@@ -30,7 +30,7 @@ interface RowMetrics {
   readonly limit: number
   readonly own: number
   readonly subtree: number
-  readonly totalPct: number
+  readonly totalPct: number | null
   readonly ownPct: number
   readonly childPct: number
   readonly parentPct: number | null
@@ -41,6 +41,14 @@ interface RowMetrics {
  * Derive the spend/limit percentages a row renders. A subtree burn is capped at
  * 100%; the own-spend band never overflows the remaining track. `parentPct` is
  * null at the root (no parent budget to consume a share of).
+ *
+ * `totalPct` is `null` when the node has no configured limit: a burn is a
+ * fraction of a ceiling, and with no ceiling there is no fraction — the row
+ * that printed `0.0%` was reporting a measured non-burn where nothing was
+ * measured, the same false negative the Limit column already dashes
+ * (AAASM-5172). The `ownPct` / `childPct` bar widths stay `0` (they draw an
+ * empty track, which honestly matches the em-dash figure) and `color` falls
+ * back to the neutral `ok` token.
  */
 function rowMetrics(node: BudgetTreeNode, parentLimit: number): RowMetrics {
   const limit = num(node.budget_limit_usd)
@@ -48,32 +56,51 @@ function rowMetrics(node: BudgetTreeNode, parentLimit: number): RowMetrics {
   const subtree = num(node.subtree_spend_usd)
   const childSpend = Math.max(0, subtree - own)
 
-  const totalPct = limit > 0 ? Math.min(100, (subtree / limit) * 100) : 0
+  const totalPct = limit > 0 ? Math.min(100, (subtree / limit) * 100) : null
   const ownPct = limit > 0 ? Math.min(100, (own / limit) * 100) : 0
   const childPct = limit > 0 ? Math.min(100 - ownPct, (childSpend / limit) * 100) : 0
   const parentPct = parentLimit > 0 ? Math.min(100, (subtree / parentLimit) * 100) : null
 
-  return { limit, own, subtree, totalPct, ownPct, childPct, parentPct, color: burnColor(totalPct) }
+  return {
+    limit,
+    own,
+    subtree,
+    totalPct,
+    ownPct,
+    childPct,
+    parentPct,
+    color: burnColor(totalPct ?? 0),
+  }
 }
 
 interface BurnMeterProps {
-  readonly totalPct: number
+  readonly totalPct: number | null
   readonly ownPct: number
   readonly childPct: number
   readonly color: string
   readonly showSub: boolean
 }
 
-/** Subtree-burn cell: total percent, an optional sub-agent share, and the bar. */
+/**
+ * Subtree-burn cell: total percent, an optional sub-agent share, and the bar.
+ *
+ * A `null` `totalPct` means the node has no limit, so there is no burn fraction
+ * to state — the meta renders an em-dash rather than a fabricated `0.0%`
+ * (AAASM-5172), and the bar draws an empty track.
+ */
 function BurnMeter({ totalPct, ownPct, childPct, color, showSub }: BurnMeterProps) {
   return (
     <div className="budget-tree__burn">
       <div className="budget-tree__burn-meta">
-        <span style={{ color, fontWeight: 600 }}>{totalPct.toFixed(1)}%</span>
+        {totalPct == null ? (
+          <span className="budget-tree__burn-absent">—</span>
+        ) : (
+          <span style={{ color, fontWeight: 600 }}>{totalPct.toFixed(1)}%</span>
+        )}
         {showSub && <span className="budget-tree__burn-sub">+{childPct.toFixed(0)}% sub-agents</span>}
       </div>
       <div className="budget-tree__burn-track">
-        <div className="budget-tree__burn-total" style={{ width: `${totalPct}%`, background: color }} />
+        <div className="budget-tree__burn-total" style={{ width: `${totalPct ?? 0}%`, background: color }} />
         {ownPct > 0 && (
           <div className="budget-tree__burn-own" style={{ width: `${ownPct}%`, background: color }} />
         )}
@@ -179,7 +206,7 @@ function BudgetRow({ node, parentLimit, expanded, onToggle }: RowProps) {
   return (
     <>
       <div
-        className={`budget-tree__row${m.totalPct >= 85 ? ' budget-tree__row--critical' : ''}`}
+        className={`budget-tree__row${m.totalPct != null && m.totalPct >= 85 ? ' budget-tree__row--critical' : ''}`}
         data-testid={`budget-node-${node.id}`}
         data-kind={node.kind}
       >

--- a/dashboard/src/components/costs/BudgetTree.tsx
+++ b/dashboard/src/components/costs/BudgetTree.tsx
@@ -26,6 +26,17 @@ function caretGlyph(hasKids: boolean, open: boolean): string {
   return open ? '▾' : '▸'
 }
 
+/**
+ * Short governance-level tag for the 9px 2-char chip. The registry emits the
+ * full Rust enum name (`L0Discover` … `L3Native`), which overflowed the chip;
+ * the leading `L<n>` is the level. An unrecognised value is passed through
+ * verbatim rather than mangled — better a wide chip than a wrong label
+ * (AAASM-5172).
+ */
+function shortGovernance(level: string): string {
+  return /^L[0-3]/.test(level) ? level.slice(0, 2) : level
+}
+
 interface RowMetrics {
   readonly limit: number
   readonly own: number
@@ -132,7 +143,11 @@ function NameCell({ node, hasKids, open, onToggle }: NameCellProps) {
       <span className="budget-tree__label" title={node.label}>
         {node.label}
       </span>
-      {node.governance_level && <span className="budget-tree__gov">{node.governance_level}</span>}
+      {node.governance_level && (
+        <span className="budget-tree__gov" title={node.governance_level}>
+          {shortGovernance(node.governance_level)}
+        </span>
+      )}
     </>
   )
 

--- a/dashboard/src/components/fleet/StatusChip.test.tsx
+++ b/dashboard/src/components/fleet/StatusChip.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { StatusChip } from './StatusChip'
+
+describe('StatusChip', () => {
+  it('styles each known status with its own kind', () => {
+    for (const status of ['active', 'idle', 'suspended', 'error'] as const) {
+      const { unmount } = render(<StatusChip status={status} />)
+      expect(screen.getByTestId('fleet-status')).toHaveClass(`fleet-status--${status}`)
+      unmount()
+    }
+  })
+
+  it('tones a running session as active while keeping the running label', () => {
+    // The active-sessions endpoint emits "running"; it must read as active
+    // (green), not fall into the grey unknown bucket, and the label must stay
+    // truthful to what the wire said (AAASM-5172).
+    render(<StatusChip status="running" />)
+    const chip = screen.getByTestId('fleet-status')
+    expect(chip).toHaveClass('fleet-status--active')
+    expect(chip).toHaveTextContent('running')
+  })
+
+  it('falls back to the unknown kind for an unrecognised status', () => {
+    render(<StatusChip status="quarantined" />)
+    expect(screen.getByTestId('fleet-status')).toHaveClass('fleet-status--unknown')
+  })
+})

--- a/dashboard/src/components/fleet/StatusChip.tsx
+++ b/dashboard/src/components/fleet/StatusChip.tsx
@@ -19,8 +19,20 @@ const GLYPH: Record<FleetStatusKind, string> = {
 
 const KNOWN: readonly FleetStatusKind[] = ['active', 'idle', 'suspended', 'error']
 
+// Synonyms the wire emits for one of the known kinds. The fleet registry and
+// `GET /api/v1/fleet/active-sessions` both live behind this chip, and the
+// sessions endpoint reports a live session as `running` where the fleet uses
+// `active`. Aliasing it here maps the *tone* (active-green glyph) without
+// widening the agent `FleetStatusKind` vocabulary — a session that is running
+// still reads "running", it just no longer falls into the grey unknown bucket
+// (AAASM-5172).
+const ALIAS: Readonly<Record<string, FleetStatusKind>> = {
+  running: 'active',
+}
+
 function classify(status: string): FleetStatusKind | 'unknown' {
-  return (KNOWN as readonly string[]).includes(status) ? (status as FleetStatusKind) : 'unknown'
+  if ((KNOWN as readonly string[]).includes(status)) return status as FleetStatusKind
+  return ALIAS[status] ?? 'unknown'
 }
 
 /**

--- a/dashboard/src/features/costs/costKpis.test.ts
+++ b/dashboard/src/features/costs/costKpis.test.ts
@@ -42,7 +42,7 @@ describe('deriveCostKpis — daily / monthly / tracked figures', () => {
     expect(kpis.monthly).toEqual({ spend: 3200, limit: 5000, pct: 64 })
   })
 
-  it('counts agents and teams tracked from the summary rows', () => {
+  it('counts agents from the summary rows and teams from the joined roster', () => {
     const kpis = deriveCostKpis(known(COSTS), known(TEAM_ROWS))
 
     expect(kpis.agentsTracked).toEqual(known(2))
@@ -195,12 +195,26 @@ describe('deriveCostKpis — AAASM-5185: a count states its own coverage', () =>
     expect(kpis.daily).toEqual({ spend: null, limit: null, pct: null })
   })
 
-  it('reports tracked counts as absent when the summary carries no breakdown', () => {
+  it('reports agentsTracked as absent when the summary carries no breakdown', () => {
     const bare: CostSummary = { date: '2026-05-13', daily_spend_usd: '42.00' }
     const kpis = deriveCostKpis(known(bare), known([]))
 
     expect(isAbsent(kpis.agentsTracked) && kpis.agentsTracked.state).toBe('unconfigured')
-    expect(isAbsent(kpis.teamsTracked) && kpis.teamsTracked.state).toBe('unconfigured')
+  })
+
+  it('counts teamsTracked from the joined roster, not the summary breakdown', () => {
+    // The "across N teams" caption must agree with the Per-team tab count, which
+    // is `teamRows.length`. Sourcing it from `summary.per_team` let the two
+    // report different team totals on one page (AAASM-5172). A resolved roster
+    // of two teams reads two teams even when the summary carried no per-team
+    // cost breakdown at all.
+    const bare: CostSummary = { date: '2026-05-13', daily_spend_usd: '42.00' }
+    const kpis = deriveCostKpis(
+      known(bare),
+      known([row({ team_id: 'a' }), row({ team_id: 'b' })]),
+    )
+
+    expect(kpis.teamsTracked).toEqual(known(2))
   })
 
   it('keeps an empty breakdown a measured zero', () => {

--- a/dashboard/src/features/costs/costKpis.ts
+++ b/dashboard/src/features/costs/costKpis.ts
@@ -67,7 +67,7 @@ export interface CostKpis {
   readonly monthly: PeriodSpend
   /** Number of agents with a per-agent cost row today. */
   readonly agentsTracked: Certain<number>
-  /** Number of teams with a per-team cost row today (the "across N teams" figure). */
+  /** Number of teams in the joined roster (the "across N teams" figure). */
   readonly teamsTracked: Certain<number>
   /**
    * `daily.spend / agentsTracked` — the mock's "Avg / agent today" KPI
@@ -222,7 +222,13 @@ export function deriveCostKpis(
     daily,
     monthly: periodSpend(summary?.monthly_spend_usd, summary?.monthly_limit_usd),
     agentsTracked,
-    teamsTracked: trackedCount(costs, summary?.per_team),
+    // The "across N teams" caption counts the same joined roster the Per-team
+    // tab counts (`teamRows`), not the summary's `per_team` breakdown array.
+    // The two are different populations — a team with agents but no cost row
+    // appears in the roster and not in the breakdown — so sourcing them
+    // separately let the KPI strip and the tab report two different team
+    // counts on one page (AAASM-5172).
+    teamsTracked: mapCertain(teamRows, rows => rows.length),
     avgPerAgent: averagePerAgent(daily.spend, agentsTracked),
   }
 }

--- a/dashboard/src/features/teams/TeamListPane.test.tsx
+++ b/dashboard/src/features/teams/TeamListPane.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TeamListPane } from './TeamListPane'
+import { known } from '../../lib/truthfulness'
+import type { TeamListRow } from './api'
+
+function row(over: Partial<TeamListRow> & { team_id: string }): TeamListRow {
+  return {
+    agent_count: 2,
+    root_agent_count: 1,
+    daily_spend_usd: null,
+    daily_limit_usd: null,
+    monthly_spend_usd: null,
+    burn_pct: null,
+    ...over,
+  }
+}
+
+function renderPane(rows: TeamListRow[]) {
+  return render(
+    <TeamListPane
+      rows={rows}
+      selectedId={undefined}
+      onSelect={vi.fn()}
+      isLoading={false}
+      isError={false}
+      orphanCount={known(0)}
+      isOrphanSelected={false}
+      onSelectOrphan={vi.fn()}
+    />,
+  )
+}
+
+describe('TeamListPane', () => {
+  it('labels the mini budget bar with $spend / $limit, not a percentage', () => {
+    // Dollar figures per design/v1/hi-fi/teams.jsx:35-37; the percentage is the
+    // bar colour signal only and must not read as text (AAASM-5172).
+    renderPane([
+      row({ team_id: 'growth', daily_spend_usd: 150, daily_limit_usd: 200, burn_pct: 75 }),
+    ])
+
+    expect(screen.getByText('$150.00 / $200')).toBeInTheDocument()
+    expect(screen.queryByText(/% burn/)).not.toBeInTheDocument()
+  })
+
+  it('omits the bar entirely when a team has no burn figure', () => {
+    renderPane([row({ team_id: 'quiet' })])
+
+    expect(screen.getByText('quiet')).toBeInTheDocument()
+    expect(screen.queryByText(/\$/)).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/teams/TeamListPane.tsx
+++ b/dashboard/src/features/teams/TeamListPane.tsx
@@ -21,14 +21,17 @@ interface TeamListPaneProps {
   onSelectOrphan: () => void
 }
 
-function MiniBudgetBar({ pct }: Readonly<{ pct: number }>) {
+function MiniBudgetBar({ pct, spend, limit }: Readonly<{ pct: number; spend: number; limit: number }>) {
   const color = budgetBucketColor(bucketForRatio(pct / 100))
   return (
     <div>
       <div className="teams-mini-bar">
         <div className="teams-mini-bar__fill" style={{ width: `${Math.min(100, pct)}%`, background: color }} />
       </div>
-      <div className="teams-mini-bar__label">{pct.toFixed(1)}% burn</div>
+      {/* Dollar figures, not the raw percentage, per design/v1/hi-fi/teams.jsx:35-37.
+          The percentage stays the colour signal on the bar above; the label is
+          the spend against the limit an operator can act on (AAASM-5172). */}
+      <div className="teams-mini-bar__label">${spend.toFixed(2)} / ${limit.toFixed(0)}</div>
     </div>
   )
 }
@@ -109,7 +112,9 @@ export function TeamListPane({
               <span className="teams-list-row__name">{row.team_id}</span>
               <span className="teams-list-row__agents">{row.agent_count}×</span>
             </div>
-            {row.burn_pct != null && <MiniBudgetBar pct={row.burn_pct} />}
+            {row.burn_pct != null && row.daily_spend_usd != null && row.daily_limit_usd != null && (
+              <MiniBudgetBar pct={row.burn_pct} spend={row.daily_spend_usd} limit={row.daily_limit_usd} />
+            )}
           </button>
         ))}
 

--- a/dashboard/src/pages/AuditLogPage.css
+++ b/dashboard/src/pages/AuditLogPage.css
@@ -394,6 +394,13 @@
   text-align: center;
 }
 
+.audit-expand-glyph {
+  color: var(--ink-4);
+  font-size: 0.65rem;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  margin-right: 0.4rem;
+}
+
 /* ── Chips ───────────────────────────────────────────────────────────── */
 .audit-chip {
   display: inline-block;

--- a/dashboard/src/pages/AuditLogPage.test.tsx
+++ b/dashboard/src/pages/AuditLogPage.test.tsx
@@ -373,6 +373,18 @@ describe('AuditLogPage', () => {
     expect(within(row).getByText('14:02:11 UTC')).toBeInTheDocument()
   })
 
+  it('shows a ▼/▲ expand glyph that mirrors the row state', async () => {
+    // The disclosure glyph from the mock (design/v1/hi-fi/audit-log.jsx) sits
+    // beside the View link and flips with the row (AAASM-5172).
+    renderPage()
+    const row = await screen.findByTestId('audit-row-1048')
+    const glyph = screen.getByTestId('audit-expand-glyph-1048')
+
+    expect(glyph).toHaveTextContent('▼')
+    fireEvent.click(row)
+    expect(screen.getByTestId('audit-expand-glyph-1048')).toHaveTextContent('▲')
+  })
+
   it('shows the trace id in the expanded metadata when the payload carries one', async () => {
     renderPage()
     fireEvent.click(await screen.findByTestId('audit-row-1048'))

--- a/dashboard/src/pages/AuditLogPage.test.tsx
+++ b/dashboard/src/pages/AuditLogPage.test.tsx
@@ -365,6 +365,14 @@ describe('AuditLogPage', () => {
     expect(within(detail).getByText(/deny-external-mail/)).toBeInTheDocument()
   })
 
+  it('labels the timestamp cell with the UTC zone', async () => {
+    // The wire timestamp is UTC; on a compliance surface the zone must be
+    // explicit so a clock time is not read as local (AAASM-5172).
+    renderPage()
+    const row = await screen.findByTestId('audit-row-1048')
+    expect(within(row).getByText('14:02:11 UTC')).toBeInTheDocument()
+  })
+
   it('shows the trace id in the expanded metadata when the payload carries one', async () => {
     renderPage()
     fireEvent.click(await screen.findByTestId('audit-row-1048'))

--- a/dashboard/src/pages/AuditLogPage.tsx
+++ b/dashboard/src/pages/AuditLogPage.tsx
@@ -373,6 +373,19 @@ export function AuditLogPage() {
                       </td>
                       <td className="audit-session">{e.session_id}</td>
                       <td>
+                        {/* The mock (design/v1/hi-fi/audit-log.jsx:145,197-199)
+                            carries a ▼/▲ disclosure glyph reflecting the row's
+                            expand state; the port dropped it for the View link
+                            alone. Both are restored — the glyph mirrors the
+                            row's click-to-expand, the link is the stable
+                            cross-reference (AAASM-5172). */}
+                        <span
+                          className="audit-expand-glyph"
+                          aria-hidden="true"
+                          data-testid={`audit-expand-glyph-${e.seq}`}
+                        >
+                          {isExp ? '▲' : '▼'}
+                        </span>
                         <Link
                           to={auditEventHref(e.seq)}
                           className="audit-event-link"

--- a/dashboard/src/pages/AuditLogPage.tsx
+++ b/dashboard/src/pages/AuditLogPage.tsx
@@ -319,7 +319,10 @@ export function AuditLogPage() {
                     >
                       <td className="audit-mono audit-session">{e.seq}</td>
                       <td>
-                        <div className="audit-cell-time">{e.timestamp.slice(11, 19)}</div>
+                        {/* The wire timestamp is UTC; on a compliance surface an
+                            unlabelled clock time invites the reader to assume it
+                            is local. Label the zone explicitly (AAASM-5172). */}
+                        <div className="audit-cell-time">{e.timestamp.slice(11, 19)} UTC</div>
                         <div className="audit-cell-date">{e.timestamp.slice(0, 10)}</div>
                       </td>
                       <td>

--- a/dashboard/src/pages/TopologyPage.test.tsx
+++ b/dashboard/src/pages/TopologyPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { UseQueryResult } from '@tanstack/react-query'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -16,9 +17,11 @@ function makeClient() {
 function renderPage() {
   return render(
     <QueryClientProvider client={makeClient()}>
-      <TraceDrawerProvider>
-        <TopologyPage />
-      </TraceDrawerProvider>
+      <MemoryRouter>
+        <TraceDrawerProvider>
+          <TopologyPage />
+        </TraceDrawerProvider>
+      </MemoryRouter>
     </QueryClientProvider>,
   )
 }
@@ -49,6 +52,19 @@ describe('TopologyPage', () => {
     expect(heading).toHaveTextContent('Topology')
     // 3 nodes across 2 teams (support × 2, analytics × 1).
     expect(screen.getByTestId('topology-meta')).toHaveTextContent('3 agents · 2 teams')
+  })
+
+  it('renders the shared empty state — not a blank canvas — for an empty graph', () => {
+    // A resolved graph with no nodes must not draw the control sidebar over a
+    // blank canvas; it shows the shared EmptyState, same as the other empty
+    // surfaces (AAASM-5172).
+    vi.spyOn(topologyApi, 'useTopologyQuery').mockReturnValue(
+      mockQuery({ data: { nodes: [], edges: [] }, isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderPage()
+
+    expect(screen.getByTestId('empty-state-overview')).toBeInTheDocument()
+    expect(screen.queryByTestId('topology-graph-wrapper')).not.toBeInTheDocument()
   })
 
   // ── The unclaimed group is not a team (AAASM-5184) ────────────────────────

--- a/dashboard/src/pages/TopologyPage.tsx
+++ b/dashboard/src/pages/TopologyPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { ignorePromise } from '../lib/ignorePromise'
 import { useTopologyQuery } from '../features/topology/api'
 import { detectDelegationCycles } from '../features/topology/hierarchy'
@@ -6,6 +7,7 @@ import { crossTeamEdges, hiddenCrossTeamCount, teamById } from '../features/topo
 import { defaultVisibleKinds } from '../features/topology/edgeKinds'
 import { countUnclaimed, realTeams } from '../features/topology/unclaimed'
 import { exportGraphJson, exportGraphSvg } from '../features/topology/exportGraph'
+import { EmptyState } from '../components/EmptyState'
 import { TopologyGraph } from '../components/topology/TopologyGraph'
 import { TopologySidebar } from '../components/topology/TopologySidebar'
 import { NodeDetailPanel } from '../components/topology/NodeDetailPanel'
@@ -30,6 +32,7 @@ const ALL_TEAMS = 'all'
 export function TopologyPage() {
   const { data, isLoading, isError, refetch } = useTopologyQuery()
   const { open: openTraceDrawer } = useTraceDrawer()
+  const navigate = useNavigate()
 
   // The selection is held as an *id*, not as the node object.
   //
@@ -212,7 +215,20 @@ export function TopologyPage() {
         </div>
       )}
 
-      {!isLoading && !isError && (
+      {/* A resolved graph with no nodes is a registered-but-empty fleet, not a
+          blank canvas beside a control sidebar that governs nothing. It gets the
+          shared EmptyState the other empty surfaces use — honest "no agents have
+          phoned home" copy, no fabricated stats (AAASM-5172; cf. CapabilityPage,
+          PoliciesPage). */}
+      {!isLoading && !isError && allNodes.length === 0 && (
+        <EmptyState
+          page="overview"
+          onCta={() => navigate('/onboarding')}
+          onSecondary={() => navigate('/onboarding')}
+        />
+      )}
+
+      {!isLoading && !isError && allNodes.length > 0 && (
         <div className="topology-page__body">
           <TopologySidebar
             stats={stats}


### PR DESCRIPTION
## Description

Eight small dashboard parity + truthfulness fixes bundled under AAASM-5172
(`truthfulness-deceptive`). Each addresses a place where the UI printed a
fabricated/misleading value, diverged from the hi-fi mock, or mis-toned a
status. The rule throughout: an absence must read as an absence (em-dash /
honest empty state), never a fake number or wrong status.

1. **Costs — team count** (`features/costs/costKpis.ts`): the "across N teams"
   KPI counted `summary.per_team` while the Per-team tab counted
   `teamRows.length` — two populations that could disagree on one page. Both now
   count the joined roster. (The `'N/A'` → em-dash half of this item was already
   fixed by a prior truthfulness ticket; only the count contradiction remained.)
2. **BudgetTree burn %** (`components/costs/BudgetTree.tsx`): a node with no limit
   rendered `0.0%` burn — a measured non-burn where nothing was measured — while
   its sibling Limit / % parent cells already dashed the same absence. Burn is now
   `number | null` and renders an em-dash when no limit is configured.
3. **Teams list figures** (`features/teams/TeamListPane.tsx`): the mini budget bar
   showed `{pct}% burn`; the mock (`design/v1/hi-fi/teams.jsx:35-37`) shows
   `$spend / $limit`. Dollar figures now label the bar; the percentage stays the
   bar's colour signal only.
4. **Topology empty state** (`pages/TopologyPage.tsx`): an empty graph rendered the
   control sidebar over a blank canvas. It now shows the shared `EmptyState`
   (`overview` copy — no fabricated stats), matching the other empty surfaces.
5. **ActiveSessions status** (`components/fleet/StatusChip.tsx`): the sessions
   endpoint emits `running`, which fell into the grey "unknown" bucket. A contained
   alias maps it to the `active` *kind* (green glyph) **without** widening the agent
   `FleetStatusKind` vocabulary; the label still reads "running".
6. **Governance level chip** (`components/costs/BudgetTree.tsx`): the raw Rust enum
   (`L0Discover`…`L3Native`) overflowed the 9px two-char chip. Rendered as
   `L0`/`L1`/`L2`/`L3`, full value in the chip `title`.
7. **Audit UTC suffix** (`pages/AuditLogPage.tsx`): compliance timestamps had no
   zone label. Appended `UTC`.
8. **Audit expand glyph** (`pages/AuditLogPage.tsx`): restored the mock's ▼/▲
   disclosure glyph (`design/v1/hi-fi/audit-log.jsx:145,197-199`) beside the
   existing View link.

## Type of Change

- [x] 🐛 Bug fix
- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5172

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Local gate (from `dashboard/`): `tsc --noEmit` clean, `eslint .` clean,
`vitest run` all green (278 files / 3101 tests). New/updated tests:
- `costKpis.test.ts` — roster-sourced `teamsTracked`
- `BudgetTree.test.tsx` — burn dash on a limitless node; two-char governance tag + full enum in title
- `TeamListPane.test.tsx` (new) — `$spend / $limit` bar label; bar omitted on absence
- `TopologyPage.test.tsx` — empty-graph `EmptyState`; harness wrapped in a Router
- `StatusChip.test.tsx` (new) — `running`→active tone; unknown fallback
- `AuditLogPage.test.tsx` — UTC label; ▼/▲ glyph state

## Checklist

- [x] Self-review of the diff completed
- [x] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)