### PR TITLE
[AAASM-5278] ✨ (aa-core): Add integration receipt, drift, repair and rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.19",
 ]
 

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -30,6 +30,9 @@ test-utils = []
 [dev-dependencies]
 proptest   = { workspace = true }
 serde_json = { workspace = true }
+# AAASM-5278: the filesystem receipt store's tests assert real permission bits
+# and real atomic renames, so they need a real directory rather than a mock.
+tempfile   = { workspace = true }
 # Self dev-dependency: turns on `serde` + `schemars` for aa-core's own test
 # build so the `types::` property tests and JsonSchema derives compile and run
 # under `cargo nextest run -p aa-core` without making those features default

--- a/aa-core/src/integration/drift.rs
+++ b/aa-core/src/integration/drift.rs
@@ -1,0 +1,754 @@
+//! Drift: what a receipt claims versus what the host actually holds.
+//!
+//! # The distinction the whole model exists for
+//!
+//! Repair is only safe because drift can tell **"the user changed something of
+//! their own"** from **"an AASM-managed value changed"**. Without that split,
+//! repair is either useless (it never writes, because it cannot tell whether a
+//! difference is its business) or dangerous (it writes over whatever it finds).
+//! The split is made by comparing two fingerprints per settings step, not one:
+//!
+//! | Managed projection | Whole document | Classification |
+//! | --- | --- | --- |
+//! | matches receipt | matches receipt | no drift |
+//! | matches receipt | differs | [`UserManagedUnrelatedChange`](DriftKind::UserManagedUnrelatedChange) — reported, never repaired |
+//! | differs | (either) | [`AasmManagedValueChanged`](DriftKind::AasmManagedValueChanged) — repairable |
+//!
+//! Because the fingerprints are canonical (see
+//! [`fingerprint`](super::fingerprint)), a reserialisation that changed only
+//! formatting is *not* drift — which is the honest consequence of the
+//! semantics-exact constraint rather than a hole in it.
+//!
+//! # Failing closed
+//!
+//! Two classifications exist purely so that "we could not tell" never renders as
+//! "nothing is wrong": [`ReceiptCorrupt`](DriftKind::ReceiptCorrupt) and
+//! [`Unobservable`](DriftKind::Unobservable). Neither is repairable. This is ADR
+//! 0015's rule — a resolution failure is observable and never silently permitted
+//! — applied to the one place in the lifecycle where a silent pass would
+//! authorise a write.
+//!
+//! Drift detection is the service's job (ADR 0030 matrix row 10): the adapter
+//! supplies the fingerprint recipe, never the comparison.
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::receipt::{IntegrationReceipt, StepReceipt};
+use super::step::{SettingsMerge, StepAction};
+use super::version::VersionCompatibility;
+
+/// The classes of divergence between a receipt and the host.
+///
+/// The ticket names seven; [`Unobservable`](Self::Unobservable) is the eighth,
+/// added because the honest answer to "the artifact could not be read" is
+/// neither "missing" nor "fine".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum DriftKind {
+    /// The document changed outside every key the receipt claims. AASM-owned
+    /// state is intact; the change is the user's and stays theirs.
+    UserManagedUnrelatedChange,
+    /// A value AASM owns no longer matches the receipt.
+    AasmManagedValueChanged,
+    /// An artifact AASM created is gone.
+    AasmArtifactMissing,
+    /// The detected tool version left the adapter's supported range since the
+    /// receipt was written.
+    ToolVersionIncompatible,
+    /// The tool is still pointed at an endpoint the runtime no longer serves.
+    RuntimeEndpointStale,
+    /// No receipt exists for a tool that appears to be integrated.
+    ReceiptMissing,
+    /// A receipt exists but could not be read or failed its integrity check.
+    ReceiptCorrupt,
+    /// An AASM-owned artifact could not be inspected, so its state is unproven.
+    Unobservable,
+}
+
+impl DriftKind {
+    /// Whether this class says something about **AASM-owned** state.
+    ///
+    /// [`UserManagedUnrelatedChange`](Self::UserManagedUnrelatedChange) is the
+    /// only one that does not, which is why it is the only one that must never
+    /// reach [`ProtectionState::Drifted`](super::ProtectionState::Drifted) as a
+    /// mismatched artifact.
+    pub fn affects_aasm_state(self) -> bool {
+        !matches!(self, Self::UserManagedUnrelatedChange)
+    }
+
+    /// Whether repair can fix this class by rewriting AASM-owned state.
+    ///
+    /// Everything else needs a human, a reinstall, or an upgrade — repair never
+    /// papers over a condition it does not understand.
+    pub fn is_repairable(self) -> bool {
+        matches!(self, Self::AasmManagedValueChanged | Self::AasmArtifactMissing)
+    }
+
+    /// Stable identifier for rendering and for the DI-API's wire form.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UserManagedUnrelatedChange => "user-managed-unrelated-change",
+            Self::AasmManagedValueChanged => "aasm-managed-value-changed",
+            Self::AasmArtifactMissing => "aasm-artifact-missing",
+            Self::ToolVersionIncompatible => "tool-version-incompatible",
+            Self::RuntimeEndpointStale => "runtime-endpoint-stale",
+            Self::ReceiptMissing => "receipt-missing",
+            Self::ReceiptCorrupt => "receipt-corrupt",
+            Self::Unobservable => "unobservable",
+        }
+    }
+}
+
+impl core::fmt::Display for DriftKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One divergence, attributed to the step and artifact it is about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DriftFinding {
+    /// What class of divergence this is.
+    pub kind: DriftKind,
+    /// The step whose receipt this contradicts, when one is identifiable.
+    pub step_id: Option<String>,
+    /// Stable identifier of what diverged, for the user and for
+    /// [`ProtectionState::Drifted`](super::ProtectionState::Drifted).
+    pub artifact: String,
+    /// What to tell the user, in words they can act on.
+    pub detail: String,
+}
+
+impl DriftFinding {
+    /// Construct one finding.
+    pub fn new(kind: DriftKind, artifact: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            kind,
+            step_id: None,
+            artifact: artifact.into(),
+            detail: detail.into(),
+        }
+    }
+
+    /// Attribute the finding to a step.
+    #[must_use]
+    pub fn for_step(mut self, step_id: impl Into<String>) -> Self {
+        self.step_id = Some(step_id.into());
+        self
+    }
+}
+
+/// Everything one drift check found.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DriftReport {
+    /// The findings, in the order they were produced.
+    pub findings: Vec<DriftFinding>,
+}
+
+impl DriftReport {
+    /// A report with nothing in it.
+    pub fn clean() -> Self {
+        Self::default()
+    }
+
+    /// Whether nothing at all diverged — including nothing the user changed.
+    pub fn is_clean(&self) -> bool {
+        self.findings.is_empty()
+    }
+
+    /// Whether AASM-owned state is intact.
+    ///
+    /// Deliberately distinct from [`is_clean`](Self::is_clean): a user who
+    /// edited their own theme has drift in the report and an intact
+    /// integration, and reporting those the same way is what would make the
+    /// product cry wolf.
+    pub fn aasm_state_is_intact(&self) -> bool {
+        !self.findings.iter().any(|f| f.kind.affects_aasm_state())
+    }
+
+    /// The artifact identifiers that belong in
+    /// [`ProtectionState::Drifted`](super::ProtectionState::Drifted) —
+    /// AASM-owned divergences only.
+    pub fn mismatched_artifacts(&self) -> Vec<String> {
+        self.findings
+            .iter()
+            .filter(|f| f.kind.affects_aasm_state())
+            .map(|f| f.artifact.clone())
+            .collect()
+    }
+
+    /// The findings repair is allowed to act on.
+    pub fn repairable(&self) -> impl Iterator<Item = &DriftFinding> {
+        self.findings.iter().filter(|f| f.kind.is_repairable())
+    }
+
+    /// Whether every AASM-affecting finding can be repaired.
+    ///
+    /// `false` when anything needs a human — a corrupt receipt, an
+    /// unreadable artifact, an incompatible tool version — so a caller can
+    /// refuse to start a repair it cannot finish.
+    pub fn is_fully_repairable(&self) -> bool {
+        self.findings
+            .iter()
+            .filter(|f| f.kind.affects_aasm_state())
+            .all(|f| f.kind.is_repairable())
+    }
+
+    /// The step ids repair would rewrite, deduplicated in first-seen order.
+    pub fn repairable_step_ids(&self) -> Vec<String> {
+        let mut seen: Vec<String> = Vec::new();
+        for id in self.repairable().filter_map(|f| f.step_id.clone()) {
+            if !seen.contains(&id) {
+                seen.push(id);
+            }
+        }
+        seen
+    }
+
+    /// Whether any finding is of `kind`.
+    pub fn contains(&self, kind: DriftKind) -> bool {
+        self.findings.iter().any(|f| f.kind == kind)
+    }
+
+    /// Record a finding.
+    pub fn push(&mut self, finding: DriftFinding) {
+        self.findings.push(finding);
+    }
+}
+
+/// What was actually seen on the host for one receipted step.
+///
+/// Produced by the service's executor, never by the client (ADR 0030 forbidden
+/// design 10).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum ArtifactObservation {
+    /// The artifact is there and both fingerprints were taken.
+    Present {
+        /// Fingerprint of the AASM-owned projection as it stands now.
+        managed_fingerprint: String,
+        /// Fingerprint of the whole document as it stands now. `None` for
+        /// artifacts that are not documents with unmanaged content — a CA PEM
+        /// AASM owns outright has nothing unmanaged in it.
+        document_fingerprint: Option<String>,
+    },
+    /// The artifact is not there.
+    Missing,
+    /// The artifact could not be inspected.
+    Unreadable {
+        /// Why, in words a user can act on.
+        reason: String,
+    },
+}
+
+/// One step's observation, paired with the step it is about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ObservedStep {
+    /// The [`StepReceipt::step_id`] this observation is of.
+    pub step_id: String,
+    /// Stable identifier of the artifact, for the report.
+    pub artifact: String,
+    /// What was seen.
+    pub observation: ArtifactObservation,
+}
+
+/// The inputs a drift check is a pure function of.
+///
+/// Holding them in one struct is what makes the classification exhaustively
+/// testable rather than logic spread across the executor's call sites — the same
+/// shape, and for the same reason, as
+/// [`StateDerivation`](super::StateDerivation).
+#[derive(Debug, Clone)]
+pub struct DriftInputs<'a> {
+    /// The receipt to compare against, when one could be loaded.
+    pub receipt: Option<&'a IntegrationReceipt>,
+    /// Set when a receipt file exists but could not be read or failed its
+    /// integrity check. Takes precedence over everything else.
+    pub receipt_unreadable: Option<String>,
+    /// One entry per receipted step the service looked at.
+    pub observed: &'a [ObservedStep],
+    /// How the tool's version now compares to the adapter's supported range.
+    pub compatibility: &'a VersionCompatibility,
+    /// The endpoint the runtime currently serves, when the caller knows it.
+    pub current_endpoint: Option<&'a str>,
+}
+
+impl DriftInputs<'_> {
+    /// Classify every divergence between the receipt and the host.
+    ///
+    /// Rule order is part of the contract:
+    ///
+    /// 1. An unreadable receipt is terminal — with no trustworthy baseline,
+    ///    every further comparison would be against a guess.
+    /// 2. A missing receipt is likewise terminal: there is nothing to diverge
+    ///    from, and the state model already reports that case as
+    ///    [`DetectedNotIntegrated`](super::ProtectionLevel::DetectedNotIntegrated).
+    /// 3. Version and endpoint conditions are recorded before per-step
+    ///    comparisons, because they explain step-level mismatches that would
+    ///    otherwise read as user tampering.
+    /// 4. Each applied step is compared; a step with no observation is
+    ///    [`Unobservable`](DriftKind::Unobservable), never "fine".
+    pub fn classify(&self) -> DriftReport {
+        let mut report = DriftReport::clean();
+
+        if let Some(reason) = &self.receipt_unreadable {
+            report.push(DriftFinding::new(
+                DriftKind::ReceiptCorrupt,
+                "integration receipt",
+                format!("the stored receipt could not be trusted: {reason}"),
+            ));
+            return report;
+        }
+
+        let Some(receipt) = self.receipt else {
+            report.push(DriftFinding::new(
+                DriftKind::ReceiptMissing,
+                "integration receipt",
+                "no receipt records what Agent Assembly applied to this tool, so nothing about it can be verified",
+            ));
+            return report;
+        };
+
+        if let VersionCompatibility::Incompatible {
+            detected, remediation, ..
+        } = self.compatibility
+        {
+            let detected = detected
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "unknown".to_string());
+            report.push(DriftFinding::new(
+                DriftKind::ToolVersionIncompatible,
+                "tool version",
+                format!(
+                    "the tool is now at {detected}, outside the range this integration was applied for: {remediation}"
+                ),
+            ));
+        }
+
+        if let (Some(receipted), Some(current)) = (receipt.receipted_endpoint(), self.current_endpoint) {
+            if receipted != current {
+                report.push(DriftFinding::new(
+                    DriftKind::RuntimeEndpointStale,
+                    "runtime endpoint",
+                    format!("the tool is still pointed at {receipted}, but the runtime now serves {current}"),
+                ));
+            }
+        }
+
+        for step in receipt.steps.iter().filter(|s| s.applied) {
+            let observed = self.observed.iter().find(|o| o.step_id == step.step_id);
+            match observed {
+                None => report.push(
+                    DriftFinding::new(
+                        DriftKind::Unobservable,
+                        artifact_label(step),
+                        "this step was not inspected, so whether Agent Assembly's changes are still in place is unproven",
+                    )
+                    .for_step(&step.step_id),
+                ),
+                Some(observed) => classify_step(step, observed, &mut report),
+            }
+        }
+
+        report
+    }
+}
+
+/// A stable, user-legible name for what a step touched.
+fn artifact_label(step: &StepReceipt) -> String {
+    match step.action.affected_paths().first() {
+        Some(path) => path.display().to_string(),
+        None => format!("{} ({})", step.step_id, step.action.kind()),
+    }
+}
+
+fn classify_step(step: &StepReceipt, observed: &ObservedStep, report: &mut DriftReport) {
+    match &observed.observation {
+        ArtifactObservation::Unreadable { reason } => report.push(
+            DriftFinding::new(
+                DriftKind::Unobservable,
+                observed.artifact.clone(),
+                format!("Agent Assembly could not inspect this artifact: {reason}"),
+            )
+            .for_step(&step.step_id),
+        ),
+        ArtifactObservation::Missing => report.push(
+            DriftFinding::new(
+                DriftKind::AasmArtifactMissing,
+                observed.artifact.clone(),
+                "an artifact Agent Assembly created is no longer there",
+            )
+            .for_step(&step.step_id),
+        ),
+        ArtifactObservation::Present {
+            managed_fingerprint,
+            document_fingerprint,
+        } => {
+            let Some(receipted) = step.fingerprint.as_deref() else {
+                // A step applied without a fingerprint has no baseline. It is
+                // already not counted as verified by the state model; here it is
+                // additionally unprovable rather than assumed intact.
+                report.push(
+                    DriftFinding::new(
+                        DriftKind::Unobservable,
+                        observed.artifact.clone(),
+                        "this step was applied without recording a fingerprint, so it has no baseline to compare against",
+                    )
+                    .for_step(&step.step_id),
+                );
+                return;
+            };
+
+            if receipted != managed_fingerprint {
+                report.push(
+                    DriftFinding::new(
+                        DriftKind::AasmManagedValueChanged,
+                        observed.artifact.clone(),
+                        "a value Agent Assembly manages no longer matches what it applied",
+                    )
+                    .for_step(&step.step_id),
+                );
+                return;
+            }
+
+            // Only a merging write leaves unmanaged content in the file for a
+            // user to change. A `Replace` step owns the file outright, so a
+            // whole-document difference there is not "unrelated".
+            let leaves_unmanaged_content = matches!(
+                &step.action,
+                StepAction::WriteManagedSettings {
+                    merge: SettingsMerge::MergeManagedKeys,
+                    ..
+                }
+            );
+            if !leaves_unmanaged_content {
+                return;
+            }
+
+            if let (Some(receipted_doc), Some(current_doc)) =
+                (step.document_fingerprint.as_deref(), document_fingerprint.as_deref())
+            {
+                if receipted_doc != current_doc {
+                    report.push(
+                        DriftFinding::new(
+                            DriftKind::UserManagedUnrelatedChange,
+                            observed.artifact.clone(),
+                            "this file changed outside the keys Agent Assembly manages; \
+                             the change is yours and repair will not touch it",
+                        )
+                        .for_step(&step.step_id),
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dev_tool::DevToolKind;
+    use crate::integration::plan::ProtectionProfile;
+    use crate::integration::state::ProtectionLevel;
+    use crate::integration::step::{ArtifactOperation, IntegrationStep, SettingsMerge, SettingsScope, StepAction};
+    use crate::integration::version::{
+        core_version, ComponentVersions, SupportedToolVersions, ToolVersion, LIFECYCLE_SCHEMA_VERSION,
+    };
+    use std::path::PathBuf;
+
+    const SETTINGS: &str = "/home/dev/.claude/settings.json";
+
+    fn settings_step() -> IntegrationStep {
+        IntegrationStep::new(
+            "settings",
+            StepAction::WriteManagedSettings {
+                scope: SettingsScope::User,
+                path: PathBuf::from(SETTINGS),
+                managed_keys: vec!["permissions".to_string()],
+                content_sha256: "abc".to_string(),
+                merge: SettingsMerge::MergeManagedKeys,
+            },
+            "write the managed settings block",
+        )
+        .with_reversal(StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: PathBuf::from(SETTINGS),
+        })
+    }
+
+    fn receipt() -> IntegrationReceipt {
+        IntegrationReceipt {
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            receipt_id: "r1".to_string(),
+            plan_id: "p1".to_string(),
+            tool: DevToolKind::ClaudeCode,
+            profile: ProtectionProfile::Recommended,
+            settings_scope: SettingsScope::User,
+            applied_at_unix_secs: 1_000_000,
+            versions: ComponentVersions {
+                core: core_version(),
+                adapter: ToolVersion::new(0, 1, 0),
+                lifecycle_schema: LIFECYCLE_SCHEMA_VERSION,
+            },
+            tool_version: Some(ToolVersion::new(2, 1, 220)),
+            steps: vec![
+                StepReceipt::applied(&settings_step(), Some("sha256:managed".to_string()))
+                    .with_document_fingerprint("sha256:doc"),
+            ],
+            planned_level: ProtectionLevel::Integrated,
+            achieved_level: ProtectionLevel::Integrated,
+            achieved_evidence: vec![],
+            verified_at_unix_secs: Some(1_000_000),
+        }
+    }
+
+    fn compatible() -> VersionCompatibility {
+        VersionCompatibility::Compatible {
+            detected: ToolVersion::new(2, 1, 220),
+        }
+    }
+
+    fn observed(managed: &str, document: &str) -> Vec<ObservedStep> {
+        vec![ObservedStep {
+            step_id: "settings".to_string(),
+            artifact: SETTINGS.to_string(),
+            observation: ArtifactObservation::Present {
+                managed_fingerprint: managed.to_string(),
+                document_fingerprint: Some(document.to_string()),
+            },
+        }]
+    }
+
+    fn inputs<'a>(
+        receipt: &'a IntegrationReceipt,
+        compat: &'a VersionCompatibility,
+        observed: &'a [ObservedStep],
+    ) -> DriftInputs<'a> {
+        DriftInputs {
+            receipt: Some(receipt),
+            receipt_unreadable: None,
+            observed,
+            compatibility: compat,
+            current_endpoint: None,
+        }
+    }
+
+    #[test]
+    fn matching_fingerprints_are_no_drift() {
+        let r = receipt();
+        let compat = compatible();
+        let obs = observed("sha256:managed", "sha256:doc");
+        let report = inputs(&r, &compat, &obs).classify();
+        assert!(report.is_clean(), "{report:?}");
+        assert!(report.aasm_state_is_intact());
+        assert!(report.mismatched_artifacts().is_empty());
+    }
+
+    #[test]
+    fn an_unrelated_user_change_is_reported_but_never_repaired() {
+        let r = receipt();
+        let compat = compatible();
+        // Managed projection unchanged, whole document changed: the user edited
+        // something of their own.
+        let obs = observed("sha256:managed", "sha256:doc-after-user-edit");
+        let report = inputs(&r, &compat, &obs).classify();
+
+        assert!(report.contains(DriftKind::UserManagedUnrelatedChange));
+        assert!(
+            report.aasm_state_is_intact(),
+            "a user's own edit must not be reported as AASM state having drifted"
+        );
+        assert!(
+            report.mismatched_artifacts().is_empty(),
+            "an unrelated user change must never reach ProtectionState::Drifted"
+        );
+        assert_eq!(
+            report.repairable().count(),
+            0,
+            "repair must have nothing to do about a key it does not own"
+        );
+    }
+
+    #[test]
+    fn a_changed_aasm_value_is_drift_and_is_repairable() {
+        let r = receipt();
+        let compat = compatible();
+        let obs = observed("sha256:tampered", "sha256:doc");
+        let report = inputs(&r, &compat, &obs).classify();
+
+        assert!(report.contains(DriftKind::AasmManagedValueChanged));
+        assert!(!report.aasm_state_is_intact());
+        assert_eq!(report.mismatched_artifacts(), vec![SETTINGS.to_string()]);
+        assert_eq!(report.repairable_step_ids(), vec!["settings".to_string()]);
+        assert!(report.is_fully_repairable());
+    }
+
+    #[test]
+    fn a_managed_change_wins_over_a_document_change() {
+        // Both hashes differ. The AASM-owned one is what repair acts on, and
+        // reporting both would double-count one edit.
+        let r = receipt();
+        let compat = compatible();
+        let obs = observed("sha256:tampered", "sha256:also-different");
+        let report = inputs(&r, &compat, &obs).classify();
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].kind, DriftKind::AasmManagedValueChanged);
+    }
+
+    #[test]
+    fn a_missing_artifact_is_drift() {
+        let r = receipt();
+        let compat = compatible();
+        let obs = vec![ObservedStep {
+            step_id: "settings".to_string(),
+            artifact: SETTINGS.to_string(),
+            observation: ArtifactObservation::Missing,
+        }];
+        let report = inputs(&r, &compat, &obs).classify();
+        assert!(report.contains(DriftKind::AasmArtifactMissing));
+        assert!(report.is_fully_repairable());
+    }
+
+    #[test]
+    fn an_unreadable_or_uninspected_artifact_fails_closed() {
+        let r = receipt();
+        let compat = compatible();
+
+        let unreadable = vec![ObservedStep {
+            step_id: "settings".to_string(),
+            artifact: SETTINGS.to_string(),
+            observation: ArtifactObservation::Unreadable {
+                reason: "permission denied".to_string(),
+            },
+        }];
+        let report = inputs(&r, &compat, &unreadable).classify();
+        assert!(report.contains(DriftKind::Unobservable));
+        assert!(!report.aasm_state_is_intact(), "unproven must not read as intact");
+        assert!(
+            !report.is_fully_repairable(),
+            "repair must not run over what it cannot read"
+        );
+
+        // No observation at all is the same answer, not a quiet pass.
+        let report = inputs(&r, &compat, &[]).classify();
+        assert!(report.contains(DriftKind::Unobservable));
+        assert!(!report.aasm_state_is_intact());
+    }
+
+    #[test]
+    fn a_corrupt_receipt_is_terminal_and_pre_empts_every_other_check() {
+        let r = receipt();
+        let compat = compatible();
+        let obs = observed("sha256:tampered", "sha256:doc");
+        let mut i = inputs(&r, &compat, &obs);
+        i.receipt_unreadable = Some("integrity hash does not match".to_string());
+        let report = i.classify();
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].kind, DriftKind::ReceiptCorrupt);
+        assert!(
+            !report.is_fully_repairable(),
+            "a corrupt receipt must never authorise a repair write"
+        );
+    }
+
+    #[test]
+    fn a_missing_receipt_is_its_own_class() {
+        let compat = compatible();
+        let report = DriftInputs {
+            receipt: None,
+            receipt_unreadable: None,
+            observed: &[],
+            compatibility: &compat,
+            current_endpoint: None,
+        }
+        .classify();
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].kind, DriftKind::ReceiptMissing);
+    }
+
+    #[test]
+    fn a_tool_upgrade_out_of_range_is_drift_that_repair_cannot_fix() {
+        let r = receipt();
+        let incompatible = SupportedToolVersions::between(ToolVersion::new(2, 0, 0), ToolVersion::new(3, 0, 0))
+            .classify(Some(&ToolVersion::new(3, 1, 0)));
+        let obs = observed("sha256:managed", "sha256:doc");
+        let report = inputs(&r, &incompatible, &obs).classify();
+
+        assert!(report.contains(DriftKind::ToolVersionIncompatible));
+        assert!(
+            !report.is_fully_repairable(),
+            "rewriting settings does not make an unsupported tool version supported"
+        );
+    }
+
+    #[test]
+    fn a_moved_runtime_endpoint_is_stale_drift() {
+        let mut r = receipt();
+        let endpoint_step = IntegrationStep::new(
+            "base-url",
+            StepAction::ConfigureModelGatewayBaseUrl {
+                scope: SettingsScope::User,
+                variable: "ANTHROPIC_BASE_URL".to_string(),
+                base_url: "http://127.0.0.1:7391".to_string(),
+            },
+            "route at the local gateway",
+        );
+        r.steps.push(StepReceipt::applied(
+            &endpoint_step,
+            Some("sha256:endpoint".to_string()),
+        ));
+
+        let compat = compatible();
+        let mut obs = observed("sha256:managed", "sha256:doc");
+        obs.push(ObservedStep {
+            step_id: "base-url".to_string(),
+            artifact: "ANTHROPIC_BASE_URL".to_string(),
+            observation: ArtifactObservation::Present {
+                managed_fingerprint: "sha256:endpoint".to_string(),
+                document_fingerprint: None,
+            },
+        });
+
+        let mut i = inputs(&r, &compat, &obs);
+        i.current_endpoint = Some("http://127.0.0.1:9999");
+        let report = i.classify();
+        assert!(report.contains(DriftKind::RuntimeEndpointStale));
+        assert!(!report.aasm_state_is_intact());
+    }
+
+    #[test]
+    fn a_replace_step_has_no_unrelated_content_to_drift() {
+        // A file AASM owns outright has nothing unmanaged in it, so a
+        // whole-document difference there is never "the user's own change".
+        let mut r = receipt();
+        r.steps[0].action = StepAction::WriteManagedSettings {
+            scope: SettingsScope::User,
+            path: PathBuf::from(SETTINGS),
+            managed_keys: vec!["permissions".to_string()],
+            content_sha256: "abc".to_string(),
+            merge: SettingsMerge::Replace,
+        };
+        let compat = compatible();
+        let obs = observed("sha256:managed", "sha256:different");
+        let report = inputs(&r, &compat, &obs).classify();
+        assert!(report.is_clean(), "{report:?}");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn drift_reports_round_trip_through_json() {
+        let r = receipt();
+        let compat = compatible();
+        let obs = observed("sha256:tampered", "sha256:doc");
+        let report = inputs(&r, &compat, &obs).classify();
+        let json = serde_json::to_string(&report).unwrap();
+        assert_eq!(serde_json::from_str::<DriftReport>(&json).unwrap(), report);
+    }
+}

--- a/aa-core/src/integration/engine.rs
+++ b/aa-core/src/integration/engine.rs
@@ -1,0 +1,1979 @@
+//! Executing a plan, repairing what drifted, and taking it all back out.
+//!
+//! # This is the service's half of ADR 0030 Decision 2
+//!
+//! Row 2 of the responsibility matrix gives plan *authoring* to the adapter; row
+//! 3 gives plan *execution*, receipt durability, transactionality and idempotence
+//! to the service, and row 10 gives it drift and repair. This module is that
+//! half, expressed against a [`StepExecutor`] so the mutation mechanics stay
+//! swappable — the Claude Code specifics are AAASM-5281's, the transport is
+//! AAASM-5279's, and neither belongs here.
+//!
+//! # Four operations, one invariant
+//!
+//! [`apply`](IntegrationEngine::apply), [`repair`](IntegrationEngine::repair),
+//! [`remove`](IntegrationEngine::remove) and
+//! [`recover`](IntegrationEngine::recover) all hold the same invariant: **never
+//! write over something you cannot account for.** Concretely —
+//!
+//! * apply refuses a plan that does not validate, and rolls itself back if a
+//!   required step fails, so a failed install leaves no half-integration;
+//! * repair refuses to run at all when any AASM-affecting drift finding is not
+//!   repairable, and touches only the steps drift named;
+//! * remove restores from the receipt's prior-state record, and reports a
+//!   residual instead of writing a value it cannot substantiate;
+//! * recover acts on the journal's deterministic rule and escalates rather than
+//!   guessing.
+//!
+//! # Idempotence is checked twice, deliberately
+//!
+//! Once inside the executor — a step whose target already holds exactly what the
+//! step would write reports [`mutated: false`](StepOutcome::mutated) and does not
+//! open the file — and once in [`apply`](IntegrationEngine::apply), which skips
+//! rewriting an unchanged receipt so that reapplying does not even churn the
+//! store's upgrade history. Either check alone would leave "nothing changed"
+//! observably false somewhere.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use super::drift::{ArtifactObservation, DriftInputs, DriftKind, DriftReport, ObservedStep};
+use super::fingerprint::{self, FingerprintError};
+use super::journal::{recovery_action, JournalOperation, OperationJournal, RecoveryAction, StepProgress};
+use super::plan::IntegrationPlan;
+use super::receipt::{IntegrationReceipt, PriorSettingsState, StepReceipt};
+use super::state::ProtectionLevel;
+use super::status::VerificationResult;
+use super::step::{
+    ArtifactOperation, IntegrationStep, SettingsMerge, SettingsScope, StepAction, StepRequirement, TrustMaterialKind,
+};
+use super::store::{ReceiptStore, StoreError};
+use super::version::{ComponentVersions, ToolVersion, VersionCompatibility};
+use crate::dev_tool::DevToolKind;
+
+/// What applying one step left behind.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct StepOutcome {
+    /// Fingerprint of the AASM-owned part of what was written.
+    pub fingerprint: Option<String>,
+    /// Fingerprint of the whole target document, when the step wrote into a
+    /// document that also holds content AASM does not own.
+    pub document_fingerprint: Option<String>,
+    /// What the target held for the claimed keys before the step ran.
+    pub prior_state: Option<PriorSettingsState>,
+    /// Whether anything on the host actually changed.
+    ///
+    /// `false` on a reapply whose target already holds exactly what the step
+    /// would write — the mechanical half of the idempotence guarantee.
+    pub mutated: bool,
+}
+
+/// Why a step could not be applied, reversed or observed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ExecutionError {
+    /// This executor has no mechanism for that action.
+    ///
+    /// An honest refusal rather than a silent success: a no-op that reports
+    /// success would produce a receipt claiming a mutation that never happened.
+    #[error("this executor cannot perform a {kind} step")]
+    Unsupported {
+        /// [`StepAction::kind`] of the action it cannot perform.
+        kind: &'static str,
+    },
+    /// The step needs rendered content the caller did not supply.
+    #[error("no rendered content was supplied for step {step_id:?}")]
+    ContentMissing {
+        /// The step that needed it.
+        step_id: String,
+    },
+    /// The rendered content does not hash to what the plan says it should.
+    ///
+    /// Fail-closed on a plan/content mismatch: the plan is what the user
+    /// reviewed, and writing different bytes than the ones described would make
+    /// the dry run a lie.
+    #[error("the content supplied for step {step_id:?} does not match the digest the plan describes")]
+    ContentMismatch {
+        /// The step whose content did not match.
+        step_id: String,
+    },
+    /// The filesystem refused.
+    #[error("{artifact}: {detail}")]
+    Io {
+        /// What was being touched.
+        artifact: String,
+        /// What went wrong.
+        detail: String,
+    },
+    /// A document could not be parsed or projected.
+    #[error("{artifact}: {source}")]
+    Fingerprint {
+        /// What was being read.
+        artifact: String,
+        /// Why.
+        #[source]
+        source: FingerprintError,
+    },
+}
+
+/// Performs the mutations a plan describes.
+///
+/// Split from the engine so the transactional, receipt-owning half is written
+/// and tested once while the per-mechanism mechanics stay per-tool.
+pub trait StepExecutor {
+    /// Perform `step`'s mutation, or report why it cannot.
+    fn apply(&mut self, step: &IntegrationStep) -> Result<StepOutcome, ExecutionError>;
+
+    /// Undo what `step` recorded. Must be idempotent: recovery may call it for a
+    /// step that was already reversed, and a second call has to succeed.
+    fn reverse(&mut self, step: &StepReceipt) -> Result<(), ExecutionError>;
+
+    /// Look at what the host currently holds for `step`.
+    fn observe(&self, step: &StepReceipt) -> ArtifactObservation;
+}
+
+/// Everything an apply needs that the plan does not carry.
+#[derive(Debug, Clone)]
+pub struct ApplyContext {
+    /// Identifier for the receipt this apply will write.
+    pub receipt_id: String,
+    /// The core, adapter and schema versions doing the work.
+    pub versions: ComponentVersions,
+    /// The tool version detected at apply time, when one was.
+    pub tool_version: Option<ToolVersion>,
+    /// Now, as seconds since the Unix epoch.
+    pub now_unix_secs: u64,
+}
+
+/// What an apply did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyOutcome {
+    /// The receipt that is now stored.
+    pub receipt: IntegrationReceipt,
+    /// Whether anything on the host changed. `false` means the integration was
+    /// already exactly as the plan describes.
+    pub mutated: bool,
+    /// Optional steps that could not be applied, with the reason. Required steps
+    /// never appear here — a failed required step aborts and rolls back.
+    pub skipped: Vec<(String, String)>,
+}
+
+/// What a repair did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepairOutcome {
+    /// The steps that were rewritten.
+    pub repaired_steps: Vec<String>,
+    /// The updated receipt.
+    pub receipt: IntegrationReceipt,
+    /// Drift that was found and deliberately left alone, because it is not
+    /// AASM's to fix.
+    pub preserved_user_changes: Vec<String>,
+}
+
+/// What a removal did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemovalOutcome {
+    /// The steps that were reversed.
+    pub reversed_steps: Vec<String>,
+    /// What could not be undone, in words the user can act on. Non-empty means
+    /// the receipt was **kept**, so status still reports what is left.
+    pub residual: Vec<String>,
+    /// Whether the receipt was deleted.
+    pub receipt_deleted: bool,
+}
+
+/// Why an engine operation could not complete.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EngineError {
+    /// The plan does not validate, so it is not executable.
+    #[error("the plan is not internally consistent: {0}")]
+    InvalidPlan(#[from] super::plan::PlanError),
+    /// A required step failed. The apply rolled itself back.
+    #[error("required step {step_id:?} failed and the apply was rolled back: {source}")]
+    RequiredStepFailed {
+        /// The step that failed.
+        step_id: String,
+        /// Why.
+        #[source]
+        source: ExecutionError,
+    },
+    /// Reversing a step failed.
+    #[error("step {step_id:?} could not be reversed: {source}")]
+    ReversalFailed {
+        /// The step that could not be reversed.
+        step_id: String,
+        /// Why.
+        #[source]
+        source: ExecutionError,
+    },
+    /// There is no receipt to operate on.
+    #[error("no receipt records an integration for this tool at {scope} scope")]
+    NoReceipt {
+        /// The scope that was looked at.
+        scope: SettingsScope,
+    },
+    /// Repair was asked to fix drift it cannot fix.
+    #[error("repair cannot proceed: {detail}")]
+    Unrepairable {
+        /// What blocks it.
+        detail: String,
+    },
+    /// An interrupted operation needs a human.
+    #[error("an interrupted operation could not be recovered automatically: {reason}")]
+    RecoveryEscalated {
+        /// What to tell the user.
+        reason: String,
+    },
+    /// Reading or writing the store failed.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+}
+
+/// Applies, repairs, removes and recovers integrations against a store.
+#[derive(Debug)]
+pub struct IntegrationEngine<E: StepExecutor> {
+    executor: E,
+    store: ReceiptStore,
+}
+
+impl<E: StepExecutor> IntegrationEngine<E> {
+    /// Build an engine over `executor` and `store`.
+    pub fn new(executor: E, store: ReceiptStore) -> Self {
+        Self { executor, store }
+    }
+
+    /// The store this engine reads and writes.
+    pub fn store(&self) -> &ReceiptStore {
+        &self.store
+    }
+
+    /// The executor, for callers that need to inspect what it recorded.
+    pub fn executor(&self) -> &E {
+        &self.executor
+    }
+
+    /// Validate `plan` and render it, without touching anything.
+    ///
+    /// The stability of the rendering is
+    /// [`IntegrationPlan::render_dry_run`]'s contract; what this adds is the
+    /// guarantee that producing it cannot mutate, because it takes `&self` and
+    /// never reaches the executor.
+    pub fn dry_run(&self, plan: &IntegrationPlan) -> Result<String, EngineError> {
+        plan.validate()?;
+        Ok(plan.render_dry_run())
+    }
+
+    /// Execute `plan`, writing a receipt.
+    ///
+    /// Ordering is the journal's: the journal is written before the first
+    /// mutation and deleted after the receipt, so a crash at any point leaves a
+    /// state [`recover`](Self::recover) can resolve without guessing.
+    ///
+    /// A failed **required** step aborts and reverses everything already
+    /// applied — a partially applied required plan is not a weaker integration,
+    /// it is an unknown one. A failed **optional** step is recorded in
+    /// [`ApplyOutcome::skipped`] and the apply continues, because an optional
+    /// step's absence is exactly what
+    /// [`StepRequirement::Optional`] means.
+    pub fn apply(&mut self, plan: &IntegrationPlan, context: &ApplyContext) -> Result<ApplyOutcome, EngineError> {
+        plan.validate()?;
+
+        let existing = self.store.load_receipt(&plan.tool, plan.settings_scope).ok().flatten();
+
+        let mut journal = OperationJournal::starting(
+            JournalOperation::Apply,
+            &plan.plan_id,
+            plan.tool.clone(),
+            plan.settings_scope,
+            context.now_unix_secs,
+            plan.steps.iter().map(|s| s.id.clone()),
+        );
+        self.store.save_journal(&journal)?;
+
+        let mut step_receipts: Vec<StepReceipt> = Vec::with_capacity(plan.steps.len());
+        let mut skipped: Vec<(String, String)> = Vec::new();
+        let mut mutated = false;
+
+        for step in &plan.steps {
+            match self.executor.apply(step) {
+                Ok(outcome) => {
+                    mutated |= outcome.mutated;
+
+                    let mut receipt = StepReceipt::applied(step, outcome.fingerprint);
+                    if let Some(doc) = outcome.document_fingerprint {
+                        receipt = receipt.with_document_fingerprint(doc);
+                    }
+                    if let Some(prior) = outcome.prior_state {
+                        receipt = receipt.with_prior_state(prior);
+                    }
+
+                    // Journalled with its reversal information *before* the next
+                    // step runs: a crash from here on has to be undoable from
+                    // the journal alone, because no receipt exists yet.
+                    journal.record_applied(receipt.clone());
+                    self.store.save_journal(&journal)?;
+                    step_receipts.push(receipt);
+                }
+                Err(source) => {
+                    journal.mark(
+                        &step.id,
+                        StepProgress::Failed {
+                            reason: source.to_string(),
+                        },
+                    );
+                    self.store.save_journal(&journal)?;
+
+                    if step.requirement == StepRequirement::Required {
+                        self.reverse_all(&mut journal, &step_receipts)?;
+                        self.store.delete_journal(&plan.tool, plan.settings_scope)?;
+                        return Err(EngineError::RequiredStepFailed {
+                            step_id: step.id.clone(),
+                            source,
+                        });
+                    }
+                    skipped.push((step.id.clone(), source.to_string()));
+                    step_receipts.push(StepReceipt::not_applied(step));
+                }
+            }
+        }
+
+        // Reusing the prior receipt's id when the plan is the same is what stops
+        // a no-op reapply from registering as an upgrade in the store's history.
+        let receipt_id = match &existing {
+            Some(prior) if prior.plan_id == plan.plan_id => prior.receipt_id.clone(),
+            _ => context.receipt_id.clone(),
+        };
+
+        let mut receipt = IntegrationReceipt {
+            schema_version: super::version::LIFECYCLE_SCHEMA_VERSION,
+            receipt_id,
+            plan_id: plan.plan_id.clone(),
+            tool: plan.tool.clone(),
+            profile: plan.profile,
+            settings_scope: plan.settings_scope,
+            applied_at_unix_secs: context.now_unix_secs,
+            versions: context.versions.clone(),
+            tool_version: context.tool_version.clone(),
+            steps: step_receipts,
+            planned_level: plan.planned_level,
+            achieved_level: ProtectionLevel::PartiallyIntegrated,
+            achieved_evidence: Vec::new(),
+            verified_at_unix_secs: None,
+        };
+        receipt.achieved_level = configuration_level(&receipt, plan.planned_level);
+
+        // A reapply that changed nothing keeps the receipt it already had,
+        // including its `applied_at` and its verification evidence: rewriting
+        // them would make an operation that mutated nothing look like a fresh
+        // install and would discard a verification that is still valid.
+        if !mutated {
+            if let Some(prior) = &existing {
+                if prior.plan_id == plan.plan_id && receipts_agree(prior, &receipt) {
+                    self.store.delete_journal(&plan.tool, plan.settings_scope)?;
+                    return Ok(ApplyOutcome {
+                        receipt: prior.clone(),
+                        mutated: false,
+                        skipped,
+                    });
+                }
+            }
+        }
+
+        self.store.save_receipt(&receipt)?;
+        self.store.delete_journal(&plan.tool, plan.settings_scope)?;
+
+        Ok(ApplyOutcome {
+            receipt,
+            mutated,
+            skipped,
+        })
+    }
+
+    /// Observe every applied step and classify what diverged.
+    pub fn detect_drift(
+        &self,
+        tool: &DevToolKind,
+        scope: SettingsScope,
+        compatibility: &VersionCompatibility,
+        current_endpoint: Option<&str>,
+    ) -> DriftReport {
+        let (receipt, unreadable) = match self.store.load_receipt(tool, scope) {
+            Ok(receipt) => (receipt, None),
+            Err(err) => {
+                let reason = err.as_untrustworthy_receipt_reason().unwrap_or_else(|| err.to_string());
+                (None, Some(reason))
+            }
+        };
+
+        let observed: Vec<ObservedStep> = receipt
+            .as_ref()
+            .map(|r| {
+                r.steps
+                    .iter()
+                    .filter(|s| s.applied)
+                    .map(|s| ObservedStep {
+                        step_id: s.step_id.clone(),
+                        artifact: artifact_label(s),
+                        observation: self.executor.observe(s),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        DriftInputs {
+            receipt: receipt.as_ref(),
+            receipt_unreadable: unreadable,
+            observed: &observed,
+            compatibility,
+            current_endpoint,
+        }
+        .classify()
+    }
+
+    /// Rewrite the AASM-owned state `report` found to have drifted, and nothing
+    /// else.
+    ///
+    /// Refuses outright when any AASM-affecting finding is not repairable: a
+    /// repair that fixed the settings while the receipt was corrupt, or while
+    /// half the artifacts were unreadable, would report success for a state it
+    /// never established.
+    pub fn repair(
+        &mut self,
+        plan: &IntegrationPlan,
+        report: &DriftReport,
+        now_unix_secs: u64,
+    ) -> Result<RepairOutcome, EngineError> {
+        if !report.is_fully_repairable() {
+            let blocking: Vec<&str> = report
+                .findings
+                .iter()
+                .filter(|f| f.kind.affects_aasm_state() && !f.kind.is_repairable())
+                .map(|f| f.kind.as_str())
+                .collect();
+            return Err(EngineError::Unrepairable {
+                detail: format!("these conditions need attention first: {}", blocking.join(", ")),
+            });
+        }
+
+        let mut receipt = self
+            .store
+            .load_receipt(&plan.tool, plan.settings_scope)?
+            .ok_or(EngineError::NoReceipt {
+                scope: plan.settings_scope,
+            })?;
+
+        let target_ids = report.repairable_step_ids();
+        let mut repaired = Vec::new();
+
+        for step in plan.steps.iter().filter(|s| target_ids.contains(&s.id)) {
+            let outcome = self
+                .executor
+                .apply(step)
+                .map_err(|source| EngineError::RequiredStepFailed {
+                    step_id: step.id.clone(),
+                    source,
+                })?;
+
+            // The prior state captured at *install* time is what removal must
+            // restore, so a repair records the new fingerprints and leaves the
+            // original prior-state snapshot alone. Overwriting it would make
+            // removal restore the tampered values rather than the user's own.
+            if let Some(existing) = receipt.steps.iter_mut().find(|s| s.step_id == step.id) {
+                existing.applied = true;
+                existing.fingerprint = outcome.fingerprint;
+                existing.document_fingerprint = outcome.document_fingerprint;
+            }
+            repaired.push(step.id.clone());
+        }
+
+        receipt.applied_at_unix_secs = now_unix_secs;
+        receipt.achieved_level = configuration_level(&receipt, plan.planned_level);
+        // A repair re-established configuration; it did not re-exercise traffic.
+        // Dropping the old evidence is what stops a repaired integration from
+        // inheriting a `GatewayProtected` claim nothing has re-substantiated.
+        receipt.achieved_evidence.clear();
+        receipt.verified_at_unix_secs = None;
+        self.store.save_receipt(&receipt)?;
+
+        Ok(RepairOutcome {
+            repaired_steps: repaired,
+            receipt,
+            preserved_user_changes: report
+                .findings
+                .iter()
+                .filter(|f| f.kind == DriftKind::UserManagedUnrelatedChange)
+                .map(|f| f.artifact.clone())
+                .collect(),
+        })
+    }
+
+    /// Record a verification pass against the stored receipt.
+    ///
+    /// Split from [`apply`](Self::apply) because verification is a *later*
+    /// observation: the receipt records the level it can currently justify and
+    /// the evidence for it, which is what lets a status read tell "verified once,
+    /// long ago" from "verified now".
+    pub fn record_verification(
+        &mut self,
+        tool: &DevToolKind,
+        scope: SettingsScope,
+        result: &VerificationResult,
+        freshness_window_secs: u64,
+    ) -> Result<IntegrationReceipt, EngineError> {
+        let mut receipt = self
+            .store
+            .load_receipt(tool, scope)?
+            .ok_or(EngineError::NoReceipt { scope })?;
+
+        let justified = result.highest_justified_level(result.verified_at_unix_secs, freshness_window_secs);
+        receipt.achieved_level = justified
+            .min(receipt.planned_level)
+            .min(receipt.profile.max_reportable_level());
+        receipt.achieved_evidence.clone_from(&result.evidence);
+        receipt.verified_at_unix_secs = Some(result.verified_at_unix_secs);
+        self.store.save_receipt(&receipt)?;
+        Ok(receipt)
+    }
+
+    /// Reverse everything the receipt records as applied and delete the receipt.
+    ///
+    /// Steps whose restoration the receipt cannot prove are reported in
+    /// [`RemovalOutcome::residual`], and their presence keeps the receipt on
+    /// disk: a user whose settings could not be fully restored must still be
+    /// able to see what Agent Assembly left behind.
+    pub fn remove(&mut self, tool: &DevToolKind, scope: SettingsScope) -> Result<RemovalOutcome, EngineError> {
+        let receipt = self
+            .store
+            .load_receipt(tool, scope)?
+            .ok_or(EngineError::NoReceipt { scope })?;
+
+        let applied: Vec<StepReceipt> = receipt.steps.iter().filter(|s| s.applied).cloned().collect();
+        let mut journal = OperationJournal::starting(
+            JournalOperation::Remove,
+            &receipt.plan_id,
+            tool.clone(),
+            scope,
+            receipt.applied_at_unix_secs,
+            applied.iter().map(|s| s.step_id.clone()),
+        );
+        self.store.save_journal(&journal)?;
+
+        let mut residual: Vec<String> = receipt
+            .unrestorable_steps()
+            .iter()
+            .map(|s| unrestorable_reason(s))
+            .collect();
+
+        let reversed = self.reverse_all(&mut journal, &applied)?;
+
+        let receipt_deleted = residual.is_empty();
+        if receipt_deleted {
+            self.store.delete_receipt(tool, scope)?;
+        } else {
+            residual.push(
+                "the integration receipt was kept so you can see what remains; remove it by hand once you are done"
+                    .to_string(),
+            );
+        }
+        self.store.delete_journal(tool, scope)?;
+
+        Ok(RemovalOutcome {
+            reversed_steps: reversed,
+            residual,
+            receipt_deleted,
+        })
+    }
+
+    /// Resolve an interrupted apply or remove.
+    ///
+    /// Safe to call at every start and safe to call twice — the journal's rule
+    /// is a pure function of two facts, and every reversal it asks for is
+    /// idempotent.
+    pub fn recover(&mut self, tool: &DevToolKind, scope: SettingsScope) -> Result<RecoveryAction, EngineError> {
+        let journal = self.store.load_journal(tool, scope)?;
+        let action = recovery_action(journal.as_ref(), self.store.receipt_exists(tool, scope));
+
+        match &action {
+            RecoveryAction::Nothing => {}
+            RecoveryAction::ClearStaleJournal => {
+                self.store.delete_journal(tool, scope)?;
+            }
+            RecoveryAction::Escalate { reason } => {
+                return Err(EngineError::RecoveryEscalated { reason: reason.clone() })
+            }
+            RecoveryAction::RollBackInterruptedApply { step_ids } => {
+                // No receipt exists — that is what makes this an interrupted
+                // apply — so the journal's own per-step outcomes are the only
+                // reversal information there is.
+                let mut journal = journal.expect("a rollback action implies a journal");
+                let steps: Vec<StepReceipt> = journal
+                    .applied_outcomes()
+                    .into_iter()
+                    .filter(|s| step_ids.contains(&s.step_id))
+                    .collect();
+                self.reverse_all(&mut journal, &steps)?;
+                self.store.delete_journal(tool, scope)?;
+            }
+            RecoveryAction::ResumeInterruptedRemove { step_ids } => {
+                // A removal still has its receipt, which is the durable home for
+                // the prior state each reversal restores.
+                let receipt = self
+                    .store
+                    .load_receipt(tool, scope)?
+                    .ok_or(EngineError::NoReceipt { scope })?;
+                let steps: Vec<StepReceipt> = receipt
+                    .steps
+                    .iter()
+                    .filter(|s| s.applied && step_ids.contains(&s.step_id))
+                    .cloned()
+                    .collect();
+
+                let mut journal = journal.expect("a resume action implies a journal");
+                self.reverse_all(&mut journal, &steps)?;
+                self.store.delete_receipt(tool, scope)?;
+                self.store.delete_journal(tool, scope)?;
+            }
+        }
+
+        Ok(action)
+    }
+
+    /// Reverse `steps` in reverse application order, journalling each one.
+    fn reverse_all(
+        &mut self,
+        journal: &mut OperationJournal,
+        steps: &[StepReceipt],
+    ) -> Result<Vec<String>, EngineError> {
+        let mut reversed = Vec::new();
+        for step in steps.iter().rev() {
+            match self.executor.reverse(step) {
+                Ok(()) => {
+                    journal.mark(&step.step_id, StepProgress::Reversed);
+                    reversed.push(step.step_id.clone());
+                }
+                Err(source) => {
+                    journal.mark(
+                        &step.step_id,
+                        StepProgress::Failed {
+                            reason: source.to_string(),
+                        },
+                    );
+                    self.store.save_journal(journal)?;
+                    return Err(EngineError::ReversalFailed {
+                        step_id: step.step_id.clone(),
+                        source,
+                    });
+                }
+            }
+            self.store.save_journal(journal)?;
+        }
+        Ok(reversed)
+    }
+}
+
+/// The highest level configuration alone can justify, capped by the plan.
+///
+/// Never above [`Integrated`](ProtectionLevel::Integrated): reaching
+/// `GatewayProtected` needs traffic that was exercised and adjudicated, which an
+/// apply does not do.
+fn configuration_level(receipt: &IntegrationReceipt, planned: ProtectionLevel) -> ProtectionLevel {
+    let required = receipt.required_steps();
+    let level = if required > 0 && receipt.verified_required_steps() >= required {
+        ProtectionLevel::Integrated
+    } else {
+        ProtectionLevel::PartiallyIntegrated
+    };
+    level.min(planned).min(receipt.profile.max_reportable_level())
+}
+
+/// Whether a freshly computed receipt describes the same host state as a stored
+/// one, ignoring the fields that move on every run.
+fn receipts_agree(stored: &IntegrationReceipt, fresh: &IntegrationReceipt) -> bool {
+    stored.steps.len() == fresh.steps.len()
+        && stored
+            .steps
+            .iter()
+            .zip(&fresh.steps)
+            .all(|(a, b)| a.step_id == b.step_id && a.applied == b.applied && a.fingerprint == b.fingerprint)
+}
+
+fn unrestorable_reason(step: &StepReceipt) -> String {
+    match &step.prior_state {
+        Some(prior) if !prior.withheld_keys.is_empty() => format!(
+            "{}: the previous value of {} was not stored because it looked like a credential, \
+             so it could not be restored",
+            artifact_label(step),
+            prior.withheld_keys.join(", ")
+        ),
+        _ => format!("{}: this step recorded no way to undo it", artifact_label(step)),
+    }
+}
+
+fn artifact_label(step: &StepReceipt) -> String {
+    match step.action.affected_paths().first() {
+        Some(path) => path.display().to_string(),
+        None => format!("{} ({})", step.step_id, step.action.kind()),
+    }
+}
+
+/// A [`StepExecutor`] for the plan steps that are pure filesystem writes.
+///
+/// # What it does and does not cover
+///
+/// Managed settings, trust material and owned artifacts — every step whose
+/// mutation is "put these bytes at this path" — are handled here, once, with the
+/// prior-state capture and idempotence check that receipts and drift depend on.
+/// Launch-environment injection, proxy variables, MCP lists, IDE registration
+/// and runtime connection are **not**: each needs mechanism the filesystem
+/// cannot supply, and each belongs to the adapter that knows its tool
+/// (AAASM-5281). Those report [`ExecutionError::Unsupported`] rather than
+/// succeeding quietly, so a receipt can never claim a mutation nothing performed.
+///
+/// # Why content is injected rather than read from the plan
+///
+/// A [`StepAction`] carries the *digest* of what will be written, not the bytes:
+/// the adapter renders the content and the service writes it (ADR 0030 matrix
+/// rows 2 and 3). This executor therefore takes the rendered content by step id
+/// and checks it against the digest the plan showed the user before writing
+/// anything.
+#[derive(Debug, Default)]
+pub struct FilesystemExecutor {
+    rendered: BTreeMap<String, String>,
+}
+
+impl FilesystemExecutor {
+    /// An executor with no content, for plans that only remove things.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Supply the content a step will write.
+    #[must_use]
+    pub fn with_content(mut self, step_id: impl Into<String>, content: impl Into<String>) -> Self {
+        self.rendered.insert(step_id.into(), content.into());
+        self
+    }
+
+    fn content_for(&self, step_id: &str, expected_sha256: &str) -> Result<&str, ExecutionError> {
+        let content = self
+            .rendered
+            .get(step_id)
+            .map(String::as_str)
+            .ok_or_else(|| ExecutionError::ContentMissing {
+                step_id: step_id.to_string(),
+            })?;
+
+        // Accept a digest over either the raw rendering or its canonical form:
+        // an adapter hashes what it produced, and the C3 constraint means the
+        // canonical form is what actually survives the write.
+        let matches = fingerprint::sha256_hex(content) == expected_sha256
+            || fingerprint::canonicalize(content).is_ok_and(|c| fingerprint::sha256_hex(&c) == expected_sha256);
+        if !matches {
+            return Err(ExecutionError::ContentMismatch {
+                step_id: step_id.to_string(),
+            });
+        }
+        Ok(content)
+    }
+
+    fn apply_settings(
+        &self,
+        step_id: &str,
+        path: &Path,
+        managed_keys: &[String],
+        content: &str,
+        merge: SettingsMerge,
+    ) -> Result<StepOutcome, ExecutionError> {
+        let label = path.display().to_string();
+        let current = read_document(path)?;
+
+        let fp = |source| ExecutionError::Fingerprint {
+            artifact: label.clone(),
+            source,
+        };
+
+        let prior_values = fingerprint::managed_projection(&current, managed_keys).map_err(fp)?;
+        let (safe_values, withheld_keys) = fingerprint::screen_managed_values(&prior_values).map_err(fp)?;
+        let prior_state = PriorSettingsState {
+            managed_values_json: safe_values,
+            absent_keys: fingerprint::absent_managed_keys(&current, managed_keys).map_err(fp)?,
+            withheld_keys,
+            document_fingerprint: fingerprint::document_fingerprint(&current).map_err(fp)?,
+        };
+
+        let next = match merge {
+            SettingsMerge::MergeManagedKeys => {
+                fingerprint::merge_managed_keys(&current, content, managed_keys).map_err(fp)?
+            }
+            SettingsMerge::Replace => fingerprint::canonicalize(content).map_err(fp)?,
+        };
+
+        let unchanged = fingerprint::canonicalize(&current).map_err(fp)? == next && path.exists();
+        if !unchanged {
+            write_preserving_mode(path, &next, step_id)?;
+        }
+
+        Ok(StepOutcome {
+            fingerprint: Some(fingerprint::managed_fingerprint(&next, managed_keys).map_err(fp)?),
+            document_fingerprint: Some(fingerprint::document_fingerprint(&next).map_err(fp)?),
+            prior_state: Some(prior_state),
+            mutated: !unchanged,
+        })
+    }
+
+    fn write_blob(&self, step_id: &str, path: &Path, content: &str) -> Result<StepOutcome, ExecutionError> {
+        let unchanged = std::fs::read_to_string(path).is_ok_and(|existing| existing == content);
+        if !unchanged {
+            write_preserving_mode(path, content, step_id)?;
+        }
+        Ok(StepOutcome {
+            fingerprint: Some(fingerprint::fingerprint_raw(content)),
+            document_fingerprint: None,
+            prior_state: None,
+            mutated: !unchanged,
+        })
+    }
+}
+
+impl StepExecutor for FilesystemExecutor {
+    fn apply(&mut self, step: &IntegrationStep) -> Result<StepOutcome, ExecutionError> {
+        match &step.action {
+            StepAction::WriteManagedSettings {
+                path,
+                managed_keys,
+                content_sha256,
+                merge,
+                ..
+            } => {
+                let content = self.content_for(&step.id, content_sha256)?.to_string();
+                self.apply_settings(&step.id, path, managed_keys, &content, *merge)
+            }
+            StepAction::MaterialiseTrustMaterial {
+                kind,
+                path,
+                content_sha256,
+            } => {
+                if *kind == TrustMaterialKind::ProxyCaTrustStoreAnchor {
+                    // A trust-store anchor is a privileged host change, not a
+                    // file write, and ADR 0030 §6.6 requires it to be its own
+                    // individually consented mechanism. Refusing here is what
+                    // stops it being smuggled in as an ordinary artifact.
+                    return Err(ExecutionError::Unsupported {
+                        kind: "trust-store-anchor",
+                    });
+                }
+                let content = self.content_for(&step.id, content_sha256)?.to_string();
+                self.write_blob(&step.id, path, &content)
+            }
+            StepAction::ManageArtifact { operation, path } => match operation {
+                ArtifactOperation::Remove => {
+                    let existed = path.exists();
+                    remove_file(path)?;
+                    Ok(StepOutcome {
+                        mutated: existed,
+                        ..StepOutcome::default()
+                    })
+                }
+                ArtifactOperation::Create | ArtifactOperation::Update => {
+                    let content =
+                        self.rendered
+                            .get(&step.id)
+                            .cloned()
+                            .ok_or_else(|| ExecutionError::ContentMissing {
+                                step_id: step.id.clone(),
+                            })?;
+                    self.write_blob(&step.id, path, &content)
+                }
+            },
+            StepAction::RunProtectionTest { .. } => {
+                // A probe mutates nothing and produces no fingerprint. Its
+                // result is evidence, adjudicated by the core, and it reaches
+                // the receipt through `record_verification`, never through here.
+                Ok(StepOutcome::default())
+            }
+            other => Err(ExecutionError::Unsupported { kind: other.kind() }),
+        }
+    }
+
+    fn reverse(&mut self, step: &StepReceipt) -> Result<(), ExecutionError> {
+        if let (Some(prior), StepAction::WriteManagedSettings { path, .. }) = (&step.prior_state, &step.action) {
+            let label = path.display().to_string();
+            let fp = |source| ExecutionError::Fingerprint {
+                artifact: label.clone(),
+                source,
+            };
+
+            if !path.exists() {
+                // Already gone. Removal has to be safe to run twice.
+                return Ok(());
+            }
+            let current = read_document(path)?;
+            let restored = fingerprint::restore_managed_keys(&current, &prior.managed_values_json, &prior.absent_keys)
+                .map_err(fp)?;
+
+            // A document left holding nothing but what AASM added is a file AASM
+            // created; leaving an empty `{}` behind would be an artifact the
+            // user never had.
+            if restored == "{}" && prior.document_fingerprint == fingerprint::fingerprint_raw("{}") {
+                return remove_file(path);
+            }
+            write_preserving_mode(path, &restored, &step.step_id)?;
+            // Deliberately not withheld keys: they were never stored, so there
+            // is nothing to write back, and `unrestorable_steps` has already
+            // told the user.
+            return Ok(());
+        }
+
+        match &step.reversal {
+            Some(StepAction::ManageArtifact {
+                operation: ArtifactOperation::Remove,
+                path,
+            }) => remove_file(path),
+            Some(other) => Err(ExecutionError::Unsupported { kind: other.kind() }),
+            None => match &step.action {
+                // A step that mutated nothing needs no reversal.
+                StepAction::RunProtectionTest { .. } => Ok(()),
+                other => Err(ExecutionError::Unsupported { kind: other.kind() }),
+            },
+        }
+    }
+
+    fn observe(&self, step: &StepReceipt) -> ArtifactObservation {
+        match &step.action {
+            StepAction::WriteManagedSettings { path, managed_keys, .. } => {
+                if !path.exists() {
+                    return ArtifactObservation::Missing;
+                }
+                let raw = match std::fs::read_to_string(path) {
+                    Ok(raw) => raw,
+                    Err(e) => return ArtifactObservation::Unreadable { reason: e.to_string() },
+                };
+                match (
+                    fingerprint::managed_fingerprint(&raw, managed_keys),
+                    fingerprint::document_fingerprint(&raw),
+                ) {
+                    (Ok(managed_fingerprint), Ok(document)) => ArtifactObservation::Present {
+                        managed_fingerprint,
+                        document_fingerprint: Some(document),
+                    },
+                    (Err(e), _) | (_, Err(e)) => ArtifactObservation::Unreadable { reason: e.to_string() },
+                }
+            }
+            StepAction::MaterialiseTrustMaterial { path, .. } | StepAction::ManageArtifact { path, .. } => {
+                match std::fs::read_to_string(path) {
+                    Ok(raw) => ArtifactObservation::Present {
+                        managed_fingerprint: fingerprint::fingerprint_raw(&raw),
+                        document_fingerprint: None,
+                    },
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => ArtifactObservation::Missing,
+                    Err(e) => ArtifactObservation::Unreadable { reason: e.to_string() },
+                }
+            }
+            other => ArtifactObservation::Unreadable {
+                reason: format!("a {} step has no filesystem state to inspect", other.kind()),
+            },
+        }
+    }
+}
+
+/// Read a JSON document, treating an absent file as an empty object.
+///
+/// An absent settings file and an empty one mean the same thing to a merge, and
+/// collapsing them here is what makes the first install and every reinstall take
+/// the same code path.
+fn read_document(path: &Path) -> Result<String, ExecutionError> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) if raw.trim().is_empty() => Ok("{}".to_string()),
+        Ok(raw) => Ok(raw),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok("{}".to_string()),
+        Err(e) => Err(ExecutionError::Io {
+            artifact: path.display().to_string(),
+            detail: e.to_string(),
+        }),
+    }
+}
+
+/// Write `body` to `path` atomically, keeping whatever mode the file already had.
+///
+/// The tool's own settings file belongs to the user, so its permissions are
+/// theirs to choose; AASM's own state is the thing this codebase pins to `0600`
+/// (see [`ReceiptStore`](super::ReceiptStore)). Writing through a temporary file
+/// and renaming keeps a crash mid-write from truncating a file the user needs.
+fn write_preserving_mode(path: &Path, body: &str, step_id: &str) -> Result<(), ExecutionError> {
+    let io = |detail: String| ExecutionError::Io {
+        artifact: format!("{} (step {step_id})", path.display()),
+        detail,
+    };
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| io(e.to_string()))?;
+    }
+
+    #[cfg(unix)]
+    let existing_mode = {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path).ok().map(|m| m.permissions().mode())
+    };
+
+    let tmp = path.with_extension("aasm-tmp");
+    std::fs::write(&tmp, body).map_err(|e| io(e.to_string()))?;
+
+    #[cfg(unix)]
+    if let Some(mode) = existing_mode {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(mode)).map_err(|e| io(e.to_string()))?;
+    }
+
+    std::fs::rename(&tmp, path).map_err(|e| io(e.to_string()))
+}
+
+fn remove_file(path: &Path) -> Result<(), ExecutionError> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(ExecutionError::Io {
+            artifact: path.display().to_string(),
+            detail: e.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integration::plan::{IntegrationRequest, ProtectionProfile};
+    use crate::integration::state::{EvidenceKind, ExerciseOutcome, ProtectionEvidence};
+    use crate::integration::status::{VerificationOutcome, VerificationResult};
+    use crate::integration::version::{core_version, SupportedToolVersions, LIFECYCLE_SCHEMA_VERSION};
+    use crate::integration::IntegrationCapability;
+    use crate::GovernanceLevel;
+    use std::path::PathBuf;
+
+    /// Fabricated to match `aa_security`'s `sk-ant-` literal pattern. Never a
+    /// credential; the `AAASM5278SYNTHETIC` marker is what the negative test
+    /// searches the persisted receipt for.
+    const SYNTHETIC_SECRET: &str =
+        "sk-ant-api03-AAASM5278SYNTHETICDONOTUSEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    const MANAGED_CONTENT: &str = r#"{"permissions":{"allow":["Bash"],"deny":[]},"permissionMode":"default"}"#;
+
+    struct Fixture {
+        _dir: tempfile::TempDir,
+        settings: PathBuf,
+        ca: PathBuf,
+        store: ReceiptStore,
+    }
+
+    fn fixture() -> Fixture {
+        let dir = tempfile::tempdir().unwrap();
+        Fixture {
+            settings: dir.path().join("tool").join("settings.json"),
+            ca: dir.path().join("aasm").join("ca.pem"),
+            store: ReceiptStore::at(dir.path().join("state")),
+            _dir: dir,
+        }
+    }
+
+    fn managed_keys() -> Vec<String> {
+        vec!["permissions".to_string(), "permissionMode".to_string()]
+    }
+
+    fn settings_step(path: &Path) -> IntegrationStep {
+        IntegrationStep::new(
+            "settings",
+            StepAction::WriteManagedSettings {
+                scope: SettingsScope::User,
+                path: path.to_path_buf(),
+                managed_keys: managed_keys(),
+                content_sha256: fingerprint::sha256_hex(MANAGED_CONTENT),
+                merge: SettingsMerge::MergeManagedKeys,
+            },
+            "write the managed settings block",
+        )
+    }
+
+    fn ca_step(path: &Path, pem: &str) -> IntegrationStep {
+        IntegrationStep::new(
+            "ca",
+            StepAction::MaterialiseTrustMaterial {
+                kind: TrustMaterialKind::ProxyCaCertificatePem,
+                path: path.to_path_buf(),
+                content_sha256: fingerprint::sha256_hex(pem),
+            },
+            "write the AASM proxy CA where the tool can read it",
+        )
+        .with_reversal(StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: path.to_path_buf(),
+        })
+    }
+
+    fn plan(f: &Fixture) -> IntegrationPlan {
+        let request = IntegrationRequest::new(
+            DevToolKind::ClaudeCode,
+            ProtectionProfile::Recommended,
+            SettingsScope::User,
+        );
+        IntegrationPlan::new(
+            "plan-1",
+            &request,
+            ProtectionLevel::Integrated,
+            GovernanceLevel::L2Enforce,
+        )
+        .with_step(settings_step(&f.settings))
+        .with_step(ca_step(
+            &f.ca,
+            "-----BEGIN CERTIFICATE-----\nAASM\n-----END CERTIFICATE-----\n",
+        ))
+    }
+
+    fn executor(_f: &Fixture) -> FilesystemExecutor {
+        FilesystemExecutor::new()
+            .with_content("settings", MANAGED_CONTENT)
+            .with_content("ca", "-----BEGIN CERTIFICATE-----\nAASM\n-----END CERTIFICATE-----\n")
+    }
+
+    fn engine(f: &Fixture) -> IntegrationEngine<FilesystemExecutor> {
+        IntegrationEngine::new(executor(f), f.store.clone())
+    }
+
+    fn context(now: u64) -> ApplyContext {
+        ApplyContext {
+            receipt_id: format!("receipt-{now}"),
+            versions: ComponentVersions {
+                core: core_version(),
+                adapter: ToolVersion::new(0, 1, 0),
+                lifecycle_schema: LIFECYCLE_SCHEMA_VERSION,
+            },
+            tool_version: Some(ToolVersion::new(2, 1, 220)),
+            now_unix_secs: now,
+        }
+    }
+
+    fn compatible() -> VersionCompatibility {
+        VersionCompatibility::Compatible {
+            detected: ToolVersion::new(2, 1, 220),
+        }
+    }
+
+    fn read_settings(f: &Fixture) -> serde_json::Value {
+        serde_json::from_str(&std::fs::read_to_string(&f.settings).unwrap()).unwrap()
+    }
+
+    fn write_settings(f: &Fixture, raw: &str) {
+        std::fs::create_dir_all(f.settings.parent().unwrap()).unwrap();
+        std::fs::write(&f.settings, raw).unwrap();
+    }
+
+    #[test]
+    fn a_dry_run_renders_the_plan_and_mutates_nothing() {
+        let f = fixture();
+        let e = engine(&f);
+        let rendered = e.dry_run(&plan(&f)).unwrap();
+
+        assert!(
+            rendered.starts_with("integration plan plan-1 for ClaudeCode"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("settings scope: user"), "{rendered}");
+        assert!(!f.settings.exists(), "a dry run must not create the target file");
+        assert!(!f.ca.exists());
+        assert!(!f.store.root().exists(), "a dry run must not create the receipt store");
+    }
+
+    #[test]
+    fn a_plan_that_does_not_validate_is_never_executed() {
+        let f = fixture();
+        let mut e = engine(&f);
+        // Two steps sharing an id: a receipt could not attribute them.
+        let broken = plan(&f).with_step(settings_step(&f.settings));
+        assert!(matches!(
+            e.apply(&broken, &context(1)),
+            Err(EngineError::InvalidPlan(_))
+        ));
+        assert!(!f.settings.exists());
+    }
+
+    #[test]
+    fn apply_writes_a_receipt_and_preserves_unmanaged_keys() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark","permissionMode":"acceptEdits"}"#);
+
+        let mut e = engine(&f);
+        let outcome = e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        assert!(outcome.mutated);
+        assert!(outcome.skipped.is_empty());
+        assert_eq!(outcome.receipt.achieved_level, ProtectionLevel::Integrated);
+        assert_eq!(
+            read_settings(&f)["theme"],
+            "dark",
+            "an unmanaged key must survive apply"
+        );
+        assert_eq!(read_settings(&f)["permissionMode"], "default");
+        assert!(f.ca.exists());
+
+        let stored = f
+            .store
+            .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored, outcome.receipt);
+        assert_eq!(stored.verified_required_steps(), stored.required_steps());
+        assert!(
+            f.store
+                .load_journal(&DevToolKind::ClaudeCode, SettingsScope::User)
+                .unwrap()
+                .is_none(),
+            "a completed apply leaves no journal"
+        );
+
+        // The prior value of the key AASM displaced is what removal restores.
+        let prior = stored.steps[0].prior_state.as_ref().unwrap();
+        assert!(prior.managed_values_json.contains("acceptEdits"));
+        assert_eq!(prior.absent_keys, vec!["permissions".to_string()]);
+    }
+
+    #[test]
+    fn reapplying_the_same_plan_mutates_nothing() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark"}"#);
+
+        let mut e = engine(&f);
+        let first = e.apply(&plan(&f), &context(1_000)).unwrap();
+        let before = std::fs::read_to_string(&f.settings).unwrap();
+        let receipt_before =
+            std::fs::read_to_string(f.store.receipt_path(&DevToolKind::ClaudeCode, SettingsScope::User)).unwrap();
+
+        let second = e.apply(&plan(&f), &context(9_999)).unwrap();
+
+        assert!(!second.mutated, "a reapply must report that it changed nothing");
+        assert_eq!(second.receipt, first.receipt, "including its applied-at timestamp");
+        assert_eq!(std::fs::read_to_string(&f.settings).unwrap(), before);
+        assert_eq!(
+            std::fs::read_to_string(f.store.receipt_path(&DevToolKind::ClaudeCode, SettingsScope::User)).unwrap(),
+            receipt_before,
+            "the stored receipt must be byte-identical after a no-op reapply"
+        );
+    }
+
+    #[test]
+    fn a_clean_install_reports_no_drift() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark"}"#);
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        let report = e.detect_drift(&DevToolKind::ClaudeCode, SettingsScope::User, &compatible(), None);
+        assert!(report.is_clean(), "{report:?}");
+    }
+
+    #[test]
+    fn reformatting_the_settings_file_is_not_drift() {
+        // The C3 constraint's honest consequence: the adapter reserialises, so
+        // comparison is over semantics. A user who pretty-printed their file has
+        // not drifted.
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark"}"#);
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        let value: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&f.settings).unwrap()).unwrap();
+        std::fs::write(&f.settings, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+
+        let report = e.detect_drift(&DevToolKind::ClaudeCode, SettingsScope::User, &compatible(), None);
+        assert!(report.is_clean(), "{report:?}");
+    }
+
+    #[test]
+    fn repair_rewrites_aasm_state_and_leaves_a_later_user_key_alone() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark"}"#);
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        // The user tampers with an AASM-managed key *and* adds one of their own
+        // after installation.
+        let mut doc = read_settings(&f);
+        doc["permissionMode"] = serde_json::json!("bypassPermissions");
+        doc["editorFontSize"] = serde_json::json!(18);
+        std::fs::write(&f.settings, doc.to_string()).unwrap();
+
+        let report = e.detect_drift(&DevToolKind::ClaudeCode, SettingsScope::User, &compatible(), None);
+        assert!(report.contains(DriftKind::AasmManagedValueChanged));
+        assert!(report.is_fully_repairable());
+
+        let outcome = e.repair(&plan(&f), &report, 2_000).unwrap();
+        assert_eq!(outcome.repaired_steps, vec!["settings".to_string()]);
+
+        let after = read_settings(&f);
+        assert_eq!(
+            after["permissionMode"], "default",
+            "the AASM-managed key must be restored"
+        );
+        assert_eq!(
+            after["editorFontSize"], 18,
+            "a user key added after installation must survive repair"
+        );
+        assert_eq!(
+            after["theme"], "dark",
+            "a user key present before installation must survive repair"
+        );
+        assert!(f.ca.exists(), "repair must not touch steps drift did not name");
+    }
+
+    #[test]
+    fn repair_does_not_run_when_only_an_unrelated_user_key_changed() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark"}"#);
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        let mut doc = read_settings(&f);
+        doc["theme"] = serde_json::json!("light");
+        std::fs::write(&f.settings, doc.to_string()).unwrap();
+
+        let report = e.detect_drift(&DevToolKind::ClaudeCode, SettingsScope::User, &compatible(), None);
+        assert!(report.contains(DriftKind::UserManagedUnrelatedChange));
+        assert!(report.aasm_state_is_intact());
+
+        let outcome = e.repair(&plan(&f), &report, 2_000).unwrap();
+        assert!(
+            outcome.repaired_steps.is_empty(),
+            "repair must have nothing to do about a key AASM does not own"
+        );
+        assert_eq!(outcome.preserved_user_changes, vec![f.settings.display().to_string()]);
+        assert_eq!(read_settings(&f)["theme"], "light", "the user's own change stands");
+    }
+
+    #[test]
+    fn a_corrupt_receipt_blocks_repair_instead_of_silently_reinstalling() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark"}"#);
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        // Hand-edit the stored receipt without recomputing its integrity hash.
+        let path = f.store.receipt_path(&DevToolKind::ClaudeCode, SettingsScope::User);
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let tampered = raw.replace("\"plan_id\": \"plan-1\"", "\"plan_id\": \"plan-forged\"");
+        assert_ne!(tampered, raw, "the fixture must actually have been modified");
+        std::fs::write(&path, tampered).unwrap();
+
+        let report = e.detect_drift(&DevToolKind::ClaudeCode, SettingsScope::User, &compatible(), None);
+        assert!(report.contains(DriftKind::ReceiptCorrupt), "{report:?}");
+        assert!(!report.is_fully_repairable());
+
+        let err = e
+            .repair(&plan(&f), &report, 2_000)
+            .expect_err("repair must refuse to write against a receipt it cannot trust");
+        assert!(matches!(err, EngineError::Unrepairable { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn a_missing_aasm_artifact_is_repaired() {
+        let f = fixture();
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+        std::fs::remove_file(&f.ca).unwrap();
+
+        let report = e.detect_drift(&DevToolKind::ClaudeCode, SettingsScope::User, &compatible(), None);
+        assert!(report.contains(DriftKind::AasmArtifactMissing));
+
+        e.repair(&plan(&f), &report, 2_000).unwrap();
+        assert!(f.ca.exists());
+        assert!(e
+            .detect_drift(&DevToolKind::ClaudeCode, SettingsScope::User, &compatible(), None)
+            .is_clean());
+    }
+
+    #[test]
+    fn a_repair_drops_the_verification_it_did_not_re_run() {
+        let f = fixture();
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+        e.record_verification(
+            &DevToolKind::ClaudeCode,
+            SettingsScope::User,
+            &VerificationResult {
+                verified_at_unix_secs: 1_000,
+                outcome: VerificationOutcome::Passed,
+                evidence: vec![ProtectionEvidence::new(
+                    IntegrationCapability::ModelPathInterception,
+                    EvidenceKind::Exercised {
+                        outcome: ExerciseOutcome::Redacted,
+                    },
+                    1_000,
+                    "probe adjudicated by the core",
+                )],
+            },
+            3_600,
+        )
+        .unwrap();
+
+        std::fs::remove_file(&f.ca).unwrap();
+        let report = e.detect_drift(&DevToolKind::ClaudeCode, SettingsScope::User, &compatible(), None);
+        let outcome = e.repair(&plan(&f), &report, 2_000).unwrap();
+
+        assert!(
+            outcome.receipt.achieved_evidence.is_empty(),
+            "a repair re-established configuration; it did not re-exercise traffic"
+        );
+        assert_eq!(outcome.receipt.verified_at_unix_secs, None);
+        assert!(outcome.receipt.achieved_level <= ProtectionLevel::Integrated);
+    }
+
+    #[test]
+    fn verification_records_the_level_and_the_evidence_that_justified_it() {
+        let f = fixture();
+        let mut e = engine(&f);
+        let request = IntegrationRequest::new(
+            DevToolKind::ClaudeCode,
+            ProtectionProfile::Recommended,
+            SettingsScope::User,
+        );
+        let probing = IntegrationPlan::new(
+            "plan-probe",
+            &request,
+            ProtectionLevel::GatewayProtected,
+            GovernanceLevel::L2Enforce,
+        )
+        .with_step(settings_step(&f.settings))
+        .with_step(
+            IntegrationStep::new(
+                "probe",
+                StepAction::RunProtectionTest {
+                    probe: crate::integration::ProbeDescriptor {
+                        id: "synthetic-secret".to_string(),
+                        mechanism: IntegrationCapability::ModelPathInterception,
+                        description: "send a synthetic secret down the model path".to_string(),
+                    },
+                },
+                "verify the model path is actually intercepted",
+            )
+            .optional(),
+        );
+
+        let applied = e.apply(&probing, &context(1_000)).unwrap();
+        assert_eq!(
+            applied.receipt.achieved_level,
+            ProtectionLevel::Integrated,
+            "an apply configures; it does not exercise traffic, so it cannot claim GatewayProtected"
+        );
+
+        let verified = e
+            .record_verification(
+                &DevToolKind::ClaudeCode,
+                SettingsScope::User,
+                &VerificationResult {
+                    verified_at_unix_secs: 1_100,
+                    outcome: VerificationOutcome::Passed,
+                    evidence: vec![ProtectionEvidence::new(
+                        IntegrationCapability::ModelPathInterception,
+                        EvidenceKind::Exercised {
+                            outcome: ExerciseOutcome::Redacted,
+                        },
+                        1_100,
+                        "the synthetic secret was redacted before egress",
+                    )],
+                },
+                3_600,
+            )
+            .unwrap();
+
+        assert_eq!(verified.achieved_level, ProtectionLevel::GatewayProtected);
+        assert_eq!(verified.verified_at_unix_secs, Some(1_100));
+        assert_eq!(
+            verified.validate(),
+            Ok(()),
+            "the claim must be one its evidence can carry"
+        );
+    }
+
+    #[test]
+    fn remove_restores_prior_state_and_keeps_later_user_changes() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark","permissionMode":"acceptEdits"}"#);
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        // The user changes something of their own after installation.
+        let mut doc = read_settings(&f);
+        doc["theme"] = serde_json::json!("light");
+        std::fs::write(&f.settings, doc.to_string()).unwrap();
+
+        let outcome = e.remove(&DevToolKind::ClaudeCode, SettingsScope::User).unwrap();
+        assert!(outcome.residual.is_empty(), "{:?}", outcome.residual);
+        assert!(outcome.receipt_deleted);
+        assert_eq!(outcome.reversed_steps, vec!["ca".to_string(), "settings".to_string()]);
+
+        let after = read_settings(&f);
+        assert_eq!(
+            after["permissionMode"], "acceptEdits",
+            "the displaced value is restored"
+        );
+        assert!(after.get("permissions").is_none(), "a key AASM added is deleted");
+        assert_eq!(after["theme"], "light", "a post-install user change survives removal");
+        assert!(!f.ca.exists(), "an artifact AASM created is deleted");
+        assert!(!f.store.receipt_exists(&DevToolKind::ClaudeCode, SettingsScope::User));
+    }
+
+    #[test]
+    fn remove_deletes_a_settings_file_it_created_outright() {
+        let f = fixture();
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+        assert!(f.settings.exists());
+
+        e.remove(&DevToolKind::ClaudeCode, SettingsScope::User).unwrap();
+        assert!(
+            !f.settings.exists(),
+            "a file that held nothing but AASM's keys is AASM's to remove"
+        );
+    }
+
+    #[test]
+    fn remove_is_idempotent_and_refuses_without_a_receipt() {
+        let f = fixture();
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+        e.remove(&DevToolKind::ClaudeCode, SettingsScope::User).unwrap();
+
+        assert!(matches!(
+            e.remove(&DevToolKind::ClaudeCode, SettingsScope::User),
+            Err(EngineError::NoReceipt { .. })
+        ));
+    }
+
+    #[test]
+    fn a_withheld_prior_value_becomes_a_residual_and_keeps_the_receipt() {
+        let f = fixture();
+        // The user keeps a credential inside a key AASM manages.
+        write_settings(
+            &f,
+            &format!(r#"{{"theme":"dark","permissionMode":"{SYNTHETIC_SECRET}"}}"#),
+        );
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        let outcome = e.remove(&DevToolKind::ClaudeCode, SettingsScope::User).unwrap();
+        assert!(
+            !outcome.receipt_deleted,
+            "the user must still be able to see what remains"
+        );
+        assert!(
+            outcome.residual.iter().any(|r| r.contains("permissionMode")),
+            "{:?}",
+            outcome.residual
+        );
+        assert!(f.store.receipt_exists(&DevToolKind::ClaudeCode, SettingsScope::User));
+    }
+
+    #[test]
+    fn no_raw_secret_from_the_settings_file_can_reach_the_receipt() {
+        let f = fixture();
+        write_settings(
+            &f,
+            &format!(r#"{{"apiKey":"{SYNTHETIC_SECRET}","permissionMode":"{SYNTHETIC_SECRET}","theme":"dark"}}"#),
+        );
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        let persisted =
+            std::fs::read_to_string(f.store.receipt_path(&DevToolKind::ClaudeCode, SettingsScope::User)).unwrap();
+
+        // The whole secret, and any recognisable fragment of it.
+        assert!(
+            !persisted.contains(SYNTHETIC_SECRET),
+            "the receipt holds the raw secret"
+        );
+        assert!(
+            !persisted.contains("AAASM5278SYNTHETIC"),
+            "the receipt holds a fragment of the secret"
+        );
+        assert!(!persisted.contains("sk-ant-"), "the receipt holds a credential prefix");
+
+        // And the file itself still has both, so the test is about the receipt
+        // rather than about the secret having been destroyed.
+        let on_disk = std::fs::read_to_string(&f.settings).unwrap();
+        assert!(on_disk.contains(SYNTHETIC_SECRET));
+
+        // The unmanaged key was never even read into a projection; the managed
+        // one was read, screened and withheld.
+        let receipt = f
+            .store
+            .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap()
+            .unwrap();
+        let prior = receipt.steps[0].prior_state.as_ref().unwrap();
+        assert_eq!(prior.withheld_keys, vec!["permissionMode".to_string()]);
+        assert!(!prior.is_fully_restorable());
+    }
+
+    /// Drive an apply and stop it after `after_steps` mutations, leaving exactly
+    /// the on-disk state a crash at that point would: a journal, the mutations
+    /// that got that far, and no receipt.
+    fn interrupt_apply_after(f: &Fixture, after_steps: usize) -> OperationJournal {
+        let p = plan(f);
+        let mut executor = executor(f);
+        let mut journal = OperationJournal::starting(
+            JournalOperation::Apply,
+            &p.plan_id,
+            DevToolKind::ClaudeCode,
+            SettingsScope::User,
+            1_000,
+            p.steps.iter().map(|s| s.id.clone()),
+        );
+        f.store.save_journal(&journal).unwrap();
+
+        for step in p.steps.iter().take(after_steps) {
+            let outcome = executor.apply(step).unwrap();
+            let mut receipt = StepReceipt::applied(step, outcome.fingerprint);
+            if let Some(doc) = outcome.document_fingerprint {
+                receipt = receipt.with_document_fingerprint(doc);
+            }
+            if let Some(prior) = outcome.prior_state {
+                receipt = receipt.with_prior_state(prior);
+            }
+            journal.record_applied(receipt);
+            f.store.save_journal(&journal).unwrap();
+        }
+        journal
+    }
+
+    #[test]
+    fn an_interrupted_apply_rolls_back_to_where_the_developer_started() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark","permissionMode":"acceptEdits"}"#);
+        let untouched = std::fs::read_to_string(&f.settings).unwrap();
+
+        // Crash after the settings write, before the CA step and before any
+        // receipt exists.
+        interrupt_apply_after(&f, 1);
+        assert_ne!(
+            std::fs::read_to_string(&f.settings).unwrap(),
+            untouched,
+            "the fixture must actually have mutated the host"
+        );
+        assert!(!f.store.receipt_exists(&DevToolKind::ClaudeCode, SettingsScope::User));
+
+        let mut e = engine(&f);
+        let action = e.recover(&DevToolKind::ClaudeCode, SettingsScope::User).unwrap();
+        assert!(
+            matches!(action, RecoveryAction::RollBackInterruptedApply { .. }),
+            "{action:?}"
+        );
+
+        let after = read_settings(&f);
+        assert_eq!(
+            after["permissionMode"], "acceptEdits",
+            "the displaced value is put back"
+        );
+        assert!(after.get("permissions").is_none(), "the key the apply added is removed");
+        assert_eq!(after["theme"], "dark");
+        assert!(!f.ca.exists(), "a step that never ran left nothing to remove");
+        assert!(
+            f.store
+                .load_journal(&DevToolKind::ClaudeCode, SettingsScope::User)
+                .unwrap()
+                .is_none(),
+            "recovery clears the journal it resolved"
+        );
+
+        // Running recovery again is a no-op, not a second rollback.
+        assert_eq!(
+            e.recover(&DevToolKind::ClaudeCode, SettingsScope::User).unwrap(),
+            RecoveryAction::Nothing
+        );
+    }
+
+    #[test]
+    fn a_crash_after_the_receipt_was_written_only_clears_the_journal() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark"}"#);
+        let mut e = engine(&f);
+        let applied = e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        // The receipt landed; the journal deletion did not.
+        let mut journal = OperationJournal::starting(
+            JournalOperation::Apply,
+            "plan-1",
+            DevToolKind::ClaudeCode,
+            SettingsScope::User,
+            1_000,
+            applied.receipt.steps.iter().map(|s| s.step_id.clone()),
+        );
+        for step in &applied.receipt.steps {
+            journal.record_applied(step.clone());
+        }
+        f.store.save_journal(&journal).unwrap();
+
+        let settings_before = std::fs::read_to_string(&f.settings).unwrap();
+        assert_eq!(
+            e.recover(&DevToolKind::ClaudeCode, SettingsScope::User).unwrap(),
+            RecoveryAction::ClearStaleJournal
+        );
+        assert_eq!(
+            std::fs::read_to_string(&f.settings).unwrap(),
+            settings_before,
+            "a completed apply must not be undone by recovery"
+        );
+        assert!(f.store.receipt_exists(&DevToolKind::ClaudeCode, SettingsScope::User));
+    }
+
+    #[test]
+    fn an_interrupted_remove_finishes_and_is_safe_to_run_twice() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark","permissionMode":"acceptEdits"}"#);
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        // A removal that got as far as the CA and then died.
+        let mut journal = OperationJournal::starting(
+            JournalOperation::Remove,
+            "plan-1",
+            DevToolKind::ClaudeCode,
+            SettingsScope::User,
+            1_000,
+            ["settings".to_string(), "ca".to_string()],
+        );
+        journal.mark("ca", StepProgress::Reversed);
+        std::fs::remove_file(&f.ca).unwrap();
+        f.store.save_journal(&journal).unwrap();
+
+        let action = e.recover(&DevToolKind::ClaudeCode, SettingsScope::User).unwrap();
+        assert!(
+            matches!(action, RecoveryAction::ResumeInterruptedRemove { .. }),
+            "{action:?}"
+        );
+        assert_eq!(
+            read_settings(&f)["permissionMode"],
+            "acceptEdits",
+            "resuming finishes the restore rather than reverting it"
+        );
+        assert!(!f.store.receipt_exists(&DevToolKind::ClaudeCode, SettingsScope::User));
+
+        // Running recovery again must be a no-op, not an error.
+        assert_eq!(
+            e.recover(&DevToolKind::ClaudeCode, SettingsScope::User).unwrap(),
+            RecoveryAction::Nothing
+        );
+    }
+
+    #[test]
+    fn recovery_escalates_a_journal_from_a_newer_core() {
+        let f = fixture();
+        let mut e = engine(&f);
+        let mut journal = OperationJournal::starting(
+            JournalOperation::Apply,
+            "plan-1",
+            DevToolKind::ClaudeCode,
+            SettingsScope::User,
+            1_000,
+            ["settings".to_string()],
+        );
+        journal.schema_version = LIFECYCLE_SCHEMA_VERSION + 1;
+        journal.mark("settings", StepProgress::Applied);
+        f.store.save_journal(&journal).unwrap();
+
+        assert!(matches!(
+            e.recover(&DevToolKind::ClaudeCode, SettingsScope::User),
+            Err(EngineError::RecoveryEscalated { .. })
+        ));
+        assert!(
+            f.store
+                .load_journal(&DevToolKind::ClaudeCode, SettingsScope::User)
+                .unwrap()
+                .is_some(),
+            "an escalated journal is kept for the human it is escalated to"
+        );
+    }
+
+    #[test]
+    fn a_failed_required_step_rolls_the_whole_apply_back() {
+        let f = fixture();
+        write_settings(&f, r#"{"theme":"dark"}"#);
+        let before = std::fs::read_to_string(&f.settings).unwrap();
+
+        // The CA step's content is not supplied, so it fails; it is required.
+        let executor = FilesystemExecutor::new().with_content("settings", MANAGED_CONTENT);
+        let mut e = IntegrationEngine::new(executor, f.store.clone());
+
+        let err = e
+            .apply(&plan(&f), &context(1_000))
+            .expect_err("a required step that cannot run must abort the apply");
+        assert!(matches!(err, EngineError::RequiredStepFailed { .. }), "{err:?}");
+
+        assert!(
+            !f.store.receipt_exists(&DevToolKind::ClaudeCode, SettingsScope::User),
+            "a failed apply must not leave a receipt claiming an integration"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&f.settings).unwrap(),
+            before,
+            "the rollback must return the settings file to what the developer had"
+        );
+        assert!(f
+            .store
+            .load_journal(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn a_failed_optional_step_is_recorded_rather_than_fatal() {
+        let f = fixture();
+        let mut optional_ca = plan(&f);
+        optional_ca.steps[1] = optional_ca.steps[1].clone().optional();
+
+        let executor = FilesystemExecutor::new().with_content("settings", MANAGED_CONTENT);
+        let mut e = IntegrationEngine::new(executor, f.store.clone());
+        let outcome = e.apply(&optional_ca, &context(1_000)).unwrap();
+
+        assert_eq!(outcome.skipped.len(), 1);
+        assert_eq!(outcome.skipped[0].0, "ca");
+        assert_eq!(
+            outcome.receipt.achieved_level,
+            ProtectionLevel::Integrated,
+            "an optional step's absence does not make the integration partial"
+        );
+        assert!(!outcome.receipt.steps[1].applied);
+    }
+
+    #[test]
+    fn content_that_does_not_match_the_reviewed_plan_is_refused() {
+        let f = fixture();
+        let executor = FilesystemExecutor::new()
+            .with_content("settings", r#"{"permissionMode":"bypassPermissions"}"#)
+            .with_content("ca", "-----BEGIN CERTIFICATE-----\nAASM\n-----END CERTIFICATE-----\n");
+        let mut e = IntegrationEngine::new(executor, f.store.clone());
+
+        let err = e
+            .apply(&plan(&f), &context(1_000))
+            .expect_err("the digest must be checked");
+        assert!(
+            matches!(
+                err,
+                EngineError::RequiredStepFailed {
+                    source: ExecutionError::ContentMismatch { .. },
+                    ..
+                }
+            ),
+            "{err:?}"
+        );
+        assert!(!f.settings.exists());
+    }
+
+    #[test]
+    fn a_trust_store_anchor_is_refused_rather_than_written_as_a_file() {
+        let f = fixture();
+        let anchor = IntegrationStep::new(
+            "anchor",
+            StepAction::MaterialiseTrustMaterial {
+                kind: TrustMaterialKind::ProxyCaTrustStoreAnchor,
+                path: f.ca.clone(),
+                content_sha256: fingerprint::sha256_hex("pem"),
+            },
+            "install the AASM CA into the system trust store",
+        );
+        let mut executor = FilesystemExecutor::new().with_content("anchor", "pem");
+        assert!(matches!(
+            executor.apply(&anchor),
+            Err(ExecutionError::Unsupported {
+                kind: "trust-store-anchor"
+            })
+        ));
+    }
+
+    #[test]
+    fn a_mechanism_this_executor_lacks_is_refused_rather_than_silently_succeeding() {
+        let mut executor = FilesystemExecutor::new();
+        let env = IntegrationStep::new(
+            "env",
+            StepAction::InjectLaunchEnvironment {
+                scope: SettingsScope::User,
+                variable: "NODE_EXTRA_CA_CERTS".to_string(),
+                value: crate::integration::EnvValue::Literal("/tmp/ca.pem".to_string()),
+            },
+            "make the tool's Node runtime trust the AASM proxy CA",
+        );
+        assert!(matches!(
+            executor.apply(&env),
+            Err(ExecutionError::Unsupported {
+                kind: "inject-launch-environment"
+            })
+        ));
+    }
+
+    #[test]
+    fn upgrading_the_plan_supersedes_the_previous_receipt() {
+        let f = fixture();
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        let mut upgraded = plan(&f);
+        upgraded.plan_id = "plan-2".to_string();
+        let outcome = e.apply(&upgraded, &context(2_000)).unwrap();
+        assert_eq!(outcome.receipt.plan_id, "plan-2");
+        assert_eq!(outcome.receipt.receipt_id, "receipt-2000");
+
+        let envelope = f
+            .store
+            .load_envelope(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap()
+            .unwrap();
+        assert_eq!(envelope.superseded.len(), 1);
+        assert_eq!(envelope.superseded[0].receipt_id, "receipt-1000");
+    }
+
+    #[test]
+    fn a_tool_upgrade_out_of_range_is_reported_and_not_repaired_away() {
+        let f = fixture();
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        let incompatible = SupportedToolVersions::between(ToolVersion::new(2, 0, 0), ToolVersion::new(3, 0, 0))
+            .classify(Some(&ToolVersion::new(3, 4, 0)));
+        let report = e.detect_drift(&DevToolKind::ClaudeCode, SettingsScope::User, &incompatible, None);
+        assert!(report.contains(DriftKind::ToolVersionIncompatible));
+
+        let err = e
+            .repair(&plan(&f), &report, 2_000)
+            .expect_err("repair cannot fix a version");
+        assert!(matches!(err, EngineError::Unrepairable { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn a_reversal_that_fails_is_reported_rather_than_silently_completing() {
+        let f = fixture();
+        let mut e = engine(&f);
+        e.apply(&plan(&f), &context(1_000)).unwrap();
+
+        // Drop the reversal information the CA step carried, leaving the engine
+        // with no way to undo it.
+        let mut receipt = f
+            .store
+            .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap()
+            .unwrap();
+        receipt.steps[1].reversal = None;
+        f.store.save_receipt(&receipt).unwrap();
+
+        let err = e
+            .remove(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .expect_err("an unreversible step must not be reported as removed");
+        assert!(matches!(err, EngineError::ReversalFailed { .. }), "{err:?}");
+        assert!(
+            f.store.receipt_exists(&DevToolKind::ClaudeCode, SettingsScope::User),
+            "the receipt survives a failed removal so the user can still see what is installed"
+        );
+        assert!(
+            f.store
+                .load_journal(&DevToolKind::ClaudeCode, SettingsScope::User)
+                .unwrap()
+                .is_some(),
+            "the journal survives so recovery can resume the removal"
+        );
+    }
+}

--- a/aa-core/src/integration/fingerprint.rs
+++ b/aa-core/src/integration/fingerprint.rs
@@ -1,0 +1,356 @@
+//! Canonical fingerprints, managed-key projections, and the screen that keeps a
+//! receipt from becoming somewhere secrets live.
+//!
+//! # Semantics-exact, not byte-exact — the AAASM-5276 C3 constraint
+//!
+//! The Spike measured that `aa-devtool-claude-code/src/apply.rs:85` reserialises
+//! the whole settings document on every write, so a user file in non-canonical
+//! formatting (tabs, comments-adjacent whitespace, a hand-chosen key order)
+//! cannot survive an install→remove cycle byte-for-byte *no matter how good the
+//! receipt is*. AAASM-5278 accepts that as a stated constraint rather than
+//! pretending otherwise, and this module is where the acceptance is made
+//! operational:
+//!
+//! * every fingerprint is taken over the **canonical JSON** of a document, never
+//!   over its bytes, so a reserialisation that changed only formatting is
+//!   correctly reported as *no drift* rather than as a change the user did not
+//!   make;
+//! * restoration is therefore verified against *semantics*, and
+//!   the removal report says so instead of implying a guarantee the write path
+//!   cannot keep.
+//!
+//! The reconsideration trigger is narrow and concrete: **if the adapter's write
+//! path stops reserialising** — a format-preserving JSON editor, or a managed
+//! block written into a region of the file the rest of which is copied verbatim
+//! — then byte-exact restore becomes achievable and this decision should be
+//! revisited, because at that point the weaker guarantee would be a choice
+//! rather than a constraint.
+//!
+//! # Why a projection, and not just "hash the file"
+//!
+//! Drift has to distinguish *a user edited something of their own* from *an
+//! AASM-owned value changed* (ADR 0030 matrix row 10; repair is only safe
+//! because of it). One hash over the whole file cannot tell those apart. So each
+//! settings step is fingerprinted twice: once over the projection of just the
+//! keys the step claims, and once over the whole document. Two hashes, two
+//! questions, and the answer to the second never authorises a write.
+//!
+//! # Why the secret screen lives here
+//!
+//! Removal restores the values that were in the file before AASM touched it,
+//! which means those values are written into a receipt. A settings file is a
+//! place users do put credentials. Screening the material *before* it reaches
+//! the receipt — rather than redacting on the way out to a log — is the only
+//! placement where "the receipt does not contain the secret" is a property of
+//! the file on disk rather than of every reader of it.
+
+use std::fmt::Write as _;
+use std::sync::OnceLock;
+
+use sha2::{Digest, Sha256};
+
+/// Prefix every fingerprint in this module carries, matching the digest format
+/// already used for policy documents in [`AuditEntry`](crate::AuditEntry).
+pub const FINGERPRINT_PREFIX: &str = "sha256:";
+
+/// Why a document could not be fingerprinted or projected.
+///
+/// Both variants are resolution failures in ADR 0015's sense: the caller must
+/// fail closed on them, never treat them as "no drift".
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum FingerprintError {
+    /// The document is not parseable JSON.
+    #[error("the document is not valid JSON: {detail}")]
+    NotJson {
+        /// The parser's complaint, without the document's contents.
+        detail: String,
+    },
+    /// The document parsed but is not a JSON object, so it has no keys to own.
+    #[error("the document is a JSON {found}, not an object")]
+    NotAnObject {
+        /// What it turned out to be.
+        found: &'static str,
+    },
+}
+
+/// Hex-encode `bytes` into a lowercase string.
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// The bare hex SHA-256 of `text`, without the [`FINGERPRINT_PREFIX`].
+///
+/// Used where an existing type already fixes the encoding — notably
+/// [`StepAction::WriteManagedSettings::content_sha256`](super::StepAction),
+/// which the lifecycle contract documents as "hex-encoded".
+pub fn sha256_hex(text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    hex(&hasher.finalize())
+}
+
+/// A prefixed fingerprint of `text` exactly as given, with no canonicalisation.
+pub fn fingerprint_raw(text: &str) -> String {
+    format!("{FINGERPRINT_PREFIX}{}", sha256_hex(text))
+}
+
+fn parse_object(raw: &str) -> Result<serde_json::Map<String, serde_json::Value>, FingerprintError> {
+    let value: serde_json::Value = serde_json::from_str(raw).map_err(|e| FingerprintError::NotJson {
+        // `to_string()` on a serde_json error carries a line/column, never the
+        // document's contents — safe to surface in a diagnostic.
+        detail: e.to_string(),
+    })?;
+    match value {
+        serde_json::Value::Object(map) => Ok(map),
+        serde_json::Value::Null => Err(FingerprintError::NotAnObject { found: "null" }),
+        serde_json::Value::Bool(_) => Err(FingerprintError::NotAnObject { found: "boolean" }),
+        serde_json::Value::Number(_) => Err(FingerprintError::NotAnObject { found: "number" }),
+        serde_json::Value::String(_) => Err(FingerprintError::NotAnObject { found: "string" }),
+        serde_json::Value::Array(_) => Err(FingerprintError::NotAnObject { found: "array" }),
+    }
+}
+
+/// The canonical rendering of `raw`: parsed, key-ordered, whitespace-free.
+///
+/// `serde_json`'s `Map` is a `BTreeMap` in this workspace (the `preserve_order`
+/// feature is deliberately not enabled), so serialization is already sorted and
+/// this is a stable function of the document's *meaning*.
+pub fn canonicalize(raw: &str) -> Result<String, FingerprintError> {
+    let map = parse_object(raw)?;
+    Ok(serde_json::Value::Object(map).to_string())
+}
+
+/// Fingerprint of the whole document's semantics.
+///
+/// Two files that differ only in formatting or key order produce the same value
+/// — see the module docs on why that is the accepted constraint and not a bug.
+pub fn document_fingerprint(raw: &str) -> Result<String, FingerprintError> {
+    Ok(fingerprint_raw(&canonicalize(raw)?))
+}
+
+/// The canonical JSON object containing only those `managed_keys` that are
+/// present in `raw`.
+///
+/// Absent keys are omitted rather than rendered as `null`, so "the key is not
+/// there" and "the key is there and holds null" stay distinguishable.
+pub fn managed_projection(raw: &str, managed_keys: &[String]) -> Result<String, FingerprintError> {
+    let map = parse_object(raw)?;
+    let mut projection = serde_json::Map::new();
+    for key in managed_keys {
+        if let Some(value) = map.get(key) {
+            projection.insert(key.clone(), value.clone());
+        }
+    }
+    Ok(serde_json::Value::Object(projection).to_string())
+}
+
+/// Fingerprint of the AASM-owned projection of `raw`.
+///
+/// This is the value a receipt stores per step and the only one a drift check
+/// may act on: a mismatch here means an AASM-managed value changed, and nothing
+/// else does.
+pub fn managed_fingerprint(raw: &str, managed_keys: &[String]) -> Result<String, FingerprintError> {
+    Ok(fingerprint_raw(&managed_projection(raw, managed_keys)?))
+}
+
+/// Which of `managed_keys` are **not** present in `raw`.
+///
+/// Recorded before an apply so removal can delete exactly the keys AASM added,
+/// rather than deleting every key it manages and taking a user's pre-existing
+/// value with it.
+pub fn absent_managed_keys(raw: &str, managed_keys: &[String]) -> Result<Vec<String>, FingerprintError> {
+    let map = parse_object(raw)?;
+    Ok(managed_keys.iter().filter(|k| !map.contains_key(*k)).cloned().collect())
+}
+
+/// Merge `incoming`'s values for `managed_keys` into `current`, leaving every
+/// other key of `current` exactly as it was.
+///
+/// This is the write shape [`SettingsMerge::MergeManagedKeys`](super::SettingsMerge)
+/// names, and the reason repair can be safe: a key the plan does not claim is
+/// never read, never written and never deleted.
+pub fn merge_managed_keys(current: &str, incoming: &str, managed_keys: &[String]) -> Result<String, FingerprintError> {
+    let mut base = parse_object(current)?;
+    let incoming = parse_object(incoming)?;
+    for key in managed_keys {
+        if let Some(value) = incoming.get(key) {
+            base.insert(key.clone(), value.clone());
+        }
+    }
+    Ok(serde_json::Value::Object(base).to_string())
+}
+
+/// Put `prior_values` back into `current` and delete `absent_keys`.
+///
+/// The inverse of [`merge_managed_keys`] against the state a receipt's prior-state
+/// record captured. Keys of `current` that neither collection names — including
+/// everything the user changed after installation — are carried through untouched.
+pub fn restore_managed_keys(
+    current: &str,
+    prior_values: &str,
+    absent_keys: &[String],
+) -> Result<String, FingerprintError> {
+    let mut base = parse_object(current)?;
+    let prior = parse_object(prior_values)?;
+    for (key, value) in prior {
+        base.insert(key, value);
+    }
+    for key in absent_keys {
+        base.remove(key);
+    }
+    Ok(serde_json::Value::Object(base).to_string())
+}
+
+fn scanner() -> &'static aa_security::CredentialScanner {
+    static SCANNER: OnceLock<aa_security::CredentialScanner> = OnceLock::new();
+    SCANNER.get_or_init(aa_security::CredentialScanner::new)
+}
+
+/// Whether `text` contains anything the deterministic credential scanner
+/// recognises as secret material.
+///
+/// The scanner's pattern set is finite, so a `false` is "nothing matched", not
+/// "there is no secret here". Callers use it to *withhold* material from a
+/// receipt, never to certify that storing it is safe — which is why a receipt's
+/// prior-state record additionally caps what it stores to the keys the plan
+/// claims.
+pub fn contains_credential_material(text: &str) -> bool {
+    !scanner().scan(text).is_clean()
+}
+
+/// The per-key secret screen: the subset of `values` (a canonical JSON object)
+/// whose keys are safe to persist, and the names of the keys that were withheld.
+///
+/// Screening per key rather than per document means one credential-bearing key
+/// does not cost the restorability of its neighbours.
+pub fn screen_managed_values(values: &str) -> Result<(String, Vec<String>), FingerprintError> {
+    let map = parse_object(values)?;
+    let mut safe = serde_json::Map::new();
+    let mut withheld = Vec::new();
+    for (key, value) in map {
+        // Scan the rendered value, not just string leaves: a secret can sit
+        // inside a nested object or an array element just as easily.
+        if contains_credential_material(&value.to_string()) {
+            withheld.push(key);
+        } else {
+            safe.insert(key, value);
+        }
+    }
+    Ok((serde_json::Value::Object(safe).to_string(), withheld))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MANAGED: &str = "permissions";
+
+    fn managed_keys() -> Vec<String> {
+        vec![MANAGED.to_string(), "permissionMode".to_string()]
+    }
+
+    #[test]
+    fn formatting_and_key_order_do_not_change_a_fingerprint() {
+        // The C3 constraint made concrete: these two documents mean the same
+        // thing and must not read as drift.
+        let pretty = "{\n  \"permissions\": {\"allow\": [\"Bash\"]},\n  \"theme\": \"dark\"\n}";
+        let terse = r#"{"theme":"dark","permissions":{"allow":["Bash"]}}"#;
+        assert_eq!(
+            document_fingerprint(pretty).unwrap(),
+            document_fingerprint(terse).unwrap()
+        );
+    }
+
+    #[test]
+    fn the_projection_sees_only_the_keys_the_step_claims() {
+        let doc = r#"{"permissions":{"allow":["Bash"]},"theme":"dark"}"#;
+        let projection = managed_projection(doc, &managed_keys()).unwrap();
+        assert_eq!(projection, r#"{"permissions":{"allow":["Bash"]}}"#);
+
+        // Changing an unmanaged key moves the document fingerprint and leaves
+        // the managed one alone — the whole basis of the drift distinction.
+        let edited = r#"{"permissions":{"allow":["Bash"]},"theme":"light"}"#;
+        assert_eq!(
+            managed_fingerprint(doc, &managed_keys()).unwrap(),
+            managed_fingerprint(edited, &managed_keys()).unwrap()
+        );
+        assert_ne!(
+            document_fingerprint(doc).unwrap(),
+            document_fingerprint(edited).unwrap()
+        );
+    }
+
+    #[test]
+    fn an_absent_key_is_not_a_null_key() {
+        let doc = r#"{"permissionMode":null}"#;
+        assert_eq!(
+            absent_managed_keys(doc, &managed_keys()).unwrap(),
+            vec![MANAGED.to_string()]
+        );
+        assert_eq!(
+            managed_projection(doc, &managed_keys()).unwrap(),
+            r#"{"permissionMode":null}"#
+        );
+    }
+
+    #[test]
+    fn merge_and_restore_leave_unrelated_keys_alone() {
+        let original = r#"{"theme":"dark"}"#;
+        let absent = absent_managed_keys(original, &managed_keys()).unwrap();
+        let prior = managed_projection(original, &managed_keys()).unwrap();
+
+        let installed = merge_managed_keys(
+            original,
+            r#"{"permissions":{"allow":[]},"permissionMode":"default"}"#,
+            &managed_keys(),
+        )
+        .unwrap();
+        assert!(installed.contains("\"theme\":\"dark\""));
+
+        // The user changes something of their own after installation.
+        let user_edited = merge_managed_keys(&installed, r#"{}"#, &[]).unwrap();
+        let user_edited = user_edited.replace("\"dark\"", "\"light\"");
+
+        let restored = restore_managed_keys(&user_edited, &prior, &absent).unwrap();
+        assert_eq!(
+            restored, r#"{"theme":"light"}"#,
+            "the post-install user change must survive removal"
+        );
+    }
+
+    #[test]
+    fn a_non_object_document_fails_closed() {
+        assert!(matches!(
+            document_fingerprint("[1,2,3]"),
+            Err(FingerprintError::NotAnObject { found: "array" })
+        ));
+        assert!(matches!(
+            document_fingerprint("not json"),
+            Err(FingerprintError::NotJson { .. })
+        ));
+    }
+
+    #[test]
+    fn credential_shaped_values_are_withheld_per_key() {
+        // Synthetic, fabricated to match the scanner's `sk-ant-` literal
+        // pattern. Never a credential.
+        let secret = "sk-ant-api03-AAASM5278SYNTHETICDONOTUSEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let values = format!(r#"{{"apiKey":"{secret}","permissionMode":"default"}}"#);
+        let (safe, withheld) = screen_managed_values(&values).unwrap();
+        assert_eq!(withheld, vec!["apiKey".to_string()]);
+        assert!(!safe.contains("AAASM5278SYNTHETIC"), "{safe}");
+        assert!(safe.contains("permissionMode"));
+    }
+
+    #[test]
+    fn content_sha256_is_hex_without_the_prefix() {
+        let hex = sha256_hex("{}");
+        assert_eq!(hex.len(), 64);
+        assert_eq!(fingerprint_raw("{}"), format!("{FINGERPRINT_PREFIX}{hex}"));
+    }
+}

--- a/aa-core/src/integration/journal.rs
+++ b/aa-core/src/integration/journal.rs
@@ -44,6 +44,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use super::receipt::StepReceipt;
 use super::step::SettingsScope;
 use super::version::LIFECYCLE_SCHEMA_VERSION;
 use crate::dev_tool::DevToolKind;
@@ -86,6 +87,14 @@ pub struct JournalEntry {
     pub step_id: String,
     /// How far it got.
     pub progress: StepProgress,
+    /// What the step left behind, recorded at the moment it completed.
+    ///
+    /// This is what makes an interrupted *apply* reversible at all: no receipt
+    /// exists yet by definition, so if the journal did not carry the prior state
+    /// and the reversal action, a rollback would have nothing to work from and
+    /// would quietly do nothing. It is dropped with the journal as soon as the
+    /// receipt — the durable home for the same information — is written.
+    pub outcome: Option<StepReceipt>,
 }
 
 /// The write-ahead record of an operation in flight.
@@ -132,6 +141,7 @@ impl OperationJournal {
                 .map(|step_id| JournalEntry {
                     step_id,
                     progress: StepProgress::Pending,
+                    outcome: None,
                 })
                 .collect(),
         }
@@ -145,8 +155,36 @@ impl OperationJournal {
             None => self.entries.push(JournalEntry {
                 step_id: step_id.to_string(),
                 progress,
+                outcome: None,
             }),
         }
+    }
+
+    /// Record a completed mutation together with what it left behind.
+    pub fn record_applied(&mut self, outcome: StepReceipt) {
+        let step_id = outcome.step_id.clone();
+        match self.entries.iter_mut().find(|e| e.step_id == step_id) {
+            Some(entry) => {
+                entry.progress = StepProgress::Applied;
+                entry.outcome = Some(outcome);
+            }
+            None => self.entries.push(JournalEntry {
+                step_id,
+                progress: StepProgress::Applied,
+                outcome: Some(outcome),
+            }),
+        }
+    }
+
+    /// What each completed step left behind, in execution order.
+    ///
+    /// The only reversal information an interrupted apply has.
+    pub fn applied_outcomes(&self) -> Vec<StepReceipt> {
+        self.entries
+            .iter()
+            .filter(|e| e.progress == StepProgress::Applied)
+            .filter_map(|e| e.outcome.clone())
+            .collect()
     }
 
     /// Steps whose mutation completed, in execution order.
@@ -365,6 +403,36 @@ mod tests {
         let mut j = journal(JournalOperation::Apply);
         j.mark("surprise", StepProgress::Applied);
         assert_eq!(j.applied_step_ids(), vec!["surprise".to_string()]);
+    }
+
+    #[test]
+    fn an_applied_step_carries_its_own_reversal_information() {
+        use crate::integration::step::{ArtifactOperation, IntegrationStep, StepAction};
+        use std::path::PathBuf;
+
+        let step = IntegrationStep::new(
+            "ca",
+            StepAction::ManageArtifact {
+                operation: ArtifactOperation::Create,
+                path: PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem"),
+            },
+            "write the CA",
+        )
+        .with_reversal(StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem"),
+        });
+
+        let mut j = journal(JournalOperation::Apply);
+        j.record_applied(StepReceipt::applied(&step, Some("sha256:ca".to_string())));
+
+        assert_eq!(j.applied_step_ids(), vec!["ca".to_string()]);
+        let outcomes = j.applied_outcomes();
+        assert_eq!(outcomes.len(), 1);
+        assert!(
+            outcomes[0].reversal.is_some(),
+            "an interrupted apply has no receipt, so the journal must carry the reversal itself"
+        );
     }
 
     #[cfg(feature = "serde")]

--- a/aa-core/src/integration/journal.rs
+++ b/aa-core/src/integration/journal.rs
@@ -1,0 +1,378 @@
+//! The write-ahead record that makes an interrupted apply or remove a *state*
+//! rather than an accident.
+//!
+//! # A partially-applied plan is normal
+//!
+//! Applying an integration writes several files. A laptop lid closes, a process
+//! is killed, a disk fills. The lifecycle already has a resting state for it —
+//! [`PartiallyIntegrated`](super::ProtectionLevel::PartiallyIntegrated) — but a
+//! resting state is only recoverable if something recorded *which* steps got as
+//! far as running. That record is this journal, and it is written **before** the
+//! first mutation, not after.
+//!
+//! # The ordering that makes recovery decidable
+//!
+//! Apply runs: write journal → mutate, marking each step as it completes → write
+//! receipt → delete journal.
+//! Remove runs: write journal → reverse each step, marking as it completes →
+//! delete receipt → delete journal.
+//!
+//! Two facts — is there a journal, is there a receipt — therefore determine the
+//! recovery action uniquely, with no guessing and no timestamps:
+//!
+//! | Journal | Receipt | What happened | [`RecoveryAction`] |
+//! | --- | --- | --- | --- |
+//! | none | any | nothing was in flight | [`Nothing`](RecoveryAction::Nothing) |
+//! | `Apply` | absent | crashed mid-apply | [`RollBackInterruptedApply`](RecoveryAction::RollBackInterruptedApply) |
+//! | `Apply` | present | crashed after the receipt was written | [`ClearStaleJournal`](RecoveryAction::ClearStaleJournal) |
+//! | `Remove` | present | crashed mid-remove | [`ResumeInterruptedRemove`](RecoveryAction::ResumeInterruptedRemove) |
+//! | `Remove` | absent | crashed after the receipt was deleted | [`ClearStaleJournal`](RecoveryAction::ClearStaleJournal) |
+//!
+//! # Why apply rolls back and remove resumes
+//!
+//! They are not symmetric, and the asymmetry is deliberate. An interrupted apply
+//! produced no receipt, so nothing can claim protection from it and the
+//! half-written state is *pure liability*: rolling it back returns the developer
+//! to exactly where they started, and re-running apply is a plan-time decision
+//! they can review again. An interrupted **remove**, by contrast, has already
+//! begun taking AASM's changes out; stopping half-way would leave AASM-owned
+//! artifacts on a host whose owner asked for them to be gone. Finishing is the
+//! only direction that honours the request, and it is safe to repeat because
+//! every reversal is idempotent — deleting an already-deleted artifact and
+//! restoring an already-restored key are both no-ops.
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::step::SettingsScope;
+use super::version::LIFECYCLE_SCHEMA_VERSION;
+use crate::dev_tool::DevToolKind;
+
+/// Which direction the interrupted operation was going.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum JournalOperation {
+    /// Steps were being applied.
+    Apply,
+    /// Steps were being reversed.
+    Remove,
+}
+
+/// How far one step got.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum StepProgress {
+    /// Not started, or started and not recorded — indistinguishable on purpose,
+    /// which is why every reversal must be idempotent.
+    Pending,
+    /// The mutation completed.
+    Applied,
+    /// The mutation was attempted and failed.
+    Failed {
+        /// Why, for the user and for the audit trail.
+        reason: String,
+    },
+    /// The mutation was undone.
+    Reversed,
+}
+
+/// One step's line in the journal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct JournalEntry {
+    /// The [`IntegrationStep::id`](super::IntegrationStep::id) this line is
+    /// about.
+    pub step_id: String,
+    /// How far it got.
+    pub progress: StepProgress,
+}
+
+/// The write-ahead record of an operation in flight.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OperationJournal {
+    /// The [`LIFECYCLE_SCHEMA_VERSION`] the writing core used.
+    pub schema_version: u32,
+    /// Which direction the operation was going.
+    pub operation: JournalOperation,
+    /// The plan or receipt the operation is executing.
+    pub plan_id: String,
+    /// The tool being operated on.
+    pub tool: DevToolKind,
+    /// Which configuration surface the operation targets. Recorded so recovery
+    /// resumes against the file the operation actually chose, not the one the
+    /// recovering process's working directory would suggest.
+    pub settings_scope: SettingsScope,
+    /// When the operation started, as seconds since the Unix epoch.
+    pub started_at_unix_secs: u64,
+    /// One line per step, in execution order.
+    pub entries: Vec<JournalEntry>,
+}
+
+impl OperationJournal {
+    /// Open a journal for `step_ids`, all [`Pending`](StepProgress::Pending).
+    pub fn starting(
+        operation: JournalOperation,
+        plan_id: impl Into<String>,
+        tool: DevToolKind,
+        settings_scope: SettingsScope,
+        started_at_unix_secs: u64,
+        step_ids: impl IntoIterator<Item = String>,
+    ) -> Self {
+        Self {
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            operation,
+            plan_id: plan_id.into(),
+            tool,
+            settings_scope,
+            started_at_unix_secs,
+            entries: step_ids
+                .into_iter()
+                .map(|step_id| JournalEntry {
+                    step_id,
+                    progress: StepProgress::Pending,
+                })
+                .collect(),
+        }
+    }
+
+    /// Record how far `step_id` got. Unknown ids are appended rather than
+    /// dropped — a step the journal did not anticipate still happened.
+    pub fn mark(&mut self, step_id: &str, progress: StepProgress) {
+        match self.entries.iter_mut().find(|e| e.step_id == step_id) {
+            Some(entry) => entry.progress = progress,
+            None => self.entries.push(JournalEntry {
+                step_id: step_id.to_string(),
+                progress,
+            }),
+        }
+    }
+
+    /// Steps whose mutation completed, in execution order.
+    pub fn applied_step_ids(&self) -> Vec<String> {
+        self.entries
+            .iter()
+            .filter(|e| e.progress == StepProgress::Applied)
+            .map(|e| e.step_id.clone())
+            .collect()
+    }
+
+    /// Steps a removal has not yet recorded as reversed, in execution order.
+    ///
+    /// Includes [`Pending`](StepProgress::Pending) and
+    /// [`Failed`](StepProgress::Failed) lines: a reversal that failed once is
+    /// retried, because leaving an AASM artifact behind after the user asked for
+    /// removal is the worse outcome.
+    pub fn unreversed_step_ids(&self) -> Vec<String> {
+        self.entries
+            .iter()
+            .filter(|e| e.progress != StepProgress::Reversed)
+            .map(|e| e.step_id.clone())
+            .collect()
+    }
+
+    /// Whether any step is recorded as having failed.
+    pub fn has_failures(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|e| matches!(e.progress, StepProgress::Failed { .. }))
+    }
+
+    /// Whether this journal was written by a core newer than the one reading it.
+    ///
+    /// Recovery refuses to act on one: replaying steps whose semantics this
+    /// build may not share is exactly the guess the lifecycle model forbids.
+    pub fn is_schema_newer_than_running_core(&self) -> bool {
+        self.schema_version > LIFECYCLE_SCHEMA_VERSION
+    }
+}
+
+/// What a recovering process must do, decided from the journal and the presence
+/// of a receipt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum RecoveryAction {
+    /// Nothing was in flight.
+    Nothing,
+    /// An apply was interrupted before its receipt was written. Reverse these
+    /// step ids in reverse execution order, then delete the journal.
+    RollBackInterruptedApply {
+        /// The steps the journal recorded as applied.
+        step_ids: Vec<String>,
+    },
+    /// A remove was interrupted. Reverse these step ids, then delete the receipt
+    /// and the journal.
+    ResumeInterruptedRemove {
+        /// The steps not yet recorded as reversed.
+        step_ids: Vec<String>,
+    },
+    /// The operation completed; only the journal outlived it. Delete it.
+    ClearStaleJournal,
+    /// The journal cannot be acted on and needs a human.
+    ///
+    /// Recovery is the one place where doing *something* is more dangerous than
+    /// doing nothing, so an unreadable journal stops here instead of guessing.
+    Escalate {
+        /// What is wrong, in words a user can act on.
+        reason: String,
+    },
+}
+
+/// Decide the recovery action from the two facts that determine it.
+///
+/// See the module docs for the table this implements and why apply and remove
+/// recover in opposite directions.
+pub fn recovery_action(journal: Option<&OperationJournal>, receipt_present: bool) -> RecoveryAction {
+    let Some(journal) = journal else {
+        return RecoveryAction::Nothing;
+    };
+
+    if journal.is_schema_newer_than_running_core() {
+        return RecoveryAction::Escalate {
+            reason: "an interrupted operation was recorded by a newer Agent Assembly release than the one \
+                     running; upgrade Agent Assembly and retry"
+                .to_string(),
+        };
+    }
+
+    match (journal.operation, receipt_present) {
+        (JournalOperation::Apply, false) => {
+            let step_ids = journal.applied_step_ids();
+            if step_ids.is_empty() {
+                // Nothing got as far as mutating anything.
+                RecoveryAction::ClearStaleJournal
+            } else {
+                RecoveryAction::RollBackInterruptedApply { step_ids }
+            }
+        }
+        (JournalOperation::Apply, true) => RecoveryAction::ClearStaleJournal,
+        (JournalOperation::Remove, true) => {
+            let step_ids = journal.unreversed_step_ids();
+            if step_ids.is_empty() {
+                RecoveryAction::ClearStaleJournal
+            } else {
+                RecoveryAction::ResumeInterruptedRemove { step_ids }
+            }
+        }
+        (JournalOperation::Remove, false) => RecoveryAction::ClearStaleJournal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn journal(operation: JournalOperation) -> OperationJournal {
+        OperationJournal::starting(
+            operation,
+            "p1",
+            DevToolKind::ClaudeCode,
+            SettingsScope::User,
+            1_000_000,
+            ["settings".to_string(), "ca".to_string(), "env".to_string()],
+        )
+    }
+
+    #[test]
+    fn no_journal_means_nothing_to_recover() {
+        assert_eq!(recovery_action(None, true), RecoveryAction::Nothing);
+        assert_eq!(recovery_action(None, false), RecoveryAction::Nothing);
+    }
+
+    #[test]
+    fn an_interrupted_apply_rolls_back_exactly_what_it_applied() {
+        let mut j = journal(JournalOperation::Apply);
+        j.mark("settings", StepProgress::Applied);
+        j.mark("ca", StepProgress::Applied);
+        // `env` never ran.
+
+        assert_eq!(
+            recovery_action(Some(&j), false),
+            RecoveryAction::RollBackInterruptedApply {
+                step_ids: vec!["settings".to_string(), "ca".to_string()],
+            },
+            "a step that never ran must not be reversed"
+        );
+    }
+
+    #[test]
+    fn an_apply_that_wrote_its_receipt_completed() {
+        let mut j = journal(JournalOperation::Apply);
+        j.mark("settings", StepProgress::Applied);
+        assert_eq!(recovery_action(Some(&j), true), RecoveryAction::ClearStaleJournal);
+    }
+
+    #[test]
+    fn an_apply_that_mutated_nothing_needs_no_rollback() {
+        let j = journal(JournalOperation::Apply);
+        assert_eq!(recovery_action(Some(&j), false), RecoveryAction::ClearStaleJournal);
+    }
+
+    #[test]
+    fn an_interrupted_remove_finishes_rather_than_reverting() {
+        let mut j = journal(JournalOperation::Remove);
+        j.mark("env", StepProgress::Reversed);
+        j.mark(
+            "ca",
+            StepProgress::Failed {
+                reason: "the file was locked".to_string(),
+            },
+        );
+
+        assert_eq!(
+            recovery_action(Some(&j), true),
+            RecoveryAction::ResumeInterruptedRemove {
+                step_ids: vec!["settings".to_string(), "ca".to_string()],
+            },
+            "a failed reversal is retried; leaving an AASM artifact behind is the worse outcome"
+        );
+        assert!(j.has_failures());
+    }
+
+    #[test]
+    fn a_remove_that_deleted_its_receipt_completed() {
+        let mut j = journal(JournalOperation::Remove);
+        j.mark("settings", StepProgress::Reversed);
+        assert_eq!(recovery_action(Some(&j), false), RecoveryAction::ClearStaleJournal);
+    }
+
+    #[test]
+    fn recovery_is_idempotent_across_repeated_runs() {
+        // Running recovery twice must ask for the same thing, because the second
+        // run cannot know the first one finished.
+        let mut j = journal(JournalOperation::Apply);
+        j.mark("settings", StepProgress::Applied);
+        let first = recovery_action(Some(&j), false);
+        let second = recovery_action(Some(&j), false);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn a_journal_from_a_newer_core_escalates_instead_of_replaying() {
+        let mut j = journal(JournalOperation::Apply);
+        j.schema_version = LIFECYCLE_SCHEMA_VERSION + 1;
+        j.mark("settings", StepProgress::Applied);
+        assert!(matches!(
+            recovery_action(Some(&j), false),
+            RecoveryAction::Escalate { .. }
+        ));
+    }
+
+    #[test]
+    fn marking_an_unanticipated_step_records_it_rather_than_dropping_it() {
+        let mut j = journal(JournalOperation::Apply);
+        j.mark("surprise", StepProgress::Applied);
+        assert_eq!(j.applied_step_ids(), vec!["surprise".to_string()]);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn journals_round_trip_through_json() {
+        let mut j = journal(JournalOperation::Apply);
+        j.mark("settings", StepProgress::Applied);
+        let json = serde_json::to_string(&j).unwrap();
+        assert_eq!(serde_json::from_str::<OperationJournal>(&json).unwrap(), j);
+    }
+}

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -63,7 +63,7 @@ pub use plan::{
     IntegrationPlan, IntegrationRequest, PlanError, PolicyProfileRef, ProtectionProfile, RemovalPlan,
     UnsupportedMechanism,
 };
-pub use receipt::{IntegrationReceipt, ReceiptError, StepReceipt};
+pub use receipt::{IntegrationReceipt, PriorSettingsState, ReceiptError, StepReceipt};
 pub use shim::{LegacyAdapterShim, LEGACY_UNSUPPORTED_REASON};
 pub use state::{
     EvidenceKind, ExerciseOutcome, ProtectionEvidence, ProtectionLevel, ProtectionState, StateDerivation,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -40,6 +40,7 @@
 
 pub mod capability;
 pub mod contract;
+pub mod drift;
 pub mod fingerprint;
 pub mod plan;
 pub mod receipt;
@@ -54,6 +55,7 @@ pub use contract::{
     capability_conformance, ConformanceViolation, DevToolIntegration, HookableTool, LaunchSpec, LaunchableTool,
     McpGovernedTool,
 };
+pub use drift::{ArtifactObservation, DriftFinding, DriftInputs, DriftKind, DriftReport, ObservedStep};
 pub use fingerprint::{
     absent_managed_keys, canonicalize, contains_credential_material, document_fingerprint, fingerprint_raw,
     managed_fingerprint, managed_projection, merge_managed_keys, restore_managed_keys, screen_managed_values,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -41,6 +41,10 @@
 pub mod capability;
 pub mod contract;
 pub mod drift;
+// The engine writes receipts, so like the store it exists only where the
+// lifecycle types can be serialized.
+#[cfg(feature = "serde")]
+pub mod engine;
 pub mod fingerprint;
 pub mod journal;
 pub mod plan;
@@ -61,6 +65,11 @@ pub use contract::{
     McpGovernedTool,
 };
 pub use drift::{ArtifactObservation, DriftFinding, DriftInputs, DriftKind, DriftReport, ObservedStep};
+#[cfg(feature = "serde")]
+pub use engine::{
+    ApplyContext, ApplyOutcome, EngineError, ExecutionError, FilesystemExecutor, IntegrationEngine, RemovalOutcome,
+    RepairOutcome, StepExecutor, StepOutcome,
+};
 pub use fingerprint::{
     absent_managed_keys, canonicalize, contains_credential_material, document_fingerprint, fingerprint_raw,
     managed_fingerprint, managed_projection, merge_managed_keys, restore_managed_keys, screen_managed_values,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -49,6 +49,10 @@ pub mod shim;
 pub mod state;
 pub mod status;
 pub mod step;
+// Persistence serializes the lifecycle types, so it exists only where their
+// `Serialize`/`Deserialize` derives do.
+#[cfg(feature = "serde")]
+pub mod store;
 pub mod version;
 
 pub use capability::{CapabilityResolution, CapabilitySupport, DevToolCapabilities, IntegrationCapability};
@@ -77,6 +81,10 @@ pub use status::{IntegrationStatus, LifecyclePhase, NextLevel, VerificationOutco
 pub use step::{
     ArtifactOperation, EnvValue, IntegrationStep, ProbeDescriptor, SettingsMerge, SettingsScope, StepAction,
     StepPrivilege, StepRequirement, TrustMaterialKind,
+};
+#[cfg(feature = "serde")]
+pub use store::{
+    ReceiptEnvelope, ReceiptStore, StoreError, SupersededReceipt, MAX_SUPERSEDED_RECEIPTS, RECEIPT_ENVELOPE_VERSION,
 };
 pub use version::{
     core_version, ComponentVersions, SupportedToolVersions, ToolVersion, VersionCompatibility, VersionParseError,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -40,6 +40,7 @@
 
 pub mod capability;
 pub mod contract;
+pub mod fingerprint;
 pub mod plan;
 pub mod receipt;
 pub mod shim;
@@ -52,6 +53,11 @@ pub use capability::{CapabilityResolution, CapabilitySupport, DevToolCapabilitie
 pub use contract::{
     capability_conformance, ConformanceViolation, DevToolIntegration, HookableTool, LaunchSpec, LaunchableTool,
     McpGovernedTool,
+};
+pub use fingerprint::{
+    absent_managed_keys, canonicalize, contains_credential_material, document_fingerprint, fingerprint_raw,
+    managed_fingerprint, managed_projection, merge_managed_keys, restore_managed_keys, screen_managed_values,
+    sha256_hex, FingerprintError, FINGERPRINT_PREFIX,
 };
 pub use plan::{
     IntegrationPlan, IntegrationRequest, PlanError, PolicyProfileRef, ProtectionProfile, RemovalPlan,

--- a/aa-core/src/integration/mod.rs
+++ b/aa-core/src/integration/mod.rs
@@ -42,6 +42,7 @@ pub mod capability;
 pub mod contract;
 pub mod drift;
 pub mod fingerprint;
+pub mod journal;
 pub mod plan;
 pub mod receipt;
 pub mod shim;
@@ -61,6 +62,7 @@ pub use fingerprint::{
     managed_fingerprint, managed_projection, merge_managed_keys, restore_managed_keys, screen_managed_values,
     sha256_hex, FingerprintError, FINGERPRINT_PREFIX,
 };
+pub use journal::{recovery_action, JournalEntry, JournalOperation, OperationJournal, RecoveryAction, StepProgress};
 pub use plan::{
     IntegrationPlan, IntegrationRequest, PlanError, PolicyProfileRef, ProtectionProfile, RemovalPlan,
     UnsupportedMechanism,

--- a/aa-core/src/integration/receipt.rs
+++ b/aa-core/src/integration/receipt.rs
@@ -26,6 +26,51 @@ use super::step::{IntegrationStep, SettingsScope, StepAction, StepRequirement};
 use super::version::{ComponentVersions, ToolVersion, LIFECYCLE_SCHEMA_VERSION};
 use crate::dev_tool::DevToolKind;
 
+/// What the step's target document held for the AASM-owned keys *before* the
+/// step ran — the restoration evidence removal is derived from.
+///
+/// # Why a structured key snapshot and not a file backup
+///
+/// A full-file backup would put every unmanaged key — including anything the
+/// user keeps in the same file — into a second copy AASM now owns and must
+/// protect, and it would restore the file as it was at install time, silently
+/// discarding everything the user changed afterwards. A structured snapshot of
+/// only the claimed keys restores exactly what AASM displaced and carries
+/// nothing else. That is also why AAASM-5278's non-goals rule out backing up a
+/// developer's home directory: the smallest sufficient record is the one that
+/// leaks least *and* preserves most.
+///
+/// # Fail closed when a prior value cannot be stored
+///
+/// A value that trips the credential screen is not stored, and its key is named
+/// in [`withheld_keys`](Self::withheld_keys). Removal then cannot prove it
+/// restored that key, so it declares a residual instead of writing a guess
+/// (ADR 0015: a resolution failure is observable, never silently permitted).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PriorSettingsState {
+    /// Canonical JSON object of the AASM-owned keys that existed before the
+    /// step ran, minus anything withheld by the credential screen.
+    pub managed_values_json: String,
+    /// AASM-owned keys the document did not have before the step ran, and which
+    /// removal must therefore delete rather than restore.
+    pub absent_keys: Vec<String>,
+    /// Keys whose prior value was withheld because it contained material the
+    /// credential scanner recognised. Non-empty means removal is knowingly
+    /// incomplete for those keys.
+    pub withheld_keys: Vec<String>,
+    /// Fingerprint of the whole document before the step ran, so a restore can
+    /// be checked against the semantics it was aiming at.
+    pub document_fingerprint: String,
+}
+
+impl PriorSettingsState {
+    /// Whether every claimed key can be restored from this record.
+    pub fn is_fully_restorable(&self) -> bool {
+        self.withheld_keys.is_empty()
+    }
+}
+
 /// What one applied step left behind.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -43,7 +88,20 @@ pub struct StepReceipt {
     /// Fingerprint of what was written, for drift detection. `None` means no
     /// fingerprint could be taken, which counts as unverified — never as
     /// verified.
+    ///
+    /// For a settings step this is the fingerprint of the **AASM-owned
+    /// projection**, not of the file: a mismatch here means an AASM-managed
+    /// value changed, and that is the only mismatch repair may act on.
     pub fingerprint: Option<String>,
+    /// Fingerprint of the whole target document immediately after the step ran.
+    ///
+    /// Its only job is to make "the user changed something of their own" a
+    /// distinguishable observation rather than an unexplained hash mismatch. It
+    /// never authorises a write — drift derived from it is reported and left
+    /// alone.
+    pub document_fingerprint: Option<String>,
+    /// What the target document held for the claimed keys before the step ran.
+    pub prior_state: Option<PriorSettingsState>,
     /// The action that undoes this one, copied from the plan so removal does not
     /// depend on the adapter still being able to re-derive it.
     pub reversal: Option<StepAction>,
@@ -58,6 +116,8 @@ impl StepReceipt {
             requirement: step.requirement,
             applied: true,
             fingerprint,
+            document_fingerprint: None,
+            prior_state: None,
             reversal: step.reversal.clone(),
         }
     }
@@ -70,14 +130,45 @@ impl StepReceipt {
             requirement: step.requirement,
             applied: false,
             fingerprint: None,
+            document_fingerprint: None,
+            prior_state: None,
             reversal: step.reversal.clone(),
         }
+    }
+
+    /// Attach the fingerprint of the whole target document after the step ran.
+    #[must_use]
+    pub fn with_document_fingerprint(mut self, fingerprint: impl Into<String>) -> Self {
+        self.document_fingerprint = Some(fingerprint.into());
+        self
+    }
+
+    /// Attach the restoration evidence captured before the step ran.
+    #[must_use]
+    pub fn with_prior_state(mut self, prior_state: PriorSettingsState) -> Self {
+        self.prior_state = Some(prior_state);
+        self
     }
 
     /// Whether this step counts towards the "every required step verifies"
     /// criterion: applied **and** fingerprinted.
     pub fn is_verified(&self) -> bool {
         self.applied && self.fingerprint.is_some()
+    }
+
+    /// Whether removal can prove it restored everything this step displaced.
+    ///
+    /// A step that was applied without capturing prior state is *not* provably
+    /// restorable — the absence of a record is not evidence there was nothing
+    /// to record.
+    pub fn is_provably_restorable(&self) -> bool {
+        if !self.applied {
+            return true;
+        }
+        match &self.prior_state {
+            Some(prior) => prior.is_fully_restorable(),
+            None => self.reversal.is_some(),
+        }
     }
 }
 
@@ -176,6 +267,29 @@ impl IntegrationReceipt {
             .iter()
             .filter(|s| s.applied && s.reversal.is_none())
             .collect()
+    }
+
+    /// Applied steps whose restoration this receipt cannot prove — either no
+    /// prior state was captured and no reversal is known, or the prior value was
+    /// withheld by the credential screen.
+    ///
+    /// Removal reports every one of these as a residual rather than writing a
+    /// value it cannot substantiate.
+    pub fn unrestorable_steps(&self) -> Vec<&StepReceipt> {
+        self.steps.iter().filter(|s| !s.is_provably_restorable()).collect()
+    }
+
+    /// The runtime or gateway endpoint the applied steps pointed the tool at,
+    /// when one was.
+    ///
+    /// Drift compares this against the endpoint currently in effect; a receipt
+    /// that names no endpoint simply cannot go stale in that direction, which is
+    /// different from being fresh.
+    pub fn receipted_endpoint(&self) -> Option<&str> {
+        self.steps.iter().filter(|s| s.applied).find_map(|s| match &s.action {
+            StepAction::ConfigureModelGatewayBaseUrl { base_url, .. } => Some(base_url.as_str()),
+            _ => None,
+        })
     }
 
     /// Whether this receipt was written by a core newer than the one reading it.
@@ -380,6 +494,61 @@ mod tests {
             reversals[0].affected_paths(),
             vec![PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem")]
         );
+    }
+
+    #[test]
+    fn a_withheld_prior_value_makes_a_step_unrestorable() {
+        let mut r = receipt(ProtectionLevel::Integrated, vec![]);
+        r.steps[0] = r.steps[0].clone().with_prior_state(PriorSettingsState {
+            managed_values_json: "{}".to_string(),
+            absent_keys: vec![],
+            withheld_keys: vec!["permissions".to_string()],
+            document_fingerprint: "sha256:before".to_string(),
+        });
+        assert_eq!(r.unrestorable_steps().len(), 1);
+
+        r.steps[0] = r.steps[0].clone().with_prior_state(PriorSettingsState {
+            managed_values_json: "{}".to_string(),
+            absent_keys: vec!["permissions".to_string()],
+            withheld_keys: vec![],
+            document_fingerprint: "sha256:before".to_string(),
+        });
+        assert!(r.unrestorable_steps().is_empty());
+    }
+
+    #[test]
+    fn an_applied_step_with_neither_prior_state_nor_a_reversal_is_unrestorable() {
+        // The absence of a record is not evidence there was nothing to record.
+        let mut r = receipt(ProtectionLevel::Integrated, vec![]);
+        r.steps[0].reversal = None;
+        assert_eq!(r.unrestorable_steps().len(), 1);
+    }
+
+    #[test]
+    fn the_receipted_endpoint_comes_from_the_applied_steps() {
+        let mut r = receipt(ProtectionLevel::Integrated, vec![]);
+        assert_eq!(r.receipted_endpoint(), None);
+
+        let endpoint = IntegrationStep::new(
+            "base-url",
+            StepAction::ConfigureModelGatewayBaseUrl {
+                scope: SettingsScope::User,
+                variable: "ANTHROPIC_BASE_URL".to_string(),
+                base_url: "http://127.0.0.1:7391".to_string(),
+            },
+            "route the tool at the local gateway",
+        );
+        r.steps.push(StepReceipt::not_applied(&endpoint));
+        assert_eq!(
+            r.receipted_endpoint(),
+            None,
+            "a step that was never applied configured no endpoint"
+        );
+
+        r.steps.pop();
+        r.steps
+            .push(StepReceipt::applied(&endpoint, Some("sha256:e".to_string())));
+        assert_eq!(r.receipted_endpoint(), Some("http://127.0.0.1:7391"));
     }
 
     #[test]

--- a/aa-core/src/integration/store.rs
+++ b/aa-core/src/integration/store.rs
@@ -1,0 +1,818 @@
+//! Where receipts and journals live on disk, and the permissions they are held
+//! to.
+//!
+//! # Why not inside the tool's own configuration tree
+//!
+//! The AAASM-5276 spike scaffolding deliberately did not store receipts under
+//! the tool's config directory, and this module keeps that decision for three
+//! reasons that are each sufficient on their own:
+//!
+//! 1. **The receipt is evidence about the tool, not configuration of it.** A
+//!    file inside `~/.claude/` is something the tool may read, rewrite,
+//!    reformat, or sync to a vendor's cloud. A record whose whole job is to say
+//!    what the tool's directory *should* contain cannot itself be one of the
+//!    things being described.
+//! 2. **Removal has to be able to empty the tool's directory.** If the receipt
+//!    lived there, removing an integration would have to either delete its own
+//!    evidence mid-operation or leave an AASM file behind in a directory it just
+//!    promised to clean.
+//! 3. **One tool per directory, many tools per developer.** Status across every
+//!    integrated tool is a single directory read here, rather than a walk of
+//!    every tool's private layout.
+//!
+//! Receipts therefore live under `${AASM_STATE_DIR:-~/.aasm}/integrations/`,
+//! the state directory the installer, the PID file and the uninstaller already
+//! use (`scripts/install-cli.sh`, `aa-cli/src/commands/pidfile.rs`).
+//!
+//! # Permissions, asserted on load and not only at creation
+//!
+//! A receipt names every file AASM governs on this host, which mechanism it
+//! relies on, and where the trust material sits — a useful map for anyone
+//! planning to defeat the integration. The directory is `0700` and each file is
+//! `0600`, matching `aa-runtime/src/ipc/server.rs:83` and
+//! `aa-proxy/src/tls/ca.rs:108-123`. As in the CA loader, the mode is
+//! **re-asserted on every load**: a file created by an older build, restored
+//! from a backup, or copied in with loose permissions must not stay
+//! group-readable across a restart, and creation-time enforcement alone cannot
+//! prevent that.
+//!
+//! # Integrity is corruption detection, not tamper prevention
+//!
+//! The envelope carries a hash over the canonical receipt. It catches truncated
+//! writes, partial syncs and hand-edits, and it makes a corrupt receipt
+//! *reportable* as [`DriftKind::ReceiptCorrupt`](super::DriftKind::ReceiptCorrupt)
+//! rather than silently misread. It is **not** a MAC and does not pretend to be:
+//! an attacker with the developer's UID can recompute it, and host-level tamper
+//! prevention is an explicit non-goal (ADR 0030 accepted risks). What it does
+//! guarantee is that a receipt that does not verify is never acted on.
+
+use std::path::{Path, PathBuf};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::fingerprint::fingerprint_raw;
+use super::journal::OperationJournal;
+use super::receipt::IntegrationReceipt;
+use super::state::ProtectionLevel;
+use super::step::SettingsScope;
+use crate::dev_tool::DevToolKind;
+
+/// Schema version of the on-disk envelope, which advances independently of
+/// [`LIFECYCLE_SCHEMA_VERSION`](super::LIFECYCLE_SCHEMA_VERSION): the way a
+/// receipt is *stored* can change
+/// without the receipt's own shape changing, and conflating the two would force
+/// a lifecycle bump for a storage-layout fix.
+pub const RECEIPT_ENVELOPE_VERSION: u32 = 1;
+
+/// How many superseded receipts an envelope keeps.
+///
+/// Bounded because the upgrade history is for explaining *this* integration's
+/// provenance, not for being an audit log — that is `aa-core::audit`'s job, and
+/// an unbounded list would grow a file that must stay readable at every start.
+pub const MAX_SUPERSEDED_RECEIPTS: usize = 8;
+
+/// Why a receipt or journal could not be read or written.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StoreError {
+    /// The filesystem refused.
+    #[error("integration state at {path} could not be accessed: {source}")]
+    Io {
+        /// What was being accessed.
+        path: PathBuf,
+        /// The underlying error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The file is not the JSON this store writes.
+    #[error("the stored integration state at {path} is unreadable: {detail}")]
+    Corrupt {
+        /// What was being read.
+        path: PathBuf,
+        /// Why it could not be read, without echoing the file's contents.
+        detail: String,
+    },
+    /// The envelope's hash does not cover what the file now contains.
+    #[error("the receipt at {path} failed its integrity check and will not be used")]
+    IntegrityMismatch {
+        /// What was being read.
+        path: PathBuf,
+    },
+    /// The envelope was written by a newer core.
+    #[error("the receipt at {path} was written by a newer Agent Assembly release (envelope v{found}, this build reads v{readable})")]
+    EnvelopeTooNew {
+        /// What was being read.
+        path: PathBuf,
+        /// The version found in the file.
+        found: u32,
+        /// The newest version this build understands.
+        readable: u32,
+    },
+    /// No state directory could be resolved.
+    #[error("no Agent Assembly state directory could be resolved; set AASM_STATE_DIR")]
+    NoStateDirectory,
+}
+
+impl StoreError {
+    /// The user-facing reason a drift check should report, or `None` when the
+    /// condition is not about the receipt's trustworthiness.
+    ///
+    /// Feeds [`DriftInputs::receipt_unreadable`](super::DriftInputs::receipt_unreadable),
+    /// which is what turns an unreadable receipt into an observable, fail-closed
+    /// state instead of an error the caller might treat as "no receipt".
+    pub fn as_untrustworthy_receipt_reason(&self) -> Option<String> {
+        match self {
+            Self::Corrupt { detail, .. } => Some(detail.clone()),
+            Self::IntegrityMismatch { .. } => Some("its integrity hash does not match its contents".to_string()),
+            Self::EnvelopeTooNew { found, readable, .. } => Some(format!(
+                "it uses storage envelope v{found} and this build reads v{readable}"
+            )),
+            Self::Io { .. } | Self::NoStateDirectory => None,
+        }
+    }
+}
+
+/// The minimum a superseded receipt is remembered by after an upgrade.
+///
+/// Deliberately not the whole prior receipt: the useful question later is "what
+/// was here before, when, and how protected was it", and keeping the full prior
+/// step list would retain prior-state snapshots — including displaced settings
+/// values — long after anything can restore them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct SupersededReceipt {
+    /// The receipt that was replaced.
+    pub receipt_id: String,
+    /// The plan it recorded.
+    pub plan_id: String,
+    /// When it was applied.
+    pub applied_at_unix_secs: u64,
+    /// The level it reached.
+    pub achieved_level: ProtectionLevel,
+    /// The core version that wrote it, so an upgrade path is legible.
+    pub core_version: String,
+    /// The adapter version that authored its plan.
+    pub adapter_version: String,
+}
+
+impl SupersededReceipt {
+    /// Summarise `receipt` for the upgrade history.
+    pub fn of(receipt: &IntegrationReceipt) -> Self {
+        Self {
+            receipt_id: receipt.receipt_id.clone(),
+            plan_id: receipt.plan_id.clone(),
+            applied_at_unix_secs: receipt.applied_at_unix_secs,
+            achieved_level: receipt.achieved_level,
+            core_version: receipt.versions.core.to_string(),
+            adapter_version: receipt.versions.adapter.to_string(),
+        }
+    }
+}
+
+/// What one receipt file holds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ReceiptEnvelope {
+    /// [`RECEIPT_ENVELOPE_VERSION`] the writing core used.
+    pub envelope_version: u32,
+    /// Hash over the canonical JSON of [`receipt`](Self::receipt).
+    pub integrity: String,
+    /// The receipt itself.
+    pub receipt: IntegrationReceipt,
+    /// Receipts this one replaced, newest first, bounded by
+    /// [`MAX_SUPERSEDED_RECEIPTS`].
+    pub superseded: Vec<SupersededReceipt>,
+}
+
+impl ReceiptEnvelope {
+    /// Seal `receipt` with its integrity hash and an upgrade history.
+    pub fn seal(receipt: IntegrationReceipt, superseded: Vec<SupersededReceipt>) -> Result<Self, StoreError> {
+        let integrity = integrity_of(&receipt)?;
+        Ok(Self {
+            envelope_version: RECEIPT_ENVELOPE_VERSION,
+            integrity,
+            receipt,
+            superseded,
+        })
+    }
+
+    /// Whether the hash still covers the receipt.
+    pub fn integrity_holds(&self) -> bool {
+        integrity_of(&self.receipt).is_ok_and(|computed| computed == self.integrity)
+    }
+}
+
+fn integrity_of(receipt: &IntegrationReceipt) -> Result<String, StoreError> {
+    // The receipt derives `Serialize` into `serde_json`'s BTreeMap-backed
+    // objects, so this rendering is already key-ordered and stable across runs.
+    let canonical = serde_json::to_string(receipt).map_err(|e| StoreError::Corrupt {
+        path: PathBuf::new(),
+        detail: e.to_string(),
+    })?;
+    Ok(fingerprint_raw(&canonical))
+}
+
+/// A stable, filesystem-safe slug for a tool.
+///
+/// `Custom` names come from adapters, so every character outside
+/// `[a-z0-9._-]` is folded to `_`: a tool name is not allowed to choose which
+/// directory its receipt lands in.
+fn tool_slug(tool: &DevToolKind) -> String {
+    let raw = match tool {
+        DevToolKind::ClaudeCode => "claude-code",
+        DevToolKind::Codex => "codex",
+        DevToolKind::GitHubCopilot => "github-copilot",
+        DevToolKind::WindsurfCascade => "windsurf-cascade",
+        DevToolKind::Custom(name) => name.as_str(),
+    };
+    raw.chars()
+        .map(|c| {
+            let c = c.to_ascii_lowercase();
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Receipts and journals on the local filesystem.
+///
+/// One store per state directory; one receipt per (tool, settings scope) pair,
+/// because the same tool integrated at user scope and at project scope are two
+/// integrations with two sets of artifacts.
+#[derive(Debug, Clone)]
+pub struct ReceiptStore {
+    root: PathBuf,
+}
+
+impl ReceiptStore {
+    /// A store rooted at `root`, which is created on first write.
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// The default store: `${AASM_STATE_DIR:-~/.aasm}/integrations`.
+    pub fn default_location() -> Result<Self, StoreError> {
+        let base = match std::env::var_os("AASM_STATE_DIR") {
+            Some(dir) if !dir.is_empty() => PathBuf::from(dir),
+            _ => dirs::home_dir().ok_or(StoreError::NoStateDirectory)?.join(".aasm"),
+        };
+        Ok(Self::at(base.join("integrations")))
+    }
+
+    /// The directory receipts and journals are written to.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Where this tool's receipt at this scope lives.
+    pub fn receipt_path(&self, tool: &DevToolKind, scope: SettingsScope) -> PathBuf {
+        self.root.join(format!("{}--{scope}.receipt.json", tool_slug(tool)))
+    }
+
+    /// Where this tool's in-flight journal at this scope lives.
+    pub fn journal_path(&self, tool: &DevToolKind, scope: SettingsScope) -> PathBuf {
+        self.root.join(format!("{}--{scope}.journal.json", tool_slug(tool)))
+    }
+
+    /// Whether a receipt exists, without reading or trusting it.
+    ///
+    /// Recovery needs this rather than a successful load: "a receipt is there"
+    /// is what the journal's ordering rule turns on, and a receipt that is
+    /// present but corrupt still means the apply reached the point of writing
+    /// one.
+    pub fn receipt_exists(&self, tool: &DevToolKind, scope: SettingsScope) -> bool {
+        self.receipt_path(tool, scope).exists()
+    }
+
+    /// Read the stored envelope, verifying its version and integrity.
+    ///
+    /// `Ok(None)` means no receipt has been written. Every other failure is an
+    /// error the caller must fail closed on — a receipt that cannot be trusted
+    /// is never reported as an absent one.
+    pub fn load_envelope(
+        &self,
+        tool: &DevToolKind,
+        scope: SettingsScope,
+    ) -> Result<Option<ReceiptEnvelope>, StoreError> {
+        let path = self.receipt_path(tool, scope);
+        let Some(raw) = read_secure(&path)? else {
+            return Ok(None);
+        };
+
+        let envelope: ReceiptEnvelope = serde_json::from_str(&raw).map_err(|e| StoreError::Corrupt {
+            path: path.clone(),
+            detail: e.to_string(),
+        })?;
+
+        if envelope.envelope_version > RECEIPT_ENVELOPE_VERSION {
+            return Err(StoreError::EnvelopeTooNew {
+                path,
+                found: envelope.envelope_version,
+                readable: RECEIPT_ENVELOPE_VERSION,
+            });
+        }
+        if !envelope.integrity_holds() {
+            return Err(StoreError::IntegrityMismatch { path });
+        }
+        Ok(Some(envelope))
+    }
+
+    /// The stored receipt, or `None` when none has been written.
+    pub fn load_receipt(
+        &self,
+        tool: &DevToolKind,
+        scope: SettingsScope,
+    ) -> Result<Option<IntegrationReceipt>, StoreError> {
+        Ok(self.load_envelope(tool, scope)?.map(|e| e.receipt))
+    }
+
+    /// Write `receipt`, folding whatever it replaced into the upgrade history.
+    ///
+    /// A previous receipt that cannot be read is *not* an error here: the new
+    /// receipt describes what is on the host now, and refusing to record it
+    /// would leave the host mutated with nothing to reverse it. The unreadable
+    /// predecessor is dropped from the history rather than guessed at.
+    pub fn save_receipt(&self, receipt: &IntegrationReceipt) -> Result<(), StoreError> {
+        let scope = receipt.settings_scope;
+        let mut superseded = Vec::new();
+        if let Ok(Some(existing)) = self.load_envelope(&receipt.tool, scope) {
+            if existing.receipt.receipt_id != receipt.receipt_id {
+                superseded.push(SupersededReceipt::of(&existing.receipt));
+            }
+            superseded.extend(existing.superseded);
+            superseded.truncate(MAX_SUPERSEDED_RECEIPTS);
+        }
+
+        let envelope = ReceiptEnvelope::seal(receipt.clone(), superseded)?;
+        let path = self.receipt_path(&receipt.tool, scope);
+        let body = serde_json::to_string_pretty(&envelope).map_err(|e| StoreError::Corrupt {
+            path: path.clone(),
+            detail: e.to_string(),
+        })?;
+        self.write_secure(&path, &body)
+    }
+
+    /// Delete the receipt. Deleting one that is not there is a success — remove
+    /// has to be safe to run twice.
+    pub fn delete_receipt(&self, tool: &DevToolKind, scope: SettingsScope) -> Result<(), StoreError> {
+        remove_if_present(&self.receipt_path(tool, scope))
+    }
+
+    /// Read the in-flight journal, if there is one.
+    pub fn load_journal(
+        &self,
+        tool: &DevToolKind,
+        scope: SettingsScope,
+    ) -> Result<Option<OperationJournal>, StoreError> {
+        let path = self.journal_path(tool, scope);
+        let Some(raw) = read_secure(&path)? else {
+            return Ok(None);
+        };
+        serde_json::from_str(&raw).map(Some).map_err(|e| StoreError::Corrupt {
+            path,
+            detail: e.to_string(),
+        })
+    }
+
+    /// Write the journal. Called before the first mutation and after each step.
+    pub fn save_journal(&self, journal: &OperationJournal) -> Result<(), StoreError> {
+        let path = self.journal_path(&journal.tool, journal.settings_scope);
+        let body = serde_json::to_string_pretty(journal).map_err(|e| StoreError::Corrupt {
+            path: path.clone(),
+            detail: e.to_string(),
+        })?;
+        self.write_secure(&path, &body)
+    }
+
+    /// Delete the journal, marking the operation complete.
+    pub fn delete_journal(&self, tool: &DevToolKind, scope: SettingsScope) -> Result<(), StoreError> {
+        remove_if_present(&self.journal_path(tool, scope))
+    }
+
+    /// Write `body` to `path` atomically, owner-only.
+    ///
+    /// Content goes to a sibling temporary file and is renamed into place, so a
+    /// crash mid-write leaves either the old file or the new one — never a
+    /// truncated receipt that would then fail its own integrity check and lock
+    /// the user out of their own integration.
+    fn write_secure(&self, path: &Path, body: &str) -> Result<(), StoreError> {
+        std::fs::create_dir_all(&self.root).map_err(|source| StoreError::Io {
+            path: self.root.clone(),
+            source,
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.root, std::fs::Permissions::from_mode(0o700)).map_err(|source| {
+                StoreError::Io {
+                    path: self.root.clone(),
+                    source,
+                }
+            })?;
+        }
+
+        let tmp = path.with_extension("tmp");
+        write_owner_only(&tmp, body)?;
+        std::fs::rename(&tmp, path).map_err(|source| StoreError::Io {
+            path: path.to_path_buf(),
+            source,
+        })
+    }
+}
+
+#[cfg(unix)]
+fn write_owner_only(path: &Path, body: &str) -> Result<(), StoreError> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // `create(true).truncate(true)` rather than `create_new`, because a previous
+    // crash may have left the temporary file behind and refusing to overwrite it
+    // would wedge every subsequent write.
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|source| StoreError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    file.write_all(body.as_bytes()).map_err(|source| StoreError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    // An existing file keeps its old mode through `OpenOptions::mode`, which
+    // only applies at creation — re-assert it so a loosened temporary file
+    // cannot launder permissions into the renamed destination.
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|source| StoreError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_owner_only(path: &Path, body: &str) -> Result<(), StoreError> {
+    // Windows ACL equivalence is a stated reconsideration trigger in ADR 0030
+    // and is not assumed here; the file is written without a mode claim rather
+    // than with one this platform cannot keep.
+    std::fs::write(path, body).map_err(|source| StoreError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Read `path`, re-asserting owner-only permissions first.
+///
+/// Returns `Ok(None)` when the file does not exist. The permission re-assertion
+/// happens *before* the read for the same reason `aa-proxy`'s CA loader does it:
+/// creation-time enforcement says nothing about a file restored from a backup or
+/// copied in by hand, and a receipt left group-readable is a map of everything
+/// AASM governs on this host.
+fn read_secure(path: &Path) -> Result<Option<String>, StoreError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path)
+            .map_err(|source| StoreError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?
+            .permissions()
+            .mode()
+            & 0o777;
+        if mode & 0o077 != 0 {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|source| {
+                StoreError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                }
+            })?;
+        }
+    }
+    std::fs::read_to_string(path)
+        .map(Some)
+        .map_err(|source| StoreError::Io {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn remove_if_present(path: &Path) -> Result<(), StoreError> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(StoreError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integration::journal::{JournalOperation, StepProgress};
+    use crate::integration::plan::ProtectionProfile;
+    use crate::integration::receipt::StepReceipt;
+    use crate::integration::step::{IntegrationStep, SettingsMerge, StepAction};
+    use crate::integration::version::{core_version, ComponentVersions, ToolVersion, LIFECYCLE_SCHEMA_VERSION};
+    use std::path::PathBuf;
+
+    fn step() -> IntegrationStep {
+        IntegrationStep::new(
+            "settings",
+            StepAction::WriteManagedSettings {
+                scope: SettingsScope::User,
+                path: PathBuf::from("/home/dev/.claude/settings.json"),
+                managed_keys: vec!["permissions".to_string()],
+                content_sha256: "abc".to_string(),
+                merge: SettingsMerge::MergeManagedKeys,
+            },
+            "write the managed settings block",
+        )
+    }
+
+    fn receipt(id: &str) -> IntegrationReceipt {
+        IntegrationReceipt {
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            receipt_id: id.to_string(),
+            plan_id: format!("plan-{id}"),
+            tool: DevToolKind::ClaudeCode,
+            profile: ProtectionProfile::Recommended,
+            settings_scope: SettingsScope::User,
+            applied_at_unix_secs: 1_000_000,
+            versions: ComponentVersions {
+                core: core_version(),
+                adapter: ToolVersion::new(0, 1, 0),
+                lifecycle_schema: LIFECYCLE_SCHEMA_VERSION,
+            },
+            tool_version: Some(ToolVersion::new(2, 1, 220)),
+            steps: vec![StepReceipt::applied(&step(), Some("sha256:managed".to_string()))],
+            planned_level: ProtectionLevel::Integrated,
+            achieved_level: ProtectionLevel::Integrated,
+            achieved_evidence: vec![],
+            verified_at_unix_secs: Some(1_000_000),
+        }
+    }
+
+    fn store() -> (tempfile::TempDir, ReceiptStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::at(dir.path().join("integrations"));
+        (dir, store)
+    }
+
+    #[test]
+    fn a_receipt_round_trips_through_the_store() {
+        let (_dir, store) = store();
+        assert_eq!(
+            store
+                .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+                .unwrap(),
+            None
+        );
+
+        let r = receipt("r1");
+        store.save_receipt(&r).unwrap();
+        assert_eq!(
+            store
+                .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+                .unwrap(),
+            Some(r)
+        );
+    }
+
+    #[test]
+    fn user_and_project_scope_are_separate_integrations() {
+        let (_dir, store) = store();
+        let user = receipt("r-user");
+        let mut project = receipt("r-project");
+        project.settings_scope = SettingsScope::Project;
+
+        store.save_receipt(&user).unwrap();
+        store.save_receipt(&project).unwrap();
+
+        assert_eq!(
+            store
+                .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+                .unwrap()
+                .unwrap()
+                .receipt_id,
+            "r-user"
+        );
+        assert_eq!(
+            store
+                .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::Project)
+                .unwrap()
+                .unwrap()
+                .receipt_id,
+            "r-project"
+        );
+    }
+
+    #[test]
+    fn a_tampered_receipt_fails_closed_rather_than_being_read() {
+        let (_dir, store) = store();
+        store.save_receipt(&receipt("r1")).unwrap();
+
+        let path = store.receipt_path(&DevToolKind::ClaudeCode, SettingsScope::User);
+        let raw = std::fs::read_to_string(&path).unwrap();
+        // Change the receipt without recomputing the envelope's hash — exactly
+        // what a hand-edit or a partial sync produces.
+        let tampered = raw.replace(
+            "\"achieved_level\": \"Integrated\"",
+            "\"achieved_level\": \"HostEnforced\"",
+        );
+        assert_ne!(tampered, raw, "the fixture must actually have been modified");
+        std::fs::write(&path, tampered).unwrap();
+
+        let err = store
+            .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .expect_err("a receipt whose hash does not match must not load");
+        assert!(matches!(err, StoreError::IntegrityMismatch { .. }), "{err:?}");
+        assert!(err.as_untrustworthy_receipt_reason().is_some());
+    }
+
+    #[test]
+    fn a_truncated_receipt_is_corrupt_not_absent() {
+        let (_dir, store) = store();
+        store.save_receipt(&receipt("r1")).unwrap();
+        let path = store.receipt_path(&DevToolKind::ClaudeCode, SettingsScope::User);
+        std::fs::write(&path, "{\"envelope_version\": 1, \"integ").unwrap();
+
+        let err = store
+            .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .expect_err("a truncated receipt must not read as no receipt");
+        assert!(matches!(err, StoreError::Corrupt { .. }), "{err:?}");
+        assert!(
+            store.receipt_exists(&DevToolKind::ClaudeCode, SettingsScope::User),
+            "recovery still needs to know the apply got as far as writing one"
+        );
+    }
+
+    #[test]
+    fn an_envelope_from_a_newer_build_is_refused() {
+        let (_dir, store) = store();
+        store.save_receipt(&receipt("r1")).unwrap();
+        let path = store.receipt_path(&DevToolKind::ClaudeCode, SettingsScope::User);
+        let raw = std::fs::read_to_string(&path).unwrap();
+        std::fs::write(
+            &path,
+            raw.replace(
+                &format!("\"envelope_version\": {RECEIPT_ENVELOPE_VERSION}"),
+                &format!("\"envelope_version\": {}", RECEIPT_ENVELOPE_VERSION + 1),
+            ),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            store.load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User),
+            Err(StoreError::EnvelopeTooNew { .. })
+        ));
+    }
+
+    #[test]
+    fn reinstalling_records_the_receipt_it_replaced() {
+        let (_dir, store) = store();
+        store.save_receipt(&receipt("r1")).unwrap();
+        store.save_receipt(&receipt("r2")).unwrap();
+
+        let envelope = store
+            .load_envelope(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap()
+            .unwrap();
+        assert_eq!(envelope.receipt.receipt_id, "r2");
+        assert_eq!(envelope.superseded.len(), 1);
+        assert_eq!(envelope.superseded[0].receipt_id, "r1");
+
+        // Saving the same receipt again is not an upgrade and must not grow the
+        // history — reapply is idempotent all the way down to the store.
+        store.save_receipt(&receipt("r2")).unwrap();
+        let envelope = store
+            .load_envelope(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap()
+            .unwrap();
+        assert_eq!(envelope.superseded.len(), 1);
+    }
+
+    #[test]
+    fn the_upgrade_history_is_bounded() {
+        let (_dir, store) = store();
+        for i in 0..(MAX_SUPERSEDED_RECEIPTS + 5) {
+            store.save_receipt(&receipt(&format!("r{i}"))).unwrap();
+        }
+        let envelope = store
+            .load_envelope(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap()
+            .unwrap();
+        assert_eq!(envelope.superseded.len(), MAX_SUPERSEDED_RECEIPTS);
+    }
+
+    #[test]
+    fn deleting_a_receipt_twice_succeeds() {
+        let (_dir, store) = store();
+        store.save_receipt(&receipt("r1")).unwrap();
+        store
+            .delete_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap();
+        store
+            .delete_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap();
+        assert!(!store.receipt_exists(&DevToolKind::ClaudeCode, SettingsScope::User));
+    }
+
+    #[test]
+    fn journals_round_trip_and_delete() {
+        let (_dir, store) = store();
+        let mut journal = OperationJournal::starting(
+            JournalOperation::Apply,
+            "p1",
+            DevToolKind::ClaudeCode,
+            SettingsScope::User,
+            1_000_000,
+            ["settings".to_string()],
+        );
+        journal.mark("settings", StepProgress::Applied);
+        store.save_journal(&journal).unwrap();
+        assert_eq!(
+            store
+                .load_journal(&DevToolKind::ClaudeCode, SettingsScope::User)
+                .unwrap(),
+            Some(journal)
+        );
+
+        store
+            .delete_journal(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap();
+        assert_eq!(
+            store
+                .load_journal(&DevToolKind::ClaudeCode, SettingsScope::User)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn receipts_are_owner_only_at_rest() {
+        use std::os::unix::fs::PermissionsExt;
+        let (_dir, store) = store();
+        store.save_receipt(&receipt("r1")).unwrap();
+
+        let path = store.receipt_path(&DevToolKind::ClaudeCode, SettingsScope::User);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "a receipt names every file AASM governs on this host"
+        );
+        assert_eq!(
+            std::fs::metadata(store.root()).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loose_permissions_are_re_asserted_on_load_not_only_at_creation() {
+        use std::os::unix::fs::PermissionsExt;
+        let (_dir, store) = store();
+        store.save_receipt(&receipt("r1")).unwrap();
+        let path = store.receipt_path(&DevToolKind::ClaudeCode, SettingsScope::User);
+
+        // Simulate a receipt restored from a backup or copied in by hand.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        store
+            .load_receipt(&DevToolKind::ClaudeCode, SettingsScope::User)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "creation-time enforcement alone cannot keep a restored file owner-only"
+        );
+    }
+
+    #[test]
+    fn a_custom_tool_name_cannot_choose_its_own_path() {
+        let (_dir, store) = store();
+        let path = store.receipt_path(
+            &DevToolKind::Custom("../../etc/Evil Tool".to_string()),
+            SettingsScope::User,
+        );
+        assert_eq!(path.parent(), Some(store.root()));
+        assert_eq!(
+            path.file_name().unwrap().to_string_lossy(),
+            ".._.._etc_evil_tool--user.receipt.json"
+        );
+    }
+}

--- a/docs/src/adr/0030-developer-integration-boundaries-and-trust-model.md
+++ b/docs/src/adr/0030-developer-integration-boundaries-and-trust-model.md
@@ -781,6 +781,20 @@ gated its steps 6–9 on the runtime becoming authoritative.
   uses `GetNamedPipeClientProcessId` rather than `SO_PEERCRED`, and DACLs rather than mode
   bits. The decision assumes equivalence; it must be re-verified when a Windows client is
   actually built (see Reconsideration triggers).
+- **Restore is semantics-exact, not byte-exact** (AAASM-5276 condition C3, accepted by
+  [AAASM-5278](https://lightning-dust-mite.atlassian.net/browse/AAASM-5278)).
+  `aa-devtool-claude-code/src/apply.rs:85` reserialises the whole settings document on every
+  write, so a user file in non-canonical formatting — hand-chosen key order, indentation,
+  trailing layout — cannot survive an install→remove cycle byte-for-byte regardless of how
+  good the receipt is. What removal does restore is the document's **meaning**: every value
+  AASM displaced is put back, every key AASM added is deleted, and every key the user
+  changed after installation is carried through untouched. Two consequences are deliberate
+  and follow from accepting it rather than working around it: fingerprints are taken over
+  canonical JSON, so a reformat is correctly reported as *no drift*; and a removal report
+  states the limitation rather than implying a guarantee the write path cannot keep. The
+  alternative — preserving the original document verbatim — was rejected as disproportionate
+  for the MVP: it needs a format-preserving JSON editor in the write path that no in-tree
+  adapter has, and it buys byte-identity in a file the tool itself rewrites.
 
 ## Explicitly forbidden designs
 
@@ -916,6 +930,11 @@ that ticket rather than as checks present in this documentation-only change.
 - **The protection-test probe becomes unable to reach the core** for some tool family —
   `GatewayProtected` would then be unreachable for it, and the ladder needs a stated answer
   rather than an implicit cap.
+- **An adapter's settings write path stops reserialising** — a format-preserving JSON editor,
+  or a managed block written into a region of a file whose remainder is copied verbatim. At
+  that point byte-exact restore becomes achievable, and the semantics-exact constraint above
+  would be a *choice* rather than a constraint; it should then be revisited rather than
+  inherited.
 
 ## Traceability
 


### PR DESCRIPTION
## Description

Implements the durable integration-state model on top of the AAASM-5277 contract: dry-run planning,
receipt persistence, drift classification, idempotent apply, repair, rollback, and deterministic
recovery from an interrupted apply or remove.

New modules under `aa-core/src/integration/`: `fingerprint` · `drift` · `journal` · `store` · `engine`,
plus restoration evidence on `StepReceipt`.

### The idea that makes safe repair possible: two fingerprints per settings step

- `StepReceipt.fingerprint` — canonical hash of the **AASM-owned key projection**
- `StepReceipt.document_fingerprint` — canonical hash of the **whole document**

Managed projection differs → `AasmManagedValueChanged`, repairable. Managed projection matches but the
document differs → `UserManagedUnrelatedChange`, which is **reported, never repaired**, and excluded
from `mismatched_artifacts()` so it can never push the integration into `ProtectionState::Drifted`.
Only `MergeManagedKeys` steps can produce that classification; a `Replace` step owns its file outright.

Distinguishing "the user edited their own key" from "someone changed ours" is the entire difference
between a repair that is safe to run unattended and one that silently eats a developer's config.

### Drift taxonomy (8 variants)

`UserManagedUnrelatedChange` · `AasmManagedValueChanged` · `AasmArtifactMissing` ·
`ToolVersionIncompatible` · `RuntimeEndpointStale` · `ReceiptMissing` · `ReceiptCorrupt` ·
**`Unobservable`** — the eighth was added during implementation because "could not read it" is neither
"missing" nor "fine", and collapsing it into either would have been a fail-open.

### Interrupted apply rolls back; interrupted remove resumes

Ordering is **journal → mutate (recording each step's own reversal information) → receipt → delete
journal**. Two facts — journal present, receipt present — determine the recovery action uniquely.

- **Interrupted apply rolls back.** No receipt exists, so half-applied state is pure liability, and the
  journal's per-step outcomes are the only reversal source.
- **Interrupted remove resumes.** Stopping would leave AASM artifacts on a host whose owner asked for
  them to be gone. Every reversal is idempotent, so resuming is safe.
- A journal written by a newer core escalates and is preserved rather than being interpreted.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Purely additive. `StepReceipt` gained `document_fingerprint` and `prior_state` plus three methods; both
existing constructors keep their signatures, so no adapter and no contract test changed.

## Related Issues

- Related Jira ticket: [AAASM-5278](https://lightning-dust-mite.atlassian.net/browse/AAASM-5278)
  (Epic [AAASM-5272](https://lightning-dust-mite.atlassian.net/browse/AAASM-5272))
- Builds on: AAASM-5277 (#1821), consumes AAASM-5276 Spike condition **C3** (#1820)
- Blocks: AAASM-5280, AAASM-5281
- Amends: **ADR 0030** — records semantics-exact restore as an accepted risk
- GitHub issues: N/A

## Architectural impact

Everything added is **service-side** and deliberately **not** re-exported through
`aa-devtool-contract` — **zero new symbols on that CODEOWNERS-gated surface**. Adapters read receipts;
they never restore, so they never need to name `PriorSettingsState`.

**ADR 0030 is amended, not rewritten.** Condition C3 is recorded in the existing *Accepted risks*
section with a narrow, falsifiable reconsideration trigger ("an adapter's settings write path stops
reserialising"), and no shipped ADR text was altered.

### The C3 decision: semantics-exact restore, accepted rather than worked around

`aa-devtool-claude-code/src/apply.rs:85` reserialises the whole settings document on every write, so a
user file in non-canonical formatting cannot survive an install→remove cycle byte-for-byte no matter how
good the receipt is. Option (b) — preserving the original document verbatim — was rejected as
disproportionate for the MVP: it needs a format-preserving JSON editor in a write path no in-tree
adapter has, to buy byte-identity in a file the tool itself rewrites.

Accepting it was made *operational*, not cosmetic: **every fingerprint is over canonical JSON, never
raw bytes**, so a pure reformat is correctly classified as *no drift*; removal restores the document's
**meaning** (displaced values back, added keys deleted, post-install user edits carried through); and
the removal report states the limitation rather than implying a guarantee the write path cannot keep.

## Security impact

- **Receipts cannot carry raw secrets.** Values are screened per-key through
  `aa_security::CredentialScanner` before they reach a receipt; screened keys are recorded in
  `withheld_keys`. Errors carry serde line/column, never file contents.
- **Storage:** `${AASM_STATE_DIR:-~/.aasm}/integrations/<tool>--<scope>.receipt.json` — the state
  directory `install-cli.sh` and `pidfile.rs` already use. Directory `0700`, files `0600`, **re-asserted
  on load** rather than only at create (following `aa-proxy/src/tls/ca.rs:108-123`), written tmp+rename.
  Deliberately **outside the tool's own config tree**: a record of what that tree should contain cannot
  be one of the things it describes, and removal must be able to empty the tree without deleting its own
  evidence.
- **Integrity:** the envelope carries a SHA-256 over the canonical receipt. This is corruption detection
  and is explicitly **not** a MAC — host tamper prevention is a stated non-goal, and claiming otherwise
  would be exactly the over-claim this Epic exists to remove.
- **Fail-closed:** a receipt whose hash does not match **refuses to load**; repair then refuses to
  proceed rather than "repairing" from unverifiable evidence. ADR 0015's discipline, applied to state.
- **Apply can never claim `GatewayProtected`.** Configuration alone caps the reported level at
  `Integrated`; only `record_verification` with *exercised* evidence lifts it.
- **Unsupported step kinds error rather than succeed quietly.** `InjectLaunchEnvironment`,
  `ConfigureProxy`, `ConfigureMcpServers`, `RegisterIdeClient` and `ConnectLocalRuntime` return
  `ExecutionError::Unsupported` — they are AAASM-5281's mechanisms, and a silent no-op would produce a
  receipt claiming a mutation nothing performed.

## Tests executed

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required

**141 `integration::` tests.** `cargo nextest run -p aa-core -p aa-devtool -p aa-devtool-contract
-p aa-devtool-claude-code` → **488 passed, 0 failed**. Re-verified after rebasing onto `main`:
`cargo nextest run -p aa-core` → **399 passed, 0 failed**.

### Three guards proved load-bearing — violated, watched fail, reverted

**A — repair must not touch a user key modified after install.** Violation: treat `MergeManagedKeys` as
`Replace`.
```
panicked at aa-core/src/integration/engine.rs:1312:9:
assertion `left == right` failed: a user key added after installation must survive repair
  left: Null
 right: 18
```

**B — a receipt whose hash does not match must fail closed, not silently repair.** Violation:
`integrity_holds() -> true`. Two tests failed:
```
panicked at aa-core/src/integration/store.rs:641:14:
a receipt whose hash does not match must not load: Some(IntegrationReceipt { … achieved_level: HostEnforced … })

panicked at aa-core/src/integration/engine.rs:1365:9:
DriftReport { findings: [] }
```
The forged receipt loaded clean and repair would have proceeded — on a receipt claiming `HostEnforced`.

**C — the secret screen.** Violation: store every value unscreened.
```
panicked at aa-core/src/integration/engine.rs:1587:9:
the receipt holds the raw secret
```

### A real bug the tests caught

The first rollback draft reversed from the *receipt* — which does not exist during an interrupted apply,
so it silently did nothing. Strengthening the interrupted-apply test to assert against real files on
disk caught it, and reversal now comes from the journal's per-step outcomes.

### No-raw-secret test

`no_raw_secret_from_the_settings_file_can_reach_the_receipt` plants a synthetic value
(`sk-ant-api03-AAASM5278SYNTHETIC…`) in **both** an unmanaged key (`apiKey`) and a managed one
(`permissionMode`), applies, then asserts the persisted receipt contains no full value, no
`AAASM5278SYNTHETIC` fragment and no `sk-ant-` prefix — **while asserting the source file still holds
it**, so the test is about the receipt rather than about destroying the user's data. Passes.

### Validation — all run and observed

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo nextest run -p aa-core -p aa-devtool -p aa-devtool-contract -p aa-devtool-claude-code` | **488 passed, 0 failed** |
| `cargo nextest run -p aa-core` (post-rebase) | **399 passed, 0 failed** |
| `cargo build --workspace` | exit 0 |
| `cargo doc --workspace --no-deps` | exit 0; only pre-existing warnings (`DenyAllEvaluator`/`PermitAllEvaluator`, untouched) |

Lefthook pre-commit (fmt + workspace clippy) passed on every commit.

## Acceptance-criteria evidence

| AC | Evidence |
|---|---|
| Stable dry-run before any mutation | `IntegrationEngine::dry_run` takes `&self` and never reaches the executor; test asserts no target file, no CA and no store directory is created |
| Versioned receipt with AASM-owned changes and restoration evidence | `schema_version` + independent `RECEIPT_ENVELOPE_VERSION`; per-step `PriorSettingsState` |
| Receipts hold no raw secrets; no credential exposure via logs/diagnostics | Per-key screen via `CredentialScanner`; `withheld_keys`; errors carry line/column only |
| Reapply is idempotent | Two layers — the executor reports `mutated: false` without opening the file, and apply skips the receipt rewrite. Test asserts the stored receipt is **byte-identical** after a no-op reapply |
| Drift distinguishes unrelated user changes from AASM-managed changes | Dual fingerprint, described above |
| Repair updates only AASM-owned state, preserves later user changes | Guard A; repair refuses outright when any AASM-affecting finding is unrepairable |
| Remove restores prior state and deletes only AASM-owned artifacts | Restores displaced values, deletes added keys, deletes a settings file it created outright, keeps post-install user edits |
| Interrupted apply and remove have deterministic recovery | Both directions tested end-to-end against real files; both idempotent on re-run |
| Version changes representable, can trigger migration or incompatible status | `EnvelopeTooNew`, `is_schema_newer_than_running_core`, journal escalation, bounded `SupersededReceipt` history, `ToolVersionIncompatible` that repair refuses |
| Unit tests cover merge, drift, repair, upgrade and rollback conflicts | 141 tests; rollback conflict is `a_reversal_that_fails_is_reported_rather_than_silently_completing` — receipt **and** journal both survive so recovery can resume |
| Conforms to the AAASM-5277 contract and AAASM-5276 evidence | Builds only on 5277 types; C3 accepted and recorded in the ADR; `SettingsScope` carried in receipt **and** journal |

## Known limitations

- **Restore is semantics-exact, not byte-exact** — recorded in ADR 0030 as an accepted risk with its
  reconsideration trigger.
- `FilesystemExecutor` covers settings, trust material and owned artifacts only. The five mechanism step
  kinds listed under Security impact return `Unsupported`; a plan using them today aborts if they are
  required, or records a skip if optional. They are AAASM-5281's.
- Envelope integrity is corruption detection, not tamper resistance.

## Dependencies / stacked PRs

Originally stacked on AAASM-5277's branch; that merged as #1821 (`eb335a23`) and this branch has been
**rebased onto `main`**, so it is independently mergeable. Tests were re-run after the rebase.

AAASM-5279 is in flight on a disjoint file set (`aa-runtime`, `aa-proto`); only `Cargo.lock` overlaps.

## Documentation and migration impact

ADR 0030 amended as described. No user-facing documentation yet — the CLI surface that exposes these
verbs is AAASM-5280, and the truthful-claims documentation is AAASM-5284.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (7 commits, one concern each)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5278]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ