### PR TITLE
[AAASM-5107] ✨ (aa-core): Attribute audit decisions to the deciding policy document

### DIFF
--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -128,12 +128,13 @@ pub struct Policy {
     pub version: Option<String>,
     pub scope: String,
     pub status: PolicyStatus,
-    /// Number of times this policy fired in the last 24 hours.
+    /// Number of times this policy document fired in the last 24 hours.
     ///
-    /// Always absent here: attributing audit events back to the policy document
-    /// that produced them needs the deciding document captured at the
-    /// enforcement boundary, which is owned by AAASM-5107. A `0` would be
-    /// indistinguishable from "fired zero times".
+    /// Sourced (AAASM-5107) by joining this row's document content digest against
+    /// the per-document decision counts from the last-24h audit window — each
+    /// policy decision records the deciding document's digest on its audit entry.
+    /// Absent, never `0`, when the document recorded no decision in the window: a
+    /// `0` would be indistinguishable from "fired zero times".
     #[serde(default, rename = "hits24h", skip_serializing_if = "Option::is_none")]
     pub hits_24h: Option<u64>,
     /// Ids of the agents whose cascade includes this policy scope.

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -198,7 +198,10 @@ pub struct MatrixQueryParams {
 /// agents and resources exist at this instant.
 async fn projected_matrix(state: &AppState) -> CapabilityMatrix {
     let records = state.agent_registry.list();
-    let mut matrix = project_matrix(&records, state);
+    // AAASM-5107 — per-document 24h decision counts, read once per request and
+    // handed to the (sync) projection so each policy row can carry `hits24h`.
+    let hits = crate::routes::policy_hits::PolicyHitCounts::from_window(&state.audit_reader).await;
+    let mut matrix = project_matrix(&records, state, &hits);
     state.capability_store.apply_overlay(&mut matrix).await;
     matrix
 }
@@ -590,7 +593,11 @@ fn collect_policy_rows(
 /// fallback no longer fires in the shipped composition root — this projection
 /// keeps the explicit lineage anyway so it stays correct under any engine,
 /// registry-wired or not.
-fn project_matrix(records: &[aa_gateway::registry::AgentRecord], state: &AppState) -> CapabilityMatrix {
+fn project_matrix(
+    records: &[aa_gateway::registry::AgentRecord],
+    state: &AppState,
+    hits: &crate::routes::policy_hits::PolicyHitCounts,
+) -> CapabilityMatrix {
     use aa_core::Capability as C;
 
     // Resource columns: the three system families, then every tool any visible

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -703,7 +703,10 @@ fn project_matrix(
                 // definition the active one for its scope. `Proposed` /
                 // `Archived` have no representation in the loaded engine.
                 status: PolicyStatus::Active,
-                hits_24h: None,
+                // AAASM-5107 — join this document's content digest against the
+                // per-document 24h decision counts. Absent (never 0) when the
+                // document recorded no decision in the window.
+                hits_24h: hits.count(&doc.content_digest()),
                 affects,
                 rules: project_rules(&doc),
             }
@@ -977,7 +980,9 @@ mod tests {
         // No enforcement_mode override was declared.
         assert!(agent.mode.is_none());
         for policy in &m.policies {
-            assert!(policy.hits_24h.is_none(), "24h hit counts have no source here");
+            // AAASM-5107 sources hits24h from the 24h audit window; this fixture
+            // seeds no decisions, so every document is absent (never a faked 0).
+            assert!(policy.hits_24h.is_none(), "no seeded decisions → hits24h absent, not 0");
         }
         let json = serde_json::to_value(agent).unwrap();
         // AAASM-5104 — `trust` is required-but-nullable: the key is always on the

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -24,6 +24,7 @@ pub mod iam;
 pub mod logs;
 pub mod ops;
 pub mod policies;
+pub mod policy_hits;
 pub mod tools;
 pub mod topology;
 pub mod traces;

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -83,6 +83,14 @@ impl DocSet {
     fn version(&self) -> Option<String> {
         self.unique().and_then(|doc| doc.policy_version.clone())
     }
+
+    /// AAASM-5107 — content digest of the unambiguous document under this key,
+    /// the identity a per-document hit count joins on. Absent when the key is
+    /// shared by two distinct live documents (nothing "the" document could be
+    /// counted for).
+    fn digest(&self) -> Option<String> {
+        self.unique().map(|doc| doc.content_digest())
+    }
 }
 
 /// Which agents a cascade-carried policy document is in force for, together with
@@ -329,6 +337,10 @@ pub async fn list_policies(
     // Resolved once per request, not per row: the walk is O(visible agents) and
     // every row looks its document up in the same map.
     let reach = policy_reach(&state, &caller);
+    // AAASM-5107 — per-document 24h decision counts, read once per request. A row
+    // whose parsed document fired at least once carries `hits24h`; one that did
+    // not stays absent (never 0) — see [`crate::routes::policy_hits`].
+    let hits = crate::routes::policy_hits::PolicyHitCounts::from_window(&state.audit_reader).await;
 
     let mut items: Vec<PolicyResponse> = Vec::with_capacity(paged.len());
     for (i, meta) in paged.into_iter().enumerate() {
@@ -341,13 +353,18 @@ pub async fn list_policies(
             .await
             .map(|snap| snap.yaml_content)
             .unwrap_or_default();
+        // The deciding-document digest is the content digest of the parsed
+        // snapshot — the same identity the gateway stamps on the audit write, so
+        // this joins to the recorded hits even across two versions of one
+        // (scope, name). An unreadable snapshot yields no digest → absent.
+        let hits_24h = document_from_yaml(&yaml).and_then(|doc| hits.count(&doc.content_digest()));
         items.push(PolicyResponse {
             name: meta.sha256[..12].to_string(),
             version: meta.timestamp,
             active: i == 0 && params.page() == 1,
             rule_count: 0,
             affects: affects_for(&yaml, &reach),
-            hits_24h: None,
+            hits_24h,
             policy_yaml: yaml,
         });
     }
@@ -676,6 +693,9 @@ pub async fn list_team_policies(
 
     let (by_key, visible_members) = team_cascade(&state, &caller, &team_id);
 
+    // AAASM-5107 — per-document 24h decision counts, read once per request.
+    let hits = crate::routes::policy_hits::PolicyHitCounts::from_window(&state.audit_reader).await;
+
     // Absent, not empty, when the team has agents whose cascade resolved nothing:
     // those agents fall back to the primary policy slot, which this projection
     // cannot enumerate (AAASM-5106). `[]` is reserved for the one case where
@@ -691,7 +711,10 @@ pub async fn list_team_policies(
                     name: key.1.clone().unwrap_or_else(|| key.0.clone()),
                     scope: key.0.clone(),
                     version: docs.version(),
-                    hits_24h: None,
+                    // Only an unambiguous key names one document, so only then can
+                    // a hit count be attributed; a key shared by two distinct live
+                    // documents stays absent rather than summing colliding docs.
+                    hits_24h: docs.digest().and_then(|d| hits.count(&d)),
                 })
                 .collect(),
         )

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -236,20 +236,21 @@ pub struct PolicyResponse {
     /// which is a different and stronger claim than "not currently loaded".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub affects: Option<Vec<String>>,
-    /// Number of times this policy fired in the last 24 hours.
+    /// Number of times this policy document fired in the last 24 hours.
     ///
-    /// **Always absent.** Nothing on the audit write path records which policy
-    /// document produced a decision: `AuditEntry` has no policy field, and the
-    /// payload's `policy_rule` is the free-text deny *reason*
-    /// (`aa_gateway::service::policy_service::evaluate_one`), empty on every
-    /// allow. `aa_gateway::engine::decision::PolicyDecision::Deny` does carry a
-    /// `source_scope`, but `into_policy_result` drops it before the audit write —
-    /// and it is scope-granular, not document-granular, so it could not name a
-    /// document even if it survived. Capturing the deciding document at decision
-    /// time is enforcement-boundary work owned by AAASM-5107; until it lands this
-    /// is reported absent rather than as a `0` that would be indistinguishable
-    /// from "fired zero times". The same field is absent for the same reason on
-    /// the capability matrix's `Policy`.
+    /// Sourced (AAASM-5107) by joining this row's document content digest against
+    /// the per-document decision counts tallied from the last-24h audit window —
+    /// each policy decision now records the deciding document's digest on its
+    /// audit entry (`AuditEntry::policy_doc_id`, stamped at the enforcement
+    /// boundary from `PolicyDocument::content_digest`). The digest distinguishes
+    /// two versions of the same `(scope, name)` pair.
+    ///
+    /// **Absent, never `0`.** A document that recorded no decision in the window,
+    /// a row whose snapshot cannot be parsed to a digest, or a key shared by two
+    /// distinct live documents (no single "the" document to count) all report
+    /// absent — preserving the absent-vs-"fired zero times" distinction
+    /// AAASM-5096 established. The same sourcing applies to the capability
+    /// matrix's `Policy.hits24h`.
     #[serde(default, rename = "hits24h", skip_serializing_if = "Option::is_none")]
     pub hits_24h: Option<u64>,
 }
@@ -611,8 +612,10 @@ pub struct TeamPolicyResponse {
     /// that declares none.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
-    /// Number of times this policy fired in the last 24 hours. **Always absent**
-    /// — see [`PolicyResponse::hits_24h`] for why no source exists.
+    /// Number of times this policy document fired in the last 24 hours. Sourced
+    /// from per-document decision counts (AAASM-5107); absent, never `0`, when
+    /// the document recorded no decision in the window — see
+    /// [`PolicyResponse::hits_24h`] for the full sourcing and absent-vs-zero rule.
     #[serde(default, rename = "hits24h", skip_serializing_if = "Option::is_none")]
     pub hits_24h: Option<u64>,
 }

--- a/aa-api/src/routes/policy_hits.rs
+++ b/aa-api/src/routes/policy_hits.rs
@@ -1,0 +1,170 @@
+//! Per-document 24h policy-decision hit counts (AAASM-5107).
+//!
+//! AAASM-5096 shipped the `hits24h` contract on `PolicyResponse`,
+//! `TeamPolicyResponse`, and the capability-matrix `Policy`, but the field was
+//! always absent because nothing on the audit-write path recorded *which*
+//! policy document produced a decision. AAASM-5107 captures the deciding
+//! document's content digest at decision time
+//! ([`aa_gateway::policy::PolicyDocument::content_digest`]) and records it on
+//! each policy-decision audit entry — both as the first-class
+//! `AuditEntry::policy_doc_id` field and as a `policy_doc_id` key in the entry's
+//! payload JSON.
+//!
+//! This module reads the last-24h audit window once per request and tallies
+//! those digests into a [`PolicyHitCounts`] the three surfaces look their own
+//! documents up in.
+//!
+//! ## Absent-vs-zero discipline
+//!
+//! [`PolicyHitCounts::count`] returns `Some(n)` with `n >= 1` for a document
+//! that fired at least once in the window, and `None` for one that did not.
+//! `hits24h` is therefore **never `0` on the wire** — a document with no
+//! recorded decision is *absent*, exactly the AAASM-5096 discipline that keeps
+//! "fired zero times" distinct from "no data to report". A window read that
+//! fails or a document whose digest never appears both surface as absent, never
+//! as a misleading `0`.
+
+use std::collections::HashMap;
+
+use aa_gateway::audit_reader::AuditReader;
+
+/// The 24-hour window, in nanoseconds, that a per-document hit count spans.
+const WINDOW_NS: u64 = 24 * 60 * 60 * 1_000_000_000;
+
+/// Cap on audit events scanned when building the counts, mirroring the analytics
+/// aggregations' bound so a hot window cannot make this read unbounded.
+const MAX_EVENTS: usize = 100_000;
+
+/// Per-document count of policy decisions recorded in the last 24 hours, keyed by
+/// the deciding document's content digest (`"sha256:<hex>"`).
+#[derive(Debug, Default, Clone)]
+pub struct PolicyHitCounts {
+    by_doc: HashMap<String, u64>,
+}
+
+impl PolicyHitCounts {
+    /// Build the counts from the last-24h audit window read through `reader`.
+    ///
+    /// Each audit entry's deciding-document digest is read from the first-class
+    /// `AuditEntry::policy_doc_id` field, falling back to the `policy_doc_id` key
+    /// in the entry's payload JSON (older entries persisted before the top-level
+    /// field was populated may carry only the payload copy). Entries with no
+    /// digest — non-decision events, or decisions the engine could not attribute
+    /// to a cascade document — are skipped.
+    pub async fn from_window(reader: &AuditReader) -> Self {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(u64::MAX);
+        let since = now.saturating_sub(WINDOW_NS);
+
+        let (entries, _total) = reader
+            .list_windowed(since, MAX_EVENTS, 0, None, None, None)
+            .await
+            .unwrap_or_default();
+
+        let mut by_doc: HashMap<String, u64> = HashMap::new();
+        for entry in &entries {
+            if let Some(id) = doc_id_of(entry) {
+                *by_doc.entry(id).or_insert(0) += 1;
+            }
+        }
+        Self { by_doc }
+    }
+
+    /// The number of decisions attributed to `digest` in the window, or `None`
+    /// when the document fired zero times — absent, never `0`. See the module
+    /// docs for the absent-vs-zero rationale.
+    pub fn count(&self, digest: &str) -> Option<u64> {
+        self.by_doc.get(digest).copied()
+    }
+}
+
+/// Resolve a policy-decision audit entry's deciding-document digest: the
+/// first-class field first, then the `policy_doc_id` payload key.
+fn doc_id_of(entry: &aa_core::audit::AuditEntry) -> Option<String> {
+    if let Some(id) = entry.policy_doc_id() {
+        return Some(id.to_string());
+    }
+    let payload: serde_json::Value = serde_json::from_str(entry.payload()).ok()?;
+    payload
+        .get("policy_doc_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_when_document_never_fired() {
+        let counts = PolicyHitCounts::default();
+        assert_eq!(
+            counts.count("sha256:never-seen"),
+            None,
+            "a document with no recorded decision must be absent, not Some(0)",
+        );
+    }
+
+    #[test]
+    fn present_count_reflects_tally() {
+        let mut by_doc = HashMap::new();
+        by_doc.insert("sha256:aaa".to_string(), 3);
+        by_doc.insert("sha256:bbb".to_string(), 1);
+        let counts = PolicyHitCounts { by_doc };
+        assert_eq!(counts.count("sha256:aaa"), Some(3));
+        assert_eq!(counts.count("sha256:bbb"), Some(1));
+        assert_eq!(counts.count("sha256:ccc"), None);
+    }
+
+    #[test]
+    fn doc_id_prefers_first_class_field_then_payload() {
+        use aa_core::audit::{AuditEntry, AuditEventType, Lineage};
+        use aa_core::identity::{AgentId, SessionId};
+        use aa_security::Redaction;
+
+        let agent = AgentId::from_bytes([1u8; 16]);
+        let session = SessionId::from_bytes([2u8; 16]);
+
+        // First-class field set → used verbatim regardless of payload.
+        let with_field = AuditEntry::new_with_lineage_redaction_and_attribution(
+            0,
+            1_000,
+            AuditEventType::PolicyViolation,
+            agent,
+            session,
+            r#"{"policy_doc_id":"sha256:from-payload"}"#.into(),
+            [0u8; 32],
+            Lineage::default(),
+            Redaction::default(),
+            Some("sha256:from-field".to_string()),
+        );
+        assert_eq!(doc_id_of(&with_field).as_deref(), Some("sha256:from-field"));
+
+        // No first-class field → fall back to the payload copy.
+        let payload_only = AuditEntry::new(
+            0,
+            1_000,
+            AuditEventType::PolicyViolation,
+            agent,
+            session,
+            r#"{"policy_doc_id":"sha256:from-payload"}"#.into(),
+            [0u8; 32],
+        );
+        assert_eq!(doc_id_of(&payload_only).as_deref(), Some("sha256:from-payload"));
+
+        // Neither → None.
+        let neither = AuditEntry::new(
+            0,
+            1_000,
+            AuditEventType::PolicyViolation,
+            agent,
+            session,
+            r#"{"action_type":"tool_call"}"#.into(),
+            [0u8; 32],
+        );
+        assert_eq!(doc_id_of(&neither), None);
+    }
+}

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -265,6 +265,15 @@ pub struct AuditEntry {
     #[cfg(feature = "std")]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
     redacted_payload: Option<String>,
+    /// AAASM-5107 — content digest (`"sha256:<hex>"`) of the policy document that
+    /// produced this decision. `None` for entries not emitted from a cascade
+    /// policy decision (e.g. lifecycle / approval-routing events, or the
+    /// primary-policy path that carries no cascade document). Appended last in
+    /// the hash input and contributing zero bytes when `None`, so entries
+    /// without it hash identically to pre-AAASM-5107 output and existing chains
+    /// keep verifying.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    policy_doc_id: Option<String>,
 }
 
 impl AuditEntry {
@@ -319,6 +328,7 @@ impl AuditEntry {
             &Lineage::default(),
             #[cfg(feature = "std")]
             &Redaction::default(),
+            None,
         );
         Self {
             seq,
@@ -340,6 +350,7 @@ impl AuditEntry {
             credential_findings: alloc::vec::Vec::new(),
             #[cfg(feature = "std")]
             redacted_payload: None,
+            policy_doc_id: None,
         }
     }
 
@@ -371,6 +382,7 @@ impl AuditEntry {
             &lineage,
             #[cfg(feature = "std")]
             &Redaction::default(),
+            None,
         );
         Self {
             seq,
@@ -392,6 +404,7 @@ impl AuditEntry {
             credential_findings: alloc::vec::Vec::new(),
             #[cfg(feature = "std")]
             redacted_payload: None,
+            policy_doc_id: None,
         }
     }
 
@@ -419,6 +432,46 @@ impl AuditEntry {
         lineage: Lineage,
         redaction: Redaction,
     ) -> Self {
+        Self::new_with_lineage_redaction_and_attribution(
+            seq,
+            timestamp_ns,
+            event_type,
+            agent_id,
+            session_id,
+            payload,
+            previous_hash,
+            lineage,
+            redaction,
+            None,
+        )
+    }
+
+    /// Create a new [`AuditEntry`] carrying lineage, credential-scanner output,
+    /// **and** the deciding policy document's content digest (`policy_doc_id`),
+    /// computing `entry_hash` over all tamper-meaningful fields (AAASM-5107).
+    ///
+    /// When `policy_doc_id == None`, the resulting `entry_hash` is identical to
+    /// [`AuditEntry::new_with_lineage_and_redaction`] with the same base fields —
+    /// the digest contributes zero bytes to the hash — so existing chains on disk
+    /// verify unchanged. The digest is a decision-attribution attribute derived
+    /// independently of this chain hash and never weakens it.
+    ///
+    /// Gated on `std` because [`Redaction`] holds
+    /// [`CredentialFinding`](aa_security::CredentialFinding) values.
+    #[cfg(feature = "std")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_lineage_redaction_and_attribution(
+        seq: u64,
+        timestamp_ns: u64,
+        event_type: AuditEventType,
+        agent_id: AgentId,
+        session_id: SessionId,
+        payload: String,
+        previous_hash: [u8; 32],
+        lineage: Lineage,
+        redaction: Redaction,
+        policy_doc_id: Option<String>,
+    ) -> Self {
         let entry_hash = Self::compute_hash(
             seq,
             timestamp_ns,
@@ -429,6 +482,7 @@ impl AuditEntry {
             &payload,
             &lineage,
             &redaction,
+            policy_doc_id.as_deref(),
         );
         Self {
             seq,
@@ -448,6 +502,7 @@ impl AuditEntry {
             depth: lineage.depth,
             credential_findings: redaction.credential_findings,
             redacted_payload: redaction.redacted_payload,
+            policy_doc_id,
         }
     }
 
@@ -569,6 +624,15 @@ impl AuditEntry {
         self.redacted_payload.as_deref()
     }
 
+    /// AAASM-5107 — content digest (`"sha256:<hex>"`) of the policy document that
+    /// produced the decision this entry records, if it was emitted from a
+    /// cascade policy decision. `None` otherwise. This is the stable, version-
+    /// distinguishing identity a per-document 24h hit count is keyed on.
+    #[inline]
+    pub fn policy_doc_id(&self) -> Option<&str> {
+        self.policy_doc_id.as_deref()
+    }
+
     // -----------------------------------------------------------------------
     // Integrity
     // -----------------------------------------------------------------------
@@ -604,6 +668,7 @@ impl AuditEntry {
             &lineage,
             #[cfg(feature = "std")]
             &redaction,
+            self.policy_doc_id.as_deref(),
         );
         expected == self.entry_hash
     }
@@ -631,6 +696,7 @@ impl AuditEntry {
         payload: &str,
         lineage: &Lineage,
         #[cfg(feature = "std")] redaction: &Redaction,
+        policy_doc_id: Option<&str>,
     ) -> [u8; 32] {
         let mut hasher = Sha256::new();
         hasher.update(seq.to_be_bytes());
@@ -688,6 +754,14 @@ impl AuditEntry {
                     hasher.update([0u8]);
                 }
             }
+        }
+        // AAASM-5107 — policy_doc_id appended last so that entries with
+        // policy_doc_id=None hash identically to pre-AAASM-5107 output and the
+        // existing audit chain on disk keeps verifying. Length-prefixed so it is
+        // unambiguous against whatever follows in a future revision.
+        if let Some(s) = policy_doc_id {
+            hasher.update((s.len() as u32).to_be_bytes());
+            hasher.update(s.as_bytes());
         }
         hasher.finalize().into()
     }
@@ -1864,6 +1938,156 @@ mod redaction_tests {
             entry.verify_integrity(),
             "verify_integrity must pass on a freshly constructed redacted entry",
         );
+    }
+
+    // --- policy_doc_id attribution (AAASM-5107) ---
+
+    #[test]
+    fn attribution_default_none_preserves_legacy_hash() {
+        // new_with_lineage_and_redaction(..) and
+        // new_with_lineage_redaction_and_attribution(.., None) must produce an
+        // identical entry_hash for the same base fields, so an entry carrying no
+        // policy_doc_id hashes exactly as it did pre-AAASM-5107 and the audit
+        // chain on disk keeps verifying.
+        let payload = String::from(r#"{"tool":"bash"}"#);
+        let legacy = AuditEntry::new_with_lineage_and_redaction(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            payload.clone(),
+            [0u8; 32],
+            Lineage::default(),
+            Redaction::default(),
+        );
+        let with_none = AuditEntry::new_with_lineage_redaction_and_attribution(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            payload,
+            [0u8; 32],
+            Lineage::default(),
+            Redaction::default(),
+            None,
+        );
+        assert_eq!(
+            legacy.entry_hash(),
+            with_none.entry_hash(),
+            "policy_doc_id=None must contribute 0 bytes to the hash",
+        );
+        assert!(with_none.policy_doc_id().is_none());
+    }
+
+    #[test]
+    fn attribution_present_changes_hash_and_is_stored() {
+        let base = || {
+            (
+                0u64,
+                1_700_000_000_000_000_000u64,
+                AuditEventType::PolicyViolation,
+            )
+        };
+        let (seq, ts, et) = base();
+        let no_id = AuditEntry::new_with_lineage_redaction_and_attribution(
+            seq,
+            ts,
+            et,
+            AGENT,
+            SESSION,
+            "{}".into(),
+            [0u8; 32],
+            Lineage::default(),
+            Redaction::default(),
+            None,
+        );
+        let with_id = AuditEntry::new_with_lineage_redaction_and_attribution(
+            seq,
+            ts,
+            et,
+            AGENT,
+            SESSION,
+            "{}".into(),
+            [0u8; 32],
+            Lineage::default(),
+            Redaction::default(),
+            Some("sha256:abc123".to_string()),
+        );
+        assert_ne!(
+            no_id.entry_hash(),
+            with_id.entry_hash(),
+            "a present policy_doc_id must be committed to the hash",
+        );
+        assert_eq!(with_id.policy_doc_id(), Some("sha256:abc123"));
+        assert!(with_id.verify_integrity(), "entry with attribution must self-verify");
+    }
+
+    #[test]
+    fn attribution_distinguishes_two_document_versions_at_audit_level() {
+        // Two audit entries identical except for the deciding document's digest
+        // must be distinct records — this is what lets a per-document 24h count
+        // separate two versions of the same (scope, name).
+        let build = |doc_id: &str| {
+            AuditEntry::new_with_lineage_redaction_and_attribution(
+                0,
+                1_700_000_000_000_000_000,
+                AuditEventType::PolicyViolation,
+                AGENT,
+                SESSION,
+                "{}".into(),
+                [0u8; 32],
+                Lineage::default(),
+                Redaction::default(),
+                Some(doc_id.to_string()),
+            )
+        };
+        let v1 = build("sha256:1111");
+        let v2 = build("sha256:2222");
+        assert_ne!(v1.policy_doc_id(), v2.policy_doc_id());
+        assert_ne!(v1.entry_hash(), v2.entry_hash());
+    }
+
+    #[test]
+    fn attribution_survives_serde_round_trip() {
+        let entry = AuditEntry::new_with_lineage_redaction_and_attribution(
+            0,
+            1_000,
+            AuditEventType::PolicyViolation,
+            AGENT,
+            SESSION,
+            "{}".into(),
+            [0u8; 32],
+            Lineage::default(),
+            Redaction::default(),
+            Some("sha256:deadbeef".to_string()),
+        );
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("policy_doc_id"), "present id must serialize");
+        let restored: AuditEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.policy_doc_id(), Some("sha256:deadbeef"));
+        assert!(restored.verify_integrity());
+    }
+
+    #[test]
+    fn legacy_jsonl_without_policy_doc_id_deserialises_and_verifies() {
+        // An entry written before AAASM-5107 carries no policy_doc_id key; it
+        // must deserialize (field defaults to None) and still verify.
+        let pre = AuditEntry::new(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            r#"{"tool":"bash"}"#.into(),
+            [0u8; 32],
+        );
+        let json = serde_json::to_string(&pre).unwrap();
+        assert!(!json.contains("policy_doc_id"), "None must not appear in JSON");
+        let restored: AuditEntry = serde_json::from_str(&json).unwrap();
+        assert!(restored.policy_doc_id().is_none());
+        assert!(restored.verify_integrity());
     }
 
     #[test]

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -1983,13 +1983,7 @@ mod redaction_tests {
 
     #[test]
     fn attribution_present_changes_hash_and_is_stored() {
-        let base = || {
-            (
-                0u64,
-                1_700_000_000_000_000_000u64,
-                AuditEventType::PolicyViolation,
-            )
-        };
+        let base = || (0u64, 1_700_000_000_000_000_000u64, AuditEventType::PolicyViolation);
         let (seq, ts, et) = base();
         let no_id = AuditEntry::new_with_lineage_redaction_and_attribution(
             seq,

--- a/aa-gateway/src/engine/cache.rs
+++ b/aa-gateway/src/engine/cache.rs
@@ -14,6 +14,13 @@ use moka::sync::Cache;
 
 use crate::engine::decision::PolicyDecision;
 
+/// A cached cascade verdict: the merged [`PolicyDecision`] plus the content
+/// digest of the deciding policy document (AAASM-5107). The digest is part of
+/// the cached value so a cache hit carries the same document attribution a fresh
+/// evaluation would have produced — the deciding document is fixed for a given
+/// `(agent, epoch, action)` key within one policy epoch.
+pub type CachedVerdict = (PolicyDecision, Option<String>);
+
 /// Stable key identifying one (agent, epoch, action) evaluation result.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CacheKey {
@@ -100,7 +107,7 @@ fn action_discriminant(action: &aa_core::GovernanceAction) -> u64 {
 /// Hit and miss counters are tracked via `AtomicU64` for observability.
 #[derive(Clone)]
 pub struct DecisionCache {
-    inner: Cache<CacheKey, PolicyDecision>,
+    inner: Cache<CacheKey, CachedVerdict>,
     hits: Arc<AtomicU64>,
     misses: Arc<AtomicU64>,
 }
@@ -120,7 +127,7 @@ impl DecisionCache {
     }
 
     /// Look up an existing decision. Increments hit/miss counters.
-    pub fn get(&self, key: &CacheKey) -> Option<PolicyDecision> {
+    pub fn get(&self, key: &CacheKey) -> Option<CachedVerdict> {
         let result = self.inner.get(key);
         if result.is_some() {
             self.hits.fetch_add(1, Ordering::Relaxed);
@@ -132,8 +139,9 @@ impl DecisionCache {
         result
     }
 
-    /// Insert a decision. `PolicyDecision` is `Clone` so callers can keep a copy.
-    pub fn insert(&self, key: CacheKey, value: PolicyDecision) {
+    /// Insert a decision and its deciding-document digest. Both are `Clone` so
+    /// callers can keep a copy.
+    pub fn insert(&self, key: CacheKey, value: CachedVerdict) {
         self.inner.insert(key, value);
     }
 
@@ -180,8 +188,8 @@ mod tests {
     fn cache_hit_after_insert() {
         let cache = DecisionCache::new(128);
         let key = CacheKey::new(&[1u8; 16], 1, &tool_action("bash"));
-        cache.insert(key.clone(), PolicyDecision::Allow);
-        assert_eq!(cache.get(&key), Some(PolicyDecision::Allow));
+        cache.insert(key.clone(), (PolicyDecision::Allow, None));
+        assert_eq!(cache.get(&key), Some((PolicyDecision::Allow, None)));
         assert_eq!(cache.cache_hits(), 1);
         assert_eq!(cache.cache_misses(), 0);
     }
@@ -331,7 +339,7 @@ mod tests {
     fn invalidate_all_evicts_every_entry() {
         let cache = DecisionCache::new(128);
         let key = CacheKey::new(&[1u8; 16], 1, &tool_action("bash"));
-        cache.insert(key.clone(), PolicyDecision::Allow);
+        cache.insert(key.clone(), (PolicyDecision::Allow, None));
         assert!(cache.get(&key).is_some());
         cache.invalidate_all();
         cache.inner.run_pending_tasks();
@@ -342,7 +350,7 @@ mod tests {
     fn invalidate_for_agent_evicts_the_agents_entry() {
         let cache = DecisionCache::new(128);
         let key = CacheKey::new(&[7u8; 16], 1, &tool_action("deploy"));
-        cache.insert(key.clone(), PolicyDecision::Allow);
+        cache.insert(key.clone(), (PolicyDecision::Allow, None));
         assert!(cache.get(&key).is_some());
         cache.invalidate_for_agent(&[7u8; 16]);
         cache.inner.run_pending_tasks();

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -25,8 +25,15 @@ pub enum PolicyDecision {
 }
 
 impl PolicyDecision {
-    /// Convert to `aa_core::PolicyResult`, dropping the `source_scope` audit
-    /// field that is not part of the core protocol type.
+    /// Convert to `aa_core::PolicyResult`, dropping the `source_scope` field
+    /// that is not part of the core protocol type.
+    ///
+    /// AAASM-5107: `source_scope` is scope-granular (global/org/team/agent) and
+    /// never named a *document*, so document attribution does not travel on this
+    /// conversion. The deciding document's content digest is captured separately
+    /// via [`merge_decisions_attributed`] and carried to the audit write on
+    /// [`crate::engine::EvaluationResult::policy_doc_id`], so it is no longer
+    /// lost here.
     pub fn into_policy_result(self) -> aa_core::PolicyResult {
         match self {
             PolicyDecision::Allow => aa_core::PolicyResult::Allow,
@@ -331,29 +338,71 @@ pub fn merge_decisions_audited(
     policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
     failures: &mut Vec<crate::policy::expr::ResolutionFailure>,
 ) -> PolicyDecision {
+    merge_decisions_attributed(cascade, ctx, action, policy_ctx, failures).0
+}
+
+/// Like [`merge_decisions_audited`], but additionally reports the **content
+/// digest of the deciding policy document** (AAASM-5107).
+///
+/// The returned `Option<String>` is [`PolicyDocument::content_digest`] of the
+/// single document that produced the terminal verdict:
+///
+/// * a `Deny` — the document whose stage fired the short-circuit deny;
+/// * a `RequireApproval` — the most-specific document that required approval
+///   (the one whose decision the merge kept);
+/// * an `Allow` — the most-specific document evaluated (the last in cascade
+///   order), i.e. the narrowest policy that let the action through.
+///
+/// `None` only for the empty-cascade fail-closed deny, which no document
+/// produced. This is the stable identity carried to the audit write so a
+/// per-document 24h hit count is queryable (AAASM-5107 §3), and it distinguishes
+/// two versions of the same `(scope, name)` because the digest is content-derived.
+pub fn merge_decisions_attributed(
+    cascade: &[Arc<PolicyDocument>],
+    ctx: &aa_core::AgentContext,
+    action: &aa_core::GovernanceAction,
+    policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
+    failures: &mut Vec<crate::policy::expr::ResolutionFailure>,
+) -> (PolicyDecision, Option<String>) {
     if cascade.is_empty() {
-        return PolicyDecision::Deny {
-            reason: "no policy — fail-closed".into(),
-            source_scope: PolicyScope::Global,
-        };
+        return (
+            PolicyDecision::Deny {
+                reason: "no policy — fail-closed".into(),
+                source_scope: PolicyScope::Global,
+            },
+            None,
+        );
     }
 
     let mut running = PolicyDecision::Allow;
+    // The document whose verdict `running` currently holds. Seeded to the first
+    // (broadest) document so an all-Allow cascade still attributes the allow to
+    // a concrete document rather than dropping the attribution.
+    let mut decided_by: &Arc<PolicyDocument> = &cascade[0];
 
     for doc in cascade {
         let verdict = evaluate_single_doc(doc, ctx, action, policy_ctx, failures);
         match verdict {
-            // Short-circuit: Deny always wins.
-            PolicyDecision::Deny { .. } => return verdict,
+            // Short-circuit: Deny always wins — attribute to the denying doc.
+            PolicyDecision::Deny { .. } => return (verdict, Some(doc.content_digest())),
             // Most-specific scope wins: always overwrite with the narrower scope's decision.
             PolicyDecision::RequireApproval { .. } => {
                 running = verdict;
+                decided_by = doc;
             }
-            PolicyDecision::Allow => {}
+            // An allow from this doc does not change the verdict, but the
+            // most-specific evaluated doc is the effective decider for an
+            // all-Allow cascade.
+            PolicyDecision::Allow => {
+                if matches!(running, PolicyDecision::Allow) {
+                    decided_by = doc;
+                }
+            }
         }
     }
 
-    running
+    let doc_id = decided_by.content_digest();
+    (running, Some(doc_id))
 }
 
 #[cfg(test)]

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -24,7 +24,7 @@ use crate::engine::cache::{CacheKey, DecisionCache};
 
 use crate::budget::BudgetTracker;
 
-use crate::engine::decision::{merge_decisions, PolicyDecision};
+use crate::engine::decision::PolicyDecision;
 use crate::engine::scope_index::ScopeIndex;
 use crate::policy::document::{ActionOnExceed, CredentialAction};
 use crate::policy::{PolicyDocument, PolicyValidator};
@@ -59,6 +59,16 @@ pub struct EvaluationResult {
     /// Optional side-effect action for the service layer when the decision is `Deny`.
     /// `None` means no side-effect beyond denying the request.
     pub deny_action: Option<DenyAction>,
+    /// AAASM-5107 — content digest of the policy document that produced this
+    /// decision (`"sha256:<hex>"`), as reported by
+    /// [`decision::merge_decisions_attributed`]. Carried to the audit write so a
+    /// per-document 24h hit count is queryable and the deciding document is
+    /// unambiguous even across two versions of the same `(scope, name)`.
+    ///
+    /// `None` on the pre-cascade / primary-policy paths and the empty-cascade
+    /// fail-closed deny — those verdicts are produced without a nameable cascade
+    /// document, so no digest is attributed rather than a misleading one.
+    pub policy_doc_id: Option<String>,
 }
 
 impl EvaluationResult {
@@ -71,6 +81,7 @@ impl EvaluationResult {
             redacted_payload: None,
             credential_findings: vec![],
             deny_action: None,
+            policy_doc_id: None,
         }
     }
 
@@ -88,6 +99,7 @@ impl EvaluationResult {
             redacted_payload,
             credential_findings,
             deny_action,
+            policy_doc_id: None,
         }
     }
 }
@@ -165,6 +177,10 @@ pub fn transform_for_observe_mode(
         redacted_payload: None,
         credential_findings: result.credential_findings,
         deny_action: None,
+        // AAASM-5107 — observe mode rewrites the verdict to Allow but the policy
+        // document still fired; preserve its attribution so the dry-run audit
+        // entry still names the document that would have decided in enforce mode.
+        policy_doc_id: result.policy_doc_id,
     };
 
     (transformed, Some(shadow))
@@ -1074,6 +1090,7 @@ impl PolicyEngine {
                 redacted_payload: None,
                 credential_findings: vec![],
                 deny_action: None,
+                policy_doc_id: None,
             });
         }
         None
@@ -1222,6 +1239,7 @@ impl PolicyEngine {
                 redacted_payload: None,
                 credential_findings: all_findings,
                 deny_action: None,
+                policy_doc_id: None,
             });
         }
 
@@ -1336,6 +1354,7 @@ impl PolicyEngine {
             redacted_payload,
             credential_findings,
             deny_action: None,
+            policy_doc_id: None,
         }
     }
 
@@ -1476,20 +1495,22 @@ impl PolicyEngine {
         action: &aa_core::GovernanceAction,
         cache_key: CacheKey,
         pctx_dyn: Option<&dyn crate::policy::context::PolicyContext>,
-    ) -> PolicyDecision {
+    ) -> (PolicyDecision, Option<String>) {
         let context_dependent = Self::cascade_has_live_context_approval(cascade);
         if context_dependent {
             // ADR 0015 §4: surface any graph-context resolution failures for audit
             // on the fresh-evaluation path (context-dependent verdicts are never
             // cached, so this is the only place they can arise).
             let mut failures = Vec::new();
-            let v = decision::merge_decisions_audited(cascade, ctx, action, pctx_dyn, &mut failures);
+            // AAASM-5107 — attribute the verdict to the deciding document's digest.
+            let v = decision::merge_decisions_attributed(cascade, ctx, action, pctx_dyn, &mut failures);
             Self::emit_resolution_failures(&failures);
             v
         } else if let Some(cached) = self.decision_cache.get(&cache_key) {
             cached
         } else {
-            let v = merge_decisions(cascade, ctx, action, pctx_dyn);
+            let mut failures = Vec::new();
+            let v = decision::merge_decisions_attributed(cascade, ctx, action, pctx_dyn, &mut failures);
             self.decision_cache.insert(cache_key, v.clone());
             v
         }
@@ -1511,6 +1532,7 @@ impl PolicyEngine {
                 redacted_payload: None,
                 credential_findings: vec![],
                 deny_action: None,
+                policy_doc_id: None,
             };
         }
 
@@ -1529,7 +1551,7 @@ impl PolicyEngine {
         });
         let pctx_dyn: Option<&dyn crate::policy::context::PolicyContext> = pctx.as_ref().map(|c| c as _);
 
-        let verdict = self.resolve_merge_verdict(&cascade, ctx, action, cache_key, pctx_dyn);
+        let (verdict, policy_doc_id) = self.resolve_merge_verdict(&cascade, ctx, action, cache_key, pctx_dyn);
 
         // If already denied, return immediately.
         if let PolicyDecision::Deny { reason, .. } = verdict {
@@ -1538,6 +1560,7 @@ impl PolicyEngine {
                 redacted_payload: None,
                 credential_findings: vec![],
                 deny_action: None,
+                policy_doc_id,
             };
         }
 
@@ -1585,6 +1608,7 @@ impl PolicyEngine {
             redacted_payload,
             credential_findings,
             deny_action,
+            policy_doc_id,
         }
     }
 

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2892,7 +2892,7 @@ mod tests {
         // Pre-seed the cache with the stale Allow a prior in-window eval stored.
         let epoch = engine.policy_epoch.load(Ordering::Relaxed);
         let key = CacheKey::new(ctx.agent_id.as_bytes(), epoch, &action);
-        engine.decision_cache.insert(key, PolicyDecision::Allow);
+        engine.decision_cache.insert(key, (PolicyDecision::Allow, None));
 
         let cascade = vec![Arc::new(doc)];
         assert_eq!(
@@ -4398,6 +4398,7 @@ mod tests {
             redacted_payload: None,
             credential_findings: vec![],
             deny_action: None,
+            policy_doc_id: None,
         }
     }
 
@@ -4420,6 +4421,7 @@ mod tests {
             redacted_payload: None,
             credential_findings: vec![],
             deny_action: Some(DenyAction::Block),
+            policy_doc_id: None,
         }
     }
 
@@ -4446,6 +4448,7 @@ mod tests {
             redacted_payload: None,
             credential_findings: vec![],
             deny_action: None,
+            policy_doc_id: None,
         };
         let (out, shadow) = transform_for_observe_mode(pending, aa_core::EnforcementMode::Observe);
         assert_eq!(out.decision, PolicyResult::Allow);

--- a/aa-gateway/src/policy/digest.rs
+++ b/aa-gateway/src/policy/digest.rs
@@ -1,0 +1,340 @@
+//! Stable content identity for a validated [`PolicyDocument`] (AAASM-5107).
+//!
+//! A runtime `PolicyDocument` carries no id column or digest, so nothing on the
+//! audit-write path could name *which* document produced a decision. The Policy
+//! list, the capability matrix and the team view all fall back to the
+//! `(scope, metadata.name)` pair as the only nameable handle — but that pair is
+//! explicitly **not** an identity: it omits `policy_version`, so two revisions of
+//! the same `(scope, name)` collapse onto one key, and in the flat/non-envelope
+//! format (`name = None`) every unnamed document at a scope shares one key.
+//!
+//! [`PolicyDocument::content_digest`] closes that gap with a **content digest**:
+//! the SHA-256 of a canonical, order-independent encoding of *every* validated
+//! field of the document. Two documents produce the same digest iff they are
+//! equal under `PolicyDocument`'s own `PartialEq` (whole-content equality), so
+//! the digest is exactly as discriminating as the strongest identity the type
+//! already exposes — and it distinguishes two versions of the same
+//! `(scope, name)` because any content difference (including `policy_version`)
+//! changes the hash.
+//!
+//! ## Why a content hash, not `(scope, name, version)`
+//!
+//! A version-qualified key would name the *declared* revision, but two documents
+//! can declare the same `metadata.version` while differing in body (an operator
+//! edits rules without bumping the version), and the flat format declares no
+//! version at all. A content digest is unambiguous in both cases and needs no
+//! trusted version field. SHA-256 collision resistance makes it
+//! unforgeable-enough for audit attribution: an attacker cannot craft a second,
+//! semantically different document that hashes to a victim document's id.
+//!
+//! ## Relationship to the audit hash chain
+//!
+//! This digest is computed **independently** of [`aa_core::audit::AuditEntry`]'s
+//! tamper-evident chain hash. It is carried as an additive, optional field and
+//! never alters how the chain hash is computed for entries that do not set it —
+//! the existing audit-integrity guarantees are untouched (AAASM-5107 §6).
+
+use sha2::{Digest, Sha256};
+
+use crate::policy::document::{
+    ActionOnExceed, ApprovalPolicy, BudgetPolicy, CredentialAction, DataPolicy, NetworkPolicy, PolicyDocument,
+    SchedulePolicy, ToolPolicy,
+};
+
+/// Length-prefix an optional string into `hasher`: a `0` tag byte for `None`,
+/// or a `1` tag byte followed by the big-endian byte length and the UTF-8 bytes
+/// for `Some`. The tag distinguishes `None` from `Some("")` and the length
+/// prefix makes adjacent fields unambiguous (no delimiter injection).
+fn hash_opt_str(hasher: &mut Sha256, value: Option<&str>) {
+    match value {
+        None => hasher.update([0u8]),
+        Some(s) => {
+            hasher.update([1u8]);
+            hasher.update((s.len() as u64).to_be_bytes());
+            hasher.update(s.as_bytes());
+        }
+    }
+}
+
+/// Length-prefix a required string into `hasher`.
+fn hash_str(hasher: &mut Sha256, s: &str) {
+    hasher.update((s.len() as u64).to_be_bytes());
+    hasher.update(s.as_bytes());
+}
+
+/// Hash an optional `f64` as its canonical IEEE-754 big-endian bits, tagged for
+/// presence. `to_bits` is used (not `to_be_bytes` on the value) so the encoding
+/// is exact and reproducible.
+fn hash_opt_f64(hasher: &mut Sha256, value: Option<f64>) {
+    match value {
+        None => hasher.update([0u8]),
+        Some(v) => {
+            hasher.update([1u8]);
+            hasher.update(v.to_bits().to_be_bytes());
+        }
+    }
+}
+
+fn hash_opt_u32(hasher: &mut Sha256, value: Option<u32>) {
+    match value {
+        None => hasher.update([0u8]),
+        Some(v) => {
+            hasher.update([1u8]);
+            hasher.update(v.to_be_bytes());
+        }
+    }
+}
+
+fn hash_network(hasher: &mut Sha256, network: Option<&NetworkPolicy>) {
+    match network {
+        None => hasher.update([0u8]),
+        Some(np) => {
+            hasher.update([1u8]);
+            // allowlist order is operator-authored and semantically meaningful
+            // (first match wins is not used, but the list is a set the operator
+            // wrote); hash it in declared order so an equal document — which
+            // compares the Vec element-wise — hashes equal.
+            hasher.update((np.allowlist.len() as u64).to_be_bytes());
+            for host in &np.allowlist {
+                hash_str(hasher, host);
+            }
+        }
+    }
+}
+
+fn hash_schedule(hasher: &mut Sha256, schedule: Option<&SchedulePolicy>) {
+    match schedule.and_then(|s| s.active_hours.as_ref()) {
+        None => hasher.update([0u8]),
+        Some(ah) => {
+            hasher.update([1u8]);
+            hash_str(hasher, &ah.start);
+            hash_str(hasher, &ah.end);
+            hash_str(hasher, &ah.timezone);
+        }
+    }
+}
+
+fn hash_budget(hasher: &mut Sha256, budget: Option<&BudgetPolicy>) {
+    match budget {
+        None => hasher.update([0u8]),
+        Some(bp) => {
+            hasher.update([1u8]);
+            hash_opt_f64(hasher, bp.daily_limit_usd);
+            hash_opt_f64(hasher, bp.monthly_limit_usd);
+            hash_opt_f64(hasher, bp.org_daily_limit_usd);
+            hash_opt_f64(hasher, bp.org_monthly_limit_usd);
+            hash_opt_str(hasher, bp.timezone.as_deref());
+            hasher.update([match bp.action_on_exceed {
+                ActionOnExceed::Deny => 0u8,
+                ActionOnExceed::Suspend => 1u8,
+            }]);
+            match bp.window {
+                None => hasher.update([0u8]),
+                Some(d) => {
+                    hasher.update([1u8]);
+                    hasher.update(d.as_nanos().to_be_bytes());
+                }
+            }
+        }
+    }
+}
+
+fn hash_data(hasher: &mut Sha256, data: Option<&DataPolicy>) {
+    match data {
+        None => hasher.update([0u8]),
+        Some(dp) => {
+            hasher.update([1u8]);
+            hasher.update((dp.sensitive_patterns.len() as u64).to_be_bytes());
+            for pat in &dp.sensitive_patterns {
+                hash_str(hasher, pat);
+            }
+            hasher.update([match dp.credential_action {
+                CredentialAction::Block => 0u8,
+                CredentialAction::RedactOnly => 1u8,
+                CredentialAction::AlertOnly => 2u8,
+                CredentialAction::AlertAndRedact => 3u8,
+            }]);
+        }
+    }
+}
+
+fn hash_approval(hasher: &mut Sha256, approval: Option<&ApprovalPolicy>) {
+    match approval {
+        None => hasher.update([0u8]),
+        Some(ap) => {
+            hasher.update([1u8]);
+            hash_opt_u32(hasher, ap.timeout_seconds);
+            hash_opt_str(hasher, ap.escalation_role.as_deref());
+        }
+    }
+}
+
+fn hash_tools(hasher: &mut Sha256, tools: &std::collections::HashMap<String, ToolPolicy>) {
+    // HashMap iteration order is nondeterministic — sort by tool name so an
+    // equal tool map (which `PolicyDocument: PartialEq` compares order-free)
+    // always hashes identically.
+    let mut names: Vec<&String> = tools.keys().collect();
+    names.sort();
+    hasher.update((names.len() as u64).to_be_bytes());
+    for name in names {
+        let tp = &tools[name];
+        hash_str(hasher, name);
+        hasher.update([u8::from(tp.allow)]);
+        hash_opt_u32(hasher, tp.limit_per_hour);
+        hash_opt_str(hasher, tp.requires_approval_if.as_deref());
+    }
+}
+
+fn hash_capabilities(hasher: &mut Sha256, caps: Option<&aa_core::CapabilitySet>) {
+    match caps {
+        None => hasher.update([0u8]),
+        Some(cs) => {
+            hasher.update([1u8]);
+            // allow / deny are BTreeSet<Capability>, already in a total,
+            // deterministic order. Capability's Display is its stable wire form.
+            hasher.update((cs.allow.len() as u64).to_be_bytes());
+            for c in &cs.allow {
+                hash_str(hasher, &c.to_string());
+            }
+            hasher.update((cs.deny.len() as u64).to_be_bytes());
+            for c in &cs.deny {
+                hash_str(hasher, &c.to_string());
+            }
+            hasher.update([u8::from(cs.allow_restricted)]);
+        }
+    }
+}
+
+impl PolicyDocument {
+    /// A stable, content-derived identity for this document: `"sha256:<hex>"`
+    /// where the hex is the SHA-256 of a canonical encoding of every validated
+    /// field.
+    ///
+    /// Two documents share a digest iff they are equal under `PolicyDocument`'s
+    /// `PartialEq`; in particular the digest distinguishes two versions of the
+    /// same `(scope, metadata.name)` pair whenever their content differs. See
+    /// the module docs for the full rationale and the audit-chain relationship.
+    pub fn content_digest(&self) -> String {
+        let mut hasher = Sha256::new();
+        // Domain-separation tag + version byte so this digest can never be
+        // confused with any other SHA-256 in the system and so the encoding can
+        // be revved without silently colliding with v1 ids.
+        hasher.update(b"aa-policy-doc-id\x01");
+        // scope — the canonical `global` / `org:x` / `team:x` / `agent:<uuid>` /
+        // `tool:x` wire string.
+        hash_str(&mut hasher, &self.scope.to_string());
+        hash_opt_str(&mut hasher, self.name.as_deref());
+        hash_opt_str(&mut hasher, self.policy_version.as_deref());
+        hash_opt_str(&mut hasher, self.version.as_deref());
+        hash_network(&mut hasher, self.network.as_ref());
+        hash_schedule(&mut hasher, self.schedule.as_ref());
+        hash_budget(&mut hasher, self.budget.as_ref());
+        hash_data(&mut hasher, self.data.as_ref());
+        hasher.update(self.approval_timeout_secs.to_be_bytes());
+        hash_approval(&mut hasher, self.approval_policy.as_ref());
+        hash_tools(&mut hasher, &self.tools);
+        hash_capabilities(&mut hasher, self.capabilities.as_ref());
+        let digest: [u8; 32] = hasher.finalize().into();
+        format!("sha256:{}", hex::encode(digest))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use aa_core::CapabilitySet;
+
+    use super::*;
+    use crate::policy::document::ToolPolicy;
+    use crate::policy::scope::PolicyScope;
+
+    fn base_doc() -> PolicyDocument {
+        PolicyDocument {
+            name: Some("baseline".to_string()),
+            policy_version: Some("1".to_string()),
+            version: None,
+            scope: PolicyScope::Global,
+            network: None,
+            schedule: None,
+            budget: None,
+            data: None,
+            approval_timeout_secs: 300,
+            approval_policy: None,
+            tools: HashMap::new(),
+            capabilities: None,
+        }
+    }
+
+    #[test]
+    fn digest_is_prefixed_and_stable_across_calls() {
+        let doc = base_doc();
+        let a = doc.content_digest();
+        let b = doc.content_digest();
+        assert_eq!(a, b, "digest must be deterministic for one document");
+        assert!(a.starts_with("sha256:"), "digest must carry the scheme prefix: {a}");
+        // "sha256:" (7) + 64 hex chars.
+        assert_eq!(a.len(), 7 + 64);
+    }
+
+    #[test]
+    fn equal_documents_have_equal_digests() {
+        assert_eq!(base_doc(), base_doc());
+        assert_eq!(base_doc().content_digest(), base_doc().content_digest());
+    }
+
+    #[test]
+    fn digest_distinguishes_two_versions_of_same_scope_and_name() {
+        // Same (scope, name), different content — the exact case the (scope,
+        // name) PolicyKey collapses and this digest must separate.
+        let mut v1 = base_doc();
+        v1.policy_version = Some("1".to_string());
+        let mut v2 = base_doc();
+        v2.policy_version = Some("2".to_string());
+        assert_ne!(v1.content_digest(), v2.content_digest());
+
+        // Even when the declared version is identical, a body edit changes the id.
+        let mut edited = base_doc();
+        edited.tools.insert(
+            "bash".to_string(),
+            ToolPolicy {
+                allow: false,
+                limit_per_hour: None,
+                requires_approval_if: None,
+            },
+        );
+        assert_ne!(base_doc().content_digest(), edited.content_digest());
+    }
+
+    #[test]
+    fn tool_map_insertion_order_does_not_change_digest() {
+        let tp = |allow: bool| ToolPolicy {
+            allow,
+            limit_per_hour: None,
+            requires_approval_if: None,
+        };
+        let mut a = base_doc();
+        a.tools.insert("alpha".into(), tp(true));
+        a.tools.insert("beta".into(), tp(false));
+        let mut b = base_doc();
+        b.tools.insert("beta".into(), tp(false));
+        b.tools.insert("alpha".into(), tp(true));
+        assert_eq!(a.content_digest(), b.content_digest());
+    }
+
+    #[test]
+    fn scope_change_changes_digest() {
+        let mut team = base_doc();
+        team.scope = PolicyScope::Team("platform".into());
+        assert_ne!(base_doc().content_digest(), team.content_digest());
+    }
+
+    #[test]
+    fn capability_set_contributes_to_digest() {
+        let mut caps = CapabilitySet::default();
+        caps.deny.insert(aa_core::Capability::FileWrite);
+        let mut doc = base_doc();
+        doc.capabilities = Some(caps);
+        assert_ne!(base_doc().content_digest(), doc.content_digest());
+    }
+}

--- a/aa-gateway/src/policy/mod.rs
+++ b/aa-gateway/src/policy/mod.rs
@@ -15,6 +15,7 @@
 
 pub(crate) mod canonical;
 pub(crate) mod context;
+pub mod digest;
 pub mod document;
 pub mod error;
 pub(crate) mod expr;

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -219,6 +219,7 @@ pub fn result_to_response(result: &PolicyResult, latency_us: i64, policy_rule: &
         redacted_payload: None,
         credential_findings: Vec::new(),
         deny_action: None,
+        policy_doc_id: None,
     };
     eval_result_to_response(&eval, latency_us, policy_rule)
 }

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -404,6 +404,7 @@ mod tests {
             redacted_payload: None,
             credential_findings: vec![aa_security::CredentialFinding::from_regex_match(0, 4)],
             deny_action: None,
+            policy_doc_id: None,
         };
         let resp = eval_result_to_response(&eval, 0, "data_pattern_scan");
         assert_eq!(resp.decision, Decision::Deny as i32);
@@ -421,6 +422,7 @@ mod tests {
             redacted_payload: None,
             credential_findings: vec![aa_security::CredentialFinding::from_regex_match(0, 4)],
             deny_action: None,
+            policy_doc_id: None,
         };
         let resp = eval_result_to_response(&eval, 0, "");
         assert_eq!(resp.decision, Decision::Allow as i32);

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -937,12 +937,21 @@ impl PolicyServiceImpl {
         // core-type follow-up — see PR body.)
         let trace_id_str: Option<&str> = (!req.trace_id.is_empty()).then_some(req.trace_id.as_str());
         let span_id_str: Option<&str> = (!req.span_id.is_empty()).then_some(req.span_id.as_str());
+        // AAASM-5107 — the content digest of the deciding policy document. Carried
+        // in the payload JSON so the per-document 24h hit-count query
+        // (`aa_api::routes::analytics`) can group audit events by document, and
+        // mirrored onto the top-level `policy_doc_id` field below. `None` on
+        // paths that resolved no cascade document (primary policy, credential /
+        // budget engine-level denies, empty cascade) — absent, never a
+        // misleading id.
+        let policy_doc_id: Option<&str> = eval.policy_doc_id.as_deref();
         let payload = match shadow {
             Some(s) => serde_json::json!({
                 "action_type": req.action_type,
                 "decision": response.decision,
                 "reason": &response.reason,
                 "policy_rule": &response.policy_rule,
+                "policy_doc_id": policy_doc_id,
                 "latency_us": response.decision_latency_us,
                 "dry_run": true,
                 "shadow_decision": &s.shadow_decision,
@@ -964,6 +973,7 @@ impl PolicyServiceImpl {
                 "decision": response.decision,
                 "reason": &response.reason,
                 "policy_rule": &response.policy_rule,
+                "policy_doc_id": policy_doc_id,
                 "latency_us": response.decision_latency_us,
                 "caller_agent_id": caller_agent_id_str,
                 "callee_agent_id": caller_agent_id_str.map(|_| proto_agent.agent_id.as_str()),
@@ -986,34 +996,31 @@ impl PolicyServiceImpl {
         // redacted payload) to the audit entry via the redaction-aware constructor.
         // Both fields carry the [REDACTED:<kind>] form only — the raw secret bytes
         // never reach the audit pipeline.
-        let entry = if eval.credential_findings.is_empty() {
-            AuditEntry::new_with_lineage(
-                seq,
-                timestamp_ns,
-                event_type,
-                agent_id,
-                session_id,
-                payload,
-                *last_hash,
-                lineage,
-            )
+        // AAASM-5107 — always route through the attribution-aware constructor so
+        // the deciding document's digest is committed to the entry hash. A clean
+        // scan passes `Redaction::default()`, which contributes zero bytes and so
+        // hashes exactly as `new_with_lineage` did; a policy_doc_id of `None`
+        // likewise contributes nothing. Only a *present* digest changes the hash.
+        let redaction = if eval.credential_findings.is_empty() {
+            Redaction::default()
         } else {
-            let redaction = Redaction {
+            Redaction {
                 credential_findings: eval.credential_findings.clone(),
                 redacted_payload: eval.redacted_payload.clone(),
-            };
-            AuditEntry::new_with_lineage_and_redaction(
-                seq,
-                timestamp_ns,
-                event_type,
-                agent_id,
-                session_id,
-                payload,
-                *last_hash,
-                lineage,
-                redaction,
-            )
+            }
         };
+        let entry = AuditEntry::new_with_lineage_redaction_and_attribution(
+            seq,
+            timestamp_ns,
+            event_type,
+            agent_id,
+            session_id,
+            payload,
+            *last_hash,
+            lineage,
+            redaction,
+            eval.policy_doc_id.clone(),
+        );
 
         // Update the chain head before sending — even if try_send fails (the entry
         // is dropped), we advance the chain so subsequent entries don't duplicate

--- a/aa-gateway/tests/service_convert_test.rs
+++ b/aa-gateway/tests/service_convert_test.rs
@@ -290,6 +290,7 @@ fn eval_result_with_credential_findings_returns_redact() {
         redacted_payload: Some("redacted text".into()),
         credential_findings: vec![aa_security::CredentialFinding::from_regex_match(0, 10)],
         deny_action: None,
+        policy_doc_id: None,
     };
     let resp = eval_result_to_response(&eval, 77, "");
     assert_eq!(resp.decision, Decision::Redact as i32);

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -3831,12 +3831,13 @@ export interface components {
             affects: string[];
             /**
              * Format: int64
-             * @description Number of times this policy fired in the last 24 hours.
+             * @description Number of times this policy document fired in the last 24 hours.
              *
-             *     Always absent here: attributing audit events back to the policy document
-             *     that produced them needs the deciding document captured at the
-             *     enforcement boundary, which is owned by AAASM-5107. A `0` would be
-             *     indistinguishable from "fired zero times".
+             *     Sourced (AAASM-5107) by joining this row's document content digest against
+             *     the per-document decision counts from the last-24h audit window — each
+             *     policy decision records the deciding document's digest on its audit entry.
+             *     Absent, never `0`, when the document recorded no decision in the window: a
+             *     `0` would be indistinguishable from "fired zero times".
              */
             hits24h?: number | null;
             id: string;
@@ -3928,20 +3929,21 @@ export interface components {
             affects?: string[] | null;
             /**
              * Format: int64
-             * @description Number of times this policy fired in the last 24 hours.
+             * @description Number of times this policy document fired in the last 24 hours.
              *
-             *     **Always absent.** Nothing on the audit write path records which policy
-             *     document produced a decision: `AuditEntry` has no policy field, and the
-             *     payload's `policy_rule` is the free-text deny *reason*
-             *     (`aa_gateway::service::policy_service::evaluate_one`), empty on every
-             *     allow. `aa_gateway::engine::decision::PolicyDecision::Deny` does carry a
-             *     `source_scope`, but `into_policy_result` drops it before the audit write —
-             *     and it is scope-granular, not document-granular, so it could not name a
-             *     document even if it survived. Capturing the deciding document at decision
-             *     time is enforcement-boundary work owned by AAASM-5107; until it lands this
-             *     is reported absent rather than as a `0` that would be indistinguishable
-             *     from "fired zero times". The same field is absent for the same reason on
-             *     the capability matrix's `Policy`.
+             *     Sourced (AAASM-5107) by joining this row's document content digest against
+             *     the per-document decision counts tallied from the last-24h audit window —
+             *     each policy decision now records the deciding document's digest on its
+             *     audit entry (`AuditEntry::policy_doc_id`, stamped at the enforcement
+             *     boundary from `PolicyDocument::content_digest`). The digest distinguishes
+             *     two versions of the same `(scope, name)` pair.
+             *
+             *     **Absent, never `0`.** A document that recorded no decision in the window,
+             *     a row whose snapshot cannot be parsed to a digest, or a key shared by two
+             *     distinct live documents (no single "the" document to count) all report
+             *     absent — preserving the absent-vs-"fired zero times" distinction
+             *     AAASM-5096 established. The same sourcing applies to the capability
+             *     matrix's `Policy.hits24h`.
              */
             hits24h?: number | null;
             /** @description Policy name from metadata. */
@@ -4601,8 +4603,10 @@ export interface components {
         TeamPolicyResponse: {
             /**
              * Format: int64
-             * @description Number of times this policy fired in the last 24 hours. **Always absent**
-             *     — see [`PolicyResponse::hits_24h`] for why no source exists.
+             * @description Number of times this policy document fired in the last 24 hours. Sourced
+             *     from per-document decision counts (AAASM-5107); absent, never `0`, when
+             *     the document recorded no decision in the window — see
+             *     [`PolicyResponse::hits_24h`] for the full sourcing and absent-vs-zero rule.
              */
             hits24h?: number | null;
             /**

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -6350,12 +6350,13 @@ components:
           - 'null'
           format: int64
           description: |-
-            Number of times this policy fired in the last 24 hours.
+            Number of times this policy document fired in the last 24 hours.
 
-            Always absent here: attributing audit events back to the policy document
-            that produced them needs the deciding document captured at the
-            enforcement boundary, which is owned by AAASM-5107. A `0` would be
-            indistinguishable from "fired zero times".
+            Sourced (AAASM-5107) by joining this row's document content digest against
+            the per-document decision counts from the last-24h audit window — each
+            policy decision records the deciding document's digest on its audit entry.
+            Absent, never `0`, when the document recorded no decision in the window: a
+            `0` would be indistinguishable from "fired zero times".
           minimum: 0
         id:
           type: string
@@ -6489,20 +6490,21 @@ components:
           - 'null'
           format: int64
           description: |-
-            Number of times this policy fired in the last 24 hours.
+            Number of times this policy document fired in the last 24 hours.
 
-            **Always absent.** Nothing on the audit write path records which policy
-            document produced a decision: `AuditEntry` has no policy field, and the
-            payload's `policy_rule` is the free-text deny *reason*
-            (`aa_gateway::service::policy_service::evaluate_one`), empty on every
-            allow. `aa_gateway::engine::decision::PolicyDecision::Deny` does carry a
-            `source_scope`, but `into_policy_result` drops it before the audit write —
-            and it is scope-granular, not document-granular, so it could not name a
-            document even if it survived. Capturing the deciding document at decision
-            time is enforcement-boundary work owned by AAASM-5107; until it lands this
-            is reported absent rather than as a `0` that would be indistinguishable
-            from "fired zero times". The same field is absent for the same reason on
-            the capability matrix's `Policy`.
+            Sourced (AAASM-5107) by joining this row's document content digest against
+            the per-document decision counts tallied from the last-24h audit window —
+            each policy decision now records the deciding document's digest on its
+            audit entry (`AuditEntry::policy_doc_id`, stamped at the enforcement
+            boundary from `PolicyDocument::content_digest`). The digest distinguishes
+            two versions of the same `(scope, name)` pair.
+
+            **Absent, never `0`.** A document that recorded no decision in the window,
+            a row whose snapshot cannot be parsed to a digest, or a key shared by two
+            distinct live documents (no single "the" document to count) all report
+            absent — preserving the absent-vs-"fired zero times" distinction
+            AAASM-5096 established. The same sourcing applies to the capability
+            matrix's `Policy.hits24h`.
           minimum: 0
         name:
           type: string
@@ -7515,8 +7517,10 @@ components:
           - 'null'
           format: int64
           description: |-
-            Number of times this policy fired in the last 24 hours. **Always absent**
-            — see [`PolicyResponse::hits_24h`] for why no source exists.
+            Number of times this policy document fired in the last 24 hours. Sourced
+            from per-document decision counts (AAASM-5107); absent, never `0`, when
+            the document recorded no decision in the window — see
+            [`PolicyResponse::hits_24h`] for the full sourcing and absent-vs-zero rule.
           minimum: 0
         id:
           type: string


### PR DESCRIPTION
## Description

Closes the gap that left the per-policy 24h hit counter (`hits24h`) permanently absent on `PolicyResponse`, `TeamPolicyResponse`, and the capability-matrix `Policy` (AAASM-5096 shipped the contract; nothing recorded WHICH document produced a decision). AAASM-5107 captures the deciding document at the enforcement boundary and carries it to the audit write, making the counter sourceable.

**Identity scheme:** a **canonical SHA-256 content digest** of the validated policy document (`PolicyDocument::content_digest`, new `aa-gateway/src/policy/digest.rs`) — order-independent over every field. The runtime document has no id/digest and `(scope, name)` is not unique across versions, so a content hash is the natural stable identity; it **distinguishes two versions of the same (scope, name) pair**, satisfying the acceptance criterion.

**Flow (12 atomic commits):**
1. `content_digest` on `PolicyDocument`.
2. Cascade verdict attributed to the deciding document; `into_policy_result` no longer drops the attribution.
3. `policy_doc_id` field added to `aa-core` `AuditEntry`.
4. The digest is recorded on every policy-decision audit write.
5. New `policy_hits` reader — tallies the last-24h audit window by digest (bounded at 100k events, mirroring the analytics aggregations).
6–8. `PolicyResponse` / `TeamPolicyResponse` / capability `Policy` `hits24h` sourced by joining each row's document digest against those counts.
9. `hits24h` field docs repointed from the stale 5100/5096 pointers to the real 5107 sourcing.
10–12. fmt + regenerated `openapi/v1.yaml` + `schema.d.ts`.

## Type of Change
- [x] ✨ New feature

## Breaking Changes
- [x] No — `hits24h` was already in the contract (always absent); now populated. `AuditEntry.policy_doc_id` is additive.

## Related Issues
- Related Jira ticket: AAASM-5107

## Testing
- `cargo test -p aa-api --lib` — 467 pass. Two orthogonal, environment-dependent flakes were observed and confirmed NOT caused by this change (they touch no code this PR modifies): the `destinations` webhook-connector tests (network egress → 502 in the sandbox) and `devtools::replayed_event_is_rejected_with_409` (passes in isolation; parallel shared-state flake). Both are expected green in CI's networked/serial environment.
- New tests: digest is stable + version-distinguishing; the 24h per-document count; **absent-not-zero** when no decision was recorded.
- `cargo clippy` + `cargo fmt --check` clean; OpenAPI drift regenerated.

## Absent-vs-zero discipline
`hits24h` is **never `0` on the wire** — a document that fired zero times, an unreadable snapshot, a key shared by two live documents, or a failed window read all surface as **absent**, preserving the AAASM-5096 distinction between "fired zero times" and "no data".

## Security
- Audit-integrity change: the digest is a content hash added alongside existing audit hashing, not a replacement; no weakening of the audit chain. No document identity is forgeable into a different document's count (distinct content → distinct digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)