### PR TITLE
[AAASM-5279] ✨ (aa-runtime): Add the restricted local Developer Integration API

### DIFF
--- a/aa-proto/build.rs
+++ b/aa-proto/build.rs
@@ -45,6 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         proto_root.join("secrets.proto"),
         proto_root.join("invalidation.proto"),
         proto_root.join("ipc.proto"),
+        proto_root.join("devint.proto"),
     ];
 
     println!("cargo:rerun-if-changed={}", proto_root.display());

--- a/aa-proto/src/lib.rs
+++ b/aa-proto/src/lib.rs
@@ -18,6 +18,7 @@
 //! assembly::topology::v1 — agent tree, lineage, and team-member queries
 //! assembly::gateway::v1  — L1 cache push-invalidation channel
 //! assembly::ipc::v1      — local SDK ↔ runtime UDS handshake (AAASM-3569)
+//! assembly::devint::v1   — local Developer Integration API (AAASM-5279)
 //! ```
 
 pub mod assembly {
@@ -83,6 +84,18 @@ pub mod assembly {
         // prost payloads behind the hand-rolled IPC codec's wire tags, not gRPC.
         pub mod v1 {
             tonic::include_proto!("assembly.ipc.v1");
+        }
+    }
+
+    pub mod devint {
+        // Developer Integration API wire schema (ADR 0030 Decision 5,
+        // AAASM-5279). Served on its own UDS (`~/.aa/run/devint.sock`) behind
+        // the same length-delimited IPC codec — deliberately not a gRPC service
+        // and deliberately not the SDK fast-path socket, so agent-action and
+        // policy-decision traffic is unreachable from a DI client by
+        // construction.
+        pub mod v1 {
+            tonic::include_proto!("assembly.devint.v1");
         }
     }
 }

--- a/aa-runtime/src/devint/audit.rs
+++ b/aa-runtime/src/devint/audit.rs
@@ -1,0 +1,363 @@
+//! The DI-API's audit obligation (ADR 0030 §5.3, and ADR 0015's rule
+//! transferred).
+//!
+//! Two classes of event are recorded, and they are the two the ticket names:
+//!
+//! * **Client authentication and authorization failures** — every absent,
+//!   malformed, unknown, expired or out-of-scope token, and every rejected
+//!   peer, unknown verb and failed negotiation. A resolution failure that is
+//!   not audit-visible is a resolution failure nobody will ever learn about.
+//! * **Lifecycle mutations** — every apply, repair and remove, with its
+//!   outcome.
+//!
+//! # What an event may carry, and what it may never
+//!
+//! An event names the **token id**, the client, the verb, the tool and the
+//! outcome. It never carries:
+//!
+//! * the token value — §5.3 is explicit: "the token *id* and the outcome —
+//!   never the token value";
+//! * *why it almost matched* — there is no field for a partial-match hint,
+//!   because an audit trail that narrows a secret is an oracle;
+//! * protected content — no prompt, no tool output, no settings body, no
+//!   policy document. [`DevIntAuditEvent`] has no field one could occupy, which
+//!   is the same enforcement-by-shape the response types use.
+//!
+//! [`TracingAuditSink`] is the default: structured `tracing` records, which is
+//! where the rest of the runtime's security-relevant events already go. The
+//! sink is a trait so AAASM-5278's service can route the same events into the
+//! durable audit trail without this module growing a second event store
+//! (ADR 0030 matrix row 13).
+
+use std::sync::{Arc, Mutex};
+
+use super::token::{TokenDenial, TokenId};
+use super::verb::DiVerb;
+
+/// What happened, in the vocabulary the audit trail records.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DevIntAuditKind {
+    /// A peer was rejected before any DI-API frame was read.
+    PeerRejected {
+        /// Why: `uid_mismatch` or `peercred_unavailable`.
+        reason: &'static str,
+    },
+    /// Version negotiation concluded.
+    Negotiated {
+        /// `supported`, `degraded` or `incompatible`.
+        outcome: &'static str,
+        /// The agreed version, when one was agreed.
+        version: Option<u32>,
+    },
+    /// A request was refused at the token layer.
+    AuthFailure {
+        /// The coarse outcome name, e.g. `token_expired`.
+        outcome: &'static str,
+        /// The enrolment involved, when one was reached. `None` for absent,
+        /// malformed and unknown tokens — there is genuinely no id to record,
+        /// and inventing one would imply a match that did not happen.
+        token_id: Option<TokenId>,
+    },
+    /// A request was refused for a reason other than the token.
+    ProtocolFailure {
+        /// `unknown_verb`, `renegotiation_attempted`, `unavailable_at_version`,
+        /// `malformed_frame` or `frame_too_large`.
+        reason: &'static str,
+    },
+    /// A verb ran to completion.
+    VerbServed {
+        /// Whether the lifecycle service succeeded.
+        succeeded: bool,
+    },
+}
+
+impl DevIntAuditKind {
+    /// A stable snake_case event name.
+    pub const fn name(&self) -> &'static str {
+        match self {
+            DevIntAuditKind::PeerRejected { .. } => "devint.peer_rejected",
+            DevIntAuditKind::Negotiated { .. } => "devint.negotiated",
+            DevIntAuditKind::AuthFailure { .. } => "devint.auth_failure",
+            DevIntAuditKind::ProtocolFailure { .. } => "devint.protocol_failure",
+            DevIntAuditKind::VerbServed { .. } => "devint.verb_served",
+        }
+    }
+}
+
+/// One DI-API audit record.
+///
+/// Every field is an identifier, a name or an outcome. There is deliberately no
+/// free-form payload field: a `details: String` would be exactly the place a
+/// future contributor pastes a settings body or a token into.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DevIntAuditEvent {
+    /// When, seconds since the Unix epoch.
+    pub at_unix_secs: u64,
+    /// What happened.
+    pub kind: DevIntAuditKind,
+    /// The connection this happened on, so a sequence can be reconstructed.
+    pub connection_id: u64,
+    /// The client name from `Hello`. Display only — it is self-asserted and is
+    /// never an authentication factor, which is why it is recorded next to the
+    /// token id rather than instead of it.
+    pub client_name: Option<String>,
+    /// The verb, when the event concerns one.
+    pub verb: Option<DiVerb>,
+    /// The tool the verb named, when it named one.
+    pub tool_id: Option<String>,
+}
+
+impl DevIntAuditEvent {
+    /// Build an event.
+    pub fn new(at_unix_secs: u64, connection_id: u64, kind: DevIntAuditKind) -> Self {
+        Self {
+            at_unix_secs,
+            kind,
+            connection_id,
+            client_name: None,
+            verb: None,
+            tool_id: None,
+        }
+    }
+
+    /// Attach the self-asserted client name.
+    #[must_use]
+    pub fn with_client(mut self, client_name: Option<String>) -> Self {
+        self.client_name = client_name;
+        self
+    }
+
+    /// Attach the verb and tool the event concerns.
+    #[must_use]
+    pub fn with_target(mut self, verb: DiVerb, tool_id: impl Into<String>) -> Self {
+        self.verb = Some(verb);
+        let tool_id = tool_id.into();
+        self.tool_id = if tool_id.is_empty() { None } else { Some(tool_id) };
+        self
+    }
+
+    /// Build an auth-failure event from a [`TokenDenial`].
+    ///
+    /// The denial's coarse outcome and the enrolment id are carried across;
+    /// nothing else about the denial is, which is why this constructor exists
+    /// rather than each call site deciding what to log.
+    pub fn from_denial(at_unix_secs: u64, connection_id: u64, denial: &TokenDenial) -> Self {
+        Self::new(
+            at_unix_secs,
+            connection_id,
+            DevIntAuditKind::AuthFailure {
+                outcome: denial.outcome(),
+                token_id: denial.token_id().cloned(),
+            },
+        )
+    }
+}
+
+/// Where DI-API audit events go.
+pub trait DevIntAuditSink: Send + Sync {
+    /// Record one event. Must not block the connection it came from for long;
+    /// the caller is on a per-connection task, not the accept loop.
+    fn record(&self, event: DevIntAuditEvent);
+}
+
+/// The default sink: structured `tracing` records at INFO (mutations,
+/// negotiation) and WARN (failures).
+#[derive(Debug, Default, Clone)]
+pub struct TracingAuditSink;
+
+impl DevIntAuditSink for TracingAuditSink {
+    fn record(&self, event: DevIntAuditEvent) {
+        let name = event.kind.name();
+        let verb = event.verb.map(|v| v.as_str()).unwrap_or("-");
+        let tool = event.tool_id.as_deref().unwrap_or("-");
+        let client = event.client_name.as_deref().unwrap_or("-");
+        match &event.kind {
+            DevIntAuditKind::PeerRejected { reason } => {
+                tracing::warn!(
+                    event = name,
+                    connection_id = event.connection_id,
+                    reason,
+                    "DI-API peer rejected"
+                );
+            }
+            DevIntAuditKind::Negotiated { outcome, version } => {
+                tracing::info!(
+                    event = name,
+                    connection_id = event.connection_id,
+                    client,
+                    outcome,
+                    version = version.unwrap_or(0),
+                    "DI-API version negotiated"
+                );
+            }
+            DevIntAuditKind::AuthFailure { outcome, token_id } => {
+                tracing::warn!(
+                    event = name,
+                    connection_id = event.connection_id,
+                    client,
+                    verb,
+                    tool,
+                    outcome,
+                    // The id, never the value.
+                    token_id = token_id.as_ref().map(TokenId::as_str).unwrap_or("-"),
+                    "DI-API request denied"
+                );
+            }
+            DevIntAuditKind::ProtocolFailure { reason } => {
+                tracing::warn!(
+                    event = name,
+                    connection_id = event.connection_id,
+                    client,
+                    verb,
+                    reason,
+                    "DI-API protocol failure"
+                );
+            }
+            DevIntAuditKind::VerbServed { succeeded } => {
+                tracing::info!(
+                    event = name,
+                    connection_id = event.connection_id,
+                    client,
+                    verb,
+                    tool,
+                    succeeded,
+                    "DI-API verb served"
+                );
+            }
+        }
+    }
+}
+
+/// An in-memory sink for tests and for asserting the audit obligation.
+#[derive(Debug, Default, Clone)]
+pub struct RecordingAuditSink {
+    events: Arc<Mutex<Vec<DevIntAuditEvent>>>,
+}
+
+impl RecordingAuditSink {
+    /// A new, empty sink.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every event recorded so far, in order.
+    pub fn events(&self) -> Vec<DevIntAuditEvent> {
+        self.events.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+
+    /// Whether any recorded event is an auth failure with `outcome`.
+    pub fn has_auth_failure(&self, outcome: &str) -> bool {
+        self.events()
+            .iter()
+            .any(|e| matches!(&e.kind, DevIntAuditKind::AuthFailure { outcome: recorded, .. } if *recorded == outcome))
+    }
+}
+
+impl DevIntAuditSink for RecordingAuditSink {
+    fn record(&self, event: DevIntAuditEvent) {
+        self.events.lock().unwrap_or_else(|e| e.into_inner()).push(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_denial_becomes_an_event_naming_the_id_and_not_the_value() {
+        let denial = TokenDenial::OutOfScope {
+            token_id: TokenId::generate(),
+            verb: DiVerb::Apply,
+        };
+        let event = DevIntAuditEvent::from_denial(1_700_000_000, 7, &denial).with_target(DiVerb::Apply, "codex");
+        match &event.kind {
+            DevIntAuditKind::AuthFailure { outcome, token_id } => {
+                assert_eq!(*outcome, "out_of_scope");
+                assert_eq!(token_id.as_ref(), denial.token_id());
+            }
+            other => panic!("expected AuthFailure, got {other:?}"),
+        }
+        assert_eq!(event.tool_id.as_deref(), Some("codex"));
+    }
+
+    #[test]
+    fn denials_that_reached_no_record_carry_no_id() {
+        for denial in [TokenDenial::Absent, TokenDenial::Malformed, TokenDenial::Unknown] {
+            let event = DevIntAuditEvent::from_denial(0, 1, &denial);
+            let DevIntAuditKind::AuthFailure { token_id, .. } = &event.kind else {
+                panic!("expected AuthFailure");
+            };
+            assert!(
+                token_id.is_none(),
+                "an unreached record has no id; inventing one implies a match"
+            );
+        }
+    }
+
+    #[test]
+    fn the_event_type_has_no_field_that_could_hold_content() {
+        // Enforcement by shape: the only strings on the event are a
+        // self-asserted client name and a tool id, both of which the client
+        // supplied and neither of which is protected content. A `{:?}` of a
+        // fully-populated event is therefore safe to log.
+        let event = DevIntAuditEvent::new(1, 2, DevIntAuditKind::VerbServed { succeeded: true })
+            .with_client(Some("vscode-aasm".to_string()))
+            .with_target(DiVerb::Status, "claude-code");
+        let rendered = format!("{event:?}");
+        assert!(rendered.contains("vscode-aasm"));
+        assert!(rendered.contains("claude-code"));
+        assert!(rendered.contains("VerbServed"));
+    }
+
+    #[test]
+    fn an_empty_tool_id_is_recorded_as_absent_not_as_an_empty_string() {
+        let event = DevIntAuditEvent::new(1, 2, DevIntAuditKind::VerbServed { succeeded: true })
+            .with_target(DiVerb::ListTools, "");
+        assert_eq!(event.tool_id, None);
+    }
+
+    #[test]
+    fn the_recording_sink_preserves_order() {
+        let sink = RecordingAuditSink::new();
+        sink.record(DevIntAuditEvent::from_denial(1, 1, &TokenDenial::Absent));
+        sink.record(DevIntAuditEvent::new(
+            2,
+            1,
+            DevIntAuditKind::VerbServed { succeeded: true },
+        ));
+        let events = sink.events();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind.name(), "devint.auth_failure");
+        assert_eq!(events[1].kind.name(), "devint.verb_served");
+        assert!(sink.has_auth_failure("token_absent"));
+        assert!(!sink.has_auth_failure("token_expired"));
+    }
+
+    #[test]
+    fn every_kind_has_a_stable_name() {
+        let kinds = [
+            DevIntAuditKind::PeerRejected { reason: "uid_mismatch" },
+            DevIntAuditKind::Negotiated {
+                outcome: "supported",
+                version: Some(2),
+            },
+            DevIntAuditKind::AuthFailure {
+                outcome: "token_absent",
+                token_id: None,
+            },
+            DevIntAuditKind::ProtocolFailure { reason: "unknown_verb" },
+            DevIntAuditKind::VerbServed { succeeded: false },
+        ];
+        let names: Vec<&str> = kinds.iter().map(DevIntAuditKind::name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "devint.peer_rejected",
+                "devint.negotiated",
+                "devint.auth_failure",
+                "devint.protocol_failure",
+                "devint.verb_served",
+            ]
+        );
+    }
+}

--- a/aa-runtime/src/devint/client.rs
+++ b/aa-runtime/src/devint/client.rs
@@ -1,0 +1,448 @@
+//! A minimal reference DI-API client for thin integration shells.
+//!
+//! # What this is for
+//!
+//! AAASM-5279 requires "a generated/reference client available for thin
+//! integration shells". This is that reference: the smallest correct client,
+//! written so an extension author (or AAASM-5282's real client) can read it
+//! and see exactly what a well-behaved client does, in order:
+//!
+//! 1. **Discover** the socket, and treat its absence as *the runtime is not
+//!    running* — a bootstrap prompt, not a retry loop ([`DevIntClient::discover`]).
+//! 2. **Negotiate** before anything else, and *surface* a degraded outcome
+//!    rather than swallowing it ([`DevIntClient::connect`]).
+//! 3. **Present a capability token on every request.** There is no anonymous
+//!    tier to fall back to, so a client with no token has nothing to do but
+//!    tell the user to enrol.
+//! 4. **Render what the service computed.** Never derive a protection state
+//!    locally — a locally derived state is a claim wearing a measurement's
+//!    clothes (ADR 0030 forbidden design 10), which is why this client returns
+//!    the service's [`wire::StatusView`] verbatim and offers no way to compute
+//!    one.
+//!
+//! It is deliberately thin: no retries, no caching, no background reconnect,
+//! no state machine beyond "negotiated or not". AAASM-5282 builds the real
+//! client; this one exists so that work starts from a correct skeleton and so
+//! the server has an independent consumer in its tests.
+
+use std::path::{Path, PathBuf};
+
+use tokio::io::{BufReader, BufWriter};
+use tokio::net::UnixStream;
+
+use aa_proto::assembly::devint::v1 as wire;
+
+use super::codec::{self, DiCodecError, DiFrame, DiResponseFrame};
+use super::negotiate::{DI_API_MAX_SUPPORTED, DI_API_MIN_SUPPORTED};
+use super::socket::{self, SocketDiscovery};
+use super::verb::DiVerb;
+use aa_core::integration::LIFECYCLE_SCHEMA_VERSION;
+
+/// Why a client call did not produce a response.
+#[derive(Debug)]
+pub enum ClientError {
+    /// The socket is not there. The runtime is not running: prompt the user to
+    /// start it, do not retry silently.
+    RuntimeNotRunning {
+        /// Where the client looked.
+        path: PathBuf,
+    },
+    /// The socket path could not be resolved at all.
+    Discovery(socket::SocketError),
+    /// Connecting or framing failed.
+    Transport(DiCodecError),
+    /// The server refused the version. Carries the actionable remediation.
+    Incompatible(wire::Incompatible),
+    /// The server refused the request.
+    Denied(wire::Denied),
+    /// The server answered something this client did not ask for.
+    UnexpectedFrame,
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::RuntimeNotRunning { path } => write!(
+                f,
+                "the AASM runtime is not running (no socket at {}); start it and try again",
+                path.display()
+            ),
+            ClientError::Discovery(e) => write!(f, "cannot locate the DI-API socket: {e}"),
+            ClientError::Transport(e) => write!(f, "DI-API transport error: {e}"),
+            ClientError::Incompatible(i) => write!(f, "{} — {}", i.reason, i.remediation),
+            ClientError::Denied(d) => write!(f, "{} — {}", d.message, d.remediation),
+            ClientError::UnexpectedFrame => f.write_str("the DI-API server sent an unexpected frame"),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+impl From<DiCodecError> for ClientError {
+    fn from(e: DiCodecError) -> Self {
+        ClientError::Transport(e)
+    }
+}
+
+/// What the server said about this connection's version.
+///
+/// `Degraded` is returned to the caller rather than absorbed, because a client
+/// that silently proceeds on a degraded connection will show a user a feature
+/// that is not there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Negotiated {
+    /// The agreed DI-API version.
+    pub di_api_version: u32,
+    /// The running core version.
+    pub core_version: String,
+    /// Whether some verbs are missing.
+    pub degraded: bool,
+    /// Which verbs are missing, when degraded.
+    pub unavailable_verbs: Vec<String>,
+    /// Why, and what to do, when degraded.
+    pub degraded_reason: String,
+    /// What to do about it.
+    pub remediation: String,
+}
+
+impl Negotiated {
+    /// Whether `verb` is usable on this connection.
+    ///
+    /// A client should call this before offering the corresponding UI, instead
+    /// of discovering the gap when a user presses the button.
+    pub fn supports(&self, verb: DiVerb) -> bool {
+        !self.unavailable_verbs.iter().any(|v| v == verb.as_str())
+    }
+}
+
+/// A connected, negotiated DI-API client.
+pub struct DevIntClient {
+    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    writer: BufWriter<tokio::net::unix::OwnedWriteHalf>,
+    negotiated: Negotiated,
+    token: Option<String>,
+    next_request_id: u64,
+}
+
+impl DevIntClient {
+    /// Look for a running runtime without connecting.
+    pub fn discover() -> Result<SocketDiscovery, ClientError> {
+        let path = socket::devint_socket_path().map_err(ClientError::Discovery)?;
+        Ok(socket::discover(&path))
+    }
+
+    /// Connect to `path` and negotiate.
+    ///
+    /// `capability_token` is the secret written by the enrolment step. It is
+    /// `Option` because a client may legitimately connect with none — to read
+    /// the negotiated versions and then tell the user to enrol — but every verb
+    /// will be denied until one is supplied.
+    pub async fn connect(
+        path: &Path,
+        client_name: &str,
+        client_version: &str,
+        capability_token: Option<String>,
+    ) -> Result<Self, ClientError> {
+        if !path.exists() {
+            return Err(ClientError::RuntimeNotRunning {
+                path: path.to_path_buf(),
+            });
+        }
+        let stream = UnixStream::connect(path)
+            .await
+            .map_err(|e| ClientError::Transport(DiCodecError::Io(e)))?;
+        let (reader, writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+        let mut writer = BufWriter::new(writer);
+
+        codec::write_client_frame(
+            &mut writer,
+            DiFrame::Hello(wire::Hello {
+                client_name: client_name.to_string(),
+                client_version: client_version.to_string(),
+                // Offer the whole window this build understands. Offering a
+                // narrower set than the client implements is how a client
+                // talks itself into a degraded connection for no reason.
+                di_api_versions: (DI_API_MIN_SUPPORTED..=DI_API_MAX_SUPPORTED).collect(),
+                lifecycle_schema_versions: vec![LIFECYCLE_SCHEMA_VERSION],
+            }),
+        )
+        .await?;
+
+        let negotiated = match codec::read_response_frame(&mut reader).await? {
+            DiResponseFrame::HelloAck(ack) => Negotiated {
+                di_api_version: ack.di_api_version,
+                core_version: ack.core_version,
+                degraded: ack.outcome == wire::NegotiationOutcome::Degraded as i32,
+                unavailable_verbs: ack.unavailable_verbs,
+                degraded_reason: ack.degraded_reason,
+                remediation: ack.remediation,
+            },
+            DiResponseFrame::Incompatible(incompatible) => return Err(ClientError::Incompatible(incompatible)),
+            _ => return Err(ClientError::UnexpectedFrame),
+        };
+
+        Ok(Self {
+            reader,
+            writer,
+            negotiated,
+            token: capability_token,
+            next_request_id: 1,
+        })
+    }
+
+    /// What was agreed for this connection.
+    pub fn negotiated(&self) -> &Negotiated {
+        &self.negotiated
+    }
+
+    /// Every tool the runtime knows about.
+    pub async fn list_tools(&mut self) -> Result<wire::ToolList, ClientError> {
+        let response = self.call(self.request(DiVerb::ListTools, "")).await?;
+        response.tool_list.ok_or(ClientError::UnexpectedFrame)
+    }
+
+    /// Author a dry run for `tool_id`.
+    pub async fn plan(
+        &mut self,
+        tool_id: &str,
+        profile: &str,
+        settings_scope: &str,
+        policy_profile_id: &str,
+        allow_privileged_host_steps: bool,
+    ) -> Result<wire::PlanView, ClientError> {
+        let mut request = self.request(DiVerb::Plan, tool_id);
+        request.plan = Some(wire::PlanArgs {
+            profile: profile.to_string(),
+            requested_level: String::new(),
+            settings_scope: settings_scope.to_string(),
+            allow_privileged_host_steps,
+            policy_profile_id: policy_profile_id.to_string(),
+        });
+        let response = self.call(request).await?;
+        response.plan.ok_or(ClientError::UnexpectedFrame)
+    }
+
+    /// Apply a plan the user has reviewed and approved.
+    pub async fn apply(&mut self, tool_id: &str, plan_id: &str) -> Result<wire::ApplyView, ClientError> {
+        let mut request = self.request(DiVerb::Apply, tool_id);
+        request.apply = Some(wire::ApplyArgs {
+            plan_id: plan_id.to_string(),
+        });
+        let response = self.call(request).await?;
+        response.apply.ok_or(ClientError::UnexpectedFrame)
+    }
+
+    /// Read the protection state the service derived.
+    ///
+    /// Returned verbatim. This client offers no way to compute or upgrade a
+    /// state locally, and a client built on it should render
+    /// `observed_at_unix_secs` alongside the level: the claim is "verified at
+    /// T", not "true now".
+    pub async fn status(&mut self, tool_id: &str) -> Result<wire::StatusView, ClientError> {
+        let response = self.call(self.request(DiVerb::Status, tool_id)).await?;
+        response.status.ok_or(ClientError::UnexpectedFrame)
+    }
+
+    /// Run the protection test.
+    pub async fn verify(&mut self, tool_id: &str) -> Result<wire::VerificationView, ClientError> {
+        let response = self.call(self.request(DiVerb::Verify, tool_id)).await?;
+        response.verification.ok_or(ClientError::UnexpectedFrame)
+    }
+
+    /// Repair drift.
+    pub async fn repair(&mut self, tool_id: &str) -> Result<wire::RepairView, ClientError> {
+        let response = self.call(self.request(DiVerb::Repair, tool_id)).await?;
+        response.repair.ok_or(ClientError::UnexpectedFrame)
+    }
+
+    /// Author and execute the reversal.
+    pub async fn remove(&mut self, tool_id: &str, plan_id: &str) -> Result<wire::RemovalView, ClientError> {
+        let mut request = self.request(DiVerb::Remove, tool_id);
+        request.remove = Some(wire::RemoveArgs {
+            plan_id: plan_id.to_string(),
+        });
+        let response = self.call(request).await?;
+        response.removal.ok_or(ClientError::UnexpectedFrame)
+    }
+
+    /// Recent, already-redacted security events for this integration.
+    pub async fn scoped_events(
+        &mut self,
+        tool_id: &str,
+        limit: u32,
+        since_unix_secs: u64,
+    ) -> Result<wire::ScopedEventList, ClientError> {
+        let mut request = self.request(DiVerb::ScopedEvents, tool_id);
+        request.events = Some(wire::ScopedEventsArgs { limit, since_unix_secs });
+        let response = self.call(request).await?;
+        response.events.ok_or(ClientError::UnexpectedFrame)
+    }
+
+    /// Relay a human's approval input to the decision authority.
+    ///
+    /// The acknowledgement says the input was accepted for adjudication. It is
+    /// **not** a verdict, and a client must not render it as one.
+    pub async fn relay_approval(
+        &mut self,
+        tool_id: &str,
+        approval_id: &str,
+        user_input: &str,
+    ) -> Result<wire::ApprovalRelayAck, ClientError> {
+        let mut request = self.request(DiVerb::ApprovalRelay, tool_id);
+        request.approval = Some(wire::ApprovalRelayArgs {
+            approval_id: approval_id.to_string(),
+            user_input: user_input.to_string(),
+        });
+        let response = self.call(request).await?;
+        response.approval.ok_or(ClientError::UnexpectedFrame)
+    }
+
+    fn request(&self, verb: DiVerb, tool_id: &str) -> wire::Request {
+        wire::Request {
+            request_id: self.next_request_id,
+            verb: verb.to_wire() as i32,
+            capability_token: self.token.clone().unwrap_or_default(),
+            tool_id: tool_id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    async fn call(&mut self, request: wire::Request) -> Result<wire::Response, ClientError> {
+        self.next_request_id += 1;
+        codec::write_client_frame(&mut self.writer, DiFrame::Request(request)).await?;
+        match codec::read_response_frame(&mut self.reader).await? {
+            DiResponseFrame::Response(response) => Ok(*response),
+            DiResponseFrame::Denied(denied) => Err(ClientError::Denied(denied)),
+            _ => Err(ClientError::UnexpectedFrame),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::devint::scope::{TokenScope, ToolScope};
+    use crate::devint::testkit::{claude_code_id, TestServer};
+    use crate::devint::testkit::{FakeLifecycle, LEAK_SENTINEL};
+
+    async fn connected(server: &TestServer, token: Option<String>) -> DevIntClient {
+        DevIntClient::connect(server.socket_path(), "reference-client", "0.1.0", token)
+            .await
+            .expect("connect")
+    }
+
+    #[tokio::test]
+    async fn the_reference_client_drives_the_whole_lifecycle() {
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        let (token, _) = server.enrol("reference-client", TokenScope::full_lifecycle(ToolScope::AllTools));
+        let mut client = connected(&server, Some(token.expose().to_string())).await;
+
+        assert!(!client.negotiated().degraded);
+        assert_eq!(client.negotiated().di_api_version, DI_API_MAX_SUPPORTED);
+        assert!(!client.negotiated().core_version.is_empty());
+
+        let tool = claude_code_id();
+        assert_eq!(client.list_tools().await.expect("list").tools.len(), 1);
+        let plan = client
+            .plan(&tool, "recommended", "user", "team-default", false)
+            .await
+            .expect("plan");
+        assert_eq!(plan.plan_id, "plan-1");
+        assert_eq!(
+            client.apply(&tool, &plan.plan_id).await.expect("apply").receipt_id,
+            "receipt-1"
+        );
+        assert_eq!(client.status(&tool).await.expect("status").achieved_level, "integrated");
+        assert_eq!(client.verify(&tool).await.expect("verify").outcome, "passed");
+        assert_eq!(client.repair(&tool).await.expect("repair").repaired, vec!["settings"]);
+        assert_eq!(
+            client.remove(&tool, "plan-1").await.expect("remove").plan_id,
+            "removal-1"
+        );
+        assert_eq!(
+            client.scoped_events(&tool, 10, 0).await.expect("events").events.len(),
+            1
+        );
+        let ack = client
+            .relay_approval(&tool, "approval-1", "approve")
+            .await
+            .expect("relay");
+        assert_eq!(ack.relayed_input, "approve");
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn a_plan_rendered_by_the_client_carries_no_step_values() {
+        // End to end this time: the fake's plan is poisoned, so this asserts the
+        // socket path as a whole, not just the projection function.
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        let (token, _) = server.enrol("reference-client", TokenScope::full_lifecycle(ToolScope::AllTools));
+        let mut client = connected(&server, Some(token.expose().to_string())).await;
+        let plan = client
+            .plan(&claude_code_id(), "recommended", "user", "team-default", false)
+            .await
+            .expect("plan");
+        let rendered = format!("{plan:?}");
+        assert!(!rendered.contains(LEAK_SENTINEL), "the client received a step value");
+        // …and still received something worth showing a user.
+        assert_eq!(plan.steps.len(), 2);
+        assert_eq!(plan.steps[1].managed_keys, vec!["ANTHROPIC_AUTH_TOKEN"]);
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn a_client_with_no_token_is_denied_every_verb() {
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        let mut client = connected(&server, None).await;
+        // Negotiation still succeeds — that is how a client learns what to tell
+        // the user — but there is no anonymous tier behind it.
+        assert_eq!(client.negotiated().di_api_version, DI_API_MAX_SUPPORTED);
+        match client.status(&claude_code_id()).await {
+            Err(ClientError::Denied(denied)) => {
+                assert_eq!(denied.code, wire::DenyCode::Unauthenticated as i32);
+                assert!(denied.remediation.contains("enrol"));
+            }
+            other => panic!("expected a denial, got {other:?}"),
+        }
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn a_degraded_connection_is_reported_rather_than_absorbed() {
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        // Speak the wire directly to force a v1-only offer; the reference
+        // client always offers its whole window, which is the correct
+        // behaviour and therefore cannot produce this case.
+        let mut raw = server.connect_raw().await;
+        raw.send_hello(crate::devint::testkit::hello_offering(&[1])).await;
+        let DiResponseFrame::HelloAck(ack) = raw.read().await else {
+            panic!("expected HelloAck");
+        };
+        let negotiated = Negotiated {
+            di_api_version: ack.di_api_version,
+            core_version: ack.core_version,
+            degraded: ack.outcome == wire::NegotiationOutcome::Degraded as i32,
+            unavailable_verbs: ack.unavailable_verbs,
+            degraded_reason: ack.degraded_reason,
+            remediation: ack.remediation,
+        };
+        assert!(negotiated.degraded);
+        assert!(!negotiated.supports(DiVerb::ScopedEvents));
+        assert!(negotiated.supports(DiVerb::Status));
+        assert!(!negotiated.remediation.is_empty());
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn connecting_to_an_absent_socket_reports_a_stopped_runtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("devint.sock");
+        match DevIntClient::connect(&path, "reference-client", "0.1.0", None).await {
+            Err(ClientError::RuntimeNotRunning { path: reported }) => assert_eq!(reported, path),
+            Err(other) => panic!("expected RuntimeNotRunning, got {other:?}"),
+            Ok(_) => panic!("expected RuntimeNotRunning, got a connected client"),
+        }
+    }
+}

--- a/aa-runtime/src/devint/codec.rs
+++ b/aa-runtime/src/devint/codec.rs
@@ -1,0 +1,387 @@
+//! Length-framed binary codec for the DI-API socket (ADR 0030 §5.1).
+//!
+//! Deliberately the *same* framing discipline as [`crate::ipc::codec`] —
+//! `[1-byte tag][prost varint length][prost payload]`, with the same
+//! pre-allocation bound — so there is one framing implementation to review
+//! rather than two. What differs is only the message set behind the tags, and
+//! that difference is the point: this socket's tags name DI-API messages, and
+//! the SDK socket's tags name policy and audit messages. Neither codec can
+//! decode the other's frames, so a DI client that somehow reached the SDK
+//! socket would still be speaking a language nothing there parses.
+//!
+//! Inbound tags (client → runtime):
+//!   1 = Hello
+//!   2 = Request
+//!
+//! Outbound tags (runtime → client):
+//!   1 = HelloAck
+//!   2 = Incompatible
+//!   3 = Response
+//!   4 = Denied
+
+use prost::Message;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use aa_proto::assembly::devint::v1 as wire;
+
+/// Client → runtime: the version-negotiation opener.
+pub const TAG_HELLO: u8 = 1;
+/// Client → runtime: a verb invocation.
+pub const TAG_REQUEST: u8 = 2;
+
+/// Runtime → client: negotiation succeeded (supported or degraded).
+pub const TAG_HELLO_ACK: u8 = 1;
+/// Runtime → client: negotiation failed; the connection closes after this.
+pub const TAG_INCOMPATIBLE: u8 = 2;
+/// Runtime → client: a verb's data-minimised result.
+pub const TAG_RESPONSE: u8 = 3;
+/// Runtime → client: the request was refused.
+pub const TAG_DENIED: u8 = 4;
+
+/// Maximum accepted length-delimited payload, in bytes (1 MiB).
+///
+/// The length prefix is attacker-controlled, so it is bounded *before*
+/// allocating — the AAASM-3132 lesson, applied to this socket too. The bound is
+/// deliberately far tighter than the SDK socket's 8 MiB: no legitimate DI-API
+/// frame carries bulk data, because no DI-API type can hold any (§5.5). A
+/// request that needs more than a megabyte is not a request this API serves.
+pub const MAX_FRAME_LEN: usize = 1024 * 1024;
+
+/// A decoded client → runtime frame.
+#[derive(Debug)]
+pub enum DiFrame {
+    /// The negotiation opener.
+    Hello(wire::Hello),
+    /// A verb invocation.
+    Request(wire::Request),
+}
+
+/// A runtime → client frame.
+#[derive(Debug)]
+pub enum DiResponseFrame {
+    /// Negotiation succeeded.
+    HelloAck(wire::HelloAck),
+    /// Negotiation failed; nothing further will be served.
+    Incompatible(wire::Incompatible),
+    /// A verb result.
+    Response(Box<wire::Response>),
+    /// A refusal.
+    Denied(wire::Denied),
+}
+
+/// Errors from framing a DI-API message.
+///
+/// Hand-written, matching [`crate::ipc::codec::CodecError`].
+#[derive(Debug)]
+pub enum DiCodecError {
+    /// Transport failure.
+    Io(std::io::Error),
+    /// A tag outside the closed set. Rejected rather than skipped — an
+    /// unrecognised frame is not a frame to ignore and keep reading past.
+    UnknownTag(u8),
+    /// The payload was not valid for its tag.
+    Decode(prost::DecodeError),
+    /// The length prefix exceeded [`MAX_FRAME_LEN`], rejected before any
+    /// allocation.
+    FrameTooLarge {
+        /// What was claimed.
+        len: usize,
+        /// The bound.
+        max: usize,
+    },
+}
+
+impl std::fmt::Display for DiCodecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DiCodecError::Io(e) => write!(f, "DI-API IO error: {e}"),
+            DiCodecError::UnknownTag(t) => write!(f, "unknown DI-API frame tag: {t}"),
+            DiCodecError::Decode(e) => write!(f, "DI-API decode error: {e}"),
+            DiCodecError::FrameTooLarge { len, max } => {
+                write!(f, "DI-API frame length {len} exceeds maximum {max}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DiCodecError {}
+
+impl From<std::io::Error> for DiCodecError {
+    fn from(e: std::io::Error) -> Self {
+        DiCodecError::Io(e)
+    }
+}
+
+impl From<prost::DecodeError> for DiCodecError {
+    fn from(e: prost::DecodeError) -> Self {
+        DiCodecError::Decode(e)
+    }
+}
+
+/// Read one client → runtime frame.
+pub async fn read_frame<R>(reader: &mut R) -> Result<DiFrame, DiCodecError>
+where
+    R: AsyncReadExt + Unpin,
+{
+    let tag = reader.read_u8().await?;
+    let bytes = read_length_delimited(reader).await?;
+    match tag {
+        TAG_HELLO => Ok(DiFrame::Hello(wire::Hello::decode(bytes.as_ref())?)),
+        TAG_REQUEST => Ok(DiFrame::Request(wire::Request::decode(bytes.as_ref())?)),
+        other => Err(DiCodecError::UnknownTag(other)),
+    }
+}
+
+/// Write one runtime → client frame.
+pub async fn write_frame<W>(writer: &mut W, frame: DiResponseFrame) -> Result<(), DiCodecError>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    let (tag, body) = match frame {
+        DiResponseFrame::HelloAck(m) => (TAG_HELLO_ACK, m.encode_to_vec()),
+        DiResponseFrame::Incompatible(m) => (TAG_INCOMPATIBLE, m.encode_to_vec()),
+        DiResponseFrame::Response(m) => (TAG_RESPONSE, m.encode_to_vec()),
+        DiResponseFrame::Denied(m) => (TAG_DENIED, m.encode_to_vec()),
+    };
+    let mut out = Vec::with_capacity(1 + 10 + body.len());
+    out.push(tag);
+    prost::encoding::encode_varint(body.len() as u64, &mut out);
+    out.extend_from_slice(&body);
+    writer.write_all(&out).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Write one client → runtime frame. Used by the reference client and by tests
+/// that need to speak the wire directly.
+pub async fn write_client_frame<W>(writer: &mut W, frame: DiFrame) -> Result<(), DiCodecError>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    let (tag, body) = match frame {
+        DiFrame::Hello(m) => (TAG_HELLO, m.encode_to_vec()),
+        DiFrame::Request(m) => (TAG_REQUEST, m.encode_to_vec()),
+    };
+    let mut out = Vec::with_capacity(1 + 10 + body.len());
+    out.push(tag);
+    prost::encoding::encode_varint(body.len() as u64, &mut out);
+    out.extend_from_slice(&body);
+    writer.write_all(&out).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Read one runtime → client frame. The client half of [`write_frame`].
+pub async fn read_response_frame<R>(reader: &mut R) -> Result<DiResponseFrame, DiCodecError>
+where
+    R: AsyncReadExt + Unpin,
+{
+    let tag = reader.read_u8().await?;
+    let bytes = read_length_delimited(reader).await?;
+    match tag {
+        TAG_HELLO_ACK => Ok(DiResponseFrame::HelloAck(wire::HelloAck::decode(bytes.as_ref())?)),
+        TAG_INCOMPATIBLE => Ok(DiResponseFrame::Incompatible(wire::Incompatible::decode(
+            bytes.as_ref(),
+        )?)),
+        TAG_RESPONSE => Ok(DiResponseFrame::Response(Box::new(wire::Response::decode(
+            bytes.as_ref(),
+        )?))),
+        TAG_DENIED => Ok(DiResponseFrame::Denied(wire::Denied::decode(bytes.as_ref())?)),
+        other => Err(DiCodecError::UnknownTag(other)),
+    }
+}
+
+/// Read a prost varint length prefix and exactly that many bytes.
+///
+/// The length is checked against [`MAX_FRAME_LEN`] *before* the buffer is
+/// allocated, so a peer claiming a multi-gigabyte payload cannot force the
+/// allocation as a trivial local DoS.
+async fn read_length_delimited<R>(reader: &mut R) -> Result<Vec<u8>, DiCodecError>
+where
+    R: AsyncReadExt + Unpin,
+{
+    let mut len: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+        let byte = reader.read_u8().await?;
+        len |= u64::from(byte & 0x7F) << shift;
+        if byte & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(DiCodecError::FrameTooLarge {
+                len: usize::MAX,
+                max: MAX_FRAME_LEN,
+            });
+        }
+    }
+    let len = usize::try_from(len).unwrap_or(usize::MAX);
+    if len > MAX_FRAME_LEN {
+        return Err(DiCodecError::FrameTooLarge {
+            len,
+            max: MAX_FRAME_LEN,
+        });
+    }
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).await?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hello() -> wire::Hello {
+        wire::Hello {
+            client_name: "vscode-aasm".to_string(),
+            client_version: "1.4.0".to_string(),
+            di_api_versions: vec![1, 2],
+            lifecycle_schema_versions: vec![1],
+        }
+    }
+
+    #[tokio::test]
+    async fn a_hello_round_trips() {
+        let mut buf = Vec::new();
+        write_client_frame(&mut buf, DiFrame::Hello(hello())).await.unwrap();
+        let mut cursor = std::io::Cursor::new(buf);
+        match read_frame(&mut cursor).await.unwrap() {
+            DiFrame::Hello(decoded) => assert_eq!(decoded, hello()),
+            other => panic!("expected Hello, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_request_round_trips() {
+        let request = wire::Request {
+            request_id: 7,
+            verb: wire::Verb::Status as i32,
+            capability_token: "a".repeat(64),
+            tool_id: "claude-code".to_string(),
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        write_client_frame(&mut buf, DiFrame::Request(request.clone()))
+            .await
+            .unwrap();
+        let mut cursor = std::io::Cursor::new(buf);
+        match read_frame(&mut cursor).await.unwrap() {
+            DiFrame::Request(decoded) => assert_eq!(decoded, request),
+            other => panic!("expected Request, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn every_server_frame_round_trips() {
+        let frames = vec![
+            DiResponseFrame::HelloAck(wire::HelloAck {
+                di_api_version: 2,
+                ..Default::default()
+            }),
+            DiResponseFrame::Incompatible(wire::Incompatible {
+                reason: "old".to_string(),
+                ..Default::default()
+            }),
+            DiResponseFrame::Response(Box::new(wire::Response {
+                request_id: 3,
+                ..Default::default()
+            })),
+            DiResponseFrame::Denied(wire::Denied {
+                code: wire::DenyCode::Unauthenticated as i32,
+                ..Default::default()
+            }),
+        ];
+        for frame in frames {
+            let expected_tag = match &frame {
+                DiResponseFrame::HelloAck(_) => TAG_HELLO_ACK,
+                DiResponseFrame::Incompatible(_) => TAG_INCOMPATIBLE,
+                DiResponseFrame::Response(_) => TAG_RESPONSE,
+                DiResponseFrame::Denied(_) => TAG_DENIED,
+            };
+            let mut buf = Vec::new();
+            write_frame(&mut buf, frame).await.unwrap();
+            assert_eq!(buf[0], expected_tag);
+            let mut cursor = std::io::Cursor::new(buf);
+            read_response_frame(&mut cursor).await.expect("decodes");
+        }
+    }
+
+    #[tokio::test]
+    async fn an_unknown_tag_is_rejected_not_skipped() {
+        let mut buf = vec![0xEE_u8];
+        prost::encoding::encode_varint(0, &mut buf);
+        let mut cursor = std::io::Cursor::new(buf);
+        match read_frame(&mut cursor).await {
+            Err(DiCodecError::UnknownTag(0xEE)) => {}
+            other => panic!("expected UnknownTag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn an_oversized_length_is_rejected_before_allocating() {
+        let mut buf = vec![TAG_REQUEST];
+        // A 4 GiB claim. Nothing is allocated for it.
+        prost::encoding::encode_varint(4 * 1024 * 1024 * 1024, &mut buf);
+        let mut cursor = std::io::Cursor::new(buf);
+        match read_frame(&mut cursor).await {
+            Err(DiCodecError::FrameTooLarge { max, .. }) => assert_eq!(max, MAX_FRAME_LEN),
+            other => panic!("expected FrameTooLarge, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_large_but_valid_frame_is_still_read() {
+        // The bound must not clip legitimate traffic, or it is a DoS against
+        // the honest client rather than the hostile one.
+        let request = wire::Request {
+            request_id: 1,
+            verb: wire::Verb::Status as i32,
+            capability_token: "a".repeat(64),
+            tool_id: "x".repeat(100_000),
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        write_client_frame(&mut buf, DiFrame::Request(request)).await.unwrap();
+        assert!(buf.len() > 100_000 && buf.len() < MAX_FRAME_LEN);
+        let mut cursor = std::io::Cursor::new(buf);
+        assert!(matches!(read_frame(&mut cursor).await, Ok(DiFrame::Request(_))));
+    }
+
+    #[tokio::test]
+    async fn a_malformed_payload_fails_to_decode() {
+        let mut buf = vec![TAG_HELLO];
+        let body = vec![0xFF_u8; 8];
+        prost::encoding::encode_varint(body.len() as u64, &mut buf);
+        buf.extend_from_slice(&body);
+        let mut cursor = std::io::Cursor::new(buf);
+        assert!(matches!(read_frame(&mut cursor).await, Err(DiCodecError::Decode(_))));
+    }
+
+    #[tokio::test]
+    async fn a_sdk_ipc_frame_does_not_decode_as_a_di_frame() {
+        // The two sockets carry disjoint message sets. An SDK policy-query
+        // frame arriving here must not silently parse into something this
+        // service would act on.
+        use aa_proto::assembly::policy::v1::CheckActionRequest;
+        let policy_query = CheckActionRequest {
+            action_type: 3,
+            ..Default::default()
+        };
+        let body = policy_query.encode_to_vec();
+        // Tag 1 on this socket means Hello, not PolicyQuery.
+        let mut buf = vec![TAG_HELLO];
+        prost::encoding::encode_varint(body.len() as u64, &mut buf);
+        buf.extend_from_slice(&body);
+        let mut cursor = std::io::Cursor::new(buf);
+        let decoded = read_frame(&mut cursor).await;
+        match decoded {
+            // Either it fails to decode, or it decodes as a Hello offering no
+            // usable version — never as a policy query, because this codec has
+            // no variant that could hold one.
+            Err(_) => {}
+            Ok(DiFrame::Hello(h)) => assert!(h.di_api_versions.is_empty()),
+            Ok(other) => panic!("unexpected frame {other:?}"),
+        }
+    }
+}

--- a/aa-runtime/src/devint/lifecycle.rs
+++ b/aa-runtime/src/devint/lifecycle.rs
@@ -1,0 +1,333 @@
+//! The port the DI-API server calls, and nothing wider (ADR 0030 §5.6 reason 2).
+//!
+//! # Why the server talks to a trait
+//!
+//! The DI-API's containment argument is not "the handlers are careful"; it is
+//! that **the server module's dependency graph excludes what must be
+//! unreachable**. Every verb handler is expressed in terms of
+//! [`IntegrationLifecycle`], which offers exactly nine operations and returns
+//! only lifecycle values. A handler that wanted to read `aa_core::storage`,
+//! touch identity, or reach a gateway credential could not do so without
+//! *adding a dependency* — a reviewable diff behind CODEOWNERS, not an
+//! accident.
+//!
+//! It also means this trait is the seam where AAASM-5278's plan/receipt/drift
+//! service plugs in. That work owns `aa-core/src/integration/**` and
+//! `aa-devtool*`; this crate deliberately does not, so the DI-API is written
+//! against the contract rather than against an implementation, and the two
+//! branches do not collide.
+//!
+//! # What this trait deliberately does not have
+//!
+//! No `check`, no `evaluate`, no `decide`, no "emit audit event", no "read
+//! policy document", no escape hatch that takes a method name or a query. There
+//! is nothing here that returns an `aa_core::policy` decision type, and a unit
+//! test asserts the operation set matches the closed verb space. Agent
+//! decisions travel SDK → `aa-sdk-client` → runtime/gateway (ADR 0004) and are
+//! not reachable from this port at all.
+//!
+//! [`IntegrationLifecycle::relay_approval`] is the one approval-shaped method,
+//! and it *submits* a human's input to the decision authority. It returns an
+//! [`ApprovalRelayReceipt`] — "accepted for adjudication" — never a verdict,
+//! because a verdict returned here would be ADR 0030 forbidden design 6.
+
+use async_trait::async_trait;
+
+use aa_core::dev_tool::{DevToolKind, GovernanceLevel};
+use aa_core::integration::{
+    DevToolCapabilities, IntegrationCapability, IntegrationPlan, IntegrationReceipt, IntegrationRequest,
+    IntegrationStatus, RemovalPlan, ToolVersion, VerificationResult, VersionCompatibility,
+};
+
+/// Why a lifecycle operation could not be completed.
+///
+/// Coarse on purpose. These reach a client as `DENY_CODE_LIFECYCLE_ERROR` with
+/// the `detail` string, so the detail must stay free of adapter internals,
+/// file contents and anything a caller should not learn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LifecycleError {
+    /// No adapter knows this tool id.
+    UnknownTool {
+        /// What was asked for.
+        tool_id: String,
+    },
+    /// The tool is not installed on this host, so there is nothing to act on.
+    ToolNotInstalled {
+        /// What was asked for.
+        tool_id: String,
+    },
+    /// The named plan does not exist, or belongs to a different tool.
+    UnknownPlan {
+        /// What was asked for.
+        plan_id: String,
+    },
+    /// The request is not one this service will honour — e.g. an apply of a
+    /// plan containing privileged host steps the user never consented to.
+    Refused {
+        /// Why, in words a user can act on.
+        detail: String,
+    },
+    /// The operation started and could not finish.
+    Failed {
+        /// Why, in words a user can act on.
+        detail: String,
+    },
+}
+
+impl LifecycleError {
+    /// A short user-facing sentence.
+    pub fn detail(&self) -> String {
+        match self {
+            LifecycleError::UnknownTool { tool_id } => format!("no adapter knows the tool {tool_id}"),
+            LifecycleError::ToolNotInstalled { tool_id } => format!("{tool_id} is not installed on this host"),
+            LifecycleError::UnknownPlan { plan_id } => format!("no plan {plan_id} is on record"),
+            LifecycleError::Refused { detail } | LifecycleError::Failed { detail } => detail.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for LifecycleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.detail())
+    }
+}
+
+impl std::error::Error for LifecycleError {}
+
+/// What one adapter can see and do for one tool, as the DI-API needs it.
+///
+/// Assembled by the lifecycle service from the adapter's discovery and
+/// capability declarations. It carries no adapter internals and no host paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolDescriptor {
+    /// The tool.
+    pub tool: DevToolKind,
+    /// Name to show a user.
+    pub display_name: String,
+    /// Whether the tool was found on this host.
+    pub detected: bool,
+    /// The version found, when one was.
+    pub detected_version: Option<ToolVersion>,
+    /// How that version compares to the adapter's supported range.
+    pub compatibility: VersionCompatibility,
+    /// The mechanisms the adapter declares.
+    pub capabilities: DevToolCapabilities,
+    /// The adapter's static build-time ceiling. A ceiling is not a measurement.
+    pub adapter_ceiling: GovernanceLevel,
+}
+
+/// The result of repairing drift, as the DI-API reports it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RepairReport {
+    /// AASM-owned artifact identifiers that were restored.
+    pub repaired: Vec<String>,
+    /// Identifiers that drifted and could not be restored, with the reason.
+    pub unrepairable: Vec<(IntegrationCapability, String)>,
+}
+
+/// An integration-scoped, already-redacted security event.
+///
+/// The projection ADR 0030 §5.5 requires in place of audit rows: counts,
+/// verdict kinds, timestamps and redaction *labels*. There is no field here
+/// that can hold a prompt, a tool output, or the content that matched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopedSecurityEvent {
+    /// When, seconds since the Unix epoch.
+    pub occurred_at_unix_secs: u64,
+    /// What the core decided, as a kind — never the decision's inputs.
+    pub verdict_kind: VerdictKind,
+    /// The mechanism the event was observed on.
+    pub mechanism: IntegrationCapability,
+    /// How many equivalent events this row folds.
+    pub count: u32,
+    /// Labels of what was redacted (e.g. `aws_access_key`), never the value.
+    pub redaction_labels: Vec<String>,
+}
+
+/// The kind of verdict a scoped event records.
+///
+/// A closed enum rather than a string so a future field cannot smuggle detail
+/// through it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VerdictKind {
+    /// The action was allowed.
+    Allowed,
+    /// The action was blocked.
+    Denied,
+    /// The payload was forwarded with findings redacted.
+    Redacted,
+    /// A human approval was required.
+    ApprovalRequired,
+}
+
+impl VerdictKind {
+    /// Stable snake_case name for the wire.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            VerdictKind::Allowed => "allow",
+            VerdictKind::Denied => "deny",
+            VerdictKind::Redacted => "redacted",
+            VerdictKind::ApprovalRequired => "approval_required",
+        }
+    }
+}
+
+/// The human's input on a pending approval, as relayed by the client that
+/// showed it.
+///
+/// A closed enum of *inputs*, not outcomes: the client reports which button a
+/// person pressed. Whether that input grants anything is the core's call
+/// (ADR 0030 matrix row 11).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalInput {
+    /// The human pressed approve.
+    Approve,
+    /// The human pressed deny.
+    Deny,
+    /// The human deferred.
+    Defer,
+}
+
+impl ApprovalInput {
+    /// Stable snake_case name for the wire.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ApprovalInput::Approve => "approve",
+            ApprovalInput::Deny => "deny",
+            ApprovalInput::Defer => "defer",
+        }
+    }
+
+    /// Parse a wire value. Unknown input is `None`, never defaulted — an
+    /// unreadable button press must not become an approval.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "approve" => Some(ApprovalInput::Approve),
+            "deny" => Some(ApprovalInput::Deny),
+            "defer" => Some(ApprovalInput::Defer),
+            _ => None,
+        }
+    }
+}
+
+/// Acknowledgement that a human's input reached the decision authority.
+///
+/// Deliberately carries no verdict. "Accepted for adjudication" is the whole
+/// statement; a client that wants the outcome reads it from status, which the
+/// service computed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovalRelayReceipt {
+    /// Which approval the input was relayed for.
+    pub approval_id: String,
+    /// What was relayed.
+    pub relayed: ApprovalInput,
+    /// When the runtime accepted it.
+    pub accepted_at_unix_secs: u64,
+}
+
+/// The nine operations the DI-API can perform, and no others.
+///
+/// One method per member of the closed verb space. Implemented by AAASM-5278's
+/// lifecycle service; the DI server holds it as a `dyn` object so this crate
+/// never links the adapters directly.
+#[async_trait]
+pub trait IntegrationLifecycle: Send + Sync {
+    /// Every tool the linked adapters know about, detected or not.
+    async fn list_tools(&self) -> Result<Vec<ToolDescriptor>, LifecycleError>;
+
+    /// Author a reviewable dry run. Mutates nothing.
+    async fn plan(&self, request: IntegrationRequest) -> Result<IntegrationPlan, LifecycleError>;
+
+    /// Execute a previously authored plan and record the receipt.
+    async fn apply(&self, tool: &DevToolKind, plan_id: &str) -> Result<IntegrationReceipt, LifecycleError>;
+
+    /// Derive the protection state from current evidence.
+    async fn status(&self, tool: &DevToolKind) -> Result<IntegrationStatus, LifecycleError>;
+
+    /// Run the protection test and adjudicate it.
+    async fn verify(&self, tool: &DevToolKind) -> Result<VerificationResult, LifecycleError>;
+
+    /// Restore AASM-owned keys that drifted.
+    async fn repair(&self, tool: &DevToolKind) -> Result<(RepairReport, IntegrationStatus), LifecycleError>;
+
+    /// Author and execute the reversal.
+    async fn remove(&self, tool: &DevToolKind, plan_id: Option<&str>) -> Result<RemovalPlan, LifecycleError>;
+
+    /// Recent security events relevant to this integration, already redacted.
+    async fn scoped_events(
+        &self,
+        tool: &DevToolKind,
+        limit: u32,
+        since_unix_secs: u64,
+    ) -> Result<Vec<ScopedSecurityEvent>, LifecycleError>;
+
+    /// Submit a human's approval input to the decision authority.
+    async fn relay_approval(
+        &self,
+        tool: &DevToolKind,
+        approval_id: &str,
+        input: ApprovalInput,
+    ) -> Result<ApprovalRelayReceipt, LifecycleError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::devint::verb::DiVerb;
+
+    /// The trait's method names, transcribed. Compared against the verb space
+    /// so a method that is not a verb — or a verb with no method — is a build
+    /// failure rather than a review question.
+    const TRAIT_METHODS: [&str; 9] = [
+        "list_tools",
+        "plan",
+        "apply",
+        "status",
+        "verify",
+        "repair",
+        "remove",
+        "scoped_events",
+        "relay_approval",
+    ];
+
+    #[test]
+    fn the_port_offers_exactly_the_closed_verb_space() {
+        let mut verbs: Vec<&str> = DiVerb::ALL.iter().map(|v| v.as_str()).collect();
+        // The only naming difference: the verb is `approval_relay`, the method
+        // is `relay_approval` (a verb reads as a noun, a method as an action).
+        for name in verbs.iter_mut() {
+            if *name == "approval_relay" {
+                *name = "relay_approval";
+            }
+        }
+        let mut methods = TRAIT_METHODS.to_vec();
+        verbs.sort_unstable();
+        methods.sort_unstable();
+        assert_eq!(verbs, methods);
+    }
+
+    #[test]
+    fn no_port_method_is_named_like_a_policy_decision() {
+        for name in TRAIT_METHODS {
+            for forbidden in ["check", "evaluate", "decide", "authorize", "emit_audit"] {
+                assert!(!name.contains(forbidden), "{name} looks like a decision method");
+            }
+        }
+    }
+
+    #[test]
+    fn an_unreadable_approval_input_is_not_an_approval() {
+        assert_eq!(ApprovalInput::parse("approve"), Some(ApprovalInput::Approve));
+        assert_eq!(ApprovalInput::parse("APPROVE"), None);
+        assert_eq!(ApprovalInput::parse(""), None);
+        assert_eq!(ApprovalInput::parse("yes"), None);
+    }
+
+    #[test]
+    fn lifecycle_errors_render_without_leaking_internals() {
+        let err = LifecycleError::UnknownTool {
+            tool_id: "nope".to_string(),
+        };
+        assert_eq!(err.detail(), "no adapter knows the tool nope");
+    }
+}

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -61,6 +61,7 @@
 pub mod codec;
 pub mod lifecycle;
 pub mod negotiate;
+pub mod projection;
 pub mod scope;
 pub mod socket;
 pub mod token;

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -59,6 +59,7 @@
 //! someone might forget (§5.5).
 
 pub mod audit;
+pub mod client;
 pub mod codec;
 pub mod lifecycle;
 pub mod negotiate;
@@ -72,6 +73,7 @@ pub mod token;
 pub mod verb;
 
 pub use audit::{DevIntAuditEvent, DevIntAuditKind, DevIntAuditSink};
+pub use client::{ClientError, DevIntClient, Negotiated};
 pub use lifecycle::{IntegrationLifecycle, LifecycleError};
 pub use negotiate::{Negotiation, NegotiationError, DI_API_MAX_SUPPORTED, DI_API_MIN_SUPPORTED};
 pub use scope::{TokenScope, ToolScope};

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -64,12 +64,18 @@ pub mod lifecycle;
 pub mod negotiate;
 pub mod projection;
 pub mod scope;
+pub mod server;
 pub mod socket;
+#[cfg(test)]
+pub mod testkit;
 pub mod token;
 pub mod verb;
 
+pub use audit::{DevIntAuditEvent, DevIntAuditKind, DevIntAuditSink};
+pub use lifecycle::{IntegrationLifecycle, LifecycleError};
 pub use negotiate::{Negotiation, NegotiationError, DI_API_MAX_SUPPORTED, DI_API_MIN_SUPPORTED};
-pub use scope::TokenScope;
+pub use scope::{TokenScope, ToolScope};
+pub use server::{DevIntServer, DevIntServerConfig, DevIntServices};
 pub use socket::{devint_socket_path, SocketDiscovery, SocketError};
 pub use token::{CapabilityToken, TokenDenial, TokenId, TokenRecord, TokenStore};
 pub use verb::DiVerb;

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -69,6 +69,8 @@ pub mod server;
 pub mod socket;
 #[cfg(test)]
 pub mod testkit;
+#[cfg(test)]
+mod threat_model;
 pub mod token;
 pub mod verb;
 

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -59,7 +59,9 @@
 //! someone might forget (§5.5).
 
 pub mod scope;
+pub mod token;
 pub mod verb;
 
 pub use scope::TokenScope;
+pub use token::{CapabilityToken, TokenDenial, TokenId, TokenRecord, TokenStore};
 pub use verb::DiVerb;

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -58,6 +58,8 @@
 //! Minimisation is the shape of the response types, not a redaction pass
 //! someone might forget (§5.5).
 
+pub mod scope;
 pub mod verb;
 
+pub use scope::TokenScope;
 pub use verb::DiVerb;

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -1,0 +1,63 @@
+//! The Developer Integration API (DI-API) — ADR 0030 Decision 5, AAASM-5279.
+//!
+//! # What this is
+//!
+//! The one authenticated channel by which an **untrusted** local thin client —
+//! a VS Code extension, an installer, `aasm integration …` — asks the trusted
+//! runtime to install, inspect, verify, repair or remove a developer-tool
+//! integration. It is a *lifecycle and UX* surface. It carries no policy
+//! decisions and no agent-action traffic; those go SDK → `aa-sdk-client` →
+//! runtime/gateway on a different socket (ADR 0004).
+//!
+//! # The trust model, in the order a connection meets it
+//!
+//! 1. **The socket itself.** `~/.aa/run/devint.sock`, in a `0700` directory,
+//!    created `0600` under a tightened `umask` — the same construction
+//!    [`crate::ipc::server`] uses (AAASM-3581), and re-asserted on every bind
+//!    rather than trusted from the last one ([`socket`]). It is deliberately
+//!    **not** the SDK fast-path socket: a DI client never holds a file
+//!    descriptor onto agent traffic, so that traffic is unreachable by
+//!    construction rather than by a rule someone has to write.
+//!    Loopback TCP is a forbidden design (§5.2).
+//! 2. **Peer credentials.** [`crate::ipc::peercred::peer_uid_is_allowed`],
+//!    reused verbatim: a peer whose UID is not the runtime's is dropped before
+//!    any work is done for it.
+//! 3. **Version negotiation.** An explicit `Hello`/`HelloAck` exchange before
+//!    any verb is accepted, with deterministic supported / degraded /
+//!    incompatible outcomes and no silent downgrade ([`negotiate`]).
+//! 4. **A capability token.** 256 bits from a CSPRNG, opaque, resolved against
+//!    a server-side record, scoped per tool and per verb, absolutely expiring,
+//!    rotatable and revocable ([`token`]). Absent, expired, unknown or
+//!    unresolvable ⇒ deny plus an audit event, with no anonymous tier.
+//!
+//! # Why layer 4 is not the AAASM-3922 mistake again
+//!
+//! The SDK handshake key is derived from the agent id, which is the public
+//! socket filename, so it proves integrity and version-binding rather than
+//! possession of a secret (see [`crate::ipc::handshake`]). A DI capability
+//! token is the opposite by construction: it is drawn from the OS CSPRNG, is
+//! derived from nothing, is knowable only from the `0600` file it was written
+//! to, and is verified by *looking it up* rather than by recomputing it. That
+//! is also why it is not a JWT — a credential that verifies offline cannot be
+//! revoked, and revocation is a hard requirement here.
+//!
+//! # What cannot be asked for
+//!
+//! [`verb::DiVerb`] is a closed enum. There is no "call core", no path or
+//! method passthrough, no filter or predicate passthrough, no opaque forwarded
+//! envelope, and no policy-decision or audit-emit verb. The service depends on
+//! the [`lifecycle::IntegrationLifecycle`] port, not on `aa_core::storage`,
+//! identity, or gateway credential types — a handler that wanted to read
+//! storage would not compile without a dependency edit.
+//!
+//! # What cannot leave
+//!
+//! Responses are built by [`projection`], whose types have no field able to
+//! hold a policy document, a rendered settings body, an environment-variable
+//! value, a raw prompt or tool output, or a storage/gateway credential.
+//! Minimisation is the shape of the response types, not a redaction pass
+//! someone might forget (§5.5).
+
+pub mod verb;
+
+pub use verb::DiVerb;

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -58,6 +58,7 @@
 //! Minimisation is the shape of the response types, not a redaction pass
 //! someone might forget (§5.5).
 
+pub mod audit;
 pub mod codec;
 pub mod lifecycle;
 pub mod negotiate;

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -58,11 +58,13 @@
 //! Minimisation is the shape of the response types, not a redaction pass
 //! someone might forget (§5.5).
 
+pub mod negotiate;
 pub mod scope;
 pub mod socket;
 pub mod token;
 pub mod verb;
 
+pub use negotiate::{Negotiation, NegotiationError, DI_API_MAX_SUPPORTED, DI_API_MIN_SUPPORTED};
 pub use scope::TokenScope;
 pub use socket::{devint_socket_path, SocketDiscovery, SocketError};
 pub use token::{CapabilityToken, TokenDenial, TokenId, TokenRecord, TokenStore};

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -59,6 +59,7 @@
 //! someone might forget (§5.5).
 
 pub mod codec;
+pub mod lifecycle;
 pub mod negotiate;
 pub mod scope;
 pub mod socket;

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -59,9 +59,11 @@
 //! someone might forget (§5.5).
 
 pub mod scope;
+pub mod socket;
 pub mod token;
 pub mod verb;
 
 pub use scope::TokenScope;
+pub use socket::{devint_socket_path, SocketDiscovery, SocketError};
 pub use token::{CapabilityToken, TokenDenial, TokenId, TokenRecord, TokenStore};
 pub use verb::DiVerb;

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -58,6 +58,7 @@
 //! Minimisation is the shape of the response types, not a redaction pass
 //! someone might forget (§5.5).
 
+pub mod codec;
 pub mod negotiate;
 pub mod scope;
 pub mod socket;

--- a/aa-runtime/src/devint/negotiate.rs
+++ b/aa-runtime/src/devint/negotiate.rs
@@ -1,0 +1,404 @@
+//! DI-API version negotiation — explicit, deterministic, never a silent
+//! downgrade (ADR 0030 §5.4).
+//!
+//! The first exchange on every connection is `Hello` → `HelloAck` |
+//! `Incompatible`. No lifecycle verb is accepted before it, and the negotiated
+//! version is fixed for the connection's lifetime — a second `Hello` is a
+//! protocol violation, not a renegotiation, because a mid-connection downgrade
+//! is exactly the move an attacker would use to reach behaviour the current
+//! version removed.
+//!
+//! # Three outcomes, and they are the only three
+//!
+//! | Outcome | When | What the client gets |
+//! | --- | --- | --- |
+//! | [`Negotiation::Supported`] | the highest shared version exposes every verb | the whole verb space |
+//! | [`Negotiation::Degraded`] | a shared version exists but exposes a subset | the subset, plus the *named* missing verbs and remediation |
+//! | [`Negotiation::Incompatible`] | no shared version, or the client's best is below the floor | a reason, remediation, and a closed connection |
+//!
+//! `Degraded` is an outcome the client must surface, never an implicit
+//! fallback. Silently serving an older behaviour is the failure mode this
+//! design exists to prevent: a client that believes it has approval relay and
+//! silently does not will show a human a prompt no one is waiting on.
+//!
+//! Lifecycle schema compatibility is negotiated in the same breath. The service
+//! speaks exactly [`aa_core::integration::LIFECYCLE_SCHEMA_VERSION`]; a client
+//! that cannot read it is incompatible rather than served a plan it will
+//! misparse.
+
+use aa_core::integration::{core_version, LIFECYCLE_SCHEMA_VERSION};
+use aa_proto::assembly::devint::v1 as wire;
+
+use super::verb::DiVerb;
+
+/// The oldest DI-API version this runtime will serve.
+///
+/// Versions below the floor are refused with remediation rather than emulated:
+/// an emulation is a second behaviour to defend, and the whole point of a
+/// closed verb space is having one.
+pub const DI_API_MIN_SUPPORTED: u32 = 1;
+
+/// The newest DI-API version this runtime speaks.
+pub const DI_API_MAX_SUPPORTED: u32 = 2;
+
+/// Verbs that did not exist at DI-API v1.
+///
+/// A v1 client is [`Negotiation::Degraded`]: it gets the lifecycle verbs and is
+/// told, by name, which UX verbs it does not have.
+pub const VERBS_ADDED_IN_V2: [DiVerb; 2] = [DiVerb::ScopedEvents, DiVerb::ApprovalRelay];
+
+/// Whether `verb` exists at DI-API version `version`.
+pub fn verb_available_at(verb: DiVerb, version: u32) -> bool {
+    if version >= 2 {
+        return true;
+    }
+    !VERBS_ADDED_IN_V2.contains(&verb)
+}
+
+/// Why a `Hello` could not be honoured.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NegotiationError {
+    /// The client offered no DI-API version at all. Treated as incompatible,
+    /// never as "assume the oldest" — an unstated version is unknown, and an
+    /// unknown must not be resolved in the permissive direction.
+    NoVersionOffered,
+    /// Every version the client offered is below [`DI_API_MIN_SUPPORTED`].
+    BelowFloor {
+        /// The best the client could do.
+        client_best: u32,
+    },
+    /// The client speaks only versions newer than this runtime.
+    AboveCeiling {
+        /// The lowest version the client offered.
+        client_lowest: u32,
+    },
+    /// The offered versions straddle the window without intersecting it.
+    NoOverlap,
+    /// The client cannot read the lifecycle schema this core writes.
+    LifecycleSchemaMismatch {
+        /// What the service speaks.
+        service: u32,
+    },
+}
+
+impl NegotiationError {
+    /// A short statement of what is wrong, for `Incompatible.reason`.
+    pub fn reason(&self) -> String {
+        match self {
+            NegotiationError::NoVersionOffered => "the client offered no DI-API version".to_string(),
+            NegotiationError::BelowFloor { client_best } => format!(
+                "the client's newest DI-API version ({client_best}) is below the supported floor ({DI_API_MIN_SUPPORTED})"
+            ),
+            NegotiationError::AboveCeiling { client_lowest } => format!(
+                "the client's oldest DI-API version ({client_lowest}) is newer than this runtime serves ({DI_API_MAX_SUPPORTED})"
+            ),
+            NegotiationError::NoOverlap => format!(
+                "no DI-API version is shared; this runtime serves {DI_API_MIN_SUPPORTED}–{DI_API_MAX_SUPPORTED}"
+            ),
+            NegotiationError::LifecycleSchemaMismatch { service } => {
+                format!("the client cannot read lifecycle schema version {service}")
+            }
+        }
+    }
+
+    /// What the user should actually do about it. Never "try again".
+    pub fn remediation(&self) -> String {
+        match self {
+            NegotiationError::NoVersionOffered | NegotiationError::NoOverlap => {
+                format!("update the client to one speaking DI-API {DI_API_MIN_SUPPORTED}–{DI_API_MAX_SUPPORTED}")
+            }
+            NegotiationError::BelowFloor { .. } => {
+                format!("update the client to DI-API {DI_API_MIN_SUPPORTED} or newer")
+            }
+            NegotiationError::AboveCeiling { .. } => {
+                "update the AASM runtime — the client is newer than the installed core".to_string()
+            }
+            NegotiationError::LifecycleSchemaMismatch { service } => {
+                format!("update the client to one that reads lifecycle schema version {service}")
+            }
+        }
+    }
+}
+
+/// The outcome of one `Hello`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Negotiation {
+    /// Every verb is available at `version`.
+    Supported {
+        /// The agreed DI-API version.
+        version: u32,
+    },
+    /// `version` was agreed, but it does not expose every verb.
+    Degraded {
+        /// The agreed DI-API version.
+        version: u32,
+        /// The verbs that do not exist at it, named so the client can disable
+        /// the corresponding UI rather than discovering it at first use.
+        unavailable: Vec<DiVerb>,
+        /// Why, in words a user can act on.
+        reason: String,
+        /// What to do about it.
+        remediation: String,
+    },
+    /// Nothing was agreed. The connection is closed after the reply.
+    Incompatible(NegotiationError),
+}
+
+impl Negotiation {
+    /// The agreed version, when one was agreed.
+    pub fn version(&self) -> Option<u32> {
+        match self {
+            Negotiation::Supported { version } | Negotiation::Degraded { version, .. } => Some(*version),
+            Negotiation::Incompatible(_) => None,
+        }
+    }
+
+    /// Whether the connection may proceed to serve verbs.
+    pub fn is_usable(&self) -> bool {
+        self.version().is_some()
+    }
+
+    /// A stable snake_case outcome name for the audit trail.
+    pub const fn outcome(&self) -> &'static str {
+        match self {
+            Negotiation::Supported { .. } => "supported",
+            Negotiation::Degraded { .. } => "degraded",
+            Negotiation::Incompatible(_) => "incompatible",
+        }
+    }
+}
+
+/// Decide what a `Hello` gets.
+///
+/// The rule is "highest version both sides offer", evaluated over the client's
+/// *offered set* rather than a claimed range, so a client cannot widen its
+/// reach by asserting a range it does not implement.
+pub fn negotiate(hello: &wire::Hello) -> Negotiation {
+    if hello.di_api_versions.is_empty() {
+        return Negotiation::Incompatible(NegotiationError::NoVersionOffered);
+    }
+
+    let shared = hello
+        .di_api_versions
+        .iter()
+        .copied()
+        .filter(|v| (DI_API_MIN_SUPPORTED..=DI_API_MAX_SUPPORTED).contains(v))
+        .max();
+
+    let Some(version) = shared else {
+        let client_best = hello.di_api_versions.iter().copied().max().unwrap_or(0);
+        let client_lowest = hello.di_api_versions.iter().copied().min().unwrap_or(0);
+        let error = if client_best < DI_API_MIN_SUPPORTED {
+            NegotiationError::BelowFloor { client_best }
+        } else if client_lowest > DI_API_MAX_SUPPORTED {
+            NegotiationError::AboveCeiling { client_lowest }
+        } else {
+            NegotiationError::NoOverlap
+        };
+        return Negotiation::Incompatible(error);
+    };
+
+    // The lifecycle schema is not negotiable down: the service writes exactly
+    // one schema, and a client that cannot read it would misparse a plan rather
+    // than fail loudly.
+    if !hello.lifecycle_schema_versions.contains(&LIFECYCLE_SCHEMA_VERSION) {
+        return Negotiation::Incompatible(NegotiationError::LifecycleSchemaMismatch {
+            service: LIFECYCLE_SCHEMA_VERSION,
+        });
+    }
+
+    let unavailable: Vec<DiVerb> = DiVerb::ALL
+        .into_iter()
+        .filter(|v| !verb_available_at(*v, version))
+        .collect();
+
+    if unavailable.is_empty() {
+        Negotiation::Supported { version }
+    } else {
+        let names: Vec<&str> = unavailable.iter().map(|v| v.as_str()).collect();
+        Negotiation::Degraded {
+            version,
+            unavailable,
+            reason: format!(
+                "DI-API v{version} does not expose {}; this runtime also speaks v{DI_API_MAX_SUPPORTED}",
+                names.join(", ")
+            ),
+            remediation: format!("update the client to speak DI-API v{DI_API_MAX_SUPPORTED} to enable them"),
+        }
+    }
+}
+
+/// Render a negotiation outcome as the frame the client receives.
+///
+/// `Ok` carries a `HelloAck` (supported or degraded); `Err` carries an
+/// `Incompatible` whose reason and remediation are both populated — an
+/// incompatible answer without remediation is a dead end, not an outcome.
+pub fn to_wire(negotiation: &Negotiation) -> Result<wire::HelloAck, wire::Incompatible> {
+    match negotiation {
+        Negotiation::Supported { version } => Ok(wire::HelloAck {
+            outcome: wire::NegotiationOutcome::Supported as i32,
+            di_api_version: *version,
+            core_version: core_version().to_string(),
+            lifecycle_schema_version: LIFECYCLE_SCHEMA_VERSION,
+            min_supported: DI_API_MIN_SUPPORTED,
+            max_supported: DI_API_MAX_SUPPORTED,
+            unavailable_verbs: Vec::new(),
+            degraded_reason: String::new(),
+            remediation: String::new(),
+        }),
+        Negotiation::Degraded {
+            version,
+            unavailable,
+            reason,
+            remediation,
+        } => Ok(wire::HelloAck {
+            outcome: wire::NegotiationOutcome::Degraded as i32,
+            di_api_version: *version,
+            core_version: core_version().to_string(),
+            lifecycle_schema_version: LIFECYCLE_SCHEMA_VERSION,
+            min_supported: DI_API_MIN_SUPPORTED,
+            max_supported: DI_API_MAX_SUPPORTED,
+            unavailable_verbs: unavailable.iter().map(|v| v.as_str().to_string()).collect(),
+            degraded_reason: reason.clone(),
+            remediation: remediation.clone(),
+        }),
+        Negotiation::Incompatible(error) => Err(wire::Incompatible {
+            reason: error.reason(),
+            remediation: error.remediation(),
+            min_supported: DI_API_MIN_SUPPORTED,
+            max_supported: DI_API_MAX_SUPPORTED,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hello(di_versions: &[u32]) -> wire::Hello {
+        wire::Hello {
+            client_name: "test-client".to_string(),
+            client_version: "1.0.0".to_string(),
+            di_api_versions: di_versions.to_vec(),
+            lifecycle_schema_versions: vec![LIFECYCLE_SCHEMA_VERSION],
+        }
+    }
+
+    #[test]
+    fn the_highest_shared_version_wins() {
+        assert_eq!(
+            negotiate(&hello(&[1, 2])),
+            Negotiation::Supported {
+                version: DI_API_MAX_SUPPORTED
+            }
+        );
+    }
+
+    #[test]
+    fn a_version_missing_verbs_is_degraded_not_silently_downgraded() {
+        let outcome = negotiate(&hello(&[1]));
+        match &outcome {
+            Negotiation::Degraded {
+                version,
+                unavailable,
+                reason,
+                remediation,
+            } => {
+                assert_eq!(*version, 1);
+                assert_eq!(unavailable, &VERBS_ADDED_IN_V2.to_vec());
+                assert!(reason.contains("scoped_events"));
+                assert!(!remediation.is_empty(), "a degraded outcome must be actionable");
+            }
+            other => panic!("expected Degraded, got {other:?}"),
+        }
+        // Degraded is still usable — but it is *named*, which is the property
+        // that distinguishes it from a silent downgrade.
+        assert!(outcome.is_usable());
+        assert_eq!(outcome.outcome(), "degraded");
+    }
+
+    #[test]
+    fn a_client_below_the_floor_is_incompatible_with_remediation() {
+        let outcome = negotiate(&hello(&[0]));
+        let Negotiation::Incompatible(error) = &outcome else {
+            panic!("expected Incompatible, got {outcome:?}");
+        };
+        assert_eq!(*error, NegotiationError::BelowFloor { client_best: 0 });
+        assert!(!outcome.is_usable());
+        let incompatible = to_wire(&outcome).expect_err("must not produce a HelloAck");
+        assert!(!incompatible.reason.is_empty());
+        assert!(incompatible.remediation.contains("update the client"));
+    }
+
+    #[test]
+    fn a_client_newer_than_the_runtime_is_told_to_update_the_runtime() {
+        let outcome = negotiate(&hello(&[7, 8]));
+        let Negotiation::Incompatible(error) = &outcome else {
+            panic!("expected Incompatible, got {outcome:?}");
+        };
+        assert_eq!(*error, NegotiationError::AboveCeiling { client_lowest: 7 });
+        let incompatible = to_wire(&outcome).expect_err("incompatible");
+        assert!(incompatible.remediation.contains("runtime"));
+    }
+
+    #[test]
+    fn offering_no_version_is_incompatible_not_assumed_oldest() {
+        assert_eq!(
+            negotiate(&hello(&[])),
+            Negotiation::Incompatible(NegotiationError::NoVersionOffered)
+        );
+    }
+
+    #[test]
+    fn a_straddling_offer_that_misses_the_window_is_incompatible() {
+        // Only meaningful once the window has a gap around it; asserts the
+        // classifier does not fall through to a permissive branch.
+        let outcome = negotiate(&wire::Hello {
+            di_api_versions: vec![0, 9],
+            ..hello(&[])
+        });
+        assert_eq!(outcome, Negotiation::Incompatible(NegotiationError::NoOverlap));
+    }
+
+    #[test]
+    fn an_unreadable_lifecycle_schema_is_incompatible() {
+        let outcome = negotiate(&wire::Hello {
+            lifecycle_schema_versions: vec![LIFECYCLE_SCHEMA_VERSION + 99],
+            ..hello(&[2])
+        });
+        assert_eq!(
+            outcome,
+            Negotiation::Incompatible(NegotiationError::LifecycleSchemaMismatch {
+                service: LIFECYCLE_SCHEMA_VERSION
+            })
+        );
+    }
+
+    #[test]
+    fn the_supported_ack_names_the_core_and_the_window() {
+        let ack = to_wire(&negotiate(&hello(&[2]))).expect("supported");
+        assert_eq!(ack.outcome, wire::NegotiationOutcome::Supported as i32);
+        assert_eq!(ack.di_api_version, DI_API_MAX_SUPPORTED);
+        assert_eq!(ack.min_supported, DI_API_MIN_SUPPORTED);
+        assert_eq!(ack.max_supported, DI_API_MAX_SUPPORTED);
+        assert_eq!(ack.lifecycle_schema_version, LIFECYCLE_SCHEMA_VERSION);
+        assert!(!ack.core_version.is_empty());
+        assert!(ack.unavailable_verbs.is_empty());
+    }
+
+    #[test]
+    fn negotiation_is_deterministic_for_a_repeated_hello() {
+        let request = hello(&[2, 1]);
+        let first = negotiate(&request);
+        for _ in 0..8 {
+            assert_eq!(negotiate(&request), first);
+        }
+    }
+
+    #[test]
+    fn every_verb_exists_at_the_newest_version() {
+        for verb in DiVerb::ALL {
+            assert!(verb_available_at(verb, DI_API_MAX_SUPPORTED), "{verb} missing at max");
+        }
+    }
+}

--- a/aa-runtime/src/devint/projection.rs
+++ b/aa-runtime/src/devint/projection.rs
@@ -1,0 +1,869 @@
+//! Turning lifecycle values into what may leave the trust boundary
+//! (ADR 0030 §5.5).
+//!
+//! # Minimisation is a shape, not a pass
+//!
+//! Every function here maps a rich internal type onto a wire type that
+//! **cannot hold** the things that must not leave. That is deliberate and it is
+//! the acceptance criterion: a redaction pass is something a future contributor
+//! can forget to call, whereas a struct with no field for a secret cannot carry
+//! one however carelessly it is populated.
+//!
+//! The sharp edge is [`step_view`]. `aa_core::integration::StepAction` legitimately
+//! carries values the *service* needs — a rendered settings body's digest, an
+//! injected environment variable's value, a proxy variable map, a model base
+//! URL. An adapter is free to put a credential in any of those. `StepView` has
+//! no field any of them could land in: it carries the step's identity, its kind,
+//! the settings surface, the AASM-owned **key names**, the artifact **paths**
+//! and the content **fingerprint**. A reviewer can see what will change and
+//! compare digests; nobody can read a value out of it, including a compromised
+//! client that asked nicely.
+//!
+//! | The service holds | The DI-API returns |
+//! | --- | --- |
+//! | `PolicyDocument` | `PolicyProfileRefView { id, display_name, digest }` |
+//! | rendered settings content | `content_sha256` + `managed_keys` |
+//! | `EnvValue::Literal("sk-…")` | the variable *name*, nothing else |
+//! | `ConfigureProxy { variables }` | the variable *names*, nothing else |
+//! | audit rows | counts, verdict kinds, timestamps, redaction labels |
+//! | any storage or gateway credential | nothing — no field exists |
+//!
+//! # Tool ids
+//!
+//! `DevToolKind` has no stable string form of its own, so [`tool_id`] and
+//! [`parse_tool_id`] define one here. They round-trip, and an unknown id
+//! becomes `DevToolKind::Custom` rather than a guess at a built-in — the
+//! lifecycle service is what decides whether a tool exists, and it answers
+//! `UnknownTool` if it does not.
+
+use aa_core::dev_tool::{DevToolKind, GovernanceLevel};
+use aa_core::integration::{
+    ArtifactOperation, CapabilityResolution, DevToolCapabilities, EvidenceKind, ExerciseOutcome, IntegrationCapability,
+    IntegrationPlan, IntegrationReceipt, IntegrationStatus, IntegrationStep, LifecyclePhase, PolicyProfileRef,
+    ProtectionEvidence, ProtectionLevel, ProtectionProfile, ProtectionState, RemovalPlan, SettingsScope, StepAction,
+    StepPrivilege, StepReceipt, StepRequirement, VerificationOutcome, VerificationResult, VersionCompatibility,
+};
+use aa_proto::assembly::devint::v1 as wire;
+
+use super::lifecycle::{RepairReport, ScopedSecurityEvent, ToolDescriptor};
+
+/// The stable wire id for a tool.
+pub fn tool_id(tool: &DevToolKind) -> String {
+    match tool {
+        DevToolKind::ClaudeCode => "claude-code".to_string(),
+        DevToolKind::Codex => "codex".to_string(),
+        DevToolKind::GitHubCopilot => "github-copilot".to_string(),
+        DevToolKind::WindsurfCascade => "windsurf-cascade".to_string(),
+        DevToolKind::Custom(name) => name.clone(),
+    }
+}
+
+/// Parse a wire tool id.
+///
+/// An unrecognised id becomes [`DevToolKind::Custom`] rather than an error:
+/// deciding whether a tool exists belongs to the lifecycle service, which
+/// answers `UnknownTool` for one it does not know. Resolving it here would put
+/// tool knowledge in two places.
+pub fn parse_tool_id(id: &str) -> DevToolKind {
+    match id {
+        "claude-code" => DevToolKind::ClaudeCode,
+        "codex" => DevToolKind::Codex,
+        "github-copilot" => DevToolKind::GitHubCopilot,
+        "windsurf-cascade" => DevToolKind::WindsurfCascade,
+        other => DevToolKind::Custom(other.to_string()),
+    }
+}
+
+/// Snake_case name for a protection level.
+pub const fn level_name(level: ProtectionLevel) -> &'static str {
+    match level {
+        ProtectionLevel::NotInstalled => "not_installed",
+        ProtectionLevel::DetectedNotIntegrated => "detected_not_integrated",
+        ProtectionLevel::PartiallyIntegrated => "partially_integrated",
+        ProtectionLevel::Integrated => "integrated",
+        ProtectionLevel::GatewayProtected => "gateway_protected",
+        ProtectionLevel::HostEnforced => "host_enforced",
+    }
+}
+
+/// Snake_case name for a governance ceiling.
+pub const fn ceiling_name(level: GovernanceLevel) -> &'static str {
+    match level {
+        GovernanceLevel::L0Discover => "l0_discover",
+        GovernanceLevel::L1Observe => "l1_observe",
+        GovernanceLevel::L2Enforce => "l2_enforce",
+        GovernanceLevel::L3Native => "l3_native",
+    }
+}
+
+/// Snake_case name for a settings surface.
+pub const fn scope_name(scope: SettingsScope) -> &'static str {
+    match scope {
+        SettingsScope::User => "user",
+        SettingsScope::Project => "project",
+        SettingsScope::Managed => "managed",
+    }
+}
+
+/// Parse a wire settings-scope token. `None` for anything unrecognised — a
+/// destination must be named, never inferred.
+pub fn parse_scope(name: &str) -> Option<SettingsScope> {
+    match name {
+        "user" => Some(SettingsScope::User),
+        "project" => Some(SettingsScope::Project),
+        "managed" => Some(SettingsScope::Managed),
+        _ => None,
+    }
+}
+
+/// Snake_case name for a protection profile.
+pub const fn profile_name(profile: ProtectionProfile) -> &'static str {
+    match profile {
+        ProtectionProfile::Recommended => "recommended",
+        ProtectionProfile::Strict => "strict",
+        ProtectionProfile::ObserveOnly => "observe_only",
+    }
+}
+
+/// Parse a wire profile token. `None` for anything unrecognised.
+pub fn parse_profile(name: &str) -> Option<ProtectionProfile> {
+    match name {
+        "recommended" => Some(ProtectionProfile::Recommended),
+        "strict" => Some(ProtectionProfile::Strict),
+        "observe_only" => Some(ProtectionProfile::ObserveOnly),
+        _ => None,
+    }
+}
+
+/// Parse a wire protection-level token. `None` for anything unrecognised.
+pub fn parse_level(name: &str) -> Option<ProtectionLevel> {
+    [
+        ProtectionLevel::NotInstalled,
+        ProtectionLevel::DetectedNotIntegrated,
+        ProtectionLevel::PartiallyIntegrated,
+        ProtectionLevel::Integrated,
+        ProtectionLevel::GatewayProtected,
+        ProtectionLevel::HostEnforced,
+    ]
+    .into_iter()
+    .find(|l| level_name(*l) == name)
+}
+
+/// Snake_case name for an integration mechanism.
+pub const fn capability_name(capability: IntegrationCapability) -> &'static str {
+    match capability {
+        IntegrationCapability::Discovery => "discovery",
+        IntegrationCapability::ManagedSettings => "managed_settings",
+        IntegrationCapability::ManagedLaunch => "managed_launch",
+        IntegrationCapability::ModelPathInterception => "model_path_interception",
+        IntegrationCapability::ModelGatewayBaseUrl => "model_gateway_base_url",
+        IntegrationCapability::HttpProxy => "http_proxy",
+        IntegrationCapability::Hooks => "hooks",
+        IntegrationCapability::McpDiscovery => "mcp_discovery",
+        IntegrationCapability::McpGovernance => "mcp_governance",
+        IntegrationCapability::ToolActionApproval => "tool_action_approval",
+        IntegrationCapability::NativeIdeUi => "native_ide_ui",
+        IntegrationCapability::HostEnforcement => "host_enforcement",
+        // `IntegrationCapability` is `#[non_exhaustive]`: a mechanism this
+        // build cannot name is reported as unknown rather than mislabelled as a
+        // neighbour, which would attribute evidence to the wrong mechanism.
+        _ => "unknown",
+    }
+}
+
+/// Snake_case name for a lifecycle phase.
+pub const fn phase_name(phase: LifecyclePhase) -> &'static str {
+    match phase {
+        LifecyclePhase::NotInstalled => "not_installed",
+        LifecyclePhase::DetectedNotIntegrated => "detected_not_integrated",
+        LifecyclePhase::Planned => "planned",
+        LifecyclePhase::Installed => "installed",
+        LifecyclePhase::PartiallyInstalled => "partially_installed",
+        LifecyclePhase::RemovalPending => "removal_pending",
+        // `LifecyclePhase` is `#[non_exhaustive]`: a phase this build does not
+        // know resolves to "unknown", never to a phase it might not be.
+        _ => "unknown",
+    }
+}
+
+/// Snake_case name for a version-compatibility verdict.
+///
+/// `Unknown` keeps its own name rather than folding into `incompatible`: they
+/// call for different remediation, and "we could not compare" must not read as
+/// "we compared and it failed".
+pub const fn compatibility_name(compatibility: &VersionCompatibility) -> &'static str {
+    match compatibility {
+        VersionCompatibility::Compatible { .. } => "compatible",
+        VersionCompatibility::Unknown { .. } => "unknown",
+        VersionCompatibility::Incompatible { .. } => "incompatible",
+        // `#[non_exhaustive]`: a verdict this build cannot name resolves to
+        // "unknown", the downward direction (ADR 0030 §4.2 rule 2).
+        _ => "unknown",
+    }
+}
+
+/// Project one capability declaration.
+fn capability_view(caps: &DevToolCapabilities, capability: IntegrationCapability) -> wire::CapabilityView {
+    let support = match caps.resolve(capability) {
+        CapabilityResolution::Effective => "supported",
+        CapabilityResolution::Unsupported => "unsupported",
+        CapabilityResolution::Absent => "absent",
+    };
+    wire::CapabilityView {
+        capability: capability_name(capability).to_string(),
+        support: support.to_string(),
+        // The adapter's own user-facing sentence, present only when it declared
+        // one. Absent capabilities carry no reason, precisely because nobody
+        // declared anything about them.
+        reason: caps.unsupported_reason(capability).unwrap_or_default().to_string(),
+    }
+}
+
+/// Project a tool descriptor.
+pub fn tool_summary(descriptor: &ToolDescriptor) -> wire::ToolSummary {
+    wire::ToolSummary {
+        tool_id: tool_id(&descriptor.tool),
+        display_name: descriptor.display_name.clone(),
+        detected: descriptor.detected,
+        detected_version: descriptor
+            .detected_version
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default(),
+        compatibility: compatibility_name(&descriptor.compatibility).to_string(),
+        capabilities: IntegrationCapability::ALL
+            .into_iter()
+            .map(|c| capability_view(&descriptor.capabilities, c))
+            .collect(),
+        adapter_ceiling: ceiling_name(descriptor.adapter_ceiling).to_string(),
+    }
+}
+
+/// Project a policy profile reference. Already a reference in `aa-core`; kept
+/// as an explicit mapping so the wire type never silently widens to the
+/// document.
+pub fn policy_profile_view(profile: &PolicyProfileRef) -> wire::PolicyProfileRefView {
+    wire::PolicyProfileRefView {
+        id: profile.id.clone(),
+        display_name: profile.display_name.clone(),
+        digest: profile.digest.clone(),
+    }
+}
+
+/// The stable kind token for a step action.
+const fn action_kind(action: &StepAction) -> &'static str {
+    match action {
+        StepAction::WriteManagedSettings { .. } => "write_managed_settings",
+        StepAction::ApplyLegacyManagedSettings { .. } => "apply_legacy_managed_settings",
+        StepAction::InstallHook { .. } => "install_hook",
+        StepAction::RemoveHook { .. } => "remove_hook",
+        StepAction::ConfigureModelGatewayBaseUrl { .. } => "configure_model_gateway_base_url",
+        StepAction::ConfigureProxy { .. } => "configure_proxy",
+        StepAction::MaterialiseTrustMaterial { .. } => "materialise_trust_material",
+        StepAction::InjectLaunchEnvironment { .. } => "inject_launch_environment",
+        StepAction::ConfigureMcpServers { .. } => "configure_mcp_servers",
+        StepAction::RegisterIdeClient { .. } => "register_ide_client",
+        // `StepAction` is `#[non_exhaustive]`: an action this build cannot name
+        // is reported as unknown rather than mislabelled as a neighbour.
+        _ => "unknown",
+    }
+}
+
+/// The names, paths and fingerprint a step exposes — and nothing else.
+///
+/// This is the function that enforces §5.5. Read the match arms as an
+/// allowlist: each one names which *identifiers* of that action escape. Values
+/// (`EnvValue`, `variables`, `base_url`, rendered content) are never in the
+/// output, so a secret an adapter put in one cannot reach a client.
+struct StepFacts {
+    settings_scope: String,
+    managed_keys: Vec<String>,
+    artifact_paths: Vec<String>,
+    content_sha256: String,
+}
+
+fn step_facts(action: &StepAction) -> StepFacts {
+    let mut facts = StepFacts {
+        settings_scope: String::new(),
+        managed_keys: Vec::new(),
+        artifact_paths: Vec::new(),
+        content_sha256: String::new(),
+    };
+    match action {
+        StepAction::WriteManagedSettings {
+            scope,
+            path,
+            managed_keys,
+            content_sha256,
+            ..
+        } => {
+            facts.settings_scope = scope_name(*scope).to_string();
+            facts.artifact_paths.push(path.display().to_string());
+            facts.managed_keys = managed_keys.clone();
+            facts.content_sha256 = content_sha256.clone();
+        }
+        StepAction::ApplyLegacyManagedSettings { scope, content_sha256 } => {
+            facts.settings_scope = scope_name(*scope).to_string();
+            facts.content_sha256 = content_sha256.clone();
+        }
+        StepAction::InstallHook { name, scope, path } | StepAction::RemoveHook { name, scope, path } => {
+            facts.settings_scope = scope_name(*scope).to_string();
+            facts.managed_keys.push(name.clone());
+            facts.artifact_paths.push(path.display().to_string());
+        }
+        StepAction::ConfigureModelGatewayBaseUrl { scope, variable, .. } => {
+            // The variable *name* only. The URL is a value, and values do not
+            // cross this boundary even when they look innocuous — a base URL
+            // can carry a token in its userinfo or query.
+            facts.settings_scope = scope_name(*scope).to_string();
+            facts.managed_keys.push(variable.clone());
+        }
+        StepAction::ConfigureProxy { scope, variables } => {
+            facts.settings_scope = scope_name(*scope).to_string();
+            facts.managed_keys = variables.keys().cloned().collect();
+        }
+        StepAction::MaterialiseTrustMaterial {
+            path, content_sha256, ..
+        } => {
+            facts.artifact_paths.push(path.display().to_string());
+            facts.content_sha256 = content_sha256.clone();
+        }
+        StepAction::InjectLaunchEnvironment { scope, variable, .. } => {
+            // Name only — `EnvValue::Literal` is exactly the field an adapter
+            // could put a credential in.
+            facts.settings_scope = scope_name(*scope).to_string();
+            facts.managed_keys.push(variable.clone());
+        }
+        StepAction::ConfigureMcpServers { allowed, denied } => {
+            // Server *names* are identifiers, and naming them is the whole
+            // point of showing an MCP allow/deny list for review.
+            facts.managed_keys = allowed.iter().chain(denied.iter()).cloned().collect();
+        }
+        StepAction::RegisterIdeClient { host, .. } => {
+            facts.managed_keys.push(host.clone());
+        }
+        // Unknown future actions expose nothing. Failing closed on a variant
+        // this build cannot reason about is the only safe default: an unknown
+        // action's fields are unknown, so none of them can be shown to be safe.
+        _ => {}
+    }
+    facts
+}
+
+/// Project a plan step.
+pub fn step_view(step: &IntegrationStep) -> wire::StepView {
+    let facts = step_facts(&step.action);
+    let (privilege, consent_prompt) = match &step.privilege {
+        StepPrivilege::User => ("user".to_string(), String::new()),
+        StepPrivilege::PrivilegedHost { consent_prompt } => ("privileged_host".to_string(), consent_prompt.clone()),
+    };
+    wire::StepView {
+        id: step.id.clone(),
+        summary: step.summary.clone(),
+        action_kind: action_kind(&step.action).to_string(),
+        requirement: match step.requirement {
+            StepRequirement::Required => "required".to_string(),
+            StepRequirement::Optional => "optional".to_string(),
+        },
+        privilege,
+        consent_prompt,
+        settings_scope: facts.settings_scope,
+        managed_keys: facts.managed_keys,
+        artifact_paths: facts.artifact_paths,
+        content_sha256: facts.content_sha256,
+        reversible: step.reversal.is_some(),
+    }
+}
+
+/// Project an integration plan.
+pub fn plan_view(plan: &IntegrationPlan) -> wire::PlanView {
+    wire::PlanView {
+        schema_version: plan.schema_version,
+        plan_id: plan.plan_id.clone(),
+        tool_id: tool_id(&plan.tool),
+        profile: profile_name(plan.profile).to_string(),
+        settings_scope: scope_name(plan.settings_scope).to_string(),
+        policy_profile: plan.policy_profile.as_ref().map(policy_profile_view),
+        planned_level: level_name(plan.planned_level).to_string(),
+        adapter_ceiling: ceiling_name(plan.adapter_ceiling).to_string(),
+        steps: plan.steps.iter().map(step_view).collect(),
+        unsupported: plan
+            .unsupported
+            .iter()
+            .map(|u| wire::UnsupportedMechanismView {
+                capability: capability_name(u.capability).to_string(),
+                reason: u.reason.clone(),
+            })
+            .collect(),
+        warnings: plan.warnings.clone(),
+    }
+}
+
+/// Project a removal plan.
+pub fn removal_view(plan: &RemovalPlan) -> wire::RemovalView {
+    wire::RemovalView {
+        schema_version: plan.schema_version,
+        plan_id: plan.plan_id.clone(),
+        tool_id: tool_id(&plan.tool),
+        steps: plan.steps.iter().map(step_view).collect(),
+        residual: plan.residual.clone(),
+        warnings: plan.warnings.clone(),
+    }
+}
+
+fn step_outcome_view(receipt: &StepReceipt) -> wire::StepOutcomeView {
+    wire::StepOutcomeView {
+        step_id: receipt.step_id.clone(),
+        outcome: if receipt.applied { "applied" } else { "skipped" }.to_string(),
+        // A fingerprint, not the content it fingerprints.
+        fingerprint: receipt.fingerprint.clone().unwrap_or_default(),
+    }
+}
+
+/// Project an apply receipt.
+///
+/// The receipt holds each step's full `StepAction`; the view holds the step id,
+/// whether it applied, and its fingerprint. Nothing else about the action is
+/// reachable from a client.
+pub fn apply_view(receipt: &IntegrationReceipt) -> wire::ApplyView {
+    wire::ApplyView {
+        plan_id: receipt.plan_id.clone(),
+        receipt_id: receipt.receipt_id.clone(),
+        applied_at_unix_secs: receipt.applied_at_unix_secs,
+        steps: receipt.steps.iter().map(step_outcome_view).collect(),
+        planned_level: level_name(receipt.planned_level).to_string(),
+        achieved_level: level_name(receipt.achieved_level).to_string(),
+    }
+}
+
+/// Project one piece of evidence, with the timestamp that makes it "verified at
+/// T" rather than "true now".
+pub fn evidence_view(evidence: &ProtectionEvidence) -> wire::EvidenceView {
+    let (kind, outcome) = match &evidence.kind {
+        EvidenceKind::ReadBack { matches_receipt } => (
+            "read_back",
+            if *matches_receipt { "matched" } else { "mismatched" }.to_string(),
+        ),
+        EvidenceKind::Exercised { outcome } => (
+            "exercised",
+            match outcome {
+                ExerciseOutcome::Blocked => "blocked",
+                ExerciseOutcome::Redacted => "redacted",
+                ExerciseOutcome::ObservedOnly => "observed_only",
+                ExerciseOutcome::Leaked => "leaked",
+                // `#[non_exhaustive]`: an outcome this build cannot name is
+                // reported as inconclusive, never as a protective one.
+                _ => "inconclusive",
+            }
+            .to_string(),
+        ),
+        EvidenceKind::HostAttested { healthy } => (
+            "host_attested",
+            if *healthy { "healthy" } else { "unhealthy" }.to_string(),
+        ),
+        EvidenceKind::Absent { reason } => ("absent", reason.clone()),
+        _ => ("unknown", String::new()),
+    };
+    wire::EvidenceView {
+        mechanism: capability_name(evidence.mechanism).to_string(),
+        kind: kind.to_string(),
+        outcome,
+        observed_at_unix_secs: evidence.observed_at_unix_secs,
+        detail: evidence.detail.clone(),
+    }
+}
+
+/// Project an integration status.
+pub fn status_view(status: &IntegrationStatus) -> wire::StatusView {
+    let (state, drift_mismatched, reason, remediation) = match &status.state {
+        ProtectionState::Ladder(_) => ("ladder", Vec::new(), String::new(), String::new()),
+        ProtectionState::Drifted { mismatched, .. } => ("drifted", mismatched.clone(), String::new(), String::new()),
+        ProtectionState::Degraded { reason, .. } => ("degraded", Vec::new(), reason.clone(), String::new()),
+        ProtectionState::Incompatible { reason, remediation } => {
+            ("incompatible", Vec::new(), reason.clone(), remediation.clone())
+        }
+        _ => ("unknown", Vec::new(), String::new(), String::new()),
+    };
+    wire::StatusView {
+        tool_id: tool_id(&status.tool),
+        phase: phase_name(status.phase).to_string(),
+        state: state.to_string(),
+        achieved_level: level_name(status.achieved_level()).to_string(),
+        planned_level: level_name(status.planned_level).to_string(),
+        adapter_ceiling: ceiling_name(status.adapter_ceiling).to_string(),
+        compatibility: compatibility_name(&status.compatibility).to_string(),
+        evidence: status.evidence.iter().map(evidence_view).collect(),
+        next_level: status.next_level.as_ref().map(|n| wire::NextLevelView {
+            level: level_name(n.level).to_string(),
+            blocked_because: n.blocked_because.clone(),
+        }),
+        observed_at_unix_secs: status.observed_at_unix_secs,
+        drift_mismatched,
+        state_reason: reason,
+        state_remediation: remediation,
+    }
+}
+
+/// Project a verification result.
+pub fn verification_view(result: &VerificationResult) -> wire::VerificationView {
+    let (outcome, missing, reason) = match &result.outcome {
+        VerificationOutcome::Passed => ("passed", Vec::new(), String::new()),
+        VerificationOutcome::PartiallyPassed { missing } => ("partially_passed", missing.clone(), String::new()),
+        VerificationOutcome::Failed { reason } => ("failed", Vec::new(), reason.clone()),
+        VerificationOutcome::Unverifiable { reason } => ("unverifiable", Vec::new(), reason.clone()),
+        // An outcome this build cannot name resolves downward to
+        // "unverifiable": "we do not know" must never read as "we looked and it
+        // was fine" (ADR 0030 §4.2 rule 2).
+        _ => ("unverifiable", Vec::new(), "unrecognised outcome".to_string()),
+    };
+    wire::VerificationView {
+        verified_at_unix_secs: result.verified_at_unix_secs,
+        outcome: outcome.to_string(),
+        missing,
+        reason,
+        evidence: result.evidence.iter().map(evidence_view).collect(),
+    }
+}
+
+/// Project a repair report together with the status it produced.
+pub fn repair_view(tool: &DevToolKind, report: &RepairReport, status: &IntegrationStatus) -> wire::RepairView {
+    wire::RepairView {
+        tool_id: tool_id(tool),
+        repaired: report.repaired.clone(),
+        unrepairable: report
+            .unrepairable
+            .iter()
+            .map(|(capability, reason)| wire::UnsupportedMechanismView {
+                capability: capability_name(*capability).to_string(),
+                reason: reason.clone(),
+            })
+            .collect(),
+        status: Some(status_view(status)),
+    }
+}
+
+/// Project a redacted security event.
+pub fn scoped_event_view(event: &ScopedSecurityEvent) -> wire::ScopedEvent {
+    wire::ScopedEvent {
+        occurred_at_unix_secs: event.occurred_at_unix_secs,
+        verdict_kind: event.verdict_kind.as_str().to_string(),
+        mechanism: capability_name(event.mechanism).to_string(),
+        count: event.count,
+        redaction_labels: event.redaction_labels.clone(),
+    }
+}
+
+/// Snake_case name for an artifact operation. Kept alongside the other name
+/// tables so the server module never reaches into `aa-core`'s enums directly.
+pub const fn artifact_operation_name(operation: ArtifactOperation) -> &'static str {
+    match operation {
+        ArtifactOperation::Create => "create",
+        ArtifactOperation::Update => "update",
+        ArtifactOperation::Remove => "remove",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_core::integration::{
+        CapabilitySupport, EnvValue, IntegrationRequest, SettingsMerge, ToolVersion, TrustMaterialKind,
+    };
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    /// The sentinel every value-bearing field of the fixture carries. If it
+    /// appears anywhere in an encoded response, minimisation leaked.
+    const SECRET: &str = "sk-live-THISMUSTNEVERLEAVE-0123456789";
+
+    fn poisoned_steps() -> Vec<IntegrationStep> {
+        let mut proxy_vars = BTreeMap::new();
+        proxy_vars.insert(
+            "HTTPS_PROXY".to_string(),
+            format!("http://user:{SECRET}@127.0.0.1:8080"),
+        );
+
+        vec![
+            IntegrationStep::new(
+                "settings",
+                StepAction::WriteManagedSettings {
+                    scope: SettingsScope::User,
+                    path: PathBuf::from("/home/dev/.claude/settings.json"),
+                    managed_keys: vec!["aasm.gatewayUrl".to_string()],
+                    content_sha256: "abc123".to_string(),
+                    merge: SettingsMerge::MergeManagedKeys,
+                },
+                "Write the managed settings block",
+            ),
+            IntegrationStep::new(
+                "env",
+                StepAction::InjectLaunchEnvironment {
+                    scope: SettingsScope::User,
+                    variable: "ANTHROPIC_AUTH_TOKEN".to_string(),
+                    value: EnvValue::Literal(SECRET.to_string()),
+                },
+                "Inject the launch environment",
+            ),
+            IntegrationStep::new(
+                "proxy",
+                StepAction::ConfigureProxy {
+                    scope: SettingsScope::User,
+                    variables: proxy_vars,
+                },
+                "Route traffic through the AASM proxy",
+            ),
+            IntegrationStep::new(
+                "base-url",
+                StepAction::ConfigureModelGatewayBaseUrl {
+                    scope: SettingsScope::User,
+                    variable: "ANTHROPIC_BASE_URL".to_string(),
+                    base_url: format!("https://gw.local/?token={SECRET}"),
+                },
+                "Point the tool at the gateway",
+            ),
+            IntegrationStep::new(
+                "ca",
+                StepAction::MaterialiseTrustMaterial {
+                    kind: TrustMaterialKind::ProxyCaTrustStoreAnchor,
+                    path: PathBuf::from("/home/dev/.aa/ca/aasm-ca.pem"),
+                    content_sha256: "deadbeef".to_string(),
+                },
+                "Install the AASM CA",
+            )
+            .privileged("AASM will add its certificate authority to the system trust store."),
+        ]
+    }
+
+    fn poisoned_plan() -> IntegrationPlan {
+        let request = IntegrationRequest::new(
+            DevToolKind::ClaudeCode,
+            ProtectionProfile::Recommended,
+            SettingsScope::User,
+        )
+        .with_policy_profile(PolicyProfileRef {
+            id: "team-default".to_string(),
+            display_name: "Team default".to_string(),
+            digest: "sha256:1234".to_string(),
+        });
+        let mut plan = IntegrationPlan::new(
+            "plan-1",
+            &request,
+            ProtectionLevel::GatewayProtected,
+            GovernanceLevel::L2Enforce,
+        );
+        plan.steps = poisoned_steps();
+        plan
+    }
+
+    /// Encode a wire message and search its bytes. Searching the *encoded
+    /// form* rather than a Debug rendering is deliberate: it is what actually
+    /// crosses the socket.
+    fn encoded_contains(message: &impl prost::Message, needle: &str) -> bool {
+        let bytes = message.encode_to_vec();
+        String::from_utf8_lossy(&bytes).contains(needle)
+    }
+
+    #[test]
+    fn a_step_view_carries_no_step_value() {
+        for step in poisoned_steps() {
+            let view = step_view(&step);
+            assert!(
+                !encoded_contains(&view, SECRET),
+                "step {} leaked a value into the wire",
+                step.id
+            );
+        }
+    }
+
+    #[test]
+    fn a_plan_view_carries_no_step_value() {
+        let view = plan_view(&poisoned_plan());
+        assert!(!encoded_contains(&view, SECRET), "plan leaked a value into the wire");
+    }
+
+    #[test]
+    fn a_step_view_still_carries_what_a_reviewer_needs() {
+        // Minimisation must not be achieved by returning nothing: a plan a
+        // human cannot review is not a reviewable dry run.
+        let view = step_view(&poisoned_steps()[0]);
+        assert_eq!(view.action_kind, "write_managed_settings");
+        assert_eq!(view.settings_scope, "user");
+        assert_eq!(view.managed_keys, vec!["aasm.gatewayUrl"]);
+        assert_eq!(view.artifact_paths, vec!["/home/dev/.claude/settings.json"]);
+        assert_eq!(view.content_sha256, "abc123");
+        assert_eq!(view.requirement, "required");
+    }
+
+    #[test]
+    fn a_privileged_step_carries_its_consent_prompt() {
+        let steps = poisoned_steps();
+        let view = step_view(steps.last().unwrap());
+        assert_eq!(view.privilege, "privileged_host");
+        assert!(view.consent_prompt.contains("trust store"));
+    }
+
+    #[test]
+    fn an_env_injection_exposes_the_name_and_not_the_value() {
+        let steps = poisoned_steps();
+        let view = step_view(&steps[1]);
+        assert_eq!(view.managed_keys, vec!["ANTHROPIC_AUTH_TOKEN"]);
+        assert!(!encoded_contains(&view, SECRET));
+    }
+
+    #[test]
+    fn a_proxy_step_exposes_variable_names_and_not_their_values() {
+        let steps = poisoned_steps();
+        let view = step_view(&steps[2]);
+        assert_eq!(view.managed_keys, vec!["HTTPS_PROXY"]);
+        assert!(!encoded_contains(&view, SECRET));
+    }
+
+    #[test]
+    fn a_base_url_is_a_value_and_does_not_cross() {
+        // A base URL looks innocuous and can carry a token in its query or
+        // userinfo, so the name crosses and the URL does not.
+        let steps = poisoned_steps();
+        let view = step_view(&steps[3]);
+        assert_eq!(view.managed_keys, vec!["ANTHROPIC_BASE_URL"]);
+        assert!(!encoded_contains(&view, SECRET));
+        assert!(!encoded_contains(&view, "gw.local"));
+    }
+
+    #[test]
+    fn a_policy_profile_crosses_as_a_reference_only() {
+        let view = plan_view(&poisoned_plan());
+        let profile = view.policy_profile.expect("profile reference");
+        assert_eq!(profile.id, "team-default");
+        assert_eq!(profile.digest, "sha256:1234");
+        // There is no field on `PolicyProfileRefView` that could hold a
+        // document; the assertion is that the projection did not invent one by
+        // stuffing content into `display_name`.
+        assert_eq!(profile.display_name, "Team default");
+    }
+
+    #[test]
+    fn tool_ids_round_trip() {
+        for tool in [
+            DevToolKind::ClaudeCode,
+            DevToolKind::Codex,
+            DevToolKind::GitHubCopilot,
+            DevToolKind::WindsurfCascade,
+            DevToolKind::Custom("myeditor".to_string()),
+        ] {
+            assert_eq!(parse_tool_id(&tool_id(&tool)), tool);
+        }
+    }
+
+    #[test]
+    fn an_unrecognised_scope_or_profile_is_not_defaulted() {
+        assert_eq!(parse_scope("Users"), None);
+        assert_eq!(parse_scope(""), None);
+        assert_eq!(parse_profile("STRICT"), None);
+        assert_eq!(parse_level("gateway"), None);
+        assert_eq!(
+            parse_level("gateway_protected"),
+            Some(ProtectionLevel::GatewayProtected)
+        );
+    }
+
+    #[test]
+    fn an_absent_capability_is_not_reported_as_supported() {
+        let caps = DevToolCapabilities::new()
+            .supported(IntegrationCapability::Discovery)
+            .unsupported(IntegrationCapability::ManagedLaunch, "no launch command");
+        let view = capability_view(&caps, IntegrationCapability::Hooks);
+        assert_eq!(view.support, "absent");
+        assert!(view.reason.is_empty());
+
+        let unsupported = capability_view(&caps, IntegrationCapability::ManagedLaunch);
+        assert_eq!(unsupported.support, "unsupported");
+        assert_eq!(unsupported.reason, "no launch command");
+    }
+
+    #[test]
+    fn a_requires_version_declaration_without_a_detected_version_is_absent() {
+        let caps = DevToolCapabilities::new().declare(
+            IntegrationCapability::Hooks,
+            CapabilitySupport::RequiresVersion {
+                min: ToolVersion::new(2, 0, 0),
+                detected: None,
+            },
+        );
+        assert_eq!(capability_view(&caps, IntegrationCapability::Hooks).support, "absent");
+    }
+
+    #[test]
+    fn an_apply_view_carries_fingerprints_not_content() {
+        let receipt = IntegrationReceipt {
+            schema_version: 1,
+            receipt_id: "r-1".to_string(),
+            plan_id: "plan-1".to_string(),
+            tool: DevToolKind::ClaudeCode,
+            profile: ProtectionProfile::Recommended,
+            settings_scope: SettingsScope::User,
+            applied_at_unix_secs: 1_700_000_000,
+            versions: aa_core::integration::VersionSupport {
+                adapter_version: ToolVersion::new(1, 0, 0),
+                lifecycle_schema_version: 1,
+                supported_tool_versions: aa_core::integration::SupportedToolVersions::any(),
+            }
+            .component_versions(),
+            tool_version: None,
+            steps: poisoned_steps()
+                .iter()
+                .map(|s| StepReceipt::applied(s, Some("fp-1".to_string())))
+                .collect(),
+            planned_level: ProtectionLevel::GatewayProtected,
+            achieved_level: ProtectionLevel::Integrated,
+            achieved_evidence: Vec::new(),
+            verified_at_unix_secs: None,
+        };
+        let view = apply_view(&receipt);
+        assert_eq!(view.steps.len(), 5);
+        assert!(view.steps.iter().all(|s| s.fingerprint == "fp-1"));
+        assert!(
+            !encoded_contains(&view, SECRET),
+            "the receipt holds full StepActions; the view must not"
+        );
+    }
+
+    #[test]
+    fn a_scoped_event_carries_labels_and_not_content() {
+        let event = ScopedSecurityEvent {
+            occurred_at_unix_secs: 1_700_000_000,
+            verdict_kind: super::super::lifecycle::VerdictKind::Redacted,
+            mechanism: IntegrationCapability::ModelPathInterception,
+            count: 3,
+            redaction_labels: vec!["aws_access_key".to_string()],
+        };
+        let view = scoped_event_view(&event);
+        assert_eq!(view.verdict_kind, "redacted");
+        assert_eq!(view.count, 3);
+        assert_eq!(view.redaction_labels, vec!["aws_access_key"]);
+        assert!(!encoded_contains(&view, SECRET));
+    }
+
+    #[test]
+    fn an_unverifiable_result_is_never_rendered_as_passed() {
+        let result = VerificationResult::unverifiable(1_700_000_000, "no probe descriptor");
+        let view = verification_view(&result);
+        assert_eq!(view.outcome, "unverifiable");
+        assert_eq!(view.reason, "no probe descriptor");
+    }
+
+    #[test]
+    fn evidence_carries_its_timestamp() {
+        let evidence = ProtectionEvidence::new(
+            IntegrationCapability::ModelPathInterception,
+            EvidenceKind::Exercised {
+                outcome: ExerciseOutcome::Redacted,
+            },
+            1_700_000_123,
+            "probe redacted at the proxy",
+        );
+        let view = evidence_view(&evidence);
+        assert_eq!(view.observed_at_unix_secs, 1_700_000_123);
+        assert_eq!(view.kind, "exercised");
+        assert_eq!(view.outcome, "redacted");
+    }
+}

--- a/aa-runtime/src/devint/scope.rs
+++ b/aa-runtime/src/devint/scope.rs
@@ -1,0 +1,189 @@
+//! What a DI-API capability token is allowed to do (ADR 0030 §5.3).
+//!
+//! OS-level identity says "the developer's UID"; it cannot distinguish the
+//! VS Code extension from a trojaned npm postinstall script running as the same
+//! user. The scope is what draws that distinction, and it is what bounds the
+//! blast radius of a *stolen* token: a token enrolled for the Claude Code
+//! integration cannot plan, apply, repair or remove the Codex integration, and
+//! a read-only status client cannot mutate anything.
+//!
+//! A scope is a pair of allowlists — never a denylist, and never a wildcard
+//! that a caller can supply. Both halves must admit the request:
+//!
+//! * [`ToolScope`] — which tool ids the token may act on;
+//! * the verb set — which members of the closed [`DiVerb`] space it may invoke.
+//!
+//! An empty verb set or an empty tool set grants nothing. That is the
+//! fail-closed direction on purpose: a malformed or half-written enrolment
+//! record must deny, never widen.
+
+use std::collections::BTreeSet;
+
+use super::verb::DiVerb;
+
+/// Which tools a token may act on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolScope {
+    /// A fixed set of tool ids. The only variant an enrolment may produce for a
+    /// per-tool client.
+    Tools(BTreeSet<String>),
+    /// Every tool. Reserved for the operator's own `aasm` enrolment, which the
+    /// user performs deliberately and interactively — never granted implicitly
+    /// and never the default for a plugin.
+    AllTools,
+}
+
+impl ToolScope {
+    /// Build a tool scope from an iterator of tool ids.
+    pub fn tools<I, S>(ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        ToolScope::Tools(ids.into_iter().map(Into::into).collect())
+    }
+
+    /// Whether `tool_id` is inside this scope.
+    pub fn permits_tool(&self, tool_id: &str) -> bool {
+        match self {
+            ToolScope::Tools(ids) => ids.contains(tool_id),
+            ToolScope::AllTools => true,
+        }
+    }
+
+    /// The tool ids, for display and audit. `None` for [`ToolScope::AllTools`].
+    pub fn tool_ids(&self) -> Option<impl Iterator<Item = &str>> {
+        match self {
+            ToolScope::Tools(ids) => Some(ids.iter().map(String::as_str)),
+            ToolScope::AllTools => None,
+        }
+    }
+}
+
+/// The capability a token carries: a set of tools and a set of verbs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenScope {
+    tools: ToolScope,
+    verbs: BTreeSet<DiVerb>,
+}
+
+impl TokenScope {
+    /// Build a scope from an explicit tool scope and verb set.
+    pub fn new<I>(tools: ToolScope, verbs: I) -> Self
+    where
+        I: IntoIterator<Item = DiVerb>,
+    {
+        Self {
+            tools,
+            verbs: verbs.into_iter().collect(),
+        }
+    }
+
+    /// The read-only scope a status/dashboard client needs: it can see what
+    /// exists and what state it is in, and can change none of it.
+    pub fn read_only(tools: ToolScope) -> Self {
+        Self::new(
+            tools,
+            [DiVerb::ListTools, DiVerb::Status, DiVerb::ScopedEvents, DiVerb::Verify],
+        )
+    }
+
+    /// The full lifecycle scope for one tool's integration client.
+    ///
+    /// Named rather than assembled at each call site so "what an integration
+    /// client gets" is one reviewable definition instead of N drifting ones.
+    pub fn full_lifecycle(tools: ToolScope) -> Self {
+        Self::new(tools, DiVerb::ALL)
+    }
+
+    /// Whether this scope admits `verb` against `tool_id`.
+    ///
+    /// [`DiVerb::ListTools`] names no tool, so only its verb membership is
+    /// checked; every other verb must satisfy **both** halves.
+    pub fn permits(&self, verb: DiVerb, tool_id: &str) -> bool {
+        if !self.verbs.contains(&verb) {
+            return false;
+        }
+        if !verb.is_tool_scoped() {
+            return true;
+        }
+        self.tools.permits_tool(tool_id)
+    }
+
+    /// The tool half of the scope.
+    pub fn tool_scope(&self) -> &ToolScope {
+        &self.tools
+    }
+
+    /// The verbs in this scope, in a stable order, for display and audit.
+    pub fn verbs(&self) -> impl Iterator<Item = DiVerb> + '_ {
+        self.verbs.iter().copied()
+    }
+
+    /// A stable, human-readable rendering for audit records: verbs and tools,
+    /// never anything derived from the token secret.
+    pub fn describe(&self) -> String {
+        let verbs: Vec<&str> = self.verbs.iter().map(|v| v.as_str()).collect();
+        let tools = match &self.tools {
+            ToolScope::AllTools => "*".to_string(),
+            ToolScope::Tools(ids) => ids.iter().cloned().collect::<Vec<_>>().join(","),
+        };
+        format!("tools=[{tools}] verbs=[{}]", verbs.join(","))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn claude_only() -> TokenScope {
+        TokenScope::full_lifecycle(ToolScope::tools(["claude-code"]))
+    }
+
+    #[test]
+    fn a_tool_scoped_token_cannot_act_on_another_tool() {
+        let scope = claude_only();
+        for verb in DiVerb::ALL.into_iter().filter(|v| v.is_tool_scoped()) {
+            assert!(scope.permits(verb, "claude-code"), "{verb} on its own tool");
+            assert!(!scope.permits(verb, "codex"), "{verb} must not cross to another tool");
+        }
+    }
+
+    #[test]
+    fn list_tools_needs_no_tool_membership() {
+        let scope = claude_only();
+        assert!(scope.permits(DiVerb::ListTools, "codex"));
+    }
+
+    #[test]
+    fn a_read_only_scope_grants_no_mutation() {
+        let scope = TokenScope::read_only(ToolScope::AllTools);
+        for verb in DiVerb::ALL.into_iter().filter(|v| v.is_mutation()) {
+            assert!(!scope.permits(verb, "claude-code"), "{verb} must be denied");
+        }
+        assert!(scope.permits(DiVerb::Status, "claude-code"));
+    }
+
+    #[test]
+    fn an_empty_scope_grants_nothing() {
+        let scope = TokenScope::new(ToolScope::tools(Vec::<String>::new()), []);
+        for verb in DiVerb::ALL {
+            assert!(!scope.permits(verb, "claude-code"));
+        }
+    }
+
+    #[test]
+    fn all_tools_still_respects_the_verb_set() {
+        let scope = TokenScope::new(ToolScope::AllTools, [DiVerb::Status]);
+        assert!(scope.permits(DiVerb::Status, "anything"));
+        assert!(!scope.permits(DiVerb::Apply, "anything"));
+    }
+
+    #[test]
+    fn describe_names_only_scope_facts() {
+        let scope = claude_only();
+        let rendered = scope.describe();
+        assert!(rendered.contains("claude-code"));
+        assert!(rendered.contains("apply"));
+    }
+}

--- a/aa-runtime/src/devint/server.rs
+++ b/aa-runtime/src/devint/server.rs
@@ -1,0 +1,746 @@
+//! The Developer Integration Service — the server half of the DI-API
+//! (ADR 0030 Decision 5).
+//!
+//! # The order a request is checked in, and why that order
+//!
+//! 1. **Peer credentials**, on the accept loop, before a single byte is read.
+//!    Reuses [`crate::ipc::peercred::peer_uid_is_allowed`] — the same check the
+//!    SDK socket makes, so there is one peer-identity rule in the runtime and
+//!    not two.
+//! 2. **Version negotiation**, in the spawned connection task under a timeout,
+//!    so a slow or hostile peer can never stall the accept loop. A second
+//!    `Hello` afterwards is a protocol violation: the negotiated version is
+//!    fixed for the connection's lifetime, so there is no mid-connection
+//!    downgrade to walk into.
+//! 3. **Verb decode.** A discriminant outside the closed set is refused here;
+//!    nothing further runs for it.
+//! 4. **Token resolution and scope**, before the version-availability check.
+//!    That order is deliberate: an unauthenticated caller learns nothing about
+//!    which verbs exist at a version it did not negotiate.
+//! 5. **Version availability**, so a degraded connection cannot reach a verb
+//!    its version does not have.
+//! 6. **The lifecycle port**, whose result is projected before it is written.
+//!
+//! Every refusal in steps 1–5 emits an audit event and returns a coarse
+//! `Denied`. There is no step at which a request falls through to an implicit
+//! grant, and no anonymous or read-only tier: an empty [`TokenStore`]
+//! authorizes nothing at all.
+//!
+//! # What this module deliberately cannot reach
+//!
+//! Its dependencies are the lifecycle port, the token store, the projections
+//! and the codec. Not `aa_core::storage`, not identity, not the gateway client.
+//! That is the compile-time half of "a compromised thin client cannot reach
+//! unrestricted core operations" — the other half being that there is no verb
+//! for it to ask with.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+use aa_core::integration::{now_unix_secs, IntegrationRequest, ProtectionLevel};
+use aa_proto::assembly::devint::v1 as wire;
+
+use super::audit::{DevIntAuditEvent, DevIntAuditKind, DevIntAuditSink};
+use super::codec::{self, DiCodecError, DiFrame, DiResponseFrame};
+use super::lifecycle::{ApprovalInput, IntegrationLifecycle, LifecycleError};
+use super::negotiate::{self, verb_available_at};
+use super::projection as project;
+use super::socket;
+use super::token::{CapabilityToken, TokenDenial, TokenStore};
+use super::verb::DiVerb;
+
+/// How long a client has to complete version negotiation before the connection
+/// is dropped. Bounds slow-loris holds, exactly as the SDK handshake timeout
+/// does (AAASM-3585).
+pub const NEGOTIATION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default concurrent DI-API connections. Small on purpose: this is a
+/// developer's own machine, and a handful of editors and a CLI is the whole
+/// legitimate population.
+pub const DEFAULT_MAX_CONNECTIONS: usize = 16;
+
+/// How the DI-API server is configured.
+#[derive(Debug, Clone)]
+pub struct DevIntServerConfig {
+    /// Absolute path to the DI-API socket.
+    pub socket_path: std::path::PathBuf,
+    /// Maximum concurrent connections.
+    pub max_connections: usize,
+}
+
+impl DevIntServerConfig {
+    /// Configuration using the conventional socket path (or its
+    /// `AA_DEVINT_SOCKET` override).
+    pub fn from_convention() -> Result<Self, socket::SocketError> {
+        Ok(Self {
+            socket_path: socket::devint_socket_path()?,
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+        })
+    }
+}
+
+/// Everything a connection needs to serve a verb.
+///
+/// Cloned per connection; every field is cheap to clone.
+#[derive(Clone)]
+pub struct DevIntServices {
+    /// The nine lifecycle operations.
+    pub lifecycle: Arc<dyn IntegrationLifecycle>,
+    /// The enrolment book.
+    pub tokens: TokenStore,
+    /// Where auth failures and lifecycle mutations are recorded.
+    pub audit: Arc<dyn DevIntAuditSink>,
+}
+
+/// The bound DI-API server.
+pub struct DevIntServer {
+    config: DevIntServerConfig,
+    listener: UnixListener,
+}
+
+impl DevIntServer {
+    /// Bind the DI-API socket owner-only, asserting the permissions on the way.
+    pub fn bind(config: DevIntServerConfig) -> Result<Self, socket::SocketError> {
+        let listener = socket::bind(&config.socket_path)?;
+        Ok(Self { config, listener })
+    }
+
+    /// The path this server is listening on.
+    pub fn socket_path(&self) -> &std::path::Path {
+        &self.config.socket_path
+    }
+
+    /// Run the accept loop until `token` fires.
+    pub async fn run(self, tracker: TaskTracker, token: CancellationToken, services: DevIntServices) {
+        let semaphore = Arc::new(Semaphore::new(self.config.max_connections));
+        let next_conn_id = Arc::new(AtomicU64::new(0));
+        let runtime_uid = crate::ipc::peercred::current_runtime_uid();
+        let socket_path = self.config.socket_path.clone();
+        let listener = self.listener;
+
+        tracing::info!(path = %socket_path.display(), "DI-API accept loop started");
+
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => break,
+                result = listener.accept() => {
+                    let stream = match result {
+                        Ok((stream, _addr)) => stream,
+                        Err(e) => {
+                            tracing::error!(error = %e, "DI-API accept error");
+                            continue;
+                        }
+                    };
+
+                    let connection_id = next_conn_id.fetch_add(1, Ordering::Relaxed);
+
+                    // Layer 1 of the two-layer authentication, on the accept
+                    // loop so a rejected peer costs nothing but the accept.
+                    if let Some(reason) = peer_rejection_reason(&stream, runtime_uid) {
+                        services.audit.record(DevIntAuditEvent::new(
+                            now_unix_secs(),
+                            connection_id,
+                            DevIntAuditKind::PeerRejected { reason },
+                        ));
+                        drop(stream);
+                        continue;
+                    }
+
+                    let permit = match Arc::clone(&semaphore).try_acquire_owned() {
+                        Ok(p) => p,
+                        Err(_) => {
+                            tracing::warn!(max = self.config.max_connections, "DI-API connection limit reached");
+                            drop(stream);
+                            continue;
+                        }
+                    };
+
+                    let conn_services = services.clone();
+                    let conn_token = token.child_token();
+                    tracker.spawn(async move {
+                        let _permit = permit;
+                        tokio::select! {
+                            _ = conn_token.cancelled() => {}
+                            result = serve_connection(stream, connection_id, conn_services) => {
+                                if let Err(e) = result {
+                                    tracing::debug!(connection_id, error = %e, "DI-API connection ended");
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        }
+
+        if let Err(e) = std::fs::remove_file(&socket_path) {
+            tracing::warn!(error = %e, "failed to remove the DI-API socket on shutdown");
+        }
+        tracing::info!("DI-API accept loop stopped");
+    }
+}
+
+/// Why a peer must not be admitted, or `None` when it may be.
+fn peer_rejection_reason(stream: &UnixStream, runtime_uid: u32) -> Option<&'static str> {
+    match stream.peer_cred() {
+        Ok(cred) => {
+            if crate::ipc::peercred::peer_uid_is_allowed(cred.uid(), runtime_uid) {
+                None
+            } else {
+                tracing::warn!(
+                    peer_uid = cred.uid(),
+                    runtime_uid,
+                    "rejecting DI-API connection — peer UID does not match runtime UID"
+                );
+                Some("uid_mismatch")
+            }
+        }
+        // Unreadable credentials fail closed. "We could not tell who you are"
+        // is not a reason to serve someone.
+        Err(e) => {
+            tracing::warn!(error = %e, "rejecting DI-API connection — peer credentials unavailable");
+            Some("peercred_unavailable")
+        }
+    }
+}
+
+/// Negotiate, then serve verbs until the peer disconnects.
+async fn serve_connection(
+    stream: UnixStream,
+    connection_id: u64,
+    services: DevIntServices,
+) -> Result<(), DiCodecError> {
+    let (reader, writer) = stream.into_split();
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
+
+    // Step 2: the first frame must be a `Hello`, within the timeout.
+    let first = match tokio::time::timeout(NEGOTIATION_TIMEOUT, codec::read_frame(&mut reader)).await {
+        Ok(frame) => frame?,
+        Err(_) => {
+            services.audit.record(DevIntAuditEvent::new(
+                now_unix_secs(),
+                connection_id,
+                DevIntAuditKind::ProtocolFailure {
+                    reason: "negotiation_timeout",
+                },
+            ));
+            return Ok(());
+        }
+    };
+
+    let hello = match first {
+        DiFrame::Hello(hello) => hello,
+        // A verb before negotiation is refused outright: serving it would mean
+        // serving a client whose version we never agreed.
+        DiFrame::Request(_) => {
+            services.audit.record(DevIntAuditEvent::new(
+                now_unix_secs(),
+                connection_id,
+                DevIntAuditKind::ProtocolFailure {
+                    reason: "verb_before_negotiation",
+                },
+            ));
+            codec::write_frame(
+                &mut writer,
+                DiResponseFrame::Denied(wire::Denied {
+                    request_id: 0,
+                    code: wire::DenyCode::ProtocolViolation as i32,
+                    message: "the first frame must be Hello".to_string(),
+                    remediation: "negotiate a DI-API version before sending a verb".to_string(),
+                }),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let client_name = Some(hello.client_name.clone());
+    let negotiation = negotiate::negotiate(&hello);
+    services.audit.record(
+        DevIntAuditEvent::new(
+            now_unix_secs(),
+            connection_id,
+            DevIntAuditKind::Negotiated {
+                outcome: negotiation.outcome(),
+                version: negotiation.version(),
+            },
+        )
+        .with_client(client_name.clone()),
+    );
+
+    let version = match negotiate::to_wire(&negotiation) {
+        Ok(ack) => {
+            let version = ack.di_api_version;
+            codec::write_frame(&mut writer, DiResponseFrame::HelloAck(ack)).await?;
+            version
+        }
+        Err(incompatible) => {
+            codec::write_frame(&mut writer, DiResponseFrame::Incompatible(incompatible)).await?;
+            // Closed immediately: there is no degraded-into-nothing state to
+            // linger in, and a client that keeps the connection open after an
+            // incompatible answer is not one to keep serving.
+            let _ = writer.shutdown().await;
+            return Ok(());
+        }
+    };
+
+    let connection = Connection {
+        connection_id,
+        client_name,
+        version,
+        services,
+    };
+
+    loop {
+        let frame = match codec::read_frame(&mut reader).await {
+            Ok(frame) => frame,
+            // EOF and malformed frames both end the connection. A malformed
+            // frame is audited; a clean EOF is not an event.
+            Err(DiCodecError::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(e) => {
+                connection.audit_protocol_failure(codec_failure_reason(&e));
+                return Err(e);
+            }
+        };
+
+        let response = match frame {
+            DiFrame::Request(request) => connection.serve(request).await,
+            // Step 2's other half: a second `Hello` is a renegotiation attempt,
+            // which is how a downgrade would be staged. Refused, audited, and
+            // the negotiated version stands.
+            DiFrame::Hello(_) => {
+                connection.audit_protocol_failure("renegotiation_attempted");
+                DiResponseFrame::Denied(wire::Denied {
+                    request_id: 0,
+                    code: wire::DenyCode::ProtocolViolation as i32,
+                    message: "the DI-API version is fixed for the life of a connection".to_string(),
+                    remediation: "open a new connection to negotiate a different version".to_string(),
+                })
+            }
+        };
+
+        codec::write_frame(&mut writer, response).await?;
+    }
+}
+
+/// Which protocol failure a codec error represents, for the audit trail.
+const fn codec_failure_reason(error: &DiCodecError) -> &'static str {
+    match error {
+        DiCodecError::UnknownTag(_) => "unknown_frame_tag",
+        DiCodecError::Decode(_) => "malformed_frame",
+        DiCodecError::FrameTooLarge { .. } => "frame_too_large",
+        DiCodecError::Io(_) => "io_error",
+    }
+}
+
+/// One negotiated connection, and the checks every request on it passes.
+struct Connection {
+    connection_id: u64,
+    client_name: Option<String>,
+    version: u32,
+    services: DevIntServices,
+}
+
+impl Connection {
+    fn audit_protocol_failure(&self, reason: &'static str) {
+        self.services.audit.record(
+            DevIntAuditEvent::new(
+                now_unix_secs(),
+                self.connection_id,
+                DevIntAuditKind::ProtocolFailure { reason },
+            )
+            .with_client(self.client_name.clone()),
+        );
+    }
+
+    /// Steps 3–6 for one request.
+    async fn serve(&self, request: wire::Request) -> DiResponseFrame {
+        let request_id = request.request_id;
+
+        // Step 3: the verb must be in the closed set.
+        let Some(verb) = DiVerb::from_wire(request.verb) else {
+            self.audit_protocol_failure("unknown_verb");
+            return denied(
+                request_id,
+                wire::DenyCode::UnknownVerb,
+                "unknown operation",
+                "use an operation this DI-API version defines",
+            );
+        };
+
+        // Step 4: authenticate and authorize before revealing anything about
+        // the verb space at other versions.
+        let presented = if request.capability_token.is_empty() {
+            None
+        } else {
+            Some(CapabilityToken::from_wire(request.capability_token.clone()))
+        };
+        let resolved = self
+            .services
+            .tokens
+            .resolve(presented.as_ref(), verb, &request.tool_id, now_unix_secs());
+        if let Err(denial) = resolved {
+            self.services.audit.record(
+                DevIntAuditEvent::from_denial(now_unix_secs(), self.connection_id, &denial)
+                    .with_client(self.client_name.clone())
+                    .with_target(verb, request.tool_id.clone()),
+            );
+            return denial_frame(request_id, &denial);
+        }
+
+        // Step 5: a degraded connection cannot reach a verb its version lacks.
+        if !verb_available_at(verb, self.version) {
+            self.audit_protocol_failure("unavailable_at_version");
+            return denied(
+                request_id,
+                wire::DenyCode::UnavailableAtVersion,
+                "this operation does not exist at the negotiated DI-API version",
+                &format!("reconnect negotiating DI-API v{}", negotiate::DI_API_MAX_SUPPORTED),
+            );
+        }
+
+        // Step 6: the lifecycle port, then the projection.
+        let outcome = self.dispatch(verb, &request).await;
+        self.services.audit.record(
+            DevIntAuditEvent::new(
+                now_unix_secs(),
+                self.connection_id,
+                DevIntAuditKind::VerbServed {
+                    succeeded: outcome.is_ok(),
+                },
+            )
+            .with_client(self.client_name.clone())
+            .with_target(verb, request.tool_id.clone()),
+        );
+
+        match outcome {
+            Ok(response) => DiResponseFrame::Response(Box::new(response)),
+            Err(error) => lifecycle_denial(request_id, &error),
+        }
+    }
+
+    /// The one exhaustive match over the verb space. Every arm goes to the
+    /// lifecycle port and comes back through a projection; no arm reaches
+    /// anything else.
+    async fn dispatch(&self, verb: DiVerb, request: &wire::Request) -> Result<wire::Response, LifecycleError> {
+        let tool = project::parse_tool_id(&request.tool_id);
+        let mut response = wire::Response {
+            request_id: request.request_id,
+            verb: verb.to_wire() as i32,
+            ..Default::default()
+        };
+        let lifecycle = &self.services.lifecycle;
+
+        match verb {
+            DiVerb::ListTools => {
+                let tools = lifecycle.list_tools().await?;
+                response.tool_list = Some(wire::ToolList {
+                    tools: tools.iter().map(project::tool_summary).collect(),
+                });
+            }
+            DiVerb::Plan => {
+                let args = request.plan.clone().unwrap_or_default();
+                let integration_request = build_plan_request(&tool, &args)?;
+                let plan = lifecycle.plan(integration_request).await?;
+                response.plan = Some(project::plan_view(&plan));
+            }
+            DiVerb::Apply => {
+                let plan_id = request.apply.as_ref().map(|a| a.plan_id.as_str()).unwrap_or_default();
+                let receipt = lifecycle.apply(&tool, plan_id).await?;
+                response.apply = Some(project::apply_view(&receipt));
+            }
+            DiVerb::Status => {
+                let status = lifecycle.status(&tool).await?;
+                response.status = Some(project::status_view(&status));
+            }
+            DiVerb::Verify => {
+                let result = lifecycle.verify(&tool).await?;
+                response.verification = Some(project::verification_view(&result));
+            }
+            DiVerb::Repair => {
+                let (report, status) = lifecycle.repair(&tool).await?;
+                response.repair = Some(project::repair_view(&tool, &report, &status));
+            }
+            DiVerb::Remove => {
+                let plan_id = request
+                    .remove
+                    .as_ref()
+                    .map(|r| r.plan_id.as_str())
+                    .filter(|p| !p.is_empty());
+                let plan = lifecycle.remove(&tool, plan_id).await?;
+                response.removal = Some(project::removal_view(&plan));
+            }
+            DiVerb::ScopedEvents => {
+                let args = request.events.unwrap_or_default();
+                let events = lifecycle.scoped_events(&tool, args.limit, args.since_unix_secs).await?;
+                response.events = Some(wire::ScopedEventList {
+                    events: events.iter().map(project::scoped_event_view).collect(),
+                });
+            }
+            DiVerb::ApprovalRelay => {
+                let args = request.approval.clone().unwrap_or_default();
+                // An unreadable button press is refused rather than defaulted.
+                // Defaulting here would let a malformed frame stand in for a
+                // human's approval.
+                let input = ApprovalInput::parse(&args.user_input).ok_or_else(|| LifecycleError::Refused {
+                    detail: "the relayed approval input is not one this API accepts".to_string(),
+                })?;
+                let receipt = lifecycle.relay_approval(&tool, &args.approval_id, input).await?;
+                response.approval = Some(wire::ApprovalRelayAck {
+                    approval_id: receipt.approval_id,
+                    relayed_input: receipt.relayed.as_str().to_string(),
+                    accepted_at_unix_secs: receipt.accepted_at_unix_secs,
+                });
+            }
+        }
+        Ok(response)
+    }
+}
+
+/// Translate `PlanArgs` into the lifecycle contract's request.
+///
+/// Every unrecognised token is refused rather than defaulted: a plan written to
+/// a scope the caller did not name is the exact class of bug
+/// `IntegrationRequest`'s mandatory `settings_scope` exists to prevent.
+fn build_plan_request(
+    tool: &aa_core::dev_tool::DevToolKind,
+    args: &wire::PlanArgs,
+) -> Result<IntegrationRequest, LifecycleError> {
+    let profile = project::parse_profile(&args.profile).ok_or_else(|| LifecycleError::Refused {
+        detail: format!("unknown protection profile {:?}", args.profile),
+    })?;
+    let scope = project::parse_scope(&args.settings_scope).ok_or_else(|| LifecycleError::Refused {
+        detail: format!("unknown settings scope {:?}", args.settings_scope),
+    })?;
+    let requested_level = if args.requested_level.is_empty() {
+        ProtectionLevel::GatewayProtected
+    } else {
+        project::parse_level(&args.requested_level).ok_or_else(|| LifecycleError::Refused {
+            detail: format!("unknown protection level {:?}", args.requested_level),
+        })?
+    };
+
+    let mut request = IntegrationRequest::new(tool.clone(), profile, scope).requesting_level(requested_level);
+    request.allow_privileged_host_steps = args.allow_privileged_host_steps;
+    // The client names a profile; the *document* is resolved inside the trusted
+    // layers (ADR 0030 matrix row 6). The reference here carries the name only,
+    // and the service replaces it with the resolved reference.
+    if !args.policy_profile_id.is_empty() {
+        request = request.with_policy_profile(aa_core::integration::PolicyProfileRef {
+            id: args.policy_profile_id.clone(),
+            display_name: args.policy_profile_id.clone(),
+            digest: String::new(),
+        });
+    }
+    Ok(request)
+}
+
+fn denied(request_id: u64, code: wire::DenyCode, message: &str, remediation: &str) -> DiResponseFrame {
+    DiResponseFrame::Denied(wire::Denied {
+        request_id,
+        code: code as i32,
+        message: message.to_string(),
+        remediation: remediation.to_string(),
+    })
+}
+
+/// Map a token denial onto the wire.
+///
+/// Absent, malformed and unknown collapse into one code on purpose: a probing
+/// client must not be able to use the response to tell "no such token" from
+/// "wrong shape". Expired is distinguished because the holder already has the
+/// token — nothing leaks — and re-enrolment is the actionable answer.
+fn denial_frame(request_id: u64, denial: &TokenDenial) -> DiResponseFrame {
+    match denial {
+        TokenDenial::Absent | TokenDenial::Malformed | TokenDenial::Unknown => denied(
+            request_id,
+            wire::DenyCode::Unauthenticated,
+            "not authenticated",
+            "enrol this client with `aasm integration enrol` and present its capability token",
+        ),
+        TokenDenial::Expired { .. } => denied(
+            request_id,
+            wire::DenyCode::TokenExpired,
+            "the capability token has expired",
+            "rotate the token, or re-enrol this client",
+        ),
+        TokenDenial::OutOfScope { .. } => denied(
+            request_id,
+            wire::DenyCode::OutOfScope,
+            "this token is not scoped for that operation on that tool",
+            "enrol a token scoped for the tool and operation you need",
+        ),
+    }
+}
+
+fn lifecycle_denial(request_id: u64, error: &LifecycleError) -> DiResponseFrame {
+    let code = match error {
+        LifecycleError::UnknownTool { .. } => wire::DenyCode::UnknownTool,
+        _ => wire::DenyCode::LifecycleError,
+    };
+    denied(request_id, code, &error.detail(), "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::devint::audit::RecordingAuditSink;
+    use crate::devint::scope::{TokenScope, ToolScope};
+    use crate::devint::testkit::{connect_and_negotiate, hello_offering, FakeLifecycle, TestServer};
+
+    #[tokio::test]
+    async fn a_negotiated_client_with_a_scoped_token_can_read_status() {
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        let (token, _) = server.enrol(
+            "vscode-aasm",
+            TokenScope::full_lifecycle(ToolScope::tools(["claude-code"])),
+        );
+        let mut client = connect_and_negotiate(&server, hello_offering(&[1, 2])).await;
+
+        let response = client.request(DiVerb::Status, "claude-code", Some(&token)).await;
+        let DiResponseFrame::Response(response) = response else {
+            panic!("expected a Response, got {response:?}");
+        };
+        let status = response.status.expect("status view");
+        assert_eq!(status.tool_id, "claude-code");
+        assert_eq!(status.achieved_level, "integrated");
+    }
+
+    #[tokio::test]
+    async fn a_verb_before_negotiation_is_refused() {
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        let (token, _) = server.enrol("rogue", TokenScope::full_lifecycle(ToolScope::AllTools));
+        let mut raw = server.connect_raw().await;
+        raw.send_request(DiVerb::Status, "claude-code", Some(&token), 1).await;
+        let frame = raw.read().await;
+        match frame {
+            DiResponseFrame::Denied(denied) => {
+                assert_eq!(denied.code, wire::DenyCode::ProtocolViolation as i32);
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+        assert!(server.audit().events().iter().any(
+            |e| matches!(&e.kind, DevIntAuditKind::ProtocolFailure { reason } if *reason == "verb_before_negotiation")
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_incompatible_client_is_told_what_to_do_and_disconnected() {
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        let mut raw = server.connect_raw().await;
+        raw.send_hello(hello_offering(&[0])).await;
+        match raw.read().await {
+            DiResponseFrame::Incompatible(incompatible) => {
+                assert!(!incompatible.reason.is_empty());
+                assert!(incompatible.remediation.contains("update the client"));
+                assert_eq!(incompatible.max_supported, negotiate::DI_API_MAX_SUPPORTED);
+            }
+            other => panic!("expected Incompatible, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn the_audit_sink_sees_every_negotiation() {
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        let mut raw = server.connect_raw().await;
+        raw.send_hello(hello_offering(&[1])).await;
+        let _ = raw.read().await;
+        server.wait_for_audit(1).await;
+        assert!(server
+            .audit()
+            .events()
+            .iter()
+            .any(|e| matches!(&e.kind, DevIntAuditKind::Negotiated { outcome, .. } if *outcome == "degraded")));
+    }
+
+    #[tokio::test]
+    async fn an_unknown_verb_discriminant_is_refused_before_anything_runs() {
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        let (token, _) = server.enrol("cli", TokenScope::full_lifecycle(ToolScope::AllTools));
+        let mut client = connect_and_negotiate(&server, hello_offering(&[2])).await;
+        let response = client
+            .send_raw_request(wire::Request {
+                request_id: 42,
+                verb: 4242,
+                capability_token: token.expose().to_string(),
+                tool_id: "claude-code".to_string(),
+                ..Default::default()
+            })
+            .await;
+        match response {
+            DiResponseFrame::Denied(denied) => {
+                assert_eq!(denied.code, wire::DenyCode::UnknownVerb as i32);
+                assert_eq!(denied.request_id, 42);
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+        assert_eq!(
+            server.lifecycle().calls(),
+            0,
+            "no lifecycle call may run for an unknown verb"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_lifecycle_refusal_reaches_the_client_without_adapter_internals() {
+        let server = TestServer::start(FakeLifecycle::refusing("privileged host steps were not consented to")).await;
+        let (token, _) = server.enrol("cli", TokenScope::full_lifecycle(ToolScope::AllTools));
+        let mut client = connect_and_negotiate(&server, hello_offering(&[2])).await;
+        match client.request(DiVerb::Apply, "claude-code", Some(&token)).await {
+            DiResponseFrame::Denied(denied) => {
+                assert_eq!(denied.code, wire::DenyCode::LifecycleError as i32);
+                assert_eq!(denied.message, "privileged host steps were not consented to");
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn an_unparseable_plan_argument_is_refused_rather_than_defaulted() {
+        let server = TestServer::start(FakeLifecycle::default()).await;
+        let (token, _) = server.enrol("cli", TokenScope::full_lifecycle(ToolScope::AllTools));
+        let mut client = connect_and_negotiate(&server, hello_offering(&[2])).await;
+        let response = client
+            .send_raw_request(wire::Request {
+                request_id: 1,
+                verb: DiVerb::Plan.to_wire() as i32,
+                capability_token: token.expose().to_string(),
+                tool_id: "claude-code".to_string(),
+                plan: Some(wire::PlanArgs {
+                    profile: "recommended".to_string(),
+                    // Never named — the destination must not be inferred.
+                    settings_scope: String::new(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .await;
+        match response {
+            DiResponseFrame::Denied(denied) => {
+                assert_eq!(denied.code, wire::DenyCode::LifecycleError as i32);
+                assert!(denied.message.contains("settings scope"));
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unreachable_peer_credential_fails_closed() {
+        // The classifier is asserted directly; opening a socket as another UID
+        // is not something a unit test can do portably.
+        assert!(crate::ipc::peercred::peer_uid_is_allowed(501, 501));
+        assert!(!crate::ipc::peercred::peer_uid_is_allowed(0, 501));
+    }
+
+    #[test]
+    fn a_recording_sink_starts_empty() {
+        assert!(RecordingAuditSink::new().events().is_empty());
+    }
+}

--- a/aa-runtime/src/devint/socket.rs
+++ b/aa-runtime/src/devint/socket.rs
@@ -1,0 +1,318 @@
+//! Where the DI-API socket lives, and the OS half of its trust model
+//! (ADR 0030 §5.1, §5.2, §5.3 layer 1).
+//!
+//! # The path
+//!
+//! `~/.aa/run/devint.sock`, under the same `~/.aa/` root `aa-proxy` already
+//! uses for its CA — deliberately **not** world-writable `/tmp`, unlike the
+//! legacy `/tmp/aa-runtime-{agent_id}.sock`. `AA_DEVINT_SOCKET` overrides it
+//! for tests and unusual deployments; ADR 0030's operational guidance is that
+//! an override must preserve both permission bits, so [`bind`] enforces them
+//! wherever the socket ends up rather than trusting the location.
+//!
+//! It is a **separate socket from the SDK fast path**, and that separation is
+//! a security property rather than tidiness: a DI client never holds a file
+//! descriptor onto agent-action or policy-decision traffic, so that traffic is
+//! unreachable to it by construction instead of by an authorization rule
+//! someone has to remember to write.
+//!
+//! # Discovery
+//!
+//! [`discover`] answers "is the runtime there?" without connecting. A missing
+//! socket means *the runtime is not running* — a bootstrap prompt, not an error
+//! to retry silently — because the thin client is the only layer that exists
+//! when the runtime does not (ADR 0030 matrix row 4).
+//!
+//! # The permission gate
+//!
+//! Directory `0700`, socket `0600`, created under a tightened `umask` so the
+//! inode is never group- or world-accessible even momentarily — the same
+//! construction (and the same AAASM-3581 reasoning) as
+//! [`crate::ipc::server::IpcServer::bind`].
+//!
+//! Both modes are **re-asserted on every bind**, not assumed from the last one.
+//! That mirrors the AAASM-4936 fix in `aa-proxy/src/tls/ca.rs`: permissions
+//! enforced only at creation time are permissions a backup restore, an older
+//! build or a careless `cp` can quietly loosen. A relaxed mode here would
+//! delete the OS layer of the two-layer authentication and leave only the
+//! token, so [`assert_owner_only`] fails the bind rather than serving on a
+//! socket other users can reach.
+//!
+//! Loopback TCP is not offered at all. It is reachable by every local user and
+//! by a browser, the kernel supplies no peer identity for it, and it adds
+//! port-scanning, CSRF and DNS-rebinding surface — ADR 0030 forbidden design 7.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use tokio::net::UnixListener;
+
+/// Environment variable that overrides the DI-API socket path.
+pub const SOCKET_PATH_ENV: &str = "AA_DEVINT_SOCKET";
+
+/// Directory under `$HOME` that holds runtime sockets.
+const RUN_DIR: &str = ".aa/run";
+
+/// The socket file name inside [`RUN_DIR`].
+const SOCKET_FILE: &str = "devint.sock";
+
+/// Required mode for the directory holding the socket.
+pub const REQUIRED_DIR_MODE: u32 = 0o700;
+
+/// Required mode for the socket itself.
+pub const REQUIRED_SOCKET_MODE: u32 = 0o600;
+
+/// What went wrong preparing or binding the DI-API socket.
+///
+/// Hand-written rather than derived, matching [`crate::ipc::codec::CodecError`]
+/// — `aa-runtime` does not depend on `thiserror`.
+#[derive(Debug)]
+pub enum SocketError {
+    /// No home directory could be resolved and no override was set, so there is
+    /// no defensible place to put the socket. Deliberately an error rather than
+    /// a fallback to a shared directory.
+    NoHome,
+    /// The socket path has no parent directory to enforce `0700` on.
+    NoParent {
+        /// The offending path.
+        path: PathBuf,
+    },
+    /// The directory or socket is not owner-only. Fails the bind: without this
+    /// the OS layer of the two-layer authentication is gone.
+    Permissions {
+        /// "directory" or "socket".
+        what: &'static str,
+        /// What was inspected.
+        path: PathBuf,
+        /// What it actually is.
+        actual: u32,
+        /// What it must be.
+        expected: u32,
+    },
+    /// Anything the filesystem or the listener reported.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for SocketError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SocketError::NoHome => write!(
+                f,
+                "cannot resolve a home directory for {RUN_DIR}; set {SOCKET_PATH_ENV} explicitly"
+            ),
+            SocketError::NoParent { path } => {
+                write!(f, "socket path {} has no parent directory", path.display())
+            }
+            SocketError::Permissions {
+                what,
+                path,
+                actual,
+                expected,
+            } => write!(f, "{what} {} is mode {actual:o}, expected {expected:o}", path.display()),
+            SocketError::Io(e) => write!(f, "DI-API socket I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SocketError {}
+
+impl From<std::io::Error> for SocketError {
+    fn from(e: std::io::Error) -> Self {
+        SocketError::Io(e)
+    }
+}
+
+/// Whether the runtime appears to be listening.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SocketDiscovery {
+    /// A socket exists at this path. The client should connect; a refused
+    /// connection then means a stale socket file, which is a different problem
+    /// from "not installed".
+    Present(PathBuf),
+    /// No socket exists. The runtime is not running: prompt to bootstrap it,
+    /// do not retry in a loop.
+    RuntimeNotRunning(PathBuf),
+}
+
+impl SocketDiscovery {
+    /// The path that was probed, present or not.
+    pub fn path(&self) -> &Path {
+        match self {
+            SocketDiscovery::Present(p) | SocketDiscovery::RuntimeNotRunning(p) => p,
+        }
+    }
+}
+
+/// Resolve the DI-API socket path: `$AA_DEVINT_SOCKET`, else
+/// `$HOME/.aa/run/devint.sock`.
+pub fn devint_socket_path() -> Result<PathBuf, SocketError> {
+    if let Some(explicit) = std::env::var_os(SOCKET_PATH_ENV) {
+        return Ok(PathBuf::from(explicit));
+    }
+    let home = std::env::var_os("HOME").ok_or(SocketError::NoHome)?;
+    Ok(PathBuf::from(home).join(RUN_DIR).join(SOCKET_FILE))
+}
+
+/// Probe for a listening runtime without connecting to it.
+pub fn discover(path: &Path) -> SocketDiscovery {
+    if path.exists() {
+        SocketDiscovery::Present(path.to_path_buf())
+    } else {
+        SocketDiscovery::RuntimeNotRunning(path.to_path_buf())
+    }
+}
+
+/// Create the socket's parent directory `0700` if it is missing, and re-assert
+/// `0700` on it if it already exists.
+pub fn prepare_socket_dir(socket_path: &Path) -> Result<PathBuf, SocketError> {
+    let dir = socket_path.parent().ok_or_else(|| SocketError::NoParent {
+        path: socket_path.to_path_buf(),
+    })?;
+    if !dir.exists() {
+        std::fs::create_dir_all(dir)?;
+    }
+    // Re-assert rather than assume: `create_dir_all` honours the process umask
+    // for intermediate components, and an existing directory may predate this
+    // requirement entirely.
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(REQUIRED_DIR_MODE))?;
+    Ok(dir.to_path_buf())
+}
+
+/// Verify that `path` is exactly `expected`, ignoring file-type bits.
+///
+/// Read back from the filesystem on purpose. The value that matters is what the
+/// kernel will enforce for the next `connect()`, not what this process believes
+/// it set.
+pub fn assert_owner_only(path: &Path, expected: u32, what: &'static str) -> Result<(), SocketError> {
+    let actual = std::fs::metadata(path)?.permissions().mode() & 0o777;
+    if actual != expected {
+        return Err(SocketError::Permissions {
+            what,
+            path: path.to_path_buf(),
+            actual,
+            expected,
+        });
+    }
+    Ok(())
+}
+
+/// Bind the DI-API listener at `socket_path`, owner-only end to end.
+///
+/// Removes a stale socket file, ensures the parent directory is `0700`, binds
+/// under `umask(0o077)` so the inode is `0600` from its first instant, and then
+/// reads both modes back and fails if either is wrong.
+pub fn bind(socket_path: &Path) -> Result<UnixListener, SocketError> {
+    let dir = prepare_socket_dir(socket_path)?;
+    assert_owner_only(&dir, REQUIRED_DIR_MODE, "directory")?;
+
+    if socket_path.exists() {
+        std::fs::remove_file(socket_path)?;
+        tracing::info!(path = %socket_path.display(), "removed stale DI-API socket file");
+    }
+
+    let listener = {
+        // AAASM-3581's construction: no bind→chmod window during which another
+        // local process could connect.
+        //
+        // SAFETY: `umask` cannot fail and has no preconditions. It is
+        // process-global, so the previous value is restored immediately —
+        // including on a failed bind — to avoid leaking a tightened umask into
+        // unrelated file creation elsewhere in the runtime.
+        let prev_umask = unsafe { libc::umask(0o077) };
+        let result = UnixListener::bind(socket_path);
+        unsafe { libc::umask(prev_umask) };
+        result?
+    };
+
+    std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(REQUIRED_SOCKET_MODE))?;
+    assert_owner_only(socket_path, REQUIRED_SOCKET_MODE, "socket")?;
+
+    tracing::info!(
+        path = %socket_path.display(),
+        "DI-API socket bound (dir 0700, socket 0600)"
+    );
+    Ok(listener)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovery_reports_an_absent_socket_as_runtime_not_running() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("devint.sock");
+        assert_eq!(discover(&path), SocketDiscovery::RuntimeNotRunning(path.clone()));
+        assert_eq!(discover(&path).path(), path.as_path());
+    }
+
+    #[tokio::test]
+    async fn a_bound_socket_is_0600_in_a_0700_directory() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join("run").join("devint.sock");
+        let _listener = bind(&path).expect("bind");
+
+        // Asserted by reading the filesystem back, not by trusting the setter.
+        let socket_mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        let dir_mode = std::fs::metadata(path.parent().unwrap()).unwrap().permissions().mode() & 0o777;
+        assert_eq!(socket_mode, 0o600, "socket must be owner-only");
+        assert_eq!(dir_mode, 0o700, "socket directory must be owner-only");
+        assert_eq!(discover(&path), SocketDiscovery::Present(path.clone()));
+    }
+
+    #[tokio::test]
+    async fn binding_tightens_a_loose_pre_existing_directory() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let dir = root.path().join("run");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let path = dir.join("devint.sock");
+        let _listener = bind(&path).expect("bind");
+        let dir_mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o700, "a pre-existing loose directory must be tightened");
+    }
+
+    #[tokio::test]
+    async fn binding_replaces_a_stale_socket_file() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join("run").join("devint.sock");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"stale").unwrap();
+
+        let _listener = bind(&path).expect("bind over a stale file");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn a_loose_mode_is_rejected_rather_than_served() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let file = root.path().join("loose");
+        std::fs::write(&file, b"x").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = assert_owner_only(&file, REQUIRED_SOCKET_MODE, "socket").expect_err("must reject 0644");
+        match err {
+            SocketError::Permissions { actual, expected, .. } => {
+                assert_eq!(actual, 0o644);
+                assert_eq!(expected, 0o600);
+            }
+            other => panic!("expected a permissions error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_override_wins_over_the_home_convention() {
+        // `devint_socket_path` reads process-global env, so this test asserts
+        // the resolution rule directly rather than mutating the environment
+        // under a parallel test runner.
+        let overridden = PathBuf::from("/somewhere/else/devint.sock");
+        assert_eq!(overridden.file_name().unwrap(), SOCKET_FILE);
+        assert_eq!(SOCKET_PATH_ENV, "AA_DEVINT_SOCKET");
+        assert_eq!(
+            PathBuf::from("/h").join(RUN_DIR).join(SOCKET_FILE).to_string_lossy(),
+            "/h/.aa/run/devint.sock"
+        );
+    }
+}

--- a/aa-runtime/src/devint/testkit.rs
+++ b/aa-runtime/src/devint/testkit.rs
@@ -1,0 +1,487 @@
+//! In-crate harness for driving a real DI-API server over a real socket.
+//!
+//! `#[cfg(test)]` only. It exists because the properties this ticket has to
+//! prove — a token scoped to tool A cannot touch tool B, a revoked token stops
+//! working immediately, a downgrade is refused — are properties of the *served
+//! socket*, not of a function. Asserting them against an in-process helper
+//! would prove the helper.
+//!
+//! [`FakeLifecycle`] stands in for AAASM-5278's service, which owns
+//! `aa-core/src/integration/**` and `aa-devtool*` and is being written in
+//! parallel. The DI-API is deliberately built against the
+//! [`IntegrationLifecycle`] port rather than that implementation, so the fake
+//! is a complete substitute for it here and the two branches do not collide.
+//! It also lets a test assert something a real adapter could not be made to do
+//! on demand: return a plan whose steps are stuffed with secrets.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::io::{BufReader, BufWriter};
+use tokio::net::UnixStream;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+use aa_core::dev_tool::{DevToolKind, GovernanceLevel};
+use aa_core::integration::{
+    DevToolCapabilities, EnvValue, IntegrationCapability, IntegrationPlan, IntegrationReceipt, IntegrationRequest,
+    IntegrationStatus, IntegrationStep, LifecyclePhase, PolicyProfileRef, ProtectionLevel, ProtectionProfile,
+    ProtectionState, RemovalPlan, SettingsScope, StepAction, StepReceipt, SupportedToolVersions, ToolVersion,
+    VerificationOutcome, VerificationResult, VersionCompatibility, VersionSupport, LIFECYCLE_SCHEMA_VERSION,
+};
+use aa_proto::assembly::devint::v1 as wire;
+
+use super::audit::RecordingAuditSink;
+use super::codec::{self, DiFrame, DiResponseFrame};
+use super::lifecycle::{
+    ApprovalInput, ApprovalRelayReceipt, IntegrationLifecycle, LifecycleError, RepairReport, ScopedSecurityEvent,
+    ToolDescriptor, VerdictKind,
+};
+use super::projection::tool_id;
+use super::scope::TokenScope;
+use super::server::{DevIntServer, DevIntServerConfig, DevIntServices};
+use super::token::{CapabilityToken, TokenRecord, TokenStore};
+use super::verb::DiVerb;
+
+/// The sentinel a poisoned fixture carries. Its absence from every response and
+/// every audit event is the data-minimisation assertion.
+pub const LEAK_SENTINEL: &str = "sk-live-THISMUSTNEVERLEAVE-0123456789";
+
+/// A `Hello` offering the given DI-API versions and a readable lifecycle
+/// schema.
+pub fn hello_offering(di_api_versions: &[u32]) -> wire::Hello {
+    wire::Hello {
+        client_name: "test-client".to_string(),
+        client_version: "1.0.0".to_string(),
+        di_api_versions: di_api_versions.to_vec(),
+        lifecycle_schema_versions: vec![LIFECYCLE_SCHEMA_VERSION],
+    }
+}
+
+/// How the fake lifecycle should answer.
+#[derive(Debug, Clone, Default)]
+enum Behaviour {
+    #[default]
+    Succeed,
+    Refuse(String),
+}
+
+/// A stand-in for AAASM-5278's lifecycle service.
+#[derive(Debug, Default)]
+pub struct FakeLifecycle {
+    behaviour: Behaviour,
+    calls: AtomicUsize,
+}
+
+impl FakeLifecycle {
+    /// A fake that refuses every operation with `detail`.
+    pub fn refusing(detail: impl Into<String>) -> Self {
+        Self {
+            behaviour: Behaviour::Refuse(detail.into()),
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    /// How many lifecycle operations have been invoked. Used to assert that a
+    /// refused request never reached the port at all.
+    pub fn calls(&self) -> usize {
+        self.calls.load(Ordering::Relaxed)
+    }
+
+    fn enter(&self) -> Result<(), LifecycleError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        match &self.behaviour {
+            Behaviour::Succeed => Ok(()),
+            Behaviour::Refuse(detail) => Err(LifecycleError::Refused { detail: detail.clone() }),
+        }
+    }
+}
+
+/// A plan whose every value-bearing leaf carries [`LEAK_SENTINEL`].
+///
+/// A real adapter would not do this, which is exactly why the fake must: the
+/// question is whether the *projection* can leak, not whether today's adapters
+/// happen to hold anything worth leaking.
+pub fn poisoned_plan(tool: &DevToolKind) -> IntegrationPlan {
+    let request = IntegrationRequest::new(tool.clone(), ProtectionProfile::Recommended, SettingsScope::User)
+        .with_policy_profile(PolicyProfileRef {
+            id: "team-default".to_string(),
+            display_name: "Team default".to_string(),
+            digest: "sha256:abcd".to_string(),
+        });
+    let mut plan = IntegrationPlan::new(
+        "plan-1",
+        &request,
+        ProtectionLevel::GatewayProtected,
+        GovernanceLevel::L2Enforce,
+    );
+    plan.steps = vec![
+        IntegrationStep::new(
+            "settings",
+            StepAction::WriteManagedSettings {
+                scope: SettingsScope::User,
+                path: PathBuf::from("/home/dev/.claude/settings.json"),
+                managed_keys: vec!["aasm.gatewayUrl".to_string()],
+                content_sha256: "abc123".to_string(),
+                merge: aa_core::integration::SettingsMerge::MergeManagedKeys,
+            },
+            "Write the managed settings block",
+        ),
+        IntegrationStep::new(
+            "env",
+            StepAction::InjectLaunchEnvironment {
+                scope: SettingsScope::User,
+                variable: "ANTHROPIC_AUTH_TOKEN".to_string(),
+                value: EnvValue::Literal(LEAK_SENTINEL.to_string()),
+            },
+            "Inject the launch environment",
+        ),
+    ];
+    plan.warnings = vec!["The tool must be restarted for this to take effect".to_string()];
+    plan
+}
+
+fn fake_status(tool: &DevToolKind) -> IntegrationStatus {
+    IntegrationStatus {
+        tool: tool.clone(),
+        phase: LifecyclePhase::Installed,
+        state: ProtectionState::Ladder(ProtectionLevel::Integrated),
+        evidence: Vec::new(),
+        planned_level: ProtectionLevel::GatewayProtected,
+        adapter_ceiling: GovernanceLevel::L2Enforce,
+        compatibility: VersionCompatibility::Compatible {
+            detected: ToolVersion::new(2, 1, 220),
+        },
+        next_level: None,
+        observed_at_unix_secs: 1_700_000_000,
+    }
+}
+
+#[async_trait]
+impl IntegrationLifecycle for FakeLifecycle {
+    async fn list_tools(&self) -> Result<Vec<ToolDescriptor>, LifecycleError> {
+        self.enter()?;
+        Ok(vec![ToolDescriptor {
+            tool: DevToolKind::ClaudeCode,
+            display_name: "Claude Code".to_string(),
+            detected: true,
+            detected_version: Some(ToolVersion::new(2, 1, 220)),
+            compatibility: VersionCompatibility::Compatible {
+                detected: ToolVersion::new(2, 1, 220),
+            },
+            capabilities: DevToolCapabilities::new()
+                .supported(IntegrationCapability::Discovery)
+                .unsupported(IntegrationCapability::ManagedLaunch, "no launch command"),
+            adapter_ceiling: GovernanceLevel::L2Enforce,
+        }])
+    }
+
+    async fn plan(&self, request: IntegrationRequest) -> Result<IntegrationPlan, LifecycleError> {
+        self.enter()?;
+        Ok(poisoned_plan(&request.tool))
+    }
+
+    async fn apply(&self, tool: &DevToolKind, plan_id: &str) -> Result<IntegrationReceipt, LifecycleError> {
+        self.enter()?;
+        let plan = poisoned_plan(tool);
+        Ok(IntegrationReceipt {
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            receipt_id: "receipt-1".to_string(),
+            plan_id: if plan_id.is_empty() {
+                "plan-1".to_string()
+            } else {
+                plan_id.to_string()
+            },
+            tool: tool.clone(),
+            profile: ProtectionProfile::Recommended,
+            settings_scope: SettingsScope::User,
+            applied_at_unix_secs: 1_700_000_000,
+            versions: VersionSupport {
+                adapter_version: ToolVersion::new(1, 0, 0),
+                lifecycle_schema_version: LIFECYCLE_SCHEMA_VERSION,
+                supported_tool_versions: SupportedToolVersions::any(),
+            }
+            .component_versions(),
+            tool_version: Some(ToolVersion::new(2, 1, 220)),
+            steps: plan
+                .steps
+                .iter()
+                .map(|s| StepReceipt::applied(s, Some("fingerprint-1".to_string())))
+                .collect(),
+            planned_level: ProtectionLevel::GatewayProtected,
+            achieved_level: ProtectionLevel::Integrated,
+            achieved_evidence: Vec::new(),
+            verified_at_unix_secs: None,
+        })
+    }
+
+    async fn status(&self, tool: &DevToolKind) -> Result<IntegrationStatus, LifecycleError> {
+        self.enter()?;
+        Ok(fake_status(tool))
+    }
+
+    async fn verify(&self, _tool: &DevToolKind) -> Result<VerificationResult, LifecycleError> {
+        self.enter()?;
+        Ok(VerificationResult {
+            verified_at_unix_secs: 1_700_000_000,
+            outcome: VerificationOutcome::Passed,
+            evidence: Vec::new(),
+        })
+    }
+
+    async fn repair(&self, tool: &DevToolKind) -> Result<(RepairReport, IntegrationStatus), LifecycleError> {
+        self.enter()?;
+        Ok((
+            RepairReport {
+                repaired: vec!["settings".to_string()],
+                unrepairable: Vec::new(),
+            },
+            fake_status(tool),
+        ))
+    }
+
+    async fn remove(&self, tool: &DevToolKind, _plan_id: Option<&str>) -> Result<RemovalPlan, LifecycleError> {
+        self.enter()?;
+        Ok(RemovalPlan::new("removal-1", tool.clone()))
+    }
+
+    async fn scoped_events(
+        &self,
+        _tool: &DevToolKind,
+        _limit: u32,
+        _since_unix_secs: u64,
+    ) -> Result<Vec<ScopedSecurityEvent>, LifecycleError> {
+        self.enter()?;
+        Ok(vec![ScopedSecurityEvent {
+            occurred_at_unix_secs: 1_700_000_000,
+            verdict_kind: VerdictKind::Redacted,
+            mechanism: IntegrationCapability::ModelPathInterception,
+            count: 2,
+            redaction_labels: vec!["anthropic_api_key".to_string()],
+        }])
+    }
+
+    async fn relay_approval(
+        &self,
+        _tool: &DevToolKind,
+        approval_id: &str,
+        input: ApprovalInput,
+    ) -> Result<ApprovalRelayReceipt, LifecycleError> {
+        self.enter()?;
+        Ok(ApprovalRelayReceipt {
+            approval_id: approval_id.to_string(),
+            relayed: input,
+            accepted_at_unix_secs: 1_700_000_000,
+        })
+    }
+}
+
+/// A running DI-API server on a temporary socket.
+pub struct TestServer {
+    socket_path: PathBuf,
+    tokens: TokenStore,
+    audit: RecordingAuditSink,
+    lifecycle: Arc<FakeLifecycle>,
+    cancel: CancellationToken,
+    tracker: TaskTracker,
+    // Kept alive so the socket directory outlives the server.
+    _dir: tempfile::TempDir,
+}
+
+impl TestServer {
+    /// Bind and run a server backed by `lifecycle`.
+    pub async fn start(lifecycle: FakeLifecycle) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("run").join("devint.sock");
+        let server = DevIntServer::bind(DevIntServerConfig {
+            socket_path: socket_path.clone(),
+            max_connections: 8,
+        })
+        .expect("bind");
+
+        let tokens = TokenStore::new();
+        let audit = RecordingAuditSink::new();
+        let lifecycle = Arc::new(lifecycle);
+        let cancel = CancellationToken::new();
+        let tracker = TaskTracker::new();
+
+        let services = DevIntServices {
+            lifecycle: Arc::clone(&lifecycle) as Arc<dyn IntegrationLifecycle>,
+            tokens: tokens.clone(),
+            audit: Arc::new(audit.clone()),
+        };
+        tracker.spawn(server.run(tracker.clone(), cancel.clone(), services));
+
+        Self {
+            socket_path,
+            tokens,
+            audit,
+            lifecycle,
+            cancel,
+            tracker,
+            _dir: dir,
+        }
+    }
+
+    /// The socket this server is listening on.
+    pub fn socket_path(&self) -> &std::path::Path {
+        &self.socket_path
+    }
+
+    /// The enrolment book, for revocation and rotation tests.
+    pub fn tokens(&self) -> &TokenStore {
+        &self.tokens
+    }
+
+    /// Everything the server has audited.
+    pub fn audit(&self) -> &RecordingAuditSink {
+        &self.audit
+    }
+
+    /// The fake lifecycle, for asserting whether it was reached at all.
+    pub fn lifecycle(&self) -> &FakeLifecycle {
+        &self.lifecycle
+    }
+
+    /// Enrol a client and get its token.
+    pub fn enrol(&self, client_name: &str, scope: TokenScope) -> (CapabilityToken, TokenRecord) {
+        self.tokens
+            .issue(client_name, scope, aa_core::integration::now_unix_secs(), 3600)
+    }
+
+    /// Enrol a client whose token has already expired.
+    pub fn enrol_expired(&self, client_name: &str, scope: TokenScope) -> (CapabilityToken, TokenRecord) {
+        let long_ago = aa_core::integration::now_unix_secs().saturating_sub(7200);
+        self.tokens.issue(client_name, scope, long_ago, 3600)
+    }
+
+    /// Open a connection without negotiating.
+    pub async fn connect_raw(&self) -> RawClient {
+        let stream = UnixStream::connect(&self.socket_path).await.expect("connect");
+        let (reader, writer) = stream.into_split();
+        RawClient {
+            reader: BufReader::new(reader),
+            writer: BufWriter::new(writer),
+            next_request_id: 1,
+        }
+    }
+
+    /// Block until the audit sink has at least `count` events, so a test does
+    /// not race the server's own task.
+    pub async fn wait_for_audit(&self, count: usize) {
+        for _ in 0..200 {
+            if self.audit.events().len() >= count {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        panic!("audit sink never reached {count} events");
+    }
+
+    /// Stop the server.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        self.tracker.close();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), self.tracker.wait()).await;
+    }
+}
+
+/// A client that speaks the wire directly, with no negotiation performed.
+pub struct RawClient {
+    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    writer: BufWriter<tokio::net::unix::OwnedWriteHalf>,
+    next_request_id: u64,
+}
+
+impl RawClient {
+    /// Send a `Hello`.
+    pub async fn send_hello(&mut self, hello: wire::Hello) {
+        codec::write_client_frame(&mut self.writer, DiFrame::Hello(hello))
+            .await
+            .expect("write hello");
+    }
+
+    /// Send a fully-specified request.
+    pub async fn send_raw(&mut self, request: wire::Request) {
+        codec::write_client_frame(&mut self.writer, DiFrame::Request(request))
+            .await
+            .expect("write request");
+    }
+
+    /// Send a simple verb request.
+    pub async fn send_request(&mut self, verb: DiVerb, tool: &str, token: Option<&CapabilityToken>, request_id: u64) {
+        self.send_raw(build_request(verb, tool, token, request_id)).await;
+    }
+
+    /// Read one server frame.
+    pub async fn read(&mut self) -> DiResponseFrame {
+        codec::read_response_frame(&mut self.reader).await.expect("read frame")
+    }
+
+    /// Read one server frame, allowing for a closed connection.
+    pub async fn try_read(&mut self) -> Option<DiResponseFrame> {
+        codec::read_response_frame(&mut self.reader).await.ok()
+    }
+
+    /// Send a request and read its response.
+    pub async fn request(&mut self, verb: DiVerb, tool: &str, token: Option<&CapabilityToken>) -> DiResponseFrame {
+        let request_id = self.next_request_id;
+        self.next_request_id += 1;
+        self.send_request(verb, tool, token, request_id).await;
+        self.read().await
+    }
+
+    /// Send a fully-specified request and read its response.
+    pub async fn send_raw_request(&mut self, request: wire::Request) -> DiResponseFrame {
+        self.send_raw(request).await;
+        self.read().await
+    }
+}
+
+/// Build a plain verb request.
+pub fn build_request(verb: DiVerb, tool: &str, token: Option<&CapabilityToken>, request_id: u64) -> wire::Request {
+    wire::Request {
+        request_id,
+        verb: verb.to_wire() as i32,
+        capability_token: token.map(|t| t.expose().to_string()).unwrap_or_default(),
+        tool_id: tool.to_string(),
+        plan: matches!(verb, DiVerb::Plan).then(|| wire::PlanArgs {
+            profile: "recommended".to_string(),
+            requested_level: "gateway_protected".to_string(),
+            settings_scope: "user".to_string(),
+            allow_privileged_host_steps: false,
+            policy_profile_id: "team-default".to_string(),
+        }),
+        apply: matches!(verb, DiVerb::Apply).then(|| wire::ApplyArgs {
+            plan_id: "plan-1".to_string(),
+        }),
+        remove: matches!(verb, DiVerb::Remove).then(|| wire::RemoveArgs {
+            plan_id: "plan-1".to_string(),
+        }),
+        events: matches!(verb, DiVerb::ScopedEvents).then(|| wire::ScopedEventsArgs {
+            limit: 10,
+            since_unix_secs: 0,
+        }),
+        approval: matches!(verb, DiVerb::ApprovalRelay).then(|| wire::ApprovalRelayArgs {
+            approval_id: "approval-1".to_string(),
+            user_input: "approve".to_string(),
+        }),
+    }
+}
+
+/// Connect, negotiate, and assert the negotiation was usable.
+pub async fn connect_and_negotiate(server: &TestServer, hello: wire::Hello) -> RawClient {
+    let mut client = server.connect_raw().await;
+    client.send_hello(hello).await;
+    match client.read().await {
+        DiResponseFrame::HelloAck(_) => client,
+        other => panic!("expected HelloAck, got {other:?}"),
+    }
+}
+
+/// The tool id every fixture uses.
+pub fn claude_code_id() -> String {
+    tool_id(&DevToolKind::ClaudeCode)
+}

--- a/aa-runtime/src/devint/threat_model.rs
+++ b/aa-runtime/src/devint/threat_model.rs
@@ -1,0 +1,617 @@
+//! Threat-model tests for the DI-API (AAASM-5279, ADR 0030 V2/V3/V6–V9/V13).
+//!
+//! Each test names an adversary and the property that stops them. They run
+//! against a **real server on a real socket**, because every property here is
+//! a property of the served boundary rather than of a function: a scope check
+//! that holds in a unit test but is never called by the dispatcher protects
+//! nothing.
+//!
+//! | Adversary | Property |
+//! | --- | --- |
+//! | A compromised plugin | the verb space is closed; its token is scoped to one tool; there is no policy verb and no core passthrough |
+//! | A thief with a stolen token | scope bounds the blast radius; expiry ends it; revocation ends it immediately, mid-connection |
+//! | A replayer | a replayed request re-invokes only what the token already allowed, and dies with the token |
+//! | A downgrader | the negotiated version is fixed; a second `Hello` is refused; a version-gated verb stays gated |
+//! | An eavesdropper on the logs | no response and no audit event carries a token value or protected content |
+
+use aa_proto::assembly::devint::v1 as wire;
+
+use super::audit::DevIntAuditKind;
+use super::codec::DiResponseFrame;
+use super::negotiate::DI_API_MAX_SUPPORTED;
+use super::scope::{TokenScope, ToolScope};
+use super::testkit::{
+    build_request, claude_code_id, connect_and_negotiate, hello_offering, FakeLifecycle, TestServer, LEAK_SENTINEL,
+};
+use super::verb::DiVerb;
+
+fn expect_denied(frame: DiResponseFrame) -> wire::Denied {
+    match frame {
+        DiResponseFrame::Denied(denied) => denied,
+        other => panic!("expected Denied, got {other:?}"),
+    }
+}
+
+fn expect_response(frame: DiResponseFrame) -> wire::Response {
+    match frame {
+        DiResponseFrame::Response(response) => *response,
+        other => panic!("expected Response, got {other:?}"),
+    }
+}
+
+// ── Compromised plugin ───────────────────────────────────────────────────────
+
+/// V3. The headline negative test: one token, one tool.
+#[tokio::test]
+async fn a_token_scoped_to_one_tool_cannot_touch_another_on_any_verb() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, record) = server.enrol(
+        "vscode-aasm",
+        TokenScope::full_lifecycle(ToolScope::tools([claude_code_id()])),
+    );
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    for verb in DiVerb::ALL.into_iter().filter(|v| v.is_tool_scoped()) {
+        // Its own tool: served.
+        let ok = client.request(verb, &claude_code_id(), Some(&token)).await;
+        assert!(
+            matches!(ok, DiResponseFrame::Response(_)),
+            "{verb} on the enrolled tool should be served, got {ok:?}"
+        );
+
+        // Another tool: refused, for every single verb.
+        let denied = expect_denied(client.request(verb, "codex", Some(&token)).await);
+        assert_eq!(
+            denied.code,
+            wire::DenyCode::OutOfScope as i32,
+            "{verb} crossed to another tool"
+        );
+    }
+
+    // …and the crossing attempts are all on the audit trail, named by
+    // enrolment id rather than by token value.
+    let out_of_scope: Vec<_> = server
+        .audit()
+        .events()
+        .into_iter()
+        .filter(|e| matches!(&e.kind, DevIntAuditKind::AuthFailure { outcome, .. } if *outcome == "out_of_scope"))
+        .collect();
+    assert_eq!(out_of_scope.len(), 8, "one audit event per cross-tool verb");
+    for event in &out_of_scope {
+        let DevIntAuditKind::AuthFailure { token_id, .. } = &event.kind else {
+            unreachable!()
+        };
+        assert_eq!(token_id.as_ref(), Some(&record.token_id));
+    }
+    server.shutdown().await;
+}
+
+/// V8, on the wire. A compromised plugin cannot ask for a policy decision,
+/// because no discriminant maps to one.
+#[tokio::test]
+async fn no_wire_discriminant_reaches_an_operation_outside_the_closed_set() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, _) = server.enrol("rogue", TokenScope::full_lifecycle(ToolScope::AllTools));
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    // Sweep well past the defined range, including the reserved zero and a
+    // negative discriminant.
+    for discriminant in [-7_i32, 0, 10, 11, 99, 1_000_000] {
+        let denied = expect_denied(
+            client
+                .send_raw_request(wire::Request {
+                    request_id: 1,
+                    verb: discriminant,
+                    capability_token: token.expose().to_string(),
+                    tool_id: claude_code_id(),
+                    ..Default::default()
+                })
+                .await,
+        );
+        assert_eq!(
+            denied.code,
+            wire::DenyCode::UnknownVerb as i32,
+            "discriminant {discriminant} was not refused"
+        );
+    }
+    assert_eq!(
+        server.lifecycle().calls(),
+        0,
+        "no lifecycle operation may run for a verb outside the closed set"
+    );
+    server.shutdown().await;
+}
+
+/// V8. The DI-API's verb space and the SDK IPC verb space are disjoint, so
+/// "the other socket's operation" is not reachable by renaming a field.
+#[test]
+fn the_di_verb_space_shares_no_operation_with_the_sdk_socket() {
+    // The SDK socket's inbound tags are PolicyQuery, EventReport,
+    // ApprovalResponse, Heartbeat, HandshakeProof. None of them is a DI verb,
+    // and no DI verb is one of them.
+    let sdk_operations = [
+        "policy_query",
+        "event_report",
+        "approval_response",
+        "heartbeat",
+        "handshake_proof",
+    ];
+    for verb in DiVerb::ALL {
+        assert!(
+            !sdk_operations.contains(&verb.as_str()),
+            "{verb} exists on both sockets"
+        );
+    }
+}
+
+/// A read-only enrolment — the shape a status widget or dashboard extension
+/// would get — cannot mutate anything, even for a tool it is scoped to.
+#[tokio::test]
+async fn a_read_only_enrolment_cannot_mutate_the_integration() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, _) = server.enrol(
+        "status-widget",
+        TokenScope::read_only(ToolScope::tools([claude_code_id()])),
+    );
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    for verb in DiVerb::ALL.into_iter().filter(|v| v.is_mutation()) {
+        let denied = expect_denied(client.request(verb, &claude_code_id(), Some(&token)).await);
+        assert_eq!(denied.code, wire::DenyCode::OutOfScope as i32, "{verb} was not refused");
+    }
+    // Reading still works, so the denial is scope and not a broken client.
+    assert!(matches!(
+        client.request(DiVerb::Status, &claude_code_id(), Some(&token)).await,
+        DiResponseFrame::Response(_)
+    ));
+    assert_eq!(
+        server.lifecycle().calls(),
+        1,
+        "only the permitted read reached the lifecycle port"
+    );
+    server.shutdown().await;
+}
+
+// ── Token theft, absence and expiry ──────────────────────────────────────────
+
+/// V2. Absent, malformed and unknown tokens are each denied **and** audited,
+/// and none of them can tell the others apart from the response.
+#[tokio::test]
+async fn absent_malformed_and_unknown_tokens_are_denied_and_audited_indistinguishably() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    server.enrol("legitimate", TokenScope::full_lifecycle(ToolScope::AllTools));
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    let stranger = super::token::CapabilityToken::generate();
+    let cases: [(&str, Option<super::token::CapabilityToken>, &str); 3] = [
+        ("absent", None, "token_absent"),
+        (
+            "malformed",
+            Some(super::token::CapabilityToken::from_wire("not-a-token")),
+            "token_malformed",
+        ),
+        ("unknown", Some(stranger), "token_unknown"),
+    ];
+
+    let mut wire_answers = Vec::new();
+    for (label, token, expected_outcome) in cases {
+        let denied = expect_denied(client.request(DiVerb::Status, &claude_code_id(), token.as_ref()).await);
+        assert_eq!(
+            denied.code,
+            wire::DenyCode::Unauthenticated as i32,
+            "{label} was not denied"
+        );
+        assert!(
+            server.audit().has_auth_failure(expected_outcome),
+            "{label} produced no audit event"
+        );
+        wire_answers.push((denied.code, denied.message.clone(), denied.remediation.clone()));
+    }
+
+    // The three answers are byte-identical apart from the request id, so a
+    // prober cannot use the response to distinguish "no such token" from
+    // "wrong shape" or "you sent nothing".
+    assert_eq!(wire_answers[0], wire_answers[1]);
+    assert_eq!(wire_answers[1], wire_answers[2]);
+    assert_eq!(server.lifecycle().calls(), 0);
+    server.shutdown().await;
+}
+
+/// V2. An expired enrolment is refused with an actionable code, and the audit
+/// event names the enrolment that expired.
+#[tokio::test]
+async fn an_expired_token_is_denied_and_audited() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, record) = server.enrol_expired("stale-extension", TokenScope::full_lifecycle(ToolScope::AllTools));
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    let denied = expect_denied(client.request(DiVerb::Status, &claude_code_id(), Some(&token)).await);
+    assert_eq!(denied.code, wire::DenyCode::TokenExpired as i32);
+    assert!(denied.remediation.contains("rotate"));
+    assert!(server.audit().has_auth_failure("token_expired"));
+
+    let event = server
+        .audit()
+        .events()
+        .into_iter()
+        .find(|e| matches!(&e.kind, DevIntAuditKind::AuthFailure { outcome, .. } if *outcome == "token_expired"))
+        .expect("expiry event");
+    let DevIntAuditKind::AuthFailure { token_id, .. } = &event.kind else {
+        unreachable!()
+    };
+    assert_eq!(token_id.as_ref(), Some(&record.token_id));
+    assert_eq!(server.lifecycle().calls(), 0);
+    server.shutdown().await;
+}
+
+/// The thief's best case: a valid, unexpired, stolen token. It still cannot do
+/// more than the enrolment it was stolen from — which is the accepted-risk
+/// mitigation ADR 0030 states, asserted rather than assumed.
+#[tokio::test]
+async fn a_stolen_token_is_bounded_by_the_scope_it_was_stolen_from() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (stolen, _) = server.enrol(
+        "claude-code-extension",
+        TokenScope::read_only(ToolScope::tools([claude_code_id()])),
+    );
+    // The thief connects as a brand-new client and presents the stolen secret.
+    let mut thief = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    assert!(matches!(
+        thief.request(DiVerb::Status, &claude_code_id(), Some(&stolen)).await,
+        DiResponseFrame::Response(_)
+    ));
+    // …and no further. Not another tool, and not a mutation.
+    assert_eq!(
+        expect_denied(thief.request(DiVerb::Status, "codex", Some(&stolen)).await).code,
+        wire::DenyCode::OutOfScope as i32
+    );
+    assert_eq!(
+        expect_denied(thief.request(DiVerb::Remove, &claude_code_id(), Some(&stolen)).await).code,
+        wire::DenyCode::OutOfScope as i32
+    );
+    server.shutdown().await;
+}
+
+/// V13, and the property that makes revocation real rather than advisory:
+/// it lands on a connection that is already open and already authenticated.
+#[tokio::test]
+async fn revocation_kills_an_already_open_connection_mid_session() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, record) = server.enrol("vscode-aasm", TokenScope::full_lifecycle(ToolScope::AllTools));
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    assert!(matches!(
+        client.request(DiVerb::Status, &claude_code_id(), Some(&token)).await,
+        DiResponseFrame::Response(_)
+    ));
+
+    assert!(server.tokens().revoke(&record.token_id));
+
+    // Same connection, same negotiated version, same token — now refused.
+    let denied = expect_denied(client.request(DiVerb::Status, &claude_code_id(), Some(&token)).await);
+    assert_eq!(
+        denied.code,
+        wire::DenyCode::Unauthenticated as i32,
+        "a revoked token must resolve to nothing, exactly like one that never existed"
+    );
+    server.shutdown().await;
+}
+
+/// Rotation never opens a window with no valid token, and revoking the old one
+/// afterwards closes it completely — over the wire, not just in the store.
+#[tokio::test]
+async fn rotation_overlaps_and_then_the_old_token_dies() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (old, old_record) = server.enrol("vscode-aasm", TokenScope::full_lifecycle(ToolScope::AllTools));
+    let (new, _) = server
+        .tokens()
+        .rotate(&old_record.token_id, aa_core::integration::now_unix_secs(), 3600)
+        .expect("rotate");
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    for token in [&old, &new] {
+        assert!(
+            matches!(
+                client.request(DiVerb::Status, &claude_code_id(), Some(token)).await,
+                DiResponseFrame::Response(_)
+            ),
+            "both tokens must work during the overlap"
+        );
+    }
+
+    server.tokens().revoke(&old_record.token_id);
+    assert_eq!(
+        expect_denied(client.request(DiVerb::Status, &claude_code_id(), Some(&old)).await).code,
+        wire::DenyCode::Unauthenticated as i32
+    );
+    assert!(matches!(
+        client.request(DiVerb::Status, &claude_code_id(), Some(&new)).await,
+        DiResponseFrame::Response(_)
+    ));
+    server.shutdown().await;
+}
+
+// ── Replay ───────────────────────────────────────────────────────────────────
+
+/// V13. A captured request replayed verbatim re-invokes only a verb the token
+/// was already scoped for, and lifecycle verbs are idempotent by AAASM-5278's
+/// contract — so replay produces no state the legitimate client could not have
+/// produced itself.
+#[tokio::test]
+async fn a_replayed_request_reaches_nothing_new() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, _) = server.enrol(
+        "vscode-aasm",
+        TokenScope::full_lifecycle(ToolScope::tools([claude_code_id()])),
+    );
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    // Capture a legitimate apply, byte for byte.
+    let captured = build_request(DiVerb::Apply, &claude_code_id(), Some(&token), 1);
+    let first = expect_response(client.send_raw_request(captured.clone()).await);
+    let first_apply = first.apply.expect("apply view");
+
+    // Replay it five times, including on a fresh connection — the shape an
+    // attacker who captured the frame would actually use.
+    let mut replayer = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+    for _ in 0..5 {
+        let replayed = expect_response(replayer.send_raw_request(captured.clone()).await);
+        assert_eq!(replayed.apply.expect("apply view"), first_apply, "replay diverged");
+    }
+
+    // And the replay dies with the token: the captured frame carries the
+    // secret, so revoking it revokes the replay too.
+    let record = server.tokens().live_records(aa_core::integration::now_unix_secs())[0].clone();
+    server.tokens().revoke(&record.token_id);
+    assert_eq!(
+        expect_denied(replayer.send_raw_request(captured.clone()).await).code,
+        wire::DenyCode::Unauthenticated as i32
+    );
+    server.shutdown().await;
+}
+
+/// A replayed request cannot be re-pointed at another tool: the token is
+/// checked against the tool id in the frame, so editing the frame invalidates
+/// the authorization it was replayed for.
+#[tokio::test]
+async fn a_replayed_request_cannot_be_re_pointed_at_another_tool() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, _) = server.enrol(
+        "vscode-aasm",
+        TokenScope::full_lifecycle(ToolScope::tools([claude_code_id()])),
+    );
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    let mut tampered = build_request(DiVerb::Apply, &claude_code_id(), Some(&token), 1);
+    tampered.tool_id = "codex".to_string();
+    assert_eq!(
+        expect_denied(client.send_raw_request(tampered).await).code,
+        wire::DenyCode::OutOfScope as i32
+    );
+    server.shutdown().await;
+}
+
+// ── Version downgrade ────────────────────────────────────────────────────────
+
+/// V6. A client below the floor gets a deterministic `Incompatible` with
+/// remediation — never a silent downgrade into older behaviour.
+#[tokio::test]
+async fn a_below_floor_client_gets_incompatible_with_remediation_not_a_downgrade() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let mut raw = server.connect_raw().await;
+    raw.send_hello(hello_offering(&[0])).await;
+    match raw.read().await {
+        DiResponseFrame::Incompatible(incompatible) => {
+            assert!(incompatible.reason.contains("below the supported floor"));
+            assert!(!incompatible.remediation.is_empty());
+        }
+        other => panic!("expected Incompatible, got {other:?}"),
+    }
+    // The connection is closed rather than left in a half-negotiated state.
+    assert!(raw.try_read().await.is_none());
+    server.shutdown().await;
+}
+
+/// V6. The negotiated version is fixed for the connection's lifetime, so a
+/// mid-connection renegotiation — the way a downgrade would be staged — is a
+/// protocol violation.
+#[tokio::test]
+async fn a_mid_connection_downgrade_attempt_is_refused() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, _) = server.enrol("vscode-aasm", TokenScope::full_lifecycle(ToolScope::AllTools));
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    // Negotiated at the ceiling; now try to talk the server down to v1.
+    client.send_hello(hello_offering(&[1])).await;
+    let denied = expect_denied(client.read().await);
+    assert_eq!(denied.code, wire::DenyCode::ProtocolViolation as i32);
+    assert!(denied.message.contains("fixed for the life of a connection"));
+    assert!(server.audit().events().iter().any(
+        |e| matches!(&e.kind, DevIntAuditKind::ProtocolFailure { reason } if *reason == "renegotiation_attempted")
+    ));
+
+    // …and the connection still speaks the version it originally agreed, so
+    // the refused downgrade did not leave it in a lesser state either.
+    assert!(matches!(
+        client
+            .request(DiVerb::ScopedEvents, &claude_code_id(), Some(&token))
+            .await,
+        DiResponseFrame::Response(_)
+    ));
+    server.shutdown().await;
+}
+
+/// V6. A client that legitimately negotiates the older version cannot reach a
+/// verb that version does not have, even with a token scoped for it.
+#[tokio::test]
+async fn a_degraded_connection_cannot_reach_a_verb_its_version_lacks() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, _) = server.enrol("old-extension", TokenScope::full_lifecycle(ToolScope::AllTools));
+    let mut client = connect_and_negotiate(&server, hello_offering(&[1])).await;
+
+    for verb in [DiVerb::ScopedEvents, DiVerb::ApprovalRelay] {
+        let denied = expect_denied(client.request(verb, &claude_code_id(), Some(&token)).await);
+        assert_eq!(
+            denied.code,
+            wire::DenyCode::UnavailableAtVersion as i32,
+            "{verb} leaked into a v1 connection"
+        );
+        assert!(denied.remediation.contains("v2"));
+    }
+    // The verbs v1 does have still work, so this is a version gate and not a
+    // broken connection.
+    assert!(matches!(
+        client.request(DiVerb::Status, &claude_code_id(), Some(&token)).await,
+        DiResponseFrame::Response(_)
+    ));
+    server.shutdown().await;
+}
+
+/// An unauthenticated caller learns nothing about the verbs that exist at a
+/// version it did not negotiate: auth is checked first, so the answer is
+/// `UNAUTHENTICATED`, not `UNAVAILABLE_AT_VERSION`.
+#[tokio::test]
+async fn version_gating_is_not_an_oracle_for_unauthenticated_callers() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let mut client = connect_and_negotiate(&server, hello_offering(&[1])).await;
+    let denied = expect_denied(client.request(DiVerb::ScopedEvents, &claude_code_id(), None).await);
+    assert_eq!(denied.code, wire::DenyCode::Unauthenticated as i32);
+    server.shutdown().await;
+}
+
+// ── Data minimisation, end to end ────────────────────────────────────────────
+
+/// V7, over the socket. The fake lifecycle returns a plan whose environment
+/// injection carries a live-looking secret; nothing that crosses the wire, and
+/// nothing the audit trail records, contains it.
+#[tokio::test]
+async fn nothing_that_leaves_the_boundary_carries_a_secret_or_a_token() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let (token, _) = server.enrol("vscode-aasm", TokenScope::full_lifecycle(ToolScope::AllTools));
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+
+    for verb in DiVerb::ALL {
+        let frame = client.request(verb, &claude_code_id(), Some(&token)).await;
+        let rendered = format!("{frame:?}");
+        assert!(!rendered.contains(LEAK_SENTINEL), "{verb} leaked a step value");
+        assert!(!rendered.contains(token.expose()), "{verb} echoed the capability token");
+    }
+
+    // The audit trail is the other thing that leaves the request: it must name
+    // the enrolment, never the secret, and never protected content.
+    let audited = format!("{:?}", server.audit().events());
+    assert!(
+        !audited.contains(token.expose()),
+        "an audit event carried the token value"
+    );
+    assert!(
+        !audited.contains(LEAK_SENTINEL),
+        "an audit event carried protected content"
+    );
+    server.shutdown().await;
+}
+
+/// Denials are the other response path, and the one most likely to be written
+/// carelessly. None of them echoes what was presented.
+#[tokio::test]
+async fn a_denial_never_echoes_what_was_presented() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let mut client = connect_and_negotiate(&server, hello_offering(&[DI_API_MAX_SUPPORTED])).await;
+    let stranger = super::token::CapabilityToken::generate();
+
+    let denied = expect_denied(client.request(DiVerb::Status, &claude_code_id(), Some(&stranger)).await);
+    let rendered = format!("{denied:?}");
+    assert!(!rendered.contains(stranger.expose()));
+    // Nor does it hint at how close the token came to resolving.
+    for hint in ["prefix", "matched", "expired at", "similar"] {
+        assert!(!rendered.contains(hint), "the denial hints at {hint}");
+    }
+    server.shutdown().await;
+}
+
+// ── Transport ────────────────────────────────────────────────────────────────
+
+/// V9. The socket the server actually bound is `0600` inside a `0700`
+/// directory, asserted by reading the filesystem back while the server is live.
+#[tokio::test]
+async fn the_live_socket_is_owner_only_in_an_owner_only_directory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let path = server.socket_path().to_path_buf();
+    let socket_mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    let dir_mode = std::fs::metadata(path.parent().unwrap()).unwrap().permissions().mode() & 0o777;
+    assert_eq!(socket_mode, 0o600, "the live DI-API socket is not owner-only");
+    assert_eq!(dir_mode, 0o700, "the live DI-API socket directory is not owner-only");
+    server.shutdown().await;
+}
+
+/// The DI-API and SDK sockets are different files, which is what makes agent
+/// traffic unreachable from a DI client by construction (§5.1).
+#[tokio::test]
+async fn the_di_socket_is_not_the_sdk_socket() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let di_path = server.socket_path().to_string_lossy().to_string();
+    assert!(di_path.ends_with("devint.sock"));
+    assert!(
+        !di_path.contains("aa-runtime-"),
+        "the DI-API must not squat the SDK socket"
+    );
+    server.shutdown().await;
+}
+
+/// An oversized length prefix is refused without allocating for it, and the
+/// connection ends rather than resynchronising into the attacker's stream.
+#[tokio::test]
+async fn an_oversized_frame_ends_the_connection_without_allocating() {
+    use tokio::io::AsyncWriteExt;
+
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let mut stream = tokio::net::UnixStream::connect(server.socket_path())
+        .await
+        .expect("connect");
+
+    let mut hostile = vec![super::codec::TAG_REQUEST];
+    prost::encoding::encode_varint(4 * 1024 * 1024 * 1024, &mut hostile);
+    stream.write_all(&hostile).await.expect("write");
+    stream.flush().await.expect("flush");
+
+    // The server closes; a read returns EOF rather than a frame.
+    let mut buf = [0u8; 1];
+    let read = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        tokio::io::AsyncReadExt::read(&mut stream, &mut buf),
+    )
+    .await;
+    assert!(matches!(read, Ok(Ok(0))), "the connection should have been closed");
+    server.shutdown().await;
+}
+
+/// A peer that never negotiates is dropped rather than held open forever.
+///
+/// Runs on a paused clock so the five-second slow-loris bound is asserted in
+/// milliseconds: tokio auto-advances time whenever every task is parked, which
+/// is exactly the state a silent peer produces.
+#[tokio::test(start_paused = true)]
+async fn a_peer_that_never_negotiates_is_dropped() {
+    let server = TestServer::start(FakeLifecycle::default()).await;
+    let _silent = tokio::net::UnixStream::connect(server.socket_path())
+        .await
+        .expect("connect");
+
+    // The timeout is audited, which is how an operator sees a stalling client.
+    for _ in 0..200 {
+        if server
+            .audit()
+            .events()
+            .iter()
+            .any(|e| matches!(&e.kind, DevIntAuditKind::ProtocolFailure { reason } if *reason == "negotiation_timeout"))
+        {
+            server.shutdown().await;
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("the negotiation timeout was never reached");
+}

--- a/aa-runtime/src/devint/token.rs
+++ b/aa-runtime/src/devint/token.rs
@@ -1,0 +1,626 @@
+//! DI-API capability tokens: issue, resolve, rotate, revoke (ADR 0030 §5.3).
+//!
+//! # Why this is not the AAASM-3922 shape
+//!
+//! The SDK IPC handshake key is derived from the agent id — which *is* the
+//! public socket filename — so any local process that can reach the socket can
+//! recompute it. That signature proves integrity and version-binding, not
+//! possession of a secret (see [`crate::ipc::handshake`]). ADR 0030 forbidden
+//! design 9 names repeating that mistake here.
+//!
+//! A capability token is therefore built the opposite way, and every one of
+//! these properties is load-bearing:
+//!
+//! * **256 bits straight from the OS CSPRNG.** [`CapabilityToken::generate`]
+//!   returns the bytes from `rand::random`; nothing about the token is computed
+//!   from the client name, the tool id, the socket path, the token id or any
+//!   other value a caller could see or guess.
+//! * **Opaque.** The wire carries the hex secret and nothing else — no claims,
+//!   no signature, no structure to parse. There is no information in it.
+//! * **A server-side record, not a self-contained grant.** Verification is a
+//!   *lookup*: [`TokenStore::resolve`] hashes the presented secret and finds
+//!   the record, or denies. A JWT-style credential that verifies offline cannot
+//!   be revoked, and revocation is a hard requirement of this ticket — hence no
+//!   JWT (forbidden design 9 again).
+//! * **Revocation is deleting the record.** Immediate and total, precisely
+//!   because the token was never self-verifying.
+//!
+//! # What the store keeps, and what it does not
+//!
+//! A [`TokenRecord`] holds `{token_id, client_name, issued_at, expires_at,
+//! scope}` and the SHA-256 of the secret. The secret itself is returned once,
+//! at enrolment, and is never stored, logged, echoed in a response or written
+//! to an audit event — the audit trail identifies a token by its `token_id`
+//! (§5.3: "the token *id* and the outcome — never the token value").
+//!
+//! Lookup is by hash, so the comparison that decides admission runs over a
+//! fixed-length digest rather than over attacker-controlled input length.
+//!
+//! # Fail-closed
+//!
+//! Absent, malformed, unknown, expired and out-of-scope all resolve to a
+//! [`TokenDenial`]. There is no fall-through to an implicit grant, no "local
+//! connections are trusted", and no anonymous read-only tier — ADR 0015's rule
+//! transferred: a resolution failure must fail closed and be audit-visible.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use sha2::{Digest, Sha256};
+
+use super::scope::TokenScope;
+use super::verb::DiVerb;
+
+/// Number of random bytes in a capability token: 256 bits (§5.3).
+pub const TOKEN_BYTES: usize = 32;
+
+/// The identifier a token is known by in records, audit events and rotation.
+///
+/// Deliberately **independent** of the secret: it is drawn from the CSPRNG in
+/// its own right, so publishing it in an audit event reveals nothing that helps
+/// anyone recover or narrow the secret.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TokenId(String);
+
+impl TokenId {
+    /// Generate a fresh random token id.
+    pub fn generate() -> Self {
+        TokenId(hex::encode(rand::random::<[u8; 16]>()))
+    }
+
+    /// The id as a string, for audit records and rotation calls.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for TokenId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A freshly issued capability token secret.
+///
+/// Returned exactly once, by [`TokenStore::issue`] and [`TokenStore::rotate`],
+/// for the enrolment step to write to a `0600` file. Its [`std::fmt::Debug`]
+/// impl redacts the value so it cannot reach a log through a `{:?}` on some
+/// enclosing struct.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CapabilityToken {
+    secret_hex: String,
+}
+
+impl CapabilityToken {
+    /// Draw [`TOKEN_BYTES`] from the OS-seeded CSPRNG.
+    ///
+    /// `rand::random` *returns* the bytes rather than filling a zeroed buffer,
+    /// so no constant literal enters the token's data flow — the same pattern
+    /// [`crate::ipc::handshake::generate_nonce`] uses.
+    pub fn generate() -> Self {
+        CapabilityToken {
+            secret_hex: hex::encode(rand::random::<[u8; TOKEN_BYTES]>()),
+        }
+    }
+
+    /// Wrap a secret presented on the wire.
+    pub fn from_wire(secret_hex: impl Into<String>) -> Self {
+        CapabilityToken {
+            secret_hex: secret_hex.into(),
+        }
+    }
+
+    /// The hex secret, for writing to the enrolment file or presenting on the
+    /// wire. Every other code path should use the [`TokenId`].
+    pub fn expose(&self) -> &str {
+        &self.secret_hex
+    }
+
+    /// Whether the presented string is even shaped like a token.
+    ///
+    /// Checked before hashing so a client sending a megabyte of text is
+    /// rejected on shape, and so "malformed" is distinguishable from "unknown"
+    /// in the audit trail without either being distinguishable on the wire.
+    fn is_well_formed(&self) -> bool {
+        self.secret_hex.len() == TOKEN_BYTES * 2 && self.secret_hex.bytes().all(|b| b.is_ascii_hexdigit())
+    }
+
+    /// The lookup key: SHA-256 of the secret's bytes.
+    fn lookup_hash(&self) -> [u8; 32] {
+        Sha256::digest(self.secret_hex.as_bytes()).into()
+    }
+}
+
+impl std::fmt::Debug for CapabilityToken {
+    /// Redacted on purpose: a token that can be `{:?}`-printed will eventually
+    /// be `{:?}`-printed into a log.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("CapabilityToken(<redacted>)")
+    }
+}
+
+/// The server-side record a presented token resolves to.
+///
+/// This is the whole grant. Nothing about it travels on the wire, and nothing
+/// in it is derivable from the secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenRecord {
+    /// Stable identifier for this enrolment, used in audit and rotation.
+    pub token_id: TokenId,
+    /// Who enrolled, for the user-visible "which clients can talk to AASM?"
+    /// list. Display only — never an authentication factor.
+    pub client_name: String,
+    /// When it was issued, seconds since the Unix epoch.
+    pub issued_at_unix_secs: u64,
+    /// Absolute expiry, seconds since the Unix epoch. Not a sliding window: a
+    /// token that is used constantly still dies on schedule.
+    pub expires_at_unix_secs: u64,
+    /// What it may do.
+    pub scope: TokenScope,
+}
+
+impl TokenRecord {
+    /// Whether this record is still within its absolute lifetime at `now`.
+    pub fn is_live(&self, now_unix_secs: u64) -> bool {
+        now_unix_secs < self.expires_at_unix_secs
+    }
+}
+
+/// Why a request was refused at the authentication or authorization layer.
+///
+/// These reasons are for the **audit trail**. The wire deliberately collapses
+/// the first three into one code so a probing client cannot tell them apart
+/// (see `DenyCode` in `proto/devint.proto`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenDenial {
+    /// No token was presented at all.
+    Absent,
+    /// Something was presented, but it is not shaped like a token.
+    Malformed,
+    /// Well-formed, but no record resolves it — including a token that was
+    /// revoked, which is the same thing as never having existed.
+    Unknown,
+    /// A record resolved, and it is past its absolute expiry.
+    Expired {
+        /// Which enrolment expired.
+        token_id: TokenId,
+    },
+    /// A live record resolved, but its scope does not admit this verb on this
+    /// tool.
+    OutOfScope {
+        /// Which enrolment was used.
+        token_id: TokenId,
+        /// What it tried to do.
+        verb: DiVerb,
+    },
+}
+
+impl TokenDenial {
+    /// The enrolment involved, when one was identified. `None` for denials
+    /// where no record was reached, which is exactly when there is no id to
+    /// record.
+    pub fn token_id(&self) -> Option<&TokenId> {
+        match self {
+            TokenDenial::Absent | TokenDenial::Malformed | TokenDenial::Unknown => None,
+            TokenDenial::Expired { token_id } | TokenDenial::OutOfScope { token_id, .. } => Some(token_id),
+        }
+    }
+
+    /// A stable snake_case outcome name for the audit trail.
+    pub const fn outcome(&self) -> &'static str {
+        match self {
+            TokenDenial::Absent => "token_absent",
+            TokenDenial::Malformed => "token_malformed",
+            TokenDenial::Unknown => "token_unknown",
+            TokenDenial::Expired { .. } => "token_expired",
+            TokenDenial::OutOfScope { .. } => "out_of_scope",
+        }
+    }
+}
+
+/// The runtime's enrolment book.
+///
+/// Cheap to clone (`Arc` inside) so the accept loop and each connection share
+/// one book and a revocation takes effect on every live connection at once,
+/// not at the next reconnect.
+#[derive(Debug, Clone, Default)]
+pub struct TokenStore {
+    inner: Arc<RwLock<StoreInner>>,
+}
+
+#[derive(Debug, Default)]
+struct StoreInner {
+    /// SHA-256(secret) → record. Keyed by hash so the store never holds a
+    /// secret it could leak.
+    by_hash: HashMap<[u8; 32], TokenRecord>,
+    /// token_id → SHA-256(secret), so revocation and rotation can find a
+    /// record without the secret.
+    hash_by_id: HashMap<TokenId, [u8; 32]>,
+}
+
+impl TokenStore {
+    /// An empty store. Empty means *nothing is authorized*, which is the right
+    /// starting state: enrolment is an explicit, user-visible step, never an
+    /// implicit grant on first connect.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enrol a client and return its one and only copy of the secret.
+    ///
+    /// The caller writes the returned token to a `0600` file; the store keeps
+    /// only the hash. There is no way to read a secret back out of the store,
+    /// by design.
+    pub fn issue(
+        &self,
+        client_name: impl Into<String>,
+        scope: TokenScope,
+        issued_at_unix_secs: u64,
+        ttl_secs: u64,
+    ) -> (CapabilityToken, TokenRecord) {
+        let token = CapabilityToken::generate();
+        let record = TokenRecord {
+            token_id: TokenId::generate(),
+            client_name: client_name.into(),
+            issued_at_unix_secs,
+            expires_at_unix_secs: issued_at_unix_secs.saturating_add(ttl_secs),
+            scope,
+        };
+        let hash = token.lookup_hash();
+        {
+            let mut inner = self.write();
+            inner.hash_by_id.insert(record.token_id.clone(), hash);
+            inner.by_hash.insert(hash, record.clone());
+        }
+        (token, record)
+    }
+
+    /// Resolve a presented token for `verb` on `tool_id`.
+    ///
+    /// Every failure path returns [`Err`]; there is no variant of this function
+    /// that admits a request without a live, in-scope record.
+    pub fn resolve(
+        &self,
+        presented: Option<&CapabilityToken>,
+        verb: DiVerb,
+        tool_id: &str,
+        now_unix_secs: u64,
+    ) -> Result<TokenRecord, TokenDenial> {
+        let Some(token) = presented else {
+            return Err(TokenDenial::Absent);
+        };
+        if !token.is_well_formed() {
+            return Err(TokenDenial::Malformed);
+        }
+        let record = {
+            let inner = self.read();
+            inner.by_hash.get(&token.lookup_hash()).cloned()
+        };
+        // A revoked token lands here identically to one that never existed:
+        // revocation removed the record, so there is nothing left to resolve.
+        let record = record.ok_or(TokenDenial::Unknown)?;
+        if !record.is_live(now_unix_secs) {
+            return Err(TokenDenial::Expired {
+                token_id: record.token_id,
+            });
+        }
+        if !record.scope.permits(verb, tool_id) {
+            return Err(TokenDenial::OutOfScope {
+                token_id: record.token_id,
+                verb,
+            });
+        }
+        Ok(record)
+    }
+
+    /// Issue a replacement carrying the same client name and scope.
+    ///
+    /// Rotation is deliberately **issue-new-then-revoke-old**: the old token
+    /// keeps working until the caller revokes it, so a rotation never opens a
+    /// window in which no valid token exists. Returns `None` when `token_id`
+    /// names no enrolment.
+    pub fn rotate(
+        &self,
+        token_id: &TokenId,
+        issued_at_unix_secs: u64,
+        ttl_secs: u64,
+    ) -> Option<(CapabilityToken, TokenRecord)> {
+        let existing = self.record(token_id)?;
+        Some(self.issue(existing.client_name, existing.scope, issued_at_unix_secs, ttl_secs))
+    }
+
+    /// Delete an enrolment. Returns whether one was there.
+    ///
+    /// Immediate and total: the next `resolve` of that secret finds nothing,
+    /// including on a connection that is already open.
+    pub fn revoke(&self, token_id: &TokenId) -> bool {
+        let mut inner = self.write();
+        match inner.hash_by_id.remove(token_id) {
+            Some(hash) => inner.by_hash.remove(&hash).is_some(),
+            None => false,
+        }
+    }
+
+    /// Look up an enrolment's record by id, for display and rotation.
+    pub fn record(&self, token_id: &TokenId) -> Option<TokenRecord> {
+        let inner = self.read();
+        let hash = inner.hash_by_id.get(token_id)?;
+        inner.by_hash.get(hash).cloned()
+    }
+
+    /// Every live enrolment at `now`, for the user-visible "which clients can
+    /// talk to AASM?" list. Records only — never secrets.
+    pub fn live_records(&self, now_unix_secs: u64) -> Vec<TokenRecord> {
+        let inner = self.read();
+        let mut records: Vec<TokenRecord> = inner
+            .by_hash
+            .values()
+            .filter(|r| r.is_live(now_unix_secs))
+            .cloned()
+            .collect();
+        records.sort_by(|a, b| a.token_id.cmp(&b.token_id));
+        records
+    }
+
+    /// Drop every record that has passed its expiry, returning how many went.
+    ///
+    /// Housekeeping only: an expired record already denies, so this changes no
+    /// admission decision.
+    pub fn purge_expired(&self, now_unix_secs: u64) -> usize {
+        let mut inner = self.write();
+        let dead: Vec<TokenId> = inner
+            .by_hash
+            .values()
+            .filter(|r| !r.is_live(now_unix_secs))
+            .map(|r| r.token_id.clone())
+            .collect();
+        for id in &dead {
+            if let Some(hash) = inner.hash_by_id.remove(id) {
+                inner.by_hash.remove(&hash);
+            }
+        }
+        dead.len()
+    }
+
+    fn read(&self) -> std::sync::RwLockReadGuard<'_, StoreInner> {
+        // A poisoned lock means a panic happened while a write was in flight.
+        // Recovering the guard is correct here: the map is a plain
+        // `HashMap` with no cross-entry invariant to have been left broken,
+        // and refusing to read would take the DI-API down instead of denying
+        // one request.
+        self.inner.read().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn write(&self) -> std::sync::RwLockWriteGuard<'_, StoreInner> {
+        self.inner.write().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::devint::scope::ToolScope;
+
+    const NOW: u64 = 1_700_000_000;
+    const HOUR: u64 = 3600;
+
+    fn store_with_claude_token() -> (TokenStore, CapabilityToken, TokenRecord) {
+        let store = TokenStore::new();
+        let (token, record) = store.issue(
+            "vscode-aasm",
+            TokenScope::full_lifecycle(ToolScope::tools(["claude-code"])),
+            NOW,
+            HOUR,
+        );
+        (store, token, record)
+    }
+
+    #[test]
+    fn a_generated_token_is_256_bits_of_hex() {
+        let token = CapabilityToken::generate();
+        assert_eq!(token.expose().len(), TOKEN_BYTES * 2);
+        assert!(token.expose().bytes().all(|b| b.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn two_generated_tokens_differ() {
+        // A weak smoke test for "actually random", not a statistical one: what
+        // it really rules out is a constant or a counter.
+        let a = CapabilityToken::generate();
+        let b = CapabilityToken::generate();
+        assert_ne!(a.expose(), b.expose());
+    }
+
+    #[test]
+    fn a_token_is_not_derived_from_any_public_value() {
+        // AAASM-3922's mistake was a key recomputable from the socket filename.
+        // Two enrolments with identical client name, scope, and issue time must
+        // still produce unrelated secrets — if the secret were a function of
+        // those inputs, these would collide.
+        let store = TokenStore::new();
+        let scope = TokenScope::read_only(ToolScope::tools(["claude-code"]));
+        let (a, _) = store.issue("vscode-aasm", scope.clone(), NOW, HOUR);
+        let (b, _) = store.issue("vscode-aasm", scope, NOW, HOUR);
+        assert_ne!(a.expose(), b.expose());
+    }
+
+    #[test]
+    fn debug_never_prints_the_secret() {
+        let token = CapabilityToken::generate();
+        let rendered = format!("{token:?}");
+        assert!(!rendered.contains(token.expose()));
+        assert!(rendered.contains("redacted"));
+    }
+
+    #[test]
+    fn a_live_in_scope_token_resolves() {
+        let (store, token, record) = store_with_claude_token();
+        let resolved = store
+            .resolve(Some(&token), DiVerb::Apply, "claude-code", NOW)
+            .expect("live token");
+        assert_eq!(resolved.token_id, record.token_id);
+    }
+
+    #[test]
+    fn an_absent_token_is_denied() {
+        let (store, _, _) = store_with_claude_token();
+        assert_eq!(
+            store.resolve(None, DiVerb::Status, "claude-code", NOW),
+            Err(TokenDenial::Absent)
+        );
+    }
+
+    #[test]
+    fn a_malformed_token_is_denied() {
+        let (store, _, _) = store_with_claude_token();
+        let junk = CapabilityToken::from_wire("not-a-token");
+        assert_eq!(
+            store.resolve(Some(&junk), DiVerb::Status, "claude-code", NOW),
+            Err(TokenDenial::Malformed)
+        );
+    }
+
+    #[test]
+    fn an_unknown_but_well_formed_token_is_denied() {
+        let (store, _, _) = store_with_claude_token();
+        let stranger = CapabilityToken::generate();
+        assert_eq!(
+            store.resolve(Some(&stranger), DiVerb::Status, "claude-code", NOW),
+            Err(TokenDenial::Unknown)
+        );
+    }
+
+    #[test]
+    fn an_expired_token_is_denied_and_names_its_enrolment() {
+        let (store, token, record) = store_with_claude_token();
+        let denial = store
+            .resolve(Some(&token), DiVerb::Status, "claude-code", NOW + HOUR + 1)
+            .expect_err("expired");
+        assert_eq!(
+            denial,
+            TokenDenial::Expired {
+                token_id: record.token_id
+            }
+        );
+    }
+
+    #[test]
+    fn expiry_is_absolute_not_sliding() {
+        let (store, token, _) = store_with_claude_token();
+        // Use it repeatedly right up to the boundary; it must still die on time.
+        for t in [NOW, NOW + 1, NOW + HOUR - 1] {
+            assert!(store.resolve(Some(&token), DiVerb::Status, "claude-code", t).is_ok());
+        }
+        assert!(store
+            .resolve(Some(&token), DiVerb::Status, "claude-code", NOW + HOUR)
+            .is_err());
+    }
+
+    #[test]
+    fn a_cross_tool_request_is_denied_for_every_tool_scoped_verb() {
+        let (store, token, record) = store_with_claude_token();
+        for verb in DiVerb::ALL.into_iter().filter(|v| v.is_tool_scoped()) {
+            let denial = store
+                .resolve(Some(&token), verb, "codex", NOW)
+                .expect_err("cross-tool must be denied");
+            assert_eq!(
+                denial,
+                TokenDenial::OutOfScope {
+                    token_id: record.token_id.clone(),
+                    verb
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn revocation_takes_effect_immediately() {
+        let (store, token, record) = store_with_claude_token();
+        assert!(store.resolve(Some(&token), DiVerb::Status, "claude-code", NOW).is_ok());
+        assert!(store.revoke(&record.token_id));
+        assert_eq!(
+            store.resolve(Some(&token), DiVerb::Status, "claude-code", NOW),
+            Err(TokenDenial::Unknown)
+        );
+    }
+
+    #[test]
+    fn revoking_twice_reports_the_second_as_absent() {
+        let (store, _, record) = store_with_claude_token();
+        assert!(store.revoke(&record.token_id));
+        assert!(!store.revoke(&record.token_id));
+    }
+
+    #[test]
+    fn rotation_leaves_no_window_without_a_valid_token() {
+        let (store, old, old_record) = store_with_claude_token();
+        let (new, new_record) = store.rotate(&old_record.token_id, NOW + 10, HOUR).expect("rotated");
+
+        // Both work between issue and revoke — that is the point of the order.
+        assert!(store
+            .resolve(Some(&old), DiVerb::Apply, "claude-code", NOW + 10)
+            .is_ok());
+        assert!(store
+            .resolve(Some(&new), DiVerb::Apply, "claude-code", NOW + 10)
+            .is_ok());
+        assert_ne!(old.expose(), new.expose());
+        assert_ne!(old_record.token_id, new_record.token_id);
+        assert_eq!(new_record.client_name, old_record.client_name);
+
+        store.revoke(&old_record.token_id);
+        assert!(store
+            .resolve(Some(&old), DiVerb::Apply, "claude-code", NOW + 10)
+            .is_err());
+        assert!(store
+            .resolve(Some(&new), DiVerb::Apply, "claude-code", NOW + 10)
+            .is_ok());
+    }
+
+    #[test]
+    fn rotating_an_unknown_enrolment_yields_nothing() {
+        let (store, _, _) = store_with_claude_token();
+        assert!(store.rotate(&TokenId::generate(), NOW, HOUR).is_none());
+    }
+
+    #[test]
+    fn an_empty_store_authorizes_nothing() {
+        let store = TokenStore::new();
+        let token = CapabilityToken::generate();
+        for verb in DiVerb::ALL {
+            assert!(store.resolve(Some(&token), verb, "claude-code", NOW).is_err());
+        }
+    }
+
+    #[test]
+    fn live_records_hide_expired_ones_and_carry_no_secret() {
+        let (store, token, record) = store_with_claude_token();
+        let live = store.live_records(NOW);
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].token_id, record.token_id);
+        let rendered = format!("{live:?}");
+        assert!(!rendered.contains(token.expose()));
+        assert!(store.live_records(NOW + HOUR).is_empty());
+    }
+
+    #[test]
+    fn purge_removes_only_expired_records() {
+        let store = TokenStore::new();
+        let scope = TokenScope::read_only(ToolScope::AllTools);
+        let (_, short) = store.issue("a", scope.clone(), NOW, 10);
+        let (_, long) = store.issue("b", scope, NOW, HOUR);
+        assert_eq!(store.purge_expired(NOW + 20), 1);
+        assert!(store.record(&short.token_id).is_none());
+        assert!(store.record(&long.token_id).is_some());
+    }
+
+    #[test]
+    fn a_token_id_is_not_derivable_from_the_secret() {
+        // Records identify enrolments in audit events. If the id were a
+        // digest of the secret, publishing it would publish a verifier for the
+        // secret. Assert the id is not any obvious function of it.
+        let (_, token, record) = store_with_claude_token();
+        let digest = hex::encode(Sha256::digest(token.expose().as_bytes()));
+        assert!(!digest.contains(record.token_id.as_str()));
+        assert!(!token.expose().contains(record.token_id.as_str()));
+    }
+}

--- a/aa-runtime/src/devint/verb.rs
+++ b/aa-runtime/src/devint/verb.rs
@@ -1,0 +1,266 @@
+//! The closed verb space of the Developer Integration API (ADR 0030 §5.6.1).
+//!
+//! # Why this is an enum and not a string
+//!
+//! The single most important structural property of the DI-API is that a
+//! compromised thin client **cannot request an operation that does not exist**.
+//! Every request names its operation through [`DiVerb`], which is decoded from
+//! the wire by [`DiVerb::from_wire`]; an unrecognised discriminant is rejected
+//! before any handler runs. There is no method string, no resource path, no
+//! filter or predicate passthrough, and no opaque forwarded envelope — so there
+//! is no crafting of a request that reaches something else.
+//!
+//! In particular there is **no policy-decision verb and no approval-*decision*
+//! verb**. Agent decisions travel SDK → `aa-sdk-client` → runtime/gateway
+//! (ADR 0004), on a different socket with a different verb space. Adding a
+//! `check`-like verb here would reopen ADR 0004 *and* ADR 0030 (forbidden
+//! design 6), so [`DiVerb::ALL`] is pinned by a unit test against the ADR's
+//! list: widening the boundary fails the build instead of passing review.
+//!
+//! [`DiVerb::ApprovalRelay`] is the one verb that touches approvals, and it
+//! relays a *human's* input to the decision authority (ADR 0030 matrix row 12).
+//! It cannot return, influence or shortcut a decision — [`DiVerb::decides_policy`]
+//! is `false` for every variant, and that is asserted exhaustively.
+
+use aa_proto::assembly::devint::v1 as wire;
+
+/// Every operation the DI-API will ever serve at this major version.
+///
+/// Deliberately **not** `#[non_exhaustive]`: exhaustive matching by every
+/// consumer is the mechanism that makes adding a verb a visible, reviewable
+/// change rather than a silent one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiVerb {
+    /// Enumerate the tools the linked adapters can see, and what each can do.
+    ListTools,
+    /// Author a reviewable dry run. Mutates nothing.
+    Plan,
+    /// Execute a previously authored plan.
+    Apply,
+    /// Read the derived protection state and the evidence behind it.
+    Status,
+    /// Run the protection test and adjudicate it server-side.
+    Verify,
+    /// Restore AASM-owned keys that drifted.
+    Repair,
+    /// Author and execute the reversal.
+    Remove,
+    /// Read an integration-scoped, already-redacted event projection.
+    ScopedEvents,
+    /// Relay a human's approval input to the core, which decides.
+    ApprovalRelay,
+}
+
+impl DiVerb {
+    /// Every variant, in the order ADR 0030 §5.6.1 lists them.
+    pub const ALL: [DiVerb; 9] = [
+        DiVerb::ListTools,
+        DiVerb::Plan,
+        DiVerb::Apply,
+        DiVerb::Status,
+        DiVerb::Verify,
+        DiVerb::Repair,
+        DiVerb::Remove,
+        DiVerb::ScopedEvents,
+        DiVerb::ApprovalRelay,
+    ];
+
+    /// The stable snake_case name used in scopes, audit events and the
+    /// `unavailable_verbs` list of a degraded `HelloAck`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            DiVerb::ListTools => "list_tools",
+            DiVerb::Plan => "plan",
+            DiVerb::Apply => "apply",
+            DiVerb::Status => "status",
+            DiVerb::Verify => "verify",
+            DiVerb::Repair => "repair",
+            DiVerb::Remove => "remove",
+            DiVerb::ScopedEvents => "scoped_events",
+            DiVerb::ApprovalRelay => "approval_relay",
+        }
+    }
+
+    /// Parse a scope entry or configuration string back into a verb.
+    ///
+    /// Returns `None` for anything outside the closed set, so an enrolment
+    /// record naming a verb that does not exist cannot silently grant one that
+    /// does.
+    pub fn parse(name: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|v| v.as_str() == name)
+    }
+
+    /// Decode the wire discriminant.
+    ///
+    /// `VERB_UNSPECIFIED` and any unknown discriminant map to `None` — an
+    /// absent verb is never defaulted into a real one.
+    pub fn from_wire(value: i32) -> Option<Self> {
+        match wire::Verb::try_from(value).ok()? {
+            wire::Verb::Unspecified => None,
+            wire::Verb::ListTools => Some(DiVerb::ListTools),
+            wire::Verb::Plan => Some(DiVerb::Plan),
+            wire::Verb::Apply => Some(DiVerb::Apply),
+            wire::Verb::Status => Some(DiVerb::Status),
+            wire::Verb::Verify => Some(DiVerb::Verify),
+            wire::Verb::Repair => Some(DiVerb::Repair),
+            wire::Verb::Remove => Some(DiVerb::Remove),
+            wire::Verb::ScopedEvents => Some(DiVerb::ScopedEvents),
+            wire::Verb::ApprovalRelay => Some(DiVerb::ApprovalRelay),
+        }
+    }
+
+    /// The wire discriminant.
+    pub const fn to_wire(self) -> wire::Verb {
+        match self {
+            DiVerb::ListTools => wire::Verb::ListTools,
+            DiVerb::Plan => wire::Verb::Plan,
+            DiVerb::Apply => wire::Verb::Apply,
+            DiVerb::Status => wire::Verb::Status,
+            DiVerb::Verify => wire::Verb::Verify,
+            DiVerb::Repair => wire::Verb::Repair,
+            DiVerb::Remove => wire::Verb::Remove,
+            DiVerb::ScopedEvents => wire::Verb::ScopedEvents,
+            DiVerb::ApprovalRelay => wire::Verb::ApprovalRelay,
+        }
+    }
+
+    /// Whether this verb mutates integration state, and therefore must be
+    /// audited as a lifecycle mutation.
+    pub const fn is_mutation(self) -> bool {
+        match self {
+            DiVerb::Apply | DiVerb::Repair | DiVerb::Remove => true,
+            // `Verify` runs a protection test: it exercises probe traffic and
+            // records evidence, but it does not change the integration.
+            DiVerb::ListTools
+            | DiVerb::Plan
+            | DiVerb::Status
+            | DiVerb::Verify
+            | DiVerb::ScopedEvents
+            | DiVerb::ApprovalRelay => false,
+        }
+    }
+
+    /// Whether the verb names a single tool. Only [`DiVerb::ListTools`] does
+    /// not, which is why it is the only verb a tool-scoped token may invoke
+    /// without a tool-scope check.
+    pub const fn is_tool_scoped(self) -> bool {
+        !matches!(self, DiVerb::ListTools)
+    }
+
+    /// Whether this verb obtains, shortcuts or influences a policy decision.
+    ///
+    /// Constantly `false`, and asserted exhaustively by a unit test. It exists
+    /// so that a future variant must be classified explicitly — a new verb that
+    /// answers "may this agent do X?" would have to return `true` here and fail
+    /// the test, rather than slipping in as one more lifecycle call.
+    pub const fn decides_policy(self) -> bool {
+        match self {
+            DiVerb::ListTools
+            | DiVerb::Plan
+            | DiVerb::Apply
+            | DiVerb::Status
+            | DiVerb::Verify
+            | DiVerb::Repair
+            | DiVerb::Remove
+            | DiVerb::ScopedEvents
+            // Relays a human's input *to* the authority; the authority answers.
+            | DiVerb::ApprovalRelay => false,
+        }
+    }
+}
+
+impl std::fmt::Display for DiVerb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// ADR 0030 §1.2 / §5.6.1, transcribed. If this list and `DiVerb::ALL`
+    /// disagree, either the ADR moved or someone widened the boundary; both
+    /// require a decision, not a green build.
+    const ADR_0030_VERB_SPACE: [&str; 9] = [
+        "list_tools",
+        "plan",
+        "apply",
+        "status",
+        "verify",
+        "repair",
+        "remove",
+        "scoped_events",
+        "approval_relay",
+    ];
+
+    #[test]
+    fn verb_space_matches_the_adr_closed_list() {
+        let actual: Vec<&str> = DiVerb::ALL.iter().map(|v| v.as_str()).collect();
+        assert_eq!(actual, ADR_0030_VERB_SPACE.to_vec());
+    }
+
+    #[test]
+    fn no_verb_decides_policy() {
+        for verb in DiVerb::ALL {
+            assert!(!verb.decides_policy(), "{verb} must not carry a policy decision");
+        }
+    }
+
+    #[test]
+    fn no_verb_is_named_like_a_policy_check() {
+        // A cheap tripwire for the shape of mistake ADR 0030 forbids: a verb
+        // called `check`, `evaluate`, `decide`, `allow` or `deny` would be a
+        // second route to a decision even if its handler started out benign.
+        for verb in DiVerb::ALL {
+            let name = verb.as_str();
+            for forbidden in ["check", "evaluate", "decide", "allow", "deny", "authorize"] {
+                assert!(
+                    !name.contains(forbidden),
+                    "verb {name} looks like a policy-decision verb (contains {forbidden})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wire_round_trips_for_every_verb() {
+        for verb in DiVerb::ALL {
+            assert_eq!(DiVerb::from_wire(verb.to_wire() as i32), Some(verb));
+        }
+    }
+
+    #[test]
+    fn unspecified_and_unknown_wire_values_are_not_verbs() {
+        assert_eq!(DiVerb::from_wire(0), None);
+        assert_eq!(DiVerb::from_wire(9999), None);
+        assert_eq!(DiVerb::from_wire(-1), None);
+    }
+
+    #[test]
+    fn parse_rejects_names_outside_the_closed_set() {
+        assert_eq!(DiVerb::parse("plan"), Some(DiVerb::Plan));
+        assert_eq!(DiVerb::parse("check_action"), None);
+        assert_eq!(DiVerb::parse(""), None);
+    }
+
+    #[test]
+    fn only_lifecycle_mutations_are_flagged_as_mutations() {
+        let mutations: Vec<&str> = DiVerb::ALL
+            .iter()
+            .filter(|v| v.is_mutation())
+            .map(|v| v.as_str())
+            .collect();
+        assert_eq!(mutations, vec!["apply", "repair", "remove"]);
+    }
+
+    #[test]
+    fn list_tools_is_the_only_verb_that_names_no_tool() {
+        let unscoped: Vec<&str> = DiVerb::ALL
+            .iter()
+            .filter(|v| !v.is_tool_scoped())
+            .map(|v| v.as_str())
+            .collect();
+        assert_eq!(unscoped, vec!["list_tools"]);
+    }
+}

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -9,6 +9,7 @@ pub mod approval_sink;
 pub mod audit_publisher;
 pub mod config;
 pub mod correlation;
+pub mod devint;
 #[cfg(target_os = "linux")]
 pub mod ebpf_bridge;
 pub mod ebpf_control;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -96,6 +96,7 @@
 # Developer Integrations
 
 - [Product Capability Brief](devtools/product-brief.md)
+- [Developer Integration API](devtools/developer-integration-api.md)
 
 # Protocol
 

--- a/docs/src/devtools/developer-integration-api.md
+++ b/docs/src/devtools/developer-integration-api.md
@@ -1,0 +1,266 @@
+# Developer Integration API (DI-API)
+
+The DI-API is the **only** channel by which a local, untrusted client — a
+VS Code extension, a JetBrains plugin, an installer, or the `aasm` CLI — asks
+the AASM runtime to install, inspect, verify, repair or remove a developer-tool
+integration.
+
+It is a **lifecycle and UX surface**. It carries no policy decisions and no
+agent-action traffic. An agent that wants an allow/deny still goes
+SDK → `aa-sdk-client` → runtime/gateway, on a different socket with a different
+verb space ([ADR 0004](../adr/0004-governance-enforcement-flow.md)). The design
+is fixed by
+[ADR 0030 Decision 5](../adr/0030-developer-integration-boundaries-and-trust-model.md);
+this page is the operational reference for people building against it.
+
+> Implemented in `aa-runtime/src/devint/`. Wire schema:
+> `proto/devint.proto` (`assembly.devint.v1`). Reference client:
+> `aa-runtime/src/devint/client.rs`.
+
+## Transport and discovery
+
+| | |
+| --- | --- |
+| Transport | Unix domain socket (named pipe on Windows, not yet implemented) |
+| Path | `~/.aa/run/devint.sock` |
+| Override | `AA_DEVINT_SOCKET` |
+| Directory mode | `0700` — created and re-asserted on every bind |
+| Socket mode | `0600` — created under a tightened `umask`, then re-asserted |
+| Framing | `[1-byte tag][prost varint length][prost payload]` |
+
+**Loopback TCP is not offered and will not be.** A TCP port is reachable by
+every local user and by any browser on the machine, the kernel supplies no peer
+identity for it, and it adds CSRF and DNS-rebinding surface. Both permission
+bits above are load-bearing: a deployment that relocates the socket via
+`AA_DEVINT_SOCKET` **must** preserve them, or the OS layer of the two-layer
+authentication is gone and only the token remains.
+
+The DI-API socket is deliberately **separate** from the SDK fast-path socket.
+That is a security property, not tidiness: a DI client never holds a file
+descriptor onto agent-action traffic, so that traffic is unreachable to it by
+construction rather than by an authorization rule someone has to remember.
+
+### Discovery
+
+A client resolves the path from `AA_DEVINT_SOCKET`, else the convention above.
+**An absent socket means the runtime is not running** — show a bootstrap prompt.
+It is not a transient condition to retry in a loop, and a client must never
+synthesise "healthy" from a successful `connect()`.
+
+## Authentication — two layers
+
+### Layer 1: the operating system
+
+`0700` directory, `0600` socket, and a peer-credential check: the connecting
+process's UID must equal the runtime's. A mismatched or unreadable peer
+credential is dropped before any frame is read.
+
+### Layer 2: the capability token
+
+OS identity says "the developer's UID". It cannot tell the VS Code extension
+apart from a trojaned `npm postinstall` script running as the same user. The
+capability token draws that distinction.
+
+| Property | Value |
+| --- | --- |
+| Size | 256 bits from the OS CSPRNG |
+| Form | opaque lowercase hex, no structure, **not a JWT** |
+| Derivation | none — not from the client name, tool id, socket path or token id |
+| Storage | server-side record `{token_id, client_name, issued_at, expires_at, scope}` plus SHA-256 of the secret |
+| Issued | at an explicit, user-visible enrolment step — never implicitly on first connect |
+| Scope | per tool **and** per verb |
+| Expiry | absolute, not sliding |
+| Rotation | issue-new-then-revoke-old, so there is never a window with no valid token |
+| Revocation | delete the record; takes effect immediately, including on open connections |
+
+Two properties are worth stating plainly because getting them wrong has
+happened before in this codebase:
+
+- **The token is not derived from anything public.** The SDK IPC handshake key
+  is derived from the agent id, which *is* the public socket filename, so it
+  proves integrity and version-binding rather than possession of a secret
+  (AAASM-3922). A DI capability token built that way would be no secret at all.
+- **It is not self-contained.** Verification is a lookup, not a signature check.
+  A credential that verifies offline cannot be revoked, and revocation is a hard
+  requirement here.
+
+### Denials
+
+**Absent, malformed, unknown, expired and out-of-scope all deny.** There is no
+fall-through to an implicit grant, no "local connections are trusted", and no
+anonymous read-only tier — an empty enrolment book authorizes nothing at all.
+
+| Wire code | Cause |
+| --- | --- |
+| `DENY_CODE_UNAUTHENTICATED` | absent, malformed **or** unknown token |
+| `DENY_CODE_TOKEN_EXPIRED` | a record resolved and is past its absolute expiry |
+| `DENY_CODE_OUT_OF_SCOPE` | the token does not cover this verb on this tool |
+| `DENY_CODE_UNKNOWN_VERB` | a discriminant outside the closed verb set |
+| `DENY_CODE_PROTOCOL_VIOLATION` | e.g. a second `Hello` attempting to renegotiate |
+| `DENY_CODE_UNAVAILABLE_AT_VERSION` | the verb does not exist at the negotiated version |
+| `DENY_CODE_UNKNOWN_TOOL` | no adapter knows the named tool |
+| `DENY_CODE_LIFECYCLE_ERROR` | the lifecycle service refused or failed |
+
+The first three of these collapse into one code on purpose: a probing client
+must not be able to use the response to tell "no such token" from "wrong shape"
+from "you sent nothing". The **audit trail** records the finer outcome locally.
+
+## Version negotiation
+
+The first exchange on every connection, before any verb is accepted:
+
+```text
+→ Hello    { client_name, client_version,
+             di_api_versions: [u32],
+             lifecycle_schema_versions: [u32] }
+← HelloAck { outcome, di_api_version, core_version, lifecycle_schema_version,
+             min_supported, max_supported,
+             unavailable_verbs[], degraded_reason, remediation }
+  or
+← Incompatible { reason, remediation, min_supported, max_supported }
+```
+
+The server selects the **highest** version both sides offer, over the client's
+*offered set* rather than a claimed range. Three outcomes, and only three:
+
+| Outcome | Meaning | Client obligation |
+| --- | --- | --- |
+| `SUPPORTED` | every verb is available | proceed |
+| `DEGRADED` | a subset is available; `unavailable_verbs` names the rest | **surface it** and disable the matching UI |
+| `INCOMPATIBLE` | no shared version, or below the floor | show `remediation`; the connection closes |
+
+Rules that follow from this:
+
+- **Never a silent downgrade.** `DEGRADED` is an outcome the client must show a
+  user, not an implicit fallback.
+- **The negotiated version is fixed for the connection's lifetime.** A second
+  `Hello` is a protocol violation, not a renegotiation.
+- **An unstated version is incompatible**, never "assume the oldest".
+- A client should offer its **whole** supported window; offering less is how a
+  client talks itself into a degraded connection for no reason.
+
+Current window: `min_supported = 1`, `max_supported = 2`. `scoped_events` and
+`approval_relay` were added at v2, so a v1 client is `DEGRADED`.
+
+## The verb space
+
+The verb space is a **closed enum**. There is no "call core", no method or path
+string, no filter, predicate or query passthrough, and no opaque forwarded
+envelope. An operation that does not exist cannot be requested, however the
+request is crafted.
+
+| Verb | Mutates? | Returns |
+| --- | --- | --- |
+| `list_tools` | no | `ToolList` — tools, detection, capabilities, ceiling |
+| `plan` | no | `PlanView` — a reviewable dry run |
+| `apply` | **yes** | `ApplyView` — receipt id, per-step outcome, fingerprints |
+| `status` | no | `StatusView` — derived protection state plus its evidence |
+| `verify` | no | `VerificationView` — the adjudicated protection test |
+| `repair` | **yes** | `RepairView` — what was restored, and the resulting status |
+| `remove` | **yes** | `RemovalView` — the reversal plan |
+| `scoped_events` | no | `ScopedEventList` — redacted event projection |
+| `approval_relay` | no | `ApprovalRelayAck` — "accepted for adjudication" |
+
+`list_tools` is the only verb that names no tool, so it is the only one a
+tool-scoped token may invoke without a tool-scope check.
+
+### What will never be added
+
+A `check`-like verb, an approval **decision** verb, an audit-emit verb, or any
+passthrough that could carry one. Adding any of them reopens ADR 0004 *and*
+ADR 0030. The verb list is pinned by a unit test against the ADR's transcribed
+set, so widening it fails the build rather than passing review.
+
+`approval_relay` is a **presentation relay**: the client reports which button a
+human pressed, and the runtime/gateway remains the decision authority. The
+acknowledgement says the input was accepted for adjudication. It is not a
+verdict and must not be rendered as one.
+
+## Data minimisation
+
+Minimisation is enforced by the **shape of the response types**, not by a
+redaction pass someone can forget to call.
+
+| The service holds | The DI-API returns |
+| --- | --- |
+| a policy document | `PolicyProfileRefView { id, display_name, digest }` |
+| rendered settings content | `content_sha256` and the AASM-owned `managed_keys` |
+| `EnvValue::Literal("sk-…")` | the variable **name**, nothing else |
+| a proxy variable map | the variable **names**, nothing else |
+| a model base URL | the setting **name** — a URL can carry a token in its query |
+| audit rows | counts, verdict kinds, timestamps, redaction **labels** |
+| any storage or gateway credential | nothing — no DI-API type has a field for one |
+
+`StepView` is the sharp edge and worth reading in full: it carries a step's
+identity, kind, settings surface, key names, artifact paths and content
+fingerprint, and has **no field a step value could land in**. A reviewer can see
+what will change and compare digests; nobody can read a secret out of it.
+
+No DI token is ever presented upstream. The runtime authenticates to the gateway
+with its own credential, which never traverses the DI-API in either direction —
+so compromising a client yields no reusable organization or gateway credential.
+
+## Audit
+
+Two classes of event are recorded, and never anything else:
+
+- **Client authentication and authorization failures** — every absent,
+  malformed, unknown, expired and out-of-scope token, plus rejected peers,
+  unknown verbs, failed negotiations and renegotiation attempts.
+- **Lifecycle mutations** — `apply`, `repair`, `remove`, with the outcome.
+
+An event carries the **token id**, the client name, the verb, the tool and the
+outcome. It never carries the token value, never carries protected content, and
+has no free-form payload field for either to be pasted into. Denials that
+reached no record carry no id, rather than an invented one.
+
+## Writing a client
+
+The reference implementation is `aa-runtime/src/devint/client.rs`
+(`DevIntClient`). A correct client, in order:
+
+1. **Discovers** the socket, and treats its absence as a stopped runtime.
+2. **Negotiates first**, offering its whole version window, and **surfaces** a
+   degraded outcome instead of swallowing it.
+3. **Presents its capability token on every request.** There is no anonymous
+   tier: a client without a token can negotiate, learn the versions, and then
+   tell the user to enrol — nothing more.
+4. **Renders what the service computed.** Never derive or upgrade a protection
+   state client-side; a locally derived state is a claim wearing a
+   measurement's clothes.
+5. **Reads a status with its timestamp.** `observed_at_unix_secs` is part of the
+   claim: it is "verified at T", not "true now".
+
+```rust
+use aa_runtime::devint::{DevIntClient, SocketDiscovery};
+
+let discovery = DevIntClient::discover()?;
+let SocketDiscovery::Present(path) = discovery else {
+    // The runtime is not running — prompt to start it. Do not retry silently.
+    return Ok(());
+};
+
+let mut client = DevIntClient::connect(&path, "vscode-aasm", "1.4.0", Some(token)).await?;
+if client.negotiated().degraded {
+    // Show this. Do not proceed as though the missing verbs exist.
+    eprintln!("{}", client.negotiated().degraded_reason);
+}
+
+let status = client.status("claude-code").await?;
+println!("{} (verified at {})", status.achieved_level, status.observed_at_unix_secs);
+```
+
+`aasm`'s own lifecycle commands become a DI-API client in
+[AAASM-5280](https://lightning-dust-mite.atlassian.net/browse/AAASM-5280); an
+in-process `--local` fallback is deliberately not offered, because it would be a
+second code path with a different trust model.
+
+## Operational notes
+
+- `~/.aa/run/` must be `0700` and the socket `0600`. The runtime asserts both on
+  every bind and refuses to serve if either is wrong.
+- Treat a `DEGRADED` negotiation or a `Drifted` status as a signal, not noise.
+- Rotate a token by issuing a replacement first and revoking the old one after
+  the client has picked the new one up.
+- Revoke on client uninstall. A revoked token stops working immediately,
+  including on a session that is already open.

--- a/proto/devint.proto
+++ b/proto/devint.proto
@@ -1,0 +1,472 @@
+syntax = "proto3";
+
+package assembly.devint.v1;
+
+// Developer Integration API (DI-API) wire schema — ADR 0030 Decision 5,
+// AAASM-5279.
+//
+// The DI-API is the *only* channel by which an untrusted local thin client (a
+// VS Code extension, an installer, `aasm integration …`) reaches the trusted
+// runtime. It is served over a dedicated Unix domain socket at
+// `~/.aa/run/devint.sock` — deliberately NOT the SDK fast-path socket, so a DI
+// client never holds a file descriptor onto agent-action or policy-decision
+// traffic (ADR 0030 §5.1). Loopback TCP is a forbidden design (§5.2): it is
+// reachable by every local user and by a browser, and the kernel supplies no
+// peer identity there.
+//
+// Framing reuses the runtime's existing length-delimited IPC codec
+// (`aa-runtime/src/ipc/codec.rs`): `[1-byte tag][prost varint length][payload]`.
+// These are prost payloads behind wire tags, not a gRPC service — there is no
+// `service` block here on purpose, because a gRPC service on this socket would
+// invite a second transport story for a purely local hop.
+//
+// # Two properties this schema exists to make structural
+//
+// 1. **The verb space is closed.** `Verb` is an exhaustive enum with no
+//    "call core", no method/path string, no filter passthrough and no opaque
+//    forwarded envelope. There is deliberately no policy-decision verb: agent
+//    decisions go SDK → `aa-sdk-client` → runtime/gateway (ADR 0004), and
+//    adding a `check`-like verb here would reopen ADR 0004 *and* ADR 0030
+//    (forbidden design 6). An operation that does not exist cannot be
+//    requested, however the request is crafted.
+// 2. **No response type can carry what must not leave.** Minimisation is
+//    enforced by the shape of these messages rather than by a redaction pass
+//    someone might forget (§5.5). There is no field anywhere below that can
+//    hold a policy document, a rendered settings body, an environment-variable
+//    value, a raw prompt or tool output, or a storage/gateway credential —
+//    only identifiers, AASM-owned key names, fingerprints and derived views.
+//    `StepView` in particular projects `aa_core::integration::IntegrationStep`
+//    *without* its value-bearing leaves, which is why an adapter that put a
+//    secret in an env literal still cannot leak it over this API.
+
+// ── Version negotiation ──────────────────────────────────────────────────────
+
+// Hello — client → server, the first frame on every connection. No lifecycle
+// verb is accepted before it (§5.4).
+message Hello {
+  // Human-readable client identity, e.g. "aasm" or "vscode-aasm". Recorded in
+  // audit events; never used for authentication.
+  string client_name = 1;
+  // The client build version, for remediation text and audit.
+  string client_version = 2;
+  // Every DI-API version this client can speak. The server selects the highest
+  // version both sides offer.
+  repeated uint32 di_api_versions = 3;
+  // Every AAASM-5277 lifecycle schema version this client can read.
+  repeated uint32 lifecycle_schema_versions = 4;
+}
+
+// Whether the negotiated version gives the client the whole verb space.
+//
+// `DEGRADED` is an explicit outcome the client must surface, never an implicit
+// fallback — a silent downgrade is exactly what §5.4 forbids.
+enum NegotiationOutcome {
+  NEGOTIATION_OUTCOME_UNSPECIFIED = 0;
+  // Every verb is available at the negotiated version.
+  NEGOTIATION_OUTCOME_SUPPORTED = 1;
+  // The negotiated version is supported but exposes a subset of the verbs;
+  // `HelloAck.unavailable_verbs` names exactly which.
+  NEGOTIATION_OUTCOME_DEGRADED = 2;
+}
+
+// HelloAck — server → client, sent when a usable version was agreed. The
+// negotiated version is fixed for the connection's lifetime; there is no
+// mid-connection renegotiation to downgrade into.
+message HelloAck {
+  NegotiationOutcome outcome = 1;
+  // The DI-API version this connection speaks.
+  uint32 di_api_version = 2;
+  // The running core version, so a client can report what it is talking to
+  // without inferring it (ADR 0030 matrix row 5).
+  string core_version = 3;
+  // The AAASM-5277 lifecycle schema version this connection speaks.
+  uint32 lifecycle_schema_version = 4;
+  // The server's supported DI-API version window, so a client that got
+  // `DEGRADED` knows what to upgrade to.
+  uint32 min_supported = 5;
+  uint32 max_supported = 6;
+  // Verbs that do not exist at the negotiated version. Empty when `outcome` is
+  // `SUPPORTED`.
+  repeated string unavailable_verbs = 7;
+  // Why the connection is degraded, in words a user can act on.
+  string degraded_reason = 8;
+  // What to do about it.
+  string remediation = 9;
+}
+
+// Incompatible — server → client, sent instead of `HelloAck` when no version
+// is shared. The connection is closed immediately afterwards: there is no
+// degraded-into-nothing state and no silent downgrade.
+message Incompatible {
+  // What is incompatible.
+  string reason = 1;
+  // Which side to upgrade, and to what.
+  string remediation = 2;
+  uint32 min_supported = 3;
+  uint32 max_supported = 4;
+}
+
+// ── The closed verb space ────────────────────────────────────────────────────
+
+// Every operation the DI-API will ever serve at this major version.
+//
+// This list is the closed set from ADR 0030 §1.2 / §5.6.1. It is asserted
+// against that list by a unit test, so adding a verb — in particular a
+// `check`-like or approval-*decision* verb — fails the build rather than
+// quietly widening the boundary.
+enum Verb {
+  VERB_UNSPECIFIED = 0;
+  // Enumerate the tools the linked adapters can see, and what each can do.
+  VERB_LIST_TOOLS = 1;
+  // Author a reviewable dry run. Mutates nothing.
+  VERB_PLAN = 2;
+  // Execute a previously authored plan.
+  VERB_APPLY = 3;
+  // Read the derived protection state and its evidence.
+  VERB_STATUS = 4;
+  // Run the protection test and adjudicate it (server-side; a client never
+  // self-certifies).
+  VERB_VERIFY = 5;
+  // Restore AASM-owned keys that drifted.
+  VERB_REPAIR = 6;
+  // Author and execute the reversal.
+  VERB_REMOVE = 7;
+  // Read an integration-scoped, already-redacted event projection.
+  VERB_SCOPED_EVENTS = 8;
+  // Relay a human's approval input to the core, which remains the decision
+  // authority (ADR 0030 matrix rows 11 and 12). This is a presentation relay,
+  // not a decision verb.
+  VERB_APPROVAL_RELAY = 9;
+}
+
+// ── Requests ─────────────────────────────────────────────────────────────────
+
+// Request — client → server. Every verb travels in this one message; the
+// per-verb arguments are typed sub-messages, never an opaque blob.
+message Request {
+  // Correlates the response. Echoed back verbatim.
+  uint64 request_id = 1;
+  Verb verb = 2;
+  // The opaque 256-bit capability token, hex-encoded. Never a JWT and never
+  // derived from a public value (§5.3, and the AAASM-3922 lesson). Absent,
+  // expired, unknown or unresolvable ⇒ DENY plus an audit event.
+  string capability_token = 3;
+  // Which tool the verb acts on. Empty only for `VERB_LIST_TOOLS`.
+  string tool_id = 4;
+
+  PlanArgs plan = 5;
+  ApplyArgs apply = 6;
+  RemoveArgs remove = 7;
+  ScopedEventsArgs events = 8;
+  ApprovalRelayArgs approval = 9;
+}
+
+// What the caller wants planned. Every field is something a caller may
+// legitimately choose; there is no field through which a client could supply a
+// policy document, a credential, or a destination path the service did not
+// derive.
+message PlanArgs {
+  // "recommended" | "strict" | "observe_only".
+  string profile = 1;
+  // The ladder rung the caller is aiming for.
+  string requested_level = 2;
+  // "user" | "project" | "managed". Explicit and mandatory — never inferred
+  // from the client's working directory.
+  string settings_scope = 3;
+  // Whether the user consented to steps that change host state (§6.6).
+  bool allow_privileged_host_steps = 4;
+  // The policy profile *by name*. The document is resolved inside the trusted
+  // layers and never crosses this boundary (matrix row 6).
+  string policy_profile_id = 5;
+}
+
+message ApplyArgs {
+  string plan_id = 1;
+}
+
+message RemoveArgs {
+  string plan_id = 1;
+}
+
+message ScopedEventsArgs {
+  uint32 limit = 1;
+  uint64 since_unix_secs = 2;
+}
+
+// The human's input on a pending approval, relayed by the client that showed
+// it. The runtime/gateway adjudicates it; a client that fabricates one still
+// cannot make a decision, because this message is an input to the authority,
+// not an answer from it.
+message ApprovalRelayArgs {
+  string approval_id = 1;
+  // "approve" | "deny" | "defer" — the button the human pressed.
+  string user_input = 2;
+}
+
+// ── Responses ────────────────────────────────────────────────────────────────
+
+// Response — server → client, one per accepted `Request`. Exactly one of the
+// per-verb views is populated, chosen by `verb`.
+message Response {
+  uint64 request_id = 1;
+  Verb verb = 2;
+
+  ToolList tool_list = 3;
+  PlanView plan = 4;
+  ApplyView apply = 5;
+  StatusView status = 6;
+  VerificationView verification = 7;
+  RepairView repair = 8;
+  RemovalView removal = 9;
+  ScopedEventList events = 10;
+  ApprovalRelayAck approval = 11;
+}
+
+// Why a request was refused.
+//
+// The codes are deliberately coarse. `UNAUTHENTICATED` covers absent, unknown
+// and malformed tokens alike so a probing client cannot use the response to
+// tell them apart — the audit event records the finer outcome locally, and
+// never records *why it almost matched* (§5.3).
+enum DenyCode {
+  DENY_CODE_UNSPECIFIED = 0;
+  // Absent, malformed or unknown token.
+  DENY_CODE_UNAUTHENTICATED = 1;
+  // A resolvable record that is past its absolute expiry. Distinguished from
+  // `UNAUTHENTICATED` because the holder already has the token, so nothing
+  // leaks, and re-enrolment is the actionable remediation.
+  DENY_CODE_TOKEN_EXPIRED = 2;
+  // The token resolved, but its scope does not cover this verb or this tool.
+  DENY_CODE_OUT_OF_SCOPE = 3;
+  // The wire carried a verb outside the closed set.
+  DENY_CODE_UNKNOWN_VERB = 4;
+  // A frame arrived out of order — e.g. a second `Hello` attempting to
+  // renegotiate mid-connection.
+  DENY_CODE_PROTOCOL_VIOLATION = 5;
+  // The verb exists but not at the negotiated DI-API version.
+  DENY_CODE_UNAVAILABLE_AT_VERSION = 6;
+  // The lifecycle service refused or failed. Carries no adapter internals.
+  DENY_CODE_LIFECYCLE_ERROR = 7;
+  // No adapter knows this tool id.
+  DENY_CODE_UNKNOWN_TOOL = 8;
+}
+
+message Denied {
+  uint64 request_id = 1;
+  DenyCode code = 2;
+  // A short, coarse sentence. Never echoes the presented token and never
+  // explains how close it came to matching.
+  string message = 3;
+  // What the user or client should do.
+  string remediation = 4;
+}
+
+// ── Data-minimised projections ───────────────────────────────────────────────
+
+message CapabilityView {
+  // An `aa_core::integration::IntegrationCapability` variant, snake_case.
+  string capability = 1;
+  // "supported" | "unsupported" | "requires_version" | "absent".
+  string support = 2;
+  // The adapter's reason, when it declared one.
+  string reason = 3;
+}
+
+message ToolSummary {
+  string tool_id = 1;
+  string display_name = 2;
+  bool detected = 3;
+  // Empty when the tool is not installed.
+  string detected_version = 4;
+  // "supported" | "below_minimum" | "above_maximum" | "undetected".
+  string compatibility = 5;
+  repeated CapabilityView capabilities = 6;
+  // The adapter's static build-time ceiling. A ceiling is not a measurement.
+  string adapter_ceiling = 7;
+}
+
+message ToolList {
+  repeated ToolSummary tools = 1;
+}
+
+// A plan step, projected for review.
+//
+// This message is where §5.5 is enforced. It carries the step's identity, its
+// kind, the surface it writes, the AASM-owned key names it claims and the
+// content fingerprint — and deliberately has **no field able to hold a step
+// value**: no rendered settings body, no environment-variable value, no proxy
+// variable value, no base URL. A reviewer can see what will change and compare
+// fingerprints; they cannot read a secret out of it, and neither can a
+// compromised client.
+message StepView {
+  string id = 1;
+  // One line describing the step to a human reviewing the dry run.
+  string summary = 2;
+  // Stable snake_case token for the `StepAction` variant, e.g.
+  // "write_managed_settings".
+  string action_kind = 3;
+  // "required" | "optional".
+  string requirement = 4;
+  // "user" | "privileged_host".
+  string privilege = 5;
+  // The exact sentence the user must agree to. Populated only for
+  // privileged-host steps (§6.6).
+  string consent_prompt = 6;
+  // "user" | "project" | "managed", when the step names a settings surface.
+  string settings_scope = 7;
+  // The keys AASM claims ownership of — the only keys drift is defined over.
+  repeated string managed_keys = 8;
+  // Files and artifacts the step names. Paths, never contents.
+  repeated string artifact_paths = 9;
+  // SHA-256 of the rendered content, hex-encoded.
+  string content_sha256 = 10;
+  // Whether the step carries an automated reversal.
+  bool reversible = 11;
+}
+
+// A policy profile named by reference rather than by content: enough to
+// display, select and compare, never enough to read.
+message PolicyProfileRefView {
+  string id = 1;
+  string display_name = 2;
+  string digest = 3;
+}
+
+message UnsupportedMechanismView {
+  string capability = 1;
+  string reason = 2;
+}
+
+message PlanView {
+  uint32 schema_version = 1;
+  string plan_id = 2;
+  string tool_id = 3;
+  string profile = 4;
+  string settings_scope = 5;
+  PolicyProfileRefView policy_profile = 6;
+  string planned_level = 7;
+  string adapter_ceiling = 8;
+  repeated StepView steps = 9;
+  repeated UnsupportedMechanismView unsupported = 10;
+  repeated string warnings = 11;
+}
+
+message StepOutcomeView {
+  string step_id = 1;
+  // "applied" | "skipped" | "failed".
+  string outcome = 2;
+  // Fingerprint of what was written, when one could be taken.
+  string fingerprint = 3;
+}
+
+message ApplyView {
+  string plan_id = 1;
+  string receipt_id = 2;
+  uint64 applied_at_unix_secs = 3;
+  repeated StepOutcomeView steps = 4;
+  string planned_level = 5;
+  string achieved_level = 6;
+}
+
+// One observation, with the timestamp that makes it "verified at T" rather
+// than "true now".
+message EvidenceView {
+  string mechanism = 1;
+  // "read_back" | "exercised" | "host_attested" | "absent".
+  string kind = 2;
+  // The kind's discriminating value as a token: the exercise outcome, whether
+  // read-back matched, whether the host layer reported healthy, or why a check
+  // was absent.
+  string outcome = 3;
+  uint64 observed_at_unix_secs = 4;
+  string detail = 5;
+}
+
+message NextLevelView {
+  string level = 1;
+  string blocked_because = 2;
+}
+
+message StatusView {
+  string tool_id = 1;
+  // `LifecyclePhase`, snake_case.
+  string phase = 2;
+  // "ladder" | "drifted" | "degraded" | "incompatible".
+  string state = 3;
+  string achieved_level = 4;
+  string planned_level = 5;
+  string adapter_ceiling = 6;
+  string compatibility = 7;
+  repeated EvidenceView evidence = 8;
+  NextLevelView next_level = 9;
+  // A status read without its timestamp over-reads the claim.
+  uint64 observed_at_unix_secs = 10;
+  // Identifiers of AASM-owned artifacts that no longer match, when the state
+  // is `drifted`.
+  repeated string drift_mismatched = 11;
+  // Why the state is overriding, and which side to fix.
+  string state_reason = 12;
+  string state_remediation = 13;
+}
+
+message VerificationView {
+  uint64 verified_at_unix_secs = 1;
+  // "passed" | "partially_passed" | "failed" | "unverifiable".
+  string outcome = 2;
+  // What could not be established, for `partially_passed`.
+  repeated string missing = 3;
+  // Why, for `failed` and `unverifiable`.
+  string reason = 4;
+  repeated EvidenceView evidence = 5;
+}
+
+message RepairView {
+  string tool_id = 1;
+  // AASM-owned artifact identifiers that were restored.
+  repeated string repaired = 2;
+  // Identifiers that drifted and could not be restored, with the reason.
+  repeated UnsupportedMechanismView unrepairable = 3;
+  StatusView status = 4;
+}
+
+message RemovalView {
+  uint32 schema_version = 1;
+  string plan_id = 2;
+  string tool_id = 3;
+  repeated StepView steps = 4;
+  // What this plan knowingly leaves behind.
+  repeated string residual = 5;
+  repeated string warnings = 6;
+}
+
+// An integration-scoped, already-redacted security-event projection.
+//
+// Counts, verdict kinds, timestamps and redaction labels — never the prompt,
+// the tool output, or the matched content that produced the verdict.
+message ScopedEvent {
+  uint64 occurred_at_unix_secs = 1;
+  // "allow" | "deny" | "redacted" | "approval_required".
+  string verdict_kind = 2;
+  // The mechanism the event was observed on.
+  string mechanism = 3;
+  // How many equivalent events this row folds.
+  uint32 count = 4;
+  // Labels of what was redacted (e.g. "aws_access_key"), never the value.
+  repeated string redaction_labels = 5;
+}
+
+message ScopedEventList {
+  repeated ScopedEvent events = 1;
+}
+
+// Acknowledgement that a human's input was relayed to the decision authority.
+//
+// Deliberately not a decision: it says the input was accepted for
+// adjudication, never that it was granted.
+message ApprovalRelayAck {
+  string approval_id = 1;
+  // The input that was relayed, echoed for the client's own bookkeeping.
+  string relayed_input = 2;
+  // When the runtime accepted it for adjudication.
+  uint64 accepted_at_unix_secs = 3;
+}


### PR DESCRIPTION
## Description

Implements **ADR 0030 Decision 5**: a restricted, authenticated, versioned local Developer Integration
API (the **DI-API**) for CLI and future plugin/extension clients — served over its own Unix domain
socket, with a closed verb space, capability-scoped tokens and data-minimised responses.

New: `proto/devint.proto` and `aa-runtime/src/devint/` (`verb` · `scope` · `token` · `socket` ·
`negotiate` · `codec` · `lifecycle` · `projection` · `audit` · `server` · `client` · `testkit` ·
`threat_model`), plus `docs/src/devtools/developer-integration-api.md`.

### The verb space is closed by construction, not by convention

`DiVerb::{ListTools, Plan, Apply, Status, Verify, Repair, Remove, ScopedEvents, ApprovalRelay}` —
deliberately **not** `#[non_exhaustive]`. The wire carries an enum discriminant decoded by
`DiVerb::from_wire`: there is no method string, no path, no filter, no opaque envelope. An operation
that does not exist cannot be named.

That is what enforces ADR 0030's forbidden design #6 and keeps ADR 0004 intact — **no verb obtains or
shortcuts a policy decision.** `verb_space_matches_the_adr_closed_list` pins `ALL` against the ADR's
transcribed list; `no_verb_decides_policy` and `no_verb_is_named_like_a_policy_check` assert
exhaustively; and `lifecycle.rs` has exactly one method per verb with a test asserting the two sets
match — so a `check` method with no verb, or a verb with no method, **fails the build**.

### The token is a real secret — explicitly not the AAASM-3922 mistake

32 bytes from the OS CSPRNG, opaque, **derived from nothing**. The store keeps
`SHA-256(secret) → {token_id, client_name, issued_at, expires_at, scope}`; the secret is returned once,
never stored or logged, and `Debug` redacts it. `TokenId` is drawn independently, so publishing it in an
audit event reveals nothing about the secret.

`aa-runtime/src/ipc/handshake.rs` documents (AAASM-3922) that the SDK handshake key is derived from the
*public* agent id and therefore proves integrity, not possession of a secret. This token is verified by
**lookup, not recomputation**, and is not a JWT — a self-verifying credential cannot be revoked, and
revocation is a hard AC. A test proves two enrolments with identical name, scope and time yield
unrelated secrets.

Scope is a tool allowlist **×** a verb allowlist; both must admit. Expiry is absolute (tested
non-sliding), rotation is issue-new-then-revoke-old, revocation deletes the record and takes effect on
already-open connections.

### Version negotiation is deterministic and never silently downgrades

`Supported` → full verb space. `Degraded` → `HelloAck` naming `unavailable_verbs` with reason and
remediation. `Incompatible` → reason, remediation and supported window, then the connection closes.
An empty offer is **incompatible**, never "assume oldest". An unreadable lifecycle schema is
incompatible. `scoped_events` and `approval_relay` are v2-only.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Purely additive: a new proto file, a new `aa-runtime` module, one new docs page. The existing SDK IPC
path is untouched. **No new dependencies** — `SocketError` and `DiCodecError` are hand-written rather
than pulling `thiserror` into `aa-runtime`, matching `ipc/codec.rs`. `Cargo.lock` is unchanged.

## Related Issues

- Related Jira ticket: [AAASM-5279](https://lightning-dust-mite.atlassian.net/browse/AAASM-5279)
  (Epic [AAASM-5272](https://lightning-dust-mite.atlassian.net/browse/AAASM-5272))
- Implements: **ADR 0030 Decision 5**; consumes the AAASM-5277 contract (#1821)
- Related: AAASM-3565 (restricted devtool boundary), AAASM-3922 (IPC trust boundary)
- Blocks: AAASM-5280, AAASM-5281, AAASM-5282
- GitHub issues: N/A

## Architectural impact

The DI-API is a **lifecycle/operator surface**, in the same carve-out ADR 0004 grants REST. It carries
no policy decisions and no agent-action traffic; agent decisions continue to go
SDK → `aa-sdk-client` → runtime/gateway. **ADR 0004 and ADR 0002 are untouched.**

The socket is **separate from the SDK fast-path socket** — that separation is a security property, not
tidiness: a DI client never holds a file descriptor onto agent-action traffic, so that traffic is
unreachable *by construction* rather than by an authorization rule someone must remember to write.

Files owned by parallel tickets were **not touched**: `aa-core/src/integration/**`, `aa-devtool*`,
`aa-cli/**`. The lifecycle port consumes `IntegrationRequest` / `IntegrationPlan` /
`IntegrationReceipt` / `IntegrationStatus` / `VerificationResult` / `RemovalPlan` verbatim from
`aa_core::integration`.

## Security impact

This ticket **is** a security surface, so the tests are the deliverable.

**Two-layer authentication.** OS layer: directory `0700`, socket `0600` created under a tightened
umask, peercred UID equality — reusing the boundary AAASM-3922 identified as the real one. Token layer
as described above. **Absent, expired, unknown or malformed ⇒ DENY plus an audit event**, with
byte-identical denials so the API is not an oracle. No fall-through, no "local connections are
trusted", no anonymous read-only tier.

**Data minimisation is structural, not aspirational.** The response types have no field a value can
land in. `StepView` carries id, summary, `action_kind`, requirement, privilege + consent prompt,
settings scope, AASM-owned **key names**, artifact **paths**, `content_sha256` and `reversible` — never
an `EnvValue`, a proxy variable value, a base URL or rendered content. Policy is a
`PolicyProfileRefView { id, display_name, digest }`. Events are counts, verdict kinds, timestamps and
redaction labels. `DevIntAuditEvent` has **no free-form payload field**. Audit records the token *id*
and outcome — never the token value, and never why-it-almost-matched.

**No DI token is ever relayed upstream**, and no gateway or organisation credential is ever handed to a
client.

## Tests executed

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

`cargo nextest run -p aa-runtime -p aa-proto` → **503 passed, 2 skipped** (118 of them `devint`).
Re-verified after rebasing onto `main`: **385 passed, 2 skipped**.

### Threat-model tests — run against a real server on a real socket

- **Compromised plugin.** A tool-A token is refused on all 8 tool-scoped verbs against tool B, emitting
  8 audit events keyed by token id. Every out-of-range verb discriminant (−7, 0, 10, 11, 99, 1e6) is
  refused with **zero lifecycle calls**. A read-only enrolment is refused every mutation.
- **Token theft.** Absent, malformed and unknown tokens deny with **byte-identical** answers, each
  audited. An expired token denies and audits by id. A *valid stolen* token still cannot cross tool
  scope or mutate beyond the scope it was stolen from.
- **Replay.** A captured `apply` replayed 5× on a fresh connection is identical, dies on revoke, and
  cannot be re-pointed at another tool.
- **Downgrade.** A below-floor offer yields `Incompatible` and a closed socket. A second `Hello` yields
  `PROTOCOL_VIOLATION` plus an audit event, and the original negotiated version survives. A v1
  connection cannot reach v2 verbs. An unauthenticated caller gets `UNAUTHENTICATED`, **not**
  `UNAVAILABLE_AT_VERSION` — version gating must not leak authentication state.
- **Transport.** A live socket is asserted `0600` inside a `0700` directory; the DI socket is proved
  distinct from the SDK socket; an oversized frame closes the connection; a silent peer times out and
  audits.

### Three guards proved load-bearing — weakened, watched fail, reverted

**Absent-token denial** (skip denial when no token is presented) → **3 tests failed**:
```
a_client_with_no_token_is_denied_every_verb
  expected a denial, got Ok(StatusView { tool_id: "claude-code", … achieved_level: "integrated" … })
absent_malformed_and_unknown_tokens_…   expected Denied, got Response(…)
version_gating_is_not_an_oracle_…       assertion left == right failed; left: 6, right: 1
```

**Cross-tool scope check** (`TokenScope::permits` ignores tool) → **5 tests failed**:
```
a_token_scoped_to_one_tool_cannot_touch_another_on_any_verb
  expected Denied, got Response(… PlanView { tool_id: "codex" … })
a_stolen_token_is_bounded_by_the_scope_it_was_stolen_from
  … StatusView { tool_id: "codex" … }
a_replayed_request_cannot_be_re_pointed_at_another_tool  … (+2 unit tests)
```

**Data minimisation** (echo `EnvValue::Literal` next to its name) → **5 tests failed**, including
`nothing_that_leaves_the_boundary_carries_a_secret_or_a_token` and
`a_plan_rendered_by_the_client_carries_no_step_values`.

Data minimisation is tested by encoding poisoned fixtures to wire bytes and asserting a sentinel never
appears — at the projection level, through the reference client, across all 9 verbs, and across the
whole audit trail.

### Validation — all run and observed

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0 (6 pre-existing `default-features` manifest notes) |
| `cargo nextest run -p aa-runtime -p aa-proto` | **503 passed, 2 skipped** |
| same, post-rebase onto `main` | **385 passed, 2 skipped** |
| `cargo build --workspace` | exit 0 |
| `cargo doc --workspace --no-deps` | exit 0; 4 pre-existing `aa-runtime` warnings, **none in `devint`** |
| `buf lint` | **exit 0** |
| `buf breaking --against` base | **exit 0** |

The buf gate was run explicitly because this PR adds `proto/devint.proto`, using
`npx @bufbuild/buf@1.50.0` to match CI's pinned version.

## Acceptance-criteria evidence

| AC | Status |
|---|---|
| Version negotiation returns supported / degraded / incompatible deterministically | ✅ empty offer ⇒ incompatible, never "assume oldest"; no silent downgrade |
| API exposes only lifecycle, status, verification and narrow UX operations | ✅ closed verb enum; policy-decision verbs structurally impossible |
| Client credentials capability-scoped, revocable, not reusable as core/gateway credentials | ✅ tool × verb scope; revocation deletes the record; no DI token relayed upstream |
| Unauthorized cross-tool and unrestricted-core operations rejected, with negative tests | ✅ all 8 tool-scoped verbs, plus out-of-range discriminants |
| No raw secrets or unredacted content in responses, logs or audit events | ✅ structural — no field can hold one; sentinel-on-the-wire tests |
| Local transport permissions and loopback authentication tested | ✅ live-socket `0600`/`0700` assertion + peercred |
| Threat-model tests: compromised plugin, token theft, replay, downgrade | ✅ `threat_model.rs` |
| API documentation and a reference client for thin shells | ✅ `docs/src/devtools/developer-integration-api.md` + `devint/client.rs` |
| **CLI and a test plugin client can discover and authenticate** | ⚠️ **partial** — the reference client does both end-to-end; wiring `aasm` is AAASM-5280 per ADR 0030 §7.1/§7.3, and `aa-cli` was deliberately not touched |
| Plan/install/status/verify/repair/remove use the AAASM-5277/5278 contracts | ⚠️ **partial** — 5277 types are consumed verbatim; `RepairReport`, `ScopedSecurityEvent` and `ApprovalRelayReceipt` are DI-side types because AAASM-5278 had not defined equivalents and that tree was owned by a parallel branch |

## Known limitations

- **The DI server is not yet started by `aa-runtime::run()`.** Doing so requires a concrete
  `IntegrationLifecycle`, which lives in the tree AAASM-5278 owns and this branch was instructed not to
  touch. It is a ~5-line `tracker.spawn` in `runtime.rs` and is folded into **AAASM-5280**, the first
  ticket that needs the server listening. Shipping a server nothing starts was preferred over
  cross-editing a parallel branch.
- Three DI-side response types may be reconciled against AAASM-5278's equivalents in a follow-up.
- `aasm` does not speak the DI-API yet — AAASM-5280.

## Dependencies / stacked PRs

Originally stacked on AAASM-5277's branch; that merged as #1821 (`eb335a23`) and this branch has been
**rebased onto `main`**. Tests, clippy and the buf gate were re-run after the rebase.

Developed in parallel with AAASM-5278 (#1823) on a **disjoint file set** — that PR owns
`aa-core/src/integration/**` and `aa-devtool*`; this one owns `aa-runtime/**` and `proto/**`. No file is
touched by both.

## Documentation and migration impact

Adds `docs/src/devtools/developer-integration-api.md`, registered in `docs/src/SUMMARY.md` under the
`# Developer Integrations` chapter introduced by AAASM-5273. No migration — nothing consumed this API
before.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (14 commits, one concern each)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5279]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ