### PR TITLE
[AAASM-5087] ✨ (budget): Configurable team-tier calendar-month budget limit

### DIFF
--- a/aa-api/src/routes/analytics.rs
+++ b/aa-api/src/routes/analytics.rs
@@ -1535,6 +1535,13 @@ pub struct BudgetTreeNode {
     /// per-agent override, mirroring the enforcement path's resolution.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub budget_limit_usd: Option<String>,
+    /// Configured calendar-month budget limit in USD for this node, if any
+    /// (decimal string). Populated for team nodes from the tracker-wide team
+    /// monthly envelope (AAASM-5087) so the Teams monthly-budget card can read
+    /// the limit off the tree; `None` for tiers without a configured monthly
+    /// cap. This is a calendar-month window, not a rolling window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub monthly_budget_limit_usd: Option<String>,
     /// Spend attributable to this node itself, excluding descendants (USD
     /// string). Org and team nodes never spend directly, so this is `"0"`.
     pub own_spend_usd: String,
@@ -1610,6 +1617,7 @@ fn build_agent_node(state: &AppState, record: &AgentRecord, depth: u32, visible:
         kind: "agent".to_string(),
         depth,
         budget_limit_usd: budget_limit.map(|d| d.to_string()),
+        monthly_budget_limit_usd: None,
         own_spend_usd: own_spend.to_string(),
         subtree_spend_usd: subtree_spend.to_string(),
         governance_level: Some(format!("{:?}", record.governance_level)),
@@ -1672,12 +1680,16 @@ pub async fn get_budget_tree(
                 .filter_map(|c| c.subtree_spend_usd.parse::<Decimal>().ok())
                 .sum();
             let budget_limit = state.budget_tracker.team_daily_limit_usd();
+            // AAASM-5087 — surface the team calendar-month limit alongside the
+            // daily one so the Teams monthly-budget card renders it.
+            let monthly_budget_limit = state.budget_tracker.team_monthly_limit_usd();
             BudgetTreeNode {
                 id: team_id.clone(),
                 label: team_id,
                 kind: "team".to_string(),
                 depth: 1,
                 budget_limit_usd: budget_limit.map(|d| d.to_string()),
+                monthly_budget_limit_usd: monthly_budget_limit.map(|d| d.to_string()),
                 own_spend_usd: Decimal::ZERO.to_string(),
                 subtree_spend_usd: subtree.to_string(),
                 governance_level: None,
@@ -1702,6 +1714,7 @@ pub async fn get_budget_tree(
         kind: "org".to_string(),
         depth: 0,
         budget_limit_usd: org_limit.map(|d| d.to_string()),
+        monthly_budget_limit_usd: None,
         own_spend_usd: Decimal::ZERO.to_string(),
         subtree_spend_usd: org_subtree.to_string(),
         governance_level: None,

--- a/aa-api/src/routes/costs.rs
+++ b/aa-api/src/routes/costs.rs
@@ -30,6 +30,13 @@ pub struct TeamCostEntry {
     pub daily_spend_usd: String,
     /// Total spend this month in USD for this team (if monthly tracking is enabled).
     pub monthly_spend_usd: Option<String>,
+    /// Configured per-team calendar-month budget limit in USD, if set
+    /// (AAASM-5087). This is the tracker-wide team envelope — the same limit
+    /// applies to every team — surfaced so the Teams monthly-budget card can
+    /// render spend against limit. `None` when no team monthly limit is
+    /// configured. This is a calendar-month window, not a rolling window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub monthly_limit_usd: Option<String>,
     /// Calendar date (YYYY-MM-DD) the daily spend applies to.
     pub date: String,
 }
@@ -107,6 +114,9 @@ pub async fn get_cost_summary(
         Vec::new()
     };
 
+    // AAASM-5087 — the per-team calendar-month limit is a single tracker-wide
+    // envelope, so resolve it once and stamp it on every team row.
+    let team_monthly_limit = state.budget_tracker.team_monthly_limit_usd().map(|d| d.to_string());
     let per_team: Vec<TeamCostEntry> = if is_admin || caller_team.is_some() {
         let mut rows: Vec<TeamCostEntry> = snapshot
             .team_budgets
@@ -117,6 +127,7 @@ pub async fn get_cost_summary(
                 team_id: team_id.clone(),
                 daily_spend_usd: state.spent_usd.to_string(),
                 monthly_spend_usd: state.monthly_spent_usd.map(|d| d.to_string()),
+                monthly_limit_usd: team_monthly_limit.clone(),
                 date: state.date.to_string(),
             })
             .collect();
@@ -213,6 +224,7 @@ mod tests {
                 team_id: "platform".to_string(),
                 daily_spend_usd: "12.00".to_string(),
                 monthly_spend_usd: None,
+                monthly_limit_usd: None,
                 date: "2026-04-30".to_string(),
             }],
         };
@@ -221,5 +233,23 @@ mod tests {
         assert_eq!(json["per_team"][0]["team_id"], "platform");
         assert_eq!(json["per_team"][0]["daily_spend_usd"], "12.00");
         assert!(json["per_team"][0]["monthly_spend_usd"].is_null());
+        // AAASM-5087: an unset team monthly limit is omitted from the wire.
+        assert!(json["per_team"][0].get("monthly_limit_usd").is_none());
+    }
+
+    // AAASM-5087 — when a team monthly limit is configured it is surfaced on
+    // every team row so the Teams monthly-budget card can render spend/limit.
+    #[test]
+    fn team_cost_entry_surfaces_configured_monthly_limit() {
+        let entry = TeamCostEntry {
+            team_id: "platform".to_string(),
+            daily_spend_usd: "12.00".to_string(),
+            monthly_spend_usd: Some("340.00".to_string()),
+            monthly_limit_usd: Some("2000.00".to_string()),
+            date: "2026-04-30".to_string(),
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["monthly_limit_usd"], "2000.00");
+        assert_eq!(json["monthly_spend_usd"], "340.00");
     }
 }

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -378,6 +378,17 @@ impl BudgetTracker {
         self.team_daily_limit_usd
     }
 
+    /// Returns the per-team calendar-month spend limit applied to each team, if set.
+    ///
+    /// Read-only companion to [`team_daily_limit_usd`](Self::team_daily_limit_usd)
+    /// for the monthly window (AAASM-5087). Like the daily variant it is the
+    /// tracker-wide team envelope, exposed so the Costs monthly KPI and the
+    /// Teams monthly-budget card can render each team's configured monthly limit
+    /// without touching the private enforcement path.
+    pub fn team_monthly_limit_usd(&self) -> Option<Decimal> {
+        self.team_monthly_limit_usd
+    }
+
     /// Returns the per-org daily spend limit applied to each org, if set.
     ///
     /// Read-only companion to [`team_daily_limit_usd`](Self::team_daily_limit_usd)

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -305,6 +305,8 @@ struct ParsedCascade {
     budget_tz: chrono_tz::Tz,
     daily_limit: Option<rust_decimal::Decimal>,
     monthly_limit: Option<rust_decimal::Decimal>,
+    team_daily_limit: Option<rust_decimal::Decimal>,
+    team_monthly_limit: Option<rust_decimal::Decimal>,
     org_daily_limit: Option<rust_decimal::Decimal>,
     org_monthly_limit: Option<rust_decimal::Decimal>,
 }
@@ -361,6 +363,19 @@ impl PolicyEngine {
             .as_ref()
             .and_then(|bp| bp.monthly_limit_usd)
             .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+        // AAASM-5087 — Lift team-tier limits from BudgetPolicy into the tracker.
+        let team_daily_limit = output
+            .document
+            .budget
+            .as_ref()
+            .and_then(|bp| bp.team_daily_limit_usd)
+            .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+        let team_monthly_limit = output
+            .document
+            .budget
+            .as_ref()
+            .and_then(|bp| bp.team_monthly_limit_usd)
+            .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
         // AAASM-2022 — Lift org-tier limits from BudgetPolicy into the tracker.
         let org_daily_limit = output
             .document
@@ -381,6 +396,12 @@ impl PolicyEngine {
             budget_tz,
             budget_alert_tx,
         );
+        if let Some(limit) = team_daily_limit {
+            budget_tracker = budget_tracker.with_team_daily_limit(limit);
+        }
+        if let Some(limit) = team_monthly_limit {
+            budget_tracker = budget_tracker.with_team_monthly_limit(limit);
+        }
         if let Some(limit) = org_daily_limit {
             budget_tracker = budget_tracker.with_org_daily_limit(limit);
         }
@@ -468,6 +489,12 @@ impl PolicyEngine {
             parsed.budget_tz,
             budget_alert_tx,
         );
+        if let Some(limit) = parsed.team_daily_limit {
+            budget_tracker = budget_tracker.with_team_daily_limit(limit);
+        }
+        if let Some(limit) = parsed.team_monthly_limit {
+            budget_tracker = budget_tracker.with_team_monthly_limit(limit);
+        }
         if let Some(limit) = parsed.org_daily_limit {
             budget_tracker = budget_tracker.with_org_daily_limit(limit);
         }
@@ -539,6 +566,9 @@ impl PolicyEngine {
         let mut budget_tz = chrono_tz::UTC;
         let mut daily_limit: Option<rust_decimal::Decimal> = None;
         let mut monthly_limit: Option<rust_decimal::Decimal> = None;
+        // AAASM-5087 — Team-tier limits from the Global-scoped doc.
+        let mut team_daily_limit: Option<rust_decimal::Decimal> = None;
+        let mut team_monthly_limit: Option<rust_decimal::Decimal> = None;
         // AAASM-2022 — Org-tier limits from the Global-scoped doc.
         let mut org_daily_limit: Option<rust_decimal::Decimal> = None;
         let mut org_monthly_limit: Option<rust_decimal::Decimal> = None;
@@ -586,6 +616,16 @@ impl PolicyEngine {
                     .as_ref()
                     .and_then(|bp| bp.monthly_limit_usd)
                     .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+                team_daily_limit = doc
+                    .budget
+                    .as_ref()
+                    .and_then(|bp| bp.team_daily_limit_usd)
+                    .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+                team_monthly_limit = doc
+                    .budget
+                    .as_ref()
+                    .and_then(|bp| bp.team_monthly_limit_usd)
+                    .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
                 org_daily_limit = doc
                     .budget
                     .as_ref()
@@ -609,6 +649,8 @@ impl PolicyEngine {
             budget_tz,
             daily_limit,
             monthly_limit,
+            team_daily_limit,
+            team_monthly_limit,
             org_daily_limit,
             org_monthly_limit,
         })
@@ -3055,6 +3097,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3081,6 +3125,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(10.0),
             monthly_limit_usd: None,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3116,6 +3162,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3155,6 +3203,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(10.0),
             monthly_limit_usd: None,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3208,6 +3258,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: None,
             monthly_limit_usd: Some(5.0),
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3234,6 +3286,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: None,
             monthly_limit_usd: Some(10.0),
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3255,6 +3309,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(2.0),
             monthly_limit_usd: Some(5.0),
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3282,6 +3338,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3308,6 +3366,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3334,6 +3394,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: None,
             monthly_limit_usd: Some(5.0),
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3360,6 +3422,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(10.0),
             monthly_limit_usd: None,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3773,6 +3837,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(10.0),
             monthly_limit_usd: None,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,
@@ -3797,6 +3863,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             org_daily_limit_usd: None,
             org_monthly_limit_usd: None,
             timezone: None,

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -44,6 +44,13 @@ pub struct BudgetPolicy {
     pub daily_limit_usd: Option<f64>,
     /// Maximum USD spend per calendar month; `None` means no limit.
     pub monthly_limit_usd: Option<f64>,
+    /// AAASM-5087 — Maximum USD spend per calendar day, per team.
+    /// Enforced independently of `daily_limit_usd` (which is the global cap).
+    /// `None` means no per-team daily limit.
+    pub team_daily_limit_usd: Option<f64>,
+    /// AAASM-5087 — Maximum USD spend per calendar month, per team.
+    /// `None` means no per-team monthly limit.
+    pub team_monthly_limit_usd: Option<f64>,
     /// AAASM-2022 — Maximum USD spend per calendar day, per organisation.
     /// Enforced independently of `daily_limit_usd` (which is the global cap).
     /// `None` means no per-org daily limit.

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -48,6 +48,12 @@ pub struct RawBudgetPolicy {
     pub daily_limit_usd: Option<f64>,
     /// Maximum USD spend per calendar month; `None` means no limit.
     pub monthly_limit_usd: Option<f64>,
+    /// AAASM-5087 — Maximum USD spend per calendar day, per team.
+    /// `None` means no per-team daily limit.
+    pub team_daily_limit_usd: Option<f64>,
+    /// AAASM-5087 — Maximum USD spend per calendar month, per team.
+    /// `None` means no per-team monthly limit.
+    pub team_monthly_limit_usd: Option<f64>,
     /// AAASM-2022 — Maximum USD spend per calendar day, per organisation.
     /// `None` means no per-org daily limit.
     pub org_daily_limit_usd: Option<f64>,

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -286,6 +286,16 @@ impl PolicyValidator {
             errors,
         );
 
+        // AAASM-5087 — Per-team limits use the same validation rules as the
+        // global limits: positive, and monthly >= daily.
+        validate_budget_limit_pair(
+            raw.team_daily_limit_usd,
+            raw.team_monthly_limit_usd,
+            "budget.team_daily_limit_usd",
+            "budget.team_monthly_limit_usd",
+            errors,
+        );
+
         // AAASM-2022 — Per-org limits use the same validation rules as the
         // global limits: positive, and monthly >= daily.
         validate_budget_limit_pair(
@@ -345,6 +355,8 @@ impl PolicyValidator {
         Some(BudgetPolicy {
             daily_limit_usd: raw.daily_limit_usd,
             monthly_limit_usd: raw.monthly_limit_usd,
+            team_daily_limit_usd: raw.team_daily_limit_usd,
+            team_monthly_limit_usd: raw.team_monthly_limit_usd,
             org_daily_limit_usd: raw.org_daily_limit_usd,
             org_monthly_limit_usd: raw.org_monthly_limit_usd,
             timezone: raw.timezone,
@@ -1616,6 +1628,8 @@ schedule:
 budget:
   daily_limit_usd: 25.0
   monthly_limit_usd: 400.0
+  team_daily_limit_usd: 40.0
+  team_monthly_limit_usd: 600.0
   org_daily_limit_usd: 50.0
   org_monthly_limit_usd: 800.0
   timezone: "UTC"
@@ -1644,6 +1658,42 @@ approval:
             out.warnings.is_empty(),
             "a fully-valid policy must produce no warnings, got: {:?}",
             out.warnings
+        );
+    }
+
+    // AAASM-5087 — the team-tier calendar-month limit parses off `budget:` and
+    // lands on the validated document so the engine can lift it into the tracker.
+    #[test]
+    fn team_monthly_limit_parses_into_budget_policy() {
+        let yaml =
+            "version: \"1.0\"\nscope: global\nbudget:\n  team_daily_limit_usd: 10.0\n  team_monthly_limit_usd: 250.0\n";
+        let out = PolicyValidator::from_yaml(yaml).expect("valid policy must load");
+        let budget = out.document.budget.expect("budget block present");
+        assert_eq!(budget.team_daily_limit_usd, Some(10.0));
+        assert_eq!(budget.team_monthly_limit_usd, Some(250.0));
+    }
+
+    // AAASM-5087 — team limits reuse the shared pair validation: a non-positive
+    // value is rejected, and monthly must be >= daily (a mis-ordered pair must
+    // fail closed rather than silently loosen the cap).
+    #[test]
+    fn team_monthly_below_daily_is_rejected() {
+        let yaml =
+            "version: \"1.0\"\nscope: global\nbudget:\n  team_daily_limit_usd: 100.0\n  team_monthly_limit_usd: 50.0\n";
+        let errs = PolicyValidator::from_yaml(yaml).expect_err("monthly < daily must be rejected");
+        assert!(
+            errs.iter().any(|e| e.field == "budget.team_monthly_limit_usd"),
+            "expected a team_monthly_limit_usd error, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn team_daily_limit_must_be_positive() {
+        let yaml = "version: \"1.0\"\nscope: global\nbudget:\n  team_daily_limit_usd: 0\n";
+        let errs = PolicyValidator::from_yaml(yaml).expect_err("non-positive team limit must be rejected");
+        assert!(
+            errs.iter().any(|e| e.field == "budget.team_daily_limit_usd"),
+            "expected a team_daily_limit_usd error, got: {errs:?}"
         );
     }
 }

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -171,24 +171,43 @@ fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAle
     } else {
         std::fs::read_to_string(policy_path).unwrap_or_default()
     };
-    let (daily_limit, monthly_limit, window) = if let Ok(output) = crate::policy::PolicyValidator::from_yaml(&yaml) {
-        let daily = output
-            .document
-            .budget
-            .as_ref()
-            .and_then(|bp| bp.daily_limit_usd)
-            .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
-        let monthly = output
-            .document
-            .budget
-            .as_ref()
-            .and_then(|bp| bp.monthly_limit_usd)
-            .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
-        let window = output.document.budget.as_ref().and_then(|bp| bp.window);
-        (daily, monthly, window)
-    } else {
-        (None, None, None)
-    };
+    #[allow(clippy::type_complexity)]
+    let (daily_limit, monthly_limit, team_daily_limit, team_monthly_limit, window) =
+        if let Ok(output) = crate::policy::PolicyValidator::from_yaml(&yaml) {
+            let daily = output
+                .document
+                .budget
+                .as_ref()
+                .and_then(|bp| bp.daily_limit_usd)
+                .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+            let monthly = output
+                .document
+                .budget
+                .as_ref()
+                .and_then(|bp| bp.monthly_limit_usd)
+                .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+            // AAASM-5087 — Lift the team-tier limits so the shipped `serve`
+            // path enforces the same team caps the cascade loaders derive.
+            // Without this the team limit stays test-only dead code, since
+            // `with_state_and_alert_sender` hardcodes it to `None` and
+            // `load_*_with_budget` adopts this tracker as-is.
+            let team_daily = output
+                .document
+                .budget
+                .as_ref()
+                .and_then(|bp| bp.team_daily_limit_usd)
+                .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+            let team_monthly = output
+                .document
+                .budget
+                .as_ref()
+                .and_then(|bp| bp.team_monthly_limit_usd)
+                .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+            let window = output.document.budget.as_ref().and_then(|bp| bp.window);
+            (daily, monthly, team_daily, team_monthly, window)
+        } else {
+            (None, None, None, None, None)
+        };
 
     let mut tracker = BudgetTracker::with_state_and_alert_sender(
         // AAASM-4793: honours AA_PRICING_FILE when the operator has set it,
@@ -199,6 +218,12 @@ fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAle
         persisted,
         budget_alert_tx,
     );
+    if let Some(limit) = team_daily_limit {
+        tracker = tracker.with_team_daily_limit(limit);
+    }
+    if let Some(limit) = team_monthly_limit {
+        tracker = tracker.with_team_monthly_limit(limit);
+    }
     if let Some(d) = window {
         tracker = tracker.with_window(crate::budget::BudgetWindow::Duration(d));
         tracing::info!(

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -2997,6 +2997,14 @@ export interface components {
             /** @description Human-readable label: org/team id, or the agent's registered name. */
             label: string;
             /**
+             * @description Configured calendar-month budget limit in USD for this node, if any
+             *     (decimal string). Populated for team nodes from the tracker-wide team
+             *     monthly envelope (AAASM-5087) so the Teams monthly-budget card can read
+             *     the limit off the tree; `None` for tiers without a configured monthly
+             *     cap. This is a calendar-month window, not a rolling window.
+             */
+            monthly_budget_limit_usd?: string | null;
+            /**
              * @description Spend attributable to this node itself, excluding descendants (USD
              *     string). Org and team nodes never spend directly, so this is `"0"`.
              */
@@ -5116,6 +5124,14 @@ export interface components {
             daily_spend_usd: string;
             /** @description Calendar date (YYYY-MM-DD) the daily spend applies to. */
             date: string;
+            /**
+             * @description Configured per-team calendar-month budget limit in USD, if set
+             *     (AAASM-5087). This is the tracker-wide team envelope — the same limit
+             *     applies to every team — surfaced so the Teams monthly-budget card can
+             *     render spend against limit. `None` when no team monthly limit is
+             *     configured. This is a calendar-month window, not a rolling window.
+             */
+            monthly_limit_usd?: string | null;
             /** @description Total spend this month in USD for this team (if monthly tracking is enabled). */
             monthly_spend_usd?: string | null;
             /** @description Team identifier. */

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -4967,6 +4967,16 @@ components:
         label:
           type: string
           description: 'Human-readable label: org/team id, or the agent''s registered name.'
+        monthly_budget_limit_usd:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Configured calendar-month budget limit in USD for this node, if any
+            (decimal string). Populated for team nodes from the tracker-wide team
+            monthly envelope (AAASM-5087) so the Teams monthly-budget card can read
+            the limit off the tree; `None` for tiers without a configured monthly
+            cap. This is a calendar-month window, not a rolling window.
         own_spend_usd:
           type: string
           description: |-
@@ -8178,6 +8188,16 @@ components:
         date:
           type: string
           description: Calendar date (YYYY-MM-DD) the daily spend applies to.
+        monthly_limit_usd:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Configured per-team calendar-month budget limit in USD, if set
+            (AAASM-5087). This is the tracker-wide team envelope — the same limit
+            applies to every team — surfaced so the Teams monthly-budget card can
+            render spend against limit. `None` when no team monthly limit is
+            configured. This is a calendar-month window, not a rolling window.
         monthly_spend_usd:
           type:
           - string

--- a/schemas/policy/v1/policy-document.schema.json
+++ b/schemas/policy/v1/policy-document.schema.json
@@ -81,6 +81,21 @@
           "description": "Maximum USD spend allowed per calendar day across all LLM API calls. Calls that would exceed this limit are denied. Must be greater than 0.",
           "type": "number",
           "exclusiveMinimum": 0
+        },
+        "monthly_limit_usd": {
+          "description": "Maximum USD spend allowed per calendar month across all LLM API calls. Calls that would exceed this limit are denied. Must be greater than 0 and >= daily_limit_usd.",
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "team_daily_limit_usd": {
+          "description": "Maximum USD spend allowed per calendar day, applied to each team. Calls that would exceed a team's daily limit are denied. Must be greater than 0.",
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "team_monthly_limit_usd": {
+          "description": "Maximum USD spend allowed per calendar month, applied to each team. Calls that would exceed a team's monthly limit are denied. Must be greater than 0 and >= team_daily_limit_usd.",
+          "type": "number",
+          "exclusiveMinimum": 0
         }
       }
     },


### PR DESCRIPTION
## Description

Rescoped per decision **A2 / ADR-0020 Option C**: makes the **team-tier limit on the EXISTING calendar-month budget** configurable (it was unconfigurable outside tests), feeding the Costs monthly KPI + Teams monthly-budget card.

**This is calendar-month, NOT a rolling window.** The calendar-month budget (, agent/team/org tiers, monthly-before-daily precedence) already existed and is enforced; this PR only adds the configurable **team-tier** daily+monthly limit fields and surfaces them. Existing calendar-month enforcement behavior is unchanged.

**What changed (6 atomic commits):**
- `team_daily_limit_usd` + `team_monthly_limit_usd` on the policy document + JSON schema (configurable via policy YAML).
- Validator: team monthly ≥ team daily, both > 0.
- Tracker: the team monthly limit is **enforced** alongside the existing daily/agent/org tiers (blocks requests; not display-only) — with tests `team_monthly_limit_exceeded_blocks` and `team_monthly_80_pct_fires_alert_with_team_id`.
- Engine lifts the configured limit from policy into the tracker.
- Costs/analytics surface each team's configured monthly limit.
- Regenerated OpenAPI + schema.

## Type of Change
- [x] ✨ New feature

## Breaking Changes
- [x] No — new optional policy fields; existing budgets unaffected.

## Related Issues
- Related Jira ticket: AAASM-5087

## Deferred (separate decision-gated ticket, per A2)
Rolling N-day window, persisted daily-usage ledger, timezone/boundary semantics, refunds/reversals, late usage events, retention/aggregation — explicitly OUT of scope here. (Follow-up ticket being filed.)

## Testing
- `cargo test -p aa-gateway --lib budget::` — 112 pass (incl. team-monthly enforcement + alert tests).
- `cargo clippy -p aa-gateway -p aa-api --all-targets` + `cargo fmt --check` clean; OpenAPI drift in sync; contract test 7/7 (no new path).

## Security
- Budgets block requests: enforcement precedence unchanged, no fail-open introduced; team monthly enforces identically to the existing agent/org monthly tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)