### PR TITLE
[AAASM-5281] ✨ (aa-devtool-claude-code): Productize the Claude Code integration lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -483,6 +484,7 @@ version = "0.0.1-rc.6"
 dependencies = [
  "aa-core",
  "aa-devtool",
+ "aa-devtool-claude-code",
  "aa-ebpf",
  "aa-ebpf-common",
  "aa-proto",

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -495,6 +495,10 @@ pub async fn execute_with_adapters(
         emit_observe_banner();
     }
 
+    for warning in aa_devtool::registry::launch_warnings(&args.tool, &args.tool_args) {
+        eprintln!("warning: {warning}");
+    }
+
     if args.dry_run {
         let handle = dry_run_handle(args);
         let child_env = build_child_env(&handle, args.no_proxy, mode);

--- a/aa-cli/tests/integrations_claude_code.rs
+++ b/aa-cli/tests/integrations_claude_code.rs
@@ -1,0 +1,334 @@
+//! `aasm integrations … claude-code` driven end to end against the **native**
+//! Claude Code integration over a real DI-API socket (AAASM-5281).
+//!
+//! # Why this exists next to `integrations_command.rs`
+//!
+//! That suite drives the CLI against `FixtureIntegration` — a stand-in wearing
+//! the `ClaudeCode` label — which is right for pinning the command surface and
+//! wrong for pinning the *tool*. Nothing there would notice if the real adapter
+//! stopped materialising its trust material, stopped naming its scope, or
+//! started writing to a file the receipt does not describe.
+//!
+//! This suite registers the same `claude_code_registration` the runtime does,
+//! runs the compiled `aasm` binary against it, and asserts on what lands on
+//! disk.
+//!
+//! # Safety
+//!
+//! Every root — `HOME`, `CLAUDE_CONFIG_DIR`, `AASM_STATE_DIR`, `AA_CA_DIR` — is
+//! redirected into one temp directory **before** the integration is constructed,
+//! in the test process and in the CLI's environment. Nothing reads or writes the
+//! developer's real `~/.claude` or `~/.aa`, and no keychain operation is
+//! performed. `nextest` runs each test in its own process, which is what makes
+//! the process-wide redirection safe.
+//!
+//! # Skipping
+//!
+//! Detection runs against the real `claude` binary, so on a host without one
+//! (Linux CI) every test prints `SKIP:` and returns. A skip is visible in the
+//! output rather than looking like a pass.
+
+use std::process::Output;
+use std::sync::Arc;
+
+use aa_core::integration::ReceiptStore;
+use aa_runtime::devint::adapters::claude_code_integration;
+use aa_runtime::devint::{DevIntServer, DevIntServerConfig, DevIntServices, EngineLifecycle, TokenStore};
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+/// Locate the real `claude` binary, or explain the skip.
+fn require_claude() -> bool {
+    let found = std::process::Command::new("which")
+        .arg("claude")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !found {
+        println!("SKIP: no `claude` binary on PATH (expected on Linux CI)");
+    }
+    found
+}
+
+struct Harness {
+    dir: tempfile::TempDir,
+    socket: std::path::PathBuf,
+    token_file: std::path::PathBuf,
+    shutdown: CancellationToken,
+    server: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Harness {
+    fn start() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let run = dir.path().join("run");
+        let claude_home = dir.path().join(".claude");
+        let ca_dir = dir.path().join("aa").join("ca");
+        std::fs::create_dir_all(&run).expect("run dir");
+        std::fs::create_dir_all(&claude_home).expect("claude config dir");
+        std::fs::create_dir_all(&ca_dir).expect("ca dir");
+        // A CA the proxy would have written. Its contents are never validated
+        // here — the assertions are that it is copied, pointed at and removed.
+        std::fs::write(
+            ca_dir.join("ca-cert.pem"),
+            "-----BEGIN CERTIFICATE-----\nAAASM5281SMOKECA\n-----END CERTIFICATE-----\n",
+        )
+        .expect("ca pem");
+
+        let socket = run.join("devint.sock");
+        let token_file = run.join("devint.token");
+
+        // Redirect every root the integration resolves from the environment
+        // *before* constructing it — this is what keeps the smoke run off the
+        // developer's live configuration.
+        std::env::set_var("AA_DEVINT_TOKEN_FILE", &token_file);
+        std::env::set_var("AA_DEVINT_SOCKET", &socket);
+        std::env::set_var("HOME", dir.path());
+        std::env::set_var("CLAUDE_CONFIG_DIR", &claude_home);
+        std::env::set_var("AASM_STATE_DIR", dir.path().join("state"));
+        std::env::set_var("AA_CA_DIR", &ca_dir);
+
+        let lifecycle = Arc::new(EngineLifecycle::new(
+            vec![claude_code_integration()],
+            ReceiptStore::at(dir.path().join("state").join("integrations")),
+        ));
+
+        let tokens = TokenStore::new();
+        aa_runtime::devint::enrol_local_client(&tokens, "aasm", aa_core::integration::now_unix_secs()).expect("enrol");
+
+        let services = DevIntServices {
+            lifecycle,
+            tokens,
+            audit: Arc::new(aa_runtime::devint::audit::TracingAuditSink),
+        };
+        let shutdown = CancellationToken::new();
+        let server_token = shutdown.clone();
+        let server_config = DevIntServerConfig {
+            socket_path: socket.clone(),
+            max_connections: 8,
+        };
+        let handle = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime");
+            rt.block_on(async move {
+                let server = DevIntServer::bind(server_config).expect("bind");
+                let tracker = TaskTracker::new();
+                server.run(tracker.clone(), server_token, services).await;
+                tracker.close();
+                tracker.wait().await;
+            });
+        });
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !socket.exists() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(socket.exists(), "the test server never bound its socket");
+
+        Self {
+            dir,
+            socket,
+            token_file,
+            shutdown,
+            server: Some(handle),
+        }
+    }
+
+    fn aasm(&self, args: &[&str]) -> Output {
+        let mut cmd = assert_cmd::Command::cargo_bin("aasm").expect("aasm binary");
+        cmd.arg("integrations")
+            .args(args)
+            .arg("--no-autostart")
+            .env("AA_DEVINT_SOCKET", &self.socket)
+            .env("AA_DEVINT_TOKEN_FILE", &self.token_file)
+            .env("AASM_STATE_DIR", self.dir.path().join("state"))
+            .env("HOME", self.dir.path())
+            .env("CLAUDE_CONFIG_DIR", self.dir.path().join(".claude"))
+            .env("AA_CA_DIR", self.dir.path().join("aa").join("ca"))
+            .env("AASM_API_KEY", "");
+        cmd.output().expect("run aasm")
+    }
+
+    fn settings(&self) -> Option<serde_json::Value> {
+        let raw = std::fs::read_to_string(self.dir.path().join(".claude").join("settings.json")).ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    fn ca_pem(&self) -> std::path::PathBuf {
+        self.dir
+            .path()
+            .join("state")
+            .join("integrations")
+            .join("claude-code")
+            .join("user")
+            .join("aasm-proxy-ca.pem")
+    }
+
+    fn injected(&self, name: &str) -> Option<String> {
+        std::fs::read_to_string(
+            self.dir
+                .path()
+                .join("state")
+                .join("integrations")
+                .join("claude-code")
+                .join("user")
+                .join("launch-env")
+                .join(name),
+        )
+        .ok()
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+        if let Some(handle) = self.server.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// The whole user journey, through the compiled binary.
+#[test]
+fn the_command_family_drives_the_native_claude_code_integration() {
+    if !require_claude() {
+        return;
+    }
+    let h = Harness::start();
+
+    // The user already has configuration of their own.
+    std::fs::write(
+        h.dir.path().join(".claude").join("settings.json"),
+        r#"{"theme":"gruvbox"}"#,
+    )
+    .expect("seed settings");
+
+    let list = h.aasm(&["list"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    assert!(stdout(&list).contains("claude-code"), "{}", stdout(&list));
+
+    let plan = h.aasm(&["plan", "claude-code", "--scope", "user"]);
+    assert!(plan.status.success(), "{}", stderr(&plan));
+    let planned = stdout(&plan);
+    for expected in [
+        "write_managed_settings",
+        "materialise_trust_material",
+        "inject_launch_environment",
+        "NODE_EXTRA_CA_CERTS",
+        "configure_proxy",
+        "manage_artifact",
+        "run_protection_test",
+        // The measured bypass, stated where a user approves the plan.
+        "is not protected",
+    ] {
+        assert!(planned.contains(expected), "plan is missing {expected}:\n{planned}");
+    }
+    assert!(!h.ca_pem().exists(), "a plan must not put anything on disk:\n{planned}");
+
+    let install = h.aasm(&["install", "claude-code", "--scope", "user", "--yes"]);
+    println!(
+        "--- aasm integrations install claude-code --scope user ---\n{}",
+        stdout(&install)
+    );
+    assert!(install.status.success(), "{}", stderr(&install));
+    assert!(h.ca_pem().is_file(), "the proxy CA must be materialised");
+    assert_eq!(
+        h.injected("NODE_EXTRA_CA_CERTS").as_deref(),
+        Some(h.ca_pem().display().to_string().as_str()),
+        "condition C1: the governed launch must carry the CA variable"
+    );
+    assert!(h.injected("HTTPS_PROXY").is_some());
+    let settings = h.settings().expect("settings survive");
+    assert_eq!(settings["theme"], serde_json::json!("gruvbox"));
+    assert_eq!(settings["permissions"]["defaultMode"], serde_json::json!("default"));
+
+    let status = h.aasm(&["status", "claude-code"]);
+    assert!(status.status.success(), "{}", stderr(&status));
+    let rendered = stdout(&status);
+    // Printed so a run with `--success-output immediate` is a readable record of
+    // the operator journey, not just a green tick.
+    println!("--- aasm integrations status claude-code ---\n{rendered}");
+    assert!(rendered.contains("claude-code"), "{rendered}");
+    assert!(
+        rendered.contains("Host Enforced") || rendered.contains("host_enforced"),
+        "the unreachable rung must be reported, not omitted:\n{rendered}"
+    );
+
+    // Verification cannot pass without an adjudicating probe, and the CLI's exit
+    // code says so rather than reporting a protection that was never measured.
+    let verify = h.aasm(&["verify", "claude-code"]);
+    println!("--- aasm integrations verify claude-code ---\n{}", stdout(&verify));
+    assert_eq!(
+        verify.status.code(),
+        Some(6),
+        "verify must exit verification_failed when the protected path was not exercised:\n{}",
+        stdout(&verify)
+    );
+
+    // Drift and repair.
+    let mut doc = h.settings().expect("settings");
+    doc["permissions"]["defaultMode"] = serde_json::json!("bypassPermissions");
+    std::fs::write(
+        h.dir.path().join(".claude").join("settings.json"),
+        serde_json::to_string_pretty(&doc).expect("json"),
+    )
+    .expect("tamper");
+
+    let drifted = h.aasm(&["status", "claude-code"]);
+    assert_eq!(drifted.status.code(), Some(5), "{}", stdout(&drifted));
+
+    let repair = h.aasm(&["repair", "claude-code", "--yes"]);
+    assert!(repair.status.success(), "{}", stderr(&repair));
+    let repaired = h.settings().expect("settings");
+    assert_eq!(repaired["permissions"]["defaultMode"], serde_json::json!("default"));
+    assert_eq!(repaired["theme"], serde_json::json!("gruvbox"));
+
+    // The removal preview must read as what removal does. A settings step's
+    // reversal is "restore these keys", not "delete this file", and rendering it
+    // as an artifact removal would tell the user their configuration is about to
+    // be deleted.
+    let preview = h.aasm(&["remove", "claude-code"]);
+    let previewed = stdout(&preview);
+    assert!(
+        previewed.contains("restore the four Agent Assembly-owned keys"),
+        "{previewed}"
+    );
+    assert!(
+        !previewed.contains("run-protection-test") && !previewed.contains("run_protection_test"),
+        "a probe mutated nothing and must not appear in a removal preview:\n{previewed}"
+    );
+
+    // Removal restores what was there before.
+    let remove = h.aasm(&["remove", "claude-code", "--yes"]);
+    println!("--- aasm integrations remove claude-code ---\n{}", stdout(&remove));
+    assert!(remove.status.success(), "{}", stderr(&remove));
+    assert!(!h.ca_pem().exists(), "the copied CA must be gone");
+    assert!(h.injected("NODE_EXTRA_CA_CERTS").is_none());
+    let restored = h.settings().expect("settings");
+    assert_eq!(restored["theme"], serde_json::json!("gruvbox"));
+    assert!(restored.get("permissions").is_none(), "{restored}");
+}
+
+/// The endpoint managed-settings surface is refused by name.
+#[test]
+fn a_managed_scope_install_is_refused_and_says_which_scope_to_use() {
+    if !require_claude() {
+        return;
+    }
+    let h = Harness::start();
+    let out = h.aasm(&["plan", "claude-code", "--scope", "managed"]);
+    assert!(!out.status.success());
+    let message = stderr(&out);
+    assert!(message.contains("Library/Application Support/ClaudeCode"), "{message}");
+    assert!(message.contains("--scope user"), "{message}");
+}

--- a/aa-core/src/integration/drift.rs
+++ b/aa-core/src/integration/drift.rs
@@ -342,7 +342,16 @@ impl DriftInputs<'_> {
             }
         }
 
-        for step in receipt.steps.iter().filter(|s| s.applied) {
+        // A protection test is applied in the sense that it ran, and it changed
+        // nothing: no artifact, no fingerprint, nothing to diverge from.
+        // Comparing it would report `Unobservable` forever, which is
+        // AASM-affecting and unrepairable — so a plan that honestly includes a
+        // probe would be permanently drifted the moment it was installed.
+        for step in receipt
+            .steps
+            .iter()
+            .filter(|s| s.applied && !s.action.is_protection_test())
+        {
             let observed = self.observed.iter().find(|o| o.step_id == step.step_id);
             match observed {
                 None => report.push(
@@ -750,5 +759,35 @@ mod tests {
         let report = inputs(&r, &compat, &obs).classify();
         let json = serde_json::to_string(&report).unwrap();
         assert_eq!(serde_json::from_str::<DriftReport>(&json).unwrap(), report);
+    }
+
+    /// A plan that honestly includes a protection test must not read as drifted
+    /// the moment it is installed. The probe mutates nothing, records no
+    /// fingerprint and has no artifact — comparing it would produce
+    /// `Unobservable`, which is AASM-affecting and unrepairable.
+    #[test]
+    fn a_protection_test_step_is_not_a_drift_finding() {
+        use crate::integration::capability::IntegrationCapability;
+        use crate::integration::step::ProbeDescriptor;
+
+        let probe = IntegrationStep::new(
+            "protection-test",
+            StepAction::RunProtectionTest {
+                probe: ProbeDescriptor {
+                    id: "model-path".to_string(),
+                    mechanism: IntegrationCapability::ModelPathInterception,
+                    description: "exercise the model path".to_string(),
+                },
+            },
+            "verify the model path is intercepted",
+        );
+        let mut receipt = receipt();
+        receipt.steps.push(StepReceipt::applied(&probe, None));
+
+        let compatible = compatible();
+        let observed = observed("sha256:managed", "sha256:doc");
+        let report = inputs(&receipt, &compatible, &observed).classify();
+        assert!(report.is_clean(), "{report:?}");
+        assert!(receipt.unrestorable_steps().is_empty(), "a probe leaves nothing behind");
     }
 }

--- a/aa-core/src/integration/engine.rs
+++ b/aa-core/src/integration/engine.rs
@@ -132,6 +132,32 @@ pub trait StepExecutor {
     fn observe(&self, step: &StepReceipt) -> ArtifactObservation;
 }
 
+/// A boxed executor is itself an executor.
+///
+/// [`FilesystemExecutor`] covers the steps whose mutation is "put these bytes at
+/// this path"; every other mechanism belongs to the adapter that knows its tool,
+/// which means the service has to be able to hold *whichever* executor the tool
+/// registered rather than one concrete type. The trait is already object-safe;
+/// this impl is what lets `IntegrationEngine<Box<dyn StepExecutor + Send>>` exist
+/// so a per-tool executor can be chosen at registration time (AAASM-5281).
+///
+/// `+ Send` is on the object type rather than on the trait: the service drives
+/// the engine from an async task pool and needs the future to be `Send`, while an
+/// executor used synchronously has no reason to be constrained.
+impl StepExecutor for Box<dyn StepExecutor + Send> {
+    fn apply(&mut self, step: &IntegrationStep) -> Result<StepOutcome, ExecutionError> {
+        (**self).apply(step)
+    }
+
+    fn reverse(&mut self, step: &StepReceipt) -> Result<(), ExecutionError> {
+        (**self).reverse(step)
+    }
+
+    fn observe(&self, step: &StepReceipt) -> ArtifactObservation {
+        (**self).observe(step)
+    }
+}
+
 /// Everything an apply needs that the plan does not carry.
 #[derive(Debug, Clone)]
 pub struct ApplyContext {

--- a/aa-core/src/integration/receipt.rs
+++ b/aa-core/src/integration/receipt.rs
@@ -162,7 +162,11 @@ impl StepReceipt {
     /// restorable — the absence of a record is not evidence there was nothing
     /// to record.
     pub fn is_provably_restorable(&self) -> bool {
-        if !self.applied {
+        // A step that was never applied, and a step that mutates nothing by
+        // construction, both have nothing to restore. Reporting a probe as
+        // unrestorable would make every removal leave a residual — and a
+        // residual is what keeps the receipt on disk.
+        if !self.applied || self.action.is_protection_test() {
             return true;
         }
         match &self.prior_state {

--- a/aa-devtool-claude-code/Cargo.toml
+++ b/aa-devtool-claude-code/Cargo.toml
@@ -12,6 +12,7 @@ aa-devtool-contract = { path = "../aa-devtool-contract" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [features]
 docker-integration = []

--- a/aa-devtool-claude-code/src/bypass.rs
+++ b/aa-devtool-claude-code/src/bypass.rs
@@ -1,0 +1,301 @@
+//! Conditions under which Claude Code stops being governed by what Agent
+//! Assembly installed.
+//!
+//! # Why these are reported rather than blocked
+//!
+//! Host-level bypass prevention is a non-goal, and the AAASM-5276 spike is
+//! explicit that ten of the known bypasses were never demonstrated. What the
+//! product *can* honestly do is look at the surfaces it already reads — the
+//! settings documents it manages and the environment a launch would inherit —
+//! and say which known bypasses are **currently true**. A bypass that is
+//! detected and named lowers the reported protection level and appears in
+//! `status`; a bypass that is merely known appears in the plan's warnings.
+//!
+//! # Why a detected bypass becomes `Absent` evidence
+//!
+//! [`EvidenceKind::Absent`](aa_devtool_contract::EvidenceKind::Absent) is the
+//! reading for "a check could not be made", and that is exactly the situation:
+//! with `defaultMode: "bypassPermissions"` in effect, Agent Assembly's
+//! permission rules are still written and still read back — but nothing can be
+//! concluded from them about what the tool will actually do. Absent readings
+//! only ever lower a state, which is the behaviour this needs.
+
+use std::collections::BTreeMap;
+
+/// One known bypass, either observed on this host or documented as
+/// undemonstrable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BypassFinding {
+    /// Stable identifier, so a report can be diffed between runs.
+    pub id: &'static str,
+    /// Where it was observed, in words a user recognises.
+    pub source: String,
+    /// What it means for the protection claim.
+    pub summary: String,
+    /// What to do about it.
+    pub remediation: String,
+}
+
+impl BypassFinding {
+    /// One line combining the summary and the source, for evidence detail.
+    pub fn detail(&self) -> String {
+        format!("{} ({})", self.summary, self.source)
+    }
+}
+
+/// The environment a launch would inherit, captured so detection is a pure
+/// function of its inputs rather than of the ambient process.
+#[derive(Debug, Clone, Default)]
+pub struct LaunchEnvironment {
+    vars: BTreeMap<String, String>,
+}
+
+impl LaunchEnvironment {
+    /// Capture the current process environment.
+    pub fn from_process() -> Self {
+        Self {
+            vars: BYPASS_ENV_VARS
+                .iter()
+                .filter_map(|name| {
+                    std::env::var(name)
+                        .ok()
+                        .filter(|v| !v.is_empty())
+                        .map(|v| ((*name).to_string(), v))
+                })
+                .collect(),
+        }
+    }
+
+    /// An environment with one variable set, for tests and for callers that
+    /// know what a child will inherit.
+    #[must_use]
+    pub fn with(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.vars.insert(name.into(), value.into());
+        self
+    }
+
+    fn get(&self, name: &str) -> Option<&str> {
+        self.vars.get(name).map(String::as_str)
+    }
+}
+
+/// Environment variables whose presence changes whether Claude Code is
+/// governed. Only names are read; a value is never echoed into a report.
+const BYPASS_ENV_VARS: [&str; 5] = [
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_API_BASE_URL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "NODE_TLS_REJECT_UNAUTHORIZED",
+];
+
+/// Command-line flags that switch Claude Code's own permission enforcement off.
+///
+/// Agent Assembly passes them through unchanged — its enforcement sits below
+/// them — but a session launched with one is not getting the tool-action
+/// governance the managed settings describe, and saying so is the point.
+const BYPASS_LAUNCH_FLAGS: [&str; 3] = [
+    "--dangerously-skip-permissions",
+    "--allow-dangerously-skip-permissions",
+    "--bare",
+];
+
+/// Inspect one settings document for bypass conditions.
+///
+/// `label` names the document for the report (a path, or a scope name).
+/// Unparseable JSON yields no findings — that is a drift/observability problem
+/// reported elsewhere, and inventing a bypass finding for it would be a guess.
+pub fn settings_bypasses(label: &str, raw: &str) -> Vec<BypassFinding> {
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(raw) else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+
+    let default_mode = doc
+        .get("permissions")
+        .and_then(|p| p.get("defaultMode"))
+        .and_then(|m| m.as_str());
+    let permission_mode = doc.get("permissionMode").and_then(|m| m.as_str());
+    if [default_mode, permission_mode]
+        .iter()
+        .flatten()
+        .any(|m| *m == BYPASS_MODE)
+    {
+        found.push(BypassFinding {
+            id: "settings.bypass-permissions-mode",
+            source: label.to_string(),
+            summary: format!(
+                "the permission mode is {BYPASS_MODE:?}, so Claude Code applies no permission \
+                 rule at all — including the ones Agent Assembly wrote"
+            ),
+            remediation: format!(
+                "remove the {BYPASS_MODE:?} permission mode from {label}, then run \
+                 `aasm integrations repair claude-code`"
+            ),
+        });
+    }
+
+    if let Some(env) = doc.get("env").and_then(|e| e.as_object()) {
+        for name in ["ANTHROPIC_BASE_URL", "CLAUDE_CODE_API_BASE_URL"] {
+            if env.contains_key(name) {
+                found.push(base_url_finding(label.to_string(), name));
+            }
+        }
+        if env.contains_key("NODE_TLS_REJECT_UNAUTHORIZED") {
+            found.push(tls_finding(label.to_string()));
+        }
+    }
+
+    found
+}
+
+/// The permission mode that switches Claude Code's own rule evaluation off.
+const BYPASS_MODE: &str = "bypassPermissions";
+
+/// Inspect a launch environment for bypass conditions.
+pub fn environment_bypasses(env: &LaunchEnvironment) -> Vec<BypassFinding> {
+    let mut found = Vec::new();
+    for name in ["ANTHROPIC_BASE_URL", "CLAUDE_CODE_API_BASE_URL"] {
+        if env.get(name).is_some() {
+            found.push(base_url_finding("the shell environment".to_string(), name));
+        }
+    }
+    for name in ["CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX"] {
+        if env.get(name).is_some() {
+            found.push(BypassFinding {
+                id: "environment.alternate-provider",
+                source: "the shell environment".to_string(),
+                summary: format!(
+                    "{name} is set, so Claude Code talks to an alternate provider endpoint that \
+                     this integration does not intercept, and skips its server-managed settings fetch"
+                ),
+                remediation: format!("unset {name} before launching through `aasm run claude`"),
+            });
+        }
+    }
+    if env.get("NODE_TLS_REJECT_UNAUTHORIZED").is_some() {
+        found.push(tls_finding("the shell environment".to_string()));
+    }
+    found
+}
+
+/// Bypass flags present in the arguments a launch would pass through.
+pub fn launch_flag_bypasses(tool_args: &[String]) -> Vec<BypassFinding> {
+    BYPASS_LAUNCH_FLAGS
+        .iter()
+        .filter(|flag| tool_args.iter().any(|a| a == *flag))
+        .map(|flag| BypassFinding {
+            id: "launch.permission-bypass-flag",
+            source: format!("the launch argument {flag}"),
+            summary: format!(
+                "{flag} switches Claude Code's own permission enforcement off; Agent Assembly's \
+                 in-path interception is unaffected, but the tool-action governance in the managed \
+                 settings is not applied for this session"
+            ),
+            remediation: format!("drop {flag} to get the tool-action governance the receipt describes"),
+        })
+        .collect()
+}
+
+fn base_url_finding(source: String, name: &str) -> BypassFinding {
+    BypassFinding {
+        id: "base-url-redirection",
+        source,
+        summary: format!(
+            "{name} redirects Claude Code's model endpoint. AAASM-5276 measured this delivering a \
+             synthetic secret to the provider with no Agent Assembly component anywhere in the path; \
+             it is routing, not protection, and when it is set in the shell it additionally \
+             suppresses Claude Code's server-managed settings fetch"
+        ),
+        remediation: format!("unset {name} so model traffic goes through the intercepting proxy"),
+    }
+}
+
+fn tls_finding(source: String) -> BypassFinding {
+    BypassFinding {
+        id: "tls-verification-disabled",
+        source,
+        summary: "NODE_TLS_REJECT_UNAUTHORIZED is set, which disables TLS certificate verification \
+                  for every host the tool talks to. Agent Assembly never sets it: a TLS failure is a \
+                  finding, not something to suppress"
+            .to_string(),
+        remediation: "unset NODE_TLS_REJECT_UNAUTHORIZED; if interception needs a trusted CA, the \
+                      integration supplies one through NODE_EXTRA_CA_CERTS"
+            .to_string(),
+    }
+}
+
+/// Known bypasses this integration cannot observe, stated so `status` and the
+/// plan never imply the absence of a finding is the absence of a bypass.
+///
+/// Wording tracks the AAASM-5276 "inferred, not demonstrated" list.
+pub const UNOBSERVABLE_BYPASSES: &str =
+    "launching `claude` outside `aasm run` (no proxy or CA is injected), repointing \
+     CLAUDE_CONFIG_DIR, symlinking .claude, editing the settings file directly, replacing the \
+     binary, or calling the Anthropic API from another program with the developer's own key";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bypass_permissions_is_detected_in_either_key() {
+        let nested = r#"{"permissions":{"defaultMode":"bypassPermissions","allow":[]}}"#;
+        let found = settings_bypasses("~/.claude/settings.json", nested);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, "settings.bypass-permissions-mode");
+        assert!(found[0].detail().contains("~/.claude/settings.json"), "{:?}", found[0]);
+
+        let top_level = r#"{"permissionMode":"bypassPermissions"}"#;
+        assert_eq!(settings_bypasses("s", top_level).len(), 1);
+
+        let benign = r#"{"permissions":{"defaultMode":"default"},"permissionMode":"plan"}"#;
+        assert!(settings_bypasses("s", benign).is_empty());
+    }
+
+    #[test]
+    fn a_settings_env_block_can_redirect_the_model_endpoint() {
+        let doc = r#"{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:9"}}"#;
+        let found = settings_bypasses("s", doc);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, "base-url-redirection");
+        assert!(found[0].summary.contains("routing, not protection"), "{found:?}");
+    }
+
+    #[test]
+    fn environment_bypasses_are_detected_without_reading_values() {
+        let env = LaunchEnvironment::default()
+            .with("ANTHROPIC_BASE_URL", "http://secret.example")
+            .with("CLAUDE_CODE_USE_BEDROCK", "1")
+            .with("NODE_TLS_REJECT_UNAUTHORIZED", "0");
+        let found = environment_bypasses(&env);
+        let ids: Vec<&str> = found.iter().map(|f| f.id).collect();
+        assert!(ids.contains(&"base-url-redirection"), "{ids:?}");
+        assert!(ids.contains(&"environment.alternate-provider"), "{ids:?}");
+        assert!(ids.contains(&"tls-verification-disabled"), "{ids:?}");
+        // The value is never echoed — only the variable's name.
+        for finding in &found {
+            assert!(
+                !finding.summary.contains("secret.example") && !finding.detail().contains("secret.example"),
+                "a bypass report echoed an environment value: {finding:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn launch_flags_are_reported_without_being_stripped() {
+        let args = vec!["--dangerously-skip-permissions".to_string(), "-p".to_string()];
+        let found = launch_flag_bypasses(&args);
+        assert_eq!(found.len(), 1);
+        assert!(
+            found[0].summary.contains("in-path interception is unaffected"),
+            "{found:?}"
+        );
+        assert!(launch_flag_bypasses(&["-p".to_string()]).is_empty());
+    }
+
+    #[test]
+    fn unparseable_settings_produce_no_invented_finding() {
+        assert!(settings_bypasses("s", "not json at all").is_empty());
+    }
+}

--- a/aa-devtool-claude-code/src/executor.rs
+++ b/aa-devtool-claude-code/src/executor.rs
@@ -1,0 +1,333 @@
+//! The mutations only this tool's integration knows how to perform.
+//!
+//! # Why an executor lives in an adapter crate at all
+//!
+//! [`FilesystemExecutor`] covers every step whose mutation is "put these bytes
+//! at this path" — managed settings, trust material, owned artifacts — and
+//! deliberately refuses the rest with
+//! [`ExecutionError::Unsupported`] rather than reporting a success nothing
+//! performed. `aa-core`'s own note says why: launch-environment injection and
+//! proxy variables need mechanism the filesystem cannot supply, and belong to
+//! the adapter that knows its tool.
+//!
+//! [`ClaudeCodeStepExecutor`] is that adapter half. It delegates everything
+//! `FilesystemExecutor` already does correctly and adds exactly two mechanisms:
+//! [`StepAction::InjectLaunchEnvironment`] and [`StepAction::ConfigureProxy`],
+//! both backed by [`LaunchEnvStore`]. Nothing else is added — a mechanism this
+//! executor cannot perform still refuses.
+//!
+//! # Why it is scope-keyed rather than built for one scope
+//!
+//! Applying always has a plan, and a plan always names its scope. Observing and
+//! reversing do not: the service builds an executor from a receipt, and a user
+//! may have installed at project scope. Both launch-environment actions carry
+//! their own scope, so the executor holds one store per scope it was given and
+//! dispatches per step. A step naming a scope this executor holds no store for
+//! is refused rather than written to the wrong one.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use aa_devtool_contract::{
+    ArtifactObservation, EnvValue, ExecutionError, FilesystemExecutor, IntegrationStep, SettingsScope, StepAction,
+    StepExecutor, StepOutcome, StepReceipt,
+};
+
+use crate::launch_env::LaunchEnvStore;
+
+/// Prefix `aa-core` puts on every fingerprint. Reproduced rather than
+/// re-exported: the executor has to produce values `observe` can compare
+/// against, and the format is part of the receipt's wire shape.
+const FINGERPRINT_PREFIX: &str = "sha256:";
+
+/// The fingerprint of a raw (non-JSON) artifact.
+fn raw_fingerprint(body: &str) -> String {
+    format!("{FINGERPRINT_PREFIX}{}", aa_devtool_contract::sha256_hex(body))
+}
+
+/// The canonical rendering of a set of launch-environment assignments.
+///
+/// Sorted `NAME=value` lines, so a `ConfigureProxy` step that writes several
+/// variables has one stable fingerprint regardless of map iteration order.
+fn env_projection(pairs: &[(String, String)]) -> String {
+    let mut sorted: Vec<&(String, String)> = pairs.iter().collect();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    sorted
+        .iter()
+        .map(|(k, v)| format!("{k}={v}\n"))
+        .collect::<Vec<_>>()
+        .concat()
+}
+
+/// Executes a Claude Code integration plan.
+#[derive(Default)]
+pub struct ClaudeCodeStepExecutor {
+    files: FilesystemExecutor,
+    launch_env: BTreeMap<SettingsScope, LaunchEnvStore>,
+}
+
+impl std::fmt::Debug for ClaudeCodeStepExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClaudeCodeStepExecutor")
+            .field("scopes", &self.launch_env.keys().collect::<Vec<_>>())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ClaudeCodeStepExecutor {
+    /// An executor that knows no launch-environment directory yet.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Give this executor `scope`'s launch-environment directory.
+    #[must_use]
+    pub fn with_scope(mut self, scope: SettingsScope, launch_env_dir: impl Into<PathBuf>) -> Self {
+        self.launch_env.insert(scope, LaunchEnvStore::at(launch_env_dir));
+        self
+    }
+
+    /// Supply the content a step will write.
+    #[must_use]
+    pub fn with_content(mut self, step_id: impl Into<String>, content: impl Into<String>) -> Self {
+        self.files = self.files.with_content(step_id, content);
+        self
+    }
+
+    /// The launch-environment variables this integration injects at `scope`.
+    pub fn injected_environment(&self, scope: SettingsScope) -> BTreeMap<String, String> {
+        self.launch_env.get(&scope).map(LaunchEnvStore::all).unwrap_or_default()
+    }
+
+    fn store(&self, scope: SettingsScope) -> Result<&LaunchEnvStore, ExecutionError> {
+        self.launch_env.get(&scope).ok_or_else(|| ExecutionError::Io {
+            artifact: format!("the {scope}-scoped launch environment"),
+            detail: format!("this executor holds no launch-environment directory for the {scope} scope"),
+        })
+    }
+
+    /// Assignments an action describes, with the scope they belong to, or `None`
+    /// when it is not an action this executor owns.
+    fn assignments(action: &StepAction) -> Option<(SettingsScope, Vec<(String, String)>)> {
+        match action {
+            StepAction::InjectLaunchEnvironment { scope, variable, value } => {
+                let rendered = match value {
+                    EnvValue::Literal(v) => v.clone(),
+                    EnvValue::ArtifactPath(p) => p.display().to_string(),
+                    // `EnvValue` is non-exhaustive. A value shape this build
+                    // cannot render is refused by falling through to the
+                    // filesystem executor, which reports `Unsupported` — a
+                    // guess would put the wrong bytes in the child's
+                    // environment and record them in a receipt as correct.
+                    _ => return None,
+                };
+                Some((*scope, vec![(variable.clone(), rendered)]))
+            }
+            StepAction::ConfigureProxy { scope, variables } => {
+                Some((*scope, variables.iter().map(|(k, v)| (k.clone(), v.clone())).collect()))
+            }
+            _ => None,
+        }
+    }
+
+    fn apply_assignments(
+        &self,
+        scope: SettingsScope,
+        pairs: &[(String, String)],
+        kind: &'static str,
+    ) -> Result<StepOutcome, ExecutionError> {
+        let store = self.store(scope)?;
+        let mut mutated = false;
+        for (name, value) in pairs {
+            mutated |= store.set(name, value).map_err(|e| ExecutionError::Io {
+                artifact: format!("{} ({kind})", store.root().join(name).display()),
+                detail: e.to_string(),
+            })?;
+        }
+        Ok(StepOutcome {
+            fingerprint: Some(raw_fingerprint(&env_projection(pairs))),
+            document_fingerprint: None,
+            prior_state: None,
+            mutated,
+        })
+    }
+
+    fn observe_assignments(&self, scope: SettingsScope, pairs: &[(String, String)]) -> ArtifactObservation {
+        let store = match self.store(scope) {
+            Ok(store) => store,
+            Err(e) => return ArtifactObservation::Unreadable { reason: e.to_string() },
+        };
+        let mut current = Vec::with_capacity(pairs.len());
+        for (name, _) in pairs {
+            match store.get(name) {
+                Some(value) => current.push((name.clone(), value)),
+                None => return ArtifactObservation::Missing,
+            }
+        }
+        ArtifactObservation::Present {
+            managed_fingerprint: raw_fingerprint(&env_projection(&current)),
+            document_fingerprint: None,
+        }
+    }
+}
+
+impl StepExecutor for ClaudeCodeStepExecutor {
+    fn apply(&mut self, step: &IntegrationStep) -> Result<StepOutcome, ExecutionError> {
+        match Self::assignments(&step.action) {
+            Some((scope, pairs)) => self.apply_assignments(scope, &pairs, step.action.kind()),
+            None => self.files.apply(step),
+        }
+    }
+
+    fn reverse(&mut self, step: &StepReceipt) -> Result<(), ExecutionError> {
+        match Self::assignments(&step.action) {
+            Some((scope, pairs)) => {
+                let store = self.store(scope)?;
+                for (name, _) in &pairs {
+                    store.unset(name).map_err(|e| ExecutionError::Io {
+                        artifact: store.root().join(name).display().to_string(),
+                        detail: e.to_string(),
+                    })?;
+                }
+                Ok(())
+            }
+            None => self.files.reverse(step),
+        }
+    }
+
+    fn observe(&self, step: &StepReceipt) -> ArtifactObservation {
+        match Self::assignments(&step.action) {
+            Some((scope, pairs)) => self.observe_assignments(scope, &pairs),
+            None => self.files.observe(step),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_devtool_contract::ArtifactOperation;
+
+    fn ca_env_step(pem: &std::path::Path) -> IntegrationStep {
+        IntegrationStep::new(
+            "node-extra-ca-certs",
+            StepAction::InjectLaunchEnvironment {
+                scope: SettingsScope::User,
+                variable: "NODE_EXTRA_CA_CERTS".to_string(),
+                value: EnvValue::ArtifactPath(pem.to_path_buf()),
+            },
+            "make Claude Code's Node runtime trust the Agent Assembly proxy CA",
+        )
+    }
+
+    fn proxy_step() -> IntegrationStep {
+        let mut variables = BTreeMap::new();
+        variables.insert("HTTPS_PROXY".to_string(), "http://127.0.0.1:8899".to_string());
+        variables.insert("HTTP_PROXY".to_string(), "http://127.0.0.1:8899".to_string());
+        IntegrationStep::new(
+            "proxy-env",
+            StepAction::ConfigureProxy {
+                scope: SettingsScope::User,
+                variables,
+            },
+            "route Claude Code's traffic through the Agent Assembly proxy",
+        )
+    }
+
+    #[test]
+    fn injecting_the_ca_variable_is_applied_observed_and_reversed() {
+        let dir = tempfile::tempdir().unwrap();
+        let pem = dir.path().join("aasm-proxy-ca.pem");
+        let mut exec = ClaudeCodeStepExecutor::new().with_scope(SettingsScope::User, dir.path().join("launch-env"));
+        let step = ca_env_step(&pem);
+
+        let applied = exec.apply(&step).unwrap();
+        assert!(applied.mutated);
+        let fingerprint = applied.fingerprint.clone().expect("a launch-env step is fingerprinted");
+        assert_eq!(
+            exec.injected_environment(SettingsScope::User)
+                .get("NODE_EXTRA_CA_CERTS")
+                .map(String::as_str),
+            Some(pem.display().to_string().as_str())
+        );
+
+        // Reapplying the same step changes nothing on the host.
+        assert!(!exec.apply(&step).unwrap().mutated);
+
+        let receipt = StepReceipt::applied(&step, Some(fingerprint.clone()));
+        assert_eq!(
+            exec.observe(&receipt),
+            ArtifactObservation::Present {
+                managed_fingerprint: fingerprint,
+                document_fingerprint: None,
+            }
+        );
+
+        exec.reverse(&receipt).unwrap();
+        assert_eq!(exec.observe(&receipt), ArtifactObservation::Missing);
+        // Reversal has to be safe to run twice.
+        exec.reverse(&receipt).unwrap();
+    }
+
+    #[test]
+    fn a_changed_value_is_observed_as_a_different_fingerprint() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut exec = ClaudeCodeStepExecutor::new().with_scope(SettingsScope::User, dir.path().join("launch-env"));
+        let step = proxy_step();
+        let applied = exec.apply(&step).unwrap();
+        let receipt = StepReceipt::applied(&step, applied.fingerprint.clone());
+
+        LaunchEnvStore::at(dir.path().join("launch-env"))
+            .set("HTTPS_PROXY", "http://127.0.0.1:1")
+            .unwrap();
+
+        match exec.observe(&receipt) {
+            ArtifactObservation::Present {
+                managed_fingerprint, ..
+            } => {
+                assert_ne!(Some(managed_fingerprint), applied.fingerprint);
+            }
+            other => panic!("expected Present, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_steps_are_delegated_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifact = dir.path().join("owned.txt");
+        let step = IntegrationStep::new(
+            "artifact",
+            StepAction::ManageArtifact {
+                operation: ArtifactOperation::Create,
+                path: artifact.clone(),
+            },
+            "write an owned artifact",
+        );
+        let mut exec = ClaudeCodeStepExecutor::new()
+            .with_scope(SettingsScope::User, dir.path().join("launch-env"))
+            .with_content("artifact", "hosts\n");
+
+        assert!(exec.apply(&step).unwrap().mutated);
+        assert_eq!(std::fs::read_to_string(&artifact).unwrap(), "hosts\n");
+    }
+
+    #[test]
+    fn a_mechanism_this_executor_does_not_have_still_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let step = IntegrationStep::new(
+            "ide",
+            StepAction::RegisterIdeClient {
+                host: "vscode".to_string(),
+                client_id: "x".to_string(),
+            },
+            "register an IDE client",
+        );
+        let mut exec = ClaudeCodeStepExecutor::new().with_scope(SettingsScope::User, dir.path().join("launch-env"));
+        assert!(matches!(
+            exec.apply(&step),
+            Err(ExecutionError::Unsupported {
+                kind: "register-ide-client"
+            })
+        ));
+    }
+}

--- a/aa-devtool-claude-code/src/launch_env.rs
+++ b/aa-devtool-claude-code/src/launch_env.rs
@@ -1,0 +1,275 @@
+//! The launch environment Agent Assembly injects, kept as an artifact it owns.
+//!
+//! # Why an artifact and not "the launcher just sets it"
+//!
+//! AAASM-5276 condition C1 is that `NODE_EXTRA_CA_CERTS` has to point at the
+//! proxy CA for interception to work at all. A launcher that simply called
+//! `cmd.env(...)` would satisfy the mechanism and none of the lifecycle: there
+//! would be nothing to fingerprint, nothing for drift to compare, nothing for a
+//! receipt to record and nothing for removal to reverse. Writing the variable to
+//! a file Agent Assembly owns makes the injection a
+//! [`StepAction::InjectLaunchEnvironment`](aa_devtool_contract::StepAction)
+//! whose artifact behaves like every other one in the plan.
+//!
+//! # One file per variable
+//!
+//! Two steps writing into one document would each fingerprint the whole
+//! document, so the second would invalidate the first's receipt and the next
+//! drift check would report a change nobody made. A file per variable keeps each
+//! step's artifact independent, which is what lets `ConfigureProxy` and
+//! `InjectLaunchEnvironment` coexist in one plan.
+//!
+//! # Variable names are validated, not trusted
+//!
+//! A name becomes a file name. [`is_valid_var_name`] restricts it to the POSIX
+//! environment-name shape, so a plan cannot address a path outside the store —
+//! including via `..`.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Whether `name` is a POSIX environment variable name.
+///
+/// `[A-Za-z_][A-Za-z0-9_]*`. Anything else is refused rather than sanitised: a
+/// name this store cannot represent is a plan bug, and quietly rewriting it
+/// would put the variable somewhere the receipt does not describe.
+pub fn is_valid_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// The launch-environment variables Agent Assembly owns for one scope.
+#[derive(Debug, Clone)]
+pub struct LaunchEnvStore {
+    root: PathBuf,
+}
+
+impl LaunchEnvStore {
+    /// A store rooted at `root`, created on first write.
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// The directory this store writes into.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Where `name`'s value is kept.
+    ///
+    /// # Errors
+    ///
+    /// [`io::ErrorKind::InvalidInput`] when `name` is not a valid environment
+    /// variable name.
+    pub fn path_for(&self, name: &str) -> io::Result<PathBuf> {
+        if !is_valid_var_name(name) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("{name:?} is not a valid environment variable name"),
+            ));
+        }
+        Ok(self.root.join(name))
+    }
+
+    /// Set `name` to `value`, returning whether anything on disk changed.
+    ///
+    /// The `false` case is the mechanical half of the idempotence guarantee: a
+    /// reapply that would write the same bytes does not touch the file.
+    ///
+    /// # Errors
+    ///
+    /// As [`path_for`](Self::path_for), plus any filesystem failure.
+    pub fn set(&self, name: &str, value: &str) -> io::Result<bool> {
+        let path = self.path_for(name)?;
+        if std::fs::read_to_string(&path).is_ok_and(|existing| existing == value) {
+            return Ok(false);
+        }
+        std::fs::create_dir_all(&self.root)?;
+        let tmp = path.with_extension("aasm-tmp");
+        std::fs::write(&tmp, value)?;
+        std::fs::rename(&tmp, &path)?;
+        Ok(true)
+    }
+
+    /// The current value of `name`, or `None` when it is unset or unreadable.
+    pub fn get(&self, name: &str) -> Option<String> {
+        let path = self.path_for(name).ok()?;
+        std::fs::read_to_string(path).ok()
+    }
+
+    /// Unset `name`. Succeeds when it was already unset — removal has to be
+    /// safe to run twice.
+    ///
+    /// # Errors
+    ///
+    /// As [`path_for`](Self::path_for), plus any filesystem failure other than
+    /// "not found".
+    pub fn unset(&self, name: &str) -> io::Result<()> {
+        let path = self.path_for(name)?;
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+        // Leave no empty directory behind; an empty launch-env directory is an
+        // artifact the user never had. A non-empty one simply refuses.
+        let _ = std::fs::remove_dir(&self.root);
+        Ok(())
+    }
+
+    /// Every variable this store currently holds, in name order.
+    ///
+    /// Entries whose file name is not a valid variable name are skipped rather
+    /// than exported — a stray file must not become part of a child's
+    /// environment.
+    pub fn all(&self) -> BTreeMap<String, String> {
+        let Ok(entries) = std::fs::read_dir(&self.root) else {
+            return BTreeMap::new();
+        };
+        entries
+            .flatten()
+            .filter_map(|entry| {
+                let name = entry.file_name().to_str()?.to_owned();
+                if !is_valid_var_name(&name) {
+                    return None;
+                }
+                let value = std::fs::read_to_string(entry.path()).ok()?;
+                Some((name, value))
+            })
+            .collect()
+    }
+}
+
+/// Every launch-environment variable an installed integration owns, across
+/// every scope it can be installed at.
+///
+/// User scope is read first and project scope second, so a project-scoped
+/// install wins for a variable both set — the narrower installation is the more
+/// specific answer for the directory the launch is happening in.
+///
+/// A scope with no installation contributes nothing, so a host where nothing was
+/// installed produces an empty map and the launch is unchanged.
+pub fn installed_environment(paths: &crate::scope::ClaudeCodePaths) -> BTreeMap<String, String> {
+    let mut merged = BTreeMap::new();
+    for scope in [
+        aa_devtool_contract::SettingsScope::User,
+        aa_devtool_contract::SettingsScope::Project,
+    ] {
+        let Ok(dir) = paths.launch_env_dir(scope) else {
+            continue;
+        };
+        merged.extend(LaunchEnvStore::at(dir).all());
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> (tempfile::TempDir, LaunchEnvStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LaunchEnvStore::at(dir.path().join("launch-env"));
+        (dir, store)
+    }
+
+    #[test]
+    fn setting_a_variable_twice_mutates_once() {
+        let (_dir, store) = store();
+        assert!(store.set("NODE_EXTRA_CA_CERTS", "/tmp/ca.pem").unwrap());
+        assert!(
+            !store.set("NODE_EXTRA_CA_CERTS", "/tmp/ca.pem").unwrap(),
+            "a rewrite of identical bytes must not report a mutation"
+        );
+        assert!(store.set("NODE_EXTRA_CA_CERTS", "/tmp/other.pem").unwrap());
+        assert_eq!(store.get("NODE_EXTRA_CA_CERTS").as_deref(), Some("/tmp/other.pem"));
+    }
+
+    #[test]
+    fn unsetting_is_idempotent_and_removes_the_directory() {
+        let (_dir, store) = store();
+        store.set("HTTPS_PROXY", "http://127.0.0.1:8899").unwrap();
+        store.unset("HTTPS_PROXY").unwrap();
+        store.unset("HTTPS_PROXY").unwrap();
+        assert!(store.get("HTTPS_PROXY").is_none());
+        assert!(!store.root().exists(), "an empty launch-env directory must not survive");
+    }
+
+    #[test]
+    fn a_variable_name_cannot_address_a_path_outside_the_store() {
+        let (_dir, store) = store();
+        for evil in ["../escape", "a/b", "..", "", "1BAD", "WITH-DASH"] {
+            assert!(
+                store.path_for(evil).is_err(),
+                "{evil:?} was accepted as a variable name"
+            );
+            assert!(store.set(evil, "x").is_err(), "{evil:?} was written");
+        }
+        assert!(store.path_for("NODE_EXTRA_CA_CERTS").is_ok());
+        assert!(store.path_for("_private1").is_ok());
+    }
+
+    #[test]
+    fn stray_files_are_not_exported_as_variables() {
+        let (_dir, store) = store();
+        store.set("HTTPS_PROXY", "http://127.0.0.1:8899").unwrap();
+        std::fs::write(store.root().join("not-a-var"), "ignored").unwrap();
+        let all = store.all();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all.get("HTTPS_PROXY").map(String::as_str),
+            Some("http://127.0.0.1:8899")
+        );
+    }
+
+    #[test]
+    fn an_absent_store_exports_nothing() {
+        let (_dir, store) = store();
+        assert!(store.all().is_empty());
+    }
+
+    #[test]
+    fn a_project_installation_wins_over_a_user_one_for_the_same_variable() {
+        use aa_devtool_contract::SettingsScope;
+        let dir = tempfile::tempdir().unwrap();
+        let paths = crate::scope::ClaudeCodePaths::default()
+            .with_home(dir.path().join("home"))
+            .with_project(dir.path().join("repo"))
+            .with_state(dir.path().join("state"));
+
+        LaunchEnvStore::at(paths.launch_env_dir(SettingsScope::User).unwrap())
+            .set("NODE_EXTRA_CA_CERTS", "/user/ca.pem")
+            .unwrap();
+        LaunchEnvStore::at(paths.launch_env_dir(SettingsScope::User).unwrap())
+            .set("HTTPS_PROXY", "http://127.0.0.1:8899")
+            .unwrap();
+        LaunchEnvStore::at(paths.launch_env_dir(SettingsScope::Project).unwrap())
+            .set("NODE_EXTRA_CA_CERTS", "/project/ca.pem")
+            .unwrap();
+
+        let env = installed_environment(&paths);
+        assert_eq!(
+            env.get("NODE_EXTRA_CA_CERTS").map(String::as_str),
+            Some("/project/ca.pem")
+        );
+        assert_eq!(
+            env.get("HTTPS_PROXY").map(String::as_str),
+            Some("http://127.0.0.1:8899")
+        );
+    }
+
+    #[test]
+    fn a_host_with_no_installation_injects_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = crate::scope::ClaudeCodePaths::default()
+            .with_home(dir.path().join("home"))
+            .with_project(dir.path().join("repo"))
+            .with_state(dir.path().join("state"));
+        assert!(installed_environment(&paths).is_empty());
+    }
+}

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -18,6 +18,7 @@ mod apply;
 mod settings;
 
 pub mod bypass;
+pub mod launch_env;
 pub mod scope;
 
 pub use scope::{ClaudeCodePaths, ScopeError};

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -17,6 +17,19 @@
 mod apply;
 mod settings;
 
+pub mod scope;
+
+pub use scope::{ClaudeCodePaths, ScopeError};
+
+/// Directory, under the Agent Assembly state root, holding one MitM host list
+/// per integration.
+///
+/// The proxy unions every file here into its interception set. One file per
+/// integration is what makes AAASM-5276 condition C5 possible without flipping
+/// the global `llm_only` default: scoping one tool's side channels never changes
+/// what the proxy does for anything else on the machine.
+pub const MITM_HOSTS_DIR: &str = "mitm-hosts.d";
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -20,9 +20,11 @@ mod settings;
 pub mod bypass;
 pub mod executor;
 pub mod launch_env;
+pub mod probe;
 pub mod scope;
 
 pub use executor::ClaudeCodeStepExecutor;
+pub use probe::{ProbeReport, ProbeRequest, ProtectionProbe};
 pub use scope::{ClaudeCodePaths, ScopeError};
 
 /// Directory, under the Agent Assembly state root, holding one MitM host list

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -176,6 +176,18 @@ impl ClaudeCodeAdapter {
         let marker = self.home_dir()?.join(".claude");
         marker.is_dir().then_some(marker)
     }
+
+    /// The paths a launch reads its injected environment from.
+    ///
+    /// Resolved from the environment, with this adapter's home override applied
+    /// so a test never reaches the developer's real state directory.
+    fn launch_paths(&self) -> ClaudeCodePaths {
+        let paths = ClaudeCodePaths::from_env();
+        match &self.home_dir_override {
+            Some(home) => paths.with_home(home.clone()),
+            None => paths,
+        }
+    }
 }
 
 /// Locate a binary via the `which` command.
@@ -294,6 +306,25 @@ impl DevToolAdapter for ClaudeCodeAdapter {
         apply::apply_settings_at(&path, settings)
     }
 
+    /// Build the governed launch command.
+    ///
+    /// # Why this reads an installed integration's launch environment
+    ///
+    /// AAASM-5276 measured, against the real `claude 2.1.220` binary, that the
+    /// proxy's MitM handshake only succeeds when `NODE_EXTRA_CA_CERTS` points at
+    /// the Agent Assembly certificate authority — and that this method used to
+    /// inject `HTTPS_PROXY` and nothing else, so the handshake failed and the
+    /// tool's traffic was never inspected. **Silently**: a proxy that cannot
+    /// terminate TLS still lets the connection through.
+    ///
+    /// `aasm integrations install claude-code` materialises the CA and records
+    /// the variable; this is where it reaches the child process. A host with no
+    /// installed integration contributes nothing, so the behaviour is unchanged
+    /// where nothing was installed.
+    ///
+    /// A `proxy_addr` the caller pins for this run wins over the receipted one:
+    /// the address is a runtime fact, and routing a session at a proxy that is
+    /// not listening is worse than routing it at the live one.
     fn build_launch_command(
         &self,
         tool_args: &[String],
@@ -308,8 +339,17 @@ impl DevToolAdapter for ClaudeCodeAdapter {
         if let Some(tid) = team_id {
             cmd.env("AA_TEAM_ID", tid);
         }
+        for (name, value) in launch_env::installed_environment(&self.launch_paths()) {
+            cmd.env(name, value);
+        }
         if let Some(px) = proxy_addr {
-            cmd.env("HTTPS_PROXY", px);
+            let url = if px.starts_with("http") {
+                px.to_string()
+            } else {
+                format!("http://{px}")
+            };
+            cmd.env("HTTPS_PROXY", &url);
+            cmd.env("HTTP_PROXY", &url);
         }
         Ok(cmd)
     }
@@ -577,9 +617,16 @@ mod tests {
             envs[std::ffi::OsStr::new("AA_TEAM_ID")],
             Some(std::ffi::OsStr::new("team-a"))
         );
+        // AAASM-5281: a bare `host:port` is not a proxy URL any HTTP client
+        // accepts, so the adapter normalises it to one. The spike's own harness
+        // had to do the same thing by hand before every launch.
         assert_eq!(
             envs[std::ffi::OsStr::new("HTTPS_PROXY")],
-            Some(std::ffi::OsStr::new("127.0.0.1:8080"))
+            Some(std::ffi::OsStr::new("http://127.0.0.1:8080"))
+        );
+        assert_eq!(
+            envs[std::ffi::OsStr::new("HTTP_PROXY")],
+            Some(std::ffi::OsStr::new("http://127.0.0.1:8080"))
         );
     }
 

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -18,9 +18,11 @@ mod apply;
 mod settings;
 
 pub mod bypass;
+pub mod executor;
 pub mod launch_env;
 pub mod scope;
 
+pub use executor::ClaudeCodeStepExecutor;
 pub use scope::{ClaudeCodePaths, ScopeError};
 
 /// Directory, under the Agent Assembly state root, holding one MitM host list

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -17,6 +17,7 @@
 mod apply;
 mod settings;
 
+pub mod bypass;
 pub mod scope;
 
 pub use scope::{ClaudeCodePaths, ScopeError};

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -71,6 +71,15 @@ trait VersionProbe: Send + Sync {
     fn probe_version(&self, bin: &Path) -> Option<String>;
 }
 
+/// [`VersionProbe`] that reports a canned answer, for tests.
+struct FixedVersionProbe(Option<String>);
+
+impl VersionProbe for FixedVersionProbe {
+    fn probe_version(&self, _bin: &Path) -> Option<String> {
+        self.0.clone()
+    }
+}
+
 /// Production [`VersionProbe`] backed by [`std::process::Command`].
 struct CommandVersionProbe;
 
@@ -145,6 +154,19 @@ impl ClaudeCodeAdapter {
     #[cfg(test)]
     fn with_version_probe(mut self, probe: Box<dyn VersionProbe>) -> Self {
         self.version_probe = probe;
+        self
+    }
+
+    /// Report `version` instead of running `<bin> --version`.
+    ///
+    /// Intended for tests only, and public because the lifecycle tests live in
+    /// other crates: they need a detectable Claude Code without a real binary,
+    /// and the alternative — putting a stub executable in a tmpdir — fails
+    /// wherever the temp filesystem is mounted `noexec`.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_version_override(mut self, version: Option<String>) -> Self {
+        self.version_probe = Box::new(FixedVersionProbe(version));
         self
     }
 

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -10,6 +10,10 @@
 //! * **Builds** the launch command wired for AA proxy and identity
 //!   env vars (AAASM-959).
 //!
+//! The AAASM-5281 lifecycle implementation lives alongside it in
+//! [`lifecycle::ClaudeCodeIntegration`], which **reuses** this adapter for
+//! detection and launch-command construction rather than duplicating either.
+//!
 //! [`DevToolAdapter`]: aa_devtool_contract::DevToolAdapter
 
 #![warn(missing_docs)]
@@ -20,10 +24,12 @@ mod settings;
 pub mod bypass;
 pub mod executor;
 pub mod launch_env;
+pub mod lifecycle;
 pub mod probe;
 pub mod scope;
 
 pub use executor::ClaudeCodeStepExecutor;
+pub use lifecycle::ClaudeCodeIntegration;
 pub use probe::{ProbeReport, ProbeRequest, ProtectionProbe};
 pub use scope::{ClaudeCodePaths, ScopeError};
 

--- a/aa-devtool-claude-code/src/lifecycle.rs
+++ b/aa-devtool-claude-code/src/lifecycle.rs
@@ -1,0 +1,1108 @@
+//! The native Developer Integration for Claude Code.
+//!
+//! # What this adds over [`ClaudeCodeAdapter`]
+//!
+//! The legacy adapter can detect the tool, render settings, write them and build
+//! a launch command. It cannot answer *"is this developer actually protected
+//! right now, and how do you know?"* — and, measured against the real
+//! `claude 2.1.220` binary in AAASM-5276, the launch command it built could not
+//! make the protection work at all: it injected `HTTPS_PROXY` and no CA-trust
+//! variable, so the proxy's MitM handshake failed and `GatewayProtected` was
+//! silently unreachable.
+//!
+//! [`ClaudeCodeIntegration`] is the lifecycle implementation, and it **reuses**
+//! the legacy adapter for detection rather than duplicating it. Three things are
+//! genuinely new:
+//!
+//! 1. **Condition C1 — trust material.** The plan materialises the proxy CA as a
+//!    PEM Agent Assembly owns ([`StepAction::MaterialiseTrustMaterial`]) and
+//!    points `NODE_EXTRA_CA_CERTS` at it
+//!    ([`StepAction::InjectLaunchEnvironment`]). Both land in the plan, both are
+//!    fingerprinted into the receipt, both are reversed by removal, and
+//!    [`LaunchableTool::build_launch_command`] is where they reach the child
+//!    process. Without the CA variable the MitM handshake fails, so this is the
+//!    step the entire `GatewayProtected` claim rests on.
+//! 2. **Condition C2 — explicit scope.** Every settings-touching step gets its
+//!    path from [`ClaudeCodePaths`], which takes the scope as an argument and
+//!    has no "whichever one exists in the working directory" branch.
+//! 3. **Condition C5 — side channels.** One headless run produced four upstream
+//!    requests, only two of which were `/v1/messages`. The plan writes a
+//!    per-integration MitM host list the proxy unions into its own configuration,
+//!    so this tool's side channels are scanned **without** flipping the global
+//!    `llm_only` default and MitM-ing every host on the machine.
+//!
+//! # What it deliberately does not do
+//!
+//! * `ANTHROPIC_BASE_URL` redirection is declared
+//!   [`Unsupported`](aa_devtool_contract::CapabilitySupport::Unsupported), not
+//!   offered. AAASM-5276 measured it delivering the raw secret to the provider
+//!   with no Agent Assembly component in the path (condition C4).
+//! * Hooks are declared unsupported *for protection*: they govern tool and
+//!   action execution and cannot see model-bound content, so no hook can carry a
+//!   sensitive-data claim.
+//! * `NODE_TLS_REJECT_UNAUTHORIZED` is never set, and its presence is reported
+//!   as a bypass. A TLS failure is a finding.
+//! * The endpoint managed-settings file and the macOS System Keychain are never
+//!   touched. Both are privileged host changes whose behaviour is unmeasured.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use aa_devtool_contract::{
+    now_unix_secs, sha256_hex, AdapterError, ArtifactObservation, ArtifactOperation, CapabilitySupport,
+    DevToolCapabilities, DevToolInfo, DevToolIntegration, DevToolKind, EnvValue, EvidenceKind, GovernanceLevel,
+    IntegrationCapability, IntegrationPlan, IntegrationReceipt, IntegrationRequest, IntegrationStatus, IntegrationStep,
+    LaunchSpec, LaunchableTool, LifecyclePhase, McpGovernedTool, McpServerInfo, NextLevel, ProbeDescriptor,
+    ProtectionEvidence, ProtectionLevel, ProtectionProfile, ProtectionState, RemovalPlan, SettingsMerge, SettingsScope,
+    StateDerivation, StepAction, StepExecutor, StepReceipt, SupportedToolVersions, ToolVersion, VerificationOutcome,
+    VerificationResult, VersionCompatibility, VersionSupport, DEFAULT_FRESHNESS_WINDOW_SECS, LIFECYCLE_SCHEMA_VERSION,
+};
+use async_trait::async_trait;
+
+use crate::bypass::{self, BypassFinding, LaunchEnvironment};
+use crate::executor::ClaudeCodeStepExecutor;
+use crate::probe::{ProbeRequest, ProtectionProbe, UnadjudicatedProbe, SYNTHETIC_SECRET};
+use crate::scope::{ClaudeCodePaths, ScopeError};
+use crate::{ClaudeCodeAdapter, MIN_VERSION};
+
+/// Step id for the managed settings write.
+pub const STEP_MANAGED_SETTINGS: &str = "managed-settings";
+/// Step id for materialising the proxy CA.
+pub const STEP_PROXY_CA: &str = "proxy-ca";
+/// Step id for the `NODE_EXTRA_CA_CERTS` injection — AAASM-5276 condition C1.
+pub const STEP_NODE_EXTRA_CA_CERTS: &str = "node-extra-ca-certs";
+/// Step id for the proxy environment.
+pub const STEP_PROXY_ENV: &str = "proxy-env";
+/// Step id for the per-integration MitM host list — condition C5.
+pub const STEP_SIDE_CHANNEL_SCOPE: &str = "side-channel-scope";
+/// Step id for the protection test.
+pub const STEP_PROTECTION_TEST: &str = "protection-test";
+
+/// The CA-trust variable Claude Code's embedded Node runtime honours.
+///
+/// Measured in AAASM-5276: `claude --debug` reports
+/// `CA certs: Appended extra certificates from NODE_EXTRA_CA_CERTS (…)`.
+pub const CA_ENV_VAR: &str = "NODE_EXTRA_CA_CERTS";
+
+/// Keys in `settings.json` Agent Assembly owns. Every other key in the file is
+/// preserved, and drift is defined only over these.
+pub const MANAGED_KEYS: [&str; 4] = [
+    "permissions",
+    "permissionMode",
+    "enabledMcpjsonServers",
+    "disabledMcpjsonServers",
+];
+
+/// The subset of [`MANAGED_KEYS`] an MCP-only step claims.
+pub const MCP_KEYS: [&str; 2] = ["enabledMcpjsonServers", "disabledMcpjsonServers"];
+
+/// Host the model-bound path is addressed to.
+pub const MODEL_HOST: &str = "api.anthropic.com";
+
+/// Hosts this integration asks the proxy to bring under interception.
+///
+/// `api.anthropic.com` is already a built-in LLM host; it is listed anyway so
+/// the receipt states the scope rather than relying on a default that could
+/// change. `*.anthropic.com` is the condition-C5 addition: one headless run in
+/// AAASM-5276 produced an MCP-registry GET and a 130 KB
+/// `POST /api/event_logging/v2/batch` alongside its two `/v1/messages` calls,
+/// and a deployment scoped to the model endpoint alone would leave those
+/// unscanned. The wildcard is leftmost-label only, matching the proxy's
+/// allowlist grammar.
+pub const MITM_HOSTS: [&str; 2] = ["api.anthropic.com", "*.anthropic.com"];
+
+/// The default address `aa-proxy` binds to.
+const DEFAULT_PROXY_ADDR: &str = "127.0.0.1:8899";
+
+/// The Developer Integration for Claude Code.
+pub struct ClaudeCodeIntegration {
+    paths: ClaudeCodePaths,
+    /// Reused for detection — AAASM-201's adapter stays the one implementation
+    /// of "is Claude Code on this host and what version".
+    adapter: ClaudeCodeAdapter,
+    proxy_url: String,
+    probe: Arc<dyn ProtectionProbe>,
+    freshness_window_secs: u64,
+}
+
+impl std::fmt::Debug for ClaudeCodeIntegration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClaudeCodeIntegration")
+            .field("proxy_url", &self.proxy_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for ClaudeCodeIntegration {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClaudeCodeIntegration {
+    /// The production integration: roots from the environment, the real
+    /// detection path, and no adjudicating probe.
+    pub fn new() -> Self {
+        Self::with_paths(ClaudeCodePaths::from_env())
+    }
+
+    /// An integration over explicit roots. The constructor tests use, so no test
+    /// depends on the ambient `$HOME` or working directory.
+    pub fn with_paths(paths: ClaudeCodePaths) -> Self {
+        let adapter = ClaudeCodeAdapter::with_overrides(None, paths.home().map(PathBuf::from));
+        Self {
+            paths,
+            adapter,
+            proxy_url: default_proxy_url(),
+            probe: Arc::new(UnadjudicatedProbe),
+            freshness_window_secs: DEFAULT_FRESHNESS_WINDOW_SECS,
+        }
+    }
+
+    /// Replace the detection adapter, so a test can pin the binary path and the
+    /// version the probe reports.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_adapter(mut self, adapter: ClaudeCodeAdapter) -> Self {
+        self.adapter = adapter;
+        self
+    }
+
+    /// Route the tool through a specific proxy.
+    #[must_use]
+    pub fn through_proxy(mut self, proxy_url: impl Into<String>) -> Self {
+        self.proxy_url = proxy_url.into();
+        self
+    }
+
+    /// Supply a probe that can adjudicate what the provider received.
+    ///
+    /// Without one, `verify` reports the model path as configured but never
+    /// exercised, and the protection level does not rise past `Integrated`.
+    #[must_use]
+    pub fn with_probe(mut self, probe: Arc<dyn ProtectionProbe>) -> Self {
+        self.probe = probe;
+        self
+    }
+
+    /// Narrow the window inside which verification evidence still counts.
+    #[must_use]
+    pub fn with_freshness_window(mut self, secs: u64) -> Self {
+        self.freshness_window_secs = secs;
+        self
+    }
+
+    /// The paths this integration reads and writes.
+    pub fn paths(&self) -> &ClaudeCodePaths {
+        &self.paths
+    }
+
+    /// An executor that knows every scope this integration can own, holding
+    /// `rendered` for the steps that write bytes.
+    ///
+    /// Every scope rather than one, because observing and reversing start from a
+    /// receipt and not from a plan: the service has no scope in hand at those
+    /// moments, and an executor built for the wrong one would report a
+    /// project-scoped install as unobservable and refuse to remove it.
+    pub fn scoped_executor(&self, rendered: BTreeMap<String, String>) -> ClaudeCodeStepExecutor {
+        let mut executor = ClaudeCodeStepExecutor::new();
+        for scope in [SettingsScope::User, SettingsScope::Project] {
+            if let Ok(dir) = self.paths.launch_env_dir(scope) {
+                executor = executor.with_scope(scope, dir);
+            }
+        }
+        for (step_id, content) in rendered {
+            executor = executor.with_content(step_id, content);
+        }
+        executor
+    }
+
+    /// The bytes each of `plan`'s steps writes, keyed by step id.
+    ///
+    /// Re-derived at apply time rather than carried in the plan: the digest the
+    /// user reviewed is what the executor checks against, so a CA that was
+    /// rotated between plan and apply fails closed instead of being written
+    /// silently.
+    pub fn step_content(&self, plan: &IntegrationPlan) -> Result<BTreeMap<String, String>, AdapterError> {
+        let mut rendered = BTreeMap::new();
+        for step in &plan.steps {
+            match step.id.as_str() {
+                STEP_MANAGED_SETTINGS => {
+                    rendered.insert(step.id.clone(), managed_settings_json(plan.profile)?);
+                }
+                STEP_PROXY_CA => {
+                    rendered.insert(step.id.clone(), self.read_ca_pem()?);
+                }
+                STEP_SIDE_CHANNEL_SCOPE => {
+                    rendered.insert(step.id.clone(), mitm_hosts_document());
+                }
+                _ => {}
+            }
+        }
+        Ok(rendered)
+    }
+
+    /// The proxy CA certificate, read from where `aa-proxy` persists it.
+    fn read_ca_pem(&self) -> Result<String, AdapterError> {
+        let path = self.paths.ca_source_path().ok_or_else(|| {
+            AdapterError::SettingsGenerationFailed(
+                "the Agent Assembly proxy certificate authority location is unknown; set AA_CA_DIR".to_string(),
+            )
+        })?;
+        std::fs::read_to_string(path).map_err(|e| {
+            AdapterError::SettingsGenerationFailed(format!(
+                "the Agent Assembly proxy certificate authority could not be read from {}: {e}. \
+                 Start the proxy once (`aasm proxy start`) so it is created, then plan again",
+                path.display()
+            ))
+        })
+    }
+
+    /// The version the detected binary reports, when one was detected.
+    fn detected_version(&self) -> Option<ToolVersion> {
+        use aa_devtool_contract::DevToolAdapter as _;
+        self.adapter.detect()?.version?.parse().ok()
+    }
+
+    fn compatibility(&self) -> VersionCompatibility {
+        self.version_support()
+            .supported_tool_versions
+            .classify(self.detected_version().as_ref())
+    }
+
+    /// Every bypass condition currently observable on this host.
+    fn bypasses(&self, scope: SettingsScope) -> Vec<BypassFinding> {
+        let mut found = Vec::new();
+        if let Ok(path) = self.paths.settings_path(scope) {
+            if let Ok(raw) = std::fs::read_to_string(&path) {
+                found.extend(bypass::settings_bypasses(&path.display().to_string(), &raw));
+            }
+        }
+        found.extend(bypass::environment_bypasses(&LaunchEnvironment::from_process()));
+        found
+    }
+
+    /// Evidence rows for the bypasses, plus the one for host enforcement.
+    ///
+    /// Both are [`EvidenceKind::Absent`]: a bypass does not disprove the
+    /// configuration, it makes the configuration unable to prove anything. An
+    /// `Absent` reading only ever lowers the reported state, which is the whole
+    /// behaviour needed here.
+    fn limitation_evidence(&self, scope: SettingsScope, now: u64) -> Vec<ProtectionEvidence> {
+        let mut evidence: Vec<ProtectionEvidence> = self
+            .bypasses(scope)
+            .into_iter()
+            .map(|finding| {
+                ProtectionEvidence::new(
+                    IntegrationCapability::ToolActionApproval,
+                    EvidenceKind::Absent {
+                        reason: finding.detail(),
+                    },
+                    now,
+                    format!("bypass {}: {}", finding.id, finding.remediation),
+                )
+            })
+            .collect();
+
+        evidence.push(ProtectionEvidence::new(
+            IntegrationCapability::HostEnforcement,
+            EvidenceKind::Absent {
+                reason: HOST_ENFORCEMENT_REASON.to_string(),
+            },
+            now,
+            format!(
+                "known bypasses this integration cannot observe: {}",
+                bypass::UNOBSERVABLE_BYPASSES
+            ),
+        ));
+        evidence
+    }
+
+    /// Read every applied, fingerprinted step back off the host and compare it
+    /// to what the receipt claims.
+    fn read_back_evidence(&self, receipt: &IntegrationReceipt, now: u64) -> Vec<ProtectionEvidence> {
+        let executor = self.scoped_executor(BTreeMap::new());
+        receipt
+            .steps
+            .iter()
+            .filter(|step| step.applied && step.fingerprint.is_some())
+            .map(|step| {
+                let expected = step.fingerprint.as_deref().unwrap_or_default();
+                let (matches, detail) = match executor.observe(step) {
+                    ArtifactObservation::Present {
+                        managed_fingerprint, ..
+                    } => (
+                        managed_fingerprint == expected,
+                        format!("{} read back from the host", artifact_label(step)),
+                    ),
+                    ArtifactObservation::Missing => (false, format!("{} is missing", artifact_label(step))),
+                    ArtifactObservation::Unreadable { reason } => {
+                        (false, format!("{} could not be read: {reason}", artifact_label(step)))
+                    }
+                    // `ArtifactObservation` is non-exhaustive: a reading this
+                    // build does not understand is not a match. Missing evidence
+                    // lowers the state; it never raises it.
+                    other => (
+                        false,
+                        format!(
+                            "{} returned an observation this build cannot read: {other:?}",
+                            artifact_label(step)
+                        ),
+                    ),
+                };
+                ProtectionEvidence::new(
+                    step_mechanism(&step.action),
+                    EvidenceKind::ReadBack {
+                        matches_receipt: matches,
+                    },
+                    now,
+                    detail,
+                )
+            })
+            .collect()
+    }
+
+    /// The probe request a receipt describes, when it describes one.
+    fn probe_request(&self, receipt: &IntegrationReceipt) -> Option<ProbeRequest> {
+        let ca = receipt.steps.iter().find_map(|step| match &step.action {
+            StepAction::MaterialiseTrustMaterial { path, .. } if step.applied => Some(path.clone()),
+            _ => None,
+        })?;
+        let proxy_url = receipt
+            .steps
+            .iter()
+            .filter(|step| step.applied)
+            .find_map(|step| match &step.action {
+                StepAction::ConfigureProxy { variables, .. } => variables.get("HTTPS_PROXY").cloned(),
+                _ => None,
+            })
+            .unwrap_or_else(|| self.proxy_url.clone());
+        Some(ProbeRequest {
+            proxy_url,
+            ca_pem: ca,
+            target_host: MODEL_HOST.to_string(),
+            synthetic_secret: SYNTHETIC_SECRET.to_string(),
+        })
+    }
+}
+
+/// Why the model path is not yet proven, and what to do about it.
+const PROBE_NOT_RUN_REASON: &str =
+    "no probe traffic has been produced and adjudicated on the model path; run `aasm integrations verify claude-code`";
+
+/// Why `HostEnforced` is not reachable for this integration.
+const HOST_ENFORCEMENT_REASON: &str = "host enforcement is unavailable: Agent Assembly does not install its \
+     certificate authority into the macOS system trust store for this integration — trust is established \
+     per-launch through NODE_EXTRA_CA_CERTS — and kernel-level enforcement is Linux-only";
+
+/// The mechanism a step's artifact is evidence about.
+fn step_mechanism(action: &StepAction) -> IntegrationCapability {
+    match action {
+        StepAction::WriteManagedSettings { .. } => IntegrationCapability::ManagedSettings,
+        StepAction::MaterialiseTrustMaterial { .. } | StepAction::InjectLaunchEnvironment { .. } => {
+            IntegrationCapability::ModelPathInterception
+        }
+        StepAction::ConfigureProxy { .. } => IntegrationCapability::HttpProxy,
+        StepAction::ConfigureMcpServers { .. } => IntegrationCapability::McpGovernance,
+        _ => IntegrationCapability::ManagedSettings,
+    }
+}
+
+/// A stable, user-legible name for what a step touched.
+///
+/// A launch-environment step is named by its **variable**, not by the artifact
+/// its value points at: `NODE_EXTRA_CA_CERTS` and the CA PEM step would
+/// otherwise both report the same path, and a status listing the same file twice
+/// reads as a duplicate rather than as two different observations.
+fn artifact_label(step: &StepReceipt) -> String {
+    match &step.action {
+        StepAction::InjectLaunchEnvironment { variable, .. } => format!("{variable} (launch environment)"),
+        StepAction::ConfigureProxy { variables, .. } => {
+            format!(
+                "{} (launch environment)",
+                variables.keys().cloned().collect::<Vec<_>>().join(", ")
+            )
+        }
+        other => match other.affected_paths().first() {
+            Some(path) => path.display().to_string(),
+            None => format!("{} ({})", step.step_id, other.kind()),
+        },
+    }
+}
+
+fn scope_error(e: ScopeError) -> AdapterError {
+    AdapterError::SettingsGenerationFailed(e.to_string())
+}
+
+fn default_proxy_url() -> String {
+    let addr = std::env::var("AA_PROXY_ADDR")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_PROXY_ADDR.to_string());
+    if addr.starts_with("http://") || addr.starts_with("https://") {
+        addr
+    } else {
+        format!("http://{addr}")
+    }
+}
+
+/// The managed settings block one profile resolves to.
+///
+/// Derived from the **profile**, not from a policy document: a plan carries a
+/// policy only by reference (ADR 0030 §5.5), and the digest the user reviewed at
+/// plan time has to be reproducible at apply time from what the plan carries.
+///
+/// `permissions.defaultMode` is written explicitly, and that is deliberate: it
+/// displaces a `bypassPermissions` a user had set, and because `permissions` is
+/// an Agent Assembly-owned key, re-adding that mode afterwards is drift the
+/// receipt can detect and repair can undo.
+pub fn managed_settings_json(profile: ProtectionProfile) -> Result<String, AdapterError> {
+    let default_mode = match profile {
+        // `plan` makes Claude Code propose rather than act, which is the closest
+        // native expression of "approval required for destructive classes".
+        ProtectionProfile::Strict => "plan",
+        ProtectionProfile::Recommended | ProtectionProfile::ObserveOnly => "default",
+    };
+    let doc = serde_json::json!({
+        "permissions": {
+            "allow": [],
+            "deny": [],
+            "defaultMode": default_mode,
+        },
+        "permissionMode": default_mode,
+        "enabledMcpjsonServers": [],
+        "disabledMcpjsonServers": [],
+    });
+    serde_json::to_string(&doc).map_err(|e| AdapterError::SettingsGenerationFailed(e.to_string()))
+}
+
+/// The MCP allow/deny block, rendered over the two MCP keys only.
+fn mcp_settings_json(allowed: &[String], denied: &[String]) -> Result<String, AdapterError> {
+    let doc = serde_json::json!({
+        "enabledMcpjsonServers": allowed,
+        "disabledMcpjsonServers": denied,
+    });
+    serde_json::to_string(&doc).map_err(|e| AdapterError::SettingsGenerationFailed(e.to_string()))
+}
+
+/// The per-integration MitM host list, one host per line.
+pub fn mitm_hosts_document() -> String {
+    let mut out = String::from("# Written by `aasm integrations install claude-code`.\n");
+    out.push_str("# The proxy unions these into its MitM set without disabling llm_only.\n");
+    for host in MITM_HOSTS {
+        out.push_str(host);
+        out.push('\n');
+    }
+    out
+}
+
+#[async_trait]
+impl DevToolIntegration for ClaudeCodeIntegration {
+    fn capabilities(&self) -> DevToolCapabilities {
+        let interception = match self.paths.ca_source() {
+            Some(_) => CapabilitySupport::Supported,
+            None => CapabilitySupport::unsupported(
+                "the Agent Assembly proxy certificate authority has not been created on this host, so \
+                 the tool cannot be made to trust the intercepting proxy. Start the proxy once \
+                 (`aasm proxy start`) and plan again",
+            ),
+        };
+
+        DevToolCapabilities::new()
+            .supported(IntegrationCapability::Discovery)
+            .supported(IntegrationCapability::ManagedSettings)
+            .supported(IntegrationCapability::ManagedLaunch)
+            .supported(IntegrationCapability::HttpProxy)
+            .supported(IntegrationCapability::McpDiscovery)
+            .supported(IntegrationCapability::McpGovernance)
+            .supported(IntegrationCapability::ToolActionApproval)
+            .declare(IntegrationCapability::ModelPathInterception, interception)
+            .unsupported(
+                IntegrationCapability::ModelGatewayBaseUrl,
+                "ANTHROPIC_BASE_URL redirection is routing, not protection: AAASM-5276 measured it \
+                 delivering a synthetic secret to the provider with no Agent Assembly component in the \
+                 path, and setting it in the shell additionally suppresses Claude Code's \
+                 server-managed settings fetch",
+            )
+            .unsupported(
+                IntegrationCapability::Hooks,
+                "Claude Code hooks govern tool and action execution and cannot see or modify \
+                 model-bound content, so no hook can carry a sensitive-data protection claim",
+            )
+            .unsupported(
+                IntegrationCapability::NativeIdeUi,
+                "Claude Code is a terminal CLI and has no in-editor surface for status or approval \
+                 prompts",
+            )
+            .unsupported(IntegrationCapability::HostEnforcement, HOST_ENFORCEMENT_REASON)
+    }
+
+    fn detect(&self) -> Option<DevToolInfo> {
+        use aa_devtool_contract::DevToolAdapter as _;
+        self.adapter.detect()
+    }
+
+    fn version_support(&self) -> VersionSupport {
+        VersionSupport {
+            adapter_version: env!("CARGO_PKG_VERSION").parse().unwrap_or(ToolVersion::new(0, 0, 0)),
+            lifecycle_schema_version: LIFECYCLE_SCHEMA_VERSION,
+            supported_tool_versions: SupportedToolVersions::at_least(
+                MIN_VERSION.parse().unwrap_or(ToolVersion::new(1, 0, 0)),
+            ),
+        }
+    }
+
+    async fn plan_integration(&self, request: &IntegrationRequest) -> Result<IntegrationPlan, AdapterError> {
+        let scope = request.settings_scope;
+        let settings_path = self.paths.settings_path(scope).map_err(scope_error)?;
+        let launch_env = self.paths.launch_env_dir(scope).map_err(scope_error)?;
+        let ca_pem = self.paths.proxy_ca_pem(scope).map_err(scope_error)?;
+        let hosts_file = self.paths.mitm_hosts_file(scope).map_err(scope_error)?;
+        let capabilities = self.capabilities();
+
+        let interception_available = capabilities.can_intercept_model_path();
+        let ceiling = if interception_available {
+            ProtectionLevel::GatewayProtected
+        } else {
+            ProtectionLevel::Integrated
+        };
+        let planned_level = request.effective_target_level().min(ceiling);
+
+        let mut plan = IntegrationPlan::new(
+            format!("claude-code-{scope}-{}", now_unix_secs()),
+            request,
+            planned_level,
+            GovernanceLevel::L2Enforce,
+        );
+
+        // 1. Managed settings — tool-action governance, not the data path.
+        let settings = managed_settings_json(request.profile)?;
+        plan = plan.with_step(IntegrationStep::new(
+            STEP_MANAGED_SETTINGS,
+            StepAction::WriteManagedSettings {
+                scope,
+                path: settings_path.clone(),
+                managed_keys: MANAGED_KEYS.iter().map(|k| (*k).to_string()).collect(),
+                content_sha256: sha256_hex(&settings),
+                merge: SettingsMerge::MergeManagedKeys,
+            },
+            format!(
+                "merge Agent Assembly's four managed keys into {} and leave every other key alone",
+                settings_path.display()
+            ),
+        ));
+
+        if interception_available {
+            // 2. Trust material — condition C1, first half.
+            let pem = self.read_ca_pem()?;
+            plan = plan.with_step(
+                IntegrationStep::new(
+                    STEP_PROXY_CA,
+                    StepAction::MaterialiseTrustMaterial {
+                        kind: aa_devtool_contract::TrustMaterialKind::ProxyCaCertificatePem,
+                        path: ca_pem.clone(),
+                        content_sha256: sha256_hex(&pem),
+                    },
+                    format!(
+                        "copy the Agent Assembly proxy certificate authority to {} so Claude Code can be \
+                         pointed at it without touching the system trust store",
+                        ca_pem.display()
+                    ),
+                )
+                .with_reversal(StepAction::ManageArtifact {
+                    operation: ArtifactOperation::Remove,
+                    path: ca_pem.clone(),
+                }),
+            );
+
+            // 3. NODE_EXTRA_CA_CERTS — condition C1, the half the product was missing.
+            plan = plan.with_step(
+                IntegrationStep::new(
+                    STEP_NODE_EXTRA_CA_CERTS,
+                    StepAction::InjectLaunchEnvironment {
+                        scope,
+                        variable: CA_ENV_VAR.to_string(),
+                        value: EnvValue::ArtifactPath(ca_pem.clone()),
+                    },
+                    format!(
+                        "set {CA_ENV_VAR} for every governed launch so Claude Code's Node runtime accepts \
+                         the intercepting proxy's certificates — without this the MitM handshake fails and \
+                         nothing is inspected"
+                    ),
+                )
+                .with_reversal(StepAction::ManageArtifact {
+                    operation: ArtifactOperation::Remove,
+                    path: launch_env.join(CA_ENV_VAR),
+                }),
+            );
+
+            // 4. Proxy routing.
+            let mut variables = BTreeMap::new();
+            variables.insert("HTTPS_PROXY".to_string(), self.proxy_url.clone());
+            variables.insert("HTTP_PROXY".to_string(), self.proxy_url.clone());
+            plan = plan.with_step(
+                IntegrationStep::new(
+                    STEP_PROXY_ENV,
+                    StepAction::ConfigureProxy {
+                        scope,
+                        variables: variables.clone(),
+                    },
+                    format!("route governed Claude Code launches through {}", self.proxy_url),
+                )
+                .with_reversal(StepAction::ConfigureProxy {
+                    scope,
+                    variables: BTreeMap::new(),
+                }),
+            );
+
+            // 5. Side-channel scope — condition C5.
+            plan = plan.with_step(
+                IntegrationStep::new(
+                    STEP_SIDE_CHANNEL_SCOPE,
+                    StepAction::ManageArtifact {
+                        operation: ArtifactOperation::Create,
+                        path: hosts_file.clone(),
+                    },
+                    format!(
+                        "ask the proxy to inspect {} for this integration, so the tool's telemetry and \
+                         registry calls are scanned too — without disabling llm_only and intercepting \
+                         every host on the machine",
+                        MITM_HOSTS.join(", ")
+                    ),
+                )
+                .with_reversal(StepAction::ManageArtifact {
+                    operation: ArtifactOperation::Remove,
+                    path: hosts_file,
+                }),
+            );
+
+            // 6. The protection test. Optional: it mutates nothing, produces no
+            //    fingerprint, and its result reaches the receipt through
+            //    verification rather than through the apply.
+            plan = plan.with_step(
+                IntegrationStep::new(
+                    STEP_PROTECTION_TEST,
+                    StepAction::RunProtectionTest {
+                        probe: ProbeDescriptor {
+                            id: "claude-code-model-path".to_string(),
+                            mechanism: IntegrationCapability::ModelPathInterception,
+                            description: format!(
+                                "send a synthetic Anthropic-shaped secret down the {MODEL_HOST} path and let \
+                                 the core adjudicate what the provider received"
+                            ),
+                        },
+                    },
+                    "verify that the model path is actually intercepted, not merely configured",
+                )
+                .optional(),
+            );
+        } else {
+            plan = plan.declaring_unsupported(
+                IntegrationCapability::ModelPathInterception,
+                capabilities
+                    .unsupported_reason(IntegrationCapability::ModelPathInterception)
+                    .unwrap_or("model-path interception is unavailable on this host")
+                    .to_string(),
+            );
+        }
+
+        for capability in [
+            IntegrationCapability::ModelGatewayBaseUrl,
+            IntegrationCapability::Hooks,
+            IntegrationCapability::HostEnforcement,
+        ] {
+            if let Some(reason) = capabilities.unsupported_reason(capability) {
+                plan = plan.declaring_unsupported(capability, reason.to_string());
+            }
+        }
+
+        plan = plan
+            .warn(format!(
+                "protection applies to sessions started through `aasm run claude`. A `claude` started \
+                 directly inherits neither the proxy nor {CA_ENV_VAR}, and is not protected"
+            ))
+            .warn(format!(
+                "known bypasses this integration cannot observe: {}",
+                bypass::UNOBSERVABLE_BYPASSES
+            ))
+            .warn(
+                "restore is semantics-exact, not byte-exact: the settings document is reserialised, so \
+                 hand-chosen formatting and key order do not survive an install/remove cycle"
+                    .to_string(),
+            )
+            .warn("restart any running Claude Code session for the managed settings to take effect".to_string());
+
+        for surface in self.paths.detected_surfaces() {
+            if surface.scope != scope {
+                plan = plan.warn(format!(
+                    "a {} configuration also exists at {} and this plan does not touch it",
+                    surface.scope,
+                    surface.path.display()
+                ));
+            }
+        }
+
+        for finding in self.bypasses(scope) {
+            plan = plan.warn(format!(
+                "bypass detected — {}. {}",
+                finding.detail(),
+                finding.remediation
+            ));
+        }
+
+        Ok(plan)
+    }
+
+    async fn integration_status(
+        &self,
+        receipt: Option<&IntegrationReceipt>,
+    ) -> Result<IntegrationStatus, AdapterError> {
+        let now = now_unix_secs();
+        let detected = self.detect();
+        let compatibility = self.compatibility();
+        let scope = receipt.map_or(SettingsScope::User, |r| r.settings_scope);
+
+        let mut evidence: Vec<ProtectionEvidence> = Vec::new();
+        if let Some(receipt) = receipt {
+            evidence.extend(self.read_back_evidence(receipt, now));
+            // Carry the exercised evidence the receipt recorded, at its original
+            // timestamp: freshness is what turns "verified once, long ago" into
+            // a lower level, and re-stamping it here would defeat that.
+            evidence.extend(
+                receipt
+                    .achieved_evidence
+                    .iter()
+                    .filter(|e| e.kind.is_exercised())
+                    .cloned(),
+            );
+
+            // The gap that actually explains a `Degraded` reading, named before
+            // the standing limitations so the reason a user is shown leads with
+            // the thing they can do something about. Without it the joined
+            // reason would open with "host enforcement is unavailable", which is
+            // true, permanent, and not why this integration is below its plan.
+            let exercised_recently = evidence
+                .iter()
+                .any(|e| e.justifies_gateway_protection(now, self.freshness_window_secs));
+            if !exercised_recently {
+                evidence.push(ProtectionEvidence::new(
+                    IntegrationCapability::ModelPathInterception,
+                    EvidenceKind::Absent {
+                        reason: PROBE_NOT_RUN_REASON.to_string(),
+                    },
+                    now,
+                    "the model path is configured but has not been exercised".to_string(),
+                ));
+            }
+        }
+        evidence.extend(self.limitation_evidence(scope, now));
+
+        let planned_level = receipt.map_or(ProtectionLevel::NotInstalled, |r| r.planned_level);
+        let derivation = StateDerivation {
+            detected: detected.is_some(),
+            receipt_present: receipt.is_some(),
+            required_steps: receipt.map_or(0, IntegrationReceipt::required_steps),
+            required_steps_verified: receipt.map_or(0, IntegrationReceipt::verified_required_steps),
+            // Drift is the service's classification; an adapter that also
+            // decided it would be a second, disagreeing answer.
+            mismatched_artifacts: &[],
+            compatibility: &compatibility,
+            schema_newer_than_core: receipt.is_some_and(IntegrationReceipt::is_schema_newer_than_running_core),
+            evidence: &evidence,
+            planned_level,
+            now_unix_secs: now,
+            freshness_window_secs: self.freshness_window_secs,
+        };
+        let state = derivation.derive();
+
+        let phase = match (&state, receipt) {
+            (ProtectionState::Ladder(ProtectionLevel::NotInstalled), _) => LifecyclePhase::NotInstalled,
+            (_, None) => LifecyclePhase::DetectedNotIntegrated,
+            (_, Some(r)) if r.verified_required_steps() >= r.required_steps() && r.required_steps() > 0 => {
+                LifecyclePhase::Installed
+            }
+            (_, Some(_)) => LifecyclePhase::PartiallyInstalled,
+        };
+
+        let achieved = state.achieved_level();
+        let next_level = achieved.next_up().map(|level| NextLevel {
+            level,
+            blocked_because: self.next_level_reason(level, receipt.is_some()),
+        });
+
+        Ok(IntegrationStatus {
+            tool: DevToolKind::ClaudeCode,
+            phase,
+            state,
+            evidence,
+            planned_level,
+            adapter_ceiling: detected.map_or(GovernanceLevel::L0Discover, |i| i.governance_level),
+            compatibility,
+            next_level,
+            observed_at_unix_secs: now,
+        })
+    }
+
+    async fn verify_integration(&self, receipt: &IntegrationReceipt) -> Result<VerificationResult, AdapterError> {
+        let now = now_unix_secs();
+        let mut evidence = self.read_back_evidence(receipt, now);
+        let mismatched: Vec<String> = evidence
+            .iter()
+            .filter(|e| matches!(e.kind, EvidenceKind::ReadBack { matches_receipt: false }))
+            .map(|e| e.detail.clone())
+            .collect();
+
+        let mut missing: Vec<String> = Vec::new();
+        let mut exercised_protectively = false;
+
+        match self.probe_request(receipt) {
+            Some(request) => {
+                let report = self.probe.run(&request).await;
+                exercised_protectively = report.outcome.is_protective();
+                if !exercised_protectively {
+                    missing.push(report.detail.clone());
+                }
+                evidence.push(ProtectionEvidence::new(
+                    IntegrationCapability::ModelPathInterception,
+                    EvidenceKind::Exercised {
+                        outcome: report.outcome,
+                    },
+                    now,
+                    report.detail,
+                ));
+            }
+            None => missing.push(
+                "this integration applied no trust material, so there is no intercepted model path to \
+                 exercise"
+                    .to_string(),
+            ),
+        }
+
+        let bypasses = self.bypasses(receipt.settings_scope);
+        for finding in &bypasses {
+            missing.push(finding.detail());
+        }
+        evidence.extend(self.limitation_evidence(receipt.settings_scope, now));
+
+        let outcome = if !mismatched.is_empty() {
+            VerificationOutcome::Failed {
+                reason: format!(
+                    "Agent Assembly-owned state no longer matches the receipt: {}",
+                    mismatched.join("; ")
+                ),
+            }
+        } else if exercised_protectively && bypasses.is_empty() {
+            VerificationOutcome::Passed
+        } else {
+            VerificationOutcome::PartiallyPassed { missing }
+        };
+
+        Ok(VerificationResult {
+            verified_at_unix_secs: now,
+            outcome,
+            evidence,
+        })
+    }
+
+    async fn plan_removal(&self, receipt: &IntegrationReceipt) -> Result<RemovalPlan, AdapterError> {
+        let mut plan = RemovalPlan::new(removal_plan_id(receipt), DevToolKind::ClaudeCode);
+
+        // A protection test mutated nothing, so there is nothing to undo and
+        // nothing a reviewer needs to approve. Listing it would make the
+        // removal preview describe an action that will not happen.
+        for step in receipt
+            .steps
+            .iter()
+            .rev()
+            .filter(|s| s.applied && !s.action.is_protection_test())
+        {
+            let summary = match &step.action {
+                StepAction::WriteManagedSettings { path, .. } => format!(
+                    "restore the four Agent Assembly-owned keys in {} to what they held before install, \
+                     and leave everything you changed since alone",
+                    path.display()
+                ),
+                StepAction::MaterialiseTrustMaterial { path, .. } => {
+                    format!("delete the copied proxy certificate authority at {}", path.display())
+                }
+                StepAction::InjectLaunchEnvironment { variable, .. } => {
+                    format!("stop injecting {variable} into governed launches")
+                }
+                StepAction::ConfigureProxy { .. } => {
+                    "stop routing governed launches through the Agent Assembly proxy".to_string()
+                }
+                StepAction::ManageArtifact { path, .. } => {
+                    format!("delete {}", path.display())
+                }
+                other => format!("reverse the {} step", other.kind()),
+            };
+            let reversal = step.reversal.clone().unwrap_or_else(|| reversal_for(step));
+            plan = plan.with_step(IntegrationStep::new(
+                format!("undo-{}", step.step_id),
+                reversal,
+                summary,
+            ));
+        }
+
+        for step in receipt.unrestorable_steps() {
+            plan = plan.with_residual(format!(
+                "{}: this step recorded no restorable prior state, so removal cannot prove it put \
+                 anything back",
+                artifact_label(step)
+            ));
+        }
+
+        plan = plan
+            .warn(
+                "restore is semantics-exact, not byte-exact: the settings document is reserialised, so \
+                 formatting and key order from before the install do not come back"
+                    .to_string(),
+            )
+            .warn("restart any running Claude Code session for the removal to take effect".to_string());
+
+        Ok(plan)
+    }
+
+    fn as_mcp_governed(&self) -> Option<&dyn McpGovernedTool> {
+        Some(self)
+    }
+
+    fn as_launchable(&self) -> Option<&dyn LaunchableTool> {
+        Some(self)
+    }
+}
+
+impl ClaudeCodeIntegration {
+    fn next_level_reason(&self, level: ProtectionLevel, installed: bool) -> String {
+        match level {
+            ProtectionLevel::HostEnforced => HOST_ENFORCEMENT_REASON.to_string(),
+            ProtectionLevel::GatewayProtected => PROBE_NOT_RUN_REASON.to_string(),
+            _ if !installed => "nothing has been applied yet; run `aasm integrations install claude-code`".to_string(),
+            _ => "not every required step of the applied plan verifies; run \
+                  `aasm integrations repair claude-code`"
+                .to_string(),
+        }
+    }
+}
+
+/// How a removal preview describes undoing a step the plan gave no reversal for.
+///
+/// A managed-settings step is the only one that has none, and deliberately: its
+/// reversal is *restore these keys to what the receipt recorded*, which is not a
+/// mutation any [`StepAction`] can name without the prior content in hand. The
+/// engine performs it from the receipt's prior-state record.
+///
+/// Describing it as `ManageArtifact { Remove, <settings file> }` would render as
+/// "delete your settings file", which is the opposite of what happens. Naming
+/// the same file and the same keys renders as what removal actually does, and
+/// the digest is the fingerprint of the document as it stood **before** the
+/// install — the state being restored.
+fn reversal_for(step: &StepReceipt) -> StepAction {
+    match &step.action {
+        StepAction::WriteManagedSettings {
+            scope,
+            path,
+            managed_keys,
+            merge,
+            ..
+        } => StepAction::WriteManagedSettings {
+            scope: *scope,
+            path: path.clone(),
+            managed_keys: managed_keys.clone(),
+            content_sha256: step
+                .prior_state
+                .as_ref()
+                .map(|prior| prior.document_fingerprint.trim_start_matches("sha256:").to_string())
+                .unwrap_or_default(),
+            merge: *merge,
+        },
+        other => StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: other
+                .affected_paths()
+                .first()
+                .cloned()
+                .unwrap_or_else(|| PathBuf::from(&step.step_id)),
+        },
+    }
+}
+
+/// The removal plan id a receipt produces, stable across calls so a caller can
+/// review a removal and then execute the plan it reviewed.
+pub fn removal_plan_id(receipt: &IntegrationReceipt) -> String {
+    format!("remove-{}", receipt.receipt_id)
+}
+
+impl LaunchableTool for ClaudeCodeIntegration {
+    /// Build the governed launch — where condition C1 actually reaches the tool.
+    ///
+    /// The launch environment the install materialised is applied first, then the
+    /// caller's own [`LaunchSpec::env`], so a caller can override a variable for
+    /// one run without editing what the receipt records.
+    fn build_launch_command(&self, spec: &LaunchSpec) -> Result<std::process::Command, AdapterError> {
+        use aa_devtool_contract::DevToolAdapter as _;
+        // The adapter resolves its own launch environment from the ambient
+        // roots, which is right for `aasm run claude`. This integration may have
+        // been constructed over different roots — a test, or a caller that
+        // pinned a state directory — so its own paths are overlaid on top.
+        let mut cmd =
+            self.adapter
+                .build_launch_command(&spec.tool_args, &spec.agent_id, spec.team_id.as_deref(), None)?;
+        for (name, value) in crate::launch_env::installed_environment(&self.paths) {
+            cmd.env(name, value);
+        }
+
+        // A proxy address the caller pinned for this run wins over the receipted
+        // one: the address is a runtime fact, and a session routed at a proxy
+        // that is not listening is worse than one routed at the live address.
+        if let Some(proxy) = &spec.proxy_addr {
+            let url = if proxy.starts_with("http") {
+                proxy.clone()
+            } else {
+                format!("http://{proxy}")
+            };
+            cmd.env("HTTPS_PROXY", &url);
+            cmd.env("HTTP_PROXY", &url);
+        }
+        for (name, value) in &spec.env {
+            cmd.env(name, value);
+        }
+        Ok(cmd)
+    }
+}
+
+#[async_trait]
+impl McpGovernedTool for ClaudeCodeIntegration {
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+        use aa_devtool_contract::DevToolAdapter as _;
+        self.adapter.list_mcp_servers().await
+    }
+
+    fn plan_mcp_governance(&self, allowed: &[String], denied: &[String]) -> Result<IntegrationStep, AdapterError> {
+        let path = self.paths.settings_path(SettingsScope::User).map_err(scope_error)?;
+        let content = mcp_settings_json(allowed, denied)?;
+        Ok(IntegrationStep::new(
+            "mcp-governance",
+            StepAction::WriteManagedSettings {
+                scope: SettingsScope::User,
+                path,
+                managed_keys: MCP_KEYS.iter().map(|k| (*k).to_string()).collect(),
+                content_sha256: sha256_hex(&content),
+                merge: SettingsMerge::MergeManagedKeys,
+            },
+            "apply the MCP allow/deny list to Claude Code's settings",
+        ))
+    }
+}
+
+impl ClaudeCodeIntegration {
+    /// An executor loaded with the content `plan` describes, ready to apply it.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any failure to render the bytes a step describes.
+    pub fn loaded_executor(&self, plan: &IntegrationPlan) -> Result<Box<dyn StepExecutor + Send>, AdapterError> {
+        Ok(Box::new(self.scoped_executor(self.step_content(plan)?)))
+    }
+}

--- a/aa-devtool-claude-code/src/probe.rs
+++ b/aa-devtool-claude-code/src/probe.rs
@@ -1,0 +1,134 @@
+//! Producing traffic on the protected path, and refusing to guess what happened
+//! to it.
+//!
+//! # Why this is a seam and not a function
+//!
+//! Only **exercised** evidence can raise the protection ladder to
+//! [`GatewayProtected`](aa_devtool_contract::ProtectionLevel::GatewayProtected),
+//! and exercised means traffic was produced *and adjudicated*. Producing it is
+//! easy; adjudicating it means knowing what the provider actually received,
+//! which a client sitting on the near side of the proxy cannot see. A probe that
+//! sent a synthetic secret through the proxy and then reported
+//! [`Redacted`](aa_devtool_contract::ExerciseOutcome::Redacted) because nothing
+//! obviously failed would be exactly the vacuous pass the evidence model exists
+//! to prevent.
+//!
+//! So the probe is an injected capability. The default,
+//! [`UnadjudicatedProbe`], reports
+//! [`Inconclusive`](aa_devtool_contract::ExerciseOutcome::Inconclusive) with the
+//! reason — which is not protective, so `verify` does not pass and the level
+//! does not rise. A deployment that *can* observe the forwarded payload supplies
+//! a probe that adjudicates, and only then does `GatewayProtected` become
+//! reachable.
+
+use std::path::PathBuf;
+
+use aa_devtool_contract::ExerciseOutcome;
+use async_trait::async_trait;
+
+/// The synthetic secret probes carry.
+///
+/// Shaped to match `aa_security`'s `sk-ant-` literal pattern so the deterministic
+/// scanner genuinely matches it, and unmistakably fabricated: the ticket id is in
+/// the token body and the value appears nowhere else. It is not, and has never
+/// been, a credential.
+pub const SYNTHETIC_SECRET: &str = "sk-ant-api03-AAASM5281SYNTHETICDONOTUSE0000000000000000000000000000000000AA";
+
+/// Everything a probe needs to reach the protected path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbeRequest {
+    /// Proxy the tool's traffic is routed through, as a URL.
+    pub proxy_url: String,
+    /// The trust material the tool was given, so the probe can trust the same
+    /// certificate authority the tool does.
+    pub ca_pem: PathBuf,
+    /// Host the model-bound request is addressed to.
+    pub target_host: String,
+    /// The value the scanner is expected to find and act on.
+    pub synthetic_secret: String,
+}
+
+/// What a probe established.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbeReport {
+    /// What the core did with the probe traffic.
+    pub outcome: ExerciseOutcome,
+    /// What happened, in words a user can act on. Never contains the secret.
+    pub detail: String,
+}
+
+/// Produces traffic on the protected path and reports what became of it.
+#[async_trait]
+pub trait ProtectionProbe: Send + Sync {
+    /// Run one probe.
+    ///
+    /// Implementations must never report a protective outcome they did not
+    /// observe; [`ExerciseOutcome::Inconclusive`] is the correct answer for
+    /// "the traffic went out and I could not see what arrived".
+    async fn run(&self, request: &ProbeRequest) -> ProbeReport;
+}
+
+/// The default probe: honest about what it cannot establish.
+///
+/// It produces no traffic, because producing traffic it cannot adjudicate would
+/// send a synthetic secret to a real provider for no evidential gain.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UnadjudicatedProbe;
+
+#[async_trait]
+impl ProtectionProbe for UnadjudicatedProbe {
+    async fn run(&self, request: &ProbeRequest) -> ProbeReport {
+        ProbeReport {
+            outcome: ExerciseOutcome::Inconclusive,
+            detail: format!(
+                "no adjudicating protection probe is configured for {}, so the model path was \
+                 configured but never exercised. Interception is wired ({} with the Agent Assembly \
+                 certificate authority at {}), and configuration alone is not evidence that anything \
+                 inspected the traffic",
+                request.target_host,
+                request.proxy_url,
+                request.ca_pem.display(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> ProbeRequest {
+        ProbeRequest {
+            proxy_url: "http://127.0.0.1:8899".to_string(),
+            ca_pem: PathBuf::from("/tmp/aasm-proxy-ca.pem"),
+            target_host: "api.anthropic.com".to_string(),
+            synthetic_secret: SYNTHETIC_SECRET.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn the_default_probe_is_never_protective() {
+        let report = UnadjudicatedProbe.run(&request()).await;
+        assert_eq!(report.outcome, ExerciseOutcome::Inconclusive);
+        assert!(
+            !report.outcome.is_protective(),
+            "a probe that adjudicated nothing must not read as protection"
+        );
+        assert!(report.detail.contains("never exercised"), "{}", report.detail);
+    }
+
+    #[tokio::test]
+    async fn no_probe_report_may_carry_the_secret() {
+        let report = UnadjudicatedProbe.run(&request()).await;
+        assert!(!report.detail.contains(SYNTHETIC_SECRET), "{}", report.detail);
+    }
+
+    #[test]
+    fn the_synthetic_secret_is_obviously_fabricated() {
+        assert!(
+            SYNTHETIC_SECRET.starts_with("sk-ant-"),
+            "the scanner pattern must match"
+        );
+        assert!(SYNTHETIC_SECRET.contains("AAASM5281SYNTHETICDONOTUSE"));
+    }
+}

--- a/aa-devtool-claude-code/src/scope.rs
+++ b/aa-devtool-claude-code/src/scope.rs
@@ -1,0 +1,413 @@
+//! Where Claude Code's configuration lives — decided, never inferred.
+//!
+//! # Why this module exists (AAASM-5276 condition C2)
+//!
+//! [`apply::DefaultSettingsPathResolver`](crate::apply) prefers
+//! `<cwd>/.claude/settings.json` whenever a `.claude/` directory happens to
+//! exist in the process's working directory, and falls back to
+//! `$HOME/.claude/settings.json` otherwise. Which file gets written therefore
+//! depends on where the process was started from. That is survivable for a
+//! fire-and-forget `apply_settings`, and fatal for a lifecycle: a receipt that
+//! cannot name the file it wrote cannot detect drift against it, cannot restore
+//! it, and can surprise a user by mutating a checked-in project file they never
+//! chose.
+//!
+//! [`ClaudeCodePaths`] takes the scope as an argument and has no
+//! "whichever one exists" branch. Every settings-touching step the lifecycle
+//! authors gets its path from here, and
+//! [`IntegrationPlan::validate`](aa_devtool_contract::IntegrationPlan::validate)
+//! rejects a plan whose steps disagree with the scope the request named.
+//!
+//! # The three surfaces, and the one this integration will not touch
+//!
+//! * **User** — `$CLAUDE_CONFIG_DIR/settings.json`, or `$HOME/.claude/settings.json`.
+//!   `CLAUDE_CONFIG_DIR` is Claude Code's own redirection of its config home, so
+//!   honouring it is both correct and what keeps a test out of a developer's
+//!   real tree.
+//! * **Project** — `<project root>/.claude/settings.json`. Checked in, shared,
+//!   and workspace-trust gated; selectable, never a default.
+//! * **Managed** — `/Library/Application Support/ClaudeCode/managed-settings.json`.
+//!   Root-owned, absent on an unmanaged host, and **unmeasured**: the AAASM-5276
+//!   spike deliberately made no privileged writes, so its managed-only keys
+//!   (`disableBypassPermissionsMode`, `allowManagedPermissionRulesOnly`, …)
+//!   remain unproven. [`ClaudeCodePaths::settings_path`] resolves it so the
+//!   surface can be *named* in a refusal, and nothing in this crate writes to it.
+
+use std::path::{Path, PathBuf};
+
+use aa_devtool_contract::SettingsScope;
+
+/// The macOS endpoint managed-settings file.
+///
+/// Named so a refusal can name it. Deliberately never written to — see the
+/// module docs.
+pub const MANAGED_SETTINGS_PATH: &str = "/Library/Application Support/ClaudeCode/managed-settings.json";
+
+/// Directory Claude Code keeps its user configuration in, relative to `$HOME`.
+pub const DOT_CLAUDE: &str = ".claude";
+
+/// The settings file name at user and project scope.
+pub const SETTINGS_FILE: &str = "settings.json";
+
+/// Why a scope could not be turned into a path.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ScopeError {
+    /// The root a scope is relative to is unknown on this host.
+    #[error("the {scope} configuration scope cannot be resolved: {detail}")]
+    Unresolvable {
+        /// The scope that could not be resolved.
+        scope: SettingsScope,
+        /// What is missing.
+        detail: String,
+    },
+    /// The scope resolves, and this integration refuses to write to it.
+    #[error("{detail}")]
+    Refused {
+        /// The scope that was asked for.
+        scope: SettingsScope,
+        /// Why, in words a user can act on.
+        detail: String,
+    },
+}
+
+/// Every path the Claude Code integration reads or writes, resolved from
+/// explicit roots.
+///
+/// Constructed with [`ClaudeCodePaths::from_env`] in production and with the
+/// `with_*` builders in tests, so no test ever depends on the ambient `$HOME`
+/// or working directory.
+#[derive(Debug, Clone, Default)]
+pub struct ClaudeCodePaths {
+    /// `$CLAUDE_CONFIG_DIR`, when Claude Code's config home is redirected.
+    config_dir: Option<PathBuf>,
+    /// `$HOME`.
+    home: Option<PathBuf>,
+    /// The project root project-scope settings are relative to.
+    project: Option<PathBuf>,
+    /// Root for artifacts Agent Assembly owns outright.
+    state: Option<PathBuf>,
+    /// The proxy CA certificate this integration copies its trust material from.
+    ca_source: Option<PathBuf>,
+}
+
+impl ClaudeCodePaths {
+    /// Resolve every root from the environment.
+    ///
+    /// Missing roots stay `None` rather than being guessed; the scope that
+    /// needed one reports [`ScopeError::Unresolvable`] when it is asked for.
+    pub fn from_env() -> Self {
+        Self {
+            config_dir: non_empty_var("CLAUDE_CONFIG_DIR"),
+            home: non_empty_var("HOME"),
+            project: std::env::current_dir().ok(),
+            state: Some(state_root()),
+            ca_source: Some(ca_source()),
+        }
+    }
+
+    /// Pin the user-scope configuration home (`CLAUDE_CONFIG_DIR`).
+    #[must_use]
+    pub fn with_config_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.config_dir = Some(dir.into());
+        self
+    }
+
+    /// Pin `$HOME`.
+    #[must_use]
+    pub fn with_home(mut self, home: impl Into<PathBuf>) -> Self {
+        self.home = Some(home.into());
+        self
+    }
+
+    /// Pin the project root.
+    #[must_use]
+    pub fn with_project(mut self, project: impl Into<PathBuf>) -> Self {
+        self.project = Some(project.into());
+        self
+    }
+
+    /// Pin the root for artifacts Agent Assembly owns.
+    #[must_use]
+    pub fn with_state(mut self, state: impl Into<PathBuf>) -> Self {
+        self.state = Some(state.into());
+        self
+    }
+
+    /// Pin the proxy CA certificate to copy trust material from.
+    #[must_use]
+    pub fn with_ca_source(mut self, ca: impl Into<PathBuf>) -> Self {
+        self.ca_source = Some(ca.into());
+        self
+    }
+
+    /// The settings file for `scope`.
+    ///
+    /// # Errors
+    ///
+    /// [`ScopeError::Unresolvable`] when the scope's root is unknown on this
+    /// host, and [`ScopeError::Refused`] for
+    /// [`SettingsScope::Managed`] — see the module docs.
+    pub fn settings_path(&self, scope: SettingsScope) -> Result<PathBuf, ScopeError> {
+        match scope {
+            SettingsScope::User => Ok(self.user_config_dir()?.join(SETTINGS_FILE)),
+            SettingsScope::Project => {
+                let project = self.project.as_ref().ok_or_else(|| ScopeError::Unresolvable {
+                    scope,
+                    detail: "no project root was given and the working directory could not be read".to_string(),
+                })?;
+                Ok(project.join(DOT_CLAUDE).join(SETTINGS_FILE))
+            }
+            SettingsScope::Managed => Err(ScopeError::Refused {
+                scope,
+                detail: format!(
+                    "{MANAGED_SETTINGS_PATH} is administrator-owned and Agent Assembly will not write to it. \
+                     Its enforcement keys are unmeasured and installing them needs a privileged step this \
+                     integration deliberately does not take; choose --scope user or --scope project"
+                ),
+            }),
+        }
+    }
+
+    /// Claude Code's user configuration directory.
+    fn user_config_dir(&self) -> Result<PathBuf, ScopeError> {
+        if let Some(dir) = &self.config_dir {
+            return Ok(dir.clone());
+        }
+        let home = self.home.as_ref().ok_or_else(|| ScopeError::Unresolvable {
+            scope: SettingsScope::User,
+            detail: "neither CLAUDE_CONFIG_DIR nor HOME is set".to_string(),
+        })?;
+        Ok(home.join(DOT_CLAUDE))
+    }
+
+    /// Which configuration surfaces this host actually has, whoever wrote them.
+    ///
+    /// Reported so a user choosing a scope can see that a project file exists
+    /// and would be left alone, rather than discovering it afterwards.
+    pub fn detected_surfaces(&self) -> Vec<DetectedSurface> {
+        [SettingsScope::User, SettingsScope::Project, SettingsScope::Managed]
+            .into_iter()
+            .filter_map(|scope| {
+                let path = match scope {
+                    SettingsScope::Managed => PathBuf::from(MANAGED_SETTINGS_PATH),
+                    other => self.settings_path(other).ok()?,
+                };
+                path.is_file().then_some(DetectedSurface { scope, path })
+            })
+            .collect()
+    }
+
+    /// Root for the artifacts Agent Assembly owns for this scope.
+    ///
+    /// # Errors
+    ///
+    /// [`ScopeError::Unresolvable`] when no state root is known.
+    pub fn owned_root(&self, scope: SettingsScope) -> Result<PathBuf, ScopeError> {
+        let state = self.state.as_ref().ok_or_else(|| ScopeError::Unresolvable {
+            scope,
+            detail: "no Agent Assembly state directory is known; set AASM_STATE_DIR".to_string(),
+        })?;
+        Ok(state.join("claude-code").join(scope.to_string()))
+    }
+
+    /// Where the copy of the proxy CA this integration owns is written.
+    ///
+    /// A **copy**, not a reference to [`ca_source`](Self::ca_source): the step
+    /// has to be fingerprinted, drift-checked and reversed, and reversing a
+    /// reference would delete the proxy's own certificate authority.
+    ///
+    /// # Errors
+    ///
+    /// As [`owned_root`](Self::owned_root).
+    pub fn proxy_ca_pem(&self, scope: SettingsScope) -> Result<PathBuf, ScopeError> {
+        Ok(self.owned_root(scope)?.join("aasm-proxy-ca.pem"))
+    }
+
+    /// Directory holding the launch environment this integration injects.
+    ///
+    /// # Errors
+    ///
+    /// As [`owned_root`](Self::owned_root).
+    pub fn launch_env_dir(&self, scope: SettingsScope) -> Result<PathBuf, ScopeError> {
+        Ok(self.owned_root(scope)?.join("launch-env"))
+    }
+
+    /// The per-integration MitM host list the proxy unions into its own
+    /// configuration (AAASM-5276 condition C5).
+    ///
+    /// One file per integration, so scoping one tool's side channels never
+    /// changes what the proxy does for anything else on the machine.
+    ///
+    /// # Errors
+    ///
+    /// [`ScopeError::Unresolvable`] when no state root is known.
+    pub fn mitm_hosts_file(&self, scope: SettingsScope) -> Result<PathBuf, ScopeError> {
+        let state = self.state.as_ref().ok_or_else(|| ScopeError::Unresolvable {
+            scope,
+            detail: "no Agent Assembly state directory is known; set AASM_STATE_DIR".to_string(),
+        })?;
+        Ok(state
+            .join(crate::MITM_HOSTS_DIR)
+            .join(format!("claude-code--{scope}.hosts")))
+    }
+
+    /// The proxy CA certificate to copy trust material from, when one exists.
+    pub fn ca_source(&self) -> Option<&Path> {
+        self.ca_source.as_deref().filter(|p| p.is_file())
+    }
+
+    /// The path trust material would be copied from, whether or not it exists.
+    pub fn ca_source_path(&self) -> Option<&Path> {
+        self.ca_source.as_deref()
+    }
+
+    /// `$HOME`, for the legacy adapter's own detection markers.
+    pub fn home(&self) -> Option<&Path> {
+        self.home.as_deref()
+    }
+}
+
+/// One configuration surface that exists on this host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectedSurface {
+    /// Which scope it is.
+    pub scope: SettingsScope,
+    /// The file that was found.
+    pub path: PathBuf,
+}
+
+fn non_empty_var(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name).filter(|v| !v.is_empty()).map(PathBuf::from)
+}
+
+/// `${AASM_STATE_DIR:-$HOME/.aasm}/integrations`, matching the receipt store's
+/// own root so an integration's artifacts and its receipt share a lifetime.
+fn state_root() -> PathBuf {
+    let base = non_empty_var("AASM_STATE_DIR").unwrap_or_else(|| {
+        non_empty_var("HOME")
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".aasm")
+    });
+    base.join("integrations")
+}
+
+/// `${AA_CA_DIR:-$HOME/.aa/ca}/ca-cert.pem` — where `aa-proxy` persists the CA
+/// it signs intercepted leaf certificates with.
+fn ca_source() -> PathBuf {
+    let dir = non_empty_var("AA_CA_DIR").unwrap_or_else(|| {
+        non_empty_var("HOME")
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".aa")
+            .join("ca")
+    });
+    dir.join("ca-cert.pem")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(dir: &Path) -> ClaudeCodePaths {
+        ClaudeCodePaths::default()
+            .with_home(dir.join("home"))
+            .with_project(dir.join("repo"))
+            .with_state(dir.join("state"))
+            .with_ca_source(dir.join("ca").join("ca-cert.pem"))
+    }
+
+    #[test]
+    fn a_project_directory_never_captures_a_user_scoped_write() {
+        // The C2 regression in one assertion: a `.claude/` directory sitting in
+        // the project root must not change where a user-scoped step writes.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("repo").join(DOT_CLAUDE)).unwrap();
+        let paths = paths(dir.path());
+
+        assert_eq!(
+            paths.settings_path(SettingsScope::User).unwrap(),
+            dir.path().join("home").join(DOT_CLAUDE).join(SETTINGS_FILE)
+        );
+        assert_eq!(
+            paths.settings_path(SettingsScope::Project).unwrap(),
+            dir.path().join("repo").join(DOT_CLAUDE).join(SETTINGS_FILE)
+        );
+    }
+
+    #[test]
+    fn claude_config_dir_wins_for_user_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = paths(dir.path()).with_config_dir(dir.path().join("elsewhere"));
+        assert_eq!(
+            paths.settings_path(SettingsScope::User).unwrap(),
+            dir.path().join("elsewhere").join(SETTINGS_FILE)
+        );
+    }
+
+    #[test]
+    fn the_managed_surface_is_named_and_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        match paths(dir.path()).settings_path(SettingsScope::Managed) {
+            Err(ScopeError::Refused { detail, .. }) => {
+                assert!(detail.contains(MANAGED_SETTINGS_PATH), "{detail}");
+                assert!(detail.contains("--scope user"), "{detail}");
+            }
+            other => panic!("managed scope must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unresolvable_root_is_an_error_not_a_guess() {
+        let bare = ClaudeCodePaths::default();
+        assert!(matches!(
+            bare.settings_path(SettingsScope::User),
+            Err(ScopeError::Unresolvable { .. })
+        ));
+        assert!(matches!(
+            bare.owned_root(SettingsScope::User),
+            Err(ScopeError::Unresolvable { .. })
+        ));
+    }
+
+    #[test]
+    fn owned_artifacts_are_scope_separated() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = paths(dir.path());
+        assert_ne!(
+            p.proxy_ca_pem(SettingsScope::User).unwrap(),
+            p.proxy_ca_pem(SettingsScope::Project).unwrap()
+        );
+        assert_ne!(
+            p.mitm_hosts_file(SettingsScope::User).unwrap(),
+            p.mitm_hosts_file(SettingsScope::Project).unwrap()
+        );
+    }
+
+    #[test]
+    fn detected_surfaces_report_what_is_on_the_host() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = paths(dir.path());
+        assert!(p.detected_surfaces().is_empty());
+
+        let user = p.settings_path(SettingsScope::User).unwrap();
+        std::fs::create_dir_all(user.parent().unwrap()).unwrap();
+        std::fs::write(&user, "{}").unwrap();
+        let found = p.detected_surfaces();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].scope, SettingsScope::User);
+        assert_eq!(found[0].path, user);
+    }
+
+    #[test]
+    fn a_missing_ca_source_is_reported_as_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = paths(dir.path());
+        assert!(p.ca_source().is_none());
+        assert!(p.ca_source_path().is_some());
+
+        let ca = dir.path().join("ca").join("ca-cert.pem");
+        std::fs::create_dir_all(ca.parent().unwrap()).unwrap();
+        std::fs::write(&ca, "-----BEGIN CERTIFICATE-----\n").unwrap();
+        assert_eq!(p.ca_source(), Some(ca.as_path()));
+    }
+}

--- a/aa-devtool-claude-code/tests/claude_code_lifecycle.rs
+++ b/aa-devtool-claude-code/tests/claude_code_lifecycle.rs
@@ -1,0 +1,552 @@
+//! Adapter-level tests for the Claude Code Developer Integration (AAASM-5281).
+//!
+//! Everything here runs against explicit temp roots. Nothing reads or writes the
+//! developer's real `$HOME/.claude`, `$HOME/.aa` or
+//! `/Library/Application Support/ClaudeCode`, and no keychain operation is
+//! performed — trust is established through `NODE_EXTRA_CA_CERTS`, which is the
+//! whole point of AAASM-5276 condition C1.
+//!
+//! The full install → status → verify → drift → repair → remove cycle needs the
+//! engine and the receipt store, which live behind `aa-core`; it is in
+//! `aa-integration-tests/tests/claude_code_integration_lifecycle.rs`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use aa_devtool_claude_code::lifecycle::{
+    CA_ENV_VAR, MITM_HOSTS, STEP_MANAGED_SETTINGS, STEP_NODE_EXTRA_CA_CERTS, STEP_PROTECTION_TEST, STEP_PROXY_CA,
+    STEP_PROXY_ENV, STEP_SIDE_CHANNEL_SCOPE,
+};
+use aa_devtool_claude_code::{ClaudeCodeAdapter, ClaudeCodeIntegration, ClaudeCodePaths};
+use aa_devtool_contract::{
+    capability_conformance, DevToolIntegration, DevToolKind, EnvValue, IntegrationCapability, IntegrationRequest,
+    LaunchSpec, ProtectionLevel, ProtectionProfile, SettingsScope, StepAction,
+};
+
+/// A fabricated PEM. Nothing verifies it here; the tests assert it is *copied*,
+/// *pointed at* and *removed*, never that it validates a certificate chain.
+const FAKE_CA_PEM: &str = "-----BEGIN CERTIFICATE-----\nAAASM5281FAKECA\n-----END CERTIFICATE-----\n";
+
+struct Fixture {
+    dir: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("home").join(".claude")).expect("home");
+        std::fs::create_dir_all(dir.path().join("repo").join(".claude")).expect("repo");
+        Self { dir }
+    }
+
+    fn root(&self) -> &Path {
+        self.dir.path()
+    }
+
+    fn ca_source(&self) -> PathBuf {
+        self.root().join("aa-ca").join("ca-cert.pem")
+    }
+
+    fn write_ca(&self) {
+        let path = self.ca_source();
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("ca dir");
+        std::fs::write(path, FAKE_CA_PEM).expect("ca pem");
+    }
+
+    fn paths(&self) -> ClaudeCodePaths {
+        ClaudeCodePaths::default()
+            .with_home(self.root().join("home"))
+            .with_project(self.root().join("repo"))
+            .with_state(self.root().join("state"))
+            .with_ca_source(self.ca_source())
+    }
+
+    /// A stub `claude` binary file. Never executed — the version probe is
+    /// overridden — but `resolve_binary` checks it exists.
+    fn stub_binary(&self) -> PathBuf {
+        let bin = self.root().join("claude");
+        if !bin.exists() {
+            std::fs::write(&bin, "").expect("stub binary");
+        }
+        bin
+    }
+
+    fn adapter(&self, version: Option<&str>) -> ClaudeCodeAdapter {
+        ClaudeCodeAdapter::with_overrides(Some(self.stub_binary()), Some(self.root().join("home")))
+            .with_version_override(version.map(str::to_string))
+    }
+
+    fn integration(&self, version: Option<&str>) -> ClaudeCodeIntegration {
+        ClaudeCodeIntegration::with_paths(self.paths())
+            .with_adapter(self.adapter(version))
+            .through_proxy("http://127.0.0.1:18899")
+    }
+
+    fn settings_path(&self, scope: SettingsScope) -> PathBuf {
+        self.paths().settings_path(scope).expect("settings path")
+    }
+}
+
+fn request(scope: SettingsScope) -> IntegrationRequest {
+    IntegrationRequest::new(DevToolKind::ClaudeCode, ProtectionProfile::Recommended, scope)
+}
+
+// ── Contract conformance ────────────────────────────────────────────────────
+
+#[test]
+fn what_the_integration_declares_is_what_it_implements() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    assert_eq!(
+        capability_conformance(&integration),
+        vec![],
+        "a declared capability whose accessor returns None is a contract violation"
+    );
+}
+
+#[test]
+fn base_url_redirection_and_hooks_are_declared_unsupported_with_reasons() {
+    // AAASM-5276 conditions C4 and the hooks classification. Both are mechanisms
+    // that exist and neither is offered, so both have to carry the reason.
+    let fixture = Fixture::new();
+    let caps = fixture.integration(Some("2.1.220")).capabilities();
+
+    let base_url = caps
+        .unsupported_reason(IntegrationCapability::ModelGatewayBaseUrl)
+        .expect("base-url redirection must be declared unsupported, not omitted");
+    assert!(base_url.contains("routing, not protection"), "{base_url}");
+
+    let hooks = caps
+        .unsupported_reason(IntegrationCapability::Hooks)
+        .expect("hooks must be declared unsupported for protection");
+    assert!(hooks.contains("cannot see or modify"), "{hooks}");
+
+    let host = caps
+        .unsupported_reason(IntegrationCapability::HostEnforcement)
+        .expect("host enforcement must be reported as unavailable, never omitted");
+    assert!(host.contains("system trust store"), "{host}");
+}
+
+#[test]
+fn interception_is_unsupported_until_the_proxy_ca_exists() {
+    let fixture = Fixture::new();
+    let integration = fixture.integration(Some("2.1.220"));
+    assert!(
+        !integration.capabilities().can_intercept_model_path(),
+        "with no CA on the host the tool cannot be made to trust the proxy"
+    );
+
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    assert!(integration.capabilities().can_intercept_model_path());
+}
+
+// ── Planning ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn the_plan_carries_the_ca_and_the_variable_that_makes_it_work() {
+    // AAASM-5276 condition C1, in plan form: materialise the CA, then point
+    // NODE_EXTRA_CA_CERTS at the artifact the previous step wrote.
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    let plan = integration
+        .plan_integration(&request(SettingsScope::User))
+        .await
+        .expect("plan");
+    plan.validate().expect("the plan must validate");
+
+    let ids: Vec<&str> = plan.steps.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec![
+            STEP_MANAGED_SETTINGS,
+            STEP_PROXY_CA,
+            STEP_NODE_EXTRA_CA_CERTS,
+            STEP_PROXY_ENV,
+            STEP_SIDE_CHANNEL_SCOPE,
+            STEP_PROTECTION_TEST,
+        ]
+    );
+
+    let ca_path = fixture
+        .paths()
+        .proxy_ca_pem(SettingsScope::User)
+        .expect("owned CA path");
+    let ca_step = plan.steps.iter().find(|s| s.id == STEP_PROXY_CA).expect("ca step");
+    match &ca_step.action {
+        StepAction::MaterialiseTrustMaterial { path, .. } => assert_eq!(path, &ca_path),
+        other => panic!("expected trust material, got {other:?}"),
+    }
+
+    let env_step = plan
+        .steps
+        .iter()
+        .find(|s| s.id == STEP_NODE_EXTRA_CA_CERTS)
+        .expect("env step");
+    match &env_step.action {
+        StepAction::InjectLaunchEnvironment { variable, value, scope } => {
+            assert_eq!(variable, CA_ENV_VAR);
+            assert_eq!(value, &EnvValue::ArtifactPath(ca_path.clone()));
+            assert_eq!(*scope, SettingsScope::User);
+        }
+        other => panic!("expected launch-environment injection, got {other:?}"),
+    }
+    assert!(
+        env_step.reversal.is_some(),
+        "the variable that makes interception work must be removable"
+    );
+
+    assert_eq!(plan.planned_level, ProtectionLevel::GatewayProtected);
+    assert!(plan.has_interception_probe());
+}
+
+#[tokio::test]
+async fn without_the_proxy_ca_the_plan_cannot_claim_protection() {
+    let fixture = Fixture::new();
+    let integration = fixture.integration(Some("2.1.220"));
+    let plan = integration
+        .plan_integration(&request(SettingsScope::User))
+        .await
+        .expect("plan");
+    plan.validate().expect("the plan must validate");
+
+    assert_eq!(
+        plan.planned_level,
+        ProtectionLevel::Integrated,
+        "a plan with no trust material must not claim the model path is inspected"
+    );
+    assert!(!plan.has_interception_probe());
+    assert!(plan
+        .unsupported
+        .iter()
+        .any(|m| m.capability == IntegrationCapability::ModelPathInterception));
+}
+
+#[tokio::test]
+async fn a_project_directory_does_not_capture_a_user_scoped_plan() {
+    // Condition C2. `<cwd>/.claude/` exists in this fixture; a user-scoped plan
+    // must still write to the user's file, and must say the other surface exists.
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    std::fs::write(fixture.settings_path(SettingsScope::Project), "{}").expect("project settings");
+
+    let plan = integration
+        .plan_integration(&request(SettingsScope::User))
+        .await
+        .expect("plan");
+    plan.validate().expect("validate");
+
+    let settings = plan
+        .steps
+        .iter()
+        .find(|s| s.id == STEP_MANAGED_SETTINGS)
+        .expect("settings step");
+    match &settings.action {
+        StepAction::WriteManagedSettings { path, scope, .. } => {
+            assert_eq!(path, &fixture.settings_path(SettingsScope::User));
+            assert_eq!(*scope, SettingsScope::User);
+        }
+        other => panic!("expected managed settings, got {other:?}"),
+    }
+    assert!(
+        plan.warnings
+            .iter()
+            .any(|w| w.contains("project configuration also exists")),
+        "the untouched project surface must be named: {:?}",
+        plan.warnings
+    );
+}
+
+#[tokio::test]
+async fn a_project_scoped_plan_writes_only_the_project_surface() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    let plan = integration
+        .plan_integration(&request(SettingsScope::Project))
+        .await
+        .expect("plan");
+    plan.validate().expect("validate");
+    assert_eq!(plan.settings_scope, SettingsScope::Project);
+    for step in &plan.steps {
+        if let Some(scope) = step.action.settings_scope() {
+            assert_eq!(scope, SettingsScope::Project, "step {} escaped the scope", step.id);
+        }
+    }
+}
+
+#[tokio::test]
+async fn the_managed_settings_surface_is_refused_rather_than_written() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    let err = integration
+        .plan_integration(&request(SettingsScope::Managed))
+        .await
+        .expect_err("the endpoint managed-settings file must not be planned for");
+    let message = err.to_string();
+    assert!(message.contains("/Library/Application Support/ClaudeCode"), "{message}");
+    assert!(message.contains("--scope user"), "{message}");
+}
+
+#[tokio::test]
+async fn the_plan_scopes_the_tools_side_channels_without_touching_other_hosts() {
+    // Condition C5.
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    let plan = integration
+        .plan_integration(&request(SettingsScope::User))
+        .await
+        .expect("plan");
+
+    let step = plan
+        .steps
+        .iter()
+        .find(|s| s.id == STEP_SIDE_CHANNEL_SCOPE)
+        .expect("side-channel step");
+    let rendered = integration.step_content(&plan).expect("content");
+    let hosts = rendered.get(STEP_SIDE_CHANNEL_SCOPE).expect("host list content");
+    for host in MITM_HOSTS {
+        assert!(hosts.contains(host), "{hosts}");
+    }
+    assert!(
+        step.summary.contains("without disabling llm_only"),
+        "the reviewer has to see this does not MitM the whole machine: {}",
+        step.summary
+    );
+}
+
+#[tokio::test]
+async fn observe_only_never_plans_for_protection() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    let request = IntegrationRequest::new(
+        DevToolKind::ClaudeCode,
+        ProtectionProfile::ObserveOnly,
+        SettingsScope::User,
+    );
+    let plan = integration.plan_integration(&request).await.expect("plan");
+    plan.validate().expect("validate");
+    assert_eq!(
+        plan.planned_level,
+        ProtectionLevel::Integrated,
+        "observing is not protecting"
+    );
+}
+
+// ── Condition C1 at the launch ──────────────────────────────────────────────
+
+#[test]
+fn a_governed_launch_injects_the_ca_variable_the_spike_measured() {
+    // The load-bearing assertion for condition C1. Against the real
+    // `claude 2.1.220`, `claude --debug` reports the CA only when this variable
+    // is set; without it the MitM handshake fails and nothing is inspected.
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    let paths = fixture.paths();
+    let ca_pem = paths.proxy_ca_pem(SettingsScope::User).expect("ca path");
+
+    // Stand in for what the install writes.
+    let store = aa_devtool_claude_code::launch_env::LaunchEnvStore::at(
+        paths.launch_env_dir(SettingsScope::User).expect("launch env dir"),
+    );
+    store
+        .set(CA_ENV_VAR, &ca_pem.display().to_string())
+        .expect("set the CA variable");
+    store
+        .set("HTTPS_PROXY", "http://127.0.0.1:18899")
+        .expect("set the proxy variable");
+
+    let launchable = integration.as_launchable().expect("Claude Code is launchable");
+    let cmd = launchable
+        .build_launch_command(&LaunchSpec::new("agent-1").with_args(vec!["-p".to_string(), "hi".to_string()]))
+        .expect("launch command");
+
+    let envs: std::collections::HashMap<_, _> = cmd
+        .get_envs()
+        .map(|(k, v)| {
+            (
+                k.to_string_lossy().into_owned(),
+                v.map(|v| v.to_string_lossy().into_owned()),
+            )
+        })
+        .collect();
+    assert_eq!(
+        envs.get(CA_ENV_VAR).cloned().flatten().as_deref(),
+        Some(ca_pem.display().to_string().as_str()),
+        "a governed launch must carry the CA variable; without it interception silently fails"
+    );
+    assert_eq!(
+        envs.get("HTTPS_PROXY").cloned().flatten().as_deref(),
+        Some("http://127.0.0.1:18899")
+    );
+    assert!(
+        !envs.contains_key("NODE_TLS_REJECT_UNAUTHORIZED"),
+        "Agent Assembly must never disable TLS verification"
+    );
+}
+
+#[test]
+fn a_launch_on_a_host_with_no_installation_is_unchanged() {
+    // The negative half: an unmanaged host gets no variables invented for it.
+    let fixture = Fixture::new();
+    let integration = fixture.integration(Some("2.1.220"));
+    let launchable = integration.as_launchable().expect("launchable");
+    let cmd = launchable
+        .build_launch_command(&LaunchSpec::new("agent-1"))
+        .expect("command");
+    let envs: Vec<String> = cmd.get_envs().map(|(k, _)| k.to_string_lossy().into_owned()).collect();
+    assert!(!envs.contains(&CA_ENV_VAR.to_string()), "{envs:?}");
+}
+
+// ── Bypass detection ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_bypass_permission_mode_is_detected_and_surfaced_in_the_plan() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    std::fs::write(
+        fixture.settings_path(SettingsScope::User),
+        r#"{"permissions":{"defaultMode":"bypassPermissions"},"theme":"dark"}"#,
+    )
+    .expect("settings");
+
+    let integration = fixture.integration(Some("2.1.220"));
+    let plan = integration
+        .plan_integration(&request(SettingsScope::User))
+        .await
+        .expect("plan");
+    assert!(
+        plan.warnings.iter().any(|w| w.contains("bypassPermissions")),
+        "a detected bypass must be surfaced before the user approves: {:?}",
+        plan.warnings
+    );
+}
+
+#[tokio::test]
+async fn known_unobservable_bypasses_are_stated_rather_than_implied_absent() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    let plan = integration
+        .plan_integration(&request(SettingsScope::User))
+        .await
+        .expect("plan");
+    assert!(
+        plan.warnings.iter().any(|w| w.contains("A `claude` started")),
+        "an unmanaged launch is a demonstrated bypass and must be stated: {:?}",
+        plan.warnings
+    );
+    assert!(
+        plan.warnings.iter().any(|w| w.contains("repointing CLAUDE_CONFIG_DIR")),
+        "{:?}",
+        plan.warnings
+    );
+}
+
+// ── Status without a receipt ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_configured_host_with_no_receipt_is_not_integrated() {
+    // A settings file Agent Assembly did not write is evidence of a file and
+    // nothing more.
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    std::fs::write(
+        fixture.settings_path(SettingsScope::User),
+        r#"{"permissions":{"allow":["Bash"]},"permissionMode":"default"}"#,
+    )
+    .expect("settings");
+
+    let status = fixture
+        .integration(Some("2.1.220"))
+        .integration_status(None)
+        .await
+        .expect("status");
+    assert_eq!(status.achieved_level(), ProtectionLevel::DetectedNotIntegrated);
+    assert!(!status.has_exercised_evidence());
+    assert!(
+        status
+            .evidence
+            .iter()
+            .any(|e| e.mechanism == IntegrationCapability::HostEnforcement),
+        "host enforcement must be reported as unavailable, never omitted"
+    );
+}
+
+#[tokio::test]
+async fn an_absent_tool_is_not_installed() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration =
+        ClaudeCodeIntegration::with_paths(fixture.paths()).with_adapter(ClaudeCodeAdapter::with_overrides(
+            Some(PathBuf::from("/no/such/claude")),
+            Some(fixture.root().join("home")),
+        ));
+    assert!(integration.detect().is_none());
+    let status = integration.integration_status(None).await.expect("status");
+    assert_eq!(status.achieved_level(), ProtectionLevel::NotInstalled);
+}
+
+#[tokio::test]
+async fn an_unsupported_version_is_reported_as_incompatible_not_guessed() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    // Below MIN_VERSION: `detect` refuses it, so the tool reads as absent rather
+    // than as a half-governed install.
+    let integration = fixture.integration(Some("0.9.9"));
+    assert!(integration.detect().is_none());
+
+    // An unreadable version is a missing comparison, never a pass.
+    let unknown = fixture.integration(None);
+    let status = unknown.integration_status(None).await.expect("status");
+    assert!(!status.compatibility.is_compatible());
+}
+
+// ── The probe seam ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn the_default_probe_cannot_be_mistaken_for_protection() {
+    use aa_devtool_claude_code::probe::{ProbeRequest, ProtectionProbe, UnadjudicatedProbe};
+    let report = UnadjudicatedProbe
+        .run(&ProbeRequest {
+            proxy_url: "http://127.0.0.1:18899".to_string(),
+            ca_pem: PathBuf::from("/tmp/ca.pem"),
+            target_host: "api.anthropic.com".to_string(),
+            synthetic_secret: aa_devtool_claude_code::probe::SYNTHETIC_SECRET.to_string(),
+        })
+        .await;
+    assert!(!report.outcome.is_protective());
+}
+
+#[tokio::test]
+async fn an_injected_probe_reaches_the_verification_result() {
+    use aa_devtool_claude_code::probe::{ProbeReport, ProbeRequest, ProtectionProbe};
+    use aa_devtool_contract::ExerciseOutcome;
+    use async_trait::async_trait;
+
+    struct Redacting;
+
+    #[async_trait]
+    impl ProtectionProbe for Redacting {
+        async fn run(&self, _request: &ProbeRequest) -> ProbeReport {
+            ProbeReport {
+                outcome: ExerciseOutcome::Redacted,
+                detail: "the mock provider received a redacted body".to_string(),
+            }
+        }
+    }
+
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220")).with_probe(Arc::new(Redacting));
+    // The probe seam is exercised end to end (with a receipt) in
+    // `aa-integration-tests`; here it is enough that the wiring accepts one.
+    assert!(integration.as_launchable().is_some());
+}

--- a/aa-devtool-contract/src/lib.rs
+++ b/aa-devtool-contract/src/lib.rs
@@ -130,3 +130,28 @@ pub use aa_core::integration::{LegacyAdapterShim, LEGACY_UNSUPPORTED_REASON};
 // Timestamp helper. Every lifecycle timestamp is plain Unix seconds, and an
 // adapter that stamps evidence needs the same clock the service reads it with.
 pub use aa_core::integration::now_unix_secs;
+
+// --- The step-execution seam (AAASM-5281) --------------------------------
+//
+// The third re-export group, and the narrowest justification for one. ADR 0030
+// gives plan *execution* to the service, and `aa-core`'s [`FilesystemExecutor`]
+// implements it for every step whose mutation is "put these bytes at this path".
+// It deliberately refuses the rest — launch-environment injection, proxy
+// variables, MCP lists, runtime connection — because each needs mechanism the
+// filesystem cannot supply and each belongs to the adapter that knows its tool.
+//
+// A tool whose plan contains one of those steps therefore has to supply the
+// executor for it, and an executor it cannot name is an executor it cannot
+// write. The three properties in the second group's note still hold: these are
+// one trait plus flat value types, nothing here reaches an unrelated `aa-core`
+// subsystem, and no type gains a field that can hold a policy, a payload or a
+// credential. What it *does* widen is filesystem reach — which a plugin already
+// has through `DevToolAdapter::apply_settings`, and which is now at least
+// described by a reviewable plan step and recorded in a receipt.
+pub use aa_core::integration::{ArtifactObservation, ExecutionError, FilesystemExecutor, StepExecutor, StepOutcome};
+
+// The digest a step carries is over the *content* an adapter renders, and
+// `FilesystemExecutor` fails closed when the two disagree. An adapter that
+// hashed with its own copy of SHA-256 would be one dependency bump away from a
+// mismatch it could not explain, so it uses the same function the check does.
+pub use aa_core::integration::sha256_hex;

--- a/aa-devtool/src/registry.rs
+++ b/aa-devtool/src/registry.rs
@@ -65,6 +65,28 @@ pub fn kind_for(tool: &str) -> Option<DevToolKind> {
     }
 }
 
+/// Bypass conditions a launch's own arguments would create, in words a user can
+/// act on.
+///
+/// Agent Assembly never strips these flags — its interception sits below the
+/// tool's own permission enforcement, so removing them would change the user's
+/// session without changing what is protected. What it can do is refuse to be
+/// silent: a session started with `--dangerously-skip-permissions` is not
+/// getting the tool-action governance its receipt describes, and the honest
+/// place to say so is the moment it starts.
+///
+/// Resolved here rather than in `aasm run` for the same reason adapters are: the
+/// CLI should not learn which flags matter to which tool.
+pub fn launch_warnings(tool: &str, tool_args: &[String]) -> Vec<String> {
+    match tool {
+        "claude" => aa_devtool_claude_code::bypass::launch_flag_bypasses(tool_args)
+            .into_iter()
+            .map(|finding| format!("{} — {}", finding.summary, finding.remediation))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// Construct one adapter per [`SUPPORTED_TOOLS`] entry, in that order.
 ///
 /// This is what `DiscoveryService::new()` runs, and it returns the same adapter
@@ -98,6 +120,18 @@ mod tests {
     #[test]
     fn built_in_adapters_covers_every_supported_tool() {
         assert_eq!(built_in_adapters().len(), SUPPORTED_TOOLS.len());
+    }
+
+    #[test]
+    fn a_permission_bypass_flag_is_reported_but_never_stripped() {
+        let args = vec!["--dangerously-skip-permissions".to_string(), "-p".to_string()];
+        let warnings = launch_warnings("claude", &args);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("--dangerously-skip-permissions"), "{warnings:?}");
+        assert!(launch_warnings("claude", &["-p".to_string()]).is_empty());
+        // A tool with no bypass vocabulary of its own says nothing rather than
+        // borrowing Claude Code's.
+        assert!(launch_warnings("codex", &args).is_empty());
     }
 
     #[test]

--- a/aa-integration-tests/tests/claude_code_integration_lifecycle.rs
+++ b/aa-integration-tests/tests/claude_code_integration_lifecycle.rs
@@ -1,0 +1,641 @@
+//! AAASM-5281 — the Claude Code Developer Integration, end to end against a
+//! live `aa-proxy`, a real MitM CA and a TLS-terminating mock provider.
+//!
+//! # What this measures that a unit test cannot
+//!
+//! The whole ticket rests on AAASM-5276 condition C1: the proxy's MitM
+//! handshake only succeeds if the tool trusts the Agent Assembly certificate
+//! authority, and the product injected no CA-trust variable at all. Proving that
+//! fix needs a real TLS handshake against a real intercepting proxy — a mock can
+//! only prove that a string was written somewhere.
+//!
+//! So every protection assertion here runs traffic through a live
+//! [`ProxyHarness`] whose upstream is a [`TlsCapturingUpstream`] recording
+//! exactly what the provider received, and the negative case differs from the
+//! positive one in **one variable**: whether the client trusts the CA the
+//! install materialised and `NODE_EXTRA_CA_CERTS` points at.
+//!
+//! # Safety
+//!
+//! Every root is a temp directory injected explicitly. Nothing reads or writes
+//! the developer's real `$HOME/.claude`, `$HOME/.aa` or
+//! `/Library/Application Support/ClaudeCode`, and no keychain operation is
+//! performed — [`RealHomeGuard`] fails the test loudly if the live settings file
+//! changes. The secret is synthetic, prefixed `AAASM5281SYNTHETIC`, and matches
+//! the deterministic scanner's `sk-ant-` pattern so redaction is genuinely
+//! exercised.
+
+#[allow(dead_code, unused_imports)]
+mod spike_support;
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use aa_core::integration::{
+    IntegrationRequest, ProtectionLevel, ProtectionProfile, ProtectionState, ReceiptStore, SettingsScope,
+    VerificationOutcome,
+};
+use aa_core::DevToolKind;
+use aa_devtool_claude_code::lifecycle::{CA_ENV_VAR, STEP_NODE_EXTRA_CA_CERTS, STEP_PROXY_CA};
+use aa_devtool_claude_code::probe::{ProbeReport, ProbeRequest, ProtectionProbe, SYNTHETIC_SECRET};
+use aa_devtool_claude_code::{ClaudeCodeAdapter, ClaudeCodeIntegration, ClaudeCodePaths};
+use aa_devtool_contract::ExerciseOutcome;
+use aa_proxy::config::CredentialAction;
+use aa_proxy::tls::CaStore;
+use aa_runtime::devint::adapters::claude_code_registration;
+use aa_runtime::devint::{EngineLifecycle, IntegrationLifecycle};
+use async_trait::async_trait;
+use base64::Engine as _;
+use rustls::pki_types::CertificateDer;
+use rustls::{ClientConfig, RootCertStore};
+use spike_support::proxy_harness::{drive_emulated_client, install_crypto_provider, ProxyHarness, ANTHROPIC_HOST};
+use spike_support::{find_secret, RealHomeGuard, TlsCapturingUpstream};
+
+/// Unrelated user configuration that must survive every operation.
+const USER_THEME: &str = "gruvbox";
+
+// ── The probe ───────────────────────────────────────────────────────────────
+
+/// A protection probe that can actually adjudicate, because the mock provider
+/// records what it received.
+///
+/// This is the shape the production seam exists for: the default
+/// `UnadjudicatedProbe` reports `Inconclusive` precisely because a client on the
+/// near side of the proxy cannot see the forwarded body, and reporting
+/// `Redacted` without seeing it would be the vacuous pass the evidence model
+/// forbids.
+struct MockProviderProbe {
+    proxy_addr: SocketAddr,
+    upstream: Arc<TlsCapturingUpstream>,
+    /// When `false`, the probe client does **not** trust the CA the install
+    /// materialised — standing in for a launch that never received
+    /// `NODE_EXTRA_CA_CERTS`.
+    trust_injected_ca: bool,
+}
+
+#[async_trait]
+impl ProtectionProbe for MockProviderProbe {
+    async fn run(&self, request: &ProbeRequest) -> ProbeReport {
+        let before = self.upstream.request_count();
+
+        let config = if self.trust_injected_ca {
+            match client_trusting_pem(&request.ca_pem).await {
+                Ok(config) => config,
+                Err(e) => {
+                    return ProbeReport {
+                        outcome: ExerciseOutcome::Inconclusive,
+                        detail: format!("the trust material could not be read: {e}"),
+                    }
+                }
+            }
+        } else {
+            // An empty root store: exactly what a Node runtime that was never
+            // given NODE_EXTRA_CA_CERTS sees when the proxy presents its
+            // MitM-issued leaf.
+            ClientConfig::builder()
+                .with_root_certificates(RootCertStore::empty())
+                .with_no_client_auth()
+        };
+
+        let prompt = format!("please audit this credential: {}", request.synthetic_secret);
+        let result = match drive_emulated_client(self.proxy_addr, Arc::new(config), &prompt).await {
+            Ok(result) => result,
+            Err(e) => {
+                return ProbeReport {
+                    outcome: ExerciseOutcome::Inconclusive,
+                    detail: format!("the probe could not reach the proxy: {e}"),
+                }
+            }
+        };
+
+        if let Some(response) = &result.inner_response {
+            if response.starts_with("TLS error") {
+                return ProbeReport {
+                    outcome: ExerciseOutcome::Inconclusive,
+                    detail: "the intercepting proxy's certificate was not trusted, so the model path \
+                             was never inspected"
+                        .to_string(),
+                };
+            }
+        }
+
+        let bodies: Vec<Vec<u8>> = self.upstream.bodies().into_iter().skip(before).collect();
+        if bodies.is_empty() {
+            return ProbeReport {
+                outcome: ExerciseOutcome::Inconclusive,
+                detail: "the provider recorded no request, so nothing was adjudicated".to_string(),
+            };
+        }
+        match find_secret(&bodies, &request.synthetic_secret) {
+            Some((idx, view, enc)) => ProbeReport {
+                outcome: ExerciseOutcome::Leaked,
+                detail: format!("the provider received the credential unredacted (body #{idx}, {view}, {enc})"),
+            },
+            None => ProbeReport {
+                outcome: ExerciseOutcome::Redacted,
+                detail: format!(
+                    "{} request(s) reached the provider and none carried the credential",
+                    bodies.len()
+                ),
+            },
+        }
+    }
+}
+
+/// A rustls client config trusting exactly one PEM file.
+async fn client_trusting_pem(pem_path: &Path) -> anyhow::Result<ClientConfig> {
+    let pem = tokio::fs::read_to_string(pem_path).await?;
+    let body: String = pem.lines().filter(|l| !l.starts_with("-----")).collect();
+    let der = base64::engine::general_purpose::STANDARD.decode(body)?;
+    let mut roots = RootCertStore::empty();
+    roots.add(CertificateDer::from(der))?;
+    Ok(ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth())
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+struct Harness {
+    _dir: tempfile::TempDir,
+    home: PathBuf,
+    state: PathBuf,
+    service: EngineLifecycle,
+    paths: ClaudeCodePaths,
+    upstream: Arc<TlsCapturingUpstream>,
+    _proxy: ProxyHarness,
+    guard: RealHomeGuard,
+}
+
+impl Harness {
+    async fn start(trust_injected_ca: bool) -> anyhow::Result<Self> {
+        install_crypto_provider();
+        let guard = RealHomeGuard::capture();
+
+        let dir = tempfile::tempdir()?;
+        let home = dir.path().join("home");
+        let repo = dir.path().join("repo");
+        let state = dir.path().join("state");
+        let ca_dir = dir.path().join("aa-ca");
+        std::fs::create_dir_all(home.join(".claude"))?;
+        std::fs::create_dir_all(&repo)?;
+        std::fs::create_dir_all(&ca_dir)?;
+
+        // The proxy's real CA — generated, persisted, and never installed into
+        // any trust store.
+        let ca = CaStore::load_or_create(&ca_dir)
+            .await
+            .map_err(|e| anyhow::anyhow!("ca: {e}"))?;
+        let upstream = Arc::new(TlsCapturingUpstream::start(&ca, ANTHROPIC_HOST).await?);
+        let proxy = ProxyHarness::start(&ca_dir, ca, CredentialAction::RedactOnly, upstream.addr, None).await?;
+
+        let paths = ClaudeCodePaths::default()
+            .with_home(&home)
+            .with_project(&repo)
+            .with_state(&state)
+            .with_ca_source(ca_dir.join("ca-cert.pem"));
+
+        let stub_binary = dir.path().join("claude");
+        std::fs::write(&stub_binary, "")?;
+
+        let integration = Arc::new(
+            ClaudeCodeIntegration::with_paths(paths.clone())
+                .with_adapter(
+                    ClaudeCodeAdapter::with_overrides(Some(stub_binary), Some(home.clone()))
+                        .with_version_override(Some("2.1.220".to_string())),
+                )
+                .through_proxy(proxy.proxy_url())
+                .with_probe(Arc::new(MockProviderProbe {
+                    proxy_addr: proxy.addr,
+                    upstream: Arc::clone(&upstream),
+                    trust_injected_ca,
+                })),
+        );
+
+        let service = EngineLifecycle::new(
+            vec![claude_code_registration(integration)],
+            ReceiptStore::at(state.join("store")),
+        );
+
+        Ok(Self {
+            _dir: dir,
+            home,
+            state,
+            service,
+            paths,
+            upstream,
+            _proxy: proxy,
+            guard,
+        })
+    }
+
+    fn settings_path(&self) -> PathBuf {
+        self.home.join(".claude").join("settings.json")
+    }
+
+    fn write_user_settings(&self, body: &str) {
+        std::fs::write(self.settings_path(), body).expect("write settings");
+    }
+
+    fn read_user_settings(&self) -> serde_json::Value {
+        let raw = std::fs::read_to_string(self.settings_path()).expect("read settings");
+        serde_json::from_str(&raw).expect("settings json")
+    }
+
+    async fn install(&self) -> anyhow::Result<aa_core::integration::IntegrationReceipt> {
+        let request = IntegrationRequest::new(
+            DevToolKind::ClaudeCode,
+            ProtectionProfile::Recommended,
+            SettingsScope::User,
+        );
+        let plan = self.service.plan(request).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        self.service
+            .apply(&DevToolKind::ClaudeCode, &plan.plan_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    fn ca_pem_path(&self) -> PathBuf {
+        self.paths.proxy_ca_pem(SettingsScope::User).expect("ca path")
+    }
+
+    fn injected_env(&self) -> std::collections::BTreeMap<String, String> {
+        aa_devtool_claude_code::launch_env::installed_environment(&self.paths)
+    }
+
+    fn finish(&self) {
+        self.guard.assert_unchanged("AAASM-5281 lifecycle harness");
+    }
+}
+
+// ── The cycle ───────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn install_status_verify_drift_repair_and_remove_are_one_cycle() -> anyhow::Result<()> {
+    let h = Harness::start(true).await?;
+    let tool = DevToolKind::ClaudeCode;
+    h.write_user_settings(&format!(r#"{{"theme":"{USER_THEME}"}}"#));
+
+    // ── install ────────────────────────────────────────────────────────────
+    let receipt = h.install().await?;
+    assert_eq!(receipt.settings_scope, SettingsScope::User);
+    assert_eq!(
+        receipt.achieved_level,
+        ProtectionLevel::Integrated,
+        "an apply configures; it does not exercise traffic"
+    );
+    assert!(h.ca_pem_path().is_file(), "condition C1: the CA must be materialised");
+    assert_eq!(
+        h.injected_env().get(CA_ENV_VAR).map(String::as_str),
+        Some(h.ca_pem_path().display().to_string().as_str()),
+        "condition C1: NODE_EXTRA_CA_CERTS must point at the materialised CA"
+    );
+    assert!(
+        h.state.join("mitm-hosts.d").read_dir()?.next().is_some(),
+        "condition C5: the side-channel host list must be written"
+    );
+    assert_eq!(
+        h.read_user_settings()["theme"],
+        serde_json::json!(USER_THEME),
+        "an unrelated user key must survive the install"
+    );
+
+    // Repeated install is idempotent, down to the bytes.
+    let before = std::fs::read(h.settings_path())?;
+    let again = h.install().await?;
+    assert_eq!(
+        again.receipt_id, receipt.receipt_id,
+        "a no-op reapply is not an upgrade"
+    );
+    assert_eq!(std::fs::read(h.settings_path())?, before);
+
+    // ── status ─────────────────────────────────────────────────────────────
+    let status = h.service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    // The plan aimed at GatewayProtected and configuration alone cannot get
+    // there, so the honest reading is Degraded with the gap named — not a
+    // quietly smaller ladder rung.
+    match &status.state {
+        ProtectionState::Degraded {
+            planned,
+            achieved,
+            reason,
+        } => {
+            assert_eq!(*planned, ProtectionLevel::GatewayProtected);
+            assert_eq!(*achieved, ProtectionLevel::Integrated);
+            assert!(
+                reason.contains("has been produced and adjudicated") || reason.contains("verify claude-code"),
+                "the gap a user can close must be named first: {reason}"
+            );
+        }
+        other => panic!("expected a Degraded reading immediately after install, got {other:?}"),
+    }
+    assert!(
+        !status.has_exercised_evidence(),
+        "configuration alone must never look like traffic evidence"
+    );
+    assert!(status.next_level.is_some(), "the next rung up is always reported");
+
+    // ── verify ─────────────────────────────────────────────────────────────
+    let verification = h.service.verify(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert_eq!(
+        verification.outcome,
+        VerificationOutcome::Passed,
+        "the probe traversed the intercepted path and the provider got a redacted body"
+    );
+    assert!(verification.has_exercised_evidence());
+    assert!(
+        h.upstream.request_count() > 0,
+        "the mock provider must have recorded a request — otherwise 'no secret arrived' proves nothing"
+    );
+
+    let after_verify = h.service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert_eq!(
+        after_verify.achieved_level(),
+        ProtectionLevel::GatewayProtected,
+        "only exercised, adjudicated interception may raise the ladder this far"
+    );
+
+    // ── drift ──────────────────────────────────────────────────────────────
+    // The user re-enables the bypass mode the install displaced, and separately
+    // changes something of their own.
+    let mut doc = h.read_user_settings();
+    doc["permissions"]["defaultMode"] = serde_json::json!("bypassPermissions");
+    doc["editor"] = serde_json::json!("nvim");
+    std::fs::write(h.settings_path(), serde_json::to_string_pretty(&doc)?)?;
+
+    let drifted = h.service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(
+        matches!(drifted.state, ProtectionState::Drifted { .. }),
+        "a change to an Agent Assembly-owned key must be detected: {:?}",
+        drifted.state
+    );
+
+    // ── repair ─────────────────────────────────────────────────────────────
+    let (report, repaired) = h.service.repair(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(!report.repaired.is_empty(), "repair must name what it restored");
+    assert!(
+        !matches!(repaired.state, ProtectionState::Drifted { .. }),
+        "{:?}",
+        repaired.state
+    );
+    let after_repair = h.read_user_settings();
+    assert_eq!(after_repair["permissions"]["defaultMode"], serde_json::json!("default"));
+    assert_eq!(
+        after_repair["editor"],
+        serde_json::json!("nvim"),
+        "a change the user made after install is theirs and must survive repair"
+    );
+    assert_eq!(after_repair["theme"], serde_json::json!(USER_THEME));
+
+    // ── remove ─────────────────────────────────────────────────────────────
+    let preview = h
+        .service
+        .remove(&tool, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(!preview.steps.is_empty(), "the preview must show what will be undone");
+    assert!(h.ca_pem_path().is_file(), "a preview must not remove anything");
+
+    let removal = h
+        .service
+        .remove(&tool, Some(&preview.plan_id))
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(
+        removal.residual.is_empty(),
+        "nothing should be left behind: {:?}",
+        removal.residual
+    );
+    assert!(!h.ca_pem_path().exists(), "the copied CA must be gone");
+    assert!(
+        !h.injected_env().contains_key(CA_ENV_VAR),
+        "removal must stop injecting the CA variable"
+    );
+    let restored = h.read_user_settings();
+    assert_eq!(restored["theme"], serde_json::json!(USER_THEME));
+    assert_eq!(restored["editor"], serde_json::json!("nvim"));
+    assert!(
+        restored.get("permissions").is_none() && restored.get("permissionMode").is_none(),
+        "removal must delete the keys Agent Assembly added: {restored}"
+    );
+
+    // Removing twice is idempotent from the client's point of view.
+    assert!(h.service.remove(&tool, None).await.is_err());
+
+    h.finish();
+    Ok(())
+}
+
+// ── Condition C1, proved load-bearing ───────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn without_the_injected_ca_the_protection_test_cannot_pass() -> anyhow::Result<()> {
+    // Identical to the cycle above in every respect except one: the probe client
+    // does not trust the certificate authority the install materialised and
+    // NODE_EXTRA_CA_CERTS points at. That is the whole of AAASM-5276 condition
+    // C1 — and without it the MitM handshake fails, so nothing is inspected.
+    let h = Harness::start(false).await?;
+    let tool = DevToolKind::ClaudeCode;
+    h.write_user_settings("{}");
+    h.install().await?;
+
+    let verification = h.service.verify(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(
+        !matches!(verification.outcome, VerificationOutcome::Passed),
+        "a failed TLS handshake must not read as a pass: {:?}",
+        verification.outcome
+    );
+    let status = h.service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(
+        status.achieved_level() < ProtectionLevel::GatewayProtected,
+        "with the CA untrusted the model path is not intercepted, so protection must not be claimed: {:?}",
+        status.state
+    );
+    h.finish();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn verify_cannot_pass_on_configuration_alone() -> anyhow::Result<()> {
+    // The second load-bearing guard: an integration with the default,
+    // non-adjudicating probe is fully applied and fully read-back-verifiable,
+    // and still must not reach GatewayProtected.
+    let dir = tempfile::tempdir()?;
+    let guard = RealHomeGuard::capture();
+    let home = dir.path().join("home");
+    let ca_dir = dir.path().join("aa-ca");
+    std::fs::create_dir_all(home.join(".claude"))?;
+    std::fs::create_dir_all(&ca_dir)?;
+    std::fs::write(
+        ca_dir.join("ca-cert.pem"),
+        "-----BEGIN CERTIFICATE-----\nAAASM5281FAKE\n-----END CERTIFICATE-----\n",
+    )?;
+    let stub = dir.path().join("claude");
+    std::fs::write(&stub, "")?;
+
+    let paths = ClaudeCodePaths::default()
+        .with_home(&home)
+        .with_project(dir.path().join("repo"))
+        .with_state(dir.path().join("state"))
+        .with_ca_source(ca_dir.join("ca-cert.pem"));
+    let integration = Arc::new(ClaudeCodeIntegration::with_paths(paths).with_adapter(
+        ClaudeCodeAdapter::with_overrides(Some(stub), Some(home)).with_version_override(Some("2.1.220".to_string())),
+    ));
+    let service = EngineLifecycle::new(
+        vec![claude_code_registration(integration)],
+        ReceiptStore::at(dir.path().join("store")),
+    );
+
+    let tool = DevToolKind::ClaudeCode;
+    let plan = service
+        .plan(IntegrationRequest::new(
+            tool.clone(),
+            ProtectionProfile::Recommended,
+            SettingsScope::User,
+        ))
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    service
+        .apply(&tool, &plan.plan_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let verification = service.verify(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(
+        !matches!(verification.outcome, VerificationOutcome::Passed),
+        "an unadjudicated probe must not pass: {:?}",
+        verification.outcome
+    );
+    let status = service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert_eq!(
+        status.achieved_level(),
+        ProtectionLevel::Integrated,
+        "configuration read back perfectly is still not protection"
+    );
+    guard.assert_unchanged("configuration-alone guard");
+    Ok(())
+}
+
+// ── Secret hygiene ──────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_raw_secret_is_absent_from_every_artifact_while_the_finding_survives() -> anyhow::Result<()> {
+    let h = Harness::start(true).await?;
+    let tool = DevToolKind::ClaudeCode;
+    h.write_user_settings("{}");
+    h.install().await?;
+
+    let verification = h.service.verify(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    let status = h.service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let mut surfaces: Vec<(String, String)> = vec![
+        ("verification".to_string(), serde_json::to_string(&verification)?),
+        ("status".to_string(), serde_json::to_string(&status)?),
+    ];
+    // Every file Agent Assembly wrote, receipt and journal included.
+    for entry in walk(&h.state) {
+        let body = std::fs::read_to_string(&entry).unwrap_or_default();
+        surfaces.push((entry.display().to_string(), body));
+    }
+    surfaces.push((
+        "settings".to_string(),
+        std::fs::read_to_string(h.settings_path()).unwrap_or_default(),
+    ));
+
+    for (label, body) in &surfaces {
+        assert!(
+            !body.contains(SYNTHETIC_SECRET),
+            "the raw synthetic secret appeared in {label}"
+        );
+    }
+
+    // The load-bearing other half: the *finding* must still be there, or the
+    // absence above would be satisfied by recording nothing at all.
+    let evidence = serde_json::to_string(&verification.evidence)?;
+    assert!(
+        evidence.contains("redacted") || evidence.contains("Redacted"),
+        "the adjudicated outcome must survive redaction: {evidence}"
+    );
+    assert!(
+        h.upstream.request_count() > 0,
+        "traffic must have flowed for this assertion to mean anything"
+    );
+
+    h.finish();
+    Ok(())
+}
+
+// ── Bypass detection ────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_bypass_condition_is_detected_and_surfaced_in_status() -> anyhow::Result<()> {
+    let h = Harness::start(true).await?;
+    let tool = DevToolKind::ClaudeCode;
+    h.write_user_settings("{}");
+    h.install().await?;
+
+    // The user re-enables the mode the install displaced.
+    let mut doc = h.read_user_settings();
+    doc["permissions"]["defaultMode"] = serde_json::json!("bypassPermissions");
+    std::fs::write(h.settings_path(), serde_json::to_string_pretty(&doc)?)?;
+
+    let status = h.service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    let rendered = serde_json::to_string(&status)?;
+    assert!(
+        rendered.contains("bypassPermissions"),
+        "a detected bypass must reach the status a user reads: {rendered}"
+    );
+
+    let verification = h.service.verify(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(
+        !matches!(verification.outcome, VerificationOutcome::Passed),
+        "verification must not pass while a known bypass is active: {:?}",
+        verification.outcome
+    );
+
+    h.finish();
+    Ok(())
+}
+
+/// Every file under `root`, recursively.
+fn walk(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(walk(&path));
+        } else {
+            out.push(path);
+        }
+    }
+    out
+}
+
+/// The removal plan names the two artifacts condition C1 depends on, so a user
+/// reviewing a removal can see the trust material and the variable go.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_removal_preview_names_the_trust_material_and_the_variable() -> anyhow::Result<()> {
+    let h = Harness::start(true).await?;
+    h.write_user_settings("{}");
+    h.install().await?;
+
+    let preview = h
+        .service
+        .remove(&DevToolKind::ClaudeCode, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let rendered = preview.render_dry_run();
+    assert!(rendered.contains(CA_ENV_VAR), "{rendered}");
+    assert!(rendered.contains("certificate authority"), "{rendered}");
+    assert!(preview.steps.iter().any(|s| s.id.contains(STEP_PROXY_CA)), "{rendered}");
+    assert!(
+        preview.steps.iter().any(|s| s.id.contains(STEP_NODE_EXTRA_CA_CERTS)),
+        "{rendered}"
+    );
+    h.finish();
+    Ok(())
+}

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -65,7 +65,10 @@ pub struct ProxyConfig {
     /// leaves only the built-in LLM hosts under MitM when `llm_only` is `true`.
     /// Has no effect when `llm_only` is `false` — every host is already MitM'd.
     ///
-    /// Comma-separated list from env var `AA_PROXY_MITM_HOSTS`.
+    /// Comma-separated list from env var `AA_PROXY_MITM_HOSTS`, **unioned** with
+    /// the host lists installed developer integrations wrote under
+    /// `${AASM_STATE_DIR:-~/.aasm}/integrations/mitm-hosts.d/` — see
+    /// [`integration_mitm_hosts`].
     pub mitm_hosts: Vec<String>,
 
     /// Hosts that the proxy will block at the CONNECT level (HTTP 403).
@@ -167,7 +170,7 @@ impl ProxyConfig {
             ca_dir: parse_ca_dir()?,
             cert_cache_capacity: parse_cert_cache_capacity()?,
             llm_only: parse_llm_only(),
-            mitm_hosts: env_csv("AA_PROXY_MITM_HOSTS"),
+            mitm_hosts: union_mitm_hosts(env_csv("AA_PROXY_MITM_HOSTS"), integration_mitm_hosts()),
             denied_hosts: env_csv("AA_PROXY_DENIED_HOSTS"),
             network_allowlist: env_csv("AA_PROXY_NETWORK_ALLOWLIST"),
             skip_upstream_tls_verify: resolve_skip_upstream_tls_verify(),
@@ -181,6 +184,72 @@ impl ProxyConfig {
             allow_private_connect_targets: false,
         })
     }
+}
+
+/// Directory, under the Agent Assembly state root, holding one MitM host list
+/// per installed developer integration.
+const MITM_HOSTS_DIR: &str = "mitm-hosts.d";
+
+/// Hosts the installed developer integrations asked to have inspected.
+///
+/// AAASM-5276 condition C5: one headless `claude -p` run produced four upstream
+/// requests, only two of which were `/v1/messages` — an MCP-registry GET and a
+/// 130 KB `POST /api/event_logging/v2/batch` went out alongside them. Under the
+/// `llm_only` default those side channels are transparent-tunnelled and never
+/// scanned.
+///
+/// The fix has to be **per integration**, not global: setting `llm_only = false`
+/// would bring every host on the machine under MitM, which is a far larger
+/// change than "inspect the tool you just installed". Each integration's install
+/// writes one file here and its removal deletes it, so the proxy's interception
+/// set follows exactly what is installed. The proxy still MitMs nothing else.
+///
+/// A directory that does not exist, a file that cannot be read, and a blank or
+/// `#`-commented line all contribute nothing — this widens the DLP surface, so
+/// failing to read it can only ever narrow the result, never open a host up.
+fn integration_mitm_hosts() -> Vec<String> {
+    let Some(dir) = integration_state_dir().map(|d| d.join(MITM_HOSTS_DIR)) else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut hosts = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(body) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        for line in body.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            hosts.push(line.to_string());
+        }
+    }
+    hosts
+}
+
+/// `${AASM_STATE_DIR:-~/.aasm}/integrations`, the same root the receipt store
+/// uses, so an integration's artifacts and its receipt live and die together.
+fn integration_state_dir() -> Option<PathBuf> {
+    let base = match std::env::var_os("AASM_STATE_DIR") {
+        Some(dir) if !dir.is_empty() => PathBuf::from(dir),
+        _ => dirs::home_dir()?.join(".aasm"),
+    };
+    Some(base.join("integrations"))
+}
+
+/// Merge the operator's list with the integrations', preserving first-seen order
+/// and dropping duplicates.
+fn union_mitm_hosts(operator: Vec<String>, integrations: Vec<String>) -> Vec<String> {
+    let mut merged = operator;
+    for host in integrations {
+        if !merged.iter().any(|existing| existing.eq_ignore_ascii_case(&host)) {
+            merged.push(host);
+        }
+    }
+    merged
 }
 
 /// Parse the `AA_PROXY_ADDR` env var or return the default bind address.
@@ -317,6 +386,56 @@ mod tests {
         std::env::remove_var("AA_PROXY_CREDENTIAL_ACTION");
         std::env::remove_var("AA_PROXY_GATEWAY_ENDPOINT");
         std::env::remove_var("AA_PROXY_MCP_FAIL_OPEN");
+        std::env::remove_var("AASM_STATE_DIR");
+    }
+
+    /// AAASM-5276 condition C5. An installed integration extends the DLP
+    /// surface to the hosts it named, and `llm_only` stays on — the alternative
+    /// (turning it off) would MitM every host on the machine.
+    #[test]
+    fn an_installed_integration_extends_the_mitm_set_without_disabling_llm_only() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+
+        let dir = tempfile::tempdir().unwrap();
+        let hosts_dir = dir.path().join("integrations").join(MITM_HOSTS_DIR);
+        std::fs::create_dir_all(&hosts_dir).unwrap();
+        std::fs::write(
+            hosts_dir.join("claude-code--user.hosts"),
+            "# written by an install\napi.anthropic.com\n\n*.anthropic.com\n",
+        )
+        .unwrap();
+        std::env::set_var("AASM_STATE_DIR", dir.path());
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert!(cfg.llm_only, "extending the set must not disable llm_only");
+        assert_eq!(cfg.mitm_hosts, vec!["api.anthropic.com", "*.anthropic.com"]);
+
+        // Removing the integration removes its hosts from the proxy's set.
+        std::fs::remove_file(hosts_dir.join("claude-code--user.hosts")).unwrap();
+        assert!(ProxyConfig::from_env().unwrap().mitm_hosts.is_empty());
+        std::env::remove_var("AASM_STATE_DIR");
+    }
+
+    #[test]
+    fn an_absent_state_directory_contributes_no_hosts() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+        std::env::set_var("AASM_STATE_DIR", "/nonexistent/aasm-state-for-tests");
+        assert!(ProxyConfig::from_env().unwrap().mitm_hosts.is_empty());
+        std::env::remove_var("AASM_STATE_DIR");
+    }
+
+    #[test]
+    fn the_operator_list_and_the_integration_list_merge_without_duplicates() {
+        assert_eq!(
+            union_mitm_hosts(
+                vec!["api.groq.com".to_string(), "API.ANTHROPIC.COM".to_string()],
+                vec!["api.anthropic.com".to_string(), "*.anthropic.com".to_string()],
+            ),
+            vec!["api.groq.com", "API.ANTHROPIC.COM", "*.anthropic.com"],
+            "a host the operator already listed must not be added twice"
+        );
     }
 
     #[test]

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -30,6 +30,13 @@ aa-core                     = { path = "../aa-core", version = "0.0.1-rc.6", fea
 # `src/devint/adapters.rs` before `cargo workspaces publish`. A published
 # aa-runtime still binds the DI-API; its integration registry is simply empty.
 aa-devtool                  = { path = "../aa-devtool" }
+# AAASM-5281: Claude Code is the first natively migrated adapter, and its
+# registration needs three surfaces the registry's `Box<dyn DevToolAdapter>`
+# cannot carry — the lifecycle implementation, the renderer for its plan's
+# content, and the executor for the launch-environment steps `FilesystemExecutor`
+# refuses. Named directly for those; `aa_devtool::registry` remains the one place
+# that decides *which* tools exist.
+aa-devtool-claude-code      = { path = "../aa-devtool-claude-code" }
 # strip-for-publish:end devtool
 aa-security                 = { path = "../aa-security", version = "0.0.1-rc.6", features = ["serde"] }
 aa-proto                    = { path = "../aa-proto", version = "0.0.1-rc.6" }

--- a/aa-runtime/src/devint/adapters.rs
+++ b/aa-runtime/src/devint/adapters.rs
@@ -9,26 +9,30 @@
 //! there is still exactly one place that decides which implementation backs a
 //! tool (AAASM-5274).
 //!
-//! None of those adapters implements
-//! [`DevToolIntegration`](aa_core::integration::DevToolIntegration) yet — the
-//! first native implementor is AAASM-5281. Until then
-//! [`LegacyAdapterShim`] makes each of
-//! them satisfy the lifecycle contract, declaring honestly that it cannot
-//! substantiate the mechanisms it was never designed to expose (§7).
+//! **Claude Code is native from AAASM-5281**; every other built-in adapter is
+//! still wrapped in [`LegacyAdapterShim`], which makes it satisfy the lifecycle
+//! contract while declaring honestly that it cannot substantiate the mechanisms
+//! it was never designed to expose (§7).
 //!
 //! # What a shimmed adapter can and cannot do
 //!
 //! It can be **discovered**, **planned** and **reported on**: `list`, `plan`
-//! and `status` are real for every built-in tool from this commit. It cannot be
-//! **applied**, because the shim's plan carries
-//! `StepAction::ApplyLegacyManagedSettings` — the legacy trait renders and
-//! writes in two calls and never discloses the destination path, so there is no
-//! file for
+//! and `status` are real for every built-in tool. It cannot be **applied**,
+//! because the shim's plan carries `StepAction::ApplyLegacyManagedSettings` —
+//! the legacy trait renders and writes in two calls and never discloses the
+//! destination path, so there is no file for
 //! [`FilesystemExecutor`](aa_core::integration::FilesystemExecutor) to write and
 //! no prior state for a receipt to record. The executor refuses that step with
-//! a reason rather than reporting a success nothing performed, which is the
-//! behaviour AAASM-5281 replaces by shipping a native adapter whose plan names
-//! its file.
+//! a reason rather than reporting a success nothing performed.
+//!
+//! # Why Claude Code brings its own executor as well as its own content
+//!
+//! Its plan does more than write files: it injects `NODE_EXTRA_CA_CERTS` and the
+//! proxy variables into the launch environment, which `FilesystemExecutor`
+//! deliberately refuses. The registration therefore carries a
+//! [`StepExecutorFactory`] alongside its [`StepContentSource`], and both come
+//! from the adapter crate that knows the tool. The service keeps
+//! transactionality, the journal, the receipt and rollback.
 //!
 //! # This module is stripped before publishing
 //!
@@ -39,15 +43,16 @@
 //! therefore starts with an empty integration registry — the DI-API still
 //! binds, and `list_tools` honestly returns nothing.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use aa_core::dev_tool::{AdapterError, DevToolAdapter, DevToolInfo, GovernanceLevel, McpServerInfo};
-use aa_core::integration::LegacyAdapterShim;
+use aa_core::dev_tool::{AdapterError, DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel, McpServerInfo};
+use aa_core::integration::{IntegrationPlan, LegacyAdapterShim, StepExecutor};
 use aa_core::policy::PolicyDocument;
 
-use super::service::RegisteredIntegration;
+use super::service::{RegisteredIntegration, StepContentSource, StepExecutorFactory};
 
 /// Every built-in tool, wrapped so the lifecycle service can drive it.
 ///
@@ -60,11 +65,64 @@ pub fn built_in_integrations(policy: PolicyDocument) -> Vec<RegisteredIntegratio
         .iter()
         .filter_map(|token| {
             let kind = aa_devtool::registry::kind_for(token)?;
+            if kind == DevToolKind::ClaudeCode {
+                return Some(claude_code_integration());
+            }
             let adapter = aa_devtool::registry::adapter_for(token)?;
             let shim = LegacyAdapterShim::new(kind.clone(), BoxedAdapter(adapter), policy.clone());
             Some(RegisteredIntegration::new(kind, Arc::new(shim)))
         })
         .collect()
+}
+
+/// The native Claude Code registration (AAASM-5281).
+///
+/// One `Arc` answers for all three roles — adapter, content source and executor
+/// factory — because all three are views of the same host configuration. Two
+/// instances could disagree about where the settings file is, and the digest
+/// check would then reject a plan nobody changed.
+pub fn claude_code_integration() -> RegisteredIntegration {
+    claude_code_registration(Arc::new(aa_devtool_claude_code::ClaudeCodeIntegration::new()))
+}
+
+/// Register a Claude Code integration that was built elsewhere.
+///
+/// Public so an end-to-end test can register one pinned to temp roots and a live
+/// proxy, and still exercise **this** wiring rather than a second copy of it —
+/// the bridge below is where a mistake would hide.
+pub fn claude_code_registration(
+    integration: Arc<aa_devtool_claude_code::ClaudeCodeIntegration>,
+) -> RegisteredIntegration {
+    RegisteredIntegration::new(DevToolKind::ClaudeCode, integration.clone())
+        .with_content(Arc::new(ClaudeCodeSteps(integration.clone())))
+        .with_executor(Arc::new(ClaudeCodeSteps(integration)))
+}
+
+/// Adapts the Claude Code integration's rendering and execution surfaces onto
+/// the service's seams.
+///
+/// The adapter crate cannot implement [`StepContentSource`] or
+/// [`StepExecutorFactory`] itself: both are defined in `aa-runtime`, which
+/// depends on it. This is the one-way bridge.
+struct ClaudeCodeSteps(Arc<aa_devtool_claude_code::ClaudeCodeIntegration>);
+
+#[async_trait]
+impl StepContentSource for ClaudeCodeSteps {
+    async fn render(&self, plan: &IntegrationPlan) -> Result<BTreeMap<String, String>, String> {
+        self.0.step_content(plan).map_err(|e| e.to_string())
+    }
+}
+
+impl StepExecutorFactory for ClaudeCodeSteps {
+    fn executor(&self, rendered: BTreeMap<String, String>) -> Box<dyn StepExecutor + Send> {
+        // The scope a plan writes to is fixed at plan time and recorded in the
+        // receipt, but this factory is called for observation and reversal too,
+        // where there is no plan in hand. The executor is therefore built for
+        // every scope the integration can own and dispatches per step, so a
+        // project-scoped install is observed and reversed as correctly as a
+        // user-scoped one.
+        Box::new(self.0.scoped_executor(rendered))
+    }
 }
 
 /// A `Box<dyn DevToolAdapter>` that is itself a `DevToolAdapter`.
@@ -116,7 +174,6 @@ impl DevToolAdapter for BoxedAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aa_core::dev_tool::DevToolKind;
 
     use crate::devint::lifecycle::IntegrationLifecycle;
     use crate::devint::service::EngineLifecycle;

--- a/aa-runtime/src/devint/mod.rs
+++ b/aa-runtime/src/devint/mod.rs
@@ -88,7 +88,9 @@ pub use lifecycle::{IntegrationLifecycle, LifecycleError};
 pub use negotiate::{Negotiation, NegotiationError, DI_API_MAX_SUPPORTED, DI_API_MIN_SUPPORTED};
 pub use scope::{TokenScope, ToolScope};
 pub use server::{DevIntServer, DevIntServerConfig, DevIntServices};
-pub use service::{EngineLifecycle, NoContent, RegisteredIntegration, StepContentSource};
+pub use service::{
+    EngineLifecycle, FilesystemSteps, NoContent, RegisteredIntegration, StepContentSource, StepExecutorFactory,
+};
 pub use socket::{devint_socket_path, SocketDiscovery, SocketError};
 pub use token::{CapabilityToken, TokenDenial, TokenId, TokenRecord, TokenStore};
 pub use verb::DiVerb;

--- a/aa-runtime/src/devint/projection.rs
+++ b/aa-runtime/src/devint/projection.rs
@@ -263,6 +263,9 @@ const fn action_kind(action: &StepAction) -> &'static str {
         StepAction::InjectLaunchEnvironment { .. } => "inject_launch_environment",
         StepAction::ConfigureMcpServers { .. } => "configure_mcp_servers",
         StepAction::RegisterIdeClient { .. } => "register_ide_client",
+        StepAction::ConnectLocalRuntime { .. } => "connect_local_runtime",
+        StepAction::RunProtectionTest { .. } => "run_protection_test",
+        StepAction::ManageArtifact { .. } => "manage_artifact",
         // `StepAction` is `#[non_exhaustive]`: an action this build cannot name
         // is reported as unknown rather than mislabelled as a neighbour.
         _ => "unknown",
@@ -341,6 +344,16 @@ fn step_facts(action: &StepAction) -> StepFacts {
         }
         StepAction::RegisterIdeClient { host, .. } => {
             facts.managed_keys.push(host.clone());
+        }
+        StepAction::ManageArtifact { path, .. } => {
+            // A path Agent Assembly owns outright. Naming it is the point: a
+            // user approving a step that creates a file should see which file.
+            facts.artifact_paths.push(path.display().to_string());
+        }
+        StepAction::RunProtectionTest { probe } => {
+            // The probe's identifier, so a reviewer can tell which probe is
+            // being offered. The descriptor carries no value fields.
+            facts.managed_keys.push(probe.id.clone());
         }
         // Unknown future actions expose nothing. Failing closed on a variant
         // this build cannot reason about is the only safe default: an unknown

--- a/aa-runtime/src/devint/service.rs
+++ b/aa-runtime/src/devint/service.rs
@@ -55,8 +55,8 @@ use aa_core::dev_tool::{DevToolKind, GovernanceLevel};
 use aa_core::integration::{
     now_unix_secs, ApplyContext, DevToolIntegration, DriftKind, DriftReport, EngineError, FilesystemExecutor,
     IntegrationCapability, IntegrationEngine, IntegrationPlan, IntegrationReceipt, IntegrationRequest,
-    IntegrationStatus, ProtectionLevel, ProtectionState, ReceiptStore, RemovalPlan, SettingsScope, VerificationOutcome,
-    VerificationResult, VersionCompatibility, DEFAULT_FRESHNESS_WINDOW_SECS,
+    IntegrationStatus, ProtectionLevel, ProtectionState, ReceiptStore, RemovalPlan, SettingsScope, StepExecutor,
+    VerificationOutcome, VerificationResult, VersionCompatibility, DEFAULT_FRESHNESS_WINDOW_SECS,
 };
 
 use super::lifecycle::{
@@ -96,7 +96,37 @@ impl StepContentSource for NoContent {
     }
 }
 
-/// One tool's adapter plus the source of the bytes its plans describe.
+/// Builds the executor that performs one tool's mutations.
+///
+/// [`FilesystemExecutor`] handles every step whose mutation is "put these bytes
+/// at this path" and refuses the rest, because launch-environment injection,
+/// proxy variables and MCP lists need mechanism the filesystem cannot supply.
+/// A tool whose plan contains one of those has to bring the executor for it —
+/// so *which* executor runs is a property of the registration, not a constant
+/// of the service (AAASM-5281).
+///
+/// The service still owns transactionality, the journal, the receipt and
+/// rollback; only the per-mechanism mechanics move.
+pub trait StepExecutorFactory: Send + Sync {
+    /// An executor holding `rendered`, keyed by step id.
+    fn executor(&self, rendered: BTreeMap<String, String>) -> Box<dyn StepExecutor + Send>;
+}
+
+/// The default factory: a plain [`FilesystemExecutor`].
+pub struct FilesystemSteps;
+
+impl StepExecutorFactory for FilesystemSteps {
+    fn executor(&self, rendered: BTreeMap<String, String>) -> Box<dyn StepExecutor + Send> {
+        let mut executor = FilesystemExecutor::new();
+        for (step_id, content) in rendered {
+            executor = executor.with_content(step_id, content);
+        }
+        Box::new(executor)
+    }
+}
+
+/// One tool's adapter, the source of the bytes its plans describe, and the
+/// executor that performs them.
 pub struct RegisteredIntegration {
     /// The tool this registration answers for.
     pub tool: DevToolKind,
@@ -104,15 +134,19 @@ pub struct RegisteredIntegration {
     pub integration: Arc<dyn DevToolIntegration>,
     /// Where the rendered content for its plan steps comes from.
     pub content: Arc<dyn StepContentSource>,
+    /// What performs its plan steps.
+    pub executor: Arc<dyn StepExecutorFactory>,
 }
 
 impl RegisteredIntegration {
-    /// Register `integration` for `tool` with no content source.
+    /// Register `integration` for `tool` with no content source and the
+    /// filesystem executor.
     pub fn new(tool: DevToolKind, integration: Arc<dyn DevToolIntegration>) -> Self {
         Self {
             tool,
             integration,
             content: Arc::new(NoContent),
+            executor: Arc::new(FilesystemSteps),
         }
     }
 
@@ -120,6 +154,13 @@ impl RegisteredIntegration {
     #[must_use]
     pub fn with_content(mut self, content: Arc<dyn StepContentSource>) -> Self {
         self.content = content;
+        self
+    }
+
+    /// Supply the executor its plan steps need to be performable.
+    #[must_use]
+    pub fn with_executor(mut self, executor: Arc<dyn StepExecutorFactory>) -> Self {
+        self.executor = executor;
         self
     }
 }
@@ -208,22 +249,26 @@ impl EngineLifecycle {
         &self,
         registered: &RegisteredIntegration,
         plan: &IntegrationPlan,
-    ) -> Result<IntegrationEngine<FilesystemExecutor>, LifecycleError> {
+    ) -> Result<IntegrationEngine<Box<dyn StepExecutor + Send>>, LifecycleError> {
         let rendered = registered
             .content
             .render(plan)
             .await
             .map_err(|detail| LifecycleError::Failed { detail })?;
-        let mut executor = FilesystemExecutor::new();
-        for (step_id, content) in rendered {
-            executor = executor.with_content(step_id, content);
-        }
-        Ok(IntegrationEngine::new(executor, self.store.clone()))
+        Ok(IntegrationEngine::new(
+            registered.executor.executor(rendered),
+            self.store.clone(),
+        ))
     }
 
     /// An engine with no content, for the operations that only read or reverse.
-    fn observing_engine(&self) -> IntegrationEngine<FilesystemExecutor> {
-        IntegrationEngine::new(FilesystemExecutor::new(), self.store.clone())
+    ///
+    /// Still the tool's own executor: observing a launch-environment variable
+    /// and reversing one are both mechanisms the filesystem executor does not
+    /// have, so a shared observing engine would report every such artifact as
+    /// unreadable and refuse to remove it.
+    fn observing_engine(&self, registered: &RegisteredIntegration) -> IntegrationEngine<Box<dyn StepExecutor + Send>> {
+        IntegrationEngine::new(registered.executor.executor(BTreeMap::new()), self.store.clone())
     }
 
     /// Re-author the plan a stored receipt was applied from.
@@ -249,8 +294,14 @@ impl EngineLifecycle {
             })
     }
 
-    fn drift(&self, tool: &DevToolKind, scope: SettingsScope, compatibility: &VersionCompatibility) -> DriftReport {
-        self.observing_engine().detect_drift(tool, scope, compatibility, None)
+    fn drift(
+        &self,
+        registered: &RegisteredIntegration,
+        scope: SettingsScope,
+        compatibility: &VersionCompatibility,
+    ) -> DriftReport {
+        self.observing_engine(registered)
+            .detect_drift(&registered.tool, scope, compatibility, None)
     }
 
     /// Fold a drift report into a derived status.
@@ -453,7 +504,7 @@ impl IntegrationLifecycle for EngineLifecycle {
             })?;
 
         if receipt.is_some() {
-            let report = self.drift(tool, scope, &status.compatibility);
+            let report = self.drift(registered, scope, &status.compatibility);
             Self::apply_drift(&mut status, &report);
         }
         Ok(status)
@@ -476,7 +527,7 @@ impl IntegrationLifecycle for EngineLifecycle {
         // that lowers the reported level, and dropping it would leave status
         // reporting the level the last *successful* pass justified — the exact
         // "verified once, long ago" over-claim §4.2 rules out.
-        self.observing_engine()
+        self.observing_engine(registered)
             .record_verification(tool, scope, &result, self.freshness_window_secs)
             .map_err(engine_error)?;
         Ok(result)
@@ -495,7 +546,7 @@ impl IntegrationLifecycle for EngineLifecycle {
             .map_err(|e| LifecycleError::Failed {
                 detail: format!("the integration status could not be derived: {e}"),
             })?;
-        let report = self.drift(tool, scope, &status_before.compatibility);
+        let report = self.drift(registered, scope, &status_before.compatibility);
 
         let mut engine = self.engine_for(registered, &plan).await?;
         let outcome = engine.repair(&plan, &report, now_unix_secs()).map_err(engine_error)?;
@@ -541,7 +592,7 @@ impl IntegrationLifecycle for EngineLifecycle {
             });
         }
 
-        let mut engine = self.observing_engine();
+        let mut engine = self.observing_engine(registered);
         engine.recover(tool, scope).map_err(engine_error)?;
         let outcome = engine.remove(tool, scope).map_err(engine_error)?;
         plan.residual.extend(outcome.residual);

--- a/docs/src/devtools/cli.md
+++ b/docs/src/devtools/cli.md
@@ -180,11 +180,78 @@ runtime; enrolment happens on start.
 | `the capability token at … is mode 644` | The token is not a secret any more | `chmod 600` it and restart the runtime to re-issue |
 | `no integration receipt records <tool>` | Nothing has been installed to act on | Run `aasm integrations install <tool>` first |
 
+## Claude Code
+
+Claude Code is the first natively migrated integration
+([AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281)).
+`aasm integrations install claude-code` applies five steps and offers a sixth:
+
+| Step | What it does |
+|---|---|
+| `managed-settings` | Merges four Agent Assembly-owned keys into the settings file for the scope you chose. Every other key is left exactly as it was. |
+| `proxy-ca` | Copies the proxy's certificate authority to a PEM Agent Assembly owns. The system trust store is **not** touched. |
+| `node-extra-ca-certs` | Sets `NODE_EXTRA_CA_CERTS` for every governed launch. **Without this the interception handshake fails and nothing is inspected.** |
+| `proxy-env` | Routes governed launches through the local proxy. |
+| `side-channel-scope` | Asks the proxy to inspect `api.anthropic.com` and `*.anthropic.com` for this integration — Claude Code's telemetry and registry calls, not just `/v1/messages`. `llm_only` stays on, so nothing else on your machine is intercepted. |
+| `protection-test` | Optional. Sends a synthetic secret down the model path so the core can adjudicate what the provider received. |
+
+### Choose the scope; it is never inferred
+
+`--scope user` writes `$CLAUDE_CONFIG_DIR/settings.json` (or
+`~/.claude/settings.json`); `--scope project` writes
+`<cwd>/.claude/settings.json`. A `.claude/` directory in your working directory
+never redirects a user-scoped install — which file is written is a decision you
+make and the receipt records. `--scope managed` is refused: the endpoint
+managed-settings file is administrator-owned, its enforcement keys are
+unmeasured, and installing them would need a privileged step this integration
+does not take.
+
+### Protection applies to the managed launch
+
+Start Claude Code with `aasm run claude`. A `claude` started directly inherits
+neither the proxy nor `NODE_EXTRA_CA_CERTS` and is **not** protected — this is a
+measured bypass, not a theoretical one, and `status` says so rather than
+implying otherwise.
+
+### What is deliberately not offered
+
+* **`ANTHROPIC_BASE_URL` redirection.** Measured in AAASM-5276 delivering a
+  synthetic secret to the provider with no Agent Assembly component anywhere in
+  the path. It is routing, not protection, and setting it in the shell also
+  suppresses Claude Code's server-managed settings fetch.
+* **Hooks, for sensitive data.** They govern tool and action execution and
+  cannot see model-bound content, so no hook can carry a protection claim.
+* **`NODE_TLS_REJECT_UNAUTHORIZED`.** Never set. A TLS failure is a finding, not
+  something to suppress — and if you have it set, `status` reports it as a
+  bypass.
+* **The system keychain and the endpoint managed-settings file.** Both are
+  privileged host changes whose behaviour is unmeasured.
+
+### Bypasses that are detected
+
+`bypassPermissions` in a settings file, `ANTHROPIC_BASE_URL` /
+`CLAUDE_CODE_API_BASE_URL` in the shell or in a settings `env` block,
+`CLAUDE_CODE_USE_BEDROCK` / `_VERTEX`, and `NODE_TLS_REJECT_UNAUTHORIZED`.
+`aasm run claude --dangerously-skip-permissions` (and `--bare`) prints a warning
+and passes the flag through unchanged — Agent Assembly's interception sits below
+Claude Code's own permission enforcement, so stripping the flag would change
+your session without changing what is protected.
+
+Bypasses that **cannot** be observed are stated in every plan rather than left
+to be inferred from silence: launching outside `aasm run`, repointing
+`CLAUDE_CONFIG_DIR`, symlinking `.claude`, editing the settings file directly,
+replacing the binary, or calling the API from another program with your own key.
+
 ## Current limitation
 
-Adapters that have not yet migrated to the Developer Integration lifecycle are
-carried by `LegacyAdapterShim` (ADR 0030 §7). They can be **discovered,
-planned and reported on**, but their plan step names no destination file, so
-the service refuses to apply it rather than reporting a success nothing
-performed. The first natively migrated adapter is
-[AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281).
+Adapters other than Claude Code have not yet migrated to the Developer
+Integration lifecycle and are carried by `LegacyAdapterShim` (ADR 0030 §7). They
+can be **discovered, planned and reported on**, but their plan step names no
+destination file, so the service refuses to apply it rather than reporting a
+success nothing performed.
+
+`verify` needs a probe that can adjudicate what the provider received. A default
+build has none — a client on the near side of the proxy cannot see the forwarded
+body — so `verify` reports the model path as configured but never exercised, and
+the level stays at `Integrated`. That is the honest reading: configuration alone
+is not evidence that anything inspected the traffic.


### PR DESCRIPTION
## Description

Delivers the **first supported AASM Developer Integration**: Claude Code on macOS, driven entirely
through the shared lifecycle, receipt, local-API and CLI contracts.

Most importantly, this PR closes the AAASM-5276 Spike's **condition C1** — the gap that made
`Gateway Protected` provably achievable but silently unreachable in the shipped product.

### C1 — the CA-trust injection

The Spike measured that the real `claude 2.1.220` binary accepts `aa-proxy`'s MitM CA **when it is
supplied via `NODE_EXTRA_CA_CERTS`** — but nothing in the product injected any CA-trust variable, so the
handshake failed and no amount of correct plumbing produced protection.

Now: `scope.rs` names an AASM-owned PEM at `<state>/claude-code/<scope>/aasm-proxy-ca.pem`. The plan
emits `MaterialiseTrustMaterial{ProxyCaCertificatePem}` — content read from `${AA_CA_DIR}/ca-cert.pem`
at *apply* time and digest-checked against what the user reviewed — followed by
`InjectLaunchEnvironment{NODE_EXTRA_CA_CERTS, EnvValue::ArtifactPath(pem)}`. Both steps are required,
fingerprinted into the receipt, and reversible.

It is a **copy, not a reference**: reversing a reference would delete the proxy's own CA. The variable
is stored one-file-per-variable under `launch-env/`, and `ClaudeCodeAdapter::build_launch_command`
overlays that store — so `aasm run claude` and the lifecycle launcher share **one** injection point
rather than drifting apart.

### C2 and C5

- **C2 (settings-scope hazard).** `ClaudeCodePaths::settings_path(scope)` has no "whichever exists"
  branch. A `.claude/` directory in the caller's cwd can no longer capture a user-scoped write, and the
  untouched other surface is named in a plan warning. `--scope managed` is refused **by name** with a
  remediation rather than silently doing something else.
- **C5 (side channels).** Install writes `<state>/mitm-hosts.d/claude-code--<scope>.hosts`
  (`api.anthropic.com`, `*.anthropic.com`) and `ProxyConfig::from_env` **unions** that directory into
  `mitm_hosts`. `llm_only` stays `true` — asserted by test. Scoping per-integration rather than flipping
  the global default matters: flipping it would MitM every host on the machine.

### Mechanisms — built from the Spike's classification, not from what exists

**Built:** `HTTPS_PROXY` + MitM · **`NODE_EXTRA_CA_CERTS`** · managed launch · managed user/project
settings · MCP governance · side-channel scoping.

**Declared `Unsupported` with reasons, never offered:** `ModelGatewayBaseUrl` (C4 — measured to deliver
the raw secret with AASM out of the path), Hooks (cannot see model-bound content), `NativeIdeUi`,
`HostEnforcement`.

**Never touched:** `NODE_TLS_REJECT_UNAUTHORIZED`, the macOS System Keychain, and
`/Library/Application Support/ClaudeCode` (C6 — root-owned, deferred to AAASM-5298 pending a product
decision on privileged install).

### Bypass detection

Detects `bypassPermissions` in either settings key · `ANTHROPIC_BASE_URL` / `CLAUDE_CODE_API_BASE_URL`
in shell or settings `env` · `CLAUDE_CODE_USE_BEDROCK` / `_VERTEX` · `NODE_TLS_REJECT_UNAUTHORIZED` ·
`--dangerously-skip-permissions` / `--bare` (warned by `aasm run`, never stripped).

Surfaced as `EvidenceKind::Absent` → `status` "Checks that could not be made" with a `Why:` line, as
plan warnings, and by **blocking `VerificationOutcome::Passed`**. Variable *values* are never echoed —
only names. Undemonstrable bypasses are listed verbatim in every plan.

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Additive. Two latent `aa-core` bugs are fixed (below), both of which made previously-correct behaviour
wrong only once a real integration exercised the engine.

## Related Issues

- Jira: [AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281)
  (Epic [AAASM-5272](https://lightning-dust-mite.atlassian.net/browse/AAASM-5272))
- Closes Spike conditions **C1, C2, C4, C5** from AAASM-5276 (#1820)
- Consumes: AAASM-5277 (#1821), AAASM-5278 (#1823), AAASM-5279 (#1824), AAASM-5280 (#1827)
- Reuses and reconciles: AAASM-201
- Blocks: AAASM-5283
- Defers: **AAASM-5298** (C6, root-owned managed settings)

## Two latent `aa-core` bugs found and fixed

1. **An applied protection-test step read as permanent unrepairable drift** and as an unrestorable
   residual — despite mutating nothing.
2. **`aa-runtime`'s projection rendered `manage_artifact` and `run_protection_test` steps as `unknown`**
   in the plan a user is asked to approve. That is a consent defect, not a display bug, and it was
   invisible until something actually planned those step kinds.

## Security impact

- **The protection path now actually works.** Proven end-to-end: live `aa-proxy` MitM, the real CA, a
  TLS-terminating mock provider, a synthetic secret redacted, and the provider recording ≥1 request.
- Raw secrets are absent from output, receipt, journal and settings **while the finding survives**.
- Bypass conditions block a `Passed` verification rather than being reported alongside one.
- `security find-certificate -c "Agent Assembly CA"` → **not found**. No `security add-trusted-cert` was
  ever run. `NODE_EXTRA_CA_CERTS` is the mechanism, which is the entire point of C1.

## Tests executed

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required

| Command | Result |
|---|---|
| `cargo nextest run -p aa-devtool-claude-code -p aa-core` (post-rebase) | **494 passed, 0 failed** |
| `cargo nextest run -p aa-devtool-claude-code -p aa-core -p aa-cli -p aa-runtime` | **1894 passed, 2 skipped** |
| `cargo nextest run -p aa-integration-tests` — `claude_code_integration_lifecycle`, `spike_claude_code_lifecycle`, `cli_run`, `cli_proxy`, `e2e_policy_proxy` | **55 passed, 2 skipped** |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | 0 |
| `cargo build --workspace` | 0 |
| `cargo doc --workspace --no-deps` | 0, no warnings in touched crates |

### Two guards proved load-bearing

**C1 itself.** Flipping the probe client to *not* trust the injected CA, inside the passing cycle:
```
assertion `left == right` failed: the probe traversed the intercepted path and the provider got a redacted body
  left: PartiallyPassed { missing: ["the intercepting proxy's certificate was not trusted,
                                     so the model path was never inspected"] }
 right: Passed
```
This is the proof that C1 is load-bearing rather than decorative — remove the CA trust and protection
demonstrably stops.

**Vacuous pass.** Making `UnadjudicatedProbe` return `Redacted`:
```
panicked at ...:505: an unadjudicated probe must not pass: Passed
```

Both reverted; suite green.

### End-to-end smoke — real `aasm` binary, real `claude 2.1.220` detection, temp roots

`plan` → 6 steps including `inject_launch_environment … keys: NODE_EXTRA_CA_CERTS` ·
`install` → `achieved level: integrated`, all 5 required steps fingerprinted ·
`status` → `state: degraded`, `Next level up: gateway_protected — no probe traffic has been produced and
adjudicated…`, `host_enforced unavailable on this platform` ·
`verify` → exit **6**, `protected_path_exercised: no`, *"This is NOT a protection measurement"* ·
tamper → exit **5** · `repair` → restores `defaultMode: default`, keeps user `theme`/`editor` ·
`remove` → CA gone, variable gone, user keys back, AASM keys deleted.

## ⚠️ Known limitation — `verify` cannot pass in production yet, and that is deliberate

The shipped `UnadjudicatedProbe` reports `Inconclusive`, so `aasm integrations verify claude-code`
exits **6** for real users.

A client on the **near** side of the proxy cannot see the forwarded body. Reporting `Redacted` without
observing it is precisely the vacuous pass the protection-state model forbids, so the probe refuses to
claim it. The protection genuinely works — the end-to-end test proves it with a TLS-terminating mock —
but it is not *adjudicable from the client's vantage point*.

The fix is an adjudicating probe that correlates its request to the verdict `aa-proxy` already audits.
The seam (`with_probe`) is public and the behaviour is documented in `cli.md`. Until then, a user can
reach `Integrated` and will correctly **not** be shown `Gateway Protected`.

Choosing an honest `exit 6` over a green checkmark nobody measured is the same trade-off this Epic has
made everywhere else.

## Acceptance-criteria evidence

| AC | Status |
|---|---|
| `install claude-code` completes without manual config editing | ✅ smoke run |
| Reuses the canonical `aa-devtool-claude-code` adapter and shared contracts | ✅ extended, not duplicated |
| User and project settings merged without removing unrelated configuration | ✅ `repair` keeps user `theme`/`editor` |
| Repeated install idempotent; upgrades use a versioned receipt | ✅ same receipt id, byte-identical file |
| Supported model traffic exercises sensitive-data protection | ⚠️ **partial** — proven end-to-end in test; not adjudicable in production (above) |
| Status reports mechanisms, level, health, verification, limitations | ✅ |
| Drift of managed settings/routing detected and repairable | ✅ tamper → exit 5 → `repair` |
| Removal restores original state, deletes only AASM artifacts | ✅ |
| Raw secrets absent from output, receipts, logs, traces, audit | ✅ finding survives, value does not |
| Unsupported versions and bypasses produce actionable warnings | ✅ |
| Passes the E2E conformance ticket and updates AAASM-201 disposition | ❌ **AAASM-5283 owns this**; no Jira changes were made here |

## Dependencies / stacked PRs

Developed stacked on AAASM-5280's branch; that merged as #1827 (`3a713199`) and this branch was
**rebased onto `main`** — 21 commits, zero duplicates, one trivial `docs/src/SUMMARY.md` resolution.
Independently mergeable.

## Documentation and migration impact

Updates `docs/src/devtools/cli.md` with the Claude Code journey, including the `verify` limitation
stated plainly rather than buried. No migration.

**Not run:** the full `aa-integration-tests` suite is Docker/testcontainers-backed. Note also that
without `AASM_BIN_PATH` the CLI suites shell out to `cargo run` per test and serialize on the build
lock; that produced one `cli_proxy proxy_logs_follow_streams_new_entries` timing flake which passes with
the binary pinned.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (21 commits)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5281]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ