### PR TITLE
[AAASM-5277] ✨ (aa-core): Add the capability-based integration lifecycle contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,9 @@ name = "aa-devtool-contract"
 version = "0.0.1-rc.6"
 dependencies = [
  "aa-core",
+ "async-trait",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ dependencies = [
  "aa-devtool-codex",
  "aa-devtool-contract",
  "aa-devtool-copilot",
+ "aa-devtool-sample-myeditor",
  "aa-devtool-windsurf",
  "async-trait",
  "futures",

--- a/aa-core/src/integration/capability.rs
+++ b/aa-core/src/integration/capability.rs
@@ -1,0 +1,420 @@
+//! What integration mechanisms a dev tool exposes — ADR 0030 Decision 3.
+//!
+//! # This is a different axis from [`crate::capability::Capability`]
+//!
+//! `aa_core::Capability` / `CapabilitySet` model **agent action** capabilities
+//! (`FileWrite`, `TerminalExec`, `NetworkOutbound`, …) and are the subject of
+//! ADR 0029. The types here model **which levers exist for wiring a developer
+//! tool into governance**. ADR 0030 §3.1 makes the distinct naming mandatory:
+//! conflating them would make ADR 0029's over-permission rule read as if it
+//! applied to integration mechanisms.
+//!
+//! # Fail-absent (ADR 0030 §3.4, transferred from ADR 0029)
+//!
+//! A capability that is **not declared** is [`CapabilityResolution::Absent`] —
+//! not `Unsupported`, and never supported. An adapter that has not been updated
+//! for a new capability has not answered the question, and a missing answer is
+//! never read as a yes. The same applies to
+//! [`CapabilitySupport::RequiresVersion`] whose `detected` is `None`: a missing
+//! version is a missing comparison.
+//!
+//! # Why `ModelPathInterception` and `ModelGatewayBaseUrl` are separate
+//!
+//! They look alike and are opposites. The AAASM-5276 spike measured, against
+//! Claude Code 2.1.220, that redirecting `ANTHROPIC_BASE_URL` delivered the raw
+//! synthetic secret to the provider with **no AASM component anywhere in the
+//! path**. Base-URL redirection is *routing*; only interception is *protection*.
+//! [`IntegrationCapability::justifies_gateway_protection`] is where that
+//! distinction is made unforgeable.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::version::ToolVersion;
+
+/// One integration mechanism a dev tool may expose.
+///
+/// Deliberately **not** named `Capability` — see the module docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum IntegrationCapability {
+    /// The adapter can detect the tool's presence and version on this host.
+    Discovery,
+    /// The adapter can render and merge a managed settings block into the
+    /// tool's native configuration.
+    ManagedSettings,
+    /// The adapter can build a governed launch command for the tool. IDE-hosted
+    /// tools (Copilot, Windsurf) declare this `Unsupported` with a reason
+    /// instead of failing at run time.
+    ManagedLaunch,
+    /// An AASM component sits **in** the tool's model-bound path and inspects
+    /// what crosses it (the MitM proxy with its CA trusted by the tool, or the
+    /// gateway on the wire). This is the only mechanism that can justify
+    /// [`ProtectionLevel::GatewayProtected`](super::ProtectionLevel::GatewayProtected).
+    ModelPathInterception,
+    /// The tool honours a configurable model base URL. This is **routing, not
+    /// protection**: pointing the tool at another endpoint changes where its
+    /// traffic goes, not whether anything inspects it.
+    ModelGatewayBaseUrl,
+    /// The tool honours `HTTP_PROXY` / `HTTPS_PROXY` or an equivalent. A
+    /// transport lever — it is how interception is often *achieved*, but on its
+    /// own it says nothing about what is on the other end of the proxy.
+    HttpProxy,
+    /// The tool exposes pre/post hooks AASM can install.
+    Hooks,
+    /// The tool exposes the MCP servers it is configured to use.
+    McpDiscovery,
+    /// The tool honours an MCP allow/deny list.
+    McpGovernance,
+    /// The tool can gate individual tool invocations on an approval decision.
+    ToolActionApproval,
+    /// A first-class in-IDE surface exists for status and approval prompts.
+    NativeIdeUi,
+    /// The integration can be backed by host controls (proxy CA in the system
+    /// trust store, eBPF probes).
+    HostEnforcement,
+}
+
+impl IntegrationCapability {
+    /// Every variant, in declaration order. Kept in step with the enum by a unit
+    /// test in this module.
+    pub const ALL: [IntegrationCapability; 12] = [
+        Self::Discovery,
+        Self::ManagedSettings,
+        Self::ManagedLaunch,
+        Self::ModelPathInterception,
+        Self::ModelGatewayBaseUrl,
+        Self::HttpProxy,
+        Self::Hooks,
+        Self::McpDiscovery,
+        Self::McpGovernance,
+        Self::ToolActionApproval,
+        Self::NativeIdeUi,
+        Self::HostEnforcement,
+    ];
+
+    /// Whether exercised evidence about this mechanism can justify
+    /// [`GatewayProtected`](super::ProtectionLevel::GatewayProtected).
+    ///
+    /// True for [`ModelPathInterception`](Self::ModelPathInterception) alone.
+    /// [`ModelGatewayBaseUrl`](Self::ModelGatewayBaseUrl) and
+    /// [`HttpProxy`](Self::HttpProxy) are routing levers: they determine where
+    /// traffic goes, not that an AASM component inspected it. The AAASM-5276
+    /// spike measured a base-URL redirection delivering a raw secret to the
+    /// provider, so treating the two as interchangeable would report protection
+    /// that had demonstrably not happened.
+    pub fn justifies_gateway_protection(self) -> bool {
+        matches!(self, Self::ModelPathInterception)
+    }
+
+    /// Whether attested evidence about this mechanism can justify
+    /// [`HostEnforced`](super::ProtectionLevel::HostEnforced).
+    pub fn justifies_host_enforcement(self) -> bool {
+        matches!(self, Self::HostEnforcement)
+    }
+
+    /// Whether MCP is involved. Used by the conformance check that pairs a
+    /// declaration with its optional accessor.
+    pub fn is_mcp(self) -> bool {
+        matches!(self, Self::McpDiscovery | Self::McpGovernance)
+    }
+}
+
+/// How one [`IntegrationCapability`] is supported by an adapter.
+///
+/// Absence of a key from [`DevToolCapabilities`] means *not declared*, which is
+/// **not** the same as [`Unsupported`](Self::Unsupported) — see the module docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum CapabilitySupport {
+    /// The adapter can do this for this tool.
+    Supported,
+    /// The adapter cannot do this, and `reason` says why in words a user can
+    /// read. This is what replaces a run-time `LaunchFailed` for a fact that was
+    /// knowable at plan time (ADR 0030 §3.2).
+    Unsupported {
+        /// User-facing explanation, surfaced in the plan's dry-run output.
+        reason: Cow<'static, str>,
+    },
+    /// The mechanism exists from `min` onwards. `detected` carries the version
+    /// actually found; `None` resolves to [`CapabilityResolution::Absent`].
+    RequiresVersion {
+        /// Lowest tool version at which this mechanism exists.
+        min: ToolVersion,
+        /// The version detected on this host, when one was.
+        detected: Option<ToolVersion>,
+    },
+}
+
+impl CapabilitySupport {
+    /// Convenience constructor for [`Unsupported`](Self::Unsupported).
+    pub fn unsupported(reason: impl Into<Cow<'static, str>>) -> Self {
+        Self::Unsupported { reason: reason.into() }
+    }
+}
+
+/// Three-valued reading of a capability declaration — the *effective* answer.
+///
+/// Only [`Effective`](Self::Effective) may raise a protection state or be shown
+/// to a user as something the product can do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum CapabilityResolution {
+    /// Declared, and substantiated on this host at this version.
+    Effective,
+    /// Declared and explicitly unavailable, with a stated reason.
+    Unsupported,
+    /// Not declared at all, or declared with a version constraint that could not
+    /// be evaluated. Never read as supported.
+    Absent,
+}
+
+/// The full set of integration mechanisms one adapter declares.
+///
+/// Built with the chaining constructors so an adapter's `capabilities()` reads
+/// as a table:
+///
+/// ```
+/// use aa_core::integration::{DevToolCapabilities, IntegrationCapability as Cap};
+///
+/// let caps = DevToolCapabilities::new()
+///     .supported(Cap::Discovery)
+///     .supported(Cap::ManagedSettings)
+///     .unsupported(Cap::ManagedLaunch, "Copilot is a VS Code extension and has no launch command");
+///
+/// assert!(caps.is_effective(Cap::Discovery));
+/// assert!(!caps.is_effective(Cap::ManagedLaunch));
+/// // Never declared at all — absent, not "unsupported".
+/// assert!(!caps.is_effective(Cap::Hooks));
+/// assert_eq!(caps.unsupported_reason(Cap::Hooks), None);
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DevToolCapabilities {
+    declared: BTreeMap<IntegrationCapability, CapabilitySupport>,
+}
+
+impl DevToolCapabilities {
+    /// An empty declaration — every capability resolves to
+    /// [`CapabilityResolution::Absent`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Declare `capability` with an explicit support value.
+    #[must_use]
+    pub fn declare(mut self, capability: IntegrationCapability, support: CapabilitySupport) -> Self {
+        self.declared.insert(capability, support);
+        self
+    }
+
+    /// Declare `capability` as [`CapabilitySupport::Supported`].
+    #[must_use]
+    pub fn supported(self, capability: IntegrationCapability) -> Self {
+        self.declare(capability, CapabilitySupport::Supported)
+    }
+
+    /// Declare `capability` as [`CapabilitySupport::Unsupported`] with a
+    /// user-facing reason.
+    #[must_use]
+    pub fn unsupported(self, capability: IntegrationCapability, reason: impl Into<Cow<'static, str>>) -> Self {
+        self.declare(capability, CapabilitySupport::unsupported(reason))
+    }
+
+    /// Declare `capability` as available from `min` onwards, having detected
+    /// `detected` on this host.
+    #[must_use]
+    pub fn requires_version(
+        self,
+        capability: IntegrationCapability,
+        min: ToolVersion,
+        detected: Option<ToolVersion>,
+    ) -> Self {
+        self.declare(capability, CapabilitySupport::RequiresVersion { min, detected })
+    }
+
+    /// The raw declaration map.
+    pub fn declared(&self) -> &BTreeMap<IntegrationCapability, CapabilitySupport> {
+        &self.declared
+    }
+
+    /// The declaration for `capability`, or `None` when it was never declared.
+    pub fn support(&self, capability: IntegrationCapability) -> Option<&CapabilitySupport> {
+        self.declared.get(&capability)
+    }
+
+    /// Resolve a declaration into its effective reading (ADR 0030 §3.4).
+    ///
+    /// * not declared ⇒ [`Absent`](CapabilityResolution::Absent)
+    /// * `Supported` ⇒ [`Effective`](CapabilityResolution::Effective)
+    /// * `Unsupported` ⇒ [`Unsupported`](CapabilityResolution::Unsupported)
+    /// * `RequiresVersion { detected: None }` ⇒
+    ///   [`Absent`](CapabilityResolution::Absent) — a missing version is a
+    ///   missing comparison, never a pass
+    /// * `RequiresVersion { detected: Some(v) }` ⇒ `Effective` when `v >= min`,
+    ///   otherwise `Unsupported` (a substantiated "no")
+    pub fn resolve(&self, capability: IntegrationCapability) -> CapabilityResolution {
+        match self.declared.get(&capability) {
+            None => CapabilityResolution::Absent,
+            Some(CapabilitySupport::Supported) => CapabilityResolution::Effective,
+            Some(CapabilitySupport::Unsupported { .. }) => CapabilityResolution::Unsupported,
+            Some(CapabilitySupport::RequiresVersion { min, detected }) => match detected {
+                None => CapabilityResolution::Absent,
+                Some(detected) if detected >= min => CapabilityResolution::Effective,
+                Some(_) => CapabilityResolution::Unsupported,
+            },
+        }
+    }
+
+    /// Shorthand for `resolve(capability) == CapabilityResolution::Effective`.
+    pub fn is_effective(&self, capability: IntegrationCapability) -> bool {
+        self.resolve(capability) == CapabilityResolution::Effective
+    }
+
+    /// The user-facing reason a capability is unavailable, when the adapter
+    /// declared one. Returns `None` for absent capabilities — there is no reason
+    /// to give for a question that was never answered.
+    pub fn unsupported_reason(&self, capability: IntegrationCapability) -> Option<&str> {
+        match self.declared.get(&capability) {
+            Some(CapabilitySupport::Unsupported { reason }) => Some(reason.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Every capability that resolves to [`CapabilityResolution::Effective`].
+    pub fn effective(&self) -> BTreeSet<IntegrationCapability> {
+        self.declared
+            .keys()
+            .copied()
+            .filter(|cap| self.is_effective(*cap))
+            .collect()
+    }
+
+    /// Whether this declaration can substantiate a claim that model-bound
+    /// traffic is inspected.
+    ///
+    /// Deliberately **not** satisfied by
+    /// [`ModelGatewayBaseUrl`](IntegrationCapability::ModelGatewayBaseUrl) or
+    /// [`HttpProxy`](IntegrationCapability::HttpProxy).
+    pub fn can_intercept_model_path(&self) -> bool {
+        self.is_effective(IntegrationCapability::ModelPathInterception)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_lists_every_variant_exactly_once() {
+        let unique: BTreeSet<_> = IntegrationCapability::ALL.iter().copied().collect();
+        assert_eq!(unique.len(), IntegrationCapability::ALL.len());
+    }
+
+    #[test]
+    fn base_url_redirection_cannot_satisfy_model_path_interception() {
+        // The AAASM-5276 measurement: with ANTHROPIC_BASE_URL redirection the raw
+        // synthetic secret reached the provider with no AASM component in the path.
+        assert!(IntegrationCapability::ModelPathInterception.justifies_gateway_protection());
+        assert!(!IntegrationCapability::ModelGatewayBaseUrl.justifies_gateway_protection());
+        assert!(!IntegrationCapability::HttpProxy.justifies_gateway_protection());
+
+        let routing_only = DevToolCapabilities::new()
+            .supported(IntegrationCapability::ModelGatewayBaseUrl)
+            .supported(IntegrationCapability::HttpProxy);
+        assert!(
+            !routing_only.can_intercept_model_path(),
+            "routing capabilities must never add up to interception"
+        );
+    }
+
+    #[test]
+    fn an_undeclared_capability_is_absent_not_unsupported() {
+        let caps = DevToolCapabilities::new().supported(IntegrationCapability::Discovery);
+        assert_eq!(
+            caps.resolve(IntegrationCapability::McpGovernance),
+            CapabilityResolution::Absent
+        );
+        assert!(!caps.is_effective(IntegrationCapability::McpGovernance));
+        assert_eq!(caps.unsupported_reason(IntegrationCapability::McpGovernance), None);
+    }
+
+    #[test]
+    fn requires_version_without_a_detected_version_is_absent() {
+        let caps =
+            DevToolCapabilities::new().requires_version(IntegrationCapability::Hooks, ToolVersion::new(2, 0, 0), None);
+        assert_eq!(caps.resolve(IntegrationCapability::Hooks), CapabilityResolution::Absent);
+        assert!(!caps.is_effective(IntegrationCapability::Hooks));
+    }
+
+    #[test]
+    fn requires_version_compares_when_a_version_is_known() {
+        let too_old = DevToolCapabilities::new().requires_version(
+            IntegrationCapability::Hooks,
+            ToolVersion::new(2, 0, 0),
+            Some(ToolVersion::new(1, 9, 0)),
+        );
+        assert_eq!(
+            too_old.resolve(IntegrationCapability::Hooks),
+            CapabilityResolution::Unsupported
+        );
+
+        let new_enough = DevToolCapabilities::new().requires_version(
+            IntegrationCapability::Hooks,
+            ToolVersion::new(2, 0, 0),
+            Some(ToolVersion::new(2, 1, 220)),
+        );
+        assert!(new_enough.is_effective(IntegrationCapability::Hooks));
+    }
+
+    #[test]
+    fn unsupported_carries_a_reason_a_user_can_read() {
+        let caps = DevToolCapabilities::new().unsupported(
+            IntegrationCapability::ManagedLaunch,
+            "GitHub Copilot is a VS Code extension and has no launch command",
+        );
+        assert_eq!(
+            caps.resolve(IntegrationCapability::ManagedLaunch),
+            CapabilityResolution::Unsupported
+        );
+        assert!(caps
+            .unsupported_reason(IntegrationCapability::ManagedLaunch)
+            .is_some_and(|r| r.contains("VS Code extension")));
+    }
+
+    #[test]
+    fn effective_returns_only_substantiated_capabilities() {
+        let caps = DevToolCapabilities::new()
+            .supported(IntegrationCapability::Discovery)
+            .supported(IntegrationCapability::ManagedSettings)
+            .unsupported(IntegrationCapability::ManagedLaunch, "no launch command")
+            .requires_version(IntegrationCapability::Hooks, ToolVersion::new(2, 0, 0), None);
+
+        let effective = caps.effective();
+        assert_eq!(
+            effective,
+            BTreeSet::from([IntegrationCapability::Discovery, IntegrationCapability::ManagedSettings])
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn capabilities_round_trip_through_json() {
+        let caps = DevToolCapabilities::new()
+            .supported(IntegrationCapability::Discovery)
+            .unsupported(IntegrationCapability::ManagedLaunch, "no launch command")
+            .requires_version(
+                IntegrationCapability::McpGovernance,
+                ToolVersion::new(1, 2, 0),
+                Some(ToolVersion::new(1, 3, 0)),
+            );
+        let json = serde_json::to_string(&caps).unwrap();
+        let restored: DevToolCapabilities = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, caps);
+    }
+}

--- a/aa-core/src/integration/contract.rs
+++ b/aa-core/src/integration/contract.rs
@@ -1,0 +1,494 @@
+//! The lifecycle trait every integration implements, and the optional mechanism
+//! sub-traits it opts into.
+//!
+//! # Why the split, and where the line is
+//!
+//! The old [`DevToolAdapter`](crate::DevToolAdapter) makes every mechanism
+//! mandatory, so `aa-devtool-codex` implements `apply_mcp_governance` as `Ok(())`
+//! with the comment *"Codex does not expose MCP governance"* — a tool that
+//! cannot do a thing is forced to claim it can and then lie quietly. Composition
+//! removes the lie: [`DevToolIntegration`] carries only what **every** tool can
+//! answer, and each mechanism lives behind an accessor whose default body
+//! returns `None`. Codex simply does not declare
+//! [`McpGovernance`](IntegrationCapability::McpGovernance) and inherits
+//! `as_mcp_governed() -> None`; Copilot does not implement
+//! [`LaunchableTool`] and says why in its capability declaration instead of
+//! failing at run time.
+//!
+//! # Why there is no `apply_integration`
+//!
+//! The adapter *authors* a plan; the service *executes* it (ADR 0030 matrix rows
+//! 2 and 3). Putting apply on the adapter trait would re-create the
+//! shared-ownership problem the matrix exists to prevent, and would put rollback
+//! correctness and crash recovery in N places instead of one.
+//!
+//! # Declared must match implemented
+//!
+//! Declaring a capability `Supported` while its accessor returns `None` is a
+//! contract violation, not a style issue: everything downstream reads the
+//! declaration. [`capability_conformance`] is the check, and it is meant to be
+//! called from every adapter's own test suite.
+
+use std::collections::BTreeMap;
+
+use crate::dev_tool::{AdapterError, DevToolInfo, McpServerInfo};
+
+use super::capability::{DevToolCapabilities, IntegrationCapability};
+use super::plan::{IntegrationPlan, IntegrationRequest, RemovalPlan};
+use super::receipt::IntegrationReceipt;
+use super::status::{IntegrationStatus, VerificationResult};
+use super::step::IntegrationStep;
+use super::version::VersionSupport;
+
+/// Everything a launch needs, gathered so [`LaunchableTool`] takes one argument
+/// rather than five positional ones.
+///
+/// `env` exists because a proxy address alone is not enough to make an
+/// Electron/Node tool trust the intercepting proxy — `NODE_EXTRA_CA_CERTS` has
+/// to point at the CA an earlier plan step materialised. A launch surface with
+/// no way to carry that variable cannot express the highest-value fix the
+/// AAASM-5276 spike identified.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LaunchSpec {
+    /// Arguments to pass through to the tool untouched.
+    pub tool_args: Vec<String>,
+    /// The agent identity the gateway issued for this run.
+    pub agent_id: String,
+    /// The team identity, when the run has one.
+    pub team_id: Option<String>,
+    /// `host:port` of the local intercepting proxy, when one is running.
+    pub proxy_addr: Option<String>,
+    /// Extra environment variables to inject, name to value.
+    pub env: BTreeMap<String, String>,
+}
+
+impl LaunchSpec {
+    /// A spec for `agent_id` with no arguments, no proxy and no extra
+    /// environment.
+    pub fn new(agent_id: impl Into<String>) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            ..Self::default()
+        }
+    }
+
+    /// Pass arguments through to the tool.
+    #[must_use]
+    pub fn with_args(mut self, tool_args: Vec<String>) -> Self {
+        self.tool_args = tool_args;
+        self
+    }
+
+    /// Route the tool through a local proxy.
+    #[must_use]
+    pub fn through_proxy(mut self, proxy_addr: impl Into<String>) -> Self {
+        self.proxy_addr = Some(proxy_addr.into());
+        self
+    }
+
+    /// Inject an environment variable into the launch.
+    #[must_use]
+    pub fn with_env(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(name.into(), value.into());
+        self
+    }
+}
+
+/// The lifecycle contract every dev-tool integration implements.
+///
+/// Object-safe and `Send + Sync`, so integrations can live in a registry and be
+/// called from the runtime's task pool.
+#[async_trait::async_trait]
+pub trait DevToolIntegration: Send + Sync {
+    /// What integration mechanisms this adapter exposes for its tool.
+    ///
+    /// A static declaration except for
+    /// [`RequiresVersion`](super::CapabilitySupport::RequiresVersion), whose
+    /// `detected` field the adapter fills from its own detection. Anything not
+    /// named here is **absent**, which is never read as supported.
+    fn capabilities(&self) -> DevToolCapabilities;
+
+    /// Detect whether the tool is installed on this host.
+    ///
+    /// Same contract as [`DevToolAdapter::detect`](crate::DevToolAdapter::detect):
+    /// `None` when the tool is absent, unreadable or unconfirmable, and no
+    /// network I/O.
+    fn detect(&self) -> Option<DevToolInfo>;
+
+    /// Which tool versions this adapter understands, plus its own version and
+    /// the lifecycle schema it was compiled against.
+    ///
+    /// Owned by the adapter because only it knows what a version *means* for its
+    /// tool (ADR 0030 matrix row 1).
+    fn version_support(&self) -> VersionSupport;
+
+    /// Author the steps needed to take this tool to the requested level.
+    ///
+    /// ### Contract
+    /// * Pure with respect to the host: planning describes mutations, it does
+    ///   not perform them. Reading the host to *decide* the steps is expected;
+    ///   writing to it is not.
+    /// * The returned plan must satisfy
+    ///   [`IntegrationPlan::validate`] — in particular every settings-touching
+    ///   step must name the scope the request asked for.
+    /// * Mechanisms the tool cannot use are reported in
+    ///   [`IntegrationPlan::unsupported`] with the reason from
+    ///   [`capabilities`](Self::capabilities), rather than failing.
+    /// * The plan's level may be **below** the requested one; it may never be
+    ///   silently above it.
+    async fn plan_integration(&self, request: &IntegrationRequest) -> Result<IntegrationPlan, AdapterError>;
+
+    /// Report what is currently true for this tool, with the evidence.
+    ///
+    /// ### Contract
+    /// * Derived on every call. Never cached — protection that has stopped
+    ///   holding must stop being reported.
+    /// * `receipt` is `None` when nothing has been applied; the answer is then
+    ///   at most
+    ///   [`DetectedNotIntegrated`](super::ProtectionLevel::DetectedNotIntegrated),
+    ///   however complete the tool's configuration happens to look.
+    /// * Missing evidence lowers the reported state; it never raises it.
+    async fn integration_status(&self, receipt: Option<&IntegrationReceipt>)
+        -> Result<IntegrationStatus, AdapterError>;
+
+    /// Check that what the receipt claims is still true.
+    ///
+    /// ### Contract
+    /// * Every observation is returned as
+    ///   [`ProtectionEvidence`](super::ProtectionEvidence) tagged with how it was
+    ///   obtained, so read-back and exercised evidence stay distinguishable.
+    /// * An adapter with no verification mechanism returns
+    ///   [`VerificationOutcome::Unverifiable`](super::VerificationOutcome::Unverifiable)
+    ///   — not [`Passed`](super::VerificationOutcome::Passed), and not an error.
+    async fn verify_integration(&self, receipt: &IntegrationReceipt) -> Result<VerificationResult, AdapterError>;
+
+    /// Author the steps that undo what the receipt records.
+    ///
+    /// ### Contract
+    /// * Derived from the receipt, not re-derived from the current host state:
+    ///   removal must undo what was done, not what would be done now.
+    /// * Anything that cannot be undone automatically is declared in
+    ///   [`RemovalPlan::residual`] rather than silently left behind.
+    async fn plan_removal(&self, receipt: &IntegrationReceipt) -> Result<RemovalPlan, AdapterError>;
+
+    /// The MCP surface, when this tool has one.
+    ///
+    /// `None` is the honest answer for a tool without MCP, and it is the default
+    /// — MCP is one optional capability among twelve, never the architecture.
+    fn as_mcp_governed(&self) -> Option<&dyn McpGovernedTool> {
+        None
+    }
+
+    /// The launch surface, when this tool has one.
+    ///
+    /// `None` for IDE-hosted tools, which have no launch command at all. Their
+    /// capability declaration carries the sentence explaining why, at plan time,
+    /// where the user can still choose a different mechanism.
+    fn as_launchable(&self) -> Option<&dyn LaunchableTool> {
+        None
+    }
+
+    /// The hook surface, when this tool has one.
+    fn as_hookable(&self) -> Option<&dyn HookableTool> {
+        None
+    }
+}
+
+/// Optional surface for tools that expose their MCP configuration.
+#[async_trait::async_trait]
+pub trait McpGovernedTool: Send + Sync {
+    /// Enumerate the MCP servers the tool is currently configured to use.
+    ///
+    /// Returns an empty `Vec` — not an error — when the tool supports MCP but
+    /// has none configured.
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError>;
+
+    /// Author the step that applies an MCP allow/deny list.
+    ///
+    /// Authoring, not applying: `denied` wins on conflict, matching the policy
+    /// engine's evaluation order.
+    fn plan_mcp_governance(&self, allowed: &[String], denied: &[String]) -> Result<IntegrationStep, AdapterError>;
+}
+
+/// Optional surface for tools that can be started through a governed launcher.
+pub trait LaunchableTool: Send + Sync {
+    /// Build the command that starts the tool with governance wiring.
+    ///
+    /// The returned command is *built*, not spawned. Returns
+    /// [`AdapterError::LaunchFailed`] only for genuine run-time failures (the
+    /// binary has moved, an argument cannot be encoded) — "this tool has no
+    /// launch command" is a capability declaration, not an error.
+    fn build_launch_command(&self, spec: &LaunchSpec) -> Result<std::process::Command, AdapterError>;
+}
+
+/// Optional surface for tools that expose installable hooks.
+pub trait HookableTool: Send + Sync {
+    /// Author the steps that install this integration's hooks.
+    fn plan_hooks(&self, request: &IntegrationRequest) -> Result<Vec<IntegrationStep>, AdapterError>;
+}
+
+/// A mismatch between what an adapter declares and what it implements.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConformanceViolation {
+    /// A capability resolves to effective but the surface that implements it is
+    /// not there.
+    #[error("{capability:?} is declared as supported but {accessor}() returns None")]
+    DeclaredWithoutSurface {
+        /// The over-claimed capability.
+        capability: IntegrationCapability,
+        /// The accessor that should have returned `Some`.
+        accessor: &'static str,
+    },
+    /// A surface is implemented but nothing declares it, so no caller will ever
+    /// find it. Under-declaring is not a security problem, but it is still a
+    /// bug: an unadvertised mechanism is an unused one.
+    #[error("{accessor}() returns Some but no corresponding capability is declared")]
+    SurfaceWithoutDeclaration {
+        /// The accessor that returned `Some`.
+        accessor: &'static str,
+    },
+}
+
+/// Check that every declared capability has the surface that implements it, and
+/// vice versa.
+///
+/// Intended to be called from each adapter's own test suite, which is why it
+/// takes `&dyn` and returns every violation rather than short-circuiting on the
+/// first.
+pub fn capability_conformance(integration: &dyn DevToolIntegration) -> Vec<ConformanceViolation> {
+    let caps = integration.capabilities();
+    let mut violations = Vec::new();
+
+    let mcp_declared = IntegrationCapability::ALL
+        .iter()
+        .filter(|cap| cap.is_mcp())
+        .any(|cap| caps.is_effective(*cap));
+    match (mcp_declared, integration.as_mcp_governed().is_some()) {
+        (true, false) => violations.push(ConformanceViolation::DeclaredWithoutSurface {
+            capability: IntegrationCapability::McpGovernance,
+            accessor: "as_mcp_governed",
+        }),
+        (false, true) => violations.push(ConformanceViolation::SurfaceWithoutDeclaration {
+            accessor: "as_mcp_governed",
+        }),
+        _ => {}
+    }
+
+    let launch_declared = caps.is_effective(IntegrationCapability::ManagedLaunch);
+    match (launch_declared, integration.as_launchable().is_some()) {
+        (true, false) => violations.push(ConformanceViolation::DeclaredWithoutSurface {
+            capability: IntegrationCapability::ManagedLaunch,
+            accessor: "as_launchable",
+        }),
+        (false, true) => violations.push(ConformanceViolation::SurfaceWithoutDeclaration {
+            accessor: "as_launchable",
+        }),
+        _ => {}
+    }
+
+    let hooks_declared = caps.is_effective(IntegrationCapability::Hooks);
+    match (hooks_declared, integration.as_hookable().is_some()) {
+        (true, false) => violations.push(ConformanceViolation::DeclaredWithoutSurface {
+            capability: IntegrationCapability::Hooks,
+            accessor: "as_hookable",
+        }),
+        (false, true) => violations.push(ConformanceViolation::SurfaceWithoutDeclaration {
+            accessor: "as_hookable",
+        }),
+        _ => {}
+    }
+
+    violations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dev_tool::DevToolKind;
+    use crate::integration::plan::{ProtectionProfile, RemovalPlan};
+    use crate::integration::state::ProtectionLevel;
+    use crate::integration::step::SettingsScope;
+    use crate::integration::version::{SupportedToolVersions, ToolVersion, LIFECYCLE_SCHEMA_VERSION};
+    use crate::integration::{LifecyclePhase, ProtectionState, VerificationResult, VersionCompatibility};
+    use crate::GovernanceLevel;
+
+    /// Minimal integration whose capability declaration the tests vary.
+    struct Stub {
+        caps: DevToolCapabilities,
+        mcp: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl DevToolIntegration for Stub {
+        fn capabilities(&self) -> DevToolCapabilities {
+            self.caps.clone()
+        }
+
+        fn detect(&self) -> Option<DevToolInfo> {
+            None
+        }
+
+        fn version_support(&self) -> VersionSupport {
+            VersionSupport {
+                adapter_version: ToolVersion::new(0, 1, 0),
+                lifecycle_schema_version: LIFECYCLE_SCHEMA_VERSION,
+                supported_tool_versions: SupportedToolVersions::at_least(ToolVersion::new(1, 0, 0)),
+            }
+        }
+
+        async fn plan_integration(&self, request: &IntegrationRequest) -> Result<IntegrationPlan, AdapterError> {
+            Ok(IntegrationPlan::new(
+                "plan",
+                request,
+                ProtectionLevel::DetectedNotIntegrated,
+                GovernanceLevel::L0Discover,
+            ))
+        }
+
+        async fn integration_status(
+            &self,
+            _receipt: Option<&IntegrationReceipt>,
+        ) -> Result<IntegrationStatus, AdapterError> {
+            Ok(IntegrationStatus {
+                tool: DevToolKind::Custom("stub".to_string()),
+                phase: LifecyclePhase::NotInstalled,
+                state: ProtectionState::Ladder(ProtectionLevel::NotInstalled),
+                evidence: Vec::new(),
+                planned_level: ProtectionLevel::NotInstalled,
+                adapter_ceiling: GovernanceLevel::L0Discover,
+                compatibility: VersionCompatibility::Unknown {
+                    reason: "stub".to_string(),
+                },
+                next_level: None,
+                observed_at_unix_secs: 0,
+            })
+        }
+
+        async fn verify_integration(&self, _receipt: &IntegrationReceipt) -> Result<VerificationResult, AdapterError> {
+            Ok(VerificationResult::unverifiable(0, "stub"))
+        }
+
+        async fn plan_removal(&self, _receipt: &IntegrationReceipt) -> Result<RemovalPlan, AdapterError> {
+            Ok(RemovalPlan::new("removal", DevToolKind::Custom("stub".to_string())))
+        }
+
+        fn as_mcp_governed(&self) -> Option<&dyn McpGovernedTool> {
+            if self.mcp {
+                Some(self)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl McpGovernedTool for Stub {
+        async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+            Ok(Vec::new())
+        }
+
+        fn plan_mcp_governance(&self, allowed: &[String], denied: &[String]) -> Result<IntegrationStep, AdapterError> {
+            Ok(IntegrationStep::new(
+                "mcp",
+                crate::integration::step::StepAction::ConfigureMcpServers {
+                    allowed: allowed.to_vec(),
+                    denied: denied.to_vec(),
+                },
+                "apply the MCP allow/deny list",
+            ))
+        }
+    }
+
+    fn _assert_object_safe(_: &dyn DevToolIntegration) {}
+    fn _assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn the_lifecycle_trait_is_object_safe_and_send_sync() {
+        let stub = Stub {
+            caps: DevToolCapabilities::new(),
+            mcp: false,
+        };
+        let as_dyn: &dyn DevToolIntegration = &stub;
+        _assert_object_safe(as_dyn);
+        _assert_send_sync::<Box<dyn DevToolIntegration>>();
+    }
+
+    #[test]
+    fn a_tool_without_mcp_needs_no_no_op_implementation() {
+        // The Codex shape: no MCP declaration, no MCP surface, nothing to stub.
+        let codex_like = Stub {
+            caps: DevToolCapabilities::new()
+                .supported(IntegrationCapability::Discovery)
+                .supported(IntegrationCapability::ManagedSettings),
+            mcp: false,
+        };
+        assert!(codex_like.as_mcp_governed().is_none());
+        assert!(capability_conformance(&codex_like).is_empty());
+    }
+
+    #[test]
+    fn declaring_mcp_without_the_surface_is_a_conformance_violation() {
+        let liar = Stub {
+            caps: DevToolCapabilities::new().supported(IntegrationCapability::McpGovernance),
+            mcp: false,
+        };
+        assert_eq!(
+            capability_conformance(&liar),
+            vec![ConformanceViolation::DeclaredWithoutSurface {
+                capability: IntegrationCapability::McpGovernance,
+                accessor: "as_mcp_governed",
+            }]
+        );
+    }
+
+    #[test]
+    fn implementing_a_surface_nobody_declared_is_also_reported() {
+        let hidden = Stub {
+            caps: DevToolCapabilities::new(),
+            mcp: true,
+        };
+        assert_eq!(
+            capability_conformance(&hidden),
+            vec![ConformanceViolation::SurfaceWithoutDeclaration {
+                accessor: "as_mcp_governed",
+            }]
+        );
+    }
+
+    #[test]
+    fn an_undeclared_capability_does_not_demand_a_surface() {
+        // Absent is not Unsupported and is not Supported — it demands nothing.
+        let minimal = Stub {
+            caps: DevToolCapabilities::new().unsupported(
+                IntegrationCapability::ManagedLaunch,
+                "this tool is a VS Code extension and has no launch command",
+            ),
+            mcp: false,
+        };
+        assert!(capability_conformance(&minimal).is_empty());
+    }
+
+    #[test]
+    fn a_launch_spec_can_carry_the_ca_variable_the_spike_needed() {
+        let spec = LaunchSpec::new("agent-1")
+            .with_args(vec!["--help".to_string()])
+            .through_proxy("127.0.0.1:8080")
+            .with_env("NODE_EXTRA_CA_CERTS", "/home/dev/.aa/ca/aasm-ca.pem");
+        assert_eq!(
+            spec.env.get("NODE_EXTRA_CA_CERTS").map(String::as_str),
+            Some("/home/dev/.aa/ca/aasm-ca.pem")
+        );
+        assert_eq!(spec.proxy_addr.as_deref(), Some("127.0.0.1:8080"));
+
+        // A request built for the same tool validates as an empty plan, so the
+        // async surface is exercised end to end in the `aa-devtool-contract`
+        // integration tests (aa-core has no async test runtime by design).
+        let request = IntegrationRequest::new(
+            DevToolKind::Custom("stub".to_string()),
+            ProtectionProfile::Recommended,
+            SettingsScope::User,
+        );
+        assert_eq!(request.settings_scope, SettingsScope::User);
+    }
+}

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -39,6 +39,7 @@
 
 pub mod capability;
 pub mod plan;
+pub mod receipt;
 pub mod state;
 pub mod status;
 pub mod step;
@@ -49,6 +50,7 @@ pub use plan::{
     IntegrationPlan, IntegrationRequest, PlanError, PolicyProfileRef, ProtectionProfile, RemovalPlan,
     UnsupportedMechanism,
 };
+pub use receipt::{IntegrationReceipt, ReceiptError, StepReceipt};
 pub use state::{
     EvidenceKind, ExerciseOutcome, ProtectionEvidence, ProtectionLevel, ProtectionState, StateDerivation,
     DEFAULT_FRESHNESS_WINDOW_SECS,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -38,11 +38,16 @@
 //! that it cannot substantiate the mechanisms it was never designed to expose.
 
 pub mod capability;
+pub mod plan;
 pub mod state;
 pub mod step;
 pub mod version;
 
 pub use capability::{CapabilityResolution, CapabilitySupport, DevToolCapabilities, IntegrationCapability};
+pub use plan::{
+    IntegrationPlan, IntegrationRequest, PlanError, PolicyProfileRef, ProtectionProfile, RemovalPlan,
+    UnsupportedMechanism,
+};
 pub use state::{
     EvidenceKind, ExerciseOutcome, ProtectionEvidence, ProtectionLevel, ProtectionState, StateDerivation,
     DEFAULT_FRESHNESS_WINDOW_SECS,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -1,0 +1,58 @@
+//! The Developer Integration lifecycle contract — ADR 0030 Decisions 3 and 4.
+//!
+//! # What this module is for
+//!
+//! [`DevToolAdapter`](crate::DevToolAdapter) can detect a tool, render settings,
+//! build a launch command and push an MCP list. It cannot answer *"is this
+//! developer actually protected right now, and how do you know?"* — there is no
+//! plan, no receipt, no verification, no drift, no removal, and every mechanism
+//! is mandatory whether or not the tool has it. This module adds the lifecycle
+//! vocabulary that does answer it, as **types and traits only**: plan authoring
+//! lives here, plan *execution*, receipt storage and drift comparison belong to
+//! the service (AAASM-5278), and the local API that carries them belongs to
+//! AAASM-5279.
+//!
+//! # The three ideas worth knowing before reading the types
+//!
+//! 1. **Capabilities are declared, three-valued and fail-absent.** An adapter
+//!    says which mechanisms it exposes; anything it did not mention is *absent*,
+//!    which is never read as supported. MCP is one capability among twelve, and
+//!    a tool that does not have it declares nothing rather than implementing a
+//!    no-op. See [`capability`].
+//! 2. **A protection state is a measurement, not a setting.** It is derived from
+//!    evidence on every read, it carries that evidence, and missing evidence
+//!    always lowers it. Configuration read back from a file can justify
+//!    [`ProtectionLevel::Integrated`] and never more; only traffic that was
+//!    exercised and adjudicated by the core can justify
+//!    [`ProtectionLevel::GatewayProtected`]. See [`state`].
+//! 3. **Authoring and executing are different jobs.** An adapter authors an
+//!    [`IntegrationPlan`]; the service executes it and owns the
+//!    [`IntegrationReceipt`]. That is why there is no `apply` method on
+//!    [`DevToolIntegration`].
+//!
+//! # Migration
+//!
+//! Nothing here replaces [`DevToolAdapter`], which is retained unchanged.
+//! [`LegacyAdapterShim`] makes any existing adapter — in-tree, out-of-tree, or
+//! the public sample — satisfy the new contract on day one, declaring honestly
+//! that it cannot substantiate the mechanisms it was never designed to expose.
+
+pub mod version;
+
+pub use version::{
+    core_version, ComponentVersions, SupportedToolVersions, ToolVersion, VersionCompatibility, VersionParseError,
+    VersionSupport, LIFECYCLE_SCHEMA_VERSION,
+};
+
+/// Seconds since the Unix epoch, saturating at zero for clocks set before it.
+///
+/// Every timestamp in this module is plain `u64` Unix seconds rather than a
+/// richer time type: these values are serialized into receipts and status
+/// responses that must survive a schema round trip through any client, and they
+/// are only ever compared against a freshness window.
+pub fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -40,6 +40,7 @@
 pub mod capability;
 pub mod plan;
 pub mod state;
+pub mod status;
 pub mod step;
 pub mod version;
 
@@ -52,6 +53,7 @@ pub use state::{
     EvidenceKind, ExerciseOutcome, ProtectionEvidence, ProtectionLevel, ProtectionState, StateDerivation,
     DEFAULT_FRESHNESS_WINDOW_SECS,
 };
+pub use status::{IntegrationStatus, LifecyclePhase, NextLevel, VerificationOutcome, VerificationResult};
 pub use step::{
     ArtifactOperation, EnvValue, IntegrationStep, ProbeDescriptor, SettingsMerge, SettingsScope, StepAction,
     StepPrivilege, StepRequirement, TrustMaterialKind,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -39,12 +39,17 @@
 
 pub mod capability;
 pub mod state;
+pub mod step;
 pub mod version;
 
 pub use capability::{CapabilityResolution, CapabilitySupport, DevToolCapabilities, IntegrationCapability};
 pub use state::{
     EvidenceKind, ExerciseOutcome, ProtectionEvidence, ProtectionLevel, ProtectionState, StateDerivation,
     DEFAULT_FRESHNESS_WINDOW_SECS,
+};
+pub use step::{
+    ArtifactOperation, EnvValue, IntegrationStep, ProbeDescriptor, SettingsMerge, SettingsScope, StepAction,
+    StepPrivilege, StepRequirement, TrustMaterialKind,
 };
 pub use version::{
     core_version, ComponentVersions, SupportedToolVersions, ToolVersion, VersionCompatibility, VersionParseError,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -38,9 +38,14 @@
 //! that it cannot substantiate the mechanisms it was never designed to expose.
 
 pub mod capability;
+pub mod state;
 pub mod version;
 
 pub use capability::{CapabilityResolution, CapabilitySupport, DevToolCapabilities, IntegrationCapability};
+pub use state::{
+    EvidenceKind, ExerciseOutcome, ProtectionEvidence, ProtectionLevel, ProtectionState, StateDerivation,
+    DEFAULT_FRESHNESS_WINDOW_SECS,
+};
 pub use version::{
     core_version, ComponentVersions, SupportedToolVersions, ToolVersion, VersionCompatibility, VersionParseError,
     VersionSupport, LIFECYCLE_SCHEMA_VERSION,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -32,7 +32,8 @@
 //!
 //! # Migration
 //!
-//! Nothing here replaces [`DevToolAdapter`], which is retained unchanged.
+//! Nothing here replaces [`DevToolAdapter`](crate::DevToolAdapter), which is
+//! retained unchanged.
 //! [`LegacyAdapterShim`] makes any existing adapter — in-tree, out-of-tree, or
 //! the public sample — satisfy the new contract on day one, declaring honestly
 //! that it cannot substantiate the mechanisms it was never designed to expose.

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -38,6 +38,7 @@
 //! that it cannot substantiate the mechanisms it was never designed to expose.
 
 pub mod capability;
+pub mod contract;
 pub mod plan;
 pub mod receipt;
 pub mod state;
@@ -46,6 +47,10 @@ pub mod step;
 pub mod version;
 
 pub use capability::{CapabilityResolution, CapabilitySupport, DevToolCapabilities, IntegrationCapability};
+pub use contract::{
+    capability_conformance, ConformanceViolation, DevToolIntegration, HookableTool, LaunchSpec, LaunchableTool,
+    McpGovernedTool,
+};
 pub use plan::{
     IntegrationPlan, IntegrationRequest, PlanError, PolicyProfileRef, ProtectionProfile, RemovalPlan,
     UnsupportedMechanism,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -37,8 +37,10 @@
 //! the public sample — satisfy the new contract on day one, declaring honestly
 //! that it cannot substantiate the mechanisms it was never designed to expose.
 
+pub mod capability;
 pub mod version;
 
+pub use capability::{CapabilityResolution, CapabilitySupport, DevToolCapabilities, IntegrationCapability};
 pub use version::{
     core_version, ComponentVersions, SupportedToolVersions, ToolVersion, VersionCompatibility, VersionParseError,
     VersionSupport, LIFECYCLE_SCHEMA_VERSION,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -41,6 +41,7 @@ pub mod capability;
 pub mod contract;
 pub mod plan;
 pub mod receipt;
+pub mod shim;
 pub mod state;
 pub mod status;
 pub mod step;
@@ -56,6 +57,7 @@ pub use plan::{
     UnsupportedMechanism,
 };
 pub use receipt::{IntegrationReceipt, ReceiptError, StepReceipt};
+pub use shim::{LegacyAdapterShim, LEGACY_UNSUPPORTED_REASON};
 pub use state::{
     EvidenceKind, ExerciseOutcome, ProtectionEvidence, ProtectionLevel, ProtectionState, StateDerivation,
     DEFAULT_FRESHNESS_WINDOW_SECS,

--- a/aa-core/src/integration/plan.rs
+++ b/aa-core/src/integration/plan.rs
@@ -1,0 +1,789 @@
+//! What the user asked for, and the reviewable plan an adapter authors in reply.
+//!
+//! An [`IntegrationPlan`] is a **dry run that has not happened yet**: it is
+//! serializable, renderable, validated before anything is executed, and it names
+//! every mechanism it *cannot* use along with the reason. That last part is what
+//! moves "GitHub Copilot is a VS Code extension and cannot be launched" from a
+//! run-time `LaunchFailed` to a plan-time statement the user can act on (ADR
+//! 0030 §3.2).
+//!
+//! Nothing in this module can carry a [`PolicyDocument`](crate::PolicyDocument).
+//! A plan names a profile by reference ([`PolicyProfileRef`]) — enough to display
+//! and compare, not enough to read — which is ADR 0030 §5.5's minimisation
+//! enforced by the shape of the type rather than by a redaction pass someone
+//! might forget.
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::capability::IntegrationCapability;
+use super::state::ProtectionLevel;
+use super::step::{IntegrationStep, SettingsScope, StepAction};
+use super::version::LIFECYCLE_SCHEMA_VERSION;
+use crate::dev_tool::{DevToolKind, GovernanceLevel};
+use crate::policy::EnforcementMode;
+
+/// The named bundle of protection settings a user chose.
+///
+/// A profile is what the user *asked for*; a [`ProtectionLevel`] is what the
+/// system can *prove*. They are separate types because a user can select
+/// `Strict` on a machine where nothing is routed through the gateway, and the
+/// honest answer there is `Integrated`, not "strict protection active".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ProtectionProfile {
+    /// The default: enforce, redact sensitive findings and proceed, approve
+    /// where policy asks.
+    Recommended,
+    /// Enforce, with a narrower egress allowlist and approval required for
+    /// destructive tool classes.
+    Strict,
+    /// Compute and audit every decision; apply none of them.
+    ObserveOnly,
+}
+
+impl ProtectionProfile {
+    /// The [`EnforcementMode`] this profile resolves to.
+    ///
+    /// [`EnforcementMode::Disabled`] is deliberately unreachable: it skips
+    /// policy evaluation entirely and is valid only in hermetic test
+    /// environments, so no user-facing profile may map to it.
+    pub fn enforcement_mode(self) -> EnforcementMode {
+        match self {
+            Self::Recommended | Self::Strict => EnforcementMode::Enforce,
+            Self::ObserveOnly => EnforcementMode::Observe,
+        }
+    }
+
+    /// Whether decisions computed under this profile are actually applied.
+    pub fn is_enforcing(self) -> bool {
+        self.enforcement_mode() == EnforcementMode::Enforce
+    }
+
+    /// The highest protection level this profile may ever be reported at.
+    ///
+    /// `ObserveOnly` is capped at [`ProtectionLevel::Integrated`]: observing is
+    /// not protecting, and displaying it as protection is the single most likely
+    /// way for the product to lie about itself.
+    pub fn max_reportable_level(self) -> ProtectionLevel {
+        match self {
+            Self::Recommended | Self::Strict => ProtectionLevel::HostEnforced,
+            Self::ObserveOnly => ProtectionLevel::Integrated,
+        }
+    }
+}
+
+/// A policy profile named by reference rather than by content.
+///
+/// Enough to display, select and compare; never enough to read the policy. The
+/// resolution from a name to a document happens inside the trusted layers (ADR
+/// 0030 matrix row 6) and the document never leaves them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PolicyProfileRef {
+    /// Stable identifier the control plane knows this profile by.
+    pub id: String,
+    /// Name to show a user.
+    pub display_name: String,
+    /// Digest of the resolved document, so two references can be compared for
+    /// equality without either side holding the content.
+    pub digest: String,
+}
+
+/// What the caller wants done.
+///
+/// Every field is something the caller may legitimately choose. There is no
+/// field a caller could use to supply a policy document, a credential or a path
+/// the service did not derive — an untrusted client can ask for an integration,
+/// never dictate its content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct IntegrationRequest {
+    /// Which tool to integrate.
+    pub tool: DevToolKind,
+    /// Which profile the user chose.
+    pub profile: ProtectionProfile,
+    /// The level the caller is aiming for. The plan may be lower; it may never
+    /// be silently higher.
+    pub requested_level: ProtectionLevel,
+    /// Which configuration surface to write. Explicit and mandatory — the
+    /// destination is never inferred from the caller's working directory.
+    pub settings_scope: SettingsScope,
+    /// Whether the caller has consented to steps that change host state. A plan
+    /// containing privileged steps that were not consented to is a plan the
+    /// service must not execute.
+    pub allow_privileged_host_steps: bool,
+    /// The policy profile the core resolved for this request, by reference.
+    pub policy_profile: Option<PolicyProfileRef>,
+}
+
+impl IntegrationRequest {
+    /// A request aiming at [`ProtectionLevel::GatewayProtected`], with no
+    /// consent for privileged host steps.
+    pub fn new(tool: DevToolKind, profile: ProtectionProfile, settings_scope: SettingsScope) -> Self {
+        Self {
+            tool,
+            profile,
+            requested_level: ProtectionLevel::GatewayProtected,
+            settings_scope,
+            allow_privileged_host_steps: false,
+            policy_profile: None,
+        }
+    }
+
+    /// Aim at a different level.
+    #[must_use]
+    pub fn requesting_level(mut self, level: ProtectionLevel) -> Self {
+        self.requested_level = level;
+        self
+    }
+
+    /// Record the user's consent to host-state changes.
+    #[must_use]
+    pub fn allowing_privileged_host_steps(mut self) -> Self {
+        self.allow_privileged_host_steps = true;
+        self
+    }
+
+    /// Attach the resolved policy profile reference.
+    #[must_use]
+    pub fn with_policy_profile(mut self, policy_profile: PolicyProfileRef) -> Self {
+        self.policy_profile = Some(policy_profile);
+        self
+    }
+
+    /// The highest level this request could honestly reach, clamped by the
+    /// profile. Choosing `ObserveOnly` and asking for `GatewayProtected` yields
+    /// `Integrated`, not the request.
+    pub fn effective_target_level(&self) -> ProtectionLevel {
+        self.requested_level.min(self.profile.max_reportable_level())
+    }
+}
+
+/// A mechanism this tool cannot use, and why, stated at plan time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct UnsupportedMechanism {
+    /// The mechanism that is unavailable.
+    pub capability: IntegrationCapability,
+    /// The user-facing reason, taken from the adapter's capability declaration.
+    pub reason: String,
+}
+
+/// Why a plan is not internally consistent.
+///
+/// These are contract violations by the adapter that authored the plan, not user
+/// errors, and the service must refuse to execute a plan that produces one.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum PlanError {
+    /// Two steps share an id, so a receipt could not key on them.
+    #[error("duplicate step id {id:?}")]
+    DuplicateStepId {
+        /// The repeated identifier.
+        id: String,
+    },
+    /// A step writes to a settings surface the plan did not declare — the exact
+    /// class of bug where the file written depends on the caller's working
+    /// directory.
+    #[error("step {id:?} writes to the {found} settings scope but the plan declared {expected}")]
+    SettingsScopeMismatch {
+        /// The offending step.
+        id: String,
+        /// The scope the plan declared.
+        expected: SettingsScope,
+        /// The scope the step named.
+        found: SettingsScope,
+    },
+    /// A privileged host step carries no consent prompt, or no way to undo it.
+    #[error("privileged host step {id:?} is missing {missing}")]
+    PrivilegedStepIncomplete {
+        /// The offending step.
+        id: String,
+        /// What it lacks.
+        missing: &'static str,
+    },
+    /// The plan claims it will reach a level the steps cannot substantiate.
+    #[error("the plan claims {claimed} but {detail}")]
+    UnsubstantiatedLevel {
+        /// The level claimed.
+        claimed: ProtectionLevel,
+        /// What is missing.
+        detail: String,
+    },
+    /// The plan claims a level above what the chosen profile may ever report.
+    #[error("profile {profile:?} may never be reported above {cap}, but the plan claims {claimed}")]
+    ProfileLevelCap {
+        /// The chosen profile.
+        profile: ProtectionProfile,
+        /// The profile's ceiling.
+        cap: ProtectionLevel,
+        /// The level claimed.
+        claimed: ProtectionLevel,
+    },
+}
+
+/// The steps one adapter says are needed to take one tool to one level.
+///
+/// Authored by the adapter, executed by the service, and shown to the user
+/// first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct IntegrationPlan {
+    /// The [`LIFECYCLE_SCHEMA_VERSION`] this plan was authored against.
+    pub schema_version: u32,
+    /// Stable identifier the subsequent apply refers to.
+    pub plan_id: String,
+    /// The tool this plan integrates.
+    pub tool: DevToolKind,
+    /// The profile the request named.
+    pub profile: ProtectionProfile,
+    /// The settings surface every settings-touching step must write to.
+    pub settings_scope: SettingsScope,
+    /// The resolved policy profile, by reference.
+    pub policy_profile: Option<PolicyProfileRef>,
+    /// The level this plan intends to reach if every step succeeds and verifies.
+    pub planned_level: ProtectionLevel,
+    /// The adapter's static build-time ceiling. A ceiling never implies a
+    /// measurement; it is carried so a user can see the gap.
+    pub adapter_ceiling: GovernanceLevel,
+    /// The steps, in execution order.
+    pub steps: Vec<IntegrationStep>,
+    /// Mechanisms this tool cannot use, with reasons.
+    pub unsupported: Vec<UnsupportedMechanism>,
+    /// Anything else the user should read before approving.
+    pub warnings: Vec<String>,
+}
+
+impl IntegrationPlan {
+    /// An empty plan for `request`, claiming `planned_level`.
+    pub fn new(
+        plan_id: impl Into<String>,
+        request: &IntegrationRequest,
+        planned_level: ProtectionLevel,
+        adapter_ceiling: GovernanceLevel,
+    ) -> Self {
+        Self {
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            plan_id: plan_id.into(),
+            tool: request.tool.clone(),
+            profile: request.profile,
+            settings_scope: request.settings_scope,
+            policy_profile: request.policy_profile.clone(),
+            planned_level,
+            adapter_ceiling,
+            steps: Vec::new(),
+            unsupported: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Append a step.
+    #[must_use]
+    pub fn with_step(mut self, step: IntegrationStep) -> Self {
+        self.steps.push(step);
+        self
+    }
+
+    /// Record a mechanism this tool cannot use, and why.
+    #[must_use]
+    pub fn declaring_unsupported(mut self, capability: IntegrationCapability, reason: impl Into<String>) -> Self {
+        self.unsupported.push(UnsupportedMechanism {
+            capability,
+            reason: reason.into(),
+        });
+        self
+    }
+
+    /// Add a warning for the user to read before approving.
+    #[must_use]
+    pub fn warn(mut self, warning: impl Into<String>) -> Self {
+        self.warnings.push(warning.into());
+        self
+    }
+
+    /// Steps the integration depends on.
+    pub fn required_steps(&self) -> impl Iterator<Item = &IntegrationStep> {
+        self.steps.iter().filter(|s| s.is_required())
+    }
+
+    /// Steps that change host state.
+    pub fn privileged_steps(&self) -> impl Iterator<Item = &IntegrationStep> {
+        self.steps.iter().filter(|s| s.is_privileged())
+    }
+
+    /// Every filesystem artifact this plan touches, deduplicated in first-seen
+    /// order.
+    pub fn affected_artifacts(&self) -> Vec<PathBuf> {
+        let mut seen = Vec::new();
+        for path in self.steps.iter().flat_map(|s| s.action.affected_paths()) {
+            if !seen.contains(&path) {
+                seen.push(path);
+            }
+        }
+        seen
+    }
+
+    /// Whether the plan contains a protection test whose probe exercises a
+    /// mechanism that actually intercepts the model path.
+    ///
+    /// A probe pointed at a routing lever is not a protection test.
+    pub fn has_interception_probe(&self) -> bool {
+        self.steps.iter().any(|step| match &step.action {
+            StepAction::RunProtectionTest { probe } => probe.mechanism.justifies_gateway_protection(),
+            _ => false,
+        })
+    }
+
+    /// Check the plan's internal consistency before anything is executed.
+    ///
+    /// The checks exist because each corresponds to a way the product could
+    /// otherwise mislead a user:
+    ///
+    /// * duplicate ids ⇒ a receipt that cannot attribute a step;
+    /// * a step writing outside the declared scope ⇒ a file written somewhere
+    ///   the user did not choose;
+    /// * a privileged step with no consent prompt or no reversal ⇒ a host change
+    ///   that was neither agreed to nor undoable;
+    /// * a claim of [`GatewayProtected`](ProtectionLevel::GatewayProtected) with
+    ///   no interception probe ⇒ a traffic claim with no plan to observe
+    ///   traffic;
+    /// * `ObserveOnly` claiming more than `Integrated` ⇒ monitoring displayed as
+    ///   protection.
+    pub fn validate(&self) -> Result<(), PlanError> {
+        let mut seen_ids: Vec<&str> = Vec::new();
+        for step in &self.steps {
+            if seen_ids.contains(&step.id.as_str()) {
+                return Err(PlanError::DuplicateStepId { id: step.id.clone() });
+            }
+            seen_ids.push(&step.id);
+
+            if let Some(found) = step.action.settings_scope() {
+                if found != self.settings_scope {
+                    return Err(PlanError::SettingsScopeMismatch {
+                        id: step.id.clone(),
+                        expected: self.settings_scope,
+                        found,
+                    });
+                }
+            }
+
+            if let super::step::StepPrivilege::PrivilegedHost { consent_prompt } = &step.privilege {
+                if consent_prompt.trim().is_empty() {
+                    return Err(PlanError::PrivilegedStepIncomplete {
+                        id: step.id.clone(),
+                        missing: "a consent prompt",
+                    });
+                }
+                if step.reversal.is_none() {
+                    return Err(PlanError::PrivilegedStepIncomplete {
+                        id: step.id.clone(),
+                        missing: "a reversal step",
+                    });
+                }
+            }
+        }
+
+        let cap = self.profile.max_reportable_level();
+        if self.planned_level > cap {
+            return Err(PlanError::ProfileLevelCap {
+                profile: self.profile,
+                cap,
+                claimed: self.planned_level,
+            });
+        }
+
+        if self.planned_level >= ProtectionLevel::GatewayProtected && !self.has_interception_probe() {
+            return Err(PlanError::UnsubstantiatedLevel {
+                claimed: self.planned_level,
+                detail: "it contains no protection test that exercises model-path interception; \
+                         routing a tool's traffic elsewhere is not evidence that anything inspected it"
+                    .to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Render the plan for user review.
+    ///
+    /// The shape is stable so the CLI, the dashboard and a golden test can all
+    /// depend on it: a header block of `key: value` lines, then `steps:`,
+    /// `unsupported:` and `warnings:` sections, each omitted when empty.
+    pub fn render_dry_run(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(out, "integration plan {} for {:?}", self.plan_id, self.tool);
+        let _ = writeln!(out, "  schema: {}", self.schema_version);
+        let _ = writeln!(
+            out,
+            "  profile: {:?} (enforcement: {:?})",
+            self.profile,
+            self.profile.enforcement_mode()
+        );
+        let _ = writeln!(out, "  settings scope: {}", self.settings_scope);
+        let _ = writeln!(
+            out,
+            "  planned level: {} (adapter ceiling: {})",
+            self.planned_level, self.adapter_ceiling
+        );
+        if let Some(profile) = &self.policy_profile {
+            let _ = writeln!(out, "  policy profile: {} ({})", profile.display_name, profile.digest);
+        }
+
+        let _ = writeln!(out, "steps:");
+        if self.steps.is_empty() {
+            let _ = writeln!(out, "  (none)");
+        }
+        for (index, step) in self.steps.iter().enumerate() {
+            let _ = writeln!(out, "  {}. {}", index + 1, step.render_dry_run());
+            if let super::step::StepPrivilege::PrivilegedHost { consent_prompt } = &step.privilege {
+                let _ = writeln!(out, "     consent: {consent_prompt}");
+            }
+        }
+
+        if !self.unsupported.is_empty() {
+            let _ = writeln!(out, "unsupported:");
+            for mechanism in &self.unsupported {
+                let _ = writeln!(out, "  - {:?}: {}", mechanism.capability, mechanism.reason);
+            }
+        }
+
+        if !self.warnings.is_empty() {
+            let _ = writeln!(out, "warnings:");
+            for warning in &self.warnings {
+                let _ = writeln!(out, "  - {warning}");
+            }
+        }
+
+        out
+    }
+}
+
+/// The steps that undo an integration.
+///
+/// Separate from [`IntegrationPlan`] because removal is not "apply in reverse":
+/// it is derived from what a receipt says was actually applied, and it must be
+/// able to admit that something cannot be undone automatically
+/// ([`residual`](Self::residual)) rather than silently leaving it behind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct RemovalPlan {
+    /// The [`LIFECYCLE_SCHEMA_VERSION`] this plan was authored against.
+    pub schema_version: u32,
+    /// Stable identifier the subsequent removal refers to.
+    pub plan_id: String,
+    /// The tool being removed.
+    pub tool: DevToolKind,
+    /// The reversal steps, in execution order.
+    pub steps: Vec<IntegrationStep>,
+    /// Things this plan knowingly leaves behind, in words a user can act on.
+    pub residual: Vec<String>,
+    /// Anything else the user should read before approving.
+    pub warnings: Vec<String>,
+}
+
+impl RemovalPlan {
+    /// An empty removal plan for `tool`.
+    pub fn new(plan_id: impl Into<String>, tool: DevToolKind) -> Self {
+        Self {
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            plan_id: plan_id.into(),
+            tool,
+            steps: Vec::new(),
+            residual: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Append a reversal step.
+    #[must_use]
+    pub fn with_step(mut self, step: IntegrationStep) -> Self {
+        self.steps.push(step);
+        self
+    }
+
+    /// Declare something this plan cannot undo.
+    #[must_use]
+    pub fn with_residual(mut self, residual: impl Into<String>) -> Self {
+        self.residual.push(residual.into());
+        self
+    }
+
+    /// Add a warning for the user to read before approving.
+    #[must_use]
+    pub fn warn(mut self, warning: impl Into<String>) -> Self {
+        self.warnings.push(warning.into());
+        self
+    }
+
+    /// Check that no two steps share an id.
+    pub fn validate(&self) -> Result<(), PlanError> {
+        let mut seen: Vec<&str> = Vec::new();
+        for step in &self.steps {
+            if seen.contains(&step.id.as_str()) {
+                return Err(PlanError::DuplicateStepId { id: step.id.clone() });
+            }
+            seen.push(&step.id);
+        }
+        Ok(())
+    }
+
+    /// Render the removal plan for user review, in the same stable shape as
+    /// [`IntegrationPlan::render_dry_run`].
+    pub fn render_dry_run(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(out, "removal plan {} for {:?}", self.plan_id, self.tool);
+        let _ = writeln!(out, "  schema: {}", self.schema_version);
+        let _ = writeln!(out, "steps:");
+        if self.steps.is_empty() {
+            let _ = writeln!(out, "  (none)");
+        }
+        for (index, step) in self.steps.iter().enumerate() {
+            let _ = writeln!(out, "  {}. {}", index + 1, step.render_dry_run());
+        }
+        if !self.residual.is_empty() {
+            let _ = writeln!(out, "left behind:");
+            for residual in &self.residual {
+                let _ = writeln!(out, "  - {residual}");
+            }
+        }
+        if !self.warnings.is_empty() {
+            let _ = writeln!(out, "warnings:");
+            for warning in &self.warnings {
+                let _ = writeln!(out, "  - {warning}");
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integration::step::{ArtifactOperation, ProbeDescriptor, SettingsMerge, StepAction};
+
+    fn request() -> IntegrationRequest {
+        IntegrationRequest::new(
+            DevToolKind::ClaudeCode,
+            ProtectionProfile::Recommended,
+            SettingsScope::User,
+        )
+    }
+
+    fn settings_step(scope: SettingsScope) -> IntegrationStep {
+        IntegrationStep::new(
+            "settings",
+            StepAction::WriteManagedSettings {
+                scope,
+                path: PathBuf::from("/home/dev/.claude/settings.json"),
+                managed_keys: vec!["permissions".to_string()],
+                content_sha256: "abc".to_string(),
+                merge: SettingsMerge::MergeManagedKeys,
+            },
+            "write the managed settings block",
+        )
+        .with_reversal(StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: PathBuf::from("/home/dev/.claude/settings.json"),
+        })
+    }
+
+    fn probe_step(mechanism: IntegrationCapability) -> IntegrationStep {
+        IntegrationStep::new(
+            "probe",
+            StepAction::RunProtectionTest {
+                probe: ProbeDescriptor {
+                    id: "synthetic-secret".to_string(),
+                    mechanism,
+                    description: "send a synthetic secret down the model path".to_string(),
+                },
+            },
+            "exercise the model path",
+        )
+    }
+
+    #[test]
+    fn observe_only_is_capped_below_protection() {
+        let observe = ProtectionProfile::ObserveOnly;
+        assert_eq!(observe.enforcement_mode(), EnforcementMode::Observe);
+        assert!(!observe.is_enforcing());
+        assert_eq!(observe.max_reportable_level(), ProtectionLevel::Integrated);
+
+        let req = IntegrationRequest::new(DevToolKind::ClaudeCode, observe, SettingsScope::User);
+        assert_eq!(req.requested_level, ProtectionLevel::GatewayProtected);
+        assert_eq!(req.effective_target_level(), ProtectionLevel::Integrated);
+
+        let plan = IntegrationPlan::new(
+            "p1",
+            &req,
+            ProtectionLevel::GatewayProtected,
+            GovernanceLevel::L2Enforce,
+        )
+        .with_step(settings_step(SettingsScope::User))
+        .with_step(probe_step(IntegrationCapability::ModelPathInterception));
+        assert!(matches!(plan.validate(), Err(PlanError::ProfileLevelCap { .. })));
+    }
+
+    #[test]
+    fn a_gateway_protected_claim_needs_an_interception_probe() {
+        let req = request();
+
+        // No probe at all.
+        let no_probe = IntegrationPlan::new(
+            "p1",
+            &req,
+            ProtectionLevel::GatewayProtected,
+            GovernanceLevel::L2Enforce,
+        )
+        .with_step(settings_step(SettingsScope::User));
+        assert!(matches!(
+            no_probe.validate(),
+            Err(PlanError::UnsubstantiatedLevel { .. })
+        ));
+
+        // A probe pointed at a routing lever is not a protection test.
+        let routing_probe = IntegrationPlan::new(
+            "p2",
+            &req,
+            ProtectionLevel::GatewayProtected,
+            GovernanceLevel::L2Enforce,
+        )
+        .with_step(settings_step(SettingsScope::User))
+        .with_step(probe_step(IntegrationCapability::ModelGatewayBaseUrl));
+        assert!(!routing_probe.has_interception_probe());
+        assert!(matches!(
+            routing_probe.validate(),
+            Err(PlanError::UnsubstantiatedLevel { .. })
+        ));
+
+        // Interception probe: accepted.
+        let interception = IntegrationPlan::new(
+            "p3",
+            &req,
+            ProtectionLevel::GatewayProtected,
+            GovernanceLevel::L2Enforce,
+        )
+        .with_step(settings_step(SettingsScope::User))
+        .with_step(probe_step(IntegrationCapability::ModelPathInterception));
+        assert_eq!(interception.validate(), Ok(()));
+    }
+
+    #[test]
+    fn a_step_may_not_write_outside_the_declared_scope() {
+        let req = request(); // declares SettingsScope::User
+        let plan = IntegrationPlan::new("p1", &req, ProtectionLevel::Integrated, GovernanceLevel::L2Enforce)
+            .with_step(settings_step(SettingsScope::Project));
+        match plan.validate() {
+            Err(PlanError::SettingsScopeMismatch { expected, found, .. }) => {
+                assert_eq!(expected, SettingsScope::User);
+                assert_eq!(found, SettingsScope::Project);
+            }
+            other => panic!("expected SettingsScopeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_step_ids_are_rejected() {
+        let req = request();
+        let plan = IntegrationPlan::new("p1", &req, ProtectionLevel::Integrated, GovernanceLevel::L2Enforce)
+            .with_step(settings_step(SettingsScope::User))
+            .with_step(settings_step(SettingsScope::User));
+        assert!(matches!(plan.validate(), Err(PlanError::DuplicateStepId { .. })));
+    }
+
+    #[test]
+    fn a_privileged_step_needs_consent_and_a_reversal() {
+        let req = request();
+
+        let no_reversal = IntegrationStep::new(
+            "trust-store",
+            StepAction::ManageArtifact {
+                operation: ArtifactOperation::Create,
+                path: PathBuf::from("/Library/Keychains/System.keychain"),
+            },
+            "install the AASM CA into the system trust store",
+        )
+        .privileged("Agent Assembly will modify your system trust store.");
+        let plan = IntegrationPlan::new("p1", &req, ProtectionLevel::Integrated, GovernanceLevel::L2Enforce)
+            .with_step(no_reversal.clone());
+        assert!(matches!(
+            plan.validate(),
+            Err(PlanError::PrivilegedStepIncomplete {
+                missing: "a reversal step",
+                ..
+            })
+        ));
+
+        let no_prompt = no_reversal
+            .clone()
+            .privileged("   ")
+            .with_reversal(StepAction::ManageArtifact {
+                operation: ArtifactOperation::Remove,
+                path: PathBuf::from("/Library/Keychains/System.keychain"),
+            });
+        let plan = IntegrationPlan::new("p2", &req, ProtectionLevel::Integrated, GovernanceLevel::L2Enforce)
+            .with_step(no_prompt);
+        assert!(matches!(
+            plan.validate(),
+            Err(PlanError::PrivilegedStepIncomplete {
+                missing: "a consent prompt",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn dry_run_has_a_stable_shape() {
+        let req = request().with_policy_profile(PolicyProfileRef {
+            id: "team-default".to_string(),
+            display_name: "Team default".to_string(),
+            digest: "sha256:abc".to_string(),
+        });
+        let plan = IntegrationPlan::new("plan-1", &req, ProtectionLevel::Integrated, GovernanceLevel::L2Enforce)
+            .with_step(settings_step(SettingsScope::User))
+            .declaring_unsupported(IntegrationCapability::ManagedLaunch, "no launch command")
+            .warn("host enforcement is unavailable on this platform");
+
+        let rendered = plan.render_dry_run();
+        let expected = "\
+integration plan plan-1 for ClaudeCode
+  schema: 1
+  profile: Recommended (enforcement: Enforce)
+  settings scope: user
+  planned level: Integrated (adapter ceiling: L2Enforce)
+  policy profile: Team default (sha256:abc)
+steps:
+  1. [required] settings (write-managed-settings): write the managed settings block
+unsupported:
+  - ManagedLaunch: no launch command
+warnings:
+  - host enforcement is unavailable on this platform
+";
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn a_removal_plan_admits_what_it_cannot_undo() {
+        let plan = RemovalPlan::new("r1", DevToolKind::Codex)
+            .with_residual("the proxy CA remains in the system trust store")
+            .warn("restart the tool for the removal to take effect");
+        assert_eq!(plan.validate(), Ok(()));
+        let rendered = plan.render_dry_run();
+        assert!(rendered.contains("steps:\n  (none)"), "{rendered}");
+        assert!(rendered.contains("left behind:"), "{rendered}");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn plans_round_trip_through_json() {
+        let req = request();
+        let plan = IntegrationPlan::new("p1", &req, ProtectionLevel::Integrated, GovernanceLevel::L2Enforce)
+            .with_step(settings_step(SettingsScope::User));
+        let json = serde_json::to_string(&plan).unwrap();
+        let restored: IntegrationPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, plan);
+    }
+}

--- a/aa-core/src/integration/receipt.rs
+++ b/aa-core/src/integration/receipt.rs
@@ -1,0 +1,414 @@
+//! The durable record of what was applied, and the evidence that justified the
+//! level it claims.
+//!
+//! # What lives here and what does not
+//!
+//! The receipt *type* is part of the lifecycle contract: an adapter reads one in
+//! [`integration_status`](super::DevToolIntegration::integration_status),
+//! [`verify_integration`](super::DevToolIntegration::verify_integration) and
+//! [`plan_removal`](super::DevToolIntegration::plan_removal). Writing one,
+//! storing one and rolling one back belong to the service (ADR 0030 matrix row
+//! 3) and are AAASM-5278's scope — an adapter never writes a receipt.
+//!
+//! # Why the receipt records both the level and its evidence
+//!
+//! So a later status read can tell "verified once, long ago" from "verified
+//! now". A receipt that recorded only `achieved_level: GatewayProtected` would
+//! be indistinguishable from one where the claim had never been substantiated,
+//! and [`IntegrationReceipt::validate`] would have nothing to check.
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::plan::ProtectionProfile;
+use super::state::{ProtectionEvidence, ProtectionLevel};
+use super::step::{IntegrationStep, SettingsScope, StepAction, StepRequirement};
+use super::version::{ComponentVersions, ToolVersion, LIFECYCLE_SCHEMA_VERSION};
+use crate::dev_tool::DevToolKind;
+
+/// What one applied step left behind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct StepReceipt {
+    /// The [`IntegrationStep::id`] this receipt records.
+    pub step_id: String,
+    /// The action that was applied.
+    pub action: StepAction,
+    /// Whether the integration depends on it.
+    pub requirement: StepRequirement,
+    /// Whether the step was actually applied. An interrupted apply leaves
+    /// `false` here, which is what makes `PartiallyIntegrated` recoverable
+    /// rather than guessed at.
+    pub applied: bool,
+    /// Fingerprint of what was written, for drift detection. `None` means no
+    /// fingerprint could be taken, which counts as unverified — never as
+    /// verified.
+    pub fingerprint: Option<String>,
+    /// The action that undoes this one, copied from the plan so removal does not
+    /// depend on the adapter still being able to re-derive it.
+    pub reversal: Option<StepAction>,
+}
+
+impl StepReceipt {
+    /// Record an applied step from the plan step it came from.
+    pub fn applied(step: &IntegrationStep, fingerprint: Option<String>) -> Self {
+        Self {
+            step_id: step.id.clone(),
+            action: step.action.clone(),
+            requirement: step.requirement,
+            applied: true,
+            fingerprint,
+            reversal: step.reversal.clone(),
+        }
+    }
+
+    /// Record a step that was planned but not applied.
+    pub fn not_applied(step: &IntegrationStep) -> Self {
+        Self {
+            step_id: step.id.clone(),
+            action: step.action.clone(),
+            requirement: step.requirement,
+            applied: false,
+            fingerprint: None,
+            reversal: step.reversal.clone(),
+        }
+    }
+
+    /// Whether this step counts towards the "every required step verifies"
+    /// criterion: applied **and** fingerprinted.
+    pub fn is_verified(&self) -> bool {
+        self.applied && self.fingerprint.is_some()
+    }
+}
+
+/// Why a receipt is not internally consistent.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ReceiptError {
+    /// The receipt claims a level its recorded evidence cannot justify.
+    #[error("the receipt claims {claimed} but {detail}")]
+    UnjustifiedAchievedLevel {
+        /// The level claimed.
+        claimed: ProtectionLevel,
+        /// What is missing.
+        detail: String,
+    },
+    /// The receipt claims a level above the plan it came from.
+    #[error("the receipt claims {achieved} but its plan only intended {planned}")]
+    AchievedAbovePlanned {
+        /// The level claimed.
+        achieved: ProtectionLevel,
+        /// The level the plan intended.
+        planned: ProtectionLevel,
+    },
+}
+
+/// The durable record of one applied integration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct IntegrationReceipt {
+    /// The [`LIFECYCLE_SCHEMA_VERSION`] the writing core used. A receipt whose
+    /// schema is newer than the reading core is reported as
+    /// [`Incompatible`](super::ProtectionState::Incompatible), never guessed at.
+    pub schema_version: u32,
+    /// Stable identifier for this receipt.
+    pub receipt_id: String,
+    /// The plan this receipt records the application of.
+    pub plan_id: String,
+    /// The tool that was integrated.
+    pub tool: DevToolKind,
+    /// The profile the user chose.
+    pub profile: ProtectionProfile,
+    /// Which configuration surface was written. Recorded so a later status read
+    /// looks at the file that was actually written, not the one the current
+    /// working directory would suggest.
+    pub settings_scope: SettingsScope,
+    /// When the plan was applied, as seconds since the Unix epoch.
+    pub applied_at_unix_secs: u64,
+    /// The core, adapter and schema versions that produced it.
+    pub versions: ComponentVersions,
+    /// The tool version detected at apply time, when one was.
+    pub tool_version: Option<ToolVersion>,
+    /// One entry per planned step, applied or not.
+    pub steps: Vec<StepReceipt>,
+    /// The level the plan intended to reach.
+    pub planned_level: ProtectionLevel,
+    /// The level actually reached at apply time.
+    pub achieved_level: ProtectionLevel,
+    /// The evidence that justified [`achieved_level`](Self::achieved_level).
+    pub achieved_evidence: Vec<ProtectionEvidence>,
+    /// When the last successful verification ran, when one has.
+    pub verified_at_unix_secs: Option<u64>,
+}
+
+impl IntegrationReceipt {
+    /// How many steps the integration depends on.
+    pub fn required_steps(&self) -> usize {
+        self.steps
+            .iter()
+            .filter(|s| s.requirement == StepRequirement::Required)
+            .count()
+    }
+
+    /// How many required steps are applied and fingerprinted.
+    pub fn verified_required_steps(&self) -> usize {
+        self.steps
+            .iter()
+            .filter(|s| s.requirement == StepRequirement::Required && s.is_verified())
+            .count()
+    }
+
+    /// The reversal actions for every step that was actually applied, in reverse
+    /// application order — the order removal must run in.
+    pub fn reversal_actions(&self) -> Vec<StepAction> {
+        self.steps
+            .iter()
+            .rev()
+            .filter(|s| s.applied)
+            .filter_map(|s| s.reversal.clone())
+            .collect()
+    }
+
+    /// Applied steps whose reversal the receipt does not know, so a removal plan
+    /// can say what it will leave behind instead of silently leaving it.
+    pub fn irreversible_steps(&self) -> Vec<&StepReceipt> {
+        self.steps
+            .iter()
+            .filter(|s| s.applied && s.reversal.is_none())
+            .collect()
+    }
+
+    /// Whether this receipt was written by a core newer than the one reading it.
+    pub fn is_schema_newer_than(&self, core_schema_version: u32) -> bool {
+        self.schema_version > core_schema_version
+    }
+
+    /// Whether this receipt was written by a core newer than the one running.
+    pub fn is_schema_newer_than_running_core(&self) -> bool {
+        self.is_schema_newer_than(LIFECYCLE_SCHEMA_VERSION)
+    }
+
+    /// Check that the level the receipt claims is one its evidence can carry.
+    ///
+    /// The claim is checked without a freshness window: a receipt records what
+    /// was true at apply time, and freshness is applied later, when the state is
+    /// re-derived on read.
+    pub fn validate(&self) -> Result<(), ReceiptError> {
+        if self.achieved_level > self.planned_level {
+            return Err(ReceiptError::AchievedAbovePlanned {
+                achieved: self.achieved_level,
+                planned: self.planned_level,
+            });
+        }
+
+        if self.achieved_level >= ProtectionLevel::GatewayProtected
+            && !self
+                .achieved_evidence
+                .iter()
+                .any(ProtectionEvidence::is_gateway_protection_grade)
+        {
+            return Err(ReceiptError::UnjustifiedAchievedLevel {
+                claimed: self.achieved_level,
+                detail: "no recorded evidence exercises a mechanism that intercepts the model path".to_string(),
+            });
+        }
+
+        if self.achieved_level >= ProtectionLevel::HostEnforced
+            && !self
+                .achieved_evidence
+                .iter()
+                .any(ProtectionEvidence::is_host_enforcement_grade)
+        {
+            return Err(ReceiptError::UnjustifiedAchievedLevel {
+                claimed: self.achieved_level,
+                detail: "no recorded evidence attests that a host-enforcement layer is healthy".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integration::capability::IntegrationCapability;
+    use crate::integration::state::{EvidenceKind, ExerciseOutcome};
+    use crate::integration::step::{ArtifactOperation, SettingsMerge};
+    use crate::integration::version::core_version;
+    use std::path::PathBuf;
+
+    fn settings_step() -> IntegrationStep {
+        IntegrationStep::new(
+            "settings",
+            StepAction::WriteManagedSettings {
+                scope: SettingsScope::User,
+                path: PathBuf::from("/home/dev/.claude/settings.json"),
+                managed_keys: vec!["permissions".to_string()],
+                content_sha256: "abc".to_string(),
+                merge: SettingsMerge::MergeManagedKeys,
+            },
+            "write the managed settings block",
+        )
+        .with_reversal(StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: PathBuf::from("/home/dev/.claude/settings.json"),
+        })
+    }
+
+    fn receipt(achieved: ProtectionLevel, evidence: Vec<ProtectionEvidence>) -> IntegrationReceipt {
+        IntegrationReceipt {
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            receipt_id: "r1".to_string(),
+            plan_id: "p1".to_string(),
+            tool: DevToolKind::ClaudeCode,
+            profile: ProtectionProfile::Recommended,
+            settings_scope: SettingsScope::User,
+            applied_at_unix_secs: 1_000_000,
+            versions: ComponentVersions {
+                core: core_version(),
+                adapter: ToolVersion::new(0, 1, 0),
+                lifecycle_schema: LIFECYCLE_SCHEMA_VERSION,
+            },
+            tool_version: Some(ToolVersion::new(2, 1, 220)),
+            steps: vec![StepReceipt::applied(&settings_step(), Some("sha256:abc".to_string()))],
+            planned_level: ProtectionLevel::GatewayProtected,
+            achieved_level: achieved,
+            achieved_evidence: evidence,
+            verified_at_unix_secs: Some(1_000_000),
+        }
+    }
+
+    fn exercised(mechanism: IntegrationCapability, outcome: ExerciseOutcome) -> ProtectionEvidence {
+        ProtectionEvidence::new(
+            mechanism,
+            EvidenceKind::Exercised { outcome },
+            1_000_000,
+            "probe adjudicated by the core",
+        )
+    }
+
+    #[test]
+    fn a_gateway_protected_claim_needs_exercised_interception_evidence() {
+        // Read-back only: rejected.
+        let read_back = receipt(
+            ProtectionLevel::GatewayProtected,
+            vec![ProtectionEvidence::new(
+                IntegrationCapability::ModelPathInterception,
+                EvidenceKind::ReadBack { matches_receipt: true },
+                1_000_000,
+                "proxy address read back from settings",
+            )],
+        );
+        assert!(matches!(
+            read_back.validate(),
+            Err(ReceiptError::UnjustifiedAchievedLevel { .. })
+        ));
+
+        // Exercised, but attributed to a routing lever: still rejected.
+        let routing = receipt(
+            ProtectionLevel::GatewayProtected,
+            vec![exercised(
+                IntegrationCapability::ModelGatewayBaseUrl,
+                ExerciseOutcome::Redacted,
+            )],
+        );
+        assert!(matches!(
+            routing.validate(),
+            Err(ReceiptError::UnjustifiedAchievedLevel { .. })
+        ));
+
+        // Exercised interception: accepted.
+        let intercepted = receipt(
+            ProtectionLevel::GatewayProtected,
+            vec![exercised(
+                IntegrationCapability::ModelPathInterception,
+                ExerciseOutcome::Redacted,
+            )],
+        );
+        assert_eq!(intercepted.validate(), Ok(()));
+    }
+
+    #[test]
+    fn a_receipt_may_not_claim_more_than_its_plan_intended() {
+        let mut r = receipt(
+            ProtectionLevel::HostEnforced,
+            vec![exercised(
+                IntegrationCapability::ModelPathInterception,
+                ExerciseOutcome::Redacted,
+            )],
+        );
+        r.planned_level = ProtectionLevel::Integrated;
+        assert!(matches!(r.validate(), Err(ReceiptError::AchievedAbovePlanned { .. })));
+    }
+
+    #[test]
+    fn a_step_without_a_fingerprint_is_not_verified() {
+        let mut r = receipt(ProtectionLevel::Integrated, vec![]);
+        assert_eq!(r.required_steps(), 1);
+        assert_eq!(r.verified_required_steps(), 1);
+
+        r.steps[0].fingerprint = None;
+        assert_eq!(
+            r.verified_required_steps(),
+            0,
+            "a missing fingerprint must not count as verified"
+        );
+    }
+
+    #[test]
+    fn reversals_run_in_reverse_application_order() {
+        let mut r = receipt(ProtectionLevel::Integrated, vec![]);
+        let second = IntegrationStep::new(
+            "ca",
+            StepAction::ManageArtifact {
+                operation: ArtifactOperation::Create,
+                path: PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem"),
+            },
+            "write the CA",
+        )
+        .with_reversal(StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem"),
+        });
+        r.steps
+            .push(StepReceipt::applied(&second, Some("sha256:def".to_string())));
+
+        let reversals = r.reversal_actions();
+        assert_eq!(reversals.len(), 2);
+        assert_eq!(
+            reversals[0].affected_paths(),
+            vec![PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem")]
+        );
+    }
+
+    #[test]
+    fn an_unreversible_applied_step_is_reportable() {
+        let mut r = receipt(ProtectionLevel::Integrated, vec![]);
+        r.steps[0].reversal = None;
+        assert_eq!(r.irreversible_steps().len(), 1);
+    }
+
+    #[test]
+    fn a_newer_schema_is_detectable() {
+        let mut r = receipt(ProtectionLevel::Integrated, vec![]);
+        assert!(!r.is_schema_newer_than_running_core());
+        r.schema_version = LIFECYCLE_SCHEMA_VERSION + 1;
+        assert!(r.is_schema_newer_than_running_core());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn receipts_round_trip_through_json() {
+        let r = receipt(
+            ProtectionLevel::GatewayProtected,
+            vec![exercised(
+                IntegrationCapability::ModelPathInterception,
+                ExerciseOutcome::Redacted,
+            )],
+        );
+        let json = serde_json::to_string(&r).unwrap();
+        let restored: IntegrationReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, r);
+    }
+}

--- a/aa-core/src/integration/shim.rs
+++ b/aa-core/src/integration/shim.rs
@@ -97,12 +97,15 @@ impl<A: DevToolAdapter> LegacyAdapterShim<A> {
             adapter,
             policy,
             // A legacy adapter declares no version range of its own, so the shim
-            // accepts every version and lets the resulting `Unknown`/`Compatible`
-            // classification flow through the normal state derivation.
+            // declares an unbounded one and lets the resulting
+            // `Unknown`/`Compatible` classification flow through the normal state
+            // derivation. It must be genuinely unbounded rather than `>= 0.0.0`:
+            // a pre-release sorts below its release, so `0.0.0` would reject the
+            // public sample's own `0.0.0-sample`.
             version_support: VersionSupport {
                 adapter_version: super::version::core_version(),
                 lifecycle_schema_version: LIFECYCLE_SCHEMA_VERSION,
-                supported_tool_versions: SupportedToolVersions::at_least(ToolVersion::new(0, 0, 0)),
+                supported_tool_versions: SupportedToolVersions::any(),
             },
         }
     }

--- a/aa-core/src/integration/shim.rs
+++ b/aa-core/src/integration/shim.rs
@@ -1,0 +1,419 @@
+//! Lets any pre-lifecycle [`DevToolAdapter`] satisfy the new contract without
+//! being rewritten.
+//!
+//! # Why a shim rather than an edit to `DevToolAdapter`
+//!
+//! ADR 0030 §7 makes migration additive: `DevToolAdapter` is retained unchanged
+//! for the whole migration, and the bridge is a separate generic type. Because
+//! [`LegacyAdapterShim`] is generic over *any* `DevToolAdapter`, every existing
+//! adapter — including the public `examples/aa-devtool-sample-myeditor`, and
+//! including out-of-tree adapters this repo has never seen — keeps compiling and
+//! gains a working lifecycle on the day the contract lands. Nothing breaks; a
+//! third party migrates when they choose to.
+//!
+//! # What the shim deliberately refuses to claim
+//!
+//! A legacy adapter can substantiate exactly two things: it can detect
+//! ([`detect`](DevToolAdapter::detect)) and it can render and write managed
+//! settings ([`generate_managed_settings`](DevToolAdapter::generate_managed_settings)
+//! and [`apply_settings`](DevToolAdapter::apply_settings)).
+//!
+//! Everything else the old trait exposes is either unverifiable or a documented
+//! no-op: `apply_mcp_governance` returns `Ok(())` for tools without MCP, and
+//! `build_launch_command` returns a run-time error for tools that cannot be
+//! launched — so the shim cannot tell a working mechanism from a stub, and it
+//! declares neither. Every other capability is
+//! [`Unsupported`](super::CapabilitySupport::Unsupported) with a reason naming
+//! the migration, which reads honestly to a user and shows up in the plan's
+//! dry-run output.
+//!
+//! Consequently a shimmed adapter can never plan
+//! [`GatewayProtected`](super::ProtectionLevel::GatewayProtected): it declares no
+//! interception mechanism and authors no protection test, so the level it claims
+//! is capped at [`Integrated`](super::ProtectionLevel::Integrated) and the plan
+//! carries a warning saying so.
+
+use std::fmt::Write as _;
+
+use sha2::{Digest, Sha256};
+
+use crate::dev_tool::{AdapterError, DevToolAdapter, DevToolInfo, DevToolKind};
+use crate::policy::PolicyDocument;
+
+use super::capability::{DevToolCapabilities, IntegrationCapability};
+use super::plan::{IntegrationPlan, IntegrationRequest, RemovalPlan};
+use super::receipt::IntegrationReceipt;
+use super::state::{
+    EvidenceKind, ProtectionEvidence, ProtectionLevel, ProtectionState, StateDerivation, DEFAULT_FRESHNESS_WINDOW_SECS,
+};
+use super::status::{IntegrationStatus, LifecyclePhase, NextLevel, VerificationResult};
+use super::step::{IntegrationStep, StepAction};
+use super::version::{SupportedToolVersions, ToolVersion, VersionSupport, LIFECYCLE_SCHEMA_VERSION};
+use super::{now_unix_secs, DevToolIntegration};
+
+/// The reason every unsubstantiated capability of a shimmed adapter carries.
+///
+/// Deliberately the same sentence everywhere so a user (and a `grep`) can tell
+/// "this tool cannot do it" from "this adapter has not been migrated yet".
+pub const LEGACY_UNSUPPORTED_REASON: &str =
+    "legacy adapter — not migrated to the Developer Integration lifecycle (ADR 0030 §7)";
+
+/// Hex-encoded SHA-256, used for the shim's content fingerprint.
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Bridges a pre-lifecycle [`DevToolAdapter`] onto [`DevToolIntegration`].
+///
+/// The policy document is supplied at construction rather than carried on
+/// [`IntegrationRequest`]: the legacy trait needs a whole
+/// [`PolicyDocument`] to render settings, and putting one on the request type
+/// would create a field an untrusted caller could populate. The service resolves
+/// the profile inside the trust boundary and hands the resolved document to the
+/// shim (ADR 0030 matrix row 6).
+pub struct LegacyAdapterShim<A: DevToolAdapter> {
+    kind: DevToolKind,
+    adapter: A,
+    policy: PolicyDocument,
+    version_support: VersionSupport,
+}
+
+impl<A: DevToolAdapter> LegacyAdapterShim<A> {
+    /// Wrap `adapter`, which governs the tool identified by `kind`, rendering
+    /// settings from `policy`.
+    ///
+    /// `kind` is explicit rather than derived from
+    /// [`detect`](DevToolAdapter::detect) because detection returns `None` on a
+    /// host where the tool is absent, and the lifecycle still has to be able to
+    /// name the tool it is reporting `NotInstalled` for.
+    pub fn new(kind: DevToolKind, adapter: A, policy: PolicyDocument) -> Self {
+        Self {
+            kind,
+            adapter,
+            policy,
+            // A legacy adapter declares no version range of its own, so the shim
+            // accepts every version and lets the resulting `Unknown`/`Compatible`
+            // classification flow through the normal state derivation.
+            version_support: VersionSupport {
+                adapter_version: super::version::core_version(),
+                lifecycle_schema_version: LIFECYCLE_SCHEMA_VERSION,
+                supported_tool_versions: SupportedToolVersions::at_least(ToolVersion::new(0, 0, 0)),
+            },
+        }
+    }
+
+    /// Override the version range the shim reports, for a legacy adapter whose
+    /// supported range is known out of band.
+    #[must_use]
+    pub fn with_version_support(mut self, version_support: VersionSupport) -> Self {
+        self.version_support = version_support;
+        self
+    }
+
+    /// The wrapped adapter.
+    pub fn inner(&self) -> &A {
+        &self.adapter
+    }
+
+    /// The tool this shim reports on.
+    pub fn kind(&self) -> &DevToolKind {
+        &self.kind
+    }
+
+    /// The tool version detected on this host, when it parses.
+    fn detected_version(&self) -> Option<ToolVersion> {
+        self.adapter.detect()?.version?.parse().ok()
+    }
+}
+
+#[async_trait::async_trait]
+impl<A: DevToolAdapter> DevToolIntegration for LegacyAdapterShim<A> {
+    fn capabilities(&self) -> DevToolCapabilities {
+        let mut caps = DevToolCapabilities::new()
+            .supported(IntegrationCapability::Discovery)
+            .supported(IntegrationCapability::ManagedSettings);
+        for capability in IntegrationCapability::ALL {
+            if matches!(
+                capability,
+                IntegrationCapability::Discovery | IntegrationCapability::ManagedSettings
+            ) {
+                continue;
+            }
+            caps = caps.unsupported(capability, LEGACY_UNSUPPORTED_REASON);
+        }
+        caps
+    }
+
+    fn detect(&self) -> Option<DevToolInfo> {
+        self.adapter.detect()
+    }
+
+    fn version_support(&self) -> VersionSupport {
+        self.version_support.clone()
+    }
+
+    async fn plan_integration(&self, request: &IntegrationRequest) -> Result<IntegrationPlan, AdapterError> {
+        let rendered = self.adapter.generate_managed_settings(&self.policy).await?;
+        let content_sha256 = sha256_hex(rendered.as_bytes());
+
+        // The legacy trait renders and writes in two calls and never discloses
+        // the destination, so the step cannot honestly name a file.
+        let step = IntegrationStep::new(
+            "legacy-managed-settings",
+            StepAction::ApplyLegacyManagedSettings {
+                scope: request.settings_scope,
+                content_sha256,
+            },
+            "apply managed settings through the pre-lifecycle adapter",
+        );
+
+        let planned_level = request.effective_target_level().min(ProtectionLevel::Integrated);
+
+        let mut plan = IntegrationPlan::new(
+            format!("legacy-{}", now_unix_secs()),
+            request,
+            planned_level,
+            self.adapter.governance_level(),
+        )
+        .with_step(step)
+        .warn(
+            "this adapter has not been migrated to the Developer Integration lifecycle; it can \
+             apply managed settings but cannot intercept the model path, so protection above \
+             Integrated is not reachable through it",
+        );
+
+        let capabilities = self.capabilities();
+        for capability in IntegrationCapability::ALL {
+            if let Some(reason) = capabilities.unsupported_reason(capability) {
+                plan = plan.declaring_unsupported(capability, reason);
+            }
+        }
+
+        Ok(plan)
+    }
+
+    async fn integration_status(
+        &self,
+        receipt: Option<&IntegrationReceipt>,
+    ) -> Result<IntegrationStatus, AdapterError> {
+        let now = now_unix_secs();
+        let detected = self.adapter.detect();
+        let compatibility = self
+            .version_support
+            .supported_tool_versions
+            .classify(self.detected_version().as_ref());
+
+        // A legacy adapter has no fingerprint recipe and no verification
+        // mechanism, so the only honest evidence is the absence of both.
+        let evidence = vec![ProtectionEvidence::new(
+            IntegrationCapability::ManagedSettings,
+            EvidenceKind::Absent {
+                reason: LEGACY_UNSUPPORTED_REASON.to_string(),
+            },
+            now,
+            "this adapter cannot read its managed settings back, so nothing can be verified",
+        )];
+
+        let planned_level = receipt
+            .map(|r| r.planned_level)
+            .unwrap_or(ProtectionLevel::DetectedNotIntegrated);
+
+        let state = StateDerivation {
+            detected: detected.is_some(),
+            receipt_present: receipt.is_some(),
+            required_steps: receipt.map(IntegrationReceipt::required_steps).unwrap_or(0),
+            required_steps_verified: receipt.map(IntegrationReceipt::verified_required_steps).unwrap_or(0),
+            mismatched_artifacts: &[],
+            compatibility: &compatibility,
+            schema_newer_than_core: receipt.is_some_and(IntegrationReceipt::is_schema_newer_than_running_core),
+            evidence: &evidence,
+            planned_level,
+            now_unix_secs: now,
+            freshness_window_secs: DEFAULT_FRESHNESS_WINDOW_SECS,
+        }
+        .derive();
+
+        let phase = match (&state, receipt.is_some()) {
+            (ProtectionState::Ladder(ProtectionLevel::NotInstalled), _) => LifecyclePhase::NotInstalled,
+            (_, false) => LifecyclePhase::DetectedNotIntegrated,
+            (_, true) => LifecyclePhase::PartiallyInstalled,
+        };
+
+        let next_level = state.achieved_level().next_up().map(|level| NextLevel {
+            level,
+            blocked_because: LEGACY_UNSUPPORTED_REASON.to_string(),
+        });
+
+        Ok(IntegrationStatus {
+            tool: detected
+                .as_ref()
+                .map(|i| i.kind.clone())
+                .unwrap_or_else(|| self.kind.clone()),
+            phase,
+            state,
+            evidence,
+            planned_level,
+            adapter_ceiling: self.adapter.governance_level(),
+            compatibility,
+            next_level,
+            observed_at_unix_secs: now,
+        })
+    }
+
+    async fn verify_integration(&self, _receipt: &IntegrationReceipt) -> Result<VerificationResult, AdapterError> {
+        // Not `Failed` — nothing failed. Nothing was looked at.
+        Ok(VerificationResult::unverifiable(
+            now_unix_secs(),
+            format!("{LEGACY_UNSUPPORTED_REASON}; it exposes no way to read its own settings back"),
+        ))
+    }
+
+    async fn plan_removal(&self, receipt: &IntegrationReceipt) -> Result<RemovalPlan, AdapterError> {
+        let mut plan = RemovalPlan::new(format!("legacy-removal-{}", now_unix_secs()), receipt.tool.clone());
+
+        for (index, action) in receipt.reversal_actions().into_iter().enumerate() {
+            plan = plan.with_step(IntegrationStep::new(
+                format!("reverse-{index}"),
+                action,
+                "undo a step recorded in the receipt",
+            ));
+        }
+
+        for step in receipt.irreversible_steps() {
+            plan = plan.with_residual(format!(
+                "step {:?} ({}) was applied by a pre-lifecycle adapter that does not report what it \
+                 wrote; remove it by hand",
+                step.step_id,
+                step.action.kind()
+            ));
+        }
+
+        if plan.steps.is_empty() {
+            plan = plan.warn(
+                "this adapter has not been migrated to the Developer Integration lifecycle and did \
+                 not record how to undo what it applied",
+            );
+        }
+
+        Ok(plan)
+    }
+}
+
+impl<A: DevToolAdapter + std::fmt::Debug> std::fmt::Debug for LegacyAdapterShim<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LegacyAdapterShim")
+            .field("kind", &self.kind)
+            .field("adapter", &self.adapter)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dev_tool::GovernanceLevel;
+    use crate::integration::capability::CapabilityResolution;
+
+    /// Smallest legal `DevToolAdapter`, standing in for any unmigrated adapter.
+    #[derive(Debug)]
+    struct Legacy;
+
+    #[async_trait::async_trait]
+    impl DevToolAdapter for Legacy {
+        fn detect(&self) -> Option<DevToolInfo> {
+            None
+        }
+
+        async fn generate_managed_settings(&self, _policy: &PolicyDocument) -> Result<String, AdapterError> {
+            Ok("{}".to_string())
+        }
+
+        async fn apply_settings(&self, _settings: &str) -> Result<(), AdapterError> {
+            Ok(())
+        }
+
+        fn build_launch_command(
+            &self,
+            _tool_args: &[String],
+            _agent_id: &str,
+            _team_id: Option<&str>,
+            _proxy_addr: Option<&str>,
+        ) -> Result<std::process::Command, AdapterError> {
+            Err(AdapterError::LaunchFailed("no launch command".to_string()))
+        }
+
+        async fn list_mcp_servers(&self) -> Result<Vec<crate::dev_tool::McpServerInfo>, AdapterError> {
+            Ok(Vec::new())
+        }
+
+        async fn apply_mcp_governance(&self, _allowed: &[String], _denied: &[String]) -> Result<(), AdapterError> {
+            Ok(())
+        }
+
+        fn governance_level(&self) -> GovernanceLevel {
+            GovernanceLevel::L1Observe
+        }
+    }
+
+    fn shim() -> LegacyAdapterShim<Legacy> {
+        LegacyAdapterShim::new(
+            DevToolKind::Custom("legacy".to_string()),
+            Legacy,
+            PolicyDocument {
+                version: 1,
+                name: "test".to_string(),
+                rules: Vec::new(),
+                enforcement_mode: crate::EnforcementMode::Enforce,
+            },
+        )
+    }
+
+    #[test]
+    fn the_shim_declares_only_what_a_legacy_adapter_can_substantiate() {
+        let caps = shim().capabilities();
+        assert!(caps.is_effective(IntegrationCapability::Discovery));
+        assert!(caps.is_effective(IntegrationCapability::ManagedSettings));
+
+        // Everything else is an explicit, reasoned "no" — not silence, and not a
+        // claim the shim cannot back.
+        for capability in IntegrationCapability::ALL {
+            if matches!(
+                capability,
+                IntegrationCapability::Discovery | IntegrationCapability::ManagedSettings
+            ) {
+                continue;
+            }
+            assert_eq!(
+                caps.resolve(capability),
+                CapabilityResolution::Unsupported,
+                "{capability:?} must not be claimed by a shimmed adapter"
+            );
+            assert_eq!(caps.unsupported_reason(capability), Some(LEGACY_UNSUPPORTED_REASON));
+        }
+
+        assert!(!caps.can_intercept_model_path());
+    }
+
+    #[test]
+    fn the_shim_exposes_no_optional_surfaces() {
+        let shim = shim();
+        assert!(shim.as_mcp_governed().is_none());
+        assert!(shim.as_launchable().is_none());
+        assert!(shim.as_hookable().is_none());
+        assert!(super::super::capability_conformance(&shim).is_empty());
+        assert_eq!(shim.inner().governance_level(), GovernanceLevel::L1Observe);
+    }
+
+    #[test]
+    fn sha256_hex_is_stable() {
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}

--- a/aa-core/src/integration/state.rs
+++ b/aa-core/src/integration/state.rs
@@ -1,0 +1,748 @@
+//! Protection state, the evidence that justifies it, and the pure derivation
+//! that turns one into the other — ADR 0030 Decision 4.
+//!
+//! # A state is a claim, and a claim needs evidence
+//!
+//! Protection state is **derived on every read, never cached**. The AAASM-5276
+//! spike measured ~66 µs between stopping the core and connections being
+//! refused: a stored level would keep displaying protection that had already
+//! ceased to exist. Nothing in this module stores a state; [`StateDerivation`]
+//! is a pure function of the inputs handed to it.
+//!
+//! # Exercised versus read back
+//!
+//! [`EvidenceKind`] separates configuration that was *read back and compared*
+//! from traffic that was *exercised and adjudicated*. A configuration can be
+//! fully applied and fully verified by read-back while no traffic has ever been
+//! protected, so only exercised evidence can raise the ladder to
+//! [`ProtectionLevel::GatewayProtected`].
+//!
+//! # Missing evidence lowers, never raises
+//!
+//! Every `Absent` reading, every `Unknown` version, every stale timestamp
+//! resolves *downward*. This is ADR 0015's fail-closed discipline applied to
+//! reporting: a claim you cannot substantiate is a claim you do not make.
+
+use std::fmt;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::capability::IntegrationCapability;
+use super::version::VersionCompatibility;
+
+/// The monotone protection ladder (ADR 0030 §4.1).
+///
+/// Ordering is meaningful and load-bearing: `NotInstalled < DetectedNotIntegrated
+/// < PartiallyIntegrated < Integrated < GatewayProtected < HostEnforced`. The
+/// overriding states (`Drifted`, `Degraded`, `Incompatible`) are **not** rungs —
+/// they live in [`ProtectionState`] and carry the highest rung last held.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ProtectionLevel {
+    /// The tool is not present on this host.
+    NotInstalled,
+    /// The tool is present, but no receipt attributes any configuration to
+    /// AASM. A settings file AASM did not write lands here, never higher.
+    DetectedNotIntegrated,
+    /// A receipt exists and at least one — but not all — required steps verify.
+    /// Also the resting state of an interrupted apply, and of a verification
+    /// that has fallen outside its freshness window.
+    PartiallyIntegrated,
+    /// Every required step verifies against the receipt and a verification is
+    /// fresh. Says nothing at all about traffic.
+    Integrated,
+    /// `Integrated`, plus probe traffic was observed and adjudicated by the core
+    /// on this integration's model path. The first rung that claims traffic is
+    /// actually governed.
+    GatewayProtected,
+    /// `GatewayProtected`, plus a host-enforcement layer reports healthy and
+    /// attributes coverage to the tool. The only rung that claims bypass
+    /// resistance.
+    HostEnforced,
+}
+
+impl ProtectionLevel {
+    /// The next rung up, or `None` at the top of the ladder. Used to satisfy the
+    /// product rule "always report the next level up and why it is not active".
+    pub fn next_up(self) -> Option<Self> {
+        match self {
+            Self::NotInstalled => Some(Self::DetectedNotIntegrated),
+            Self::DetectedNotIntegrated => Some(Self::PartiallyIntegrated),
+            Self::PartiallyIntegrated => Some(Self::Integrated),
+            Self::Integrated => Some(Self::GatewayProtected),
+            Self::GatewayProtected => Some(Self::HostEnforced),
+            Self::HostEnforced => None,
+        }
+    }
+}
+
+impl fmt::Display for ProtectionLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::NotInstalled => "NotInstalled",
+            Self::DetectedNotIntegrated => "DetectedNotIntegrated",
+            Self::PartiallyIntegrated => "PartiallyIntegrated",
+            Self::Integrated => "Integrated",
+            Self::GatewayProtected => "GatewayProtected",
+            Self::HostEnforced => "HostEnforced",
+        };
+        f.write_str(s)
+    }
+}
+
+/// What is proven to be true for one integration right now — a ladder rung, or
+/// one of the three overriding states that replace it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum ProtectionState {
+    /// A rung of the monotone ladder.
+    Ladder(ProtectionLevel),
+    /// A receipt exists and at least one AASM-owned fingerprint mismatches, or
+    /// an AASM-owned artifact is missing. Changes to keys the receipt does not
+    /// claim never produce this state.
+    Drifted {
+        /// The highest rung held before drift was detected.
+        last_held: ProtectionLevel,
+        /// Identifiers of the AASM-owned artifacts that no longer match.
+        mismatched: Vec<String>,
+    },
+    /// Integrated, but a runtime dependency of a planned capability is
+    /// unavailable, so the achieved level is strictly below the planned one.
+    /// Carries both so the gap is legible.
+    Degraded {
+        /// The level the plan intended to reach.
+        planned: ProtectionLevel,
+        /// The level the evidence currently supports.
+        achieved: ProtectionLevel,
+        /// What is missing, in words a user can act on.
+        reason: String,
+    },
+    /// The detected tool version is outside the adapter's supported range, or a
+    /// receipt's schema version is newer than the running core. Terminal until
+    /// the user upgrades one side.
+    Incompatible {
+        /// What is incompatible.
+        reason: String,
+        /// Which side to upgrade.
+        remediation: String,
+    },
+}
+
+impl ProtectionState {
+    /// The ladder rung this state reports, including the rung an overriding
+    /// state last held.
+    pub fn achieved_level(&self) -> ProtectionLevel {
+        match self {
+            Self::Ladder(level) => *level,
+            Self::Drifted { last_held, .. } => *last_held,
+            Self::Degraded { achieved, .. } => *achieved,
+            Self::Incompatible { .. } => ProtectionLevel::DetectedNotIntegrated,
+        }
+    }
+
+    /// Whether this state replaces a ladder rung rather than being one.
+    pub fn is_overriding(&self) -> bool {
+        !matches!(self, Self::Ladder(_))
+    }
+}
+
+/// What was actually observed, and how.
+///
+/// The distinction between the variants is the whole point: `ReadBack` proves a
+/// file says what the receipt claims; only `Exercised` proves anything about
+/// traffic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum EvidenceKind {
+    /// Configuration was read back from the tool's live config and compared to
+    /// the receipt. Can justify at most [`ProtectionLevel::Integrated`].
+    ReadBack {
+        /// Whether the value read back equalled the value the receipt claims.
+        matches_receipt: bool,
+    },
+    /// Probe traffic was produced and adjudicated **by the core**. The only kind
+    /// that can justify [`ProtectionLevel::GatewayProtected`].
+    Exercised {
+        /// What the core did with the probe.
+        outcome: ExerciseOutcome,
+    },
+    /// A host-enforcement layer reported on itself and attributed coverage to
+    /// the tool's process.
+    HostAttested {
+        /// Whether the layer reported healthy.
+        healthy: bool,
+    },
+    /// A check could not be made. Recorded so the gap is legible; never raises a
+    /// state.
+    Absent {
+        /// Why the check could not be made.
+        reason: String,
+    },
+}
+
+impl EvidenceKind {
+    /// Whether this is exercised (traffic-level) evidence.
+    pub fn is_exercised(&self) -> bool {
+        matches!(self, Self::Exercised { .. })
+    }
+
+    /// Whether this is read-back (configuration-level) evidence that matched.
+    pub fn is_matching_read_back(&self) -> bool {
+        matches!(self, Self::ReadBack { matches_receipt: true })
+    }
+}
+
+/// What the core did with the probe traffic of a protection test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum ExerciseOutcome {
+    /// The synthetic secret was redacted before egress.
+    Redacted,
+    /// The request was blocked.
+    Blocked,
+    /// The finding was audited and the payload forwarded unchanged — the
+    /// `Observe only` profile. Deliberately **not** protective: observing is not
+    /// protecting, and displaying it as protection is the single most likely way
+    /// for the product to lie.
+    ObservedOnly,
+    /// The probe reached the provider unprotected — no AASM component was in the
+    /// path. This is the outcome the AAASM-5276 spike measured for base-URL
+    /// redirection.
+    Leaked,
+    /// The probe ran but could not be adjudicated.
+    Inconclusive,
+}
+
+impl ExerciseOutcome {
+    /// Whether this outcome demonstrates that something protective happened.
+    pub fn is_protective(self) -> bool {
+        matches!(self, Self::Redacted | Self::Blocked)
+    }
+}
+
+/// One observation, attributed to the mechanism it is evidence *about*, with the
+/// timestamp that makes it "verified at T" rather than "true now".
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ProtectionEvidence {
+    /// The mechanism this observation is about.
+    pub mechanism: IntegrationCapability,
+    /// What was observed, and how.
+    pub kind: EvidenceKind,
+    /// When it was observed, as seconds since the Unix epoch.
+    pub observed_at_unix_secs: u64,
+    /// Human-readable detail for status output and audit.
+    pub detail: String,
+}
+
+impl ProtectionEvidence {
+    /// Construct one observation.
+    pub fn new(
+        mechanism: IntegrationCapability,
+        kind: EvidenceKind,
+        observed_at_unix_secs: u64,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            mechanism,
+            kind,
+            observed_at_unix_secs,
+            detail: detail.into(),
+        }
+    }
+
+    /// Whether this observation is inside the freshness window ending at `now`.
+    ///
+    /// Evidence timestamped in the future is treated as fresh; clock skew is not
+    /// something this type can adjudicate.
+    pub fn is_fresh(&self, now_unix_secs: u64, window_secs: u64) -> bool {
+        now_unix_secs.saturating_sub(self.observed_at_unix_secs) <= window_secs
+    }
+
+    /// Whether this observation is of the *kind and mechanism* that could
+    /// justify [`ProtectionLevel::GatewayProtected`], ignoring freshness.
+    ///
+    /// Both halves are required and neither is sufficient:
+    ///
+    /// * the mechanism must actually intercept the model path — routing levers
+    ///   ([`ModelGatewayBaseUrl`](IntegrationCapability::ModelGatewayBaseUrl),
+    ///   [`HttpProxy`](IntegrationCapability::HttpProxy)) never qualify;
+    /// * the observation must be [`Exercised`](EvidenceKind::Exercised) with a
+    ///   protective outcome — read-back evidence never qualifies, however
+    ///   complete.
+    pub fn is_gateway_protection_grade(&self) -> bool {
+        self.mechanism.justifies_gateway_protection()
+            && matches!(&self.kind, EvidenceKind::Exercised { outcome } if outcome.is_protective())
+    }
+
+    /// [`is_gateway_protection_grade`](Self::is_gateway_protection_grade) **and**
+    /// inside the freshness window.
+    pub fn justifies_gateway_protection(&self, now_unix_secs: u64, window_secs: u64) -> bool {
+        self.is_gateway_protection_grade() && self.is_fresh(now_unix_secs, window_secs)
+    }
+
+    /// Whether this observation is of the kind and mechanism that could justify
+    /// [`ProtectionLevel::HostEnforced`], ignoring freshness.
+    pub fn is_host_enforcement_grade(&self) -> bool {
+        self.mechanism.justifies_host_enforcement() && matches!(self.kind, EvidenceKind::HostAttested { healthy: true })
+    }
+
+    /// [`is_host_enforcement_grade`](Self::is_host_enforcement_grade) **and**
+    /// inside the freshness window.
+    pub fn justifies_host_enforcement(&self, now_unix_secs: u64, window_secs: u64) -> bool {
+        self.is_host_enforcement_grade() && self.is_fresh(now_unix_secs, window_secs)
+    }
+}
+
+/// Default freshness window for verification evidence: 24 hours.
+///
+/// Callers may narrow it; the point of naming it is that "verified once, long
+/// ago" and "verified now" must not read the same.
+pub const DEFAULT_FRESHNESS_WINDOW_SECS: u64 = 24 * 60 * 60;
+
+/// The inputs from which a [`ProtectionState`] is derived.
+///
+/// Everything here is supplied by the trusted service (ADR 0030 matrix row 14);
+/// no field can be populated by a thin client. Holding the inputs in one struct
+/// is what makes the derivation a pure, exhaustively testable function rather
+/// than logic spread across call sites.
+#[derive(Debug, Clone)]
+pub struct StateDerivation<'a> {
+    /// Whether `detect()` found the tool.
+    pub detected: bool,
+    /// Whether a receipt exists for this (tool, user) pair.
+    pub receipt_present: bool,
+    /// How many steps of the applied plan were required.
+    pub required_steps: usize,
+    /// How many of those verified present by fingerprint.
+    pub required_steps_verified: usize,
+    /// AASM-owned artifacts whose fingerprints no longer match.
+    pub mismatched_artifacts: &'a [String],
+    /// How the detected tool version compares to the adapter's supported range.
+    pub compatibility: &'a VersionCompatibility,
+    /// Whether a receipt's schema version is newer than this core can read.
+    pub schema_newer_than_core: bool,
+    /// Everything observed about this integration.
+    pub evidence: &'a [ProtectionEvidence],
+    /// The level the applied plan intended to reach.
+    pub planned_level: ProtectionLevel,
+    /// Now, as seconds since the Unix epoch.
+    pub now_unix_secs: u64,
+    /// How old verification evidence may be and still count.
+    pub freshness_window_secs: u64,
+}
+
+impl StateDerivation<'_> {
+    /// Derive the reported state from the evidence.
+    ///
+    /// The order of the rules is itself part of the contract:
+    ///
+    /// 1. An unreadable schema or an incompatible version is terminal —
+    ///    reporting a rung for a tool the adapter does not understand would be a
+    ///    guess.
+    /// 2. The ladder is climbed only as far as the evidence reaches, and an
+    ///    `Unknown` version caps it at
+    ///    [`PartiallyIntegrated`](ProtectionLevel::PartiallyIntegrated) (rule 2:
+    ///    an unresolvable version resolves downward).
+    /// 3. Drift overrides the rung it replaces, carrying the rung last held.
+    /// 4. A rung below the planned level, at or above `Integrated`, is reported
+    ///    as `Degraded` so the gap is visible rather than silently smaller.
+    pub fn derive(&self) -> ProtectionState {
+        if self.schema_newer_than_core {
+            return ProtectionState::Incompatible {
+                reason: "this integration's receipt was written by a newer Agent Assembly release \
+                         than the one running"
+                    .to_string(),
+                remediation: "upgrade Agent Assembly, or remove and reinstall the integration".to_string(),
+            };
+        }
+
+        if let VersionCompatibility::Incompatible {
+            detected, remediation, ..
+        } = self.compatibility
+        {
+            let detected = detected
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "unknown".to_string());
+            return ProtectionState::Incompatible {
+                reason: format!("the detected tool version ({detected}) is outside this adapter's supported range"),
+                remediation: remediation.clone(),
+            };
+        }
+
+        let ladder = self.ladder();
+
+        if !self.mismatched_artifacts.is_empty() {
+            return ProtectionState::Drifted {
+                last_held: ladder,
+                mismatched: self.mismatched_artifacts.to_vec(),
+            };
+        }
+
+        if ladder >= ProtectionLevel::Integrated && ladder < self.planned_level {
+            return ProtectionState::Degraded {
+                planned: self.planned_level,
+                achieved: ladder,
+                reason: self.degradation_reason(),
+            };
+        }
+
+        ProtectionState::Ladder(ladder)
+    }
+
+    /// Climb the ladder as far as the evidence reaches.
+    fn ladder(&self) -> ProtectionLevel {
+        if !self.detected {
+            return ProtectionLevel::NotInstalled;
+        }
+        if !self.receipt_present {
+            // A settings file AASM did not write is evidence of a file, nothing
+            // more (ADR 0030 §4.2 rule 1).
+            return ProtectionLevel::DetectedNotIntegrated;
+        }
+
+        let all_required_verified = self.required_steps > 0 && self.required_steps_verified >= self.required_steps;
+        if !all_required_verified {
+            return ProtectionLevel::PartiallyIntegrated;
+        }
+
+        let fresh = |e: &ProtectionEvidence| e.is_fresh(self.now_unix_secs, self.freshness_window_secs);
+
+        let verification_is_fresh = self
+            .evidence
+            .iter()
+            .any(|e| fresh(e) && (e.kind.is_matching_read_back() || e.kind.is_exercised()));
+        if !verification_is_fresh {
+            // Evidence decays rather than persisting on the strength of an old
+            // result (ADR 0030 §4.2 rule 3).
+            return ProtectionLevel::PartiallyIntegrated;
+        }
+
+        // An unresolvable version is a missing comparison; it resolves downward.
+        if !self.compatibility.is_compatible() {
+            return ProtectionLevel::PartiallyIntegrated;
+        }
+
+        let gateway_protected = self
+            .evidence
+            .iter()
+            .any(|e| e.justifies_gateway_protection(self.now_unix_secs, self.freshness_window_secs));
+        if !gateway_protected {
+            return ProtectionLevel::Integrated;
+        }
+
+        let host_enforced = self
+            .evidence
+            .iter()
+            .any(|e| e.justifies_host_enforcement(self.now_unix_secs, self.freshness_window_secs));
+        if host_enforced {
+            ProtectionLevel::HostEnforced
+        } else {
+            ProtectionLevel::GatewayProtected
+        }
+    }
+
+    /// Assemble a user-actionable reason from whatever `Absent` evidence exists.
+    fn degradation_reason(&self) -> String {
+        let missing: Vec<&str> = self
+            .evidence
+            .iter()
+            .filter_map(|e| match &e.kind {
+                EvidenceKind::Absent { reason } => Some(reason.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        if missing.is_empty() {
+            "the achieved protection level is below the level this integration planned for".to_string()
+        } else {
+            missing.join("; ")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integration::version::{SupportedToolVersions, ToolVersion};
+
+    const NOW: u64 = 1_000_000;
+    const WINDOW: u64 = DEFAULT_FRESHNESS_WINDOW_SECS;
+
+    fn compatible() -> VersionCompatibility {
+        VersionCompatibility::Compatible {
+            detected: ToolVersion::new(2, 1, 220),
+        }
+    }
+
+    fn read_back(mechanism: IntegrationCapability) -> ProtectionEvidence {
+        ProtectionEvidence::new(
+            mechanism,
+            EvidenceKind::ReadBack { matches_receipt: true },
+            NOW,
+            "managed settings read back and matched the receipt",
+        )
+    }
+
+    fn exercised(mechanism: IntegrationCapability, outcome: ExerciseOutcome) -> ProtectionEvidence {
+        ProtectionEvidence::new(mechanism, EvidenceKind::Exercised { outcome }, NOW, "probe adjudicated")
+    }
+
+    fn derivation<'a>(
+        compat: &'a VersionCompatibility,
+        evidence: &'a [ProtectionEvidence],
+        mismatched: &'a [String],
+    ) -> StateDerivation<'a> {
+        StateDerivation {
+            detected: true,
+            receipt_present: true,
+            required_steps: 2,
+            required_steps_verified: 2,
+            mismatched_artifacts: mismatched,
+            compatibility: compat,
+            schema_newer_than_core: false,
+            evidence,
+            planned_level: ProtectionLevel::GatewayProtected,
+            now_unix_secs: NOW,
+            freshness_window_secs: WINDOW,
+        }
+    }
+
+    #[test]
+    fn the_ladder_is_ordered() {
+        assert!(ProtectionLevel::NotInstalled < ProtectionLevel::DetectedNotIntegrated);
+        assert!(ProtectionLevel::PartiallyIntegrated < ProtectionLevel::Integrated);
+        assert!(ProtectionLevel::Integrated < ProtectionLevel::GatewayProtected);
+        assert!(ProtectionLevel::GatewayProtected < ProtectionLevel::HostEnforced);
+        assert_eq!(ProtectionLevel::HostEnforced.next_up(), None);
+        assert_eq!(
+            ProtectionLevel::Integrated.next_up(),
+            Some(ProtectionLevel::GatewayProtected)
+        );
+    }
+
+    #[test]
+    fn gateway_protected_is_unreachable_from_read_back_only_evidence() {
+        // Fully applied, fully verified by read-back — and still not protected,
+        // because no traffic has ever been exercised.
+        let compat = compatible();
+        let evidence = [
+            read_back(IntegrationCapability::ManagedSettings),
+            read_back(IntegrationCapability::ModelPathInterception),
+        ];
+        let state = derivation(&compat, &evidence, &[]).derive();
+        assert_eq!(
+            state,
+            ProtectionState::Degraded {
+                planned: ProtectionLevel::GatewayProtected,
+                achieved: ProtectionLevel::Integrated,
+                reason: "the achieved protection level is below the level this integration planned for".to_string(),
+            }
+        );
+        assert_eq!(state.achieved_level(), ProtectionLevel::Integrated);
+    }
+
+    #[test]
+    fn base_url_redirection_cannot_reach_gateway_protected() {
+        // Exercised evidence — but attributed to a routing lever, not to
+        // interception. AAASM-5276 measured exactly this shape leaking a secret.
+        let compat = compatible();
+        let evidence = [
+            read_back(IntegrationCapability::ManagedSettings),
+            exercised(IntegrationCapability::ModelGatewayBaseUrl, ExerciseOutcome::Redacted),
+        ];
+        let state = derivation(&compat, &evidence, &[]).derive();
+        assert_eq!(state.achieved_level(), ProtectionLevel::Integrated);
+        assert!(
+            state.achieved_level() < ProtectionLevel::GatewayProtected,
+            "routing must never be reported as protection"
+        );
+    }
+
+    #[test]
+    fn exercised_interception_reaches_gateway_protected() {
+        let compat = compatible();
+        let evidence = [
+            read_back(IntegrationCapability::ManagedSettings),
+            exercised(IntegrationCapability::ModelPathInterception, ExerciseOutcome::Redacted),
+        ];
+        let state = derivation(&compat, &evidence, &[]).derive();
+        assert_eq!(state, ProtectionState::Ladder(ProtectionLevel::GatewayProtected));
+    }
+
+    #[test]
+    fn observe_only_traffic_is_not_protection() {
+        let compat = compatible();
+        let evidence = [
+            read_back(IntegrationCapability::ManagedSettings),
+            exercised(
+                IntegrationCapability::ModelPathInterception,
+                ExerciseOutcome::ObservedOnly,
+            ),
+        ];
+        let state = derivation(&compat, &evidence, &[]).derive();
+        assert_eq!(state.achieved_level(), ProtectionLevel::Integrated);
+    }
+
+    #[test]
+    fn host_enforcement_requires_gateway_protection_first() {
+        let compat = compatible();
+        let attested = ProtectionEvidence::new(
+            IntegrationCapability::HostEnforcement,
+            EvidenceKind::HostAttested { healthy: true },
+            NOW,
+            "proxy CA present in the trust store",
+        );
+
+        // Attestation alone does not skip a rung.
+        let without_traffic = [read_back(IntegrationCapability::ManagedSettings), attested.clone()];
+        assert_eq!(
+            derivation(&compat, &without_traffic, &[]).derive().achieved_level(),
+            ProtectionLevel::Integrated
+        );
+
+        let with_traffic = [
+            read_back(IntegrationCapability::ManagedSettings),
+            exercised(IntegrationCapability::ModelPathInterception, ExerciseOutcome::Blocked),
+            attested,
+        ];
+        assert_eq!(
+            derivation(&compat, &with_traffic, &[]).derive(),
+            ProtectionState::Ladder(ProtectionLevel::HostEnforced)
+        );
+    }
+
+    #[test]
+    fn a_settings_file_without_a_receipt_is_detected_not_integrated() {
+        let compat = compatible();
+        let evidence = [read_back(IntegrationCapability::ManagedSettings)];
+        let mut d = derivation(&compat, &evidence, &[]);
+        d.receipt_present = false;
+        assert_eq!(
+            d.derive(),
+            ProtectionState::Ladder(ProtectionLevel::DetectedNotIntegrated)
+        );
+    }
+
+    #[test]
+    fn stale_verification_decays_to_partially_integrated() {
+        let compat = compatible();
+        let stale = [ProtectionEvidence::new(
+            IntegrationCapability::ManagedSettings,
+            EvidenceKind::ReadBack { matches_receipt: true },
+            NOW - WINDOW - 1,
+            "verified a long time ago",
+        )];
+        assert_eq!(
+            derivation(&compat, &stale, &[]).derive().achieved_level(),
+            ProtectionLevel::PartiallyIntegrated
+        );
+    }
+
+    #[test]
+    fn missing_evidence_only_ever_lowers_the_state() {
+        let compat = compatible();
+        let base = [
+            read_back(IntegrationCapability::ManagedSettings),
+            exercised(IntegrationCapability::ModelPathInterception, ExerciseOutcome::Redacted),
+        ];
+        let high = derivation(&compat, &base, &[]).derive().achieved_level();
+
+        let with_absent = [
+            read_back(IntegrationCapability::ManagedSettings),
+            exercised(IntegrationCapability::ModelPathInterception, ExerciseOutcome::Redacted),
+            ProtectionEvidence::new(
+                IntegrationCapability::HostEnforcement,
+                EvidenceKind::Absent {
+                    reason: "host enforcement is unavailable on this platform".to_string(),
+                },
+                NOW,
+                "no eBPF on macOS",
+            ),
+        ];
+        let with_gap = derivation(&compat, &with_absent, &[]).derive().achieved_level();
+        assert!(with_gap <= high, "an Absent reading must never raise the state");
+    }
+
+    #[test]
+    fn an_unresolvable_version_resolves_downward() {
+        let unknown = VersionCompatibility::Unknown {
+            reason: "version probe failed".to_string(),
+        };
+        let evidence = [
+            read_back(IntegrationCapability::ManagedSettings),
+            exercised(IntegrationCapability::ModelPathInterception, ExerciseOutcome::Redacted),
+        ];
+        assert_eq!(
+            derivation(&unknown, &evidence, &[]).derive().achieved_level(),
+            ProtectionLevel::PartiallyIntegrated
+        );
+    }
+
+    #[test]
+    fn drift_overrides_the_rung_and_carries_it() {
+        let compat = compatible();
+        let evidence = [
+            read_back(IntegrationCapability::ManagedSettings),
+            exercised(IntegrationCapability::ModelPathInterception, ExerciseOutcome::Redacted),
+        ];
+        let mismatched = ["~/.claude/settings.json#permissions".to_string()];
+        let state = derivation(&compat, &evidence, &mismatched).derive();
+        assert_eq!(
+            state,
+            ProtectionState::Drifted {
+                last_held: ProtectionLevel::GatewayProtected,
+                mismatched: mismatched.to_vec(),
+            }
+        );
+        assert!(state.is_overriding());
+    }
+
+    #[test]
+    fn an_incompatible_version_is_terminal_and_actionable() {
+        let supported = SupportedToolVersions::at_least(ToolVersion::new(3, 0, 0));
+        let incompatible = supported.classify(Some(&ToolVersion::new(2, 1, 220)));
+        let evidence = [read_back(IntegrationCapability::ManagedSettings)];
+        match derivation(&incompatible, &evidence, &[]).derive() {
+            ProtectionState::Incompatible { remediation, .. } => {
+                assert!(remediation.contains("upgrade"), "{remediation}");
+            }
+            other => panic!("expected Incompatible, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_receipt_written_by_a_newer_core_is_incompatible() {
+        let compat = compatible();
+        let evidence = [read_back(IntegrationCapability::ManagedSettings)];
+        let mut d = derivation(&compat, &evidence, &[]);
+        d.schema_newer_than_core = true;
+        assert!(matches!(d.derive(), ProtectionState::Incompatible { .. }));
+    }
+
+    #[test]
+    fn an_uninstalled_tool_is_not_installed() {
+        let compat = compatible();
+        let mut d = derivation(&compat, &[], &[]);
+        d.detected = false;
+        assert_eq!(d.derive(), ProtectionState::Ladder(ProtectionLevel::NotInstalled));
+    }
+
+    #[test]
+    fn an_interrupted_apply_rests_at_partially_integrated() {
+        let compat = compatible();
+        let evidence = [read_back(IntegrationCapability::ManagedSettings)];
+        let mut d = derivation(&compat, &evidence, &[]);
+        d.required_steps_verified = 1;
+        assert_eq!(
+            d.derive().achieved_level(),
+            ProtectionLevel::PartiallyIntegrated,
+            "an interrupted apply must not read as integrated"
+        );
+    }
+}

--- a/aa-core/src/integration/status.rs
+++ b/aa-core/src/integration/status.rs
@@ -1,0 +1,382 @@
+//! What `status` and `verify` return.
+//!
+//! # Two axes, because they answer different questions
+//!
+//! [`LifecyclePhase`] answers *"where is this integration in its lifecycle?"* —
+//! planned, installed, being removed. [`ProtectionState`] answers *"what is
+//! proven to be true right now, and by what evidence?"*. Collapsing them would
+//! force a single enum to mean both "an apply is in progress" and "traffic is
+//! governed", which is how a status ends up reporting installation progress as
+//! though it were protection.
+//!
+//! Every state the ticket asks for maps onto exactly one of the two:
+//!
+//! | Asked for | Where it lives |
+//! | --- | --- |
+//! | detected but not installed | [`LifecyclePhase::DetectedNotIntegrated`] |
+//! | planned | [`LifecyclePhase::Planned`] |
+//! | installed | [`LifecyclePhase::Installed`] |
+//! | partially installed | [`LifecyclePhase::PartiallyInstalled`] |
+//! | removal pending | [`LifecyclePhase::RemovalPending`] |
+//! | drifted | [`ProtectionState::Drifted`] |
+//! | degraded | [`ProtectionState::Degraded`] |
+//! | incompatible | [`ProtectionState::Incompatible`] |
+//!
+//! # Never a bare boolean
+//!
+//! [`IntegrationStatus`] carries the achieved level *and* the evidence that
+//! produced it, split into what was exercised and what was merely read back, so
+//! a user can reason about their own risk instead of reading one word.
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::capability::IntegrationCapability;
+use super::state::{ProtectionEvidence, ProtectionLevel, ProtectionState};
+use super::version::VersionCompatibility;
+use crate::dev_tool::{DevToolKind, GovernanceLevel};
+
+/// Where an integration is in its lifecycle, independent of what it protects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum LifecyclePhase {
+    /// The tool is not on this host.
+    NotInstalled,
+    /// The tool is present and AASM has applied nothing to it.
+    DetectedNotIntegrated,
+    /// A plan exists and has been shown to the user; nothing has been applied.
+    Planned,
+    /// Every required step of a plan has been applied.
+    Installed,
+    /// Some but not all required steps have been applied — including the resting
+    /// state of an interrupted apply.
+    PartiallyInstalled,
+    /// A removal plan has been accepted and not yet completed.
+    RemovalPending,
+}
+
+/// The next rung up and why it is not active.
+///
+/// Present even when the answer is "not available on this platform": silence
+/// reads as "there is nothing above what I have", which is the over-claim the
+/// protection-level model exists to prevent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct NextLevel {
+    /// The rung above the one currently achieved.
+    pub level: ProtectionLevel,
+    /// Why it is not active, in words a user can act on.
+    pub blocked_because: String,
+}
+
+/// The machine-readable answer to "is this developer actually protected right
+/// now, and how do you know?".
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct IntegrationStatus {
+    /// The tool being reported on.
+    pub tool: DevToolKind,
+    /// Where the integration is in its lifecycle.
+    pub phase: LifecyclePhase,
+    /// What the evidence proves.
+    pub state: ProtectionState,
+    /// The evidence itself, so the claim carries its provenance.
+    pub evidence: Vec<ProtectionEvidence>,
+    /// The level the applied plan intended to reach.
+    pub planned_level: ProtectionLevel,
+    /// The adapter's static build-time ceiling. A ceiling is not a measurement.
+    pub adapter_ceiling: GovernanceLevel,
+    /// How the detected tool version compares to the adapter's supported range.
+    pub compatibility: VersionCompatibility,
+    /// The rung above the current one, and why it is not active.
+    pub next_level: Option<NextLevel>,
+    /// When this status was derived, as seconds since the Unix epoch. A status
+    /// read without its timestamp over-reads the claim: it is "verified at T",
+    /// not "true now".
+    pub observed_at_unix_secs: u64,
+}
+
+impl IntegrationStatus {
+    /// The ladder rung this status reports.
+    pub fn achieved_level(&self) -> ProtectionLevel {
+        self.state.achieved_level()
+    }
+
+    /// Evidence produced by exercising traffic.
+    pub fn exercised_evidence(&self) -> impl Iterator<Item = &ProtectionEvidence> {
+        self.evidence.iter().filter(|e| e.kind.is_exercised())
+    }
+
+    /// Evidence produced by reading configuration back and comparing it.
+    pub fn read_back_evidence(&self) -> impl Iterator<Item = &ProtectionEvidence> {
+        self.evidence.iter().filter(|e| e.kind.is_matching_read_back())
+    }
+
+    /// Whether anything at all has been exercised. A status with no exercised
+    /// evidence is a statement about configuration, not about traffic.
+    pub fn has_exercised_evidence(&self) -> bool {
+        self.exercised_evidence().next().is_some()
+    }
+}
+
+/// Whether a verification pass proved what it set out to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum VerificationOutcome {
+    /// Every check the adapter set out to run passed.
+    Passed,
+    /// Some checks passed and some could not be completed.
+    PartiallyPassed {
+        /// What could not be established.
+        missing: Vec<String>,
+    },
+    /// A check ran and failed.
+    Failed {
+        /// Why.
+        reason: String,
+    },
+    /// No check could be run at all — the honest answer for an adapter that has
+    /// no verification mechanism, and deliberately distinct from
+    /// [`Failed`](Self::Failed) so "we did not look" is never read as "we looked
+    /// and it was fine".
+    Unverifiable {
+        /// Why nothing could be checked.
+        reason: String,
+    },
+}
+
+impl VerificationOutcome {
+    /// Whether the pass established anything positive.
+    pub fn is_positive(&self) -> bool {
+        matches!(self, Self::Passed | Self::PartiallyPassed { .. })
+    }
+}
+
+/// The result of one verification pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct VerificationResult {
+    /// When the pass ran, as seconds since the Unix epoch.
+    pub verified_at_unix_secs: u64,
+    /// What it established.
+    pub outcome: VerificationOutcome,
+    /// Everything observed, exercised and read back alike.
+    pub evidence: Vec<ProtectionEvidence>,
+}
+
+impl VerificationResult {
+    /// A pass that established nothing, with the reason why.
+    pub fn unverifiable(verified_at_unix_secs: u64, reason: impl Into<String>) -> Self {
+        Self {
+            verified_at_unix_secs,
+            outcome: VerificationOutcome::Unverifiable { reason: reason.into() },
+            evidence: Vec::new(),
+        }
+    }
+
+    /// Attach an observation.
+    #[must_use]
+    pub fn with_evidence(mut self, evidence: ProtectionEvidence) -> Self {
+        self.evidence.push(evidence);
+        self
+    }
+
+    /// Whether any traffic was exercised during this pass.
+    pub fn has_exercised_evidence(&self) -> bool {
+        self.evidence.iter().any(|e| e.kind.is_exercised())
+    }
+
+    /// Every mechanism this pass observed.
+    pub fn observed_mechanisms(&self) -> Vec<IntegrationCapability> {
+        let mut seen: Vec<IntegrationCapability> = Vec::new();
+        for mechanism in self.evidence.iter().map(|e| e.mechanism) {
+            if !seen.contains(&mechanism) {
+                seen.push(mechanism);
+            }
+        }
+        seen
+    }
+
+    /// The highest rung this pass's evidence alone can justify.
+    ///
+    /// Caps at [`ProtectionLevel::Integrated`] for read-back-only evidence, no
+    /// matter how much of it there is: a configuration can be fully applied and
+    /// fully verified by read-back while no traffic has ever been protected.
+    pub fn highest_justified_level(&self, now_unix_secs: u64, window_secs: u64) -> ProtectionLevel {
+        let gateway = self
+            .evidence
+            .iter()
+            .any(|e| e.justifies_gateway_protection(now_unix_secs, window_secs));
+        let host = self
+            .evidence
+            .iter()
+            .any(|e| e.justifies_host_enforcement(now_unix_secs, window_secs));
+
+        if gateway && host {
+            ProtectionLevel::HostEnforced
+        } else if gateway {
+            ProtectionLevel::GatewayProtected
+        } else if self.outcome.is_positive()
+            && self
+                .evidence
+                .iter()
+                .any(|e| e.kind.is_matching_read_back() && e.is_fresh(now_unix_secs, window_secs))
+        {
+            ProtectionLevel::Integrated
+        } else {
+            ProtectionLevel::PartiallyIntegrated
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integration::state::{EvidenceKind, ExerciseOutcome};
+    use crate::integration::version::ToolVersion;
+
+    const NOW: u64 = 1_000_000;
+    const WINDOW: u64 = 3600;
+
+    fn read_back(mechanism: IntegrationCapability) -> ProtectionEvidence {
+        ProtectionEvidence::new(
+            mechanism,
+            EvidenceKind::ReadBack { matches_receipt: true },
+            NOW,
+            "read back and matched",
+        )
+    }
+
+    fn exercised(mechanism: IntegrationCapability, outcome: ExerciseOutcome) -> ProtectionEvidence {
+        ProtectionEvidence::new(mechanism, EvidenceKind::Exercised { outcome }, NOW, "probe adjudicated")
+    }
+
+    fn status(state: ProtectionState, evidence: Vec<ProtectionEvidence>) -> IntegrationStatus {
+        IntegrationStatus {
+            tool: DevToolKind::ClaudeCode,
+            phase: LifecyclePhase::Installed,
+            state,
+            evidence,
+            planned_level: ProtectionLevel::GatewayProtected,
+            adapter_ceiling: GovernanceLevel::L2Enforce,
+            compatibility: VersionCompatibility::Compatible {
+                detected: ToolVersion::new(2, 1, 220),
+            },
+            next_level: None,
+            observed_at_unix_secs: NOW,
+        }
+    }
+
+    #[test]
+    fn status_splits_exercised_from_read_back_evidence() {
+        let s = status(
+            ProtectionState::Ladder(ProtectionLevel::GatewayProtected),
+            vec![
+                read_back(IntegrationCapability::ManagedSettings),
+                exercised(IntegrationCapability::ModelPathInterception, ExerciseOutcome::Redacted),
+            ],
+        );
+        assert_eq!(s.read_back_evidence().count(), 1);
+        assert_eq!(s.exercised_evidence().count(), 1);
+        assert!(s.has_exercised_evidence());
+        assert_eq!(s.achieved_level(), ProtectionLevel::GatewayProtected);
+    }
+
+    #[test]
+    fn a_configuration_only_status_admits_it_has_exercised_nothing() {
+        let s = status(
+            ProtectionState::Ladder(ProtectionLevel::Integrated),
+            vec![read_back(IntegrationCapability::ManagedSettings)],
+        );
+        assert!(!s.has_exercised_evidence());
+    }
+
+    #[test]
+    fn read_back_only_verification_caps_at_integrated() {
+        let result = VerificationResult {
+            verified_at_unix_secs: NOW,
+            outcome: VerificationOutcome::Passed,
+            evidence: vec![
+                read_back(IntegrationCapability::ManagedSettings),
+                read_back(IntegrationCapability::ModelPathInterception),
+            ],
+        };
+        assert!(!result.has_exercised_evidence());
+        assert_eq!(result.highest_justified_level(NOW, WINDOW), ProtectionLevel::Integrated);
+    }
+
+    #[test]
+    fn exercised_routing_does_not_lift_the_cap() {
+        let result = VerificationResult {
+            verified_at_unix_secs: NOW,
+            outcome: VerificationOutcome::Passed,
+            evidence: vec![
+                read_back(IntegrationCapability::ManagedSettings),
+                exercised(IntegrationCapability::ModelGatewayBaseUrl, ExerciseOutcome::Redacted),
+            ],
+        };
+        assert!(result.has_exercised_evidence());
+        assert_eq!(
+            result.highest_justified_level(NOW, WINDOW),
+            ProtectionLevel::Integrated,
+            "exercising a routing lever is not exercising interception"
+        );
+    }
+
+    #[test]
+    fn exercised_interception_lifts_to_gateway_protected() {
+        let result = VerificationResult {
+            verified_at_unix_secs: NOW,
+            outcome: VerificationOutcome::Passed,
+            evidence: vec![
+                read_back(IntegrationCapability::ManagedSettings),
+                exercised(IntegrationCapability::ModelPathInterception, ExerciseOutcome::Blocked),
+            ],
+        };
+        assert_eq!(
+            result.highest_justified_level(NOW, WINDOW),
+            ProtectionLevel::GatewayProtected
+        );
+        assert_eq!(
+            result.observed_mechanisms(),
+            vec![
+                IntegrationCapability::ManagedSettings,
+                IntegrationCapability::ModelPathInterception
+            ]
+        );
+    }
+
+    #[test]
+    fn stale_evidence_does_not_justify_anything() {
+        let result = VerificationResult {
+            verified_at_unix_secs: NOW - WINDOW - 1,
+            outcome: VerificationOutcome::Passed,
+            evidence: vec![ProtectionEvidence::new(
+                IntegrationCapability::ModelPathInterception,
+                EvidenceKind::Exercised {
+                    outcome: ExerciseOutcome::Redacted,
+                },
+                NOW - WINDOW - 1,
+                "verified a long time ago",
+            )],
+        };
+        assert_eq!(
+            result.highest_justified_level(NOW, WINDOW),
+            ProtectionLevel::PartiallyIntegrated
+        );
+    }
+
+    #[test]
+    fn unverifiable_is_not_failure_and_justifies_nothing() {
+        let result = VerificationResult::unverifiable(NOW, "this adapter has no verification mechanism");
+        assert!(!result.outcome.is_positive());
+        assert!(!result.has_exercised_evidence());
+        assert_eq!(
+            result.highest_justified_level(NOW, WINDOW),
+            ProtectionLevel::PartiallyIntegrated
+        );
+        assert!(matches!(result.outcome, VerificationOutcome::Unverifiable { .. }));
+    }
+}

--- a/aa-core/src/integration/step.rs
+++ b/aa-core/src/integration/step.rs
@@ -1,0 +1,576 @@
+//! The unit of work an [`IntegrationPlan`](super::IntegrationPlan) is made of.
+//!
+//! # Who executes these
+//!
+//! Nobody, here. ADR 0030 Decision 2 splits plan *authoring* (row 2, the
+//! adapter) from plan *execution* (row 3, the service): a step is a **described**
+//! mutation, not a performed one. Execution, receipt durability and rollback are
+//! AAASM-5278's scope; this module only has to make every mutation the product
+//! needs describable, reversible and reviewable before it happens.
+//!
+//! # Why trust material and launch environment are first-class step kinds
+//!
+//! The AAASM-5276 spike measured, against Claude Code 2.1.220, that
+//! `NODE_EXTRA_CA_CERTS` pointing at the AASM proxy CA is what makes MitM
+//! interception work at all — and that the product injects only `HTTPS_PROXY`
+//! today. Without
+//! [`MaterialiseTrustMaterial`](StepAction::MaterialiseTrustMaterial) and
+//! [`InjectLaunchEnvironment`](StepAction::InjectLaunchEnvironment) the
+//! highest-value fix available to the product would be unrepresentable in a plan,
+//! unrecorded in a receipt, and therefore unremovable.
+//!
+//! # Why [`SettingsScope`] is explicit and mandatory
+//!
+//! Also measured in AAASM-5276: `aa-devtool-claude-code/src/apply.rs` silently
+//! prefers `<cwd>/.claude/settings.json` whenever a `.claude/` directory happens
+//! to exist in the caller's working directory. Which file gets written therefore
+//! depends on where the process was started from. Every settings-touching step
+//! names its scope, plans validate that every step agrees with the plan's scope,
+//! and the receipt records it — so the destination is a decision, never a
+//! side effect of `cwd`.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::PathBuf;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::capability::IntegrationCapability;
+
+/// Which configuration surface a settings-touching step writes to.
+///
+/// There is no "whichever one happens to exist" variant, deliberately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum SettingsScope {
+    /// The user's own configuration, typically under the home directory.
+    /// Applies to every project the user opens.
+    User,
+    /// Configuration checked in next to a project, applying only inside it.
+    Project,
+    /// An administrator-managed surface the tool treats as authoritative over
+    /// the other two.
+    Managed,
+}
+
+impl fmt::Display for SettingsScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::User => "user",
+            Self::Project => "project",
+            Self::Managed => "managed",
+        };
+        f.write_str(s)
+    }
+}
+
+/// How a managed settings write combines with what is already in the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum SettingsMerge {
+    /// Replace the file's entire contents. Only safe for files AASM owns
+    /// outright.
+    Replace,
+    /// Merge only the keys the step claims, leaving everything else untouched.
+    /// Required for any file the user also edits — drift detection is defined
+    /// over AASM-owned keys, so a step that clobbers unowned keys makes drift
+    /// undecidable.
+    MergeManagedKeys,
+}
+
+/// What kind of trust material a step puts on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum TrustMaterialKind {
+    /// The AASM proxy CA certificate, PEM-encoded, written where the tool can be
+    /// pointed at it (e.g. via `NODE_EXTRA_CA_CERTS`). A user-scoped file, not a
+    /// host change.
+    ProxyCaCertificatePem,
+    /// The same CA installed into the OS or user trust store. A **privileged
+    /// host change** — always an individually consented step with a matching
+    /// removal step (ADR 0030 §6.6).
+    ProxyCaTrustStoreAnchor,
+}
+
+/// The value an injected environment variable takes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum EnvValue {
+    /// A literal string.
+    Literal(String),
+    /// The path of an artifact an earlier step in the same plan materialises —
+    /// how `NODE_EXTRA_CA_CERTS` is wired to the CA PEM without either step
+    /// having to know the other's implementation.
+    ArtifactPath(PathBuf),
+}
+
+impl fmt::Display for EnvValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Literal(v) => f.write_str(v),
+            Self::ArtifactPath(p) => write!(f, "{}", p.display()),
+        }
+    }
+}
+
+/// What a protection test should exercise.
+///
+/// The adapter supplies the descriptor; it does **not** judge the result (ADR
+/// 0030 matrix row 9). `mechanism` is what makes the resulting
+/// [`ProtectionEvidence`](super::ProtectionEvidence) attributable — an outcome
+/// that cannot be attributed to an intercepting mechanism cannot raise the
+/// ladder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ProbeDescriptor {
+    /// Stable identifier for this probe.
+    pub id: String,
+    /// The mechanism the probe traffic is meant to exercise.
+    pub mechanism: IntegrationCapability,
+    /// What the probe does, for the dry-run rendering.
+    pub description: String,
+}
+
+/// Lifecycle operation on an artifact AASM owns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ArtifactOperation {
+    /// Create an artifact that did not exist.
+    Create,
+    /// Rewrite an artifact AASM already owns.
+    Update,
+    /// Delete an artifact AASM owns.
+    Remove,
+}
+
+/// The concrete mutation a step describes.
+///
+/// `#[non_exhaustive]` because new tools bring new mechanisms; adding a variant
+/// must not break an out-of-tree adapter that matches on this enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum StepAction {
+    /// Write or merge a managed settings block into the tool's native config.
+    WriteManagedSettings {
+        /// Which configuration surface to write.
+        scope: SettingsScope,
+        /// The exact file to write. Named, never inferred from `cwd`.
+        path: PathBuf,
+        /// The keys AASM claims ownership of — the only keys drift is defined
+        /// over.
+        managed_keys: Vec<String>,
+        /// SHA-256 of the rendered content, hex-encoded, for the receipt's
+        /// fingerprint.
+        content_sha256: String,
+        /// How to combine with existing content.
+        merge: SettingsMerge,
+    },
+    /// Apply managed settings through a pre-lifecycle
+    /// [`DevToolAdapter`](crate::DevToolAdapter).
+    ///
+    /// Produced only by
+    /// [`LegacyAdapterShim`](super::LegacyAdapterShim): the legacy trait renders
+    /// and writes in two calls and never discloses the destination path, so the
+    /// honest description of that mutation cannot name a file. Migrated adapters
+    /// use [`WriteManagedSettings`](Self::WriteManagedSettings).
+    ApplyLegacyManagedSettings {
+        /// The scope the caller requested. The legacy adapter may not honour it
+        /// — that is precisely why this variant is distinguishable.
+        scope: SettingsScope,
+        /// SHA-256 of the rendered content, hex-encoded.
+        content_sha256: String,
+    },
+    /// Install a hook into the tool's hook surface.
+    InstallHook {
+        /// Hook name as the tool knows it.
+        name: String,
+        /// Which configuration surface carries the hook.
+        scope: SettingsScope,
+        /// The hook script or configuration file.
+        path: PathBuf,
+    },
+    /// Remove a hook AASM installed.
+    RemoveHook {
+        /// Hook name as the tool knows it.
+        name: String,
+        /// Which configuration surface carries the hook.
+        scope: SettingsScope,
+        /// The hook script or configuration file.
+        path: PathBuf,
+    },
+    /// Point the tool at a model base URL.
+    ///
+    /// **Routing, not protection.** On its own this changes where traffic goes
+    /// and nothing else; a plan whose only model-path step is this one cannot
+    /// reach [`GatewayProtected`](super::ProtectionLevel::GatewayProtected).
+    ConfigureModelGatewayBaseUrl {
+        /// Which configuration surface carries the setting.
+        scope: SettingsScope,
+        /// The environment variable or settings key that holds the URL.
+        variable: String,
+        /// The URL to route to.
+        base_url: String,
+    },
+    /// Set proxy variables (or the equivalent launcher wiring) so the tool's
+    /// traffic traverses the AASM proxy.
+    ConfigureProxy {
+        /// Which configuration surface carries the variables.
+        scope: SettingsScope,
+        /// Variable name to value.
+        variables: BTreeMap<String, String>,
+    },
+    /// Put trust material on disk so the tool will accept the intercepting
+    /// proxy's certificates.
+    MaterialiseTrustMaterial {
+        /// What kind of material.
+        kind: TrustMaterialKind,
+        /// Where it goes.
+        path: PathBuf,
+        /// SHA-256 of the material, hex-encoded.
+        content_sha256: String,
+    },
+    /// Inject an environment variable into the tool's launch environment.
+    ///
+    /// The lever `NODE_EXTRA_CA_CERTS` needs: a proxy address alone does not
+    /// make an Electron/Node tool trust the proxy's CA.
+    InjectLaunchEnvironment {
+        /// Which configuration surface carries the injection.
+        scope: SettingsScope,
+        /// Variable name.
+        variable: String,
+        /// Variable value.
+        value: EnvValue,
+    },
+    /// Apply an MCP allow/deny list to the tool's MCP configuration.
+    ConfigureMcpServers {
+        /// Servers explicitly permitted.
+        allowed: Vec<String>,
+        /// Servers explicitly denied. Denied wins on conflict, matching the
+        /// policy engine's evaluation order.
+        denied: Vec<String>,
+    },
+    /// Register an IDE extension or client with the integration.
+    RegisterIdeClient {
+        /// The IDE host (e.g. `vscode`, `jetbrains`).
+        host: String,
+        /// The extension or client identifier.
+        client_id: String,
+    },
+    /// Connect the tool to the local runtime.
+    ConnectLocalRuntime {
+        /// Explicit socket path, when the plan pins one rather than relying on
+        /// the documented convention.
+        socket_path: Option<PathBuf>,
+    },
+    /// Run a protection test and let the core adjudicate the result.
+    RunProtectionTest {
+        /// What to exercise.
+        probe: ProbeDescriptor,
+    },
+    /// Create, update or remove an artifact AASM owns.
+    ManageArtifact {
+        /// Which operation.
+        operation: ArtifactOperation,
+        /// The artifact.
+        path: PathBuf,
+    },
+}
+
+impl StepAction {
+    /// The settings scope this action writes to, when it writes settings at all.
+    ///
+    /// Used by [`IntegrationPlan::validate`](super::IntegrationPlan::validate)
+    /// to reject a plan whose steps disagree with the scope the request named.
+    pub fn settings_scope(&self) -> Option<SettingsScope> {
+        match self {
+            Self::WriteManagedSettings { scope, .. }
+            | Self::ApplyLegacyManagedSettings { scope, .. }
+            | Self::InstallHook { scope, .. }
+            | Self::RemoveHook { scope, .. }
+            | Self::ConfigureModelGatewayBaseUrl { scope, .. }
+            | Self::ConfigureProxy { scope, .. }
+            | Self::InjectLaunchEnvironment { scope, .. } => Some(*scope),
+            Self::MaterialiseTrustMaterial { .. }
+            | Self::ConfigureMcpServers { .. }
+            | Self::RegisterIdeClient { .. }
+            | Self::ConnectLocalRuntime { .. }
+            | Self::RunProtectionTest { .. }
+            | Self::ManageArtifact { .. } => None,
+        }
+    }
+
+    /// The filesystem artifacts this action touches, for the plan's
+    /// affected-artifact list and the removal plan's coverage check.
+    pub fn affected_paths(&self) -> Vec<PathBuf> {
+        match self {
+            Self::WriteManagedSettings { path, .. }
+            | Self::InstallHook { path, .. }
+            | Self::RemoveHook { path, .. }
+            | Self::MaterialiseTrustMaterial { path, .. }
+            | Self::ManageArtifact { path, .. } => vec![path.clone()],
+            Self::InjectLaunchEnvironment {
+                value: EnvValue::ArtifactPath(path),
+                ..
+            } => vec![path.clone()],
+            _ => Vec::new(),
+        }
+    }
+
+    /// Whether this action is a protection test — the only action whose result
+    /// can produce exercised evidence.
+    pub fn is_protection_test(&self) -> bool {
+        matches!(self, Self::RunProtectionTest { .. })
+    }
+
+    /// Short, stable identifier for the action kind, used in dry-run rendering
+    /// so the output does not change shape when a variant gains a field.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::WriteManagedSettings { .. } => "write-managed-settings",
+            Self::ApplyLegacyManagedSettings { .. } => "apply-legacy-managed-settings",
+            Self::InstallHook { .. } => "install-hook",
+            Self::RemoveHook { .. } => "remove-hook",
+            Self::ConfigureModelGatewayBaseUrl { .. } => "configure-model-base-url",
+            Self::ConfigureProxy { .. } => "configure-proxy",
+            Self::MaterialiseTrustMaterial { .. } => "materialise-trust-material",
+            Self::InjectLaunchEnvironment { .. } => "inject-launch-environment",
+            Self::ConfigureMcpServers { .. } => "configure-mcp-servers",
+            Self::RegisterIdeClient { .. } => "register-ide-client",
+            Self::ConnectLocalRuntime { .. } => "connect-local-runtime",
+            Self::RunProtectionTest { .. } => "run-protection-test",
+            Self::ManageArtifact { .. } => "manage-artifact",
+        }
+    }
+}
+
+/// Whether a step must succeed for the integration to be considered applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum StepRequirement {
+    /// The integration is not applied unless this step verifies. Only required
+    /// steps count towards
+    /// [`Integrated`](super::ProtectionLevel::Integrated).
+    Required,
+    /// A best-effort improvement; its absence lowers the achieved level but does
+    /// not make the integration partial.
+    Optional,
+}
+
+/// Whether a step changes host state outside the developer's own tool
+/// configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum StepPrivilege {
+    /// Touches only files the developer already owns.
+    User,
+    /// Changes host state — trust store, kernel probes, launch agents. Must be
+    /// individually consented and individually reversible; never bundled into
+    /// "install" and never implied by choosing a profile (ADR 0030 §6.6).
+    PrivilegedHost {
+        /// The exact sentence shown to the user before this step runs.
+        consent_prompt: String,
+    },
+}
+
+/// One reviewable, reversible unit of an integration plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct IntegrationStep {
+    /// Stable identifier, unique within its plan. Receipts key on it.
+    pub id: String,
+    /// The mutation this step describes.
+    pub action: StepAction,
+    /// Whether the integration depends on it.
+    pub requirement: StepRequirement,
+    /// Whether it changes host state.
+    pub privilege: StepPrivilege,
+    /// The action that undoes it. `None` means the step has no automated
+    /// reversal — allowed for steps that mutate nothing (a protection test) but
+    /// rejected by [`IntegrationPlan::validate`](super::IntegrationPlan::validate)
+    /// for privileged ones.
+    pub reversal: Option<StepAction>,
+    /// One line describing the step to a human reviewing the dry run.
+    pub summary: String,
+}
+
+impl IntegrationStep {
+    /// A required, user-scoped step with no reversal.
+    pub fn new(id: impl Into<String>, action: StepAction, summary: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            action,
+            requirement: StepRequirement::Required,
+            privilege: StepPrivilege::User,
+            reversal: None,
+            summary: summary.into(),
+        }
+    }
+
+    /// Mark the step optional.
+    #[must_use]
+    pub fn optional(mut self) -> Self {
+        self.requirement = StepRequirement::Optional;
+        self
+    }
+
+    /// Attach the action that undoes this step.
+    #[must_use]
+    pub fn with_reversal(mut self, reversal: StepAction) -> Self {
+        self.reversal = Some(reversal);
+        self
+    }
+
+    /// Mark the step as changing host state, with the sentence the user must
+    /// agree to.
+    #[must_use]
+    pub fn privileged(mut self, consent_prompt: impl Into<String>) -> Self {
+        self.privilege = StepPrivilege::PrivilegedHost {
+            consent_prompt: consent_prompt.into(),
+        };
+        self
+    }
+
+    /// Whether the integration depends on this step.
+    pub fn is_required(&self) -> bool {
+        self.requirement == StepRequirement::Required
+    }
+
+    /// Whether this step changes host state.
+    pub fn is_privileged(&self) -> bool {
+        matches!(self.privilege, StepPrivilege::PrivilegedHost { .. })
+    }
+
+    /// Render one dry-run line. Stable shape: flags, id, kind, summary.
+    pub fn render_dry_run(&self) -> String {
+        let mut flags = vec![if self.is_required() { "required" } else { "optional" }];
+        if self.is_privileged() {
+            flags.push("privileged-host");
+        }
+        if self.reversal.is_none() {
+            flags.push("no-automated-reversal");
+        }
+        format!(
+            "[{}] {} ({}): {}",
+            flags.join(","),
+            self.id,
+            self.action.kind(),
+            self.summary
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ca_step() -> IntegrationStep {
+        IntegrationStep::new(
+            "materialise-ca",
+            StepAction::MaterialiseTrustMaterial {
+                kind: TrustMaterialKind::ProxyCaCertificatePem,
+                path: PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem"),
+                content_sha256: "abc123".to_string(),
+            },
+            "write the AASM proxy CA where the tool can read it",
+        )
+        .with_reversal(StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem"),
+        })
+    }
+
+    #[test]
+    fn trust_material_and_launch_env_are_expressible_and_linked() {
+        // The AAASM-5276 fix in plan form: materialise the CA, then point
+        // NODE_EXTRA_CA_CERTS at the artifact the previous step wrote.
+        let ca = ca_step();
+        let env = IntegrationStep::new(
+            "inject-node-ca",
+            StepAction::InjectLaunchEnvironment {
+                scope: SettingsScope::User,
+                variable: "NODE_EXTRA_CA_CERTS".to_string(),
+                value: EnvValue::ArtifactPath(PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem")),
+            },
+            "make the tool's Node runtime trust the AASM proxy CA",
+        );
+
+        assert_eq!(ca.action.affected_paths(), env.action.affected_paths());
+        assert_eq!(env.action.settings_scope(), Some(SettingsScope::User));
+    }
+
+    #[test]
+    fn every_settings_touching_action_names_its_scope() {
+        let write = StepAction::WriteManagedSettings {
+            scope: SettingsScope::Project,
+            path: PathBuf::from("/repo/.claude/settings.json"),
+            managed_keys: vec!["permissions".to_string()],
+            content_sha256: "deadbeef".to_string(),
+            merge: SettingsMerge::MergeManagedKeys,
+        };
+        assert_eq!(write.settings_scope(), Some(SettingsScope::Project));
+
+        // Actions that touch no settings surface say so rather than defaulting.
+        assert_eq!(
+            StepAction::ConfigureMcpServers {
+                allowed: vec![],
+                denied: vec![]
+            }
+            .settings_scope(),
+            None
+        );
+    }
+
+    #[test]
+    fn dry_run_lines_carry_the_flags_a_reviewer_needs() {
+        let privileged = IntegrationStep::new(
+            "trust-store",
+            StepAction::MaterialiseTrustMaterial {
+                kind: TrustMaterialKind::ProxyCaTrustStoreAnchor,
+                path: PathBuf::from("/Library/Keychains/System.keychain"),
+                content_sha256: "abc123".to_string(),
+            },
+            "install the AASM proxy CA into the system trust store",
+        )
+        .privileged("Agent Assembly will add its certificate authority to your system trust store.")
+        .with_reversal(StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: PathBuf::from("/Library/Keychains/System.keychain"),
+        });
+
+        let line = privileged.render_dry_run();
+        assert!(line.starts_with("[required,privileged-host]"), "{line}");
+        assert!(line.contains("materialise-trust-material"), "{line}");
+
+        let probe = IntegrationStep::new(
+            "probe",
+            StepAction::RunProtectionTest {
+                probe: ProbeDescriptor {
+                    id: "synthetic-secret".to_string(),
+                    mechanism: IntegrationCapability::ModelPathInterception,
+                    description: "send a synthetic secret down the model path".to_string(),
+                },
+            },
+            "verify the model path is actually intercepted",
+        )
+        .optional();
+        assert!(
+            probe.render_dry_run().starts_with("[optional,no-automated-reversal]"),
+            "{}",
+            probe.render_dry_run()
+        );
+        assert!(probe.action.is_protection_test());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn steps_round_trip_through_json() {
+        let step = ca_step();
+        let json = serde_json::to_string(&step).unwrap();
+        let restored: IntegrationStep = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, step);
+    }
+}

--- a/aa-core/src/integration/version.rs
+++ b/aa-core/src/integration/version.rs
@@ -206,18 +206,35 @@ pub fn core_version() -> ToolVersion {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SupportedToolVersions {
-    /// Lowest tool version this adapter supports, inclusive.
-    pub min: ToolVersion,
+    /// Lowest tool version this adapter supports, inclusive. `None` means the
+    /// adapter claims no known lower bound.
+    ///
+    /// A bound is `Option` on both ends rather than defaulting the lower one to
+    /// `0.0.0`, because `0.0.0` is *not* the bottom of the ordering: a
+    /// pre-release sorts below its release, so `0.0.0-sample` is below `0.0.0`
+    /// and a "no lower bound" expressed as `0.0.0` would reject it. That is not
+    /// hypothetical — it is exactly what `examples/aa-devtool-sample-myeditor`
+    /// reports, and an adapter that has declared no range must not be able to
+    /// call a version incompatible by accident.
+    pub min: Option<ToolVersion>,
     /// First tool version this adapter does **not** support, exclusive. `None`
     /// means the adapter claims no known upper bound.
     pub max_exclusive: Option<ToolVersion>,
 }
 
 impl SupportedToolVersions {
+    /// A range with no bound at either end — every version is inside it.
+    pub fn any() -> Self {
+        Self {
+            min: None,
+            max_exclusive: None,
+        }
+    }
+
     /// A range with a lower bound and no known upper bound.
     pub fn at_least(min: ToolVersion) -> Self {
         Self {
-            min,
+            min: Some(min),
             max_exclusive: None,
         }
     }
@@ -225,7 +242,7 @@ impl SupportedToolVersions {
     /// A half-open range `[min, max_exclusive)`.
     pub fn between(min: ToolVersion, max_exclusive: ToolVersion) -> Self {
         Self {
-            min,
+            min: Some(min),
             max_exclusive: Some(max_exclusive),
         }
     }
@@ -234,7 +251,8 @@ impl SupportedToolVersions {
     pub fn contains(&self, version: &ToolVersion) -> bool {
         // `Option::is_none_or` would read better but is stable only from 1.82;
         // this crate's MSRV is 1.75.
-        version >= &self.min && self.max_exclusive.as_ref().map_or(true, |max| version < max)
+        self.min.as_ref().map_or(true, |min| version >= min)
+            && self.max_exclusive.as_ref().map_or(true, |max| version < max)
     }
 
     /// Classify a detected version against this range.
@@ -256,8 +274,12 @@ impl SupportedToolVersions {
             };
         }
 
-        let remediation = if detected < &self.min {
-            format!("upgrade the tool to {} or newer", self.min)
+        let below_min = self.min.as_ref().is_some_and(|min| detected < min);
+        let remediation = if below_min {
+            format!(
+                "upgrade the tool to {} or newer",
+                self.min.as_ref().expect("below_min implies a lower bound")
+            )
         } else {
             format!(
                 "this Agent Assembly build supports tool versions below {}; upgrade Agent Assembly",
@@ -438,6 +460,20 @@ mod tests {
             }
             other => panic!("expected Incompatible, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn an_unbounded_range_accepts_pre_releases_below_zero() {
+        // `0.0.0` is not the bottom of the ordering: a pre-release sorts below
+        // its release. An adapter that declared no range must not reject the
+        // public sample's own "0.0.0-sample".
+        let any = SupportedToolVersions::any();
+        let sample: ToolVersion = "0.0.0-sample".parse().unwrap();
+        assert!(any.contains(&sample));
+        assert!(any.classify(Some(&sample)).is_compatible());
+
+        // Whereas an explicit `>= 0.0.0` genuinely does exclude it.
+        assert!(!SupportedToolVersions::at_least(ToolVersion::new(0, 0, 0)).contains(&sample));
     }
 
     #[test]

--- a/aa-core/src/integration/version.rs
+++ b/aa-core/src/integration/version.rs
@@ -1,0 +1,462 @@
+//! Version representation and compatibility classification for Developer
+//! Integrations.
+//!
+//! # Why a hand-rolled version type
+//!
+//! Version comparison is load-bearing for two ADR 0030 rules — Decision 2 row 1
+//! ("only the adapter knows what a version *means* for its tool") and Decision 4's
+//! `Incompatible` state, which must be **reportable** rather than silently
+//! degrading. `aa-core` is the dependency-light domain crate every adapter links
+//! transitively, so this module implements the small subset of ordering the
+//! contract actually needs (`major.minor.patch` plus "a pre-release sorts below
+//! its release") instead of pulling a general-purpose semver parser into it.
+//!
+//! # The fail-absent rule this module encodes
+//!
+//! [`SupportedToolVersions::classify`] never answers
+//! [`VersionCompatibility::Compatible`] when the detected version is unknown. A
+//! missing version is a **missing comparison**, not a pass — ADR 0029's rule 1,
+//! transferred by ADR 0030 §3.4 rule 2.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Wire-schema version of the Developer Integration lifecycle types in this
+/// module tree.
+///
+/// Carried by [`IntegrationPlan`](crate::integration::IntegrationPlan) and
+/// [`IntegrationReceipt`](crate::integration::IntegrationReceipt) so a receipt
+/// written by a newer core can be detected — and reported as
+/// [`ProtectionState::Incompatible`](crate::integration::ProtectionState::Incompatible)
+/// — rather than misread by an older one (ADR 0030 §4.1).
+pub const LIFECYCLE_SCHEMA_VERSION: u32 = 1;
+
+/// Failure to parse a [`ToolVersion`] from a string.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("not a recognisable version string: {input:?} ({detail})")]
+pub struct VersionParseError {
+    /// The string that could not be parsed.
+    pub input: String,
+    /// Why it could not be parsed.
+    pub detail: &'static str,
+}
+
+/// A dotted numeric version with an optional pre-release tag.
+///
+/// Accepts `1`, `1.2`, `1.2.3`, `1.2.3-rc.6` and `1.2.3+build.7` (build metadata
+/// is parsed and discarded, matching semver's rule that it does not participate
+/// in ordering). Missing components default to zero, so `1.2` == `1.2.0`.
+///
+/// ## Ordering
+///
+/// Numeric components compare first. When they are equal, a version **with** a
+/// pre-release tag sorts **below** the same version without one, so
+/// `2.1.0-rc.1 < 2.1.0`. This is why [`Ord`] is implemented by hand: the derived
+/// implementation would order `None < Some(_)` and invert that rule.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "String", into = "String"))]
+pub struct ToolVersion {
+    major: u64,
+    minor: u64,
+    patch: u64,
+    pre: Option<String>,
+}
+
+impl ToolVersion {
+    /// Construct a release version (no pre-release tag).
+    pub const fn new(major: u64, minor: u64, patch: u64) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+            pre: None,
+        }
+    }
+
+    /// Major component.
+    pub const fn major(&self) -> u64 {
+        self.major
+    }
+
+    /// Minor component.
+    pub const fn minor(&self) -> u64 {
+        self.minor
+    }
+
+    /// Patch component.
+    pub const fn patch(&self) -> u64 {
+        self.patch
+    }
+
+    /// Pre-release tag, if the version carried one (`rc.6` for `0.0.1-rc.6`).
+    pub fn pre_release(&self) -> Option<&str> {
+        self.pre.as_deref()
+    }
+}
+
+impl fmt::Display for ToolVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
+        match &self.pre {
+            Some(pre) => write!(f, "-{pre}"),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Ord for ToolVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.major, self.minor, self.patch)
+            .cmp(&(other.major, other.minor, other.patch))
+            .then_with(|| match (&self.pre, &other.pre) {
+                (None, None) => Ordering::Equal,
+                // A release outranks its own pre-releases.
+                (None, Some(_)) => Ordering::Greater,
+                (Some(_), None) => Ordering::Less,
+                (Some(a), Some(b)) => a.cmp(b),
+            })
+    }
+}
+
+impl PartialOrd for ToolVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl FromStr for ToolVersion {
+    type Err = VersionParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim().trim_start_matches('v');
+        // Build metadata never participates in ordering, so drop it up front.
+        let without_build = trimmed.split('+').next().unwrap_or(trimmed);
+        let (core, pre) = match without_build.split_once('-') {
+            Some((core, pre)) if !pre.is_empty() => (core, Some(pre.to_string())),
+            _ => (without_build, None),
+        };
+
+        let mut parts = core.split('.');
+        let mut next = |detail: &'static str| -> Result<u64, VersionParseError> {
+            match parts.next() {
+                None => Ok(0),
+                Some(raw) => raw.parse::<u64>().map_err(|_| VersionParseError {
+                    input: s.to_string(),
+                    detail,
+                }),
+            }
+        };
+
+        let major = next("major component is not a number")?;
+        let minor = next("minor component is not a number")?;
+        let patch = next("patch component is not a number")?;
+        if parts.next().is_some() {
+            return Err(VersionParseError {
+                input: s.to_string(),
+                detail: "more than three dotted numeric components",
+            });
+        }
+
+        Ok(Self {
+            major,
+            minor,
+            patch,
+            pre,
+        })
+    }
+}
+
+impl TryFrom<String> for ToolVersion {
+    type Error = VersionParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl From<ToolVersion> for String {
+    fn from(value: ToolVersion) -> Self {
+        value.to_string()
+    }
+}
+
+/// The `aa-core` version the running lifecycle implementation was built from.
+///
+/// # Panics
+///
+/// Panics if `aa-core`'s own `CARGO_PKG_VERSION` stops being parseable by
+/// [`ToolVersion`]. That is a build-configuration error, not a runtime
+/// condition, and is covered by a unit test in this module.
+pub fn core_version() -> ToolVersion {
+    env!("CARGO_PKG_VERSION")
+        .parse()
+        .expect("aa-core CARGO_PKG_VERSION must parse as a ToolVersion")
+}
+
+/// The range of tool versions one adapter claims to understand.
+///
+/// Owned by the adapter (ADR 0030 Decision 2, row 1): a generic comparator in
+/// the service would have to encode per-tool knowledge, which is the adapter's
+/// entire reason to exist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct SupportedToolVersions {
+    /// Lowest tool version this adapter supports, inclusive.
+    pub min: ToolVersion,
+    /// First tool version this adapter does **not** support, exclusive. `None`
+    /// means the adapter claims no known upper bound.
+    pub max_exclusive: Option<ToolVersion>,
+}
+
+impl SupportedToolVersions {
+    /// A range with a lower bound and no known upper bound.
+    pub fn at_least(min: ToolVersion) -> Self {
+        Self {
+            min,
+            max_exclusive: None,
+        }
+    }
+
+    /// A half-open range `[min, max_exclusive)`.
+    pub fn between(min: ToolVersion, max_exclusive: ToolVersion) -> Self {
+        Self {
+            min,
+            max_exclusive: Some(max_exclusive),
+        }
+    }
+
+    /// Whether `version` falls inside this range.
+    pub fn contains(&self, version: &ToolVersion) -> bool {
+        // `Option::is_none_or` would read better but is stable only from 1.82;
+        // this crate's MSRV is 1.75.
+        version >= &self.min && self.max_exclusive.as_ref().map_or(true, |max| version < max)
+    }
+
+    /// Classify a detected version against this range.
+    ///
+    /// A `detected` of `None` yields [`VersionCompatibility::Unknown`], **never**
+    /// [`VersionCompatibility::Compatible`] — see the module docs.
+    pub fn classify(&self, detected: Option<&ToolVersion>) -> VersionCompatibility {
+        let Some(detected) = detected else {
+            return VersionCompatibility::Unknown {
+                reason: "the tool's version could not be determined; a missing version is a \
+                         missing comparison, not a pass"
+                    .to_string(),
+            };
+        };
+
+        if self.contains(detected) {
+            return VersionCompatibility::Compatible {
+                detected: detected.clone(),
+            };
+        }
+
+        let remediation = if detected < &self.min {
+            format!("upgrade the tool to {} or newer", self.min)
+        } else {
+            format!(
+                "this Agent Assembly build supports tool versions below {}; upgrade Agent Assembly",
+                self.max_exclusive
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| "the adapter's upper bound".to_string())
+            )
+        };
+
+        VersionCompatibility::Incompatible {
+            detected: Some(detected.clone()),
+            supported: self.clone(),
+            remediation,
+        }
+    }
+}
+
+/// Outcome of comparing a detected tool version against an adapter's supported
+/// range.
+///
+/// `Unknown` exists as a distinct variant precisely so that "we could not tell"
+/// can never be rendered as "compatible".
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum VersionCompatibility {
+    /// The detected version is inside the adapter's supported range.
+    Compatible {
+        /// The version that was detected and compared.
+        detected: ToolVersion,
+    },
+    /// No comparison could be made. Resolves **downward** wherever a protection
+    /// state is derived (ADR 0030 §4.2 rule 2).
+    Unknown {
+        /// User-facing explanation of why the comparison could not be made.
+        reason: String,
+    },
+    /// The detected version is outside the adapter's supported range.
+    Incompatible {
+        /// The version that was detected, when one was.
+        detected: Option<ToolVersion>,
+        /// The range the adapter claims to support.
+        supported: SupportedToolVersions,
+        /// Actionable text telling the user which side to upgrade.
+        remediation: String,
+    },
+}
+
+impl VersionCompatibility {
+    /// True only for [`Compatible`](Self::Compatible). `Unknown` is deliberately
+    /// not compatible.
+    pub fn is_compatible(&self) -> bool {
+        matches!(self, Self::Compatible { .. })
+    }
+
+    /// True for [`Incompatible`](Self::Incompatible).
+    pub fn is_incompatible(&self) -> bool {
+        matches!(self, Self::Incompatible { .. })
+    }
+}
+
+/// The versions of every component that participates in one integration.
+///
+/// Recorded in [`IntegrationReceipt`](crate::integration::IntegrationReceipt) so
+/// a later status read can tell "verified by an older core" from "verified by
+/// this one".
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ComponentVersions {
+    /// `aa-core` version the lifecycle implementation was built from.
+    pub core: ToolVersion,
+    /// The adapter crate's own version.
+    pub adapter: ToolVersion,
+    /// [`LIFECYCLE_SCHEMA_VERSION`] the adapter was compiled against.
+    pub lifecycle_schema: u32,
+}
+
+/// Everything an adapter declares about versions, returned as one value so the
+/// lifecycle trait needs a single accessor rather than three.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct VersionSupport {
+    /// The adapter crate's own version.
+    pub adapter_version: ToolVersion,
+    /// [`LIFECYCLE_SCHEMA_VERSION`] the adapter was compiled against.
+    pub lifecycle_schema_version: u32,
+    /// Tool versions this adapter claims to understand.
+    pub supported_tool_versions: SupportedToolVersions,
+}
+
+impl VersionSupport {
+    /// Combine the adapter's declaration with the running [`core_version`].
+    pub fn component_versions(&self) -> ComponentVersions {
+        ComponentVersions {
+            core: core_version(),
+            adapter: self.adapter_version.clone(),
+            lifecycle_schema: self.lifecycle_schema_version,
+        }
+    }
+
+    /// Whether the adapter's schema version is one this core can read.
+    ///
+    /// An adapter compiled against a *newer* schema than the running core is
+    /// reported as incompatible rather than read optimistically.
+    pub fn is_schema_readable(&self) -> bool {
+        self.lifecycle_schema_version <= LIFECYCLE_SCHEMA_VERSION
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_the_shapes_real_tools_report() {
+        // Claude Code 2.1.220, measured in the AAASM-5276 spike.
+        assert_eq!("2.1.220".parse::<ToolVersion>().unwrap(), ToolVersion::new(2, 1, 220));
+        assert_eq!("v1.4".parse::<ToolVersion>().unwrap(), ToolVersion::new(1, 4, 0));
+        assert_eq!("3".parse::<ToolVersion>().unwrap(), ToolVersion::new(3, 0, 0));
+
+        let rc: ToolVersion = "0.0.1-rc.6".parse().unwrap();
+        assert_eq!(rc.pre_release(), Some("rc.6"));
+        assert_eq!(rc.to_string(), "0.0.1-rc.6");
+
+        // Build metadata parses but does not survive into the value.
+        assert_eq!(
+            "1.2.3+build.9".parse::<ToolVersion>().unwrap(),
+            ToolVersion::new(1, 2, 3)
+        );
+    }
+
+    #[test]
+    fn rejects_non_numeric_and_over_long_versions() {
+        assert!("1.x.3".parse::<ToolVersion>().is_err());
+        assert!("1.2.3.4".parse::<ToolVersion>().is_err());
+    }
+
+    #[test]
+    fn a_pre_release_sorts_below_its_release() {
+        let rc: ToolVersion = "2.1.0-rc.1".parse().unwrap();
+        let release = ToolVersion::new(2, 1, 0);
+        assert!(rc < release, "{rc} must sort below {release}");
+        assert!(ToolVersion::new(2, 0, 9) < rc);
+    }
+
+    #[test]
+    fn core_version_is_parseable() {
+        // Guards the documented panic in `core_version`.
+        let v = core_version();
+        assert!(v.to_string().starts_with(&format!("{}.", v.major())));
+    }
+
+    #[test]
+    fn unknown_version_is_never_compatible() {
+        let supported = SupportedToolVersions::at_least(ToolVersion::new(2, 0, 0));
+        let classified = supported.classify(None);
+        assert!(!classified.is_compatible());
+        assert!(matches!(classified, VersionCompatibility::Unknown { .. }));
+    }
+
+    #[test]
+    fn classify_reports_which_side_to_upgrade() {
+        let supported = SupportedToolVersions::between(ToolVersion::new(2, 0, 0), ToolVersion::new(3, 0, 0));
+
+        assert!(supported.classify(Some(&ToolVersion::new(2, 1, 220))).is_compatible());
+
+        match supported.classify(Some(&ToolVersion::new(1, 9, 0))) {
+            VersionCompatibility::Incompatible { remediation, .. } => {
+                assert!(remediation.contains("upgrade the tool"), "{remediation}");
+            }
+            other => panic!("expected Incompatible, got {other:?}"),
+        }
+
+        match supported.classify(Some(&ToolVersion::new(3, 0, 0))) {
+            VersionCompatibility::Incompatible { remediation, .. } => {
+                assert!(remediation.contains("upgrade Agent Assembly"), "{remediation}");
+            }
+            other => panic!("expected Incompatible, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn version_support_flags_a_newer_schema_as_unreadable() {
+        let support = VersionSupport {
+            adapter_version: ToolVersion::new(1, 0, 0),
+            lifecycle_schema_version: LIFECYCLE_SCHEMA_VERSION + 1,
+            supported_tool_versions: SupportedToolVersions::at_least(ToolVersion::new(1, 0, 0)),
+        };
+        assert!(!support.is_schema_readable());
+        assert_eq!(support.component_versions().core, core_version());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn tool_version_round_trips_as_a_string() {
+        let original: ToolVersion = "2.1.220-rc.6".parse().unwrap();
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, "\"2.1.220-rc.6\"");
+        assert_eq!(serde_json::from_str::<ToolVersion>(&json).unwrap(), original);
+    }
+}

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -34,6 +34,8 @@ pub mod config;
 pub mod dev_tool;
 pub mod evaluators;
 pub mod identity;
+#[cfg(feature = "std")]
+pub mod integration;
 #[cfg(feature = "alloc")]
 pub mod llm;
 pub mod net;

--- a/aa-devtool-contract/Cargo.toml
+++ b/aa-devtool-contract/Cargo.toml
@@ -17,5 +17,15 @@ publish = false  # internal contract crate; not a published surface
 [dependencies]
 aa-core = { path = "../aa-core", features = ["std", "serde"] }
 
+# Test-only. `tests/lifecycle_contract.rs` implements the AAASM-5277 lifecycle
+# traits for a CLI, an IDE-hosted and a SaaS tool using *only* this crate's
+# re-exports, which is what proves the audited surface is sufficient for a real
+# adapter. Those impls need the same async/serde tooling any adapter crate
+# already carries; none of it is a runtime dependency of the facade itself.
+[dev-dependencies]
+async-trait = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/aa-devtool-contract/src/lib.rs
+++ b/aa-devtool-contract/src/lib.rs
@@ -26,6 +26,13 @@
 //! `aa-core` modules (`policy::`, `identity`, `storage`, `config`, …) — only the
 //! flat value types and the adapter trait the plugins consume.
 //!
+//! The list is in two groups. The first is the original `DevToolAdapter`
+//! surface (AAASM-3565). The second is the Developer Integration lifecycle
+//! contract (AAASM-5277, ADR 0030 §7.1) — the capability, plan, receipt, status
+//! and evidence types plus the lifecycle traits. The second group is additive:
+//! `DevToolAdapter` and everything around it is retained unchanged, and
+//! [`LegacyAdapterShim`] bridges any adapter that has not migrated.
+//!
 //! [`aa-core`]: aa_core
 
 #![warn(missing_docs)]
@@ -42,3 +49,84 @@ pub use aa_core::{Capability, CapabilitySet};
 
 // --- Audit pipeline entry the SaaS overlay emits (aa_core::audit) --------
 pub use aa_core::AuditEntry;
+
+// --- Developer Integration lifecycle contract (aa_core::integration) ------
+//
+// AAASM-5277 / ADR 0030 §7.1. This is the second re-export group, and it is
+// the largest widening this crate has taken. Three properties keep it
+// reviewable, and a reviewer should check all three on any future addition:
+//
+//   1. Every symbol below is either a **flat value type** (a struct or enum of
+//      owned primitives, paths and other symbols in this list) or one of the
+//      five lifecycle traits. No `aa_core` module is re-exported.
+//   2. Nothing here transitively reaches `aa_core::storage`, `identity`,
+//      `config`, the gateway credential types or the LLM/approval subsystems —
+//      the prohibition in the module docs above is unchanged and still binding.
+//   3. No lifecycle type has a field that can hold a `PolicyDocument`, a raw
+//      payload or a credential. A policy is named by `PolicyProfileRef`
+//      (id + display name + digest) — enough to display and compare, never
+//      enough to read (ADR 0030 §5.5).
+//
+// `PolicyDocument` itself remains reachable only through the pre-existing
+// policy group above, which the legacy `DevToolAdapter` surface requires.
+
+// The lifecycle trait plus the optional mechanism surfaces an adapter opts
+// into. Composition is what lets a tool without MCP or without a launch
+// command implement nothing rather than a misleading no-op.
+pub use aa_core::integration::{DevToolIntegration, HookableTool, LaunchSpec, LaunchableTool, McpGovernedTool};
+
+// The conformance check every adapter's own test suite is expected to call:
+// declaring a capability whose accessor returns `None` is a contract
+// violation, and adapters can only see it through this crate.
+pub use aa_core::integration::{capability_conformance, ConformanceViolation};
+
+// The capability axis (ADR 0030 Decision 3). Deliberately NOT
+// `aa_core::Capability` — that is the agent-action axis re-exported above and
+// governed by ADR 0029; §3.1 makes the distinct names mandatory.
+pub use aa_core::integration::{CapabilityResolution, CapabilitySupport, DevToolCapabilities, IntegrationCapability};
+
+// Request and plan authoring. `ProtectionProfile` and `PolicyProfileRef` are
+// what an adapter reads instead of a policy document.
+pub use aa_core::integration::{
+    IntegrationPlan, IntegrationRequest, PlanError, PolicyProfileRef, ProtectionProfile, RemovalPlan,
+    UnsupportedMechanism,
+};
+
+// Step vocabulary. Every variant of `StepAction` is constructible only from
+// these, so an adapter cannot describe a mutation the plan model cannot render
+// for review or record for removal.
+pub use aa_core::integration::{
+    ArtifactOperation, EnvValue, IntegrationStep, ProbeDescriptor, SettingsMerge, SettingsScope, StepAction,
+    StepPrivilege, StepRequirement, TrustMaterialKind,
+};
+
+// Receipts are read by adapters (status, verify, plan_removal) and written
+// only by the service — the type is shared, the authority is not.
+pub use aa_core::integration::{IntegrationReceipt, ReceiptError, StepReceipt};
+
+// Status and verification results, including the exercised-vs-read-back
+// distinction that keeps `GatewayProtected` honest.
+pub use aa_core::integration::{IntegrationStatus, LifecyclePhase, NextLevel, VerificationOutcome, VerificationResult};
+
+// Protection state and the evidence it is derived from. `StateDerivation` is
+// re-exported because an adapter's `integration_status` must derive the state
+// through it rather than inventing a second derivation.
+pub use aa_core::integration::{
+    EvidenceKind, ExerciseOutcome, ProtectionEvidence, ProtectionLevel, ProtectionState, StateDerivation,
+    DEFAULT_FRESHNESS_WINDOW_SECS,
+};
+
+// Version representation and compatibility classification, owned by the
+// adapter (ADR 0030 matrix row 1).
+pub use aa_core::integration::{
+    ComponentVersions, SupportedToolVersions, ToolVersion, VersionCompatibility, VersionParseError, VersionSupport,
+    LIFECYCLE_SCHEMA_VERSION,
+};
+
+// The migration bridge, so an unmigrated adapter — including any out-of-tree
+// one — satisfies the lifecycle contract without being rewritten (ADR 0030 §7).
+pub use aa_core::integration::{LegacyAdapterShim, LEGACY_UNSUPPORTED_REASON};
+
+// Timestamp helper. Every lifecycle timestamp is plain Unix seconds, and an
+// adapter that stamps evidence needs the same clock the service reads it with.
+pub use aa_core::integration::now_unix_secs;

--- a/aa-devtool-contract/tests/lifecycle_contract.rs
+++ b/aa-devtool-contract/tests/lifecycle_contract.rs
@@ -1,0 +1,889 @@
+//! Contract tests for the Developer Integration lifecycle (AAASM-5277).
+//!
+//! # Why they live in this crate
+//!
+//! Two things are under test at once. The obvious one is that the three tool
+//! categories ADR 0030 §3.5 distinguishes — CLI, IDE-hosted and SaaS — can each
+//! be expressed without declaring a capability they do not have. The less
+//! obvious one is that they can be expressed **using only what
+//! `aa-devtool-contract` re-exports**: these fixtures never name `aa_core`, so
+//! if the audited re-export list were insufficient for a real adapter, this file
+//! would not compile.
+//!
+//! The fixtures are deliberately shaped like the real tools:
+//!
+//! * [`CliTool`] is the Claude Code shape — launchable, MCP-governed, and the
+//!   only one that can put an AASM component in its model path.
+//! * [`IdeHostedTool`] is the Copilot shape — no launch command at all, so it
+//!   implements no launch surface and says why at plan time.
+//! * [`SaasTool`] is the hosted-agent shape — nothing local to configure, so it
+//!   is capped at observation and implements none of the optional surfaces.
+//!
+//! Not one of them contains an `Ok(())` stub or an `unimplemented!()`.
+
+use std::path::PathBuf;
+
+use aa_devtool_contract::{
+    capability_conformance, AdapterError, ArtifactOperation, DevToolCapabilities, DevToolInfo, DevToolIntegration,
+    DevToolKind, EnvValue, EvidenceKind, ExerciseOutcome, GovernanceLevel, HookableTool, IntegrationCapability,
+    IntegrationPlan, IntegrationReceipt, IntegrationRequest, IntegrationStatus, IntegrationStep, LaunchSpec,
+    LaunchableTool, LifecyclePhase, McpGovernedTool, McpServerInfo, PlanError, ProbeDescriptor, ProtectionEvidence,
+    ProtectionLevel, ProtectionProfile, ProtectionState, RemovalPlan, SettingsMerge, SettingsScope, StateDerivation,
+    StepAction, SupportedToolVersions, ToolVersion, TrustMaterialKind, VerificationOutcome, VerificationResult,
+    VersionCompatibility, VersionSupport, DEFAULT_FRESHNESS_WINDOW_SECS, LIFECYCLE_SCHEMA_VERSION,
+};
+
+const NOW: u64 = 1_700_000_000;
+
+fn version_support(min: ToolVersion) -> VersionSupport {
+    VersionSupport {
+        adapter_version: ToolVersion::new(0, 1, 0),
+        lifecycle_schema_version: LIFECYCLE_SCHEMA_VERSION,
+        supported_tool_versions: SupportedToolVersions::at_least(min),
+    }
+}
+
+fn info(kind: DevToolKind, version: &str, level: GovernanceLevel) -> DevToolInfo {
+    DevToolInfo {
+        kind,
+        version: Some(version.to_string()),
+        install_path: PathBuf::from("/usr/local/bin/tool"),
+        governance_level: level,
+        supports_mcp: false,
+        supports_managed_settings: true,
+    }
+}
+
+fn empty_status(tool: DevToolKind, phase: LifecyclePhase, state: ProtectionState) -> IntegrationStatus {
+    IntegrationStatus {
+        tool,
+        phase,
+        state,
+        evidence: Vec::new(),
+        planned_level: ProtectionLevel::DetectedNotIntegrated,
+        adapter_ceiling: GovernanceLevel::L1Observe,
+        compatibility: VersionCompatibility::Unknown {
+            reason: "not probed in this fixture".to_string(),
+        },
+        next_level: None,
+        observed_at_unix_secs: NOW,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI tool — the Claude Code shape.
+// ---------------------------------------------------------------------------
+
+struct CliTool;
+
+impl CliTool {
+    const CA_PATH: &'static str = "/home/dev/.aa/ca/aasm-ca.pem";
+}
+
+#[async_trait::async_trait]
+impl DevToolIntegration for CliTool {
+    fn capabilities(&self) -> DevToolCapabilities {
+        DevToolCapabilities::new()
+            .supported(IntegrationCapability::Discovery)
+            .supported(IntegrationCapability::ManagedSettings)
+            .supported(IntegrationCapability::ManagedLaunch)
+            .supported(IntegrationCapability::ModelPathInterception)
+            .supported(IntegrationCapability::ModelGatewayBaseUrl)
+            .supported(IntegrationCapability::HttpProxy)
+            .supported(IntegrationCapability::Hooks)
+            .supported(IntegrationCapability::McpDiscovery)
+            .supported(IntegrationCapability::McpGovernance)
+            .supported(IntegrationCapability::ToolActionApproval)
+            .unsupported(
+                IntegrationCapability::NativeIdeUi,
+                "this tool is a terminal CLI with no IDE surface",
+            )
+            .unsupported(
+                IntegrationCapability::HostEnforcement,
+                "host enforcement is unavailable on this platform",
+            )
+    }
+
+    fn detect(&self) -> Option<DevToolInfo> {
+        Some(info(DevToolKind::ClaudeCode, "2.1.220", GovernanceLevel::L2Enforce))
+    }
+
+    fn version_support(&self) -> VersionSupport {
+        version_support(ToolVersion::new(2, 0, 0))
+    }
+
+    async fn plan_integration(&self, request: &IntegrationRequest) -> Result<IntegrationPlan, AdapterError> {
+        let scope = request.settings_scope;
+        let plan = IntegrationPlan::new(
+            "cli-plan",
+            request,
+            request.effective_target_level(),
+            GovernanceLevel::L2Enforce,
+        )
+        .with_step(
+            IntegrationStep::new(
+                "settings",
+                StepAction::WriteManagedSettings {
+                    scope,
+                    path: PathBuf::from("/home/dev/.claude/settings.json"),
+                    managed_keys: vec!["permissions".to_string()],
+                    content_sha256: "sha-settings".to_string(),
+                    merge: SettingsMerge::MergeManagedKeys,
+                },
+                "write the managed settings block",
+            )
+            .with_reversal(StepAction::ManageArtifact {
+                operation: ArtifactOperation::Remove,
+                path: PathBuf::from("/home/dev/.claude/settings.json"),
+            }),
+        )
+        .with_step(
+            IntegrationStep::new(
+                "ca",
+                StepAction::MaterialiseTrustMaterial {
+                    kind: TrustMaterialKind::ProxyCaCertificatePem,
+                    path: PathBuf::from(Self::CA_PATH),
+                    content_sha256: "sha-ca".to_string(),
+                },
+                "write the AASM proxy CA where the tool's runtime can read it",
+            )
+            .with_reversal(StepAction::ManageArtifact {
+                operation: ArtifactOperation::Remove,
+                path: PathBuf::from(Self::CA_PATH),
+            }),
+        )
+        .with_step(
+            IntegrationStep::new(
+                "node-ca",
+                StepAction::InjectLaunchEnvironment {
+                    scope,
+                    variable: "NODE_EXTRA_CA_CERTS".to_string(),
+                    value: EnvValue::ArtifactPath(PathBuf::from(Self::CA_PATH)),
+                },
+                "make the tool's Node runtime trust the AASM proxy CA",
+            )
+            .with_reversal(StepAction::InjectLaunchEnvironment {
+                scope,
+                variable: "NODE_EXTRA_CA_CERTS".to_string(),
+                value: EnvValue::Literal(String::new()),
+            }),
+        )
+        .with_step(IntegrationStep::new(
+            "probe",
+            StepAction::RunProtectionTest {
+                probe: ProbeDescriptor {
+                    id: "synthetic-secret".to_string(),
+                    mechanism: IntegrationCapability::ModelPathInterception,
+                    description: "send a synthetic secret down the model path".to_string(),
+                },
+            },
+            "prove the model path is actually intercepted",
+        ))
+        .declaring_unsupported(
+            IntegrationCapability::HostEnforcement,
+            "host enforcement is unavailable on this platform",
+        );
+
+        Ok(plan)
+    }
+
+    async fn integration_status(
+        &self,
+        receipt: Option<&IntegrationReceipt>,
+    ) -> Result<IntegrationStatus, AdapterError> {
+        let compatibility = self
+            .version_support()
+            .supported_tool_versions
+            .classify(Some(&ToolVersion::new(2, 1, 220)));
+        let evidence = vec![
+            ProtectionEvidence::new(
+                IntegrationCapability::ManagedSettings,
+                EvidenceKind::ReadBack { matches_receipt: true },
+                NOW,
+                "settings read back and matched the receipt",
+            ),
+            ProtectionEvidence::new(
+                IntegrationCapability::ModelPathInterception,
+                EvidenceKind::Exercised {
+                    outcome: ExerciseOutcome::Redacted,
+                },
+                NOW,
+                "the synthetic secret was redacted before egress",
+            ),
+        ];
+
+        let state = StateDerivation {
+            detected: true,
+            receipt_present: receipt.is_some(),
+            required_steps: receipt.map(IntegrationReceipt::required_steps).unwrap_or(0),
+            required_steps_verified: receipt.map(IntegrationReceipt::verified_required_steps).unwrap_or(0),
+            mismatched_artifacts: &[],
+            compatibility: &compatibility,
+            schema_newer_than_core: false,
+            evidence: &evidence,
+            planned_level: ProtectionLevel::GatewayProtected,
+            now_unix_secs: NOW,
+            freshness_window_secs: DEFAULT_FRESHNESS_WINDOW_SECS,
+        }
+        .derive();
+
+        Ok(IntegrationStatus {
+            tool: DevToolKind::ClaudeCode,
+            phase: if receipt.is_some() {
+                LifecyclePhase::Installed
+            } else {
+                LifecyclePhase::DetectedNotIntegrated
+            },
+            state,
+            evidence,
+            planned_level: ProtectionLevel::GatewayProtected,
+            adapter_ceiling: GovernanceLevel::L2Enforce,
+            compatibility,
+            next_level: None,
+            observed_at_unix_secs: NOW,
+        })
+    }
+
+    async fn verify_integration(&self, _receipt: &IntegrationReceipt) -> Result<VerificationResult, AdapterError> {
+        Ok(VerificationResult {
+            verified_at_unix_secs: NOW,
+            outcome: VerificationOutcome::Passed,
+            evidence: vec![ProtectionEvidence::new(
+                IntegrationCapability::ModelPathInterception,
+                EvidenceKind::Exercised {
+                    outcome: ExerciseOutcome::Redacted,
+                },
+                NOW,
+                "the synthetic secret was redacted before egress",
+            )],
+        })
+    }
+
+    async fn plan_removal(&self, receipt: &IntegrationReceipt) -> Result<RemovalPlan, AdapterError> {
+        let mut plan = RemovalPlan::new("cli-removal", receipt.tool.clone());
+        for (index, action) in receipt.reversal_actions().into_iter().enumerate() {
+            plan = plan.with_step(IntegrationStep::new(
+                format!("reverse-{index}"),
+                action,
+                "undo a recorded step",
+            ));
+        }
+        Ok(plan)
+    }
+
+    fn as_mcp_governed(&self) -> Option<&dyn McpGovernedTool> {
+        Some(self)
+    }
+
+    fn as_launchable(&self) -> Option<&dyn LaunchableTool> {
+        Some(self)
+    }
+
+    fn as_hookable(&self) -> Option<&dyn HookableTool> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl McpGovernedTool for CliTool {
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+        Ok(vec![McpServerInfo {
+            name: "filesystem".to_string(),
+            command: "mcp-filesystem".to_string(),
+            args: Vec::new(),
+        }])
+    }
+
+    fn plan_mcp_governance(&self, allowed: &[String], denied: &[String]) -> Result<IntegrationStep, AdapterError> {
+        Ok(IntegrationStep::new(
+            "mcp",
+            StepAction::ConfigureMcpServers {
+                allowed: allowed.to_vec(),
+                denied: denied.to_vec(),
+            },
+            "apply the MCP allow/deny list",
+        ))
+    }
+}
+
+impl LaunchableTool for CliTool {
+    fn build_launch_command(&self, spec: &LaunchSpec) -> Result<std::process::Command, AdapterError> {
+        let mut command = std::process::Command::new("claude");
+        command.args(&spec.tool_args);
+        command.env("AASM_AGENT_ID", &spec.agent_id);
+        if let Some(proxy) = &spec.proxy_addr {
+            command.env("HTTPS_PROXY", proxy);
+        }
+        for (name, value) in &spec.env {
+            command.env(name, value);
+        }
+        Ok(command)
+    }
+}
+
+impl HookableTool for CliTool {
+    fn plan_hooks(&self, request: &IntegrationRequest) -> Result<Vec<IntegrationStep>, AdapterError> {
+        Ok(vec![IntegrationStep::new(
+            "pre-tool-hook",
+            StepAction::InstallHook {
+                name: "PreToolUse".to_string(),
+                scope: request.settings_scope,
+                path: PathBuf::from("/home/dev/.claude/hooks/aasm-pre-tool.sh"),
+            },
+            "install the pre-tool governance hook",
+        )])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IDE-hosted tool — the Copilot shape. No launch command exists.
+// ---------------------------------------------------------------------------
+
+struct IdeHostedTool;
+
+#[async_trait::async_trait]
+impl DevToolIntegration for IdeHostedTool {
+    fn capabilities(&self) -> DevToolCapabilities {
+        // McpDiscovery / McpGovernance are not mentioned at all: this adapter has
+        // not answered the question, which is absent — not a claim either way.
+        DevToolCapabilities::new()
+            .supported(IntegrationCapability::Discovery)
+            .supported(IntegrationCapability::ManagedSettings)
+            .supported(IntegrationCapability::NativeIdeUi)
+            .supported(IntegrationCapability::ToolActionApproval)
+            .unsupported(
+                IntegrationCapability::ManagedLaunch,
+                "GitHub Copilot is a VS Code extension and has no launch command",
+            )
+            .unsupported(
+                IntegrationCapability::ModelPathInterception,
+                "the IDE host owns the network stack; AASM cannot place itself in the model path",
+            )
+    }
+
+    fn detect(&self) -> Option<DevToolInfo> {
+        Some(info(DevToolKind::GitHubCopilot, "1.4.0", GovernanceLevel::L2Enforce))
+    }
+
+    fn version_support(&self) -> VersionSupport {
+        version_support(ToolVersion::new(1, 0, 0))
+    }
+
+    async fn plan_integration(&self, request: &IntegrationRequest) -> Result<IntegrationPlan, AdapterError> {
+        let caps = self.capabilities();
+        let mut plan = IntegrationPlan::new(
+            "ide-plan",
+            request,
+            // No interception mechanism, so the honest ceiling is Integrated
+            // regardless of what was requested.
+            request.effective_target_level().min(ProtectionLevel::Integrated),
+            GovernanceLevel::L2Enforce,
+        )
+        .with_step(
+            IntegrationStep::new(
+                "settings",
+                StepAction::WriteManagedSettings {
+                    scope: request.settings_scope,
+                    path: PathBuf::from("/home/dev/Library/Application Support/Code/User/settings.json"),
+                    managed_keys: vec!["github.copilot.advanced".to_string()],
+                    content_sha256: "sha-vscode".to_string(),
+                    merge: SettingsMerge::MergeManagedKeys,
+                },
+                "merge the managed keys into the IDE host's user settings",
+            )
+            .with_reversal(StepAction::ManageArtifact {
+                operation: ArtifactOperation::Update,
+                path: PathBuf::from("/home/dev/Library/Application Support/Code/User/settings.json"),
+            }),
+        )
+        .with_step(IntegrationStep::new(
+            "register",
+            StepAction::RegisterIdeClient {
+                host: "vscode".to_string(),
+                client_id: "agent-assembly.aasm".to_string(),
+            },
+            "register the AASM extension as the status and approval surface",
+        ));
+
+        for capability in [
+            IntegrationCapability::ManagedLaunch,
+            IntegrationCapability::ModelPathInterception,
+        ] {
+            if let Some(reason) = caps.unsupported_reason(capability) {
+                plan = plan.declaring_unsupported(capability, reason);
+            }
+        }
+
+        Ok(plan)
+    }
+
+    async fn integration_status(
+        &self,
+        _receipt: Option<&IntegrationReceipt>,
+    ) -> Result<IntegrationStatus, AdapterError> {
+        Ok(empty_status(
+            DevToolKind::GitHubCopilot,
+            LifecyclePhase::DetectedNotIntegrated,
+            ProtectionState::Ladder(ProtectionLevel::DetectedNotIntegrated),
+        ))
+    }
+
+    async fn verify_integration(&self, _receipt: &IntegrationReceipt) -> Result<VerificationResult, AdapterError> {
+        Ok(VerificationResult {
+            verified_at_unix_secs: NOW,
+            outcome: VerificationOutcome::PartiallyPassed {
+                missing: vec!["model-path interception is not available for an IDE-hosted tool".to_string()],
+            },
+            evidence: vec![ProtectionEvidence::new(
+                IntegrationCapability::ManagedSettings,
+                EvidenceKind::ReadBack { matches_receipt: true },
+                NOW,
+                "the managed keys read back unchanged",
+            )],
+        })
+    }
+
+    async fn plan_removal(&self, receipt: &IntegrationReceipt) -> Result<RemovalPlan, AdapterError> {
+        Ok(RemovalPlan::new("ide-removal", receipt.tool.clone()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SaaS tool — nothing local to configure, capped at observation.
+// ---------------------------------------------------------------------------
+
+struct SaasTool;
+
+#[async_trait::async_trait]
+impl DevToolIntegration for SaasTool {
+    fn capabilities(&self) -> DevToolCapabilities {
+        DevToolCapabilities::new()
+            .unsupported(IntegrationCapability::Discovery, "no local install to detect")
+            .unsupported(
+                IntegrationCapability::ManagedSettings,
+                "the agent runs in the vendor's tenant; there is no local settings surface",
+            )
+            .unsupported(
+                IntegrationCapability::ManagedLaunch,
+                "the agent is started by the vendor, not by this host",
+            )
+            .supported(IntegrationCapability::HostEnforcement)
+    }
+
+    fn detect(&self) -> Option<DevToolInfo> {
+        None
+    }
+
+    fn version_support(&self) -> VersionSupport {
+        version_support(ToolVersion::new(0, 0, 0))
+    }
+
+    async fn plan_integration(&self, request: &IntegrationRequest) -> Result<IntegrationPlan, AdapterError> {
+        let caps = self.capabilities();
+        let mut plan = IntegrationPlan::new(
+            "saas-plan",
+            request,
+            // Nothing local to install, so nothing above "we can see it" is
+            // claimable.
+            ProtectionLevel::DetectedNotIntegrated,
+            GovernanceLevel::L1Observe,
+        )
+        .with_step(IntegrationStep::new(
+            "connect",
+            StepAction::ConnectLocalRuntime { socket_path: None },
+            "attach egress observation for this tenant's traffic",
+        ))
+        .warn("this tool is observed at the network edge only; nothing is configured on this host");
+
+        for capability in [
+            IntegrationCapability::Discovery,
+            IntegrationCapability::ManagedSettings,
+            IntegrationCapability::ManagedLaunch,
+        ] {
+            if let Some(reason) = caps.unsupported_reason(capability) {
+                plan = plan.declaring_unsupported(capability, reason);
+            }
+        }
+
+        Ok(plan)
+    }
+
+    async fn integration_status(
+        &self,
+        _receipt: Option<&IntegrationReceipt>,
+    ) -> Result<IntegrationStatus, AdapterError> {
+        Ok(empty_status(
+            DevToolKind::Custom("saas-agent".to_string()),
+            LifecyclePhase::NotInstalled,
+            ProtectionState::Ladder(ProtectionLevel::NotInstalled),
+        ))
+    }
+
+    async fn verify_integration(&self, _receipt: &IntegrationReceipt) -> Result<VerificationResult, AdapterError> {
+        Ok(VerificationResult::unverifiable(
+            NOW,
+            "there is nothing on this host to read back",
+        ))
+    }
+
+    async fn plan_removal(&self, receipt: &IntegrationReceipt) -> Result<RemovalPlan, AdapterError> {
+        Ok(RemovalPlan::new("saas-removal", receipt.tool.clone()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+fn request(tool: DevToolKind, profile: ProtectionProfile) -> IntegrationRequest {
+    IntegrationRequest::new(tool, profile, SettingsScope::User)
+}
+
+#[test]
+fn all_three_categories_are_expressible_without_a_single_no_op() {
+    let integrations: Vec<Box<dyn DevToolIntegration>> =
+        vec![Box::new(CliTool), Box::new(IdeHostedTool), Box::new(SaasTool)];
+    for integration in &integrations {
+        assert!(
+            capability_conformance(integration.as_ref()).is_empty(),
+            "every declaration must be backed by the surface that implements it"
+        );
+    }
+}
+
+#[test]
+fn mcp_is_one_optional_capability_among_many() {
+    // One of three tool categories has MCP at all. A design in which "plugin"
+    // means "MCP server" would force the other two into stubs.
+    assert!(CliTool.as_mcp_governed().is_some());
+    assert!(IdeHostedTool.as_mcp_governed().is_none());
+    assert!(SaasTool.as_mcp_governed().is_none());
+
+    // And the two without it declare nothing rather than declaring a lie.
+    assert!(!IdeHostedTool
+        .capabilities()
+        .is_effective(IntegrationCapability::McpGovernance));
+    assert_eq!(
+        IdeHostedTool
+            .capabilities()
+            .unsupported_reason(IntegrationCapability::McpGovernance),
+        None,
+        "an unanswered question must not be reported as an answered one"
+    );
+}
+
+#[test]
+fn a_tool_without_a_launch_command_says_so_instead_of_implementing_one() {
+    assert!(IdeHostedTool.as_launchable().is_none());
+    assert!(SaasTool.as_launchable().is_none());
+
+    let caps = IdeHostedTool.capabilities();
+    let reason = caps
+        .unsupported_reason(IntegrationCapability::ManagedLaunch)
+        .expect("the reason must be available at plan time");
+    assert!(reason.contains("VS Code extension"), "{reason}");
+}
+
+#[tokio::test]
+async fn the_cli_plan_wires_the_ca_the_spike_measured_and_probes_the_result() {
+    let plan = CliTool
+        .plan_integration(&request(DevToolKind::ClaudeCode, ProtectionProfile::Recommended))
+        .await
+        .expect("planning must succeed");
+
+    assert_eq!(plan.validate(), Ok(()));
+    assert_eq!(plan.planned_level, ProtectionLevel::GatewayProtected);
+    assert!(plan.has_interception_probe());
+
+    // The CA is materialised and the launch environment points at that exact
+    // artifact — the combination AAASM-5276 found missing.
+    let ca = PathBuf::from(CliTool::CA_PATH);
+    assert!(plan.affected_artifacts().contains(&ca));
+    let injects_ca = plan.steps.iter().any(|step| {
+        matches!(
+            &step.action,
+            StepAction::InjectLaunchEnvironment { variable, value, .. }
+                if variable == "NODE_EXTRA_CA_CERTS" && value == &EnvValue::ArtifactPath(ca.clone())
+        )
+    });
+    assert!(injects_ca, "the plan must point the tool's runtime at the CA it wrote");
+
+    // Every step that mutates something can be undone. The protection test is
+    // the only step with no reversal, because it changes nothing.
+    for step in plan.steps.iter().filter(|s| !s.action.is_protection_test()) {
+        assert!(step.reversal.is_some(), "step {} has no reversal", step.id);
+    }
+}
+
+#[tokio::test]
+async fn the_ide_plan_is_capped_at_integrated_and_explains_why() {
+    let plan = IdeHostedTool
+        .plan_integration(&request(DevToolKind::GitHubCopilot, ProtectionProfile::Strict))
+        .await
+        .expect("planning must succeed");
+
+    assert_eq!(plan.validate(), Ok(()));
+    assert_eq!(plan.planned_level, ProtectionLevel::Integrated);
+    assert!(!plan.has_interception_probe());
+
+    let reasons: Vec<&str> = plan.unsupported.iter().map(|m| m.reason.as_str()).collect();
+    assert!(
+        reasons.iter().any(|r| r.contains("no launch command")),
+        "the plan must carry the launch reason a user can act on: {reasons:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_saas_plan_touches_nothing_local() {
+    let plan = SaasTool
+        .plan_integration(&request(
+            DevToolKind::Custom("saas-agent".to_string()),
+            ProtectionProfile::Recommended,
+        ))
+        .await
+        .expect("planning must succeed");
+
+    assert_eq!(plan.validate(), Ok(()));
+    assert_eq!(plan.planned_level, ProtectionLevel::DetectedNotIntegrated);
+    assert!(
+        plan.affected_artifacts().is_empty(),
+        "a SaaS tool has no local artifact to touch"
+    );
+    assert!(plan.steps.iter().all(|step| step.action.settings_scope().is_none()));
+    assert_eq!(plan.unsupported.len(), 3);
+}
+
+#[tokio::test]
+async fn observe_only_cannot_plan_protection_for_any_category() {
+    // The profile clamps every category identically: monitoring is never
+    // displayed as protection.
+    let plan = CliTool
+        .plan_integration(&request(DevToolKind::ClaudeCode, ProtectionProfile::ObserveOnly))
+        .await
+        .expect("planning must succeed");
+    assert_eq!(plan.planned_level, ProtectionLevel::Integrated);
+    assert_eq!(plan.validate(), Ok(()));
+}
+
+#[tokio::test]
+async fn a_plan_that_over_claims_is_rejected_before_anything_runs() {
+    // Same steps as the CLI plan, minus the probe: the claim no longer has a
+    // way to be substantiated, and validation says so.
+    let request = request(DevToolKind::ClaudeCode, ProtectionProfile::Recommended);
+    let full = CliTool.plan_integration(&request).await.unwrap();
+    let mut stripped = full.clone();
+    stripped.steps.retain(|step| !step.action.is_protection_test());
+
+    assert_eq!(full.validate(), Ok(()));
+    assert!(matches!(
+        stripped.validate(),
+        Err(PlanError::UnsubstantiatedLevel { .. })
+    ));
+}
+
+#[tokio::test]
+async fn plans_serialize_and_render_for_review() {
+    let plan = CliTool
+        .plan_integration(&request(DevToolKind::ClaudeCode, ProtectionProfile::Recommended))
+        .await
+        .unwrap();
+
+    let json = serde_json::to_string(&plan).expect("plans must be serializable");
+    let restored: IntegrationPlan = serde_json::from_str(&json).expect("plans must round-trip");
+    assert_eq!(restored, plan);
+
+    let rendered = plan.render_dry_run();
+    assert!(
+        rendered.starts_with("integration plan cli-plan for ClaudeCode\n"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("  settings scope: user\n"), "{rendered}");
+    assert!(rendered.contains("planned level: GatewayProtected"), "{rendered}");
+    assert!(rendered.contains("unsupported:\n  - HostEnforcement:"), "{rendered}");
+    // Every step is listed, numbered, with its flags.
+    assert_eq!(rendered.matches("[required").count(), plan.required_steps().count());
+}
+
+#[tokio::test]
+async fn status_reports_a_level_with_its_evidence_not_a_boolean() {
+    let status = CliTool.integration_status(None).await.unwrap();
+    // No receipt: a fully configured-looking host is still not integrated.
+    assert_eq!(status.achieved_level(), ProtectionLevel::DetectedNotIntegrated);
+    assert_eq!(status.phase, LifecyclePhase::DetectedNotIntegrated);
+    // The evidence travels with the claim, split by how it was obtained.
+    assert_eq!(status.exercised_evidence().count(), 1);
+    assert_eq!(status.read_back_evidence().count(), 1);
+}
+
+#[tokio::test]
+async fn verification_distinguishes_exercised_from_read_back_and_from_not_looking() {
+    let receipt = sample_receipt();
+
+    let cli = CliTool.verify_integration(&receipt).await.unwrap();
+    assert!(cli.has_exercised_evidence());
+    assert_eq!(
+        cli.highest_justified_level(NOW, DEFAULT_FRESHNESS_WINDOW_SECS),
+        ProtectionLevel::GatewayProtected
+    );
+
+    let ide = IdeHostedTool.verify_integration(&receipt).await.unwrap();
+    assert!(!ide.has_exercised_evidence());
+    assert_eq!(
+        ide.highest_justified_level(NOW, DEFAULT_FRESHNESS_WINDOW_SECS),
+        ProtectionLevel::Integrated,
+        "read-back evidence alone can never justify a traffic claim"
+    );
+
+    let saas = SaasTool.verify_integration(&receipt).await.unwrap();
+    assert!(matches!(saas.outcome, VerificationOutcome::Unverifiable { .. }));
+    assert_eq!(
+        saas.highest_justified_level(NOW, DEFAULT_FRESHNESS_WINDOW_SECS),
+        ProtectionLevel::PartiallyIntegrated,
+        "\"we did not look\" must not read as \"we looked and it was fine\""
+    );
+}
+
+#[tokio::test]
+async fn removal_is_derived_from_the_receipt_not_re_derived_from_the_host() {
+    let receipt = sample_receipt();
+    let plan = CliTool.plan_removal(&receipt).await.unwrap();
+    assert_eq!(plan.validate(), Ok(()));
+    assert_eq!(plan.steps.len(), receipt.reversal_actions().len());
+    assert!(!plan.steps.is_empty());
+}
+
+#[tokio::test]
+async fn the_launch_surface_carries_the_environment_interception_needs() {
+    let launchable = CliTool.as_launchable().expect("this tool is launchable");
+    let spec = LaunchSpec::new("agent-1")
+        .with_args(vec!["--print".to_string()])
+        .through_proxy("127.0.0.1:8080")
+        .with_env("NODE_EXTRA_CA_CERTS", CliTool::CA_PATH);
+    let command = launchable.build_launch_command(&spec).unwrap();
+
+    let envs: Vec<(String, Option<String>)> = command
+        .get_envs()
+        .map(|(k, v)| {
+            (
+                k.to_string_lossy().into_owned(),
+                v.map(|v| v.to_string_lossy().into_owned()),
+            )
+        })
+        .collect();
+    assert!(envs.contains(&("NODE_EXTRA_CA_CERTS".to_string(), Some(CliTool::CA_PATH.to_string()))));
+    assert!(envs.contains(&("HTTPS_PROXY".to_string(), Some("127.0.0.1:8080".to_string()))));
+}
+
+#[tokio::test]
+async fn the_mcp_surface_authors_a_step_rather_than_applying_one() {
+    let mcp = CliTool.as_mcp_governed().expect("this tool is MCP-governed");
+    assert_eq!(mcp.list_mcp_servers().await.unwrap().len(), 1);
+
+    let step = mcp
+        .plan_mcp_governance(&["filesystem".to_string()], &["shell".to_string()])
+        .unwrap();
+    match &step.action {
+        StepAction::ConfigureMcpServers { allowed, denied } => {
+            assert_eq!(allowed, &["filesystem".to_string()]);
+            assert_eq!(denied, &["shell".to_string()]);
+        }
+        other => panic!("expected ConfigureMcpServers, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn an_incompatible_tool_version_is_reportable_rather_than_silently_degrading() {
+    let supported = CliTool.version_support().supported_tool_versions;
+    let too_old = supported.classify(Some(&ToolVersion::new(1, 9, 0)));
+    assert!(too_old.is_incompatible());
+
+    let state = StateDerivation {
+        detected: true,
+        receipt_present: true,
+        required_steps: 1,
+        required_steps_verified: 1,
+        mismatched_artifacts: &[],
+        compatibility: &too_old,
+        schema_newer_than_core: false,
+        evidence: &[],
+        planned_level: ProtectionLevel::GatewayProtected,
+        now_unix_secs: NOW,
+        freshness_window_secs: DEFAULT_FRESHNESS_WINDOW_SECS,
+    }
+    .derive();
+
+    match state {
+        ProtectionState::Incompatible { remediation, .. } => {
+            assert!(remediation.contains("upgrade"), "{remediation}");
+        }
+        other => panic!("expected Incompatible, got {other:?}"),
+    }
+}
+
+/// A receipt shaped like one the service would have written for the CLI plan.
+fn sample_receipt() -> IntegrationReceipt {
+    use aa_devtool_contract::{ComponentVersions, StepReceipt};
+
+    let step = IntegrationStep::new(
+        "settings",
+        StepAction::WriteManagedSettings {
+            scope: SettingsScope::User,
+            path: PathBuf::from("/home/dev/.claude/settings.json"),
+            managed_keys: vec!["permissions".to_string()],
+            content_sha256: "sha-settings".to_string(),
+            merge: SettingsMerge::MergeManagedKeys,
+        },
+        "write the managed settings block",
+    )
+    .with_reversal(StepAction::ManageArtifact {
+        operation: ArtifactOperation::Remove,
+        path: PathBuf::from("/home/dev/.claude/settings.json"),
+    });
+
+    IntegrationReceipt {
+        schema_version: LIFECYCLE_SCHEMA_VERSION,
+        receipt_id: "r1".to_string(),
+        plan_id: "cli-plan".to_string(),
+        tool: DevToolKind::ClaudeCode,
+        profile: ProtectionProfile::Recommended,
+        settings_scope: SettingsScope::User,
+        applied_at_unix_secs: NOW,
+        versions: ComponentVersions {
+            core: ToolVersion::new(0, 0, 1),
+            adapter: ToolVersion::new(0, 1, 0),
+            lifecycle_schema: LIFECYCLE_SCHEMA_VERSION,
+        },
+        tool_version: Some(ToolVersion::new(2, 1, 220)),
+        steps: vec![StepReceipt::applied(&step, Some("sha-settings".to_string()))],
+        planned_level: ProtectionLevel::GatewayProtected,
+        achieved_level: ProtectionLevel::GatewayProtected,
+        achieved_evidence: vec![ProtectionEvidence::new(
+            IntegrationCapability::ModelPathInterception,
+            EvidenceKind::Exercised {
+                outcome: ExerciseOutcome::Redacted,
+            },
+            NOW,
+            "the synthetic secret was redacted before egress",
+        )],
+        verified_at_unix_secs: Some(NOW),
+    }
+}
+
+#[test]
+fn a_receipt_cannot_claim_protection_its_evidence_does_not_carry() {
+    let good = sample_receipt();
+    assert_eq!(good.validate(), Ok(()));
+
+    // Swap the exercised interception evidence for a routing lever. Nothing else
+    // changes — and the claim becomes unjustifiable.
+    let mut routing = sample_receipt();
+    routing.achieved_evidence = vec![ProtectionEvidence::new(
+        IntegrationCapability::ModelGatewayBaseUrl,
+        EvidenceKind::Exercised {
+            outcome: ExerciseOutcome::Redacted,
+        },
+        NOW,
+        "traffic was redirected to another base URL",
+    )];
+    assert!(routing.validate().is_err());
+}

--- a/aa-devtool/Cargo.toml
+++ b/aa-devtool/Cargo.toml
@@ -25,6 +25,13 @@ tokio = { workspace = true, features = ["full"] }
 [dev-dependencies]
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+# AAASM-5277: `tests/legacy_shim_sample.rs` drives the *unmodified* public
+# sample adapter through the new lifecycle contract via `LegacyAdapterShim`,
+# which is what makes ADR 0030 §7's "nothing breaks on day one" checkable. The
+# test cannot live in the sample crate — the sample staying untouched is the
+# property under test. Dev-only and `publish = false` on both sides, so this
+# adds no crates.io surface.
+aa-devtool-sample-myeditor = { path = "../examples/aa-devtool-sample-myeditor" }
 
 [lints]
 workspace = true

--- a/aa-devtool/tests/legacy_shim_sample.rs
+++ b/aa-devtool/tests/legacy_shim_sample.rs
@@ -1,0 +1,252 @@
+//! The public sample adapter, driven through the new lifecycle contract.
+//!
+//! # What this file is actually asserting
+//!
+//! `examples/aa-devtool-sample-myeditor` is the reference a third-party adapter
+//! author copies, and ADR 0030 §7 promises it keeps compiling and working
+//! **unchanged** when the lifecycle contract lands. That promise is only worth
+//! something if something exercises it, so this file takes the sample exactly as
+//! it is — not a copy, not a variant — and runs the whole lifecycle over it
+//! through [`LegacyAdapterShim`].
+//!
+//! It lives in `aa-devtool` rather than in the sample crate because the sample
+//! must stay untouched: adding a test to it would be a change to the very thing
+//! under test. The sample is a dev-dependency here, so if it stopped compiling
+//! against the contract this file would not build.
+//!
+//! The second thing asserted is that the shim does not *flatter* the sample. A
+//! bridge that let an unmigrated adapter report `Integrated` or claim MCP
+//! governance (which the sample's `apply_mcp_governance` does implement, and
+//! which the shim has no way to distinguish from the `Ok(())` stub the old trait
+//! invites) would defeat the point of the migration. Every assertion below about
+//! what the shim *refuses* to claim is as load-bearing as the ones about what it
+//! produces.
+
+use std::path::PathBuf;
+
+use aa_devtool_contract::{
+    capability_conformance, CapabilityResolution, DevToolAdapter, DevToolIntegration, DevToolKind, EnforcementMode,
+    IntegrationCapability, LegacyAdapterShim, PolicyDocument, ProtectionLevel, ProtectionProfile, ProtectionState,
+    SettingsScope, StepAction, VerificationOutcome, LEGACY_UNSUPPORTED_REASON,
+};
+use aa_devtool_sample_myeditor::{MyEditorAdapter, MYEDITOR_BIN_ENV, MYEDITOR_KIND_ID};
+
+/// The sample's own MCP fixture, resolved from this crate so the sample is
+/// consumed exactly as an out-of-tree adapter author would consume it.
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../examples/aa-devtool-sample-myeditor/fixtures/mcp_servers.json")
+}
+
+fn policy() -> PolicyDocument {
+    PolicyDocument {
+        version: 1,
+        name: "sample".to_string(),
+        rules: Vec::new(),
+        enforcement_mode: EnforcementMode::Enforce,
+    }
+}
+
+fn shim() -> LegacyAdapterShim<MyEditorAdapter> {
+    LegacyAdapterShim::new(
+        DevToolKind::Custom(MYEDITOR_KIND_ID.to_string()),
+        MyEditorAdapter::new(fixture_path()),
+        policy(),
+    )
+}
+
+fn request() -> aa_devtool_contract::IntegrationRequest {
+    aa_devtool_contract::IntegrationRequest::new(
+        DevToolKind::Custom(MYEDITOR_KIND_ID.to_string()),
+        ProtectionProfile::Recommended,
+        SettingsScope::User,
+    )
+}
+
+/// Sets `MYEDITOR_BIN` for the duration of a test so the sample's env-var probe
+/// succeeds. Nextest runs each test in its own process, so this cannot leak into
+/// another test.
+struct DetectableSample;
+
+impl DetectableSample {
+    fn new() -> Self {
+        std::env::set_var(MYEDITOR_BIN_ENV, "/usr/local/bin/myeditor");
+        Self
+    }
+}
+
+impl Drop for DetectableSample {
+    fn drop(&mut self) {
+        std::env::remove_var(MYEDITOR_BIN_ENV);
+    }
+}
+
+#[test]
+fn the_unmodified_sample_satisfies_the_new_contract() {
+    let shim = shim();
+
+    // The legacy trait and the lifecycle trait are both satisfied by the same
+    // object, which is the whole point of an additive migration.
+    let _legacy: &dyn DevToolAdapter = shim.inner();
+    let lifecycle: &dyn DevToolIntegration = &shim;
+    assert!(
+        lifecycle.detect().is_none(),
+        "the sample only detects when its env var is set"
+    );
+
+    // And the shim's declaration is internally consistent.
+    assert!(capability_conformance(lifecycle).is_empty());
+}
+
+#[test]
+fn the_shim_declares_only_discovery_and_managed_settings() {
+    let caps = shim().capabilities();
+    assert!(caps.is_effective(IntegrationCapability::Discovery));
+    assert!(caps.is_effective(IntegrationCapability::ManagedSettings));
+
+    // The sample *does* implement `apply_mcp_governance`, and the shim still
+    // refuses to claim MCP governance: from behind the legacy trait a working
+    // implementation is indistinguishable from the `Ok(())` stub the old
+    // contract invites, and an unverifiable claim is not made.
+    assert_eq!(
+        caps.resolve(IntegrationCapability::McpGovernance),
+        CapabilityResolution::Unsupported
+    );
+    assert_eq!(
+        caps.unsupported_reason(IntegrationCapability::McpGovernance),
+        Some(LEGACY_UNSUPPORTED_REASON)
+    );
+    assert!(!caps.can_intercept_model_path());
+}
+
+#[tokio::test]
+async fn the_sample_yields_a_valid_one_step_plan() {
+    let _detectable = DetectableSample::new();
+    let shim = shim();
+
+    let plan = shim.plan_integration(&request()).await.expect("planning must succeed");
+
+    assert_eq!(plan.validate(), Ok(()));
+    assert_eq!(plan.steps.len(), 1);
+    assert_eq!(plan.settings_scope, SettingsScope::User);
+
+    // The step is the legacy-specific variant, because the old trait renders and
+    // writes in two calls and never discloses where it wrote.
+    match &plan.steps[0].action {
+        StepAction::ApplyLegacyManagedSettings { scope, content_sha256 } => {
+            assert_eq!(*scope, SettingsScope::User);
+            assert_eq!(content_sha256.len(), 64, "a hex SHA-256 of the rendered settings");
+        }
+        other => panic!("expected ApplyLegacyManagedSettings, got {other:?}"),
+    }
+
+    // The digest is of what the sample actually rendered.
+    let rendered = shim
+        .inner()
+        .generate_managed_settings(&policy())
+        .await
+        .expect("the sample renders settings");
+    assert!(rendered.contains("aa-devtool-sample-myeditor"));
+
+    // Capped at Integrated, with the reason visible in the dry run.
+    assert_eq!(plan.planned_level, ProtectionLevel::Integrated);
+    let rendered_plan = plan.render_dry_run();
+    assert!(
+        rendered_plan.contains("apply-legacy-managed-settings"),
+        "{rendered_plan}"
+    );
+    assert!(rendered_plan.contains("warnings:"), "{rendered_plan}");
+    assert!(
+        rendered_plan.contains("cannot intercept the model path"),
+        "{rendered_plan}"
+    );
+}
+
+#[tokio::test]
+async fn a_shimmed_plan_can_never_claim_gateway_protection() {
+    let _detectable = DetectableSample::new();
+
+    // Even when the caller explicitly asks for it.
+    let plan = shim()
+        .plan_integration(&request().requesting_level(ProtectionLevel::HostEnforced))
+        .await
+        .unwrap();
+    assert_eq!(plan.planned_level, ProtectionLevel::Integrated);
+    assert!(!plan.has_interception_probe());
+    assert_eq!(plan.validate(), Ok(()));
+}
+
+#[tokio::test]
+async fn status_without_a_receipt_stops_at_detected_not_integrated() {
+    let _detectable = DetectableSample::new();
+    let status = shim().integration_status(None).await.unwrap();
+
+    assert_eq!(
+        status.state,
+        ProtectionState::Ladder(ProtectionLevel::DetectedNotIntegrated)
+    );
+    assert!(!status.has_exercised_evidence());
+    // The gap is named rather than left silent.
+    let next = status.next_level.expect("the next rung must be reported");
+    assert_eq!(next.level, ProtectionLevel::PartiallyIntegrated);
+    assert_eq!(next.blocked_because, LEGACY_UNSUPPORTED_REASON);
+}
+
+#[tokio::test]
+async fn an_absent_sample_reports_not_installed() {
+    // No env var: the sample's probe fails, and the shim must not invent a state.
+    let status = shim().integration_status(None).await.unwrap();
+    assert_eq!(status.state, ProtectionState::Ladder(ProtectionLevel::NotInstalled));
+}
+
+#[tokio::test]
+async fn verification_reports_unverifiable_rather_than_passed() {
+    let _detectable = DetectableSample::new();
+    let shim = shim();
+    let plan = shim.plan_integration(&request()).await.unwrap();
+
+    let receipt = aa_devtool_contract::IntegrationReceipt {
+        schema_version: aa_devtool_contract::LIFECYCLE_SCHEMA_VERSION,
+        receipt_id: "r1".to_string(),
+        plan_id: plan.plan_id.clone(),
+        tool: DevToolKind::Custom(MYEDITOR_KIND_ID.to_string()),
+        profile: ProtectionProfile::Recommended,
+        settings_scope: SettingsScope::User,
+        applied_at_unix_secs: aa_devtool_contract::now_unix_secs(),
+        versions: shim.version_support().component_versions(),
+        tool_version: Some("0.0.0-sample".parse().unwrap()),
+        steps: vec![aa_devtool_contract::StepReceipt::applied(
+            &plan.steps[0],
+            Some("fingerprint".to_string()),
+        )],
+        planned_level: ProtectionLevel::Integrated,
+        achieved_level: ProtectionLevel::PartiallyIntegrated,
+        achieved_evidence: Vec::new(),
+        verified_at_unix_secs: None,
+    };
+    assert_eq!(receipt.validate(), Ok(()));
+
+    let result = shim.verify_integration(&receipt).await.unwrap();
+    match &result.outcome {
+        VerificationOutcome::Unverifiable { reason } => {
+            assert!(reason.contains(LEGACY_UNSUPPORTED_REASON), "{reason}");
+        }
+        other => panic!("a legacy adapter must not report a verification it did not run: {other:?}"),
+    }
+    assert!(!result.has_exercised_evidence());
+
+    // With a receipt present but nothing verifiable, the ladder rests at
+    // PartiallyIntegrated — never at Integrated.
+    let status = shim.integration_status(Some(&receipt)).await.unwrap();
+    assert_eq!(status.achieved_level(), ProtectionLevel::PartiallyIntegrated);
+
+    // Removal is derived from the receipt, and admits what it cannot undo.
+    let removal = shim.plan_removal(&receipt).await.unwrap();
+    assert_eq!(removal.validate(), Ok(()));
+    assert!(removal.steps.is_empty(), "the sample records no reversal action");
+    assert_eq!(removal.residual.len(), 1);
+    assert!(
+        removal.residual[0].contains("remove it by hand"),
+        "{:?}",
+        removal.residual
+    );
+}

--- a/docs/src/adr/0030-developer-integration-boundaries-and-trust-model.md
+++ b/docs/src/adr/0030-developer-integration-boundaries-and-trust-model.md
@@ -1,6 +1,6 @@
 # ADR 0030: Developer Integration Boundaries, Capability Model & Local Trust Model
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07
 **Ticket**: [AAASM-5275](https://lightning-dust-mite.atlassian.net/browse/AAASM-5275)
 
@@ -936,4 +936,4 @@ that ticket rather than as checks present in this documentation-only change.
 | [ADR 0029](0029-capability-over-permission-derivation.md) | Complements — fail-absent, declared-vs-effective, never fabricate a grant (§3.4) |
 | AAASM-3565 | `aa-devtool-contract` — the compile-time restricted boundary this ADR preserves |
 | AAASM-3579 / AAASM-3581 / AAASM-3585 / AAASM-3666 / AAASM-3922 | The existing `aa-runtime` IPC trust model reused by Decision 5, including the "derived from a public identifier is not a secret" finding |
-| Implementation PRs | TBD |
+| [#TBD](https://github.com/ai-agent-assembly/agent-assembly/pull/TBD) | Implementation PR — [AAASM-5277](https://lightning-dust-mite.atlassian.net/browse/AAASM-5277): the capability model (Decision 3), the protection-state model (Decision 4), the lifecycle traits and `LegacyAdapterShim` (§7). **Ratifies this ADR.** |

--- a/docs/src/adr/0030-developer-integration-boundaries-and-trust-model.md
+++ b/docs/src/adr/0030-developer-integration-boundaries-and-trust-model.md
@@ -936,4 +936,4 @@ that ticket rather than as checks present in this documentation-only change.
 | [ADR 0029](0029-capability-over-permission-derivation.md) | Complements — fail-absent, declared-vs-effective, never fabricate a grant (§3.4) |
 | AAASM-3565 | `aa-devtool-contract` — the compile-time restricted boundary this ADR preserves |
 | AAASM-3579 / AAASM-3581 / AAASM-3585 / AAASM-3666 / AAASM-3922 | The existing `aa-runtime` IPC trust model reused by Decision 5, including the "derived from a public identifier is not a secret" finding |
-| [#TBD](https://github.com/ai-agent-assembly/agent-assembly/pull/TBD) | Implementation PR — [AAASM-5277](https://lightning-dust-mite.atlassian.net/browse/AAASM-5277): the capability model (Decision 3), the protection-state model (Decision 4), the lifecycle traits and `LegacyAdapterShim` (§7). **Ratifies this ADR.** |
+| [#1821](https://github.com/ai-agent-assembly/agent-assembly/pull/1821) | Implementation PR — [AAASM-5277](https://lightning-dust-mite.atlassian.net/browse/AAASM-5277): the capability model (Decision 3), the protection-state model (Decision 4), the lifecycle traits and `LegacyAdapterShim` (§7). **Ratifies this ADR.** |


### PR DESCRIPTION
## Description

Introduces the **capability-based Developer Integration lifecycle contract** specified by
[ADR 0030](https://github.com/ai-agent-assembly/agent-assembly/blob/main/docs/src/adr/0030-developer-integration-boundaries-and-trust-model.md),
and **ratifies that ADR** (`Proposed` → `Accepted`).

New module `aa-core/src/integration/` — `version` · `capability` · `state` · `step` · `plan` ·
`status` · `receipt` · `contract` · `shim`. Types are pure and dependency-light; no persistence, no
transport, no per-tool logic.

**Trait split.** `DevToolIntegration` carries only what *every* tool can answer — capabilities,
detect, version support, plan, status, verify, plan_removal. Mechanism-specific surfaces live behind
`as_mcp_governed()` / `as_launchable()` / `as_hookable()`, defaulting to `None`, so a tool with no MCP
support or no launch command implements **nothing** rather than a misleading stub. `LaunchSpec`
replaces five positional arguments and carries an env map — which is the lever the `NODE_EXTRA_CA_CERTS`
fix needs.

**`apply` is deliberately not on the adapter trait.** ADR 0030 §3.3 assigns plan *authoring* to the
adapter and plan *execution* to the service. The adapter describes; the service mutates. Repair is
drift-driven and belongs to AAASM-5278 for the same reason. (Flagged for reviewers: if the AC's
"install/apply" is read as requiring adapter methods, that reopens ADR 0030 §3.3 rather than being a
gap here.)

### The six Spike findings are implemented, not deferred

Each was measured in AAASM-5276 against the real `claude 2.1.220` binary:

1. **`StepAction` has trust-material and launch-env kinds.** Without them the Spike's highest-value
   fix — injecting `NODE_EXTRA_CA_CERTS` so the MitM CA is accepted — could not be expressed in a plan
   at all.
2. **`ModelPathInterception` and `ModelGatewayBaseUrl` are separate capabilities.** Measured: with
   base-URL redirection the raw secret reached the provider with **no AASM component in the path**.
   The type system now makes it impossible to treat routing as protection.
3. **`SettingsScope` (`User`/`Project`/`Managed`) is explicit** in both plan and receipt, with a
   validation rule — the current adapter picks its target file from the caller's working directory.
4. **`EvidenceKind` separates *exercised* from *read-back*.** Only exercised evidence can raise the
   ladder to `GatewayProtected`.
5. **Protection state is derived on every read, never cached** — the Spike measured ~66 µs from core
   stop to connections refused, so a stored level would keep displaying protection that had ceased.
6. **The receipt records the achieved level *and* its justifying evidence**, so `status` can tell
   "verified once, long ago" from "verified now".

Missing evidence always resolves **downward** — every `Absent` reading, `Unknown` version and stale
timestamp lowers the reported level. That is ADR 0015's fail-closed discipline applied to reporting.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Purely additive. The existing `DevToolAdapter` trait is untouched, and `LegacyAdapterShim` bridges every
existing adapter onto the new contract. **`examples/aa-devtool-sample-myeditor` is byte-identical** to
base — `git diff --exit-code b4ab0f5e..HEAD -- examples/` exits 0 — and is driven through the shim by a
new test, so a regression would fail to compile rather than pass silently.

## Related Issues

- Related Jira ticket: [AAASM-5277](https://lightning-dust-mite.atlassian.net/browse/AAASM-5277)
  (Epic [AAASM-5272](https://lightning-dust-mite.atlassian.net/browse/AAASM-5272))
- Implements + ratifies: **ADR 0030** (AAASM-5275, #1818)
- Consumes: AAASM-5276 Spike findings (#1820)
- Blocks: AAASM-5278, AAASM-5279
- GitHub issues: N/A

## Architectural impact

This is the contract layer of ADR 0030's four-layer model. Adapters (L-C) author plans; the Developer
Integration Service (L-B) executes them. Nothing here performs I/O, stores state, or opens a socket.

**ADR 0030 status moves `Proposed` → `Accepted`** in a dedicated final commit, with the Traceability
table's implementation-PR row filled in.

## Security impact

**⚠️ This PR widens `aa-devtool-contract/src/lib.rs`, which is a CODEOWNERS-gated, security-reviewed
surface. It needs a security reviewer.**

**53 symbols added**, all from `aa_core::integration`: 7 traits/functions, 4 capability types, 7 plan
types, 10 step types, 3 receipt types, 5 status types, 7 state types, 7 version types, 3 shim/misc.
The full per-group rationale is recorded **inline in the file** for the reviewer.

Constraints held:

- Every symbol is a flat value type or a trait — **no `aa_core` module is re-exported**.
- **Nothing from `storage`, `identity`, `config`, or the gateway/token types.**
- **No lifecycle type has a field capable of holding a `PolicyDocument`, a payload, or a credential.**
  `PolicyProfileRef` exists specifically to keep `PolicyDocument` out of plans.
- `core_version` was deliberately **not** exported — it is reachable via
  `VersionSupport::component_versions()`.
- `StateDerivation` is exported so adapters *derive* protection state rather than inventing a second
  derivation — the single-source-of-truth argument that AAASM-5274 had to fix for governance levels.

The contract's purpose is to make over-claiming a compile-time impossibility rather than a review
convention.

## Tests executed

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

**89 new tests** (66 `aa-core` unit, 16 contract, 7 devtool). Contract tests cover **CLI, IDE-hosted and
SaaS-style** capability combinations — an explicit AC:

- `IdeHostedTool` implements no `LaunchableTool` at all and declares
  `ManagedLaunch: Unsupported { "GitHub Copilot is a VS Code extension and has no launch command" }`,
  surfaced in `IntegrationPlan::unsupported` at plan time. It never mentions MCP, so MCP resolves
  *Absent* rather than "unsupported" — the distinction matters.
- `SaasTool` declares Discovery/ManagedSettings/ManagedLaunch unsupported with reasons, implements none
  of the three optional surfaces, plans one non-mutating step, and asserts `affected_artifacts()` is empty.
- `capability_conformance` is clean for all three and **fails** when a declaration has no backing
  surface (tested).

### The central invariant was proved load-bearing — twice

**Mutation (a)** — made `IntegrationCapability::justifies_gateway_protection` also accept
`ModelGatewayBaseUrl`. **6 tests failed across 5 modules and 2 crates:**

```
aa-core  base_url_redirection_cannot_satisfy_model_path_interception
  panicked: assertion failed: !IntegrationCapability::ModelGatewayBaseUrl.justifies_gateway_protection()
aa-core  base_url_redirection_cannot_reach_gateway_protected
  left: GatewayProtected   right: Integrated
aa-core  a_gateway_protected_claim_needs_an_interception_probe
aa-core  a_gateway_protected_claim_needs_exercised_interception_evidence
aa-core  exercised_routing_does_not_lift_the_cap
aa-devtool-contract  a_receipt_cannot_claim_protection_its_evidence_does_not_carry
Summary: 343 tests run: 337 passed, 6 failed
```

**Mutation (b)** — made `is_gateway_protection_grade` accept matching read-back evidence.
**3 tests failed**, including
`gateway_protected_is_unreachable_from_read_back_only_evidence`
(`left: Ladder(GatewayProtected)` vs `right: Degraded { planned: GatewayProtected, achieved: Integrated }`).

Both mutations reverted; tree clean; 343/343 pass.

### Validation — all run and observed

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --all-targets -- -D warnings` | 0 (also `--all-features`, the pre-commit form, on **each of the 15 commits**) |
| `cargo nextest run -p aa-core -p aa-devtool-contract -p aa-devtool -p aa-cli` | **1183 passed, 0 failed** |
| `cargo test -p aa-core --doc` | 9 passed |
| `cargo build --workspace` | 0 |
| `cargo doc --workspace --no-deps` | 0, **zero warnings from any new file** |

## Acceptance-criteria evidence

| AC | Evidence |
|---|---|
| Lifecycle contract supports plan, install/apply, status, verify, repair, remove | `DevToolIntegration` carries plan/status/verify/plan_removal; apply and repair are service verbs per ADR 0030 §3.3 — see the note above |
| Capabilities explicit, MCP optional | `IntegrationCapability` + three-valued `CapabilitySupport`; MCP is one of many, resolving *Absent* when unmentioned |
| Tools without launch or MCP need no misleading no-ops | Optional sub-traits defaulting to `None`; `IdeHostedTool` / `SaasTool` fixtures |
| Plans serializable and suitable for dry-run review | serde round-trip tests + stable dry-run rendering |
| Status returns protection level plus evidence, not booleans | `IntegrationStatus` + `ProtectionEvidence` split exercised/read-back |
| Version compatibility and incompatible-tool reporting | `ToolVersion`, `SupportedToolVersions`, `VersionCompatibility` — incompatibility is terminal, not silently degraded |
| Existing adapters migrate incrementally with documented compatibility | `LegacyAdapterShim` + `LEGACY_UNSUPPORTED_REASON`; sample driven through it by test |
| Unit and contract tests cover CLI, IDE and SaaS capability combinations | `aa-devtool-contract/tests/lifecycle_contract.rs` |
| Contract remains restricted, no unrelated `aa-core` APIs | 53 flat symbols, rationale inline; nothing from storage/identity/config/gateway |
| Reflects approved findings from AAASM-5275 and AAASM-5276 | ADR ratified here; all six Spike findings implemented |

## Known limitations

- **`apply` and `repair` are not adapter methods** — by ADR 0030 §3.3. They are service verbs and land
  with AAASM-5278 (drift/rollback execution) and AAASM-5279 (the API that exposes them).
- No persistence: `IntegrationReceipt` is a value type. Storage, tamper-evidence, schema versioning and
  concurrent-install locking are AAASM-5278's.
- Two **dev-only** dependency edges added: `aa-devtool-contract` → async-trait/serde_json/tokio, and
  `aa-devtool` → `examples/aa-devtool-sample-myeditor`. Both sides are `publish = false`; no runtime
  surface changes.

## Dependencies / stacked PRs

Cut from `main` @ `b4ab0f5e`; independently mergeable.

**AAASM-5278 and AAASM-5279 are stacked on this branch** and will be rebased onto `main` after it merges.

## Documentation and migration impact

ADR 0030 is updated in place (status + traceability). Module-level rustdoc documents the *why* for each
decision, citing the ADR section and the AAASM-5276 measurement that motivated it. Migration for adapter
authors is opt-in: existing `DevToolAdapter` implementations keep working through `LegacyAdapterShim`
with no source changes.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (15 commits, one type/concern each)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5277]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ