### PR TITLE
[AAASM-5106] 🐛 (aa-api): Render Unknown, not a false Allow/No-policy, when the cascade is unloaded

### DIFF
--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -188,6 +188,24 @@ pub struct CapabilityMatrix {
     pub agents: Vec<CapabilityAgent>,
     pub policies: Vec<Policy>,
     pub sample_calls: Vec<SampleCall>,
+    /// Whether the projecting engine actually carries a policy cascade
+    /// (`PolicyEngine::cascade_loaded`). AAASM-5106 / ADR 0024: when the cascade
+    /// is unloaded — the state of every shipped aa-api deployment today, which
+    /// loads its policy through `load_from_file` and leaves `scope_index` empty —
+    /// `decide()` falls through to `Allow` for every cell, so the grid asserts an
+    /// unbroken wall of `ALLOW` for capabilities the primary policy actually
+    /// denies. `false` here is the matrix-level "not evaluated — policy cascade
+    /// not loaded" signal the dashboard renders as an unavailable state, so an
+    /// operator never reads a fabricated `Allow` as a real grant. It is a fact
+    /// about the projection's *data*, never an operator choice; the enforcement
+    /// path (`evaluate_primary`) is unaffected.
+    ///
+    /// Required-but-always-present, not optional: the key is always on the wire,
+    /// so a client reads an explicit `false` it must handle rather than a missing
+    /// field it can shrug off — the same absent-vs-unknown discipline as
+    /// [`CapabilityAgent::trust`] and `TeamPoliciesResponse::policies`.
+    #[schema(required = true)]
+    pub cascade_loaded: bool,
 }
 
 /// One agent row in the dashboard Capability Matrix.
@@ -464,6 +482,7 @@ mod tests {
             agents: vec![],
             policies: vec![],
             sample_calls: vec![],
+            cascade_loaded: false,
         };
         let json = serde_json::to_value(&matrix).unwrap();
         assert!(json["resources"].is_array());
@@ -471,6 +490,11 @@ mod tests {
         assert!(json["policies"].is_array());
         assert!(json["sampleCalls"].is_array(), "field must be `sampleCalls`");
         assert!(json.get("sample_calls").is_none());
+        // AAASM-5106 — the loaded/unavailable signal is always on the wire in
+        // camelCase, so a client cannot silently drop it and read a fabricated
+        // Allow as real.
+        assert_eq!(json["cascadeLoaded"], serde_json::json!(false));
+        assert!(json.get("cascade_loaded").is_none(), "snake_case must not appear");
     }
 
     #[test]

--- a/aa-api/src/models/topology.rs
+++ b/aa-api/src/models/topology.rs
@@ -237,7 +237,8 @@ pub struct PolicyChainTier {
     "chain": [{ "tier": "global", "scope": "global", "policies": ["baseline"] }],
     "allow": ["file_read"],
     "deny": ["terminal_exec"],
-    "allow_restricted": true
+    "allow_restricted": true,
+    "cascade_loaded": true
 }))]
 pub struct NodeEffectivePermissions {
     /// Cascade tiers that apply to this agent, broadest → narrowest.
@@ -251,6 +252,24 @@ pub struct NodeEffectivePermissions {
     /// Whether an allow-list restriction is in force — anything absent from
     /// `allow` is denied, even when `allow` is empty.
     pub allow_restricted: bool,
+    /// Whether the projecting engine actually carries a policy cascade
+    /// (`PolicyEngine::cascade_loaded`). AAASM-5106 / ADR 0024: with no cascade
+    /// loaded — every shipped aa-api deployment — the walk resolves nothing, so
+    /// every tier's `policies` is empty and `allow` / `deny` are empty. That is
+    /// **not** the real permission set: enforcement falls back to the primary
+    /// policy slot this projection cannot enumerate. `false` here is the
+    /// loaded/unavailable signal the dashboard renders as "policy inheritance
+    /// unknown — cascade not loaded", so an empty chain never reads as a real
+    /// "no policies apply". Distinct from a *loaded* cascade whose walk carries no
+    /// document at a tier, which is real state ("no team policy"). This changes
+    /// no enforcement; it only annotates the projection's confidence in its own
+    /// output.
+    ///
+    /// Required-but-always-present, matching `AgentNode`'s null discipline for
+    /// unmeasured fields: the key is always on the wire so a client cannot read
+    /// an empty chain as authoritative by omission.
+    #[schema(required = true)]
+    pub cascade_loaded: bool,
 }
 
 /// Minimal agent representation used in list and tree responses.

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -1301,7 +1301,13 @@ mod tests {
         // A real policy in the engine's cascade.
         let loaded = state_with_policies(
             vec![record_with_tier(0x01, "a", &[], 1)],
-            vec![policy_doc("baseline", PolicyScope::Global, None, &[("bash", true)], None)],
+            vec![policy_doc(
+                "baseline",
+                PolicyScope::Global,
+                None,
+                &[("bash", true)],
+                None,
+            )],
         );
         let loaded_matrix = matrix_for(&loaded).await;
         assert!(

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -825,6 +825,12 @@ fn project_matrix(
         // that nothing computes today; the policy-replay story (AAASM-5094) owns
         // that surface, so the dimension is reported empty rather than invented.
         sample_calls: Vec::new(),
+        // AAASM-5106 / ADR 0024 — the matrix-level loaded/unavailable signal. With
+        // no cascade loaded, every `decide()` cell falls through to `Allow`
+        // (nothing constrains it), so the grid's ALLOW readings are not
+        // measurements. The dashboard renders the whole grid as "not evaluated"
+        // when this is `false` rather than trusting those cells.
+        cascade_loaded: state.policy_engine.cascade_loaded(),
     }
 }
 
@@ -1273,6 +1279,41 @@ mod tests {
         );
         assert!(agent.note.is_none());
         assert!(agent.caps.values().all(|c| c.flag.is_none()));
+    }
+
+    #[tokio::test]
+    async fn matrix_reports_cascade_unloaded_and_distinguishes_it_from_a_real_policy() {
+        // AAASM-5106 / ADR 0024 §6(2): an empty cascade and a genuinely loaded
+        // policy must produce *different* responses, or the honesty fix is
+        // cosmetic. The cells themselves may still read Allow by fall-through
+        // (that is `decide()`'s documented behaviour and left to the enforcement
+        // twin), but the matrix-level `cascade_loaded` flag is what lets the
+        // dashboard tell the fabricated grid apart from a real one.
+
+        // No policy loaded — the state of every shipped aa-api deployment.
+        let unloaded = state_with(vec![record_with_tier(0x01, "a", &[], 1)]);
+        let unloaded_matrix = matrix_for(&unloaded).await;
+        assert!(
+            !unloaded_matrix.cascade_loaded,
+            "no cascade loaded -> the matrix must report cascade_loaded=false, not a confident grid"
+        );
+
+        // A real policy in the engine's cascade.
+        let loaded = state_with_policies(
+            vec![record_with_tier(0x01, "a", &[], 1)],
+            vec![policy_doc("baseline", PolicyScope::Global, None, &[("bash", true)], None)],
+        );
+        let loaded_matrix = matrix_for(&loaded).await;
+        assert!(
+            loaded_matrix.cascade_loaded,
+            "a loaded cascade must report cascade_loaded=true so its verdicts read as real"
+        );
+
+        // The two are distinguishable on the wire — the whole point of the flag.
+        assert_ne!(
+            unloaded_matrix.cascade_loaded, loaded_matrix.cascade_loaded,
+            "an unloaded cascade must not be indistinguishable from a real default-allow policy"
+        );
     }
 
     #[tokio::test]

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -720,9 +720,13 @@ pub async fn list_team_policies(
     // Only once a cascade *is* loaded does `[]` become a claim the data can
     // support: it is then reserved for the one case where "nothing is in force"
     // is genuinely true — a loaded cascade plus no visible agent to govern.
-    let policies = if !state.policy_engine.cascade_loaded() {
-        None
-    } else if by_key.is_empty() && visible_members > 0 {
+    // Absent (never `Some([])`) in two distinct cases that share one honest
+    // answer — "this view cannot assert nothing is in force":
+    //   1. the engine carries no cascade at all (AAASM-5106) — a `[]` here would
+    //      falsely read as "No policy in force" while the primary slot enforces;
+    //   2. a loaded cascade resolved nothing for agents that fell back to the
+    //      primary slot this projection cannot enumerate.
+    let policies = if !state.policy_engine.cascade_loaded() || (by_key.is_empty() && visible_members > 0) {
         None
     } else {
         Some(

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -646,6 +646,12 @@ pub struct TeamPoliciesResponse {
     /// `scope_index` empty, and nothing else in aa-api ever calls
     /// `load_cascade_from_dir` (AAASM-5106). Emitting `[]` there would render as
     /// "No policy is in force for this team" while a policy *is* being enforced.
+    ///
+    /// The handler reads that state from the engine's authoritative
+    /// [`cascade_loaded`](aa_gateway::engine::PolicyEngine::cascade_loaded) signal
+    /// (`false` ⇒ `null`), rather than inferring it from an empty result — an
+    /// empty result over a team with no visible agents is otherwise
+    /// indistinguishable from the genuinely-empty case and used to leak `[]`.
     //
     // Required-but-nullable, not optional: the key is always on the wire, so a
     // client reads an explicit `null` it has to handle rather than a missing
@@ -700,11 +706,23 @@ pub async fn list_team_policies(
     // AAASM-5107 — per-document 24h decision counts, read once per request.
     let hits = crate::routes::policy_hits::PolicyHitCounts::from_window(&state.audit_reader).await;
 
-    // Absent, not empty, when the team has agents whose cascade resolved nothing:
-    // those agents fall back to the primary policy slot, which this projection
-    // cannot enumerate (AAASM-5106). `[]` is reserved for the one case where
-    // "nothing is in force" is actually true — no visible agent to govern.
-    let policies = if by_key.is_empty() && visible_members > 0 {
+    // Absent, not empty, whenever the engine carries no cascade at all: every
+    // shipped aa-api deployment loads the policy through `load_from_file`, which
+    // populates the primary slot and leaves `scope_index` empty (AAASM-5106), so
+    // every agent's cascade resolves nothing and each falls back to the primary
+    // policy slot this projection cannot enumerate. The authoritative signal for
+    // that is the engine's own `cascade_loaded()`, not the `by_key`/member
+    // heuristic below: the heuristic mistakes an unloaded cascade for "nothing is
+    // in force" whenever the team has zero visible members, emitting `[]` — which
+    // the card renders as "No policy is in force for this team" while a policy is
+    // in fact being enforced from the primary slot. See ADR 0024.
+    //
+    // Only once a cascade *is* loaded does `[]` become a claim the data can
+    // support: it is then reserved for the one case where "nothing is in force"
+    // is genuinely true — a loaded cascade plus no visible agent to govern.
+    let policies = if !state.policy_engine.cascade_loaded() {
+        None
+    } else if by_key.is_empty() && visible_members > 0 {
         None
     } else {
         Some(
@@ -1554,6 +1572,31 @@ mod tests {
             serde_json::Value::Null,
             "an unresolvable mapping must be null — `[]` would assert that nothing governs \
              this team while the primary slot is enforcing: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn team_policies_are_unknown_not_empty_when_no_cascade_and_no_members() {
+        // AAASM-5106 gap: an unloaded cascade AND zero visible members. The old
+        // `by_key.is_empty() && visible_members > 0` heuristic mistook this for
+        // "nothing governs this team" and emitted `[]`, which the card renders as
+        // "No policy is in force for this team" — false while the primary slot is
+        // enforcing. With no cascade loaded the honest answer is `null`, whatever
+        // the member count: the engine's `cascade_loaded()` is `false`, so nothing
+        // this projection could enumerate is in force *through the cascade*, and
+        // it must not claim to know that nothing is in force at all.
+        let state = state_with(vec![]);
+        assert!(
+            !state.policy_engine.cascade_loaded(),
+            "fixture precondition: no cascade is loaded"
+        );
+
+        let body = team_policies_json(&state, admin(), "team-alpha").await;
+        assert_eq!(
+            body["policies"],
+            serde_json::Value::Null,
+            "an unloaded cascade must be null even with zero members — `[]` here is the \
+             leak the authoritative signal closes: {body}"
         );
     }
 

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -500,9 +500,14 @@ fn project_graph_nodes(records: &[AgentRecord], state: &AppState) -> Vec<AgentNo
             let agent_id = AgentId::from_bytes(record.agent_id);
             let lineage = state.agent_registry.lineage(&record.agent_id).unwrap_or_default();
             let cascade = state.policy_engine.collect_cascade_with_lineage(&agent_id, &lineage);
-            node.policy_count = cascade_loaded.then(|| cascade.len() as u32);
-            node.effective_permissions =
-                Some(project_effective_permissions(record, &cascade, &agent_id, &lineage, cascade_loaded));
+            node.policy_count = cascade_loaded.then_some(cascade.len() as u32);
+            node.effective_permissions = Some(project_effective_permissions(
+                record,
+                &cascade,
+                &agent_id,
+                &lineage,
+                cascade_loaded,
+            ));
             let limit_usd = state
                 .budget_tracker
                 .agent_daily_limit_usd(&agent_id)

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -416,6 +416,7 @@ fn project_effective_permissions(
     cascade: &[Arc<aa_gateway::policy::PolicyDocument>],
     agent_id: &AgentId,
     lineage: &Lineage,
+    cascade_loaded: bool,
 ) -> NodeEffectivePermissions {
     use aa_core::Capability as C;
 
@@ -448,6 +449,12 @@ fn project_effective_permissions(
         allow,
         deny: deny.into_iter().collect(),
         allow_restricted: merged.allow_is_restricted(),
+        // AAASM-5106 / ADR 0024 — annotate whether this projection saw a real
+        // cascade. When `false`, the empty chain / allow / deny above are the
+        // fall-through of an unloaded cascade, not a real "no policies apply":
+        // the dashboard renders "policy inheritance unknown" rather than a
+        // confident empty chain.
+        cascade_loaded,
     }
 }
 
@@ -477,6 +484,15 @@ fn project_graph_nodes(records: &[AgentRecord], state: &AppState) -> Vec<AgentNo
     // "no limit" placeholder rather than a misleading 0).
     let global_daily_limit = state.budget_tracker.daily_limit_usd();
 
+    // AAASM-5106 / ADR 0024 — whether the engine carries a cascade at all. When it
+    // does not (every shipped aa-api deployment), the per-agent cascade walk below
+    // resolves nothing, so `policy_count` would be a misleading `0` and the
+    // permission chain an empty-but-confident answer. `policy_count` is left
+    // `None` in that case — the same "null, not a misleading zero" discipline the
+    // list/tree/team endpoints already apply to it — and the chain carries
+    // `cascade_loaded=false` so the dashboard renders "unknown", not "no policies".
+    let cascade_loaded = state.policy_engine.cascade_loaded();
+
     let mut nodes: Vec<AgentNode> = records
         .iter()
         .map(|record| {
@@ -484,8 +500,9 @@ fn project_graph_nodes(records: &[AgentRecord], state: &AppState) -> Vec<AgentNo
             let agent_id = AgentId::from_bytes(record.agent_id);
             let lineage = state.agent_registry.lineage(&record.agent_id).unwrap_or_default();
             let cascade = state.policy_engine.collect_cascade_with_lineage(&agent_id, &lineage);
-            node.policy_count = Some(cascade.len() as u32);
-            node.effective_permissions = Some(project_effective_permissions(record, &cascade, &agent_id, &lineage));
+            node.policy_count = cascade_loaded.then(|| cascade.len() as u32);
+            node.effective_permissions =
+                Some(project_effective_permissions(record, &cascade, &agent_id, &lineage, cascade_loaded));
             let limit_usd = state
                 .budget_tracker
                 .agent_daily_limit_usd(&agent_id)
@@ -1491,6 +1508,10 @@ mod graph_tests {
             Some(1),
             "policy_count reads off the same lineage-resolved cascade"
         );
+        assert!(
+            perms.cascade_loaded,
+            "a loaded cascade must report cascade_loaded=true so the chain reads as real"
+        );
     }
 
     /// The chain lists only the tiers the agent actually has. An agent with no
@@ -1508,6 +1529,32 @@ mod graph_tests {
         assert!(perms.allow.is_empty());
         assert!(perms.deny.is_empty());
         assert!(!perms.allow_restricted);
+    }
+
+    /// AAASM-5106 / ADR 0024 — with no cascade loaded (every shipped deployment),
+    /// the empty chain and zero policy count are the fall-through of an unloaded
+    /// cascade, not a real "no policies apply". `policy_count` must be `null`
+    /// (never a misleading `0`) and `cascade_loaded` must be `false`, so the panel
+    /// renders "policy inheritance unknown" rather than a confident empty chain.
+    #[tokio::test]
+    async fn an_unloaded_cascade_reports_unknown_not_zero_policies() {
+        let state = state_with(vec![record(0x01, "a", Some("team-alpha"))]);
+        assert!(
+            !state.policy_engine.cascade_loaded(),
+            "fixture precondition: no cascade is loaded"
+        );
+
+        let graph = graph_for(admin(), &state).await;
+        let node = &graph.nodes[0];
+        assert_eq!(
+            node.policy_count, None,
+            "an unloaded cascade must leave policy_count null, not a fabricated Some(0)"
+        );
+        let perms = node.effective_permissions.as_ref().expect("chain present");
+        assert!(
+            !perms.cascade_loaded,
+            "an unloaded cascade must report cascade_loaded=false so the empty chain reads as unknown"
+        );
     }
 
     /// An empty merged allow-list carrying a restriction is deny-all, not

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1986,6 +1986,27 @@ impl PolicyEngine {
         self.cascade.load().scope_index.policies_for_scope(scope).to_vec()
     }
 
+    /// Whether this engine actually carries a policy cascade — i.e. its
+    /// `scope_index` holds at least one scoped document.
+    ///
+    /// This is the *loaded / unavailable* signal for cascade-derived **reporting
+    /// projections** (AAASM-5106): the capability matrix, the topology permission
+    /// chain, and the Teams active-policies list all read the cascade, and when it
+    /// is empty they would otherwise render a confident but false answer (an
+    /// all-`allow` grid, a zero-policy chain, "no policy is in force") that the
+    /// enforcement path — which falls back to the primary policy slot — does not
+    /// agree with. `false` here means those projections must render
+    /// *Unknown / Unconfigured / Not evaluated* rather than inferring permission
+    /// from the absence of cascade data. This never changes enforcement: it only
+    /// tells a read-only projection whether the cascade slot it is about to
+    /// summarise carries anything. See ADR 0024.
+    ///
+    /// Returns an owned `bool` computed under the [`ArcSwap`] guard; the guard
+    /// cannot outlive the call.
+    pub fn cascade_loaded(&self) -> bool {
+        !self.cascade.load().scope_index.is_empty()
+    }
+
     /// Look up a policy previously registered via [`Self::load_policy`]
     /// by its [`scope_index::PolicyId`].
     ///
@@ -4170,6 +4191,43 @@ mod tests {
         assert!(
             !engine.cascade.load().scope_index.is_empty(),
             "directory loader must populate the scope_index (cascade active)"
+        );
+    }
+
+    /// AAASM-5106 — `cascade_loaded()` is the loaded/unavailable signal the
+    /// reporting projections read to tell "the engine carries no cascade" apart
+    /// from "this agent/team genuinely has no policy". A primary-only engine
+    /// (`load_from_file` semantics, which every shipped aa-api deployment uses)
+    /// reports `false`; a directory-loaded cascade reports `true`.
+    #[test]
+    fn cascade_loaded_reflects_scope_index_population() {
+        // Primary-only engine: empty scope_index, so the cascade is not loaded.
+        let primary_only = make_engine(empty_doc());
+        assert!(
+            !primary_only.cascade_loaded(),
+            "a primary-only engine carries no cascade — cascade_loaded() must be false"
+        );
+
+        // Directory-loaded engine: a populated scope_index means a live cascade.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("000-global.yaml"),
+            "apiVersion: agent-assembly.dev/v1alpha1\n\
+             kind: GovernancePolicy\n\
+             metadata:\n  name: reg-global\n  version: \"0.1.0\"\n\
+             spec:\n  tools: {}\n",
+        )
+        .unwrap();
+        let budget = Arc::new(BudgetTracker::new(
+            crate::budget::PricingTable::default_table(),
+            None,
+            None,
+            chrono_tz::UTC,
+        ));
+        let cascade_engine = PolicyEngine::load_cascade_from_dir_with_budget(tmp.path(), budget).expect("loads");
+        assert!(
+            cascade_engine.cascade_loaded(),
+            "a directory-loaded engine carries a cascade — cascade_loaded() must be true"
         );
     }
 

--- a/dashboard/src/api/__tests__/capability.test.ts
+++ b/dashboard/src/api/__tests__/capability.test.ts
@@ -27,6 +27,7 @@ function stubMatrix(): CapabilityMatrix {
     ],
     policies: [],
     sampleCalls: [],
+    cascadeLoaded: true,
   }
 }
 

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -3114,6 +3114,25 @@ export interface components {
          */
         CapabilityMatrix: {
             agents: components["schemas"]["CapabilityAgent"][];
+            /**
+             * @description Whether the projecting engine actually carries a policy cascade
+             *     (`PolicyEngine::cascade_loaded`). AAASM-5106 / ADR 0024: when the cascade
+             *     is unloaded — the state of every shipped aa-api deployment today, which
+             *     loads its policy through `load_from_file` and leaves `scope_index` empty —
+             *     `decide()` falls through to `Allow` for every cell, so the grid asserts an
+             *     unbroken wall of `ALLOW` for capabilities the primary policy actually
+             *     denies. `false` here is the matrix-level "not evaluated — policy cascade
+             *     not loaded" signal the dashboard renders as an unavailable state, so an
+             *     operator never reads a fabricated `Allow` as a real grant. It is a fact
+             *     about the projection's *data*, never an operator choice; the enforcement
+             *     path (`evaluate_primary`) is unaffected.
+             *
+             *     Required-but-always-present, not optional: the key is always on the wire,
+             *     so a client reads an explicit `false` it must handle rather than a missing
+             *     field it can shrug off — the same absent-vs-unknown discipline as
+             *     [`CapabilityAgent::trust`] and `TeamPoliciesResponse::policies`.
+             */
+            cascadeLoaded: boolean;
             policies: components["schemas"]["Policy"][];
             resources: components["schemas"]["Resource"][];
             sampleCalls: components["schemas"]["SampleCall"][];
@@ -3824,6 +3843,7 @@ export interface components {
          *         "file_read"
          *       ],
          *       "allow_restricted": true,
+         *       "cascade_loaded": true,
          *       "chain": [
          *         {
          *           "policies": [
@@ -3849,6 +3869,25 @@ export interface components {
              *     `allow` is denied, even when `allow` is empty.
              */
             allow_restricted: boolean;
+            /**
+             * @description Whether the projecting engine actually carries a policy cascade
+             *     (`PolicyEngine::cascade_loaded`). AAASM-5106 / ADR 0024: with no cascade
+             *     loaded — every shipped aa-api deployment — the walk resolves nothing, so
+             *     every tier's `policies` is empty and `allow` / `deny` are empty. That is
+             *     **not** the real permission set: enforcement falls back to the primary
+             *     policy slot this projection cannot enumerate. `false` here is the
+             *     loaded/unavailable signal the dashboard renders as "policy inheritance
+             *     unknown — cascade not loaded", so an empty chain never reads as a real
+             *     "no policies apply". Distinct from a *loaded* cascade whose walk carries no
+             *     document at a tier, which is real state ("no team policy"). This changes
+             *     no enforcement; it only annotates the projection's confidence in its own
+             *     output.
+             *
+             *     Required-but-always-present, matching `AgentNode`'s null discipline for
+             *     unmeasured fields: the key is always on the wire so a client cannot read
+             *     an empty chain as authoritative by omission.
+             */
+            cascade_loaded: boolean;
             /** @description Cascade tiers that apply to this agent, broadest → narrowest. */
             chain: components["schemas"]["PolicyChainTier"][];
             /**
@@ -5144,6 +5183,12 @@ export interface components {
              *     `scope_index` empty, and nothing else in aa-api ever calls
              *     `load_cascade_from_dir` (AAASM-5106). Emitting `[]` there would render as
              *     "No policy is in force for this team" while a policy *is* being enforced.
+             *
+             *     The handler reads that state from the engine's authoritative
+             *     [`cascade_loaded`](aa_gateway::engine::PolicyEngine::cascade_loaded) signal
+             *     (`false` ⇒ `null`), rather than inferring it from an empty result — an
+             *     empty result over a team with no visible agents is otherwise
+             *     indistinguishable from the genuinely-empty case and used to leak `[]`.
              */
             policies: components["schemas"]["TeamPolicyResponse"][] | null;
             /** @description The team the mapping was resolved for, echoed from the request. */

--- a/dashboard/src/components/topology/NodeDetailPanel.test.tsx
+++ b/dashboard/src/components/topology/NodeDetailPanel.test.tsx
@@ -312,6 +312,7 @@ describe('NodeDetailPanel — lineage, cross-team, suspend/resume', () => {
     allow: ['file_read'],
     deny: ['terminal_exec'],
     allowRestricted: true,
+    cascadeLoaded: true,
   } as const
 
   function stubLineageOnly() {
@@ -358,6 +359,7 @@ describe('NodeDetailPanel — lineage, cross-team, suspend/resume', () => {
         allow: [],
         deny: [],
         allowRestricted: false,
+        cascadeLoaded: true,
       },
     })
     expect(screen.getByTestId('node-detail-inheritance-effective')).toHaveTextContent('baseline')
@@ -372,6 +374,7 @@ describe('NodeDetailPanel — lineage, cross-team, suspend/resume', () => {
         allow: [],
         deny: [],
         allowRestricted: true,
+        cascadeLoaded: true,
       },
     })
     // An empty allow-list with the flag set is deny-all (AAASM-4154); reading it
@@ -387,6 +390,32 @@ describe('NodeDetailPanel — lineage, cross-team, suspend/resume', () => {
 
     expect(screen.queryByTestId('node-detail-inheritance-chain')).toBeNull()
     expect(screen.getByTestId('node-detail-inheritance-empty')).toHaveTextContent('—')
+  })
+
+  it('renders the chain and policy count as unknown when the cascade is unloaded', () => {
+    // AAASM-5106 / ADR 0024 — with no cascade loaded, the empty chain and zero
+    // policy count are the fall-through of missing data, not a real "no policies
+    // apply". Both render as an "unknown" state rather than a confident answer.
+    stubLineageOnly()
+    renderWith({
+      ...NODE,
+      policyCount: null,
+      effectivePermissions: {
+        chain: [{ tier: 'global', scope: 'global', policies: [] }],
+        allow: [],
+        deny: [],
+        allowRestricted: false,
+        cascadeLoaded: false,
+      },
+    })
+
+    // The chain collapses to a single "unknown" marker — not a stack of "none"
+    // rows, which would read as an authored absence of policy.
+    expect(screen.getByTestId('node-detail-inheritance-unloaded')).toBeInTheDocument()
+    expect(screen.queryByTestId('node-detail-inheritance-chain')).toBeNull()
+    // The policy count is unknown, never a fabricated "0 policies".
+    expect(screen.getByTestId('node-detail-policy-count-absent')).toBeInTheDocument()
+    expect(screen.queryByTestId('node-detail-policy-count')).toBeNull()
   })
 
   it('renders the delegation lineage chain from the lineage query', () => {

--- a/dashboard/src/components/topology/NodeDetailPanel.tsx
+++ b/dashboard/src/components/topology/NodeDetailPanel.tsx
@@ -19,6 +19,15 @@ const RECENT_EVENT_LIMIT = 5
 const NO_LIMIT_DETAIL = 'No daily budget limit is configured for this agent'
 
 /**
+ * Why the policy count and inheritance chain are unknown (AAASM-5106 / ADR 0024).
+ *
+ * When the engine carries no cascade, this projection resolves nothing for the
+ * agent — but a policy IS in force from the primary slot, which it cannot name.
+ * The honest surface is "unknown", not a confident "0 policies" / empty chain.
+ */
+const NO_CASCADE_DETAIL = 'Policy cascade is not loaded — a policy may still be in force but cannot be resolved here'
+
+/**
  * Why the two governance buttons are inert (AAASM-5140).
  *
  * Cascade-apply and the enforcement-mode toggle have no write endpoint: the
@@ -202,9 +211,20 @@ export function NodeDetailPanel({ node, onClose, onViewTrace, nodes = [], edges 
           <Field
             label="Applied"
             value={
-              <span data-testid="node-detail-policy-count">
-                {node.policyCount} {node.policyCount === 1 ? 'policy' : 'policies'}
-              </span>
+              node.policyCount === null ? (
+                // AAASM-5106 / ADR 0024 — no cascade loaded: the count is not a
+                // measurement, so it renders "unknown" rather than a fabricated
+                // "0 policies" that would read as "nothing governs this agent".
+                <AbsenceMarker
+                  state="unconfigured"
+                  detail={NO_CASCADE_DETAIL}
+                  testId="node-detail-policy-count-absent"
+                />
+              ) : (
+                <span data-testid="node-detail-policy-count">
+                  {node.policyCount} {node.policyCount === 1 ? 'policy' : 'policies'}
+                </span>
+              )
             }
           />
         </section>
@@ -456,12 +476,30 @@ function effectiveSummary(permissions: NodeEffectivePermissions): string {
  * Renders the no-data affordance when the payload carries no chain at all — an
  * empty chain would read as "no policies apply", which is a different claim.
  * A tier that applies but carries no document is real state and reads "none".
+ *
+ * When the payload's `cascadeLoaded` is `false` (AAASM-5106 / ADR 0024) the
+ * whole chain is the fall-through of an unloaded cascade, not a real cascade
+ * that happens to carry no documents — so it renders a single "unknown" state
+ * rather than a chain of "none" rows that would read as an authored absence of
+ * policy.
  */
 function PolicyInheritance({ permissions }: Readonly<{ permissions?: NodeEffectivePermissions | null }>) {
   if (!permissions) {
     return (
       <div className="node-detail-panel__hint" data-testid="node-detail-inheritance-empty">
         —
+      </div>
+    )
+  }
+  if (!permissions.cascadeLoaded) {
+    return (
+      <div className="node-detail-panel__hint" data-testid="node-detail-inheritance-unloaded">
+        <AbsenceMarker
+          state="unconfigured"
+          detail={NO_CASCADE_DETAIL}
+          showLabel
+          testId="node-detail-inheritance-unloaded-marker"
+        />
       </div>
     )
   }

--- a/dashboard/src/features/capability/__tests__/cascadeEvidence.test.ts
+++ b/dashboard/src/features/capability/__tests__/cascadeEvidence.test.ts
@@ -3,7 +3,7 @@ import { isAbsent, isKnown } from '../../../lib/truthfulness'
 import { cascadeEvidenceFromQuery } from '../api'
 import type { CapabilityMatrix } from '../types'
 
-function matrix(policyCount: number): CapabilityMatrix {
+function matrix(policyCount: number, cascadeLoaded = true): CapabilityMatrix {
   return {
     resources: [],
     agents: [],
@@ -16,6 +16,7 @@ function matrix(policyCount: number): CapabilityMatrix {
       rules: [],
     })),
     sampleCalls: [],
+    cascadeLoaded,
   }
 }
 
@@ -71,5 +72,14 @@ describe('cascadeEvidenceFromQuery', () => {
     const evidence = cascadeEvidenceFromQuery({ data: null })
     expect(isKnown(evidence)).toBe(false)
     expect(isAbsent(evidence) && evidence.state).toBe('unknown')
+  })
+
+  it('treats an unloaded cascade as zero documents even when policies are listed', () => {
+    // AAASM-5106 / ADR 0024: the engine's authoritative `cascadeLoaded=false`
+    // wins over the policy-list length. A matrix that happens to carry a policy
+    // row but reports no cascade loaded is still `unconfigured`, so the summary
+    // cannot read those rows as measured verdicts.
+    const evidence = cascadeEvidenceFromQuery({ data: matrix(2, false) })
+    expect(isKnown(evidence) && evidence.value.documentCount).toBe(0)
   })
 })

--- a/dashboard/src/features/capability/api.test.tsx
+++ b/dashboard/src/features/capability/api.test.tsx
@@ -44,6 +44,7 @@ const SPARSE_MATRIX: CapabilityMatrix = {
   ],
   policies: [{ id: 'global', name: 'global', scope: 'global', status: 'active', affects: [], rules: [] }],
   sampleCalls: [],
+  cascadeLoaded: true,
 }
 
 afterEach(() => vi.restoreAllMocks())

--- a/dashboard/src/features/capability/api.ts
+++ b/dashboard/src/features/capability/api.ts
@@ -3,6 +3,7 @@ import { capabilityClient } from '../../api/capability'
 import {
   certainFromQuery,
   isKnown,
+  known,
   propagateAbsence,
   type CascadeEvidence,
   type Certain,
@@ -37,9 +38,14 @@ export function useCapabilityMatrixQuery() {
  *  - the request failed or is still in flight — `certainFromQuery` maps that to
  *    `unavailable` / `unknown`, so a rejected fetch can never reach the summary
  *    row as a count;
- *  - the request succeeded but the cascade resolved no documents — the
- *    AAASM-5106 condition, mapped by `cascadeEvidenceOf` to a zero
- *    `documentCount`, which the verdict rules then fold to `unconfigured`.
+ *  - the request succeeded but the engine carries no cascade — the AAASM-5106
+ *    condition. The authoritative source for that is the matrix-level
+ *    `cascadeLoaded` flag (ADR 0024), not the length of the `policies` array: a
+ *    loaded cascade can legitimately carry no capability-declaring document, so
+ *    an empty `policies` list is not by itself proof the cascade is unloaded.
+ *    When `cascadeLoaded` is `false` the evidence is a zero `documentCount`,
+ *    which the verdict rules fold to `unconfigured`; otherwise the real document
+ *    count flows through.
  *
  * Takes the query outcome rather than calling the hook itself so the optimistic
  * matrix the page holds during a bulk override still flows through the same
@@ -49,5 +55,9 @@ export function cascadeEvidenceFromQuery(
   outcome: QueryOutcome<CapabilityMatrix>,
 ): Certain<CascadeEvidence> {
   const matrix = certainFromQuery(outcome)
-  return isKnown(matrix) ? cascadeEvidenceOf(matrix.value.policies) : propagateAbsence(matrix)
+  if (!isKnown(matrix)) return propagateAbsence(matrix)
+  // The engine's own loaded/unavailable signal wins: an unloaded cascade is
+  // `unconfigured` even if the projection happened to list a policy row.
+  if (!matrix.value.cascadeLoaded) return known({ documentCount: 0 })
+  return cascadeEvidenceOf(matrix.value.policies)
 }

--- a/dashboard/src/features/capability/fixtures.ts
+++ b/dashboard/src/features/capability/fixtures.ts
@@ -265,4 +265,7 @@ export const CAPABILITY_MATRIX_FIXTURE: CapabilityMatrix = {
   agents: AGENTS,
   policies: POLICIES,
   sampleCalls: SAMPLE_CALLS,
+  // This fixture is a fully-populated matrix, so the cascade is loaded and its
+  // verdicts are real measurements (AAASM-5106).
+  cascadeLoaded: true,
 }

--- a/dashboard/src/features/capability/types.ts
+++ b/dashboard/src/features/capability/types.ts
@@ -110,6 +110,17 @@ export interface CapabilityMatrix {
   agents: CapabilityAgent[]
   policies: Policy[]
   sampleCalls: SampleCall[]
+  /**
+   * Whether the projecting engine actually carries a policy cascade
+   * (AAASM-5106 / ADR 0024). `false` — the state of every shipped deployment —
+   * means every cell fell through to `allow` because nothing constrained it, so
+   * the grid's ALLOW readings are not measurements. The page renders the grid as
+   * "not evaluated — policy cascade not loaded" in that case rather than trusting
+   * the fabricated allows. Read authoritatively rather than inferred from an
+   * empty `policies` array: an empty list can also mean a loaded cascade with no
+   * capability-declaring document, which is a different, real answer.
+   */
+  cascadeLoaded: boolean
 }
 
 export interface OverrideRequest {

--- a/dashboard/src/features/topology/api.test.tsx
+++ b/dashboard/src/features/topology/api.test.tsx
@@ -28,6 +28,7 @@ const API_GRAPH: components['schemas']['TopologyGraphResponse'] = {
         allow: [],
         deny: ['terminal_exec'],
         allow_restricted: false,
+        cascade_loaded: true,
       },
     },
     { id: 'agent-2', name: 'data-analyst', depth: 1, status: 'suspended', team_id: 'analytics', mode: 'enforce', flagged: false, trust: null },

--- a/dashboard/src/features/topology/mapGraph.test.ts
+++ b/dashboard/src/features/topology/mapGraph.test.ts
@@ -52,9 +52,14 @@ describe('mapTopologyGraph', () => {
     expect(mapTopologyGraph(graph).nodes[0].team).toBe(UNCLAIMED_TEAM)
   })
 
-  it('defaults owner / policyCount / budget to neutral placeholders when absent', () => {
+  it('maps an absent owner / policyCount / budget to their honest placeholders', () => {
+    // AAASM-5106 / ADR 0024 — an absent `policy_count` maps to `null` ("unknown"),
+    // not `0`: the backend now emits `null` when no cascade is loaded, and a `0`
+    // would read as "no policies apply" while the primary slot is enforcing.
+    // owner falls back to '' and budget spend to 0 (both real neutral defaults);
+    // budgetLimit stays null (unconfigured).
     const { nodes } = mapTopologyGraph({ nodes: [node()], edges: [] })
-    expect(nodes[0]).toMatchObject({ owner: '', policyCount: 0, budgetSpend: 0, budgetLimit: null })
+    expect(nodes[0]).toMatchObject({ owner: '', policyCount: null, budgetSpend: 0, budgetLimit: null })
   })
 
   it('carries live owner / policy_count / budget through to the view model (AAASM-5045)', () => {
@@ -141,6 +146,7 @@ describe('mapTopologyGraph', () => {
             allow: ['file_read'],
             deny: ['terminal_exec'],
             allow_restricted: true,
+            cascade_loaded: true,
           },
         }),
       ],
@@ -154,6 +160,7 @@ describe('mapTopologyGraph', () => {
       allow: ['file_read'],
       deny: ['terminal_exec'],
       allowRestricted: true,
+      cascadeLoaded: true,
     })
   })
 

--- a/dashboard/src/features/topology/mapGraph.ts
+++ b/dashboard/src/features/topology/mapGraph.ts
@@ -70,6 +70,10 @@ function toPermissions(raw: ApiPermissions | null | undefined): NodeEffectivePer
     allow: raw.allow ?? [],
     deny: raw.deny ?? [],
     allowRestricted: raw.allow_restricted,
+    // AAASM-5106 / ADR 0024 — the loaded/unavailable signal. Defaults to `false`
+    // (unknown) if an older payload omits it, so a missing signal never reads as
+    // a confident "cascade loaded".
+    cascadeLoaded: raw.cascade_loaded ?? false,
   }
 }
 
@@ -85,12 +89,13 @@ function mapNode(n: ApiNode): TopologyNode {
     // Live values enriched by the graph endpoint (AAASM-5045); null-safe — an
     // absent field keeps the prior neutral placeholder (see module doc).
     owner: n.owner ?? '',
-    // `policy_count` and `budget` are nullable on the wire for the projections
-    // that skip their lookups, but `project_graph_nodes` sets both
-    // unconditionally (`aa-api/src/routes/topology.rs:427,434`), and this mapper
-    // only ever sees that endpoint's payload. The `?? 0` fallbacks are therefore
-    // unreachable rather than a defaulted absence.
-    policyCount: n.policy_count ?? 0,
+    // `policy_count` is `null` when the engine carries no cascade (AAASM-5106 /
+    // ADR 0024) — every shipped deployment — and a real count when it does. It
+    // is carried through as `null` (never coerced to `0`) so the panel renders
+    // "unknown" rather than a fabricated "0 policies". `budget` is set
+    // unconditionally by `project_graph_nodes`, so its `?? 0` fallback is only a
+    // defensive default for an older/partial payload.
+    policyCount: n.policy_count ?? null,
     budgetSpend: n.budget?.spend_usd ?? 0,
     // `limit_usd` is the one genuinely-absent number here: the server emits
     // `null` when neither a per-agent nor a server-wide daily limit is

--- a/dashboard/src/features/topology/types.ts
+++ b/dashboard/src/features/topology/types.ts
@@ -56,6 +56,15 @@ export interface NodeEffectivePermissions {
   readonly allow: readonly string[]
   readonly deny: readonly string[]
   readonly allowRestricted: boolean
+  /**
+   * Whether the projecting engine actually carried a policy cascade
+   * (AAASM-5106 / ADR 0024). `false` — every shipped deployment — means the
+   * empty `chain` / `allow` / `deny` above are the fall-through of an unloaded
+   * cascade, not a real "no policies apply": enforcement falls back to a primary
+   * policy slot this projection cannot name. The panel renders "policy
+   * inheritance unknown" in that case rather than a confident empty chain.
+   */
+  readonly cascadeLoaded: boolean
 }
 
 /**
@@ -84,17 +93,17 @@ export interface TopologyNode {
   /** Operator / engineer who owns the agent. Surfaced in the node detail panel (AAASM-1337). */
   readonly owner: string
   /**
-   * Number of policies whose scope cascade applies to this agent.
+   * Number of policies whose scope cascade applies to this agent, or `null`
+   * when the count is not a measurement.
    *
-   * Deliberately **not** nullable, even though `AgentNode.policy_count` is
-   * nullable on the wire. That nullability exists for the list / tree / team
-   * projections, which skip the policy-engine lookup; this view model is only
-   * ever built from `GET /api/v1/topology`, and that endpoint's
-   * `project_graph_nodes` assigns it unconditionally
-   * (`aa-api/src/routes/topology.rs:427`). A count that is always resolved is a
-   * measurement, so it stays a plain number.
+   * Nullable because `project_graph_nodes` now leaves `policy_count` null when
+   * the engine carries no cascade at all (AAASM-5106 / ADR 0024): every shipped
+   * deployment loads a single primary policy and no cascade, so the walk
+   * resolves nothing and a `0` here would read as a real "no policies apply"
+   * while the primary slot is enforcing. `null` renders as "unknown", never a
+   * misleading `0`. When a cascade *is* loaded the count is a real measurement.
    */
-  readonly policyCount: number
+  readonly policyCount: number | null
   /**
    * Spend recorded against this agent for the current day, in USD.
    *

--- a/dashboard/src/pages/CapabilityPage.css
+++ b/dashboard/src/pages/CapabilityPage.css
@@ -132,6 +132,12 @@
   flex: 1;
 }
 
+/* AAASM-5106 / ADR 0024 — matrix-level "cascade not loaded" banner, sat above
+   the grid so the operator sees it before reading any cell. */
+.capability-cascade-banner {
+  margin: 12px 0;
+}
+
 .capability-verbs {
   margin-left: auto;
   display: flex;

--- a/dashboard/src/pages/CapabilityPage.test.tsx
+++ b/dashboard/src/pages/CapabilityPage.test.tsx
@@ -106,6 +106,7 @@ const EXEC_HEAVY_MATRIX: CapabilityMatrix = {
   ],
   policies: FIXTURE.policies,
   sampleCalls: [],
+  cascadeLoaded: true,
 }
 
 /**
@@ -185,6 +186,25 @@ describe('CapabilityPage', () => {
     const readRadio = screen.getByRole('radio', { name: 'read' })
     fireEvent.click(readRadio)
     expect(readRadio).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('shows the "cascade not loaded" banner when the matrix reports it, not for a loaded one', async () => {
+    // AAASM-5106 / ADR 0024 — an unloaded cascade means every ALLOW cell is a
+    // fall-through, not a measurement, so the page warns rather than presenting
+    // a confident grid.
+    getMatrix.mockResolvedValue({ ...FIXTURE, cascadeLoaded: false })
+    renderPage()
+    await screen.findByTestId('capability-cascade-unloaded')
+    expect(screen.getByTestId('capability-cascade-unloaded-state')).toHaveTextContent(
+      /not evaluated/i,
+    )
+  })
+
+  it('does not show the "cascade not loaded" banner for a loaded matrix', async () => {
+    getMatrix.mockResolvedValue(FIXTURE) // fixture is cascadeLoaded: true
+    renderPage()
+    await screen.findByRole('heading', { name: /Capability/ })
+    expect(screen.queryByTestId('capability-cascade-unloaded')).not.toBeInTheDocument()
   })
 
   it('shows the matrix tab count badge and the summary row', async () => {

--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -11,6 +11,7 @@ import { EmptyState } from '../components/EmptyState'
 import { ErrorState } from '../components/ErrorState'
 import { LoadingState } from '../components/LoadingState'
 import { useToast } from '../components/Toast'
+import { StatusState } from '../components/truthfulness'
 import { BulkActionBar } from '../features/capability/BulkActionBar'
 import { CapabilityMatrixGrid, type CellSelection } from '../features/capability/CapabilityMatrixGrid'
 import { CapabilityFilterBar } from '../features/capability/CapabilityFilterBar'
@@ -257,6 +258,31 @@ export function CapabilityPage() {
           </div>
         </div>
       </nav>
+
+      {/* AAASM-5106 / ADR 0024 — when the engine carries no policy cascade,
+          every grid cell falls through to `allow` because nothing constrained
+          it, so the grid's ALLOW readings are not measurements. Surface a
+          matrix-level "not evaluated" banner that tells the operator the grid
+          cannot be trusted, rather than letting a uniform wall of ALLOW read as
+          a clean bill of health. This is the interim honesty fix; per-cell
+          rendering is a scoped follow-up. */}
+      {tab === 'matrix' && matrix && !matrix.cascadeLoaded && (
+        <div className="capability-cascade-banner" data-testid="capability-cascade-unloaded">
+          <StatusState
+            state="unconfigured"
+            title="Capability matrix not evaluated"
+            description={
+              <>
+                No policy cascade is loaded, so these cells are not a measurement of what each
+                agent can do — an unconstrained cell reads as <code>allow</code> by default.
+                Enforcement is unaffected and still applies the active policy; this page cannot
+                resolve it until the cascade is loaded.
+              </>
+            }
+            testId="capability-cascade-unloaded-state"
+          />
+        </div>
+      )}
 
       {tab === 'matrix' && matrix && (
         <CapabilityFilterBar

--- a/dashboard/tests/e2e/review-aaasm-5099.spec.ts
+++ b/dashboard/tests/e2e/review-aaasm-5099.spec.ts
@@ -48,6 +48,9 @@ const NODES = [
       allow: ['file_read'],
       deny: ['terminal_exec'],
       allow_restricted: true,
+      // AAASM-5106 / ADR 0024: the cascade is loaded for this node, so the panel
+      // renders the real inheritance chain rather than the "unloaded" marker.
+      cascade_loaded: true,
     },
   },
   {

--- a/dashboard/tests/e2e/review-aaasm-5099.spec.ts
+++ b/dashboard/tests/e2e/review-aaasm-5099.spec.ts
@@ -110,7 +110,7 @@ async function bootstrap(page: Page, theme: Theme): Promise<Harness> {
   // Permissive fallback first (least specific); specific fixtures registered
   // afterwards win, since Playwright matches most-recently-added first.
   await page.route('**/api/**', (r) => r.fulfill({ json: {} }))
-  await page.route('**/api/v1/topology', (r) => r.fulfill({ json: { nodes: NODES, edges: EDGES } }))
+  await page.route('**/api/v1/topology', (r) => r.fulfill({ json: { nodes: NODES, edges: EDGES, cascade_loaded: true } }))
   await page.route('**/api/v1/topology/nodes/*/events', (r) => r.fulfill({ json: [] }))
   await page.route('**/api/v1/topology/lineage/**', (r) => r.fulfill({ json: LINEAGE }))
   await page.route('**/api/v1/approvals**', (r) => r.fulfill({ json: [] }))

--- a/dashboard/tests/e2e/review-aaasm-5187.spec.ts
+++ b/dashboard/tests/e2e/review-aaasm-5187.spec.ts
@@ -114,6 +114,8 @@ const MATRIX = {
     },
   ],
   sampleCalls: [],
+  // AAASM-5106: a real cascade is loaded, so the summary reports real counts.
+  cascadeLoaded: true,
 }
 
 /** The agent record `GET /api/v1/agents/{id}` returns for a matrix row. */

--- a/dashboard/tests/e2e/verify-aaasm-5090.spec.ts
+++ b/dashboard/tests/e2e/verify-aaasm-5090.spec.ts
@@ -77,6 +77,9 @@ const MATRIX = {
   ],
   // Call samples need a proposed-vs-current policy diff nothing computes yet.
   sampleCalls: [],
+  // AAASM-5106 / ADR 0024: a cascade is loaded (the baseline policy above), so
+  // the matrix projects real cells rather than folding to "not evaluated".
+  cascadeLoaded: true,
 }
 
 async function bootstrap(page: Page, theme: Theme) {

--- a/dashboard/tests/e2e/verify-aaasm-5173.spec.ts
+++ b/dashboard/tests/e2e/verify-aaasm-5173.spec.ts
@@ -87,11 +87,14 @@ const MATRIX_NO_CASCADE = {
   agents: AGENTS,
   policies: [],
   sampleCalls: [],
+  // AAASM-5106: no cascade loaded — the summary must read Unknown, not a real 0.
+  cascadeLoaded: false,
 }
 
 /** The same fleet, with one policy document actually in force. */
 const MATRIX_WITH_CASCADE = {
   ...MATRIX_NO_CASCADE,
+  cascadeLoaded: true,
   policies: [
     {
       id: 'global/baseline',

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -5153,11 +5153,31 @@ components:
       - agents
       - policies
       - sampleCalls
+      - cascadeLoaded
       properties:
         agents:
           type: array
           items:
             $ref: '#/components/schemas/CapabilityAgent'
+        cascadeLoaded:
+          type: boolean
+          description: |-
+            Whether the projecting engine actually carries a policy cascade
+            (`PolicyEngine::cascade_loaded`). AAASM-5106 / ADR 0024: when the cascade
+            is unloaded — the state of every shipped aa-api deployment today, which
+            loads its policy through `load_from_file` and leaves `scope_index` empty —
+            `decide()` falls through to `Allow` for every cell, so the grid asserts an
+            unbroken wall of `ALLOW` for capabilities the primary policy actually
+            denies. `false` here is the matrix-level "not evaluated — policy cascade
+            not loaded" signal the dashboard renders as an unavailable state, so an
+            operator never reads a fabricated `Allow` as a real grant. It is a fact
+            about the projection's *data*, never an operator choice; the enforcement
+            path (`evaluate_primary`) is unaffected.
+
+            Required-but-always-present, not optional: the key is always on the wire,
+            so a client reads an explicit `false` it must handle rather than a missing
+            field it can shrug off — the same absent-vs-unknown discipline as
+            [`CapabilityAgent::trust`] and `TeamPoliciesResponse::policies`.
         policies:
           type: array
           items:
@@ -6311,6 +6331,7 @@ components:
       - allow
       - deny
       - allow_restricted
+      - cascade_loaded
       properties:
         allow:
           type: array
@@ -6324,6 +6345,25 @@ components:
           description: |-
             Whether an allow-list restriction is in force — anything absent from
             `allow` is denied, even when `allow` is empty.
+        cascade_loaded:
+          type: boolean
+          description: |-
+            Whether the projecting engine actually carries a policy cascade
+            (`PolicyEngine::cascade_loaded`). AAASM-5106 / ADR 0024: with no cascade
+            loaded — every shipped aa-api deployment — the walk resolves nothing, so
+            every tier's `policies` is empty and `allow` / `deny` are empty. That is
+            **not** the real permission set: enforcement falls back to the primary
+            policy slot this projection cannot enumerate. `false` here is the
+            loaded/unavailable signal the dashboard renders as "policy inheritance
+            unknown — cascade not loaded", so an empty chain never reads as a real
+            "no policies apply". Distinct from a *loaded* cascade whose walk carries no
+            document at a tier, which is real state ("no team policy"). This changes
+            no enforcement; it only annotates the projection's confidence in its own
+            output.
+
+            Required-but-always-present, matching `AgentNode`'s null discipline for
+            unmeasured fields: the key is always on the wire so a client cannot read
+            an empty chain as authoritative by omission.
         chain:
           type: array
           items:
@@ -6340,6 +6380,7 @@ components:
         allow:
         - file_read
         allow_restricted: true
+        cascade_loaded: true
         chain:
         - policies:
           - baseline
@@ -8220,6 +8261,12 @@ components:
             `scope_index` empty, and nothing else in aa-api ever calls
             `load_cascade_from_dir` (AAASM-5106). Emitting `[]` there would render as
             "No policy is in force for this team" while a policy *is* being enforced.
+
+            The handler reads that state from the engine's authoritative
+            [`cascade_loaded`](aa_gateway::engine::PolicyEngine::cascade_loaded) signal
+            (`false` ⇒ `null`), rather than inferring it from an empty result — an
+            empty result over a team with no visible agents is otherwise
+            indistinguishable from the genuinely-empty case and used to leak `[]`.
         team_id:
           type: string
           description: The team the mapping was resolved for, echoed from the request.


### PR DESCRIPTION
## Description

The **interim truthfulness fix** for AAASM-5106 (decision B1). In every shipped aa-api deployment the policy scope-index cascade is empty (aa-api builds the engine via `load_from_file`, never `load_cascade_from_dir`), so every cascade-derived reporting projection rendered a confident, FALSE answer — worst of all the Teams card asserting "No policy is in force" while the primary slot actively enforces, and the capability matrix reading **ALLOW** for capabilities that are actually denied.

Enforcement was never affected (it falls back to the primary slot); only the reporting surfaces lied. This PR makes them honest.

**What changed:**
- `aa-gateway`: new `PolicyEngine::cascade_loaded()` — the loaded/unavailable signal (`!scope_index.is_empty()`).
- **Teams active-policies**: returns `policies: None` (Unknown) when the cascade is unloaded, never `Some([])` — so the UI never says "No policy is in force" from an empty data source.
- **Capability matrix**: carries a `cascade_loaded` flag; when false, the matrix renders **not-evaluated** rather than the unsound ALLOW-by-default cells.
- **Topology permission chain**: `policy_count`/effective-permissions render Unknown, not a real "no policies", when unloaded.
- Dashboard consumes the signal on all three surfaces via the existing truthfulness vocabulary (StatusState / Certain / display helpers).

## Type of Change
- [x] 🐛 Bug fix

## Breaking Changes
- [x] No — additive `cascade_loaded` signal + absent-vs-empty discipline; enforcement unchanged.

## Related Issues
- Related Jira ticket: AAASM-5106 (interim fix)
- **Real fix (loader wiring) tracked separately as AAASM-5299** — this PR deliberately does NOT wire aa-api to load the cascade; it only stops the shipped surfaces from lying while unloaded.

## Testing
- Rust: `cascade_loaded_reflects_scope_index_population`; per-surface `matrix_reports_cascade_unloaded_and_distinguishes_it_from_a_real_policy`, `team_policies_are_unknown_not_empty_when_the_engine_carries_no_cascade` (+ zero-members variant). With a loaded cascade the real answer still flows.
- `cargo test -p aa-gateway -p aa-api` green; `clippy --all-targets` + `fmt` clean; OpenAPI drift in sync.
- Dashboard: `tsc` + `eslint` clean; `vitest` 3117 pass.

## Truthfulness
- Never a confident Allow / No-policy / zero when the cascade is unloaded — the exact false-positive family this ticket exists to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)