### PR TITLE
[AAASM-5193] ♻️ (alerts): Align dashboard severity to the backend's canonical levels

### DIFF
--- a/dashboard/src/features/alerts/AlertCardFeed.tsx
+++ b/dashboard/src/features/alerts/AlertCardFeed.tsx
@@ -10,17 +10,16 @@ import { useState } from 'react'
 import { SeverityBadge } from './SeverityBadge'
 import { StatusBadge } from './StatusBadge'
 import { CATEGORY_META, deriveCategory } from './alertCategory'
-import type { Alert, AlertRule, Severity } from './types'
+import type { Alert, AlertRule, AlertSeverity } from './types'
 
-// Severity is a closed 4-member app union; `normaliseAlert`/`canonicalSeverity`
-// in parseAlert.ts validate the wire value into it before an Alert ever exists
-// — narrow-union Record gap (AAASM-5245 gap 2).
+// AlertSeverity is the closed 3-member alert-emission union (AAASM-5193);
+// `normaliseAlert`/`canonicalSeverity` in parseAlert.ts validate the wire value
+// into it before an Alert ever exists — narrow-union Record gap (AAASM-5245 gap 2).
 // eslint-disable-next-line no-restricted-syntax
-const SEVERITY_BORDER: Record<Severity, string> = {
+const SEVERITY_BORDER: Record<AlertSeverity, string> = {
   CRITICAL: 'var(--severity-critical)',
-  HIGH: 'var(--severity-high)',
-  MEDIUM: 'var(--severity-medium)',
-  LOW: 'var(--severity-low)',
+  WARNING: 'var(--severity-warning)',
+  INFO: 'var(--severity-info)',
 }
 
 function formatDuration(firstFiredAt: string, resolvedAt: string | null): string {

--- a/dashboard/src/features/alerts/AlertDetailContent.test.tsx
+++ b/dashboard/src/features/alerts/AlertDetailContent.test.tsx
@@ -35,7 +35,7 @@ function makeDetail(patch: Partial<AlertDetail> = {}): AlertDetail {
     id: 'a-1',
     ruleId: 'rule-1',
     ruleName: 'Budget burn',
-    severity: 'HIGH',
+    severity: 'WARNING',
     status: 'FIRING',
     agentId: 'agent-7',
     firstFiredAt: '2026-05-14T09:00:00Z',

--- a/dashboard/src/features/alerts/AlertFilterBar.test.tsx
+++ b/dashboard/src/features/alerts/AlertFilterBar.test.tsx
@@ -24,12 +24,12 @@ describe('AlertFilterBar', () => {
   it('removes an already-selected severity when its chip is clicked again', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    const value: AlertFilters = { ...DEFAULT_ALERT_FILTERS, severities: ['CRITICAL', 'HIGH'] }
+    const value: AlertFilters = { ...DEFAULT_ALERT_FILTERS, severities: ['CRITICAL', 'WARNING'] }
     render(<AlertFilterBar value={value} onChange={onChange} />)
     const chip = screen.getByTestId('alerts-filter-severity-CRITICAL')
     expect(chip).toHaveAttribute('aria-pressed', 'true')
     await user.click(chip)
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ severities: ['HIGH'] }))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ severities: ['WARNING'] }))
   })
 
   it('toggles a status chip', async () => {

--- a/dashboard/src/features/alerts/AlertFilterBar.tsx
+++ b/dashboard/src/features/alerts/AlertFilterBar.tsx
@@ -1,11 +1,11 @@
-import type { AlertFilters, AlertStatus, Severity, TimeRangePreset } from './types'
+import type { AlertFilters, AlertSeverity, AlertStatus, TimeRangePreset } from './types'
 
 interface AlertFilterBarProps {
   value: AlertFilters
   onChange: (next: AlertFilters) => void
 }
 
-const ALL_SEVERITIES: readonly Severity[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']
+const ALL_SEVERITIES: readonly AlertSeverity[] = ['CRITICAL', 'WARNING', 'INFO']
 const ALL_STATUSES: readonly AlertStatus[] = ['FIRING', 'RESOLVED', 'SUPPRESSED']
 const TIME_RANGES: readonly TimeRangePreset[] = ['24h', '7d', '30d', 'custom']
 

--- a/dashboard/src/features/alerts/AlertList.test.tsx
+++ b/dashboard/src/features/alerts/AlertList.test.tsx
@@ -8,7 +8,7 @@ const ROWS: readonly Alert[] = [
     id: 'a-low',
     ruleId: 'r1',
     ruleName: 'low rule',
-    severity: 'LOW',
+    severity: 'INFO',
     status: 'RESOLVED',
     agentId: 'aa-z',
     firstFiredAt: '2026-05-13T10:00:00Z',
@@ -29,8 +29,8 @@ const ROWS: readonly Alert[] = [
   {
     id: 'a-med',
     ruleId: 'r3',
-    ruleName: 'med rule',
-    severity: 'MEDIUM',
+    ruleName: 'mid rule',
+    severity: 'WARNING',
     status: 'SUPPRESSED',
     agentId: 'aa-m',
     firstFiredAt: '2026-05-13T08:30:00Z',
@@ -49,8 +49,8 @@ describe('AlertList', () => {
     render(<AlertList rows={ROWS} />)
     const rows = screen.getAllByTestId('alert-row')
     expect(within(rows[0]).getByText('CRITICAL')).toBeInTheDocument()
-    expect(within(rows[1]).getByText('MEDIUM')).toBeInTheDocument()
-    expect(within(rows[2]).getByText('LOW')).toBeInTheDocument()
+    expect(within(rows[1]).getByText('WARNING')).toBeInTheDocument()
+    expect(within(rows[2]).getByText('INFO')).toBeInTheDocument()
   })
 
   it('flips severity order when the column header is clicked', async () => {
@@ -58,7 +58,7 @@ describe('AlertList', () => {
     render(<AlertList rows={ROWS} />)
     await user.click(screen.getByTestId('alerts-th-severity'))
     const rows = screen.getAllByTestId('alert-row')
-    expect(within(rows[0]).getByText('LOW')).toBeInTheDocument()
+    expect(within(rows[0]).getByText('INFO')).toBeInTheDocument()
     expect(within(rows[2]).getByText('CRITICAL')).toBeInTheDocument()
   })
 

--- a/dashboard/src/features/alerts/AlertList.tsx
+++ b/dashboard/src/features/alerts/AlertList.tsx
@@ -10,7 +10,7 @@ import {
 } from '@tanstack/react-table'
 import { SeverityBadge } from './SeverityBadge'
 import { StatusBadge } from './StatusBadge'
-import { SEVERITY_ORDER, type Alert, type AlertStatus, type Severity } from './types'
+import { ALERT_SEVERITY_ORDER, type Alert, type AlertSeverity, type AlertStatus } from './types'
 
 interface AlertListProps {
   rows: readonly Alert[]
@@ -19,10 +19,10 @@ interface AlertListProps {
   loading?: boolean
 }
 
-// CRITICAL > HIGH > MEDIUM > LOW (descending = most severe first).
-const SEVERITY_RANK: Record<Severity, number> = Object.fromEntries(
-  SEVERITY_ORDER.map((s, i) => [s, SEVERITY_ORDER.length - i]),
-) as Record<Severity, number>
+// CRITICAL > WARNING > INFO (descending = most severe first).
+const SEVERITY_RANK: Record<AlertSeverity, number> = Object.fromEntries(
+  ALERT_SEVERITY_ORDER.map((s, i) => [s, ALERT_SEVERITY_ORDER.length - i]),
+) as Record<AlertSeverity, number>
 
 // AlertStatus is a closed 3-member app union; `canonicalStatus` in
 // parseAlert.ts validates the wire value into it before an Alert ever exists —

--- a/dashboard/src/features/alerts/AlertStatsStrip.test.tsx
+++ b/dashboard/src/features/alerts/AlertStatsStrip.test.tsx
@@ -3,9 +3,9 @@ import { describe, expect, it, vi } from 'vitest'
 import { AlertStatsStrip } from './AlertStatsStrip'
 import { coversWholeFleet, statsScopeNote } from './alertsCoverage'
 import { absent, known, type Certain } from '../../lib/truthfulness'
-import type { Alert, Severity, AlertStatus } from './types'
+import type { Alert, AlertSeverity, AlertStatus } from './types'
 
-function alert(id: string, severity: Severity, status: AlertStatus): Alert {
+function alert(id: string, severity: AlertSeverity, status: AlertStatus): Alert {
   return {
     id,
     ruleId: 'r',
@@ -22,17 +22,17 @@ function alert(id: string, severity: Severity, status: AlertStatus): Alert {
 const ALERTS: readonly Alert[] = [
   alert('a1', 'CRITICAL', 'FIRING'),
   alert('a2', 'CRITICAL', 'FIRING'),
-  alert('a3', 'HIGH', 'FIRING'),
-  alert('a4', 'MEDIUM', 'RESOLVED'),
-  alert('a5', 'LOW', 'SUPPRESSED'),
+  alert('a3', 'WARNING', 'FIRING'),
+  alert('a4', 'INFO', 'RESOLVED'),
+  alert('a5', 'INFO', 'SUPPRESSED'),
 ]
 
 interface StripProps {
   alerts: Certain<readonly Alert[]>
   total: Certain<number>
-  activeSeverities: Severity[]
+  activeSeverities: AlertSeverity[]
   activeStatuses: AlertStatus[]
-  onToggleSeverity: (s: Severity) => void
+  onToggleSeverity: (s: AlertSeverity) => void
   onToggleStatus: (s: AlertStatus) => void
 }
 
@@ -51,12 +51,11 @@ function renderStrip(overrides: Partial<StripProps> = {}) {
 }
 
 describe('AlertStatsStrip', () => {
-  it('derives the five tile counts from the loaded alerts', () => {
+  it('derives the four tile counts from the loaded alerts', () => {
     renderStrip()
     expect(screen.getByTestId('alerts-stat-count-CRITICAL')).toHaveTextContent('2')
-    expect(screen.getByTestId('alerts-stat-count-HIGH')).toHaveTextContent('1')
-    expect(screen.getByTestId('alerts-stat-count-MEDIUM')).toHaveTextContent('1')
-    expect(screen.getByTestId('alerts-stat-count-LOW')).toHaveTextContent('1')
+    expect(screen.getByTestId('alerts-stat-count-WARNING')).toHaveTextContent('1')
+    expect(screen.getByTestId('alerts-stat-count-INFO')).toHaveTextContent('2')
     // Three of the five alerts are FIRING.
     expect(screen.getByTestId('alerts-stat-count-FIRING')).toHaveTextContent('3')
   })
@@ -109,7 +108,7 @@ describe('AlertStatsStrip', () => {
   it('marks a tile pressed when its filter is active', () => {
     renderStrip({ activeSeverities: ['CRITICAL'] })
     expect(screen.getByTestId('alerts-stat-tile-CRITICAL')).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByTestId('alerts-stat-tile-HIGH')).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('alerts-stat-tile-WARNING')).toHaveAttribute('aria-pressed', 'false')
   })
 })
 

--- a/dashboard/src/features/alerts/AlertStatsStrip.tsx
+++ b/dashboard/src/features/alerts/AlertStatsStrip.tsx
@@ -1,10 +1,10 @@
 // Clickable 5-tile stats strip — the signature element of
 // design/v1/hi-fi/alerts.jsx, adapted to this dashboard's taxonomy.
 //
-// The spec strip mixes two severities + three categories. This impl keeps its
-// own enum (CRITICAL / HIGH / MEDIUM / LOW + FIRING / RESOLVED / SUPPRESSED),
-// so the strip surfaces the four severity buckets plus the FIRING headline
-// count. Each tile toggles the SAME filter model the filter bar drives (single
+// The spec strip mixes two severities + three categories. This impl surfaces
+// the three backend-emittable severity buckets (CRITICAL / WARNING / INFO —
+// AAASM-5193) plus the FIRING headline count. Each tile toggles the SAME filter
+// model the filter bar drives (single
 // source of truth). Categories are a separate, client-derived filter (see
 // AlertCategoryFilter) because no first-class category field exists.
 //
@@ -18,28 +18,27 @@
 import { TruthfulValue } from '../../components/truthfulness'
 import { isKnown, mapCertain, type Certain } from '../../lib/truthfulness'
 import { statsScopeNote } from './alertsCoverage'
-import type { Alert, AlertStatus, Severity } from './types'
+import type { Alert, AlertSeverity, AlertStatus } from './types'
 
 interface AlertStatsStripProps {
   /** The loaded page of alerts, or the absence that stands in for it. */
   alerts: Certain<readonly Alert[]>
   /** Alerts across all pages per the server envelope; absent when unknown. */
   total: Certain<number>
-  activeSeverities: readonly Severity[]
+  activeSeverities: readonly AlertSeverity[]
   activeStatuses: readonly AlertStatus[]
-  onToggleSeverity: (severity: Severity) => void
+  onToggleSeverity: (severity: AlertSeverity) => void
   onToggleStatus: (status: AlertStatus) => void
 }
 
 type Tile =
-  | { kind: 'severity'; key: Severity; label: string; color: string }
+  | { kind: 'severity'; key: AlertSeverity; label: string; color: string }
   | { kind: 'status'; key: AlertStatus; label: string; color: string }
 
 const TILES: readonly Tile[] = [
   { kind: 'severity', key: 'CRITICAL', label: 'critical', color: 'var(--severity-critical)' },
-  { kind: 'severity', key: 'HIGH', label: 'high', color: 'var(--severity-high)' },
-  { kind: 'severity', key: 'MEDIUM', label: 'medium', color: 'var(--severity-medium)' },
-  { kind: 'severity', key: 'LOW', label: 'low', color: 'var(--severity-low)' },
+  { kind: 'severity', key: 'WARNING', label: 'warning', color: 'var(--severity-warning)' },
+  { kind: 'severity', key: 'INFO', label: 'info', color: 'var(--severity-info)' },
   { kind: 'status', key: 'FIRING', label: 'firing', color: 'var(--danger)' },
 ]
 
@@ -67,7 +66,7 @@ export function AlertStatsStrip({
         data-testid="alerts-stats-strip"
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(5, 1fr)',
+          gridTemplateColumns: 'repeat(4, 1fr)',
           gap: '1px',
           background: 'var(--surface-card-border)',
           border: '1px solid var(--surface-card-border)',

--- a/dashboard/src/features/alerts/SeverityBadge.test.tsx
+++ b/dashboard/src/features/alerts/SeverityBadge.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import { SeverityBadge } from './SeverityBadge'
-import type { Severity } from './types'
+import { SeverityBadge, type BadgeSeverity } from './SeverityBadge'
 
 // AAASM-5217: `severity` reaches this component from the single-alert-detail
 // path (`useAlertQuery` in `api.ts`) through a bare `as T` cast with no
@@ -9,18 +8,25 @@ import type { Severity } from './types'
 // hostile or malformed value must not resolve `SEVERITY_BG[severity]` to
 // `undefined` (a silently blank badge) or an inherited `Object.prototype`
 // member.
+//
+// AAASM-5193: the badge renders both ladders — an alert's AlertSeverity
+// (CRITICAL/WARNING/INFO) and a rule's RuleSeverity (CRITICAL/HIGH/MEDIUM/LOW) —
+// so every member of that union must render with a real background.
 describe('SeverityBadge', () => {
-  it.each(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as const)('renders the %s badge', (severity) => {
-    render(<SeverityBadge severity={severity} />)
-    expect(screen.getByTestId(`severity-badge-${severity}`)).toHaveTextContent(severity)
-  })
+  it.each(['CRITICAL', 'WARNING', 'INFO', 'HIGH', 'MEDIUM', 'LOW'] as const)(
+    'renders the %s badge',
+    (severity) => {
+      render(<SeverityBadge severity={severity} />)
+      expect(screen.getByTestId(`severity-badge-${severity}`)).toHaveTextContent(severity)
+    },
+  )
 
   it.each([
     ['a plain unknown severity', 'EXTREME'],
     ['the inherited "__proto__" key', '__proto__'],
     ['the inherited "constructor" key', 'constructor'],
   ])('renders %s as the unknown badge with a real background, not undefined', (_label, value) => {
-    render(<SeverityBadge severity={value as unknown as Severity} />)
+    render(<SeverityBadge severity={value as unknown as BadgeSeverity} />)
     const badge = screen.getByTestId('severity-badge-unknown')
     expect(badge).toHaveTextContent(value)
     expect(badge.style.background).not.toBe('')

--- a/dashboard/src/features/alerts/SeverityBadge.tsx
+++ b/dashboard/src/features/alerts/SeverityBadge.tsx
@@ -1,29 +1,38 @@
-import type { Severity } from './types'
+import type { AlertSeverity, RuleSeverity } from './types'
 
 /**
- * 4-bucket severity colour scheme — each severity gets its own token
- * (red / orange / yellow / blue). The Sub-task AC for AAASM-1073
- * originally specified only 3 buckets (CRITICAL+HIGH share red), but
- * the parent Story (AAASM-118) AC prescribed 4 distinct colours; the
- * more specific spec wins.
- *
- * AAASM-1374 formalised this decision (Option 1 — keep 4 colours).
- * AAASM-1395's design-fidelity spec asserts each of the four
- * `--severity-*` tokens; collapsing buckets here would break it.
+ * The badge renders both vocabularies (AAASM-5193): an *alert's*
+ * {@link AlertSeverity} (`CRITICAL` / `WARNING` / `INFO`) and a *rule's*
+ * {@link RuleSeverity} (`CRITICAL` / `HIGH` / `MEDIUM` / `LOW`). Its accepted
+ * input is therefore the union of the two — the one place the two severity
+ * ladders visibly meet — so it carries a colour token for every level either
+ * can produce.
  */
-// Severity is a closed 4-member app union, validated onto an Alert by
-// `canonicalSeverity` in parseAlert.ts before this component ever sees one —
-// narrow-union Record gap (AAASM-5245 gap 2).
+export type BadgeSeverity = AlertSeverity | RuleSeverity
+
+/**
+ * Per-level colour scheme — each severity gets its own token. Historic
+ * decisions: AAASM-1073/118 kept distinct buckets; AAASM-1374 formalised it;
+ * AAASM-1395's design-fidelity spec asserts the `--severity-*` tokens.
+ */
+// BadgeSeverity is a closed union; alert values are validated by
+// `canonicalSeverity` in parseAlert.ts before this component sees them, and the
+// `isSeverity` guard below fails closed for anything else — narrow-union Record
+// gap (AAASM-5245 gap 2).
 // eslint-disable-next-line no-restricted-syntax
-const SEVERITY_BG: Record<Severity, string> = {
+const SEVERITY_BG: Record<BadgeSeverity, string> = {
   CRITICAL: 'var(--severity-critical)',
+  WARNING: 'var(--severity-warning)',
+  INFO: 'var(--severity-info)',
   HIGH: 'var(--severity-high)',
   MEDIUM: 'var(--severity-medium)',
   LOW: 'var(--severity-low)',
 }
 
-const KNOWN_SEVERITIES: ReadonlySet<string> = new Set<Severity>([
+const KNOWN_SEVERITIES: ReadonlySet<string> = new Set<BadgeSeverity>([
   'CRITICAL',
+  'WARNING',
+  'INFO',
   'HIGH',
   'MEDIUM',
   'LOW',
@@ -42,11 +51,11 @@ const KNOWN_SEVERITIES: ReadonlySet<string> = new Set<Severity>([
  * (`background: undefined`, a silently blank badge) or an inherited
  * `Object.prototype` member.
  */
-function isSeverity(value: string): value is Severity {
+function isSeverity(value: string): value is BadgeSeverity {
   return KNOWN_SEVERITIES.has(value)
 }
 
-export function SeverityBadge({ severity }: Readonly<{ severity: Severity }>) {
+export function SeverityBadge({ severity }: Readonly<{ severity: BadgeSeverity }>) {
   const known = isSeverity(severity)
   return (
     <span

--- a/dashboard/src/features/alerts/SeveritySelect.tsx
+++ b/dashboard/src/features/alerts/SeveritySelect.tsx
@@ -1,9 +1,9 @@
 import { useFormContext } from 'react-hook-form'
 import { SeverityBadge } from './SeverityBadge'
-import type { Severity } from './types'
+import type { RuleSeverity } from './types'
 import type { RuleFormValues } from './ruleFormSchema'
 
-const OPTIONS: readonly Severity[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']
+const OPTIONS: readonly RuleSeverity[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']
 
 export function SeveritySelect() {
   const { register, formState } = useFormContext<RuleFormValues>()

--- a/dashboard/src/features/alerts/alertBadge.test.ts
+++ b/dashboard/src/features/alerts/alertBadge.test.ts
@@ -24,7 +24,7 @@ describe('criticalFiringCount', () => {
       alert({ id: '1' }),
       alert({ id: '2', status: 'RESOLVED', resolvedAt: '2026-05-13T10:00:00Z' }),
       alert({ id: '3', status: 'SUPPRESSED' }),
-      alert({ id: '4', severity: 'HIGH' }),
+      alert({ id: '4', severity: 'WARNING' }),
     ]
     expect(criticalFiringCount(rows)).toBe(1)
   })
@@ -44,7 +44,7 @@ describe('isOpenIncident', () => {
 
 describe('criticalFiringBadge', () => {
   it('reports a real zero as a known value', () => {
-    const badge = criticalFiringBadge(known([alert({ severity: 'LOW' })]))
+    const badge = criticalFiringBadge(known([alert({ severity: 'INFO' })]))
     expect(badge).toEqual({ known: true, value: 0 })
   })
 

--- a/dashboard/src/features/alerts/alertCategory.test.ts
+++ b/dashboard/src/features/alerts/alertCategory.test.ts
@@ -31,7 +31,7 @@ function alert(id: string, ruleId: string): Alert {
     id,
     ruleId,
     ruleName: ruleId,
-    severity: 'HIGH',
+    severity: 'WARNING',
     status: 'FIRING',
     agentId: null,
     firstFiredAt: '2026-05-14T09:00:00Z',

--- a/dashboard/src/features/alerts/alertFilters.test.ts
+++ b/dashboard/src/features/alerts/alertFilters.test.ts
@@ -23,7 +23,7 @@ const RECENT = alert({ id: 'a' })
 const OTHER = alert({
   id: 'b',
   ruleName: 'low signal',
-  severity: 'LOW',
+  severity: 'INFO',
   status: 'RESOLVED',
   agentId: 'aa-2',
   firstFiredAt: '2026-05-13T08:00:00Z',

--- a/dashboard/src/features/alerts/alertsStreamSync.test.ts
+++ b/dashboard/src/features/alerts/alertsStreamSync.test.ts
@@ -55,7 +55,7 @@ describe('applyFire', () => {
   })
 
   it('replaces an existing alert with the same id rather than duplicating', () => {
-    const client = seed(page([{ ...FIRING, severity: 'LOW' }], 7))
+    const client = seed(page([{ ...FIRING, severity: 'INFO' }], 7))
     applyFire(client, FIRING)
     expect(cached(client)?.items).toHaveLength(1)
     expect(cached(client)?.items[0].severity).toBe('CRITICAL')

--- a/dashboard/src/features/alerts/parseAlert.test.ts
+++ b/dashboard/src/features/alerts/parseAlert.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { criticalFiringBadge, criticalFiringCount } from './alertBadge'
 import { AlertShapeError, canonicalSeverity, canonicalStatus, normaliseAlert, parseAlertList } from './parseAlert'
+import { ALERT_SEVERITY_ORDER } from './types'
 import { known } from '../../lib/truthfulness'
 
 /**
@@ -39,8 +40,8 @@ describe('canonicalStatus / canonicalSeverity — the live wire vocabulary', () 
 
   it.each([
     ['critical', 'CRITICAL'],
-    ['warning', 'HIGH'],
-    ['info', 'LOW'],
+    ['warning', 'WARNING'],
+    ['info', 'INFO'],
   ])('maps wire severity %s onto %s', (wire, expected) => {
     expect(canonicalSeverity(wire)).toBe(expected)
   })
@@ -205,5 +206,56 @@ describe('the nav badge counts real backend payloads (AAASM-5149 regression guar
       wireAlert({ id: 'a2', severity: 'critical', status: 'resolved' }),
     ])
     expect(criticalFiringBadge(known(page))).toEqual(known(0))
+  })
+})
+
+/**
+ * The severity-vocabulary contract guard (AAASM-5193).
+ *
+ * The dashboard's alert-severity set must be *exactly* the image of the
+ * backend's emittable wire severities under `canonicalSeverity` — no more, no
+ * less. The backend `AlertSeverity` `Display` impl
+ * (`aa-api/src/alerts/mod.rs`) emits exactly these three literals; they are the
+ * single source of truth, transcribed here the same way the wire fixtures above
+ * are.
+ *
+ * This is the test that fails if a frontend-only severity level ever reappears.
+ * `MEDIUM` was the historical offender: it lived in the dashboard's severity
+ * union but no real `AlertResponse` payload could ever carry it (the rule engine
+ * collapses onto critical/warning/info before firing). Reintroducing it — or
+ * any other level the wire cannot produce — as an alert severity would make
+ * `ALERT_SEVERITY_ORDER` disagree with the derived set, and this goes red.
+ * `MEDIUM` remaining reachable on the *rule-authoring* ladder (`RuleSeverity`)
+ * is deliberate and is not exercised here, because a rule severity is not an
+ * emitted alert severity.
+ */
+describe('alert severity set is exactly derivable from the wire enum (AAASM-5193 guard)', () => {
+  // The backend's canonical wire severities — `AlertSeverity`'s `Display`
+  // output. Update this only when the backend enum changes, never to match a
+  // frontend-only level.
+  const WIRE_SEVERITIES = ['critical', 'warning', 'info'] as const
+
+  it('derives the dashboard alert vocabulary 1:1 from the wire, with nothing extra', () => {
+    const derived = new Set(WIRE_SEVERITIES.map((w) => canonicalSeverity(w)))
+
+    // Every dashboard alert severity must be produced by some wire value…
+    for (const level of ALERT_SEVERITY_ORDER) {
+      expect(derived.has(level)).toBe(true)
+    }
+    // …and the dashboard must carry no alert severity the wire cannot produce.
+    // Set sizes matching (both 3) proves the mapping is a bijection: a
+    // frontend-only level like MEDIUM would make one side larger and fail here.
+    expect(derived.size).toBe(ALERT_SEVERITY_ORDER.length)
+    expect([...derived].sort()).toEqual([...ALERT_SEVERITY_ORDER].sort())
+  })
+
+  it('rejects a frontend-only severity that the wire cannot emit', () => {
+    // MEDIUM is the canonical regression: reachable on the RuleSeverity ladder,
+    // never on an emitted alert. The alert boundary must not admit it.
+    expect(() => canonicalSeverity('MEDIUM')).toThrow(AlertShapeError)
+    expect(() => canonicalSeverity('medium')).toThrow(AlertShapeError)
+    // HIGH/LOW were the old lossy remap targets; they are not alert severities.
+    expect(() => canonicalSeverity('HIGH')).toThrow(AlertShapeError)
+    expect(() => canonicalSeverity('LOW')).toThrow(AlertShapeError)
   })
 })

--- a/dashboard/src/features/alerts/parseAlert.ts
+++ b/dashboard/src/features/alerts/parseAlert.ts
@@ -5,11 +5,12 @@
 // wire does not speak the dashboard's vocabulary:
 //
 //   wire (aa-api/src/alerts/mod.rs)     dashboard (./types.ts)
-//   status:   "unresolved"              AlertStatus: 'FIRING'
-//             "resolved"                             'RESOLVED'
-//             "suppressed"                           'SUPPRESSED'
-//   severity: "info" | "warning"        Severity: 'CRITICAL' | 'HIGH'
-//             | "critical"                        | 'MEDIUM'   | 'LOW'
+//   status:   "unresolved"              AlertStatus:   'FIRING'
+//             "resolved"                               'RESOLVED'
+//             "suppressed"                             'SUPPRESSED'
+//   severity: "critical"                AlertSeverity: 'CRITICAL'
+//             "warning"                                'WARNING'
+//             "info"                                   'INFO'
 //
 // So `a.severity === 'CRITICAL' && a.status === 'FIRING'` could never match a
 // real payload. The nav badge therefore counted zero for every live response,
@@ -23,7 +24,7 @@
 // and `certainFromQuery` renders `unavailable` — the same treatment a failed
 // request gets. A payload we cannot read is not an empty fleet.
 
-import type { Alert, AlertStatus, Severity } from './types'
+import type { Alert, AlertSeverity, AlertStatus } from './types'
 
 /**
  * Raised when a payload cannot be understood.
@@ -58,20 +59,20 @@ const WIRE_STATUS: ReadonlyMap<string, AlertStatus> = new Map([
  * Severity vocabulary as `aa-api` actually serialises it.
  *
  * Source: `AlertSeverity` + its `Display` impl (aa-api/src/alerts/mod.rs:96-115),
- * which emits `"info" | "warning" | "critical"`.
+ * which emits exactly `"critical" | "warning" | "info"`.
  *
- * Only `critical → CRITICAL` is load-bearing for this ticket, and it is exact.
- * The other two are an *ordinal alignment* between a three-level backend ladder
- * and a four-level dashboard ladder, not a mapping the product has ratified:
- * `MEDIUM` is unreachable from the current wire, so `warning` lands on `HIGH`
- * and `info` on `LOW`. Flagged in the PR for ratification; if the rule-engine
- * Stories (AAASM-1385…1389) settle on a different ladder, this table is the one
- * place that changes.
+ * AAASM-5193 ratified the mapping: the dashboard's alert vocabulary is now the
+ * same three levels, spelled upper-case, so this table is a lossless 1:1
+ * rename rather than an ordinal alignment onto a wider dashboard ladder. There
+ * is no unreachable member — the earlier `warning → HIGH` / `info → LOW` remap
+ * left `MEDIUM` unreachable from any real payload, the frontend-only state this
+ * ticket removed (ADR 0026 D2). `MEDIUM` survives only where it is genuinely
+ * authorable — the `RuleSeverity` ladder — never on an emitted alert.
  */
-const WIRE_SEVERITY: ReadonlyMap<string, Severity> = new Map([
+const WIRE_SEVERITY: ReadonlyMap<string, AlertSeverity> = new Map([
   ['critical', 'CRITICAL'],
-  ['warning', 'HIGH'],
-  ['info', 'LOW'],
+  ['warning', 'WARNING'],
+  ['info', 'INFO'],
 ])
 
 /** The dashboard's own vocabulary, accepted unchanged. */
@@ -80,11 +81,10 @@ const CANONICAL_STATUS: ReadonlySet<string> = new Set<AlertStatus>([
   'RESOLVED',
   'SUPPRESSED',
 ])
-const CANONICAL_SEVERITY: ReadonlySet<string> = new Set<Severity>([
+const CANONICAL_SEVERITY: ReadonlySet<string> = new Set<AlertSeverity>([
   'CRITICAL',
-  'HIGH',
-  'MEDIUM',
-  'LOW',
+  'WARNING',
+  'INFO',
 ])
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -114,10 +114,10 @@ export function canonicalStatus(raw: unknown): AlertStatus {
 }
 
 /** Canonicalise one severity. Same contract as {@link canonicalStatus}. */
-export function canonicalSeverity(raw: unknown): Severity {
+export function canonicalSeverity(raw: unknown): AlertSeverity {
   const value = str(raw)
   if (value === null) throw new AlertShapeError('alert.severity is not a string')
-  if (CANONICAL_SEVERITY.has(value)) return value as Severity
+  if (CANONICAL_SEVERITY.has(value)) return value as AlertSeverity
   const mapped = WIRE_SEVERITY.get(value.toLowerCase())
   if (mapped) return mapped
   throw new AlertShapeError(`unrecognised alert severity: ${JSON.stringify(value)}`)

--- a/dashboard/src/features/alerts/ruleFormSchema.ts
+++ b/dashboard/src/features/alerts/ruleFormSchema.ts
@@ -67,10 +67,10 @@ export type RuleFormValues = z.infer<typeof ruleFormSchema>
 
 // Compile-time sanity: the literal arrays the schema relies on must match
 // the unions exported from `types.ts`.
-import type { AlertMetric, AlertOperator, Severity, EvaluationWindowSeconds } from './types'
+import type { AlertMetric, AlertOperator, RuleSeverity, EvaluationWindowSeconds } from './types'
 // `satisfies` performs the union/literal-array conformance check at compile
 // time without binding a runtime value, so no `void`-discard is needed.
 METRICS satisfies readonly AlertMetric[]
 OPERATORS satisfies readonly AlertOperator[]
-SEVERITIES satisfies readonly Severity[]
+SEVERITIES satisfies readonly RuleSeverity[]
 EVAL_WINDOWS satisfies readonly EvaluationWindowSeconds[]

--- a/dashboard/src/features/alerts/types.ts
+++ b/dashboard/src/features/alerts/types.ts
@@ -5,9 +5,43 @@
 // Query hooks defined in AAASM-1075 will narrow these against the
 // auto-generated OpenAPI types once the spec is regenerated.
 
-export type Severity = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW'
+/**
+ * Severity of an alert *as emitted by the backend* (AAASM-5193).
+ *
+ * The wire is the single source of truth: `AlertResponse.severity`
+ * (`aa-api/src/routes/alerts.rs`) is the `Display` of `AlertSeverity`
+ * (`aa-api/src/alerts/mod.rs`), which serialises exactly three values —
+ * `critical` / `warning` / `info`. This union is those three, spelled in the
+ * dashboard's upper-case convention, so `parseAlert.ts` maps them 1:1 with no
+ * lossy remap and no member the backend cannot produce.
+ *
+ * This is deliberately distinct from {@link RuleSeverity}: an *alert* can only
+ * ever carry one of these three, whereas a *rule* is authored with the
+ * four-level `RuleSeverity` ladder. Conflating the two (a single four-member
+ * `Severity`) left `MEDIUM` unreachable from any real alert payload — the
+ * frontend-only state AAASM-5193 removed, following the ADR 0026 D2 precedent
+ * of narrowing an enum to what the projection can actually emit.
+ */
+export type AlertSeverity = 'CRITICAL' | 'WARNING' | 'INFO'
 
-export const SEVERITY_ORDER: readonly Severity[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as const
+/**
+ * Alert severity ordering, most-severe first. Mirrors the backend ladder
+ * `Critical > Warning > Info`.
+ */
+export const ALERT_SEVERITY_ORDER: readonly AlertSeverity[] = ['CRITICAL', 'WARNING', 'INFO'] as const
+
+/**
+ * Severity assigned when *authoring an alert rule* (AAASM-5193).
+ *
+ * Matches the backend `RuleSeverity` enum (`aa-api/src/alerts/rules/types.rs`),
+ * whose wire form is the four upper-case levels `CRITICAL` / `HIGH` / `MEDIUM` /
+ * `LOW`. All four are genuinely authorable, so — unlike {@link AlertSeverity} —
+ * `MEDIUM` is reachable here and stays. The rule engine collapses these onto the
+ * three-level {@link AlertSeverity} ladder when it fires an alert.
+ */
+export type RuleSeverity = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW'
+
+export const RULE_SEVERITY_ORDER: readonly RuleSeverity[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as const
 
 export type AlertStatus = 'FIRING' | 'RESOLVED' | 'SUPPRESSED'
 
@@ -15,7 +49,7 @@ export interface Alert {
   id: string
   ruleId: string
   ruleName: string
-  severity: Severity
+  severity: AlertSeverity
   status: AlertStatus
   agentId: string | null
   /** ISO 8601 timestamp when the rule first matched. */
@@ -29,7 +63,7 @@ export interface Alert {
 export type TimeRangePreset = '24h' | '7d' | '30d' | 'custom'
 
 export interface AlertFilters {
-  severities: readonly Severity[]
+  severities: readonly AlertSeverity[]
   statuses: readonly AlertStatus[]
   agentQuery: string
   /** Free-text search over rule name, agent id, and alert id (AAASM-5146). */
@@ -71,7 +105,7 @@ export interface AlertRule {
   operator: AlertOperator
   threshold: number
   evaluationWindowSeconds: EvaluationWindowSeconds
-  severity: Severity
+  severity: RuleSeverity
   destinationIds: readonly string[]
   dedupWindowSeconds: number
   suppressionLabels: Readonly<Record<string, string>>
@@ -110,7 +144,7 @@ export interface PagerDutyDestination extends DestinationBase {
   kind: 'pagerduty'
   config: {
     routingKey: string
-    severityMap?: Readonly<Partial<Record<Severity, string>>>
+    severityMap?: Readonly<Partial<Record<RuleSeverity, string>>>
   }
 }
 

--- a/dashboard/src/features/alerts/urlFilters.test.ts
+++ b/dashboard/src/features/alerts/urlFilters.test.ts
@@ -5,7 +5,7 @@ import { DEFAULT_ALERT_FILTERS, type AlertFilters } from './types'
 describe('urlFilters', () => {
   it('round-trips a complex filter through search params', () => {
     const filters: AlertFilters = {
-      severities: ['CRITICAL', 'HIGH'],
+      severities: ['CRITICAL', 'WARNING'],
       statuses: ['FIRING'],
       agentQuery: 'aa-001',
       q: 'budget burn',

--- a/dashboard/src/features/alerts/urlFilters.ts
+++ b/dashboard/src/features/alerts/urlFilters.ts
@@ -2,17 +2,17 @@ import {
   DEFAULT_ALERT_FILTERS,
   type AlertFilters,
   type AlertStatus,
-  type Severity,
+  type AlertSeverity,
   type TimeRangePreset,
 } from './types'
 
-const SEVERITY_VALUES: ReadonlySet<Severity> = new Set(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'])
+const SEVERITY_VALUES: ReadonlySet<AlertSeverity> = new Set(['CRITICAL', 'WARNING', 'INFO'])
 const STATUS_VALUES: ReadonlySet<AlertStatus> = new Set(['FIRING', 'RESOLVED', 'SUPPRESSED'])
 const RANGE_VALUES: ReadonlySet<TimeRangePreset> = new Set(['24h', '7d', '30d', 'custom'])
 
 export function filtersFromSearchParams(sp: URLSearchParams): AlertFilters {
-  const severities = sp.getAll('severity').filter((v): v is Severity =>
-    SEVERITY_VALUES.has(v as Severity),
+  const severities = sp.getAll('severity').filter((v): v is AlertSeverity =>
+    SEVERITY_VALUES.has(v as AlertSeverity),
   )
   const statuses = sp.getAll('status').filter((v): v is AlertStatus =>
     STATUS_VALUES.has(v as AlertStatus),

--- a/dashboard/src/pages/AlertsPage.test.tsx
+++ b/dashboard/src/pages/AlertsPage.test.tsx
@@ -22,7 +22,7 @@ const FIRING: Alert = {
   id: 'a-1',
   ruleId: 'r-1',
   ruleName: 'Budget burn',
-  severity: 'HIGH',
+  severity: 'WARNING',
   status: 'FIRING',
   agentId: 'agent-7',
   firstFiredAt: '2026-05-14T09:00:00Z',
@@ -194,7 +194,7 @@ describe('AlertsPage', () => {
 
   it('updates the URL filters when a severity chip is toggled', () => {
     setup()
-    fireEvent.click(screen.getByTestId('alerts-filter-severity-HIGH'))
+    fireEvent.click(screen.getByTestId('alerts-filter-severity-WARNING'))
     expect(screen.getByRole('heading', { level: 1, name: 'Alerts' })).toBeInTheDocument()
   })
 
@@ -208,14 +208,14 @@ describe('AlertsPage', () => {
     })
     expect(screen.getByTestId('alerts-stats-strip')).toBeInTheDocument()
     expect(screen.getByTestId('alerts-stat-count-CRITICAL')).toHaveTextContent('2')
-    expect(screen.getByTestId('alerts-stat-count-HIGH')).toHaveTextContent('1')
+    expect(screen.getByTestId('alerts-stat-count-WARNING')).toHaveTextContent('1')
     // Two of the three loaded alerts are FIRING.
     expect(screen.getByTestId('alerts-stat-count-FIRING')).toHaveTextContent('2')
   })
 
   it('toggling a stats tile writes the matching severity filter to the URL', () => {
     setup()
-    fireEvent.click(screen.getByTestId('alerts-stat-tile-HIGH'))
+    fireEvent.click(screen.getByTestId('alerts-stat-tile-WARNING'))
     expect(screen.getByRole('heading', { level: 1, name: 'Alerts' })).toBeInTheDocument()
   })
 

--- a/dashboard/src/pages/AlertsPage.tsx
+++ b/dashboard/src/pages/AlertsPage.tsx
@@ -26,7 +26,7 @@ import {
   filtersFromSearchParams,
   filtersToSearchParams,
 } from '../features/alerts/urlFilters'
-import type { Alert, AlertFilters, AlertRule, AlertStatus, Severity } from '../features/alerts/types'
+import type { Alert, AlertFilters, AlertRule, AlertSeverity, AlertStatus } from '../features/alerts/types'
 import { alertsCountLabel, coversWholeFleet } from '../features/alerts/alertsCoverage'
 import { TruthfulValue } from '../components/truthfulness'
 import {
@@ -123,7 +123,7 @@ export function AlertsPage() {
   // Stats-strip tiles reuse the single filter model the filter bar drives:
   // toggling a tile adds/removes the matching severity/status filter.
   const toggleSeverity = useCallback(
-    (s: Severity) =>
+    (s: AlertSeverity) =>
       setFilters({ ...filters, severities: toggleFilterValue(filters.severities, s) }),
     [filters, setFilters],
   )

--- a/dashboard/src/pages/OverviewPage.kpis.test.ts
+++ b/dashboard/src/pages/OverviewPage.kpis.test.ts
@@ -65,28 +65,27 @@ function valueOf<T>(value: Certain<T>): T {
 }
 
 describe('compareBySeverity', () => {
-  it('orders CRITICAL before HIGH before MEDIUM before LOW', () => {
+  it('orders CRITICAL before WARNING before INFO', () => {
     const alerts = [
-      makeAlert({ id: 'lo', severity: 'LOW' }),
-      makeAlert({ id: 'med', severity: 'MEDIUM' }),
+      makeAlert({ id: 'lo', severity: 'INFO' }),
+      makeAlert({ id: 'warn', severity: 'WARNING' }),
       makeAlert({ id: 'crit', severity: 'CRITICAL' }),
-      makeAlert({ id: 'hi', severity: 'HIGH' }),
     ]
     const sorted = [...alerts].sort(compareBySeverity).map((a) => a.id)
-    expect(sorted).toEqual(['crit', 'hi', 'med', 'lo'])
+    expect(sorted).toEqual(['crit', 'warn', 'lo'])
   })
 
   it('treats equal severities as equal (returns 0)', () => {
-    expect(compareBySeverity(makeAlert({ severity: 'HIGH' }), makeAlert({ severity: 'HIGH' }))).toBe(
-      0,
-    )
+    expect(
+      compareBySeverity(makeAlert({ severity: 'WARNING' }), makeAlert({ severity: 'WARNING' })),
+    ).toBe(0)
   })
 })
 
 describe('pickTopAlert', () => {
   it('returns the most-severe alert', () => {
     const top = pickTopAlert([
-      makeAlert({ id: 'med', severity: 'MEDIUM' }),
+      makeAlert({ id: 'warn', severity: 'WARNING' }),
       makeAlert({ id: 'crit', severity: 'CRITICAL' }),
     ])
     expect(top?.id).toBe('crit')
@@ -258,9 +257,9 @@ describe('deriveOverviewKpis', () => {
       [makeFleetAgent()],
       known([
         makeAlert({ id: 'resolved-crit', severity: 'CRITICAL', status: 'RESOLVED' }),
-        makeAlert({ id: 'firing-med', severity: 'MEDIUM', status: 'FIRING' }),
+        makeAlert({ id: 'firing-med', severity: 'WARNING', status: 'FIRING' }),
         makeAlert({ id: 'firing-crit', severity: 'CRITICAL', status: 'FIRING' }),
-        makeAlert({ id: 'suppressed-hi', severity: 'HIGH', status: 'SUPPRESSED' }),
+        makeAlert({ id: 'suppressed-hi', severity: 'WARNING', status: 'SUPPRESSED' }),
       ]),
       ENFORCEMENT_OK,
     )

--- a/dashboard/src/pages/OverviewPage.kpis.ts
+++ b/dashboard/src/pages/OverviewPage.kpis.ts
@@ -16,7 +16,7 @@ import { absent, isKnown, known, propagateAbsence, type Certain } from '../lib/t
  */
 
 /** Severity ordering used to pick the single most-urgent firing alert. */
-const SEVERITY_RANK = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 } as const
+const SEVERITY_RANK = { CRITICAL: 0, WARNING: 1, INFO: 2 } as const
 
 /** Sort comparator: most-severe alert first. */
 export function compareBySeverity(a: Alert, b: Alert): number {

--- a/dashboard/src/pages/OverviewPage.test.tsx
+++ b/dashboard/src/pages/OverviewPage.test.tsx
@@ -383,8 +383,8 @@ describe('OverviewPage', () => {
       agents: [makeAgent()],
       alerts: [
         makeAlert({ id: 'c', severity: 'CRITICAL', ruleName: 'shell.exec', agentId: 'bot-x' }),
-        makeAlert({ id: 'h', severity: 'HIGH', ruleName: 'net.egress', agentId: null }),
-        makeAlert({ id: 'm', severity: 'MEDIUM', ruleName: 'budget breach', agentId: 'bot-y' }),
+        makeAlert({ id: 'h', severity: 'WARNING', ruleName: 'net.egress', agentId: null }),
+        makeAlert({ id: 'm', severity: 'INFO', ruleName: 'budget breach', agentId: 'bot-y' }),
       ],
     })
     renderPage()
@@ -393,8 +393,8 @@ describe('OverviewPage', () => {
     // The panel says what it is, and reports the alerts' real severities.
     expect(recent).toHaveTextContent('recent alerts')
     expect(recent).toHaveTextContent('critical')
-    expect(recent).toHaveTextContent('high')
-    expect(recent).toHaveTextContent('medium')
+    expect(recent).toHaveTextContent('warning')
+    expect(recent).toHaveTextContent('info')
 
     // No severity is dressed up as an enforcement decision that never occurred.
     expect(recent).not.toHaveTextContent('deny')

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -222,15 +222,14 @@ function LayerCard({
  * verdict. Severity is a real field the alerts API emits, so tinting it asserts
  * nothing the data does not already say (AAASM-5116).
  */
-// Alert['severity'] is the closed 4-member Severity union, validated onto an
-// Alert by `canonicalSeverity` in parseAlert.ts — narrow-union Record gap
-// (AAASM-5245 gap 2).
+// Alert['severity'] is the closed 3-member AlertSeverity union (AAASM-5193),
+// validated onto an Alert by `canonicalSeverity` in parseAlert.ts — narrow-union
+// Record gap (AAASM-5245 gap 2).
 // eslint-disable-next-line no-restricted-syntax
 const SEVERITY_TONE: Record<Alert['severity'], string> = {
   CRITICAL: 'var(--danger)',
-  HIGH: 'var(--warn)',
-  MEDIUM: 'var(--info)',
-  LOW: 'var(--ink-4)',
+  WARNING: 'var(--warn)',
+  INFO: 'var(--info)',
 }
 
 function shortTime(iso: string): string {

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -207,11 +207,16 @@
   --trend-positive: #10b981;
   --trend-negative: #f43f5e;
 
-  /* ── Severity palette (alert badges) ─────────────────────── */
-  /* Ordered from highest to lowest severity. CRITICAL matches
-     --status-danger-solid; HIGH matches --chart-cat-8; MEDIUM/LOW
-     introduce new yellow-500 / blue-400 tokens for alerts only. */
+  /* ── Severity palette ─────────────────────────────────────── */
+  /* Two ladders share this palette (AAASM-5193). Alerts carry the
+     three backend-emittable levels CRITICAL / WARNING / INFO; rules
+     are authored on the four-level CRITICAL / HIGH / MEDIUM / LOW
+     ladder. CRITICAL matches --status-danger-solid; HIGH matches
+     --chart-cat-8. WARNING reuses the amber HIGH hue and INFO reuses
+     the blue LOW hue so the two ladders read consistently. */
   --severity-critical: #dc2626;
+  --severity-warning: #f97316;
+  --severity-info: #60a5fa;
   --severity-high: #f97316;
   --severity-medium: #eab308;
   --severity-low: #60a5fa;

--- a/dashboard/tests/e2e/aaasm-5021-shell-chrome.spec.ts
+++ b/dashboard/tests/e2e/aaasm-5021-shell-chrome.spec.ts
@@ -59,7 +59,7 @@ const POLICIES = [
 const ALERTS = {
   items: [
     { id: 'al-1', ruleId: 'r1', ruleName: 'budget breach', severity: 'CRITICAL', status: 'FIRING', agentId: 'agent-1', firstFiredAt: '2026-06-01T10:00:00Z', resolvedAt: null, destinationIds: [] },
-    { id: 'al-2', ruleId: 'r2', ruleName: 'anomaly', severity: 'HIGH', status: 'FIRING', agentId: 'agent-2', firstFiredAt: '2026-06-01T10:00:00Z', resolvedAt: null, destinationIds: [] },
+    { id: 'al-2', ruleId: 'r2', ruleName: 'anomaly', severity: 'WARNING', status: 'FIRING', agentId: 'agent-2', firstFiredAt: '2026-06-01T10:00:00Z', resolvedAt: null, destinationIds: [] },
   ],
 }
 

--- a/dashboard/tests/e2e/alerts-5026-verify.spec.ts
+++ b/dashboard/tests/e2e/alerts-5026-verify.spec.ts
@@ -24,7 +24,7 @@ function rule(id: string, name: string, metric: string) {
     operator: '>',
     threshold: 80,
     evaluationWindowSeconds: 300,
-    severity: 'HIGH',
+    severity: 'WARNING',
     destinationIds: [],
     dedupWindowSeconds: 600,
     suppressionLabels: {},

--- a/dashboard/tests/e2e/alerts-design-fidelity.spec.ts
+++ b/dashboard/tests/e2e/alerts-design-fidelity.spec.ts
@@ -46,11 +46,13 @@ const EVIDENCE_DIR = resolve(process.cwd(), 'docs/verification/aaasm-1395')
 //    getComputedStyle returns colors in that form. ──────────────────────────
 
 const TOKEN_RGB = {
-  // Severity scale (alert-specific, see styles.css "alerts only" section).
+  // Alert severity scale (AAASM-5193): alerts emit exactly CRITICAL/WARNING/INFO.
+  // The HIGH/MEDIUM/LOW tokens still exist for the 4-level *rule* ladder, but an
+  // alert can never carry them, so this alert-surface test covers the three an
+  // alert can actually render.
   severityCritical: 'rgb(220, 38, 38)', // #dc2626 — --severity-critical
-  severityHigh: 'rgb(249, 115, 22)',    // #f97316 — --severity-high
-  severityMedium: 'rgb(234, 179, 8)',   // #eab308 — --severity-medium
-  severityLow: 'rgb(96, 165, 250)',     // #60a5fa — --severity-low
+  severityWarning: 'rgb(249, 115, 22)', // #f97316 — --severity-warning
+  severityInfo: 'rgb(96, 165, 250)',    // #60a5fa — --severity-info
   // Status pair tokens.
   statusDangerBg: 'rgb(254, 226, 226)',         // #fee2e2 — FIRING bg
   statusDangerTextStrong: 'rgb(153, 27, 27)',   // #991b1b — FIRING fg
@@ -103,10 +105,10 @@ const ALERTS = [
     destinationIds: ['dst-slack-ops'],
   },
   {
-    id: 'alert-high',
+    id: 'alert-warning',
     ruleId: 'rule-aaasm1395',
     ruleName: 'Budget guardrail',
-    severity: 'HIGH',
+    severity: 'WARNING',
     status: 'FIRING',
     agentId: 'aa-002',
     firstFiredAt: '2026-05-14T08:55:00Z',
@@ -114,10 +116,10 @@ const ALERTS = [
     destinationIds: ['dst-slack-ops'],
   },
   {
-    id: 'alert-medium',
+    id: 'alert-info',
     ruleId: 'rule-aaasm1395',
     ruleName: 'Budget guardrail',
-    severity: 'MEDIUM',
+    severity: 'INFO',
     status: 'SUPPRESSED',
     agentId: 'aa-003',
     firstFiredAt: '2026-05-14T08:50:00Z',
@@ -125,14 +127,15 @@ const ALERTS = [
     destinationIds: ['dst-slack-ops'],
   },
   {
-    id: 'alert-low',
+    // A RESOLVED row for StatusBadge coverage; its severity is immaterial here.
+    id: 'alert-resolved',
     ruleId: 'rule-aaasm1395',
     ruleName: 'Budget guardrail',
-    severity: 'LOW',
-    status: 'FIRING',
+    severity: 'WARNING',
+    status: 'RESOLVED',
     agentId: 'aa-004',
     firstFiredAt: '2026-05-14T08:45:00Z',
-    resolvedAt: null,
+    resolvedAt: '2026-05-14T08:50:00Z',
     destinationIds: ['dst-slack-ops'],
   },
 ]
@@ -204,7 +207,7 @@ test.describe('AAASM-1395 — Alerts UI design fidelity', () => {
     await page.screenshot({ path: `${EVIDENCE_DIR}/01-alerts-shell.png`, fullPage: true })
   })
 
-  test('SeverityBadge backgrounds resolve to --severity-* tokens for all 4 buckets', async ({ page }) => {
+  test('SeverityBadge backgrounds resolve to --severity-* tokens for the alert buckets', async ({ page }) => {
     await gotoAlerts(page)
 
     const critical = await page
@@ -213,23 +216,17 @@ test.describe('AAASM-1395 — Alerts UI design fidelity', () => {
       .evaluate(el => getComputedStyle(el).backgroundColor)
     expect(critical).toBe(TOKEN_RGB.severityCritical)
 
-    const high = await page
-      .locator('[data-testid="severity-badge-HIGH"]')
+    const warning = await page
+      .locator('[data-testid="severity-badge-WARNING"]')
       .first()
       .evaluate(el => getComputedStyle(el).backgroundColor)
-    expect(high).toBe(TOKEN_RGB.severityHigh)
+    expect(warning).toBe(TOKEN_RGB.severityWarning)
 
-    const medium = await page
-      .locator('[data-testid="severity-badge-MEDIUM"]')
+    const info = await page
+      .locator('[data-testid="severity-badge-INFO"]')
       .first()
       .evaluate(el => getComputedStyle(el).backgroundColor)
-    expect(medium).toBe(TOKEN_RGB.severityMedium)
-
-    const low = await page
-      .locator('[data-testid="severity-badge-LOW"]')
-      .first()
-      .evaluate(el => getComputedStyle(el).backgroundColor)
-    expect(low).toBe(TOKEN_RGB.severityLow)
+    expect(info).toBe(TOKEN_RGB.severityInfo)
 
     await page.screenshot({ path: `${EVIDENCE_DIR}/02-severity-badge-tokens.png`, fullPage: true })
   })

--- a/dashboard/tests/e2e/review-aaasm-5150.spec.ts
+++ b/dashboard/tests/e2e/review-aaasm-5150.spec.ts
@@ -94,7 +94,7 @@ function alert(id: string, severity: string, status: string, ageMinutes: number)
 const ALERTS = [
   alert('al-1', 'CRITICAL', 'FIRING', 5),
   alert('al-2', 'CRITICAL', 'FIRING', 20),
-  alert('al-3', 'HIGH', 'FIRING', 45),
+  alert('al-3', 'WARNING', 'FIRING', 45),
 ]
 
 /** A page of 3 rows out of a fleet of 214 — the truncation the mock never had. */
@@ -269,7 +269,7 @@ test.describe('AAASM-5150 review — the Alerts surface tells the truth', () => 
       await expect(page.getByTestId('alerts-empty-no-alerts')).toHaveCount(0)
 
       // No tile may report a business value it does not have.
-      for (const key of ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'FIRING']) {
+      for (const key of ['CRITICAL', 'WARNING', 'INFO', 'FIRING']) {
         await expect(page.getByTestId(`alerts-stat-count-${key}`)).toContainText('—')
         await expect(page.getByTestId(`alerts-stat-tile-${key}`)).toBeDisabled()
       }
@@ -310,7 +310,7 @@ test.describe('AAASM-5150 review — the Alerts surface tells the truth', () => 
       }
 
       // The chip that used to return an identical list now narrows the feed.
-      await page.getByTestId('alerts-filter-severity-HIGH').click()
+      await page.getByTestId('alerts-filter-severity-WARNING').click()
       await expect(page.getByTestId('alert-row')).toHaveCount(1)
       // Narrowed: shown and loaded are both page figures, named together.
       await expect(page.getByTestId('alerts-count')).toContainText('1 of 3 alerts')

--- a/dashboard/tests/e2e/verify-aaasm-5063.spec.ts
+++ b/dashboard/tests/e2e/verify-aaasm-5063.spec.ts
@@ -158,7 +158,7 @@ const ALERTS = {
     {
       id: 'al-2',
       ruleName: 'pg.users narrowed',
-      severity: 'HIGH',
+      severity: 'WARNING',
       status: 'FIRING',
       agentId: 'support-triage',
       firstFiredAt: '2026-06-01T14:01:54Z',
@@ -166,7 +166,7 @@ const ALERTS = {
     {
       id: 'al-3',
       ruleName: 'gmail/send scrubbed',
-      severity: 'MEDIUM',
+      severity: 'INFO',
       status: 'FIRING',
       agentId: 'sales-outreach',
       firstFiredAt: '2026-06-01T14:01:41Z',

--- a/dashboard/tests/e2e/verify-aaasm-5113.spec.ts
+++ b/dashboard/tests/e2e/verify-aaasm-5113.spec.ts
@@ -95,7 +95,7 @@ const ALERTS = {
       id: 'al-2',
       ruleId: 'r-2',
       ruleName: 'budget breach',
-      severity: 'MEDIUM',
+      severity: 'WARNING',
       status: 'FIRING',
       agentId: null,
       firstFiredAt: '2026-07-26T14:01:41Z',
@@ -230,7 +230,7 @@ test.describe('AAASM-5113 — Overview asserts only what it measured', () => {
       const recent = page.getByTestId('overview-recent')
       await expect(recent).toContainText('recent alerts')
       await expect(recent).toContainText('critical')
-      await expect(recent).toContainText('medium')
+      await expect(recent).toContainText('warning')
       for (const verdict of ['deny', 'narrow', 'scrub']) {
         await expect(recent).not.toContainText(verdict)
       }

--- a/docs/src/adr/0026-open-dashboard-product-semantics.md
+++ b/docs/src/adr/0026-open-dashboard-product-semantics.md
@@ -284,6 +284,46 @@ FE client exposes only `getMatrix` and `applyOverride`. The confirmation step is
 compensating control. An undo affordance is tracked as follow-up work rather than
 half-built here; see the PR discussion on AAASM-5124.
 
+### Update — AAASM-5193 (alert severity vocabulary, 2026-07)
+
+**Same defect family as Decision 2, recorded here rather than in a new ADR.** The
+Alerts dashboard advertised a four-level severity ladder — `CRITICAL` / `HIGH` /
+`MEDIUM` / `LOW` — in its type, legend/stats tiles, filter chips, and sort/tone maps.
+But the backend emits only three: `AlertResponse.severity`
+(`aa-api/src/routes/alerts.rs`) is the `Display` of `AlertSeverity`
+(`aa-api/src/alerts/mod.rs`), which serialises exactly `critical` / `warning` /
+`info`. The stopgap normalisation added under AAASM-5149
+(`dashboard/src/features/alerts/parseAlert.ts`) mapped `warning → HIGH` and
+`info → LOW`, leaving **`MEDIUM` unreachable from any real alert payload** — a
+frontend-only state, the exact shape Decision 2 removed for `narrow`/`approval`.
+
+**Resolved by following Decision 2's precedent (option A):** narrow the alert surface
+to what the projection can emit, do not preserve an aspirational level to match a mock.
+
+- **Root cause was a *conflated type*, not a spurious level.** The single `Severity`
+  union served two vocabularies at once: an alert's emitted severity *and* a rule's
+  authored severity. The rule ladder is genuinely four-level — backend `RuleSeverity`
+  (`aa-api/src/alerts/rules/types.rs`) has `Critical`/`High`/`Medium`/`Low`, all
+  authorable — so `MEDIUM` is real *there*. Deleting `MEDIUM` outright would have been
+  the same defect inverted: removing a state the rule builder can actually produce.
+- **Fix: split the type.** `AlertSeverity` = `CRITICAL | WARNING | INFO` (the three
+  wire-emittable levels, spelled upper-case, mapped 1:1 with no lossy remap);
+  `RuleSeverity` = `CRITICAL | HIGH | MEDIUM | LOW` (unchanged, matches the backend
+  enum). Every alert-emission surface now references `AlertSeverity`; the rule builder
+  references `RuleSeverity`; `SeverityBadge` renders the union of the two.
+- **No wire contract changes.** This is a dashboard-only narrowing, exactly as Decision
+  2 was — `AlertSeverity` (Rust) and `RuleSeverity` (Rust) are untouched.
+- **Guarded against recurrence.** A contract test
+  (`dashboard/src/features/alerts/parseAlert.test.ts`) asserts the dashboard's alert
+  severity set is *exactly* the image of the backend's emittable wire severities under
+  `canonicalSeverity` — a bijection. A frontend-only level like `MEDIUM` reappearing on
+  the alert path fails the test. `MEDIUM` staying reachable on the `RuleSeverity` ladder
+  is deliberate and out of the guard's scope, because a rule severity is not an emitted
+  alert severity.
+
+Implemented under
+[AAASM-5193](https://lightning-dust-mite.atlassian.net/browse/AAASM-5193).
+
 ---
 
 ## Decision 3 — Scrub detector toggles: real capability or read-only list?
@@ -678,6 +718,10 @@ state.
   Real enforcement wiring (option (c) of
   [AAASM-5178](https://lightning-dust-mite.atlassian.net/browse/AAASM-5178)) is
   deferred to its own ADR alongside ADR 0021.
+- Decision 2's precedent (narrow an advertised enum to the projection's emittable set)
+  was applied to alert severity under
+  [AAASM-5193](https://lightning-dust-mite.atlassian.net/browse/AAASM-5193); see the
+  Update at the end of that section.
 - Decision 3 sits inside ADR 0015's DLP trust boundary.
 - Decision 4 continues ADR 0021, which named the absent-vs-defaulted problem without
   settling it.


### PR DESCRIPTION
## Description

The Alerts dashboard advertised a four-level severity ladder — `CRITICAL` / `HIGH` / `MEDIUM` / `LOW` — in its type, stats-strip tiles, filter chips, and sort/tone maps. But the backend emits only **three** alert severities: `AlertResponse.severity` (`aa-api/src/routes/alerts.rs`) is the `Display` of `AlertSeverity` (`aa-api/src/alerts/mod.rs`), which serialises exactly `critical` / `warning` / `info`. The AAASM-5149 stopgap normalisation mapped `warning → HIGH` and `info → LOW`, which left **`MEDIUM` unreachable from any real alert payload** — a frontend-only state that could never appear on a live response.

This PR uses the generated backend contract as the source of truth and narrows the dashboard's alert vocabulary to exactly what the backend can emit, following the ADR 0026 Decision 2 precedent (narrow an advertised enum to the projection's emittable set; do not preserve an aspirational level to match a mock).

### Root cause: a conflated type, not a spurious level

The single `Severity` union served two vocabularies at once — an *alert's emitted* severity **and** an *alert rule's authored* severity. The rule ladder is genuinely four-level (backend `RuleSeverity` in `aa-api/src/alerts/rules/types.rs` has `Critical`/`High`/`Medium`/`Low`, all authorable), so `MEDIUM` is real *there*. Deleting `MEDIUM` outright would have broken the rule builder. The fix is therefore to **split the type**, not to blanket-remove `MEDIUM`.

### Final severity mapping

| wire (`AlertResponse.severity`) | dashboard `AlertSeverity` |
|---|---|
| `critical` | `CRITICAL` |
| `warning` | `WARNING` |
| `info` | `INFO` |

- `AlertSeverity` = `CRITICAL \| WARNING \| INFO` — the 3 wire-emittable levels, spelled upper-case, mapped **1:1 with no lossy remap**. This is the ticket's preferred option (align labels to the wire vocabulary directly).
- `RuleSeverity` = `CRITICAL \| HIGH \| MEDIUM \| LOW` — unchanged, matches the backend enum. `MEDIUM` survives here because it is genuinely authorable on a rule.
- `SeverityBadge` renders the union of the two ladders.

`MEDIUM` no longer appears on any alert-emission surface (type, stats tiles, legend, filter chips, sort rank, tone map).

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No — dashboard-only narrowing. No wire contract changes: `AlertSeverity` (Rust) and `RuleSeverity` (Rust) are untouched. The URL `?severity=` param now admits only the 3 emittable values; stale `HIGH`/`MEDIUM`/`LOW` params are ignored (they never matched a live alert anyway).

## Related Issues

- Related Jira ticket: AAASM-5193
- ADR: amends ADR 0026 (Decision 2 family) with an `Update — AAASM-5193` section

## Testing

- [x] Unit tests added / updated

**Guard test.** A contract test in `dashboard/src/features/alerts/parseAlert.test.ts` asserts the dashboard's alert-severity set is *exactly* the image of the backend's emittable wire severities (`critical`/`warning`/`info`) under `canonicalSeverity` — a bijection. A frontend-only level like `MEDIUM` reappearing on the alert path makes the derived set disagree with `ALERT_SEVERITY_ORDER` and fails the test; the boundary is also asserted to reject `MEDIUM`/`HIGH`/`LOW` directly. `MEDIUM` staying reachable on the `RuleSeverity` ladder is deliberate and out of the guard's scope.

Gates (dashboard):
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint .` — clean
- `pnpm exec vitest run` — 3117 passed (280 files)

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (ADR 0026 amended)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)