### PR TITLE
[AAASM-5089] ✨ (ws): Carry the decision bucket on live audit events for Live-Ops counters

### DIFF
--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -64,6 +64,18 @@ pub enum ViolationPayload {
         /// (awaiting human approval).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         status: Option<String>,
+        /// Governance decision bucket from the proto `Decision`, in the
+        /// dashboard's decision-mix vocabulary — one of `"allow"` (proto
+        /// `ALLOW`), `"scrub"` (proto `REDACT`), `"pending"` (proto
+        /// `PENDING`), or `"deny"` (proto `DENY`). Distinct from `status`,
+        /// which collapses allow/redact into `"running"` and so cannot feed
+        /// the Live Ops allow/scrub/deny/await counters. Omitted when the
+        /// decision is unspecified. There is deliberately no `"narrow"`
+        /// bucket: the proto `Decision` enum has no such variant, so no
+        /// event can be attributed to it (matches
+        /// `analytics::decision_mix_bucket`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        decision: Option<String>,
         /// Observed latency in milliseconds. Optional today — populated once
         /// the audit pipeline tracks per-action duration end-to-end.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -184,6 +196,7 @@ mod tests {
             op_type: Some("tool_call".into()),
             resource: Some("gmail.send".into()),
             status: Some("running".into()),
+            decision: Some("allow".into()),
             latency_ms: Some(834),
             team: Some("support".into()),
             call_stack: None,
@@ -193,6 +206,7 @@ mod tests {
         assert_eq!(json["op_type"], "tool_call");
         assert_eq!(json["resource"], "gmail.send");
         assert_eq!(json["status"], "running");
+        assert_eq!(json["decision"], "allow");
         assert_eq!(json["latency_ms"], 834);
         assert_eq!(json["team"], "support");
     }
@@ -206,6 +220,7 @@ mod tests {
             op_type: Some("llm_call".into()),
             resource: Some("gpt-4o".into()),
             status: Some("running".into()),
+            decision: Some("allow".into()),
             latency_ms: Some(600),
             team: None,
             call_stack: None,
@@ -216,6 +231,7 @@ mod tests {
             op_type,
             resource,
             status,
+            decision,
             latency_ms,
             team,
             ..
@@ -226,6 +242,7 @@ mod tests {
         assert_eq!(op_type.as_deref(), Some("llm_call"));
         assert_eq!(resource.as_deref(), Some("gpt-4o"));
         assert_eq!(status.as_deref(), Some("running"));
+        assert_eq!(decision.as_deref(), Some("allow"));
         assert_eq!(latency_ms, Some(600));
         assert_eq!(team, None);
     }
@@ -242,6 +259,7 @@ mod tests {
             op_type: None,
             resource: None,
             status: None,
+            decision: None,
             latency_ms: None,
             team: None,
             call_stack: None,
@@ -251,6 +269,7 @@ mod tests {
         assert!(!obj.contains_key("op_type"));
         assert!(!obj.contains_key("resource"));
         assert!(!obj.contains_key("status"));
+        assert!(!obj.contains_key("decision"));
         assert!(!obj.contains_key("latency_ms"));
         assert!(!obj.contains_key("team"));
         assert!(!obj.contains_key("call_stack"));
@@ -265,6 +284,7 @@ mod tests {
             op_type: Some("tool_call".into()),
             resource: Some("gmail.send".into()),
             status: Some("running".into()),
+            decision: Some("allow".into()),
             latency_ms: Some(500),
             team: None,
             call_stack: Some(vec![CallStackNode {

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -438,6 +438,7 @@ fn build_violation_payload(ev: &aa_runtime::pipeline::event::PipelineEvent) -> V
 
             let op_type = action_type_label(enriched.inner.action_type);
             let status = decision_label(enriched.inner.decision);
+            let decision = decision_bucket_label(enriched.inner.decision);
             let team = if enriched.inner.team_id.is_empty() {
                 None
             } else {
@@ -453,6 +454,7 @@ fn build_violation_payload(ev: &aa_runtime::pipeline::event::PipelineEvent) -> V
                 op_type,
                 resource,
                 status,
+                decision,
                 latency_ms,
                 team,
                 call_stack,
@@ -571,6 +573,25 @@ fn decision_label(raw: i32) -> Option<String> {
         Decision::Allow | Decision::Redact => "running",
         Decision::Deny => "blocked",
         Decision::Pending => "pending",
+        Decision::Unspecified => return None,
+    };
+    Some(label.to_string())
+}
+
+/// Map the proto `Decision` enum (raw `i32`) to the dashboard's decision-mix
+/// bucket vocabulary for the Live-Ops allow/scrub/pending/deny counters
+/// (AAASM-5089). Unlike [`decision_label`], which collapses Allow and Redact
+/// into `running`, this keeps them distinct: `Redact` is the scrub outcome the
+/// counters need to separate from a plain allow. There is no `narrow` bucket —
+/// the proto `Decision` has no such variant.
+fn decision_bucket_label(raw: i32) -> Option<String> {
+    use aa_proto::assembly::common::v1::Decision;
+    let decision = Decision::try_from(raw).ok()?;
+    let label = match decision {
+        Decision::Allow => "allow",
+        Decision::Redact => "scrub",
+        Decision::Pending => "pending",
+        Decision::Deny => "deny",
         Decision::Unspecified => return None,
     };
     Some(label.to_string())

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -951,6 +951,22 @@ mod tests {
         assert_eq!(fields.status.as_deref(), Some("running"));
     }
 
+    #[test]
+    fn decision_bucket_separates_allow_from_scrub_unlike_status() {
+        // The Live-Ops counters (AAASM-5089) need allow and scrub distinct — the
+        // `status` field collapses both into "running", so the bucket must not.
+        assert_eq!(decision_bucket_label(Decision::Allow as i32).as_deref(), Some("allow"));
+        assert_eq!(decision_bucket_label(Decision::Redact as i32).as_deref(), Some("scrub"));
+        assert_eq!(
+            decision_bucket_label(Decision::Pending as i32).as_deref(),
+            Some("pending")
+        );
+        assert_eq!(decision_bucket_label(Decision::Deny as i32).as_deref(), Some("deny"));
+        // Unspecified / unknown carry no bucket rather than a fabricated one.
+        assert_eq!(decision_bucket_label(Decision::Unspecified as i32), None);
+        assert_eq!(decision_bucket_label(9999), None);
+    }
+
     fn extract_call_stack(p: ViolationPayload) -> Option<Vec<CallStackNode>> {
         match p {
             ViolationPayload::Audit { call_stack, .. } => call_stack,

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -757,6 +757,7 @@ mod tests {
                 op_type,
                 resource,
                 status,
+                decision: _,
                 latency_ms,
                 team,
                 call_stack: _,

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -5368,6 +5368,19 @@ export interface components {
              *     steps). Omitted when the producer did not record a stack.
              */
             call_stack?: components["schemas"]["CallStackNode"][] | null;
+            /**
+             * @description Governance decision bucket from the proto `Decision`, in the
+             *     dashboard's decision-mix vocabulary — one of `"allow"` (proto
+             *     `ALLOW`), `"scrub"` (proto `REDACT`), `"pending"` (proto
+             *     `PENDING`), or `"deny"` (proto `DENY`). Distinct from `status`,
+             *     which collapses allow/redact into `"running"` and so cannot feed
+             *     the Live Ops allow/scrub/deny/await counters. Omitted when the
+             *     decision is unspecified. There is deliberately no `"narrow"`
+             *     bucket: the proto `Decision` enum has no such variant, so no
+             *     event can be attributed to it (matches
+             *     `analytics::decision_mix_bucket`).
+             */
+            decision?: string | null;
             /** @enum {string} */
             kind: "audit";
             /**

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -8592,6 +8592,21 @@ components:
             description: |-
               Hierarchical call stack for the operation (LLM / tool / result
               steps). Omitted when the producer did not record a stack.
+          decision:
+            type:
+            - string
+            - 'null'
+            description: |-
+              Governance decision bucket from the proto `Decision`, in the
+              dashboard's decision-mix vocabulary — one of `"allow"` (proto
+              `ALLOW`), `"scrub"` (proto `REDACT`), `"pending"` (proto
+              `PENDING`), or `"deny"` (proto `DENY`). Distinct from `status`,
+              which collapses allow/redact into `"running"` and so cannot feed
+              the Live Ops allow/scrub/deny/await counters. Omitted when the
+              decision is unspecified. There is deliberately no `"narrow"`
+              bucket: the proto `Decision` enum has no such variant, so no
+              event can be attributed to it (matches
+              `analytics::decision_mix_bucket`).
           kind:
             type: string
             enum:


### PR DESCRIPTION
## Description

Enriches the real-time decision event stream (`/api/v1/ws/events`) so the Live-Ops allow/scrub/deny/await counters can be sourced from **real** events (AAASM-5089).

**Context corrected during investigation:** the Live-Ops feed transport is NOT mock — `dashboard/src/features/liveOps/useLiveOpsStream.ts` already consumes the real gateway WebSocket. The actual gap is two-fold: (1) the WS audit payload's `status` field collapses proto `ALLOW` and `REDACT` into a single `running`, so the wire event could not distinguish an allowed op from a scrubbed one — exactly the distinction the allow/scrub counters need; and (2) the Live-Ops stat-tile counters are currently derived from the **decorative `PipelineCanvas`** random particle fates (AAASM-1338), not from real events.

**This PR delivers the enabling backend slice:**
- Adds an optional `decision` field to `ViolationPayload::Audit` carrying the dashboard decision-mix vocabulary (`allow`/`scrub`/`pending`/`deny`), stamped from the proto `Decision` via a new `decision_bucket_label` — kept distinct from `status` (which still collapses allow/redact into `running`). No `narrow` bucket: proto `Decision` has no such variant (honest, not fabricated).
- Regenerated OpenAPI + `schema.d.ts` (the WS payload is a `ToSchema` type).
- Test asserting the bucket separates allow from scrub and folds Unspecified/unknown to absent.

## Type of Change
- [x] ✨ New feature

## Breaking Changes
- [x] No — `decision` is an optional additive field on the WS audit payload.

## Related Issues
- Related Jira ticket: AAASM-5089

## Scope / follow-up (honest)
This lands the backend capability — real per-event decision buckets are now on the wire. **Rewiring the Live-Ops stat tiles to derive counters from the real stream** (replacing the decorative `PipelineCanvas` random-particle counters) is a self-contained FE follow-up touching `useLiveOpsStream` (carry `decision` onto `LiveOperation`) + `LiveOpsPage` (tally from `ops` instead of `onCounters`) + the PipelineCanvas/LiveOps tests. I scoped it separately rather than bundle a large FE-counter refactor into this backend PR; recommend a follow-up ticket. The counters remain decorative until then — no *new* fabrication is introduced by this PR.

## Testing
- `cargo test -p aa-api --lib ws` green (incl. the new bucket test); `cargo clippy -p aa-api --all-targets` (caught + fixed a test-destructure) + `fmt` clean; OpenAPI drift in sync; contract test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)