### PR TITLE
[AAASM-5175] ✨ (aa-api): Evaluate capability over-permission

### DIFF
--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -76,7 +76,12 @@ pub struct CapCell {
     pub write: Decision,
     pub delete: Decision,
     pub exec: Decision,
-    /// Marks this cell for UI attention (e.g. over-permissioned).
+    /// `Some(true)` when this cell's grant is over-permission — the agent is
+    /// effectively allowed a destructive system verb its declared `RiskTier`
+    /// baseline does not warrant (AAASM-5175, ADR 0029). Absent when the cell is
+    /// within baseline, or when the agent is not evaluated (no resolvable tier,
+    /// or an empty cascade). Only the offending marker is emitted; a per-cell
+    /// `false` is not, so the UI highlights positives without negative clutter.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flag: Option<bool>,
 }
@@ -226,11 +231,20 @@ pub struct CapabilityAgent {
     pub status: AgentStatus,
     /// ISO 8601 UTC timestamp of the agent's most recent heartbeat.
     pub last_seen: String,
-    /// Always absent: flagging an agent as over-permissioned is a scoring rule
-    /// with no implementation in the gateway (see `trust`).
+    /// Over-permission verdict (AAASM-5175, ADR 0029): `Some(true)` when the
+    /// agent is effectively granted a destructive system capability its declared
+    /// `RiskTier` baseline does not warrant, `Some(false)` when it was evaluated
+    /// and found within baseline. Absent when the agent is *not* evaluated — it
+    /// declared no resolvable risk tier, or its policy cascade is empty (in which
+    /// case every cell is `Allow` by fall-through and flagging would be a false
+    /// positive). This is a structural grant-vs-posture signal, distinct from the
+    /// behavioural `trust` score (ADR 0019) and the topology violation-volume flag.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flagged: Option<bool>,
-    /// Always absent: no operator-authored per-agent note exists in the registry.
+    /// When `flagged` is `Some(true)`, a human-readable explanation naming the
+    /// tier and the offending grants (e.g. "Low-risk agent granted file_delete,
+    /// terminal_exec beyond its tier baseline"). Absent otherwise — there is no
+    /// operator-authored note source, so a note only ever accompanies a flag.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     /// Resource-id → CapCell mapping for this agent.

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -63,6 +63,7 @@ use crate::models::capability::{
     Verb,
 };
 use crate::routes::enforcement_mirror::{agent_tool_ids, cascade_denies_all_egress, cascade_denies_tool};
+use crate::routes::over_permission;
 use crate::state::AppState;
 
 /// Reasons a revoke request can fail.
@@ -494,35 +495,70 @@ fn decide(caps: &aa_core::CapabilitySet, cap: &aa_core::Capability) -> Decision 
 /// `egress_denied` carries the network stage's verdict (see
 /// [`cascade_denies_all_egress`]); the capability set alone cannot see an
 /// allowlist-based deny.
-fn system_cell(caps: &aa_core::CapabilitySet, resource_id: &str, egress_denied: bool) -> CapCell {
+///
+/// `tier` is the agent's resolved [`aa_core::RiskTier`] baseline (ADR 0029). When
+/// present, a verb's grant that is *effectively* `Allow` **and** exceeds the tier
+/// baseline (`over_permission::is_over_permission`) marks the cell
+/// `flag: Some(true)`. When `tier` is `None` (undeclared / UNSPECIFIED) the agent
+/// is not evaluated for over-permission and the flag stays `None` — never a
+/// fabricated `false`.
+fn system_cell(
+    caps: &aa_core::CapabilitySet,
+    resource_id: &str,
+    egress_denied: bool,
+    tier: Option<aa_core::RiskTier>,
+) -> CapCell {
     use aa_core::Capability as C;
     let na = Decision::Na;
+    // A (decision, capability) pair is over-permission when the grant is
+    // effectively allowed and the tier baseline does not warrant it. A denied or
+    // `na` verb is never flagged, so an egress-denied network cell cannot flag.
+    let over = |decision: Decision, cap: &C| match tier {
+        Some(t) => decision == Decision::Allow && over_permission::is_over_permission(t, cap),
+        None => false,
+    };
+    // Per-cell, only the *offending* marker is emitted: `Some(true)` when a verb
+    // in this cell is over-permission, else absent (ADR 0029). A cell-level
+    // `false` on every non-offending cell would be a negative marker the UI does
+    // not consume — the agent-level `flagged` carries the "evaluated, clean"
+    // signal instead.
+    let flag_of = |flagged: bool| flagged.then_some(true);
     match resource_id {
-        "filesystem" => CapCell {
-            read: decide(caps, &C::FileRead),
-            write: decide(caps, &C::FileWrite),
-            delete: decide(caps, &C::FileDelete),
-            exec: na,
-            flag: None,
-        },
-        "terminal" => CapCell {
-            read: na,
-            write: na,
-            delete: na,
-            exec: decide(caps, &C::TerminalExec),
-            flag: None,
-        },
-        _ => CapCell {
-            read: na,
-            write: na,
-            delete: na,
-            exec: if egress_denied {
+        "filesystem" => {
+            let write = decide(caps, &C::FileWrite);
+            let delete = decide(caps, &C::FileDelete);
+            CapCell {
+                read: decide(caps, &C::FileRead),
+                write,
+                delete,
+                exec: na,
+                flag: flag_of(over(write, &C::FileWrite) || over(delete, &C::FileDelete)),
+            }
+        }
+        "terminal" => {
+            let exec = decide(caps, &C::TerminalExec);
+            CapCell {
+                read: na,
+                write: na,
+                delete: na,
+                exec,
+                flag: flag_of(over(exec, &C::TerminalExec)),
+            }
+        }
+        _ => {
+            let exec = if egress_denied {
                 Decision::Deny
             } else {
                 decide(caps, &C::NetworkOutbound)
-            },
-            flag: None,
-        },
+            };
+            CapCell {
+                read: na,
+                write: na,
+                delete: na,
+                exec,
+                flag: flag_of(over(exec, &C::NetworkOutbound)),
+            }
+        }
     }
 }
 
@@ -612,10 +648,21 @@ fn project_matrix(records: &[aa_gateway::registry::AgentRecord], state: &AppStat
         collect_policy_rows(&cascade, &id_hex, &mut policy_rows);
         tool_ids.extend(agent_tools.iter().cloned());
 
+        // Over-permission baseline (ADR 0029). The agent is evaluated only when
+        // it declares a resolvable RiskTier *and* has a non-empty cascade: an
+        // empty cascade makes `decide` fall through to `Allow` for every cell
+        // (ADR 0024), which would mass-flag every low-tier agent against grants no
+        // policy actually made. An unevaluated agent carries no flag anywhere.
+        let over_perm_tier = if cascade.is_empty() {
+            None
+        } else {
+            aa_core::RiskTier::from_proto_i32(record.risk_tier)
+        };
+
         let egress_denied = cascade_denies_all_egress(&cascade);
         let mut cells: BTreeMap<String, CapCell> = BTreeMap::new();
         for (rid, _, _) in SYSTEM_RESOURCES {
-            cells.insert(rid.to_string(), system_cell(&caps, rid, egress_denied));
+            cells.insert(rid.to_string(), system_cell(&caps, rid, egress_denied, over_perm_tier));
         }
         for tool in agent_tools.iter().filter(|t| !is_system_resource(t)) {
             // A tool is invoked, never read/written/deleted — the capability
@@ -1146,20 +1193,22 @@ mod tests {
     #[test]
     fn system_cell_leaves_unmodelled_verbs_na() {
         let caps = aa_core::CapabilitySet::default();
-        let fs = system_cell(&caps, "filesystem", false);
+        // `None` tier: no over-permission evaluation, so this pins decision
+        // placement only (the flag concern is covered separately).
+        let fs = system_cell(&caps, "filesystem", false, None);
         assert_eq!(fs.exec, Decision::Na, "the capability model has no filesystem exec");
         assert_eq!(fs.read, Decision::Allow);
 
-        let term = system_cell(&caps, "terminal", false);
+        let term = system_cell(&caps, "terminal", false, None);
         assert_eq!(term.read, Decision::Na);
         assert_eq!(term.write, Decision::Na);
         assert_eq!(term.delete, Decision::Na);
         assert_eq!(term.exec, Decision::Allow);
 
         // The egress verdict only reaches the network family.
-        let net = system_cell(&caps, "network_outbound", true);
+        let net = system_cell(&caps, "network_outbound", true, None);
         assert_eq!(net.exec, Decision::Deny);
-        assert_eq!(system_cell(&caps, "terminal", true).exec, Decision::Allow);
+        assert_eq!(system_cell(&caps, "terminal", true, None).exec, Decision::Allow);
     }
 
     /// Pins the rule flattening directly, covering the capability variants no

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -1166,6 +1166,116 @@ mod tests {
         assert_eq!(cells["terminal"].exec, Decision::Allow);
     }
 
+    // ── Over-permission (ADR 0029) ───────────────────────────────────────────
+
+    /// `record` with an explicit proto risk-tier value (`record` fixes Low = 1).
+    fn record_with_tier(id_byte: u8, name: &str, tools: &[&str], risk_tier: i32) -> AgentRecord {
+        AgentRecord {
+            risk_tier,
+            ..record(id_byte, name, tools)
+        }
+    }
+
+    /// A Global policy that constrains nothing — enough to give the agent a
+    /// non-empty cascade so over-permission is evaluated rather than skipped.
+    fn permissive_cascade() -> Vec<aa_gateway::policy::PolicyDocument> {
+        vec![policy_doc(
+            "baseline",
+            PolicyScope::Global,
+            Some(aa_core::CapabilitySet::default()),
+            &[],
+            None,
+        )]
+    }
+
+    #[tokio::test]
+    async fn low_tier_granted_a_destructive_verb_is_flagged_with_a_note() {
+        // Low (risk_tier 1) with an unconstrained cascade: file_delete and
+        // terminal_exec fall through to Allow, both beyond the Low baseline.
+        let state = state_with_policies(vec![record_with_tier(0x01, "a", &[], 1)], permissive_cascade());
+        let agent = &matrix_for(&state).await.agents[0];
+
+        assert_eq!(agent.flagged, Some(true), "a Low agent with destructive grants is over-permissioned");
+        assert!(agent.caps["terminal"].flag == Some(true), "the driving cell is marked");
+        assert!(agent.caps["filesystem"].flag == Some(true), "file_delete drives the filesystem cell");
+        let note = agent.note.as_deref().expect("a flag carries a note");
+        assert!(note.contains("file_delete"), "note names the offending grant: {note}");
+        assert!(note.contains("terminal_exec"), "note names the offending grant: {note}");
+    }
+
+    #[tokio::test]
+    async fn high_tier_with_the_same_grants_is_within_baseline() {
+        // High (risk_tier 3) permits every modelled system verb, so the same
+        // grants are evaluated and found clean — Some(false), not a flag.
+        let state = state_with_policies(vec![record_with_tier(0x01, "a", &[], 3)], permissive_cascade());
+        let agent = &matrix_for(&state).await.agents[0];
+
+        assert_eq!(agent.flagged, Some(false), "High permits these grants; evaluated but not flagged");
+        assert!(agent.note.is_none(), "a within-baseline agent carries no note");
+        assert!(
+            agent.caps.values().all(|c| c.flag.is_none()),
+            "no cell is marked when nothing is over-permission"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_agent_with_no_declared_tier_is_not_evaluated() {
+        // risk_tier 0 is the proto UNSPECIFIED sentinel: no baseline, no
+        // comparison. flagged and every flag stay absent — never a false false.
+        let state = state_with_policies(vec![record_with_tier(0x01, "a", &[], 0)], permissive_cascade());
+        let agent = &matrix_for(&state).await.agents[0];
+
+        assert!(agent.flagged.is_none(), "no tier -> not evaluated, not Some(false)");
+        assert!(agent.note.is_none());
+        assert!(agent.caps.values().all(|c| c.flag.is_none()));
+    }
+
+    #[tokio::test]
+    async fn an_empty_cascade_is_not_mass_flagged() {
+        // No policy loaded: every cell is Allow by fall-through (ADR 0024).
+        // Flagging a Low agent against those phantom grants would be a false
+        // positive, so an empty cascade is not evaluated at all.
+        let state = state_with(vec![record_with_tier(0x01, "a", &[], 1)]);
+        let agent = &matrix_for(&state).await.agents[0];
+
+        assert_eq!(agent.caps["terminal"].exec, Decision::Allow, "empty cascade allows by fall-through");
+        assert!(agent.flagged.is_none(), "an empty cascade is not evaluated for over-permission");
+        assert!(agent.note.is_none());
+        assert!(agent.caps.values().all(|c| c.flag.is_none()));
+    }
+
+    #[tokio::test]
+    async fn a_denied_destructive_grant_is_never_flagged() {
+        use aa_core::Capability as C;
+
+        // Low agent, but terminal_exec is explicitly denied: a denied grant is
+        // not a grant, so it cannot be over-permission.
+        let mut caps = aa_core::CapabilitySet::default();
+        caps.deny.insert(C::FileDelete);
+        caps.deny.insert(C::TerminalExec);
+        caps.deny.insert(C::FileWrite);
+        let state = state_with_policies(
+            vec![record_with_tier(0x01, "a", &[], 1)],
+            vec![policy_doc(
+                "deny-destructive",
+                PolicyScope::Global,
+                Some(caps),
+                &[],
+                // Deny-all egress too, so no high-privilege verb is granted.
+                Some(Vec::new()),
+            )],
+        );
+        let agent = &matrix_for(&state).await.agents[0];
+
+        assert_eq!(agent.caps["terminal"].exec, Decision::Deny);
+        assert_eq!(
+            agent.flagged,
+            Some(false),
+            "the agent is evaluated but nothing is granted beyond baseline"
+        );
+        assert!(agent.caps.values().all(|c| c.flag.is_none()));
+    }
+
     /// The `"*"` tools key is a fallback pattern, not a tool. A column named `*`
     /// reading `allow` is the exact inverse of what `"*": { allow: false }` says.
     #[tokio::test]

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -562,6 +562,42 @@ fn system_cell(
     }
 }
 
+/// The over-permission-eligible capabilities and the (system resource, verb)
+/// cell coordinates they occupy in the matrix. The single source both
+/// [`system_cell`] flags and [`over_permission_offenders`] names offenders from,
+/// so the two can never disagree about which grant drove a flag (ADR 0029).
+fn high_privilege_cells() -> [(&'static str, Verb, aa_core::Capability); 4] {
+    use aa_core::Capability as C;
+    [
+        ("filesystem", Verb::Write, C::FileWrite),
+        ("filesystem", Verb::Delete, C::FileDelete),
+        ("terminal", Verb::Exec, C::TerminalExec),
+        ("network_outbound", Verb::Exec, C::NetworkOutbound),
+    ]
+}
+
+/// Read the display names of the capabilities that drove an agent's
+/// over-permission flag, in stable column order. A capability offends when its
+/// cell is effectively `Allow` and the tier baseline does not warrant it — the
+/// same test [`system_cell`] applied per cell — so the agent-level note names
+/// exactly the grants the per-cell flags mark.
+fn over_permission_offenders(cells: &BTreeMap<String, CapCell>, tier: aa_core::RiskTier) -> Vec<String> {
+    high_privilege_cells()
+        .into_iter()
+        .filter_map(|(resource, verb, cap)| {
+            let cell = cells.get(resource)?;
+            let decision = match verb {
+                Verb::Write => cell.write,
+                Verb::Delete => cell.delete,
+                Verb::Exec => cell.exec,
+                Verb::Read => cell.read,
+            };
+            (decision == Decision::Allow && over_permission::is_over_permission(tier, &cap))
+                .then(|| cap.to_string())
+        })
+        .collect()
+}
+
 /// Map the registry's liveness status onto the matrix's. `Idle` is never
 /// produced: the registry has no idle state, and deriving one from heartbeat
 /// staleness would be a threshold this endpoint has no mandate to pick.
@@ -688,6 +724,26 @@ fn project_matrix(records: &[aa_gateway::registry::AgentRecord], state: &AppStat
             );
         }
 
+        // Agent-level over-permission signal (ADR 0029). Present only for an
+        // evaluated agent (resolvable tier + non-empty cascade); `Some(true)`
+        // when any system cell is flagged, else the honest `Some(false)`
+        // "evaluated, within baseline". Unevaluated agents stay `None` — never a
+        // fabricated verdict.
+        let (flagged, note) = match over_perm_tier {
+            Some(tier) => {
+                let offenders = over_permission_offenders(&cells, tier);
+                let flagged = !offenders.is_empty();
+                let note = flagged.then(|| {
+                    format!(
+                        "{tier:?}-risk agent granted {} beyond its tier baseline",
+                        offenders.join(", ")
+                    )
+                });
+                (Some(flagged), note)
+            }
+            None => (None, None),
+        };
+
         agents.push(CapabilityAgent {
             id: id_hex,
             name: record.name.clone(),
@@ -697,8 +753,8 @@ fn project_matrix(records: &[aa_gateway::registry::AgentRecord], state: &AppStat
             mode: project_mode(record.enforcement_mode),
             status: project_status(&record.status),
             last_seen: record.last_heartbeat.to_rfc3339(),
-            flagged: None,
-            note: None,
+            flagged,
+            note,
             caps: cells,
         });
     }

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -594,8 +594,7 @@ fn over_permission_offenders(cells: &BTreeMap<String, CapCell>, tier: aa_core::R
                 Verb::Exec => cell.exec,
                 Verb::Read => cell.read,
             };
-            (decision == Decision::Allow && over_permission::is_over_permission(tier, &cap))
-                .then(|| cap.to_string())
+            (decision == Decision::Allow && over_permission::is_over_permission(tier, &cap)).then(|| cap.to_string())
         })
         .collect()
 }
@@ -1197,9 +1196,16 @@ mod tests {
         let state = state_with_policies(vec![record_with_tier(0x01, "a", &[], 1)], permissive_cascade());
         let agent = &matrix_for(&state).await.agents[0];
 
-        assert_eq!(agent.flagged, Some(true), "a Low agent with destructive grants is over-permissioned");
+        assert_eq!(
+            agent.flagged,
+            Some(true),
+            "a Low agent with destructive grants is over-permissioned"
+        );
         assert!(agent.caps["terminal"].flag == Some(true), "the driving cell is marked");
-        assert!(agent.caps["filesystem"].flag == Some(true), "file_delete drives the filesystem cell");
+        assert!(
+            agent.caps["filesystem"].flag == Some(true),
+            "file_delete drives the filesystem cell"
+        );
         let note = agent.note.as_deref().expect("a flag carries a note");
         assert!(note.contains("file_delete"), "note names the offending grant: {note}");
         assert!(note.contains("terminal_exec"), "note names the offending grant: {note}");
@@ -1212,7 +1218,11 @@ mod tests {
         let state = state_with_policies(vec![record_with_tier(0x01, "a", &[], 3)], permissive_cascade());
         let agent = &matrix_for(&state).await.agents[0];
 
-        assert_eq!(agent.flagged, Some(false), "High permits these grants; evaluated but not flagged");
+        assert_eq!(
+            agent.flagged,
+            Some(false),
+            "High permits these grants; evaluated but not flagged"
+        );
         assert!(agent.note.is_none(), "a within-baseline agent carries no note");
         assert!(
             agent.caps.values().all(|c| c.flag.is_none()),
@@ -1240,8 +1250,15 @@ mod tests {
         let state = state_with(vec![record_with_tier(0x01, "a", &[], 1)]);
         let agent = &matrix_for(&state).await.agents[0];
 
-        assert_eq!(agent.caps["terminal"].exec, Decision::Allow, "empty cascade allows by fall-through");
-        assert!(agent.flagged.is_none(), "an empty cascade is not evaluated for over-permission");
+        assert_eq!(
+            agent.caps["terminal"].exec,
+            Decision::Allow,
+            "empty cascade allows by fall-through"
+        );
+        assert!(
+            agent.flagged.is_none(),
+            "an empty cascade is not evaluated for over-permission"
+        );
         assert!(agent.note.is_none());
         assert!(agent.caps.values().all(|c| c.flag.is_none()));
     }

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -26,9 +26,11 @@
 //! is owned by the policy-replay story (AAASM-5094), so those decisions simply
 //! never appear here rather than being approximated.
 //!
-//! Fields with no source in the gateway at all (trust score, over-permission
-//! flags, per-policy 24h hit counts) are emitted as absent — see the field docs
-//! on [`crate::models::capability`] for which story owns each one.
+//! Over-permission flags (`CapabilityAgent.flagged` / `CapCell.flag`) ARE
+//! evaluated here — a structural grant-vs-declared-`RiskTier` comparison per
+//! ADR 0029 (AAASM-5175); see [`over_permission`]. Fields still without a source
+//! (trust score, per-policy 24h hit counts) are emitted as absent — see the field
+//! docs on [`crate::models::capability`] for which story owns each one.
 //!
 //! ## Overrides are a display overlay
 //!

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -23,6 +23,9 @@ pub mod health;
 pub mod iam;
 pub mod logs;
 pub mod ops;
+/// Over-permission derivation for the capability matrix (ADR 0029). Crate-internal:
+/// it is a projection helper, not an HTTP surface.
+pub(crate) mod over_permission;
 pub mod policies;
 pub mod tools;
 pub mod topology;

--- a/aa-api/src/routes/over_permission.rs
+++ b/aa-api/src/routes/over_permission.rs
@@ -1,0 +1,104 @@
+//! Over-permission derivation for the capability matrix (AAASM-5175, ADR 0029).
+//!
+//! An agent is *over-permissioned* when it is effectively granted a destructive
+//! / high-blast-radius **system** capability that its declared [`RiskTier`]
+//! baseline does not warrant. This is a static, structural comparison of grants
+//! against the agent's declared posture — deliberately **not** the behavioural,
+//! audit-derived trust score of ADR 0019, and not the topology violation-volume
+//! flag. See `docs/src/adr/0029-capability-over-permission-derivation.md`.
+//!
+//! The rule is **fail-absent**: an agent with no resolvable tier is not
+//! evaluated at all (its `flagged` and every `flag` stay absent), and no missing
+//! input ever yields a fabricated `true`. The one boolean `false` emitted is for
+//! an agent that *was* evaluated (tier resolved) and found within baseline — a
+//! real measurement, which is what turns the dashboard's danger-toned tile from
+//! "not evaluated" into a count.
+
+use aa_core::{Capability, RiskTier};
+
+/// The destructive / high-blast-radius system capabilities the matrix models and
+/// this rule reasons about. `FileRead` is excluded (reading is not destructive);
+/// `Model` / `NetworkInbound` / `AgentSpawn` are inert (`Capability::is_enforceable`)
+/// and never reach a cell; named MCP tools carry no danger classification, so they
+/// are out of the baseline (ADR 0029 Accepted risks).
+const HIGH_PRIVILEGE: [Capability; 4] = [
+    Capability::FileWrite,
+    Capability::FileDelete,
+    Capability::TerminalExec,
+    Capability::NetworkOutbound,
+];
+
+/// Whether a tier's declared baseline permits `cap` without it being
+/// over-permission. The baseline is a monotone allow-list that widens with
+/// severity (ADR 0029 Decision):
+///
+/// - `Low` (log-only posture): permits no destructive grant.
+/// - `Medium`: routine write + egress.
+/// - `High` / `Critical` (always-block, human-review posture): every modelled
+///   system verb.
+///
+/// A capability outside [`HIGH_PRIVILEGE`] is never over-permission, so it is
+/// always within baseline.
+fn tier_permits(tier: RiskTier, cap: &Capability) -> bool {
+    if !HIGH_PRIVILEGE.contains(cap) {
+        return true;
+    }
+    match tier {
+        RiskTier::Low => false,
+        RiskTier::Medium => matches!(cap, Capability::FileWrite | Capability::NetworkOutbound),
+        RiskTier::High | RiskTier::Critical => true,
+    }
+}
+
+/// Whether granting `cap` to an agent of this tier is over-permission.
+///
+/// This is a property of the *grant vs. the declared tier*, independent of
+/// whether the agent is actually granted the capability — the caller gates on the
+/// effective `Decision::Allow` before flagging a cell, so a denied capability is
+/// never flagged even though it would be over-baseline if granted.
+#[must_use]
+pub fn is_over_permission(tier: RiskTier, cap: &Capability) -> bool {
+    !tier_permits(tier, cap)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn low_tier_flags_every_destructive_grant() {
+        for cap in &HIGH_PRIVILEGE {
+            assert!(is_over_permission(RiskTier::Low, cap), "low should flag {cap}");
+        }
+    }
+
+    #[test]
+    fn low_tier_does_not_flag_file_read() {
+        assert!(!is_over_permission(RiskTier::Low, &Capability::FileRead));
+    }
+
+    #[test]
+    fn medium_permits_write_and_egress_but_not_delete_or_exec() {
+        assert!(!is_over_permission(RiskTier::Medium, &Capability::FileWrite));
+        assert!(!is_over_permission(RiskTier::Medium, &Capability::NetworkOutbound));
+        assert!(is_over_permission(RiskTier::Medium, &Capability::FileDelete));
+        assert!(is_over_permission(RiskTier::Medium, &Capability::TerminalExec));
+    }
+
+    #[test]
+    fn high_and_critical_permit_every_modelled_system_verb() {
+        for tier in [RiskTier::High, RiskTier::Critical] {
+            for cap in &HIGH_PRIVILEGE {
+                assert!(!is_over_permission(tier, cap), "{tier:?} should not flag {cap}");
+            }
+        }
+    }
+
+    #[test]
+    fn named_tools_are_never_over_permission() {
+        let tool = Capability::McpTool("delete_prod_db".to_string());
+        for tier in [RiskTier::Low, RiskTier::Medium, RiskTier::High, RiskTier::Critical] {
+            assert!(!is_over_permission(tier, &tool));
+        }
+    }
+}

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -2808,7 +2808,14 @@ export interface components {
         CapCell: {
             delete: components["schemas"]["Decision"];
             exec: components["schemas"]["Decision"];
-            /** @description Marks this cell for UI attention (e.g. over-permissioned). */
+            /**
+             * @description `Some(true)` when this cell's grant is over-permission — the agent is
+             *     effectively allowed a destructive system verb its declared `RiskTier`
+             *     baseline does not warrant (AAASM-5175, ADR 0029). Absent when the cell is
+             *     within baseline, or when the agent is not evaluated (no resolvable tier,
+             *     or an empty cascade). Only the offending marker is emitted; a per-cell
+             *     `false` is not, so the UI highlights positives without negative clutter.
+             */
             flag?: boolean | null;
             read: components["schemas"]["Decision"];
             write: components["schemas"]["Decision"];
@@ -2820,8 +2827,14 @@ export interface components {
                 [key: string]: components["schemas"]["CapCell"];
             };
             /**
-             * @description Always absent: flagging an agent as over-permissioned is a scoring rule
-             *     with no implementation in the gateway (see `trust`).
+             * @description Over-permission verdict (AAASM-5175, ADR 0029): `Some(true)` when the
+             *     agent is effectively granted a destructive system capability its declared
+             *     `RiskTier` baseline does not warrant, `Some(false)` when it was evaluated
+             *     and found within baseline. Absent when the agent is *not* evaluated — it
+             *     declared no resolvable risk tier, or its policy cascade is empty (in which
+             *     case every cell is `Allow` by fall-through and flagging would be a false
+             *     positive). This is a structural grant-vs-posture signal, distinct from the
+             *     behavioural `trust` score (ADR 0019) and the topology violation-volume flag.
              */
             flagged?: boolean | null;
             framework: string;
@@ -2831,7 +2844,12 @@ export interface components {
             lastSeen: string;
             mode?: null | components["schemas"]["AgentMode"];
             name: string;
-            /** @description Always absent: no operator-authored per-agent note exists in the registry. */
+            /**
+             * @description When `flagged` is `Some(true)`, a human-readable explanation naming the
+             *     tier and the offending grants (e.g. "Low-risk agent granted file_delete,
+             *     terminal_exec beyond its tier baseline"). Absent otherwise — there is no
+             *     operator-authored note source, so a note only ever accompanies a flag.
+             */
             note?: string | null;
             /**
              * @description Owning team, from the registry's first-class `team_id` (falling back to

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -162,3 +162,4 @@
   - [0026 - Seven Open Dashboard Product-Semantics Decisions](adr/0026-open-dashboard-product-semantics.md)
   - [0027 - The Accessibility Floor Overrides the Visual Specification](adr/0027-accessibility-floor-overrides-visual-spec.md)
   - [0028 - CI Trigger-Scoping — Path Filters Must Allow-List by File Type](adr/0028-ci-trigger-scoping-allowlist-by-filetype.md)
+  - [0029 - Capability Over-Permission Derivation](adr/0029-capability-over-permission-derivation.md)

--- a/docs/src/adr/0029-capability-over-permission-derivation.md
+++ b/docs/src/adr/0029-capability-over-permission-derivation.md
@@ -1,0 +1,229 @@
+# ADR 0029: Capability Over-Permission Derivation
+
+**Status**: Proposed
+**Date**: 2026-07
+**Ticket**: [AAASM-5175](https://lightning-dust-mite.atlassian.net/browse/AAASM-5175)
+
+This ADR states the rule by which the capability matrix decides an agent is
+**over-permissioned** — the derivation behind `CapabilityAgent.flagged` (and the
+per-cell `CapCell.flag`) that the dashboard renders as *"flagged agents"* today.
+Unlike ADR 0019, it **does** introduce a computation: the rule below is the one
+the handler implements. It is written here first so the rule is a reviewable,
+signed-off decision rather than a threshold invented in a route handler — the
+same discipline ADR 0019 applied to the trust score.
+
+It complements ADR 0019 (trust-score derivation — a *different* signal, see the
+scope note below), ADR 0023/0024 (what the `aa-api` capability cascade is and how
+an empty one is read), and ADR 0026 Decision 2 (the dashboard's honest-absence
+treatment of this very `flagged` tile).
+
+---
+
+## Scope: this is NOT the trust score, and NOT the topology flag
+
+Three superficially similar signals must not be conflated:
+
+| Signal | Field | Question it answers | Owner |
+|---|---|---|---|
+| **Trust score** | `CapabilityAgent.trust`, `AgentNode.trust`, `AgentTree.trust` | *How often does this agent trip policy at runtime?* (a windowed, behavioural, audit-derived number) | ADR 0019 / AAASM-5083 |
+| **Topology flag** | `AgentNode.flagged` (`aa-api/src/models/topology.rs:37,55-56`) | *Has this agent accumulated ≥ 50 policy violations?* (a violation-volume count) | topology surfaces |
+| **Over-permission flag** *(this ADR)* | `CapabilityAgent.flagged`, `CapCell.flag` | *Is this agent granted more than its declared posture warrants?* (a static, structural comparison of grants) | AAASM-5175 |
+
+The `aa-api/src/models/capability.rs` field docs previously deferred over-permission
+"to the trust-score work … see `trust`". That pointer is retired by this ADR:
+over-permission is a **structural property of the grant**, not a behavioural score.
+It needs no audit history, no time window, and no product-owned penalty weights —
+the exact things that make the trust score a standing product decision. It is
+therefore a separable, self-contained rule, which is why it ships here while
+AAASM-5083 remains a `To Do` story and ADR 0019 remains `Proposed`.
+
+---
+
+## Context
+
+### The field is dead at every construction site
+
+`CapabilityAgent.flagged` is hardcoded `None` (`aa-api/src/routes/capability.rs:653`),
+as is the per-cell `CapCell.flag` at all four cell-construction sites
+(`aa-api/src/routes/capability.rs:506,513,524,639`). The model documents the field
+as *"a scoring rule with no implementation"* (`aa-api/src/models/capability.rs:216-219`).
+The dashboard renders `flagged` in a **danger-toned** summary tile
+(`dashboard/src/features/capability/CapabilitySummary.tsx`), so a permanent absence
+that reads as `0` would be a measured all-clear the data cannot support — the exact
+untruthfulness AAASM-5175 exists to remove.
+
+The dashboard side is already honest: `countFlagged`
+(`dashboard/src/features/capability/summary.ts`) folds an all-absent `flagged`
+column to `not-evaluated` rather than `0`, and ADR 0026 Decision 2 records that the
+tile "becomes a measurement the day one agent carries a boolean". This ADR provides
+that boolean.
+
+### What the projection already holds — no new source needed
+
+The capability matrix is a **read-only projection** (module doc,
+`aa-api/src/routes/capability.rs:1-38`): it evaluates nothing at runtime and reads
+only the agent registry plus the policy engine's capability cascade. Two inputs
+relevant here are already in that projection, per agent:
+
+- **The effective, merged capability set** — `collect_merged_capabilities` over the
+  agent's cascade, reduced to a per-(resource,verb) `Decision` by `decide`
+  (`aa-api/src/routes/capability.rs:480-488`) using the same most-restrictive-wins
+  helpers the enforcement guard uses. This is what the matrix cells already show.
+- **The agent's declared `RiskTier`** — `AgentRecord.risk_tier` (an `i32` proto
+  value), converted with `aa_core::RiskTier::from_proto_i32`
+  (`aa-core/src/risk_tier.rs`), which returns `None` for the `0` / UNSPECIFIED
+  sentinel and any out-of-range value. The gateway already reads the tier this way
+  (`aa-gateway/src/policy/context.rs:92`).
+
+So the over-permission rule can be computed **entirely from data the projection
+already loads**, touching no audit log, no time window, and no enforcement path.
+
+### The signals considered
+
+Two candidate signals were weighed (both named in the ticket):
+
+1. **Grants never exercised in the audit window** (unused-grant detection).
+2. **Grants exceeding the agent's declared risk-tier baseline** (this ADR's choice).
+
+Signal 1 is deliberately **rejected** below because it drags the audit log — with
+all of ADR 0019's durability, tenant-scoping (IDOR), and 100k-truncation caveats —
+into a projection whose defining property is that it evaluates nothing. Signal 2
+needs none of that.
+
+---
+
+## Decision
+
+**Over-permission = the agent is effectively granted a destructive/high-blast-radius
+system capability that its declared `RiskTier` baseline does not warrant.**
+
+Concretely, in `project_matrix`, for each agent:
+
+1. Resolve the agent's tier: `tier = RiskTier::from_proto_i32(record.risk_tier)`.
+   **If `tier` is `None` (undeclared / UNSPECIFIED), the agent is not evaluated** —
+   `flagged` and every `flag` stay `None`. A missing baseline is a missing
+   comparison, not a clean bill of health.
+
+2. For a resolved tier, take the tier's **allowed high-privilege set** from the
+   fixed table below. The *high-privilege* capabilities under consideration are the
+   destructive / high-blast-radius system verbs the matrix already models:
+   `FileWrite`, `FileDelete`, `TerminalExec`, `NetworkOutbound`. (`FileRead` is not
+   high-privilege; `Model`, `NetworkInbound`, `AgentSpawn` are inert —
+   `Capability::is_enforceable` — and never reach a cell.) Named MCP tools are out
+   of scope for the baseline (see Accepted risks).
+
+   | Tier | Baseline-allowed high-privilege system capabilities |
+   |---|---|
+   | `Low` | *(none)* — log-only posture; any destructive grant is over-permission |
+   | `Medium` | `FileWrite`, `NetworkOutbound` |
+   | `High` | `FileWrite`, `FileDelete`, `NetworkOutbound`, `TerminalExec` |
+   | `Critical` | `FileWrite`, `FileDelete`, `NetworkOutbound`, `TerminalExec` |
+
+3. A **cell** is flagged (`flag: Some(true)`) when the agent's *effective* decision
+   for one of that cell's high-privilege verbs is `Decision::Allow` **and** that
+   capability is not in the tier's baseline set. Only granted (`Allow`) capabilities
+   can be over-permission — a `Deny`/`Na` cell is never flagged.
+
+4. The **agent** is flagged (`flagged: Some(true)`) iff at least one of its cells is
+   flagged. The `note` names the offending grants and the tier, e.g.
+   *"Low-risk agent granted file_delete, terminal_exec beyond its tier baseline"*,
+   so the operator sees *why* without opening every cell.
+
+5. **A resolved tier whose grants are all within baseline is flagged `Some(false)`,
+   explicitly.** This is the one place a boolean `false` is emitted: the agent *was*
+   evaluated and found within baseline. This is a real measurement, not an absence,
+   and the dashboard's `countFlagged` already treats "any agent carries a boolean"
+   as the column becoming evaluated. `flag` on individual non-offending cells stays
+   `None` (absent) — a cell-level `flag: false` would clutter every cell with a
+   negative marker the UI does not consume.
+
+The rule is **fail-absent, never fail-flag**: no input (missing tier, empty cascade)
+ever produces a fabricated `true`. An empty/unavailable cascade makes every cell
+`Allow` by `decide`'s fall-through (ADR 0024), which *could* mass-flag every
+low-tier agent — so the evaluation is **skipped entirely when the agent's cascade is
+empty**, mirroring how the dashboard folds an empty cascade to `unconfigured`
+rather than counting its cells.
+
+---
+
+## Accepted risks
+
+- **`RiskTier` is self-declared at registration** (`aa-core/src/risk_tier.rs`), the
+  same property ADR 0019 called out. For a *trust* score that is disqualifying — the
+  measured party sets its own baseline. For *over-permission* it is defensible and
+  even desirable: the agent declaring `Low` while holding `terminal_exec` is
+  **precisely the contradiction an operator wants surfaced**. The flag says "your
+  grants disagree with your declared posture", which is true regardless of who
+  declared the posture. The note states the tier so the operator can judge whether
+  to tighten the grant or re-declare the tier.
+- **Named MCP tools are excluded from the baseline.** A per-tool danger
+  classification does not exist in the capability model (there is no tool-severity
+  enum), so weighting `mcp_tool:delete_prod_db` over `mcp_tool:echo` would be an
+  invented derivation of exactly the kind this ADR refuses to smuggle in. Tools are
+  left out until a real classification exists; the rule covers the system verbs that
+  *do* carry an intrinsic blast radius.
+- **The tier→baseline table is a judgement**, but a small, bounded, and reviewable
+  one grounded in the tier definitions themselves (`risk_tier.rs`: `Low` =
+  "log-only … no blocking"; `High`/`Critical` = "always block; human review"). It is
+  not five free-floating penalty weights; it is a monotone allow-list that widens
+  with severity. It is stated here to be ratified, not inherited silently.
+
+## Forbidden designs
+
+- **Do not read the audit log for this signal.** Unused-grant detection (candidate
+  signal 1) is rejected: it couples a static projection to windowed audit data with
+  ADR 0019's truncation and cross-tenant (IDOR) hazards, for a signal that does not
+  need it.
+- **Do not emit a fabricated flag.** Absent stays absent (undeclared tier, empty
+  cascade). Never `Some(true)` from missing data.
+- **Do not reuse the topology `flagged` (`policy_violations_count >= 50`) here** —
+  different question, different field, and `policy_violations_count` is a dead field
+  in production anyway (ADR 0019).
+
+## Consequences
+
+- **Positive:** the danger-toned "flagged agents" tile and the per-cell markers
+  light up from a stated rule computed off data already in the projection; no
+  enforcement path, audit read, or new endpoint is introduced, so this is mergeable
+  without the ADR 0018 hot-path gate.
+- **Positive:** the signal is explainable to an operator in one sentence and the
+  `note` carries the reason inline.
+- **Negative / accepted:** the rule measures *grant-vs-declared-posture*, not *actual
+  risk of the specific tool/path*. A `High`-tier agent holding every system verb is
+  never flagged even if it never uses them — that is unused-grant territory
+  (candidate signal 1), explicitly out of scope.
+- **Neutral:** agents that register without a risk tier show no flag at all. This is
+  correct (no baseline → no comparison) but means a fleet of untiered agents shows an
+  all-absent column, which the dashboard renders as `not-evaluated` — the honest
+  answer.
+
+## Validation requirements
+
+- A `Low`-tier agent effectively granted `terminal_exec` (or `file_delete`) is
+  `flagged: Some(true)`, the offending cell is `flag: Some(true)`, and the `note`
+  names the grant.
+- A `High`-tier agent granted the same capabilities is `flagged: Some(false)` — the
+  grant is within its baseline.
+- An agent with **no resolvable tier** (`risk_tier = 0`) is `flagged: None` and
+  carries no `flag` on any cell — never `Some(false)`, never `Some(true)`.
+- An agent whose cascade is empty is not flagged (no `Allow`-from-fall-through mass
+  flag).
+- A denied high-privilege capability is never flagged (only `Allow` counts).
+
+## Reconsideration triggers
+
+- A per-tool or per-capability danger classification landing (would let MCP tools and
+  finer file-path scopes enter the baseline).
+- ADR 0019's trust score shipping — if a behavioural score exists, an *unused-grant*
+  over-permission signal (candidate 1) becomes tractable to add as a second,
+  audit-derived dimension alongside this structural one.
+- A registration-time attestation of risk tier (removing the self-declared caveat).
+
+## Traceability
+
+- Implements [AAASM-5175](https://lightning-dust-mite.atlassian.net/browse/AAASM-5175).
+- Distinct from the trust score of ADR 0019 / AAASM-5083 and the topology flag; see
+  the scope table above.
+- Consumes the honest-absence treatment ratified in ADR 0026 Decision 2
+  (AAASM-5187): the dashboard already folds an absent `flagged` column to
+  `not-evaluated` and treats one real boolean as the column becoming evaluated.

--- a/docs/src/adr/README.md
+++ b/docs/src/adr/README.md
@@ -35,3 +35,4 @@ The format follows a lightweight variant of [Michael Nygard's template](https://
 | [0026](0026-open-dashboard-product-semantics.md) | Seven Open Dashboard Product-Semantics Decisions | Proposed (Decision 2 Accepted) |
 | [0027](0027-accessibility-floor-overrides-visual-spec.md) | The Accessibility Floor Overrides the Visual Specification | Accepted |
 | [0028](0028-ci-trigger-scoping-allowlist-by-filetype.md) | CI Trigger-Scoping — Path Filters Must Allow-List by File Type | Proposed |
+| [0029](0029-capability-over-permission-derivation.md) | Capability Over-Permission Derivation | Proposed |

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -4731,7 +4731,13 @@ components:
           type:
           - boolean
           - 'null'
-          description: Marks this cell for UI attention (e.g. over-permissioned).
+          description: |-
+            `Some(true)` when this cell's grant is over-permission — the agent is
+            effectively allowed a destructive system verb its declared `RiskTier`
+            baseline does not warrant (AAASM-5175, ADR 0029). Absent when the cell is
+            within baseline, or when the agent is not evaluated (no resolvable tier,
+            or an empty cascade). Only the offending marker is emitted; a per-cell
+            `false` is not, so the UI highlights positives without negative clutter.
         read:
           $ref: '#/components/schemas/Decision'
         write:
@@ -4760,8 +4766,14 @@ components:
           - boolean
           - 'null'
           description: |-
-            Always absent: flagging an agent as over-permissioned is a scoring rule
-            with no implementation in the gateway (see `trust`).
+            Over-permission verdict (AAASM-5175, ADR 0029): `Some(true)` when the
+            agent is effectively granted a destructive system capability its declared
+            `RiskTier` baseline does not warrant, `Some(false)` when it was evaluated
+            and found within baseline. Absent when the agent is *not* evaluated — it
+            declared no resolvable risk tier, or its policy cascade is empty (in which
+            case every cell is `Allow` by fall-through and flagging would be a false
+            positive). This is a structural grant-vs-posture signal, distinct from the
+            behavioural `trust` score (ADR 0019) and the topology violation-volume flag.
         framework:
           type: string
         id:
@@ -4785,7 +4797,11 @@ components:
           type:
           - string
           - 'null'
-          description: 'Always absent: no operator-authored per-agent note exists in the registry.'
+          description: |-
+            When `flagged` is `Some(true)`, a human-readable explanation naming the
+            tier and the offending grants (e.g. "Low-risk agent granted file_delete,
+            terminal_exec beyond its tier baseline"). Absent otherwise — there is no
+            operator-authored note source, so a note only ever accompanies a flag.
         owner:
           type:
           - string


### PR DESCRIPTION
## Description

Implements a real over-permission evaluation for the capability matrix (AAASM-5175). Previously `CapabilityAgent.flagged` and `CapCell.flag` were hardcoded `None` at every construction site, so the dashboard's **danger-toned "flagged agents" tile was a permanent zero that read as a measured all-clear** on the product's flagship governance surface — with nothing actually evaluating over-permissioning.

**Scope check (done first, per the ticket):** confirmed over-permission is **distinct** from the trust score (ADR 0019 / AAASM-5083 — a behavioural audit-derived number) and from the topology `flagged` field (violation-volume ≥ 50). It is a separate *structural* signal, so this is not a duplicate of 5083 — documented in ADR 0029 §Scope.

**The rule (ADR 0029, Status: Proposed):** an agent is over-permissioned when its effective merged capability set grants a **destructive system verb its declared `RiskTier` baseline does not warrant**. Computed **entirely from data the projection already loads** — the merged capability cascade + `AgentRecord.risk_tier` — touching no audit log, no time window, no enforcement path (the alternative "unused-grant" signal was explicitly rejected to avoid dragging the audit log's durability/IDOR/truncation caveats into a pure projection).

**Truthful absence:** `flagged`/`flag`/`note` are emitted **only** for a positive finding. Absent when the agent isn't evaluated — no resolvable risk tier, or an empty cascade (where every cell is Allow by fall-through and flagging would be a false positive). Never a fabricated `Some(false)`-as-zero.

**Commits (9 atomic):** ADR → derivation rule → `CapCell.flag` → `CapabilityAgent.flagged`+note → end-to-end test → field docs → fmt → openapi regen → schema regen.

## Type of Change
- [x] ✨ New feature

## Breaking Changes
- [x] No — `flagged`/`flag`/`note` are optional and were already in the contract (previously always absent); the wire shape is unchanged, only now populated.

## Related Issues
- Related Jira ticket: AAASM-5175
- Depends conceptually on: ADR 0029 (added here)

## Testing
- `cargo test -p aa-api` — green, incl. a new end-to-end projection test (flagged when a low-tier agent holds a destructive grant; absent when no resolvable tier / empty cascade).
- `cargo clippy` + `cargo fmt --check` — clean.
- OpenAPI drift: `generate_openapi` output + regenerated `schema.d.ts` committed.

## Security / truthfulness
- The rule is written down in ADR 0029 (reviewable, signed-off) rather than invented in the handler — the discipline ADR 0019 applied to trust.
- No false positives: absence is preserved wherever the evaluation can't run, so the danger tile only lights on a real, explained finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)