### PR TITLE
[AAASM-5284] 📝 (docs): Publish Developer Integration onboarding, levels and limitations

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -96,6 +96,9 @@
 # Developer Integrations
 
 - [Product Capability Brief](devtools/product-brief.md)
+- [Onboarding a Developer Integration](devtools/onboarding.md)
+- [Protection Levels](devtools/protection-levels.md)
+- [Limitations and Known Bypasses](devtools/limitations.md)
 - [Developer Integration API](devtools/developer-integration-api.md)
 - [`aasm integrations` CLI](devtools/cli.md)
 - [Thin-Client Reference Implementation](devtools/reference-client.md)

--- a/docs/src/devtools/cli.md
+++ b/docs/src/devtools/cli.md
@@ -252,6 +252,15 @@ success nothing performed.
 
 `verify` needs a probe that can adjudicate what the provider received. A default
 build has none — a client on the near side of the proxy cannot see the forwarded
-body — so `verify` reports the model path as configured but never exercised, and
-the level stays at `Integrated`. That is the honest reading: configuration alone
-is not evidence that anything inspected the traffic.
+body — so `verify` reports the model path as configured but never exercised, the
+level stays at `Integrated`, and the command **exits `6`**. That is the honest
+reading: configuration alone is not evidence that anything inspected the traffic.
+See [Limitations](limitations.md#verify-cannot-adjudicate-so-it-exits-6).
+
+## See also
+
+* [Onboarding a Developer Integration](onboarding.md) — the same journey as a
+  walkthrough, with troubleshooting.
+* [Protection levels](protection-levels.md) — what `Integrated`,
+  `Gateway Protected` and `Host Enforced` mean.
+* [Limitations and known bypasses](limitations.md).

--- a/docs/src/devtools/limitations.md
+++ b/docs/src/devtools/limitations.md
@@ -1,0 +1,327 @@
+# Limitations and known bypasses
+
+Everything on this page is a limit that exists **today**, in the shipped code, on
+the platform the MVP targets. It is written so that a security reviewer can read
+it instead of reverse-engineering the integration, and so that nothing here has
+to be discovered the hard way.
+
+The evidence base is `verification-reports/AAASM-5276-claude-code-mechanism-matrix.md`
+— the measured mechanism matrix from the Claude Code lifecycle Spike — plus the
+adapter code that shipped in
+[AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281). A
+claim that traces to neither is not on this page.
+
+## Capability status legend
+
+| Status | Meaning |
+|---|---|
+| **Supported** | Shipped and exercised by tests. |
+| **Experimental** | Shipped, but its evidence is incomplete or its shape may change. |
+| **Planned** | Not built. The ticket that builds it is named. |
+| **Unsupported** | Deliberately not offered, with a reason. |
+
+| Capability | Status | Note |
+|---|---|---|
+| Managed settings write / merge / restore | **Supported** | Four owned keys; every other key preserved. |
+| Proxy CA materialisation + `NODE_EXTRA_CA_CERTS` injection | **Supported** | AAASM-5276 condition C1. |
+| HTTPS interception and redaction on the model path | **Supported** | Measured against the real binary; see [`verify`](#verify-cannot-adjudicate-so-it-exits-6) for why the *level* still does not rise. |
+| Side-channel scoping (`*.anthropic.com`) | **Supported** | Condition C5. |
+| MCP loading control (`enabledMcpjsonServers` / `disabledMcpjsonServers`) | **Supported** | Optional, defence-in-depth. Never required for protection. |
+| Drift detection and repair | **Supported** | Detected at `status`/`verify` time, not in real time. |
+| Adjudicating protection probe | **Planned** | The default probe cannot see the forwarded body. |
+| `strict` blocking on a high-severity scanner finding | **Planned** | [AAASM-5277](https://lightning-dust-mite.atlassian.net/browse/AAASM-5277), [AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281). Today `strict` redacts, like `recommended`. |
+| Endpoint managed-settings enforcement keys | **Planned / unmeasured** | [AAASM-5298](https://lightning-dust-mite.atlassian.net/browse/AAASM-5298). |
+| Byte-exact configuration restore | **Unsupported** | Semantics-exact by accepted constraint (C3). |
+| `ANTHROPIC_BASE_URL` redirection as a protection mechanism | **Unsupported** | Measured delivering the raw secret. |
+| Host-level bypass prevention | **Unsupported** | Explicit non-goal. |
+| Lifecycle for Codex / Copilot / Windsurf | **Planned** | Carried by `LegacyAdapterShim`; apply is refused. |
+| Windows / Linux | **Unsupported** | macOS is the MVP platform. |
+
+---
+
+## Known bypasses: demonstrated versus inferred
+
+This split is published deliberately. Presenting the two groups as one
+undifferentiated list would overstate what has actually been tested — a
+demonstrated bypass is a measurement, an inferred one is a documented belief, and
+a reader deciding how much to trust this integration needs to know which is
+which.
+
+### Demonstrated by the AAASM-5276 harness
+
+Three, each asserted positively by a test:
+
+1. **`ANTHROPIC_BASE_URL` pointed at any endpoint removes Agent Assembly from
+   the path; the raw secret arrives.** Shown with both the real `claude 2.1.220`
+   binary and an emulated client.
+2. **Launching `claude` outside the managed path (no `HTTPS_PROXY`) is
+   unprotected.**
+3. **`Observe`/`AlertOnly` forwards the secret unchanged** — correct behaviour,
+   and the reason observe-only must never render as protection.
+
+### Inferred, not demonstrated
+
+Documented, **not measured** by the Spike:
+
+`--dangerously-skip-permissions` · `defaultMode: bypassPermissions` · `--bare` ·
+unsetting the proxy env in the shell · repointing `CLAUDE_CONFIG_DIR` ·
+symlinking `.claude` · replacing the binary · calling the API directly with the
+user's own key · switching provider (`CLAUDE_CODE_USE_BEDROCK` /
+`CLAUDE_CODE_USE_VERTEX`) · running a pre-managed-settings release · a hook
+exiting `1` instead of `2`.
+
+> The Spike's summary sentence counts these as *ten*; the enumeration above is
+> its own list and contains eleven items, because two permission-bypass flags are
+> enumerated separately. **The list is the claim, not the count.**
+
+Neither list is asserted to be exhaustive. "No finding" is not "no bypass".
+
+### Which of these the shipped integration can actually see
+
+Detection is not prevention. Where a bypass is detectable, the shipped adapter
+names it, lowers the reported protection level, and puts it in `status`; where it
+is not, the plan states so explicitly rather than leaving you to infer it from
+silence (`aa-devtool-claude-code/src/bypass.rs`).
+
+| Bypass | Detected? | Where it is looked for |
+|---|---|---|
+| `permissionMode` / `permissions.defaultMode` = `bypassPermissions` | **Yes** | The managed settings document. Becomes **Absent** evidence: the rules are still written and still read back, but nothing can be concluded from them about what the tool will do. |
+| `ANTHROPIC_BASE_URL` / `CLAUDE_CODE_API_BASE_URL` | **Yes** | The shell environment *and* a settings `env` block. |
+| `CLAUDE_CODE_USE_BEDROCK` / `_VERTEX` | **Yes** | The shell environment. |
+| `NODE_TLS_REJECT_UNAUTHORIZED` | **Yes** | The shell environment and a settings `env` block. |
+| `--dangerously-skip-permissions`, `--allow-dangerously-skip-permissions`, `--bare` | **Yes** | The launch arguments. Reported and **passed through unchanged** — Agent Assembly's interception sits *below* Claude Code's own permission enforcement, so stripping the flag would change your session without changing what is protected. |
+| Launching `claude` outside `aasm run` | **No** | No proxy or CA is injected; there is nothing to observe. |
+| Repointing `CLAUDE_CONFIG_DIR` | **No** | — |
+| Symlinking `.claude` | **No** | — |
+| Editing the settings file directly | **No** *(as a bypass)* | Surfaces later as **drift** at the next `status`/`verify`, not as a bypass at launch. |
+| Replacing the `claude` binary | **No** | — |
+| Calling the Anthropic API from another program with your own key | **No** | Not this tool, not this path. |
+| A hook exiting `1` instead of `2` | **No** | Hooks carry no sensitive-data claim here (see below). |
+
+**A bypass is not a failure.** An unprotected launch is reported as a bypass, not
+as an Agent Assembly error, because the remedy is different and blaming the
+system trains people to ignore real failures.
+
+---
+
+## `ANTHROPIC_BASE_URL` is routing, not protection
+
+Redirecting Claude Code's model endpoint is **unsuitable for protection** and is
+deliberately not offered as a mechanism (AAASM-5276 condition **C4**).
+
+It was measured, with both the real binary and an emulated client, delivering the
+synthetic secret to the provider **with no Agent Assembly component anywhere in
+the path**. Setting it in the shell additionally suppresses Claude Code's
+server-managed settings fetch.
+
+This is why the lifecycle contract keeps `ModelPathInterception` and
+`ModelGatewayBaseUrl` as separate capabilities. They look alike and they are
+opposites: the first is a protection capability, the second is routing that
+*removes* protection.
+
+## `verify` cannot adjudicate, so it exits `6`
+
+**On a default build, `aasm integrations verify claude-code` exits `6`
+(`verification_failed`) even on a completely correct installation.**
+
+Raising the level to `Gateway Protected` requires *exercised* evidence, and
+exercised means the traffic was produced **and adjudicated**. Adjudicating means
+knowing what the provider actually received — and a client on the **near side of
+the proxy cannot see the forwarded body**. The shipped default probe,
+`UnadjudicatedProbe`, therefore reports `Inconclusive` with its reason, and
+produces no traffic at all: sending a synthetic secret to a real provider for no
+evidential gain would be worse than saying nothing
+(`aa-devtool-claude-code/src/probe.rs`).
+
+A probe that returned `Redacted` because nothing obviously failed would be a
+**vacuous pass**, which is precisely what the evidence model exists to prevent.
+
+The consequence to be clear about: **you can reach `Integrated` and will
+correctly not be shown `Gateway Protected`, even though the protection genuinely
+works.** AAASM-5276 proved it end to end against the real `claude 2.1.220` binary
+and a TLS-terminating mock provider — every upstream request traversed the proxy,
+the scanner matched, and the forwarded body carried `[REDACTED:AnthropicKey]`
+while remaining valid Messages JSON.
+
+**Planned:** a deployment that can observe the forwarded payload supplies a probe
+that adjudicates, and only then does `GatewayProtected` become reachable. The
+probe is an injected capability specifically so that this can land without
+changing the evidence model.
+
+Read exit `6` on an otherwise-clean install as **"not measured"**, not as
+**"measured and failed"** — and read `status` for which it is.
+
+## The managed-settings path is unmeasured
+
+`/Library/Application Support/ClaudeCode/managed-settings.json` is the endpoint
+managed-settings file. Its managed-only keys —
+`allowManagedPermissionRulesOnly`, `disableBypassPermissionsMode`, and others —
+are **the strongest available counters to the bypasses listed above**.
+
+They are **unmeasured**. The directory did not exist on the Spike host, creating
+it requires root, and the Spike deliberately made no privileged writes. Nothing
+in `aa-devtool-claude-code` writes to it; `--scope managed` is refused, and the
+path is resolved only so a refusal can name it
+(`aa-devtool-claude-code/src/scope.rs`).
+
+> **Therefore: no non-overridable-enforcement claim is made anywhere in this
+> product** (AAASM-5276 condition **C6**). Nothing in these docs, the CLI or any
+> client should be read as implying that a bypass is prevented rather than
+> detected.
+
+Measuring this path on a managed/MDM macOS device is tracked as
+[AAASM-5298](https://lightning-dust-mite.atlassian.net/browse/AAASM-5298). It is
+a product decision rather than an engineering default, because it introduces a
+**privileged install step**.
+
+## Restore is semantics-exact, not byte-exact
+
+Accepted constraint C3
+([ADR 0030 — Accepted risks](../adr/0030-developer-integration-boundaries-and-trust-model.md);
+AAASM-5276 condition **C3**, accepted by
+[AAASM-5278](https://lightning-dust-mite.atlassian.net/browse/AAASM-5278)).
+
+`aa-devtool-claude-code/src/apply.rs` **reserialises the whole settings
+document** on every write. A user file in non-canonical formatting — hand-chosen
+key order, unusual indentation, trailing layout — therefore cannot survive an
+install → remove cycle byte-for-byte, no matter how good the receipt is.
+
+What removal **does** restore is the document's *meaning*:
+
+* every value Agent Assembly displaced is put back;
+* every key Agent Assembly added is deleted;
+* every key you changed after installation is carried through untouched.
+
+Two consequences follow deliberately from accepting this rather than working
+around it. Fingerprints are taken over **canonical JSON**, so a reformat is
+correctly reported as *no drift*. And a removal report **states the limitation**
+rather than implying a guarantee the write path cannot keep.
+
+The alternative — preserving the original document verbatim — was rejected as
+disproportionate for the MVP: it needs a format-preserving JSON editor no in-tree
+adapter has, and it buys byte-identity in a file the tool itself rewrites. If an
+adapter's write path ever stops reserialising, this becomes a *choice* rather
+than a constraint and should be revisited rather than inherited.
+
+## The scanner only recognises the shapes it knows
+
+Detection is deterministic and **pattern-based** (`aa-security`'s
+`CredentialScanner`). "Detected" means *matched by the pattern set*; it does not
+mean *understood*.
+
+A credential whose shape is not in the pattern set passes through
+unrecognised — a bespoke internal token, a secret with no distinguishing prefix,
+a value split across fields. There is no claim of complete detection, and the
+Spike explicitly does not license one.
+
+Two knock-on limits worth stating:
+
+* **An undetected secret is not absent from audit records.** If the scanner never
+  classified a value as a secret, it was never redacted, and it may appear in a
+  recorded payload like any other content.
+* **Redaction is not encryption and not a DLP product.** An oversized field that
+  cannot be scanned reliably is replaced wholesale with `[REDACTED:OVERSIZED]` —
+  the scanner fails closed — but that is a containment behaviour, not detection.
+
+## Hooks cannot carry a sensitive-data claim
+
+Claude Code hooks govern **tool and action execution**. They cannot see or modify
+model-bound prompt content, so no hook can support a sensitive-data protection
+claim. They remain available for tool governance; they are never a substitute for
+in-path interception.
+
+`NODE_TLS_REJECT_UNAUTHORIZED` is **never set** by Agent Assembly. Setting it
+would make interception "work" by disabling certificate verification, and a TLS
+failure is a finding, not something to suppress. If you have it set, `status`
+reports it as a bypass.
+
+## Other tools are not yet on this lifecycle
+
+Codex, GitHub Copilot and Windsurf Cascade are carried by `LegacyAdapterShim`
+(ADR 0030 §7). They can be **discovered, planned and reported on**, but their
+plan steps name no destination file, so the service **refuses to apply** rather
+than reporting a success that performed nothing. Their per-capability tiers in
+the [capability matrix](../governance/capability-matrix.md) come from their
+adapters' declarations, not from a measured Spike.
+
+## Timing and freshness
+
+* **Drift is found when `status`/`verify` runs**, so a window exists between a
+  change and its discovery. Between two verifications a state can be reported
+  that has since become false. The evidence carries its timestamp — the claim is
+  *"verified at T"*, not *"true now"* — but a consumer that ignores the timestamp
+  will over-read it.
+* **Protection state is re-derived on read, never cached.** AAASM-5276 measured
+  ~0.07 ms from core stop to connections being refused; a cached level would keep
+  displaying protection that no longer exists.
+* **Repair is deliberately narrow.** It will not overwrite a key it does not own,
+  even when that key is the cause of the drift — it reports and stops.
+
+---
+
+## What stays local, and what is never recorded
+
+These two are guarantees rather than limitations, but they belong beside the
+limitations because each has its own edge.
+
+**Raw content is processed locally.** Scanning and redaction happen in the Agent
+Assembly runtime on your machine. Raw file contents and raw prompt text are not
+shipped to Agent Assembly infrastructure in order to be analysed.
+
+> That is not the same as *your content stays on your machine*. The point of the
+> tool is to send prompts to a model provider; Agent Assembly's job is to make
+> what is sent safe, not to prevent sending. Where an org deployment is
+> configured, policy documents, audit **metadata** and decision records may be
+> forwarded to a control plane. Metadata is not raw content, but it is not
+> nothing either.
+
+**Raw secret material is never written** to logs, traces, audit events,
+installation receipts, API responses or diagnostic output. Findings are recorded
+as metadata — kind, position, count — and the redaction record deliberately
+stores no raw value (`aa-security/src/redaction.rs`). Diagnostics produced for
+support are subject to the same rule; troubleshooting is not an exemption.
+
+This is enforced by the **shape of the types**, not by a redaction pass someone
+can forget to call. Across the DI-API, a rendered settings body becomes a
+`content_sha256` plus the owned key names; an environment value becomes the
+variable's **name**; a model base URL becomes the setting's **name**, because a
+URL can carry a token in its query string. `StepView` — the sharpest edge — has
+**no field a step value could land in**. A bypass report likewise echoes variable
+names only and never their values, asserted by a test that plants a sentinel
+value and fails if it appears.
+
+> The edge: this does not govern the tool's own records. Claude Code's
+> transcripts, your shell history and your provider's server-side logs are
+> outside Agent Assembly's control entirely.
+
+---
+
+## What is never claimed
+
+Stated positively so it can be quoted:
+
+* **No host-level bypass prevention.** A user or process able to launch the tool
+  outside the managed path is outside enforcement, at every level available.
+* **No protection for unmanaged direct provider connections.**
+* **No complete secret detection.**
+* **No protection while the core is stopped.** Protection is a running-system
+  property; when the core is down the product says *not protected*, not
+  *protection unknown*.
+* **No universal interception of every AI development tool.**
+* **No claim that a settings file alone proves model-egress protection.** A
+  configuration is intent; a level is behaviour.
+* **No claim that MCP is required for, or equivalent to, protection.** It is one
+  optional mechanism among several.
+
+---
+
+## References
+
+* [Onboarding a Developer Integration](onboarding.md)
+* [Protection levels](protection-levels.md)
+* [Product Capability Brief](product-brief.md) §8 (guarantees and their limits),
+  §10.3 (non-goals)
+* [L0–L3 Capability Matrix](../governance/capability-matrix.md)
+* [ADR 0030 — Developer Integration boundaries and trust model](../adr/0030-developer-integration-boundaries-and-trust-model.md)
+* `verification-reports/AAASM-5276-claude-code-mechanism-matrix.md` — the measured
+  evidence this page is derived from (in-repo; not part of the published book)

--- a/docs/src/devtools/onboarding.md
+++ b/docs/src/devtools/onboarding.md
@@ -1,0 +1,384 @@
+# Onboarding a Developer Integration
+
+This is the path from *nothing installed* to *a Claude Code integration whose
+protection state you can read and act on*, using the commands that exist today
+and describing what they actually do.
+
+It is deliberately not a marketing walkthrough. Two of the steps below end in a
+state that is **weaker than you might expect**, and both are called out where you
+will hit them rather than in a footnote:
+
+* `aasm integrations verify claude-code` **exits `6` on a default build** — see
+  [Step 6](#step-6--verify-and-the-exit-6-you-will-see).
+* `Gateway Protected` is therefore **not reachable** from a default build, even
+  though the interception it describes was measured working end to end.
+
+> **Scope.** Claude Code on macOS is the only natively migrated integration
+> ([AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281)).
+> Codex, GitHub Copilot and Windsurf Cascade are carried by `LegacyAdapterShim`:
+> they can be discovered, planned and reported on, but an apply is refused rather
+> than reported as a success that performed nothing
+> ([`aasm integrations` CLI](cli.md)).
+
+---
+
+## Before you start
+
+| Requirement | Why | How to check |
+|---|---|---|
+| macOS | The MVP platform ([product brief](product-brief.md) §10). | — |
+| Claude Code **≥ 1.0.0** | The adapter's `MIN_VERSION`. A lower version is reported as *absent*, not as partially supported, so nothing is written for it (`aa-devtool-claude-code/src/lib.rs`). | `claude --version` |
+| `aasm` | The reference client for the [Developer Integration API](developer-integration-api.md). | `aasm --version` |
+| An Agent Assembly runtime | Every lifecycle operation runs inside `aa-runtime`. There is no in-process fallback. | see below |
+
+### The Developer Integration API is opt-in
+
+`aa-runtime` does **not** serve the DI-API unless it is asked to. The surface is
+gated on `AA_DEVINT_ENABLED`, read at startup and **off by default**
+(`aa-runtime/src/config.rs`). A runtime started without it comes up perfectly
+healthy and simply has no integrations socket — which is why the CLI's error text
+names the variable rather than telling you to "check the logs".
+
+You do not normally set it yourself. **When no runtime is listening, `aasm`
+starts one with `AA_DEVINT_ENABLED=1` set**, says so on `stderr`, and waits for
+the socket to bind:
+
+```console
+$ aasm integrations list
+Starting Agent Assembly runtime…
+Agent Assembly core 0.0.1-rc.6 (DI-API v2)
+```
+
+Pass `--no-autostart` — it is global across all `integrations` subcommands — to
+turn a missing runtime into **exit `7`** instead. Use it in CI, where leaving a
+daemon behind is worse than failing. If you start the runtime yourself, start it
+with `AA_DEVINT_ENABLED=1`.
+
+Notices, prompts and errors go to `stderr`; reports go to `stdout`. So
+`aasm integrations status claude-code --output json | jq` stays parseable even on
+the run that had to start the runtime first.
+
+---
+
+## Step 1 — Discover what is here
+
+```console
+$ aasm integrations list
+TOOL             VERSION      COMPAT       STATE          PROTECTION
+claude-code      2.1.220      compatible   ladder         detected_not_integrated
+codex            0.144.6      compatible   ladder         detected_not_integrated
+github-copilot   -            unknown      ladder         not_installed
+windsurf-cascade -            unknown      ladder         not_installed
+```
+
+`--capabilities` expands each tool to its declared mechanisms rather than the
+summary row. Nothing here mutates anything.
+
+## Step 2 — Read the plan before anything is written
+
+```console
+$ aasm integrations plan claude-code --profile recommended --scope user
+```
+
+`plan` is a dry run that mutates nothing, and it is the honest place to decide
+whether you want this. It names every file, key and artifact an install would
+touch — and it also names the bypasses this integration **cannot** observe, so
+you never have to read the absence of a finding as the absence of a bypass.
+
+### Choose the scope; it is never inferred
+
+`--scope` defaults to `user`.
+
+| Scope | Writes | Notes |
+|---|---|---|
+| `user` | `$CLAUDE_CONFIG_DIR/settings.json`, else `~/.claude/settings.json` | The default. |
+| `project` | `<cwd>/.claude/settings.json` | Checked in and shared. Selectable, never a default. |
+| `managed` | — | **Refused.** See below. |
+
+A `.claude/` directory in your working directory never redirects a `user`-scoped
+install. This is deliberate: the underlying `apply` resolver *does* prefer a
+project file whenever one exists, and a lifecycle whose destination depends on
+where you happened to `cd` cannot write a receipt it can later compare drift
+against or restore from (AAASM-5276 condition **C2**;
+`aa-devtool-claude-code/src/scope.rs`).
+
+`--scope managed` is refused with the path named:
+`/Library/Application Support/ClaudeCode/managed-settings.json` is
+administrator-owned, its enforcement keys are **unmeasured**, and installing them
+would require a privileged step this integration does not take. See
+[Limitations](limitations.md#the-managed-settings-path-is-unmeasured).
+
+## Step 3 — Choose a profile
+
+`--profile` selects what the integration *does about* what it detects. A profile
+is what you chose; a **level** is what the system can prove it is currently doing
+([Protection levels](protection-levels.md)).
+
+| Profile | `EnforcementMode` | Sensitive-data finding on a model-bound path | Egress | Budget |
+|---|---|---|---|---|
+| `recommended` *(default)* | `Enforce` | **Redact and proceed.** The match is replaced with a `[REDACTED:<kind>]` placeholder and the request continues. | Policy allowlist enforced at the wire by `aa-proxy`. | Enforced. |
+| `strict` | `Enforce` | Redact and proceed **today**. Blocking on a configured high-severity class is _planned_ — see below. | Same enforcement, narrower default allowlist. | Enforced; `Suspend` available. |
+| `observe-only` | `Observe` | **Recorded only; the payload is forwarded unchanged.** | Evaluated and audited; nothing blocked. | Tracked, not enforced. |
+
+Three things about this table are load-bearing:
+
+* **`strict` does not yet block on a scanner finding.** The core's policy
+  pipeline redacts unconditionally; blocking is _planned_
+  ([AAASM-5277](https://lightning-dust-mite.atlassian.net/browse/AAASM-5277),
+  [AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281)).
+  Until it lands, `strict` differs from `recommended` on egress, approvals and
+  budget only.
+* **`observe-only` forwards the secret.** That is correct behaviour for
+  `EnforcementMode::Observe`, it was measured in AAASM-5276, and it is why
+  `observe-only` is **never** displayed as protection: status says *monitoring*,
+  with a standing not-enforcing warning.
+* **Org policy clamps your choice.** Profiles merge with the org cascade under
+  most-restrictive-wins, so a local profile may tighten and can never loosen.
+
+`EnforcementMode::Disabled` is not reachable from any profile, ever.
+
+## Step 4 — Install
+
+```console
+$ aasm integrations install claude-code --profile recommended --scope user
+```
+
+The plan is shown and you are asked to confirm. `--yes` is **required** for
+non-interactive runs and for `--output json`/`yaml`, which have no way to answer
+a prompt — without it the command aborts with exit `9` and changes nothing.
+Silence is not consent. `--dry-run` shows the plan and stops, exactly as `plan`
+does.
+
+The Claude Code plan applies five steps and offers a sixth
+(`aa-devtool-claude-code/src/lifecycle.rs`):
+
+| Step | What it does |
+|---|---|
+| `managed-settings` | Merges the four Agent Assembly-owned keys — `permissions`, `permissionMode`, `enabledMcpjsonServers`, `disabledMcpjsonServers` — into the settings file for the scope you chose. Every other key is left exactly as it was (`apply.rs`). |
+| `proxy-ca` | Copies the proxy's certificate authority to a PEM Agent Assembly owns. **The system trust store is not touched.** |
+| `node-extra-ca-certs` | Sets `NODE_EXTRA_CA_CERTS` for every governed launch. **Without this the interception handshake fails and nothing is inspected** — and it fails *silently*, because a proxy that cannot terminate TLS still lets the connection through. This is AAASM-5276 condition **C1**. |
+| `proxy-env` | Routes governed launches through the local proxy. |
+| `side-channel-scope` | Asks the proxy to inspect `api.anthropic.com` and `*.anthropic.com` for this integration. One headless `claude -p` run was measured producing four upstream requests — two `/v1/messages` POSTs, an MCP-registry GET, and a 130 KB telemetry batch — so scoping to the model endpoint alone would leave real channels unscanned (condition **C5**). `llm_only` stays on, so nothing else on your machine is intercepted. |
+| `protection-test` | **Optional.** Sends a synthetic secret down the model path so the core can adjudicate what the provider received. |
+
+Two flags exist because two things must be consented to explicitly:
+
+* `--allow-privileged-host-steps` is **off by default**. A privileged step is
+  never implied by a profile, and a plan containing one cannot be applied unless
+  it was planned with the flag — the plan is the record of what was consented to.
+* `--policy-profile <name>` resolves a policy document by name. The document
+  itself never crosses the DI-API boundary; only its id, display name and digest
+  do.
+
+**Install is idempotent.** A second install on an unchanged system applies no
+additional mutation. If a step fails mid-plan the install is reported as
+*partial* — `the install is partial — N step(s) failed` — and you should run
+`status`, then `repair` or `remove`. A partial install is never presented as
+reduced protection.
+
+## Step 5 — Launch through the managed path
+
+```console
+$ aasm run claude
+```
+
+A `claude` started directly inherits neither the proxy nor
+`NODE_EXTRA_CA_CERTS` and is **not protected**. This is a measured bypass, not a
+theoretical one — AAASM-5276 asserts it positively — and `status` reports it as a
+bypass rather than as an Agent Assembly failure. The distinction matters because
+the remedy is different.
+
+`aasm run claude --dangerously-skip-permissions` (and `--bare`) prints a warning
+and **passes the flag through unchanged**. Agent Assembly's interception sits
+below Claude Code's own permission enforcement, so stripping the flag would
+change your session without changing what is protected.
+
+## Step 6 — Verify, and the exit `6` you will see
+
+```console
+$ aasm integrations verify claude-code
+claude-code — verification passed
+  ran at:               1785391172 (unix)
+  protected path exercised: no
+
+Assertions:
+  [--] protected_path_exercised               nothing protective was observed on the model-bound path
+  ...
+
+This is NOT a protection measurement. Configuration that exists is not evidence
+that anything was protected; the protected path must be exercised and adjudicated.
+$ echo $?
+6
+```
+
+> ### ⚠ On a default build, `verify` exits `6` — and that is correct
+>
+> `verify` succeeds only when the outcome is `passed` **and** the protected path
+> was actually exercised. Exercising it means knowing what the provider
+> *received*, and **a client on the near side of the proxy cannot see the
+> forwarded body**. The shipped default probe, `UnadjudicatedProbe`, therefore
+> reports `Inconclusive` and produces no traffic at all — sending a synthetic
+> secret to a real provider for no evidential gain would be worse than saying
+> nothing (`aa-devtool-claude-code/src/probe.rs`).
+>
+> A probe that returned `Redacted` because nothing obviously failed would be a
+> vacuous pass, and the evidence model exists to prevent exactly that.
+>
+> **What this means for you:** a correct, fully-applied installation reaches
+> `Integrated` and will correctly **not** show `Gateway Protected` — even though
+> the underlying protection genuinely works. AAASM-5276 proved it end to end
+> against the real `claude 2.1.220` binary and a TLS-terminating mock provider:
+> every upstream request traversed the proxy, the scanner matched the synthetic
+> secret, and the forwarded body carried `[REDACTED:AnthropicKey]` while
+> remaining valid Messages JSON.
+>
+> **What is planned:** a deployment that *can* observe the forwarded payload
+> supplies a probe that adjudicates, and only then does `GatewayProtected` become
+> reachable. The probe is an injected capability precisely so that this can land
+> without changing the evidence model. Until it does, treat exit `6` on an
+> otherwise-clean install as *"not measured"*, not as *"measured and failed"* —
+> and read `status` for which is which.
+
+The probe uses a **synthetic** secret chosen by the adapter and run by the
+service. No real credential is ever read, sent or printed.
+
+## Step 7 — Read status
+
+```console
+$ aasm integrations status claude-code
+```
+
+`status` reports the achieved level *and the observation that justifies it*,
+split by how it was obtained:
+
+* **Exercised evidence** — traffic was produced and adjudicated by the core. The
+  only kind that can justify `gateway_protected`.
+* **Read-back evidence** — configuration was compared to the receipt. Justifies
+  at most `integrated`.
+* **Checks that could not be made** — recorded, so the gap is legible rather than
+  invisible.
+
+Every rung of the ladder is listed, **including the ones this host cannot
+reach**. `host_enforced` renders as *unavailable on this platform* rather than
+being omitted: silence there reads as "there is nothing above what I have".
+
+The timestamp is part of the claim. A status says *verified at T*, not *true
+now*.
+
+## Step 8 — Repair drift
+
+```console
+$ aasm integrations repair claude-code
+```
+
+`status` exits `5` when Agent Assembly-owned state no longer matches its receipt.
+`repair` re-applies **only** Agent Assembly-owned values; it never rewrites a key
+it does not own, even when that key is the cause of the drift — it reports it
+instead. `--dry-run` shows what drifted and stops; `--yes` skips the prompt.
+
+Drift is found when `status`/`verify` runs, so a window exists between a change
+and its discovery. Some drift is unrepairable in place — the tool removed the
+config surface, or its schema changed — and needs a reinstall.
+
+## Step 9 — Remove
+
+```console
+$ aasm integrations remove claude-code
+```
+
+Removal uses the receipt to restore the pre-install value of every managed key —
+restoring the original where one existed, deleting the key where none did — and
+removes only Agent Assembly-owned artifacts. `--dry-run` shows the restoration
+actions and stops. `--force` answers *"remove anyway and leave those behind"*
+for artifacts that could not be reversed; it never removes anything the plan did
+not name.
+
+**Restoration is semantics-exact, not byte-exact.** If your settings file used
+hand-chosen key ordering or unusual indentation, it will not come back
+byte-identical — the write path reserialises the whole document. Every *value*
+is restored. See
+[Limitations](limitations.md#restore-is-semantics-exact-not-byte-exact).
+
+Without a receipt, removal refuses to guess: it reports what Agent Assembly
+believes it owns and requires explicit confirmation before touching anything.
+
+---
+
+## Exit codes
+
+Branch on the code, not on the message.
+
+| Code | Name | Meaning |
+|---|---|---|
+| `0` | `success` | The operation completed |
+| `1` | `internal_error` | A transport or lifecycle failure |
+| `3` | `unsupported` | The tool, mechanism or verb is not available here |
+| `4` | `incompatible` | This client, the core or the tool version do not agree |
+| `5` | `drifted` | Agent Assembly-owned state no longer matches its receipt — run `repair` |
+| `6` | `verification_failed` | The protection test did not establish protection |
+| `7` | `runtime_unavailable` | No runtime is listening and none could be started |
+| `8` | `denied` | The runtime refused this client — re-enrol or fix permissions |
+| `9` | `aborted` | Nothing was changed — declined, or no confirmation was possible |
+
+`2` is left to `clap` for usage errors, so "you typed the command wrong" stays
+distinguishable from a real outcome.
+
+```bash
+aasm integrations verify claude-code || case $? in
+  6) echo 'not protected' ;;
+  5) aasm integrations repair claude-code --yes ;;
+esac
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Exit | What it means | What to do |
+|---|---|---|---|
+| `the Agent Assembly runtime is not running` | `7` | No socket, and `--no-autostart` was passed. | Start `aa-runtime` with `AA_DEVINT_ENABLED=1`, or drop the flag and let `aasm` start it. |
+| A started runtime never binds | `7` | The runtime came up without the DI-API surface. | `AA_DEVINT_ENABLED=1` must be set for it to serve this surface; check the runtime's logs. |
+| `<tool> is not installed on this host` | `3` | The adapter is registered; the tool is not. | Install the tool, then re-run. |
+| `<tool> <version> is outside the range this adapter supports` | `4` | Version incompatibility. A version below `MIN_VERSION` is reported as *absent* — nothing was written. | Upgrade the tool, or upgrade Agent Assembly. |
+| `<reason> — upgrade …` on connect | `4` | This `aasm` and the running core do not share a DI-API version. | Upgrade both; they ship as one versioned unit. |
+| A `DEGRADED` negotiation | — | The negotiated DI-API version lacks some verbs; `unavailable_verbs` names them. Never a silent downgrade. | Upgrade the older side. Do not use the missing verbs. |
+| `status` reports drift | `5` | Live state no longer matches the receipt. The reported level drops **before** repair is attempted. | `aasm integrations repair <tool>`. If unrepairable, reinstall. |
+| `this is NOT a protection measurement` | `6` | The protected path was not exercised. On a default build this is the expected outcome — see [Step 6](#step-6--verify-and-the-exit-6-you-will-see). | Launch through `aasm run claude` and verify again; on a default build the level stays `Integrated`. |
+| `the install is partial — N step(s) failed` | — | Some steps applied, some did not. Never a reduced protection level. | `status`, then `repair` or `remove`. |
+| `no integration receipt records <tool>` | — | Nothing has been installed to act on. | `aasm integrations install <tool>` first. |
+| `the capability token at … is mode 644` | `8` | The token is readable by more than its owner, so it is **refused rather than used** — a filesystem mistake must not become a silent authentication downgrade. | `chmod 600` it and restart the runtime to re-issue. |
+| `this aasm is not enrolled with the running runtime` | `8` | No capability token. There is no anonymous tier. | Restart the runtime; enrolment happens on start. |
+| Apply refused for `codex` / `github-copilot` / `windsurf-cascade` | `3` | These are carried by `LegacyAdapterShim`; their plan steps name no destination file. | Nothing to do — the refusal is deliberate, and preferable to a success that performed nothing. |
+
+---
+
+## Who is responsible for what
+
+A recurring source of confusion is which component decides anything. It is
+always the core.
+
+| Layer | Owns | Never does |
+|---|---|---|
+| **`aasm integrations` / a plugin / an IDE extension** | Rendering, prompting, choosing a scope and profile, showing evidence. | Mutating tool config, evaluating policy, scanning content, or deriving a protection level. |
+| **`DevToolAdapter`** (`aa-devtool-claude-code`) | Per-tool knowledge: detection, which files and keys exist, authoring the plan, declaring bypasses. Runs *inside* the trusted runtime. | Deciding policy outcomes, or asserting protection on the core's behalf. |
+| **Core runtime and gateway** | Policy evaluation, sensitive-data detection and redaction, egress allow/deny, approvals, audit, and the protection level itself. | Trusting a client's claim about any of the above. |
+
+**MCP is optional.** It is one of the mechanisms an integration may govern —
+specifically, *which* MCP servers the tool may load — and it is not the
+integration architecture. The client-to-core protocol is the
+[DI-API](developer-integration-api.md), not MCP. An integration that uses no MCP
+at all is fully governed; an integration that uses MCP is governed by exactly the
+same mechanisms. See the
+[thin-client reference implementation](reference-client.md).
+
+---
+
+## Where to go next
+
+* [Protection levels](protection-levels.md) — what `Integrated`,
+  `Gateway Protected` and `Host Enforced` mean, and their testable entry criteria.
+* [Limitations and known bypasses](limitations.md) — what this does not cover,
+  split into what was demonstrated and what was only inferred.
+* [`aasm integrations` CLI](cli.md) — the full command reference.
+* [L0–L3 Capability Matrix](../governance/capability-matrix.md) — the
+  per-capability tier declarations.

--- a/docs/src/devtools/product-brief.md
+++ b/docs/src/devtools/product-brief.md
@@ -12,8 +12,8 @@ productization (`AAASM-5281`) all implement against.
 > builds it. Nothing here should be read as a shipped capability unless it is cited to code.
 >
 > This document deliberately does **not** fill in the Claude Code row of the
-> [L0–L3 Capability Matrix](../governance/capability-matrix.md) — that row stays `TBD` until
-> `AAASM-5276` produces evidence and `AAASM-5284` publishes it.
+> [L0–L3 Capability Matrix](../governance/capability-matrix.md). That row was filled by
+> `AAASM-5284` from the `AAASM-5276` evidence and is canonical there, not here.
 
 ---
 
@@ -818,7 +818,12 @@ corresponding section of this document changes rather than being quietly worked 
 ## References
 
 - [L0–L3 Governance Capability Matrix](../governance/capability-matrix.md) — canonical tier
-  definitions and per-tool declarations. The Claude Code row is `TBD` by design.
+  definitions and per-tool declarations, including the Claude Code row.
+- [Onboarding a Developer Integration](onboarding.md) — the install → verify → operate → remove
+  path with the commands and exit codes that exist today.
+- [Protection levels](protection-levels.md) — §7 restated as an operational reference.
+- [Limitations and known bypasses](limitations.md) — the demonstrated-versus-inferred bypass
+  split and the other honest limits.
 - [Protection and enforcement](../security/protection-model.md) — the policy pipeline, redaction
   semantics and fail-closed behaviour this brief's guarantees rest on.
 - [Three-layer defense in depth](../security/three-layer-defense.md) — SDK / proxy / eBPF.

--- a/docs/src/devtools/protection-levels.md
+++ b/docs/src/devtools/protection-levels.md
@@ -1,0 +1,180 @@
+# Protection levels
+
+A **profile** is what you chose. A **level** is what the system can prove it is
+currently doing. They are separate because you can choose `strict` on a machine
+where the tool is not routed through the gateway — and the honest answer there is
+`Integrated`, not *strict protection active*.
+
+> **The governing rule: the existence of a configuration file is never sufficient
+> evidence for a protection level.** Configuration expresses intent. A level is a
+> claim about behaviour, and a claim about behaviour requires an observation of
+> behaviour.
+
+This page restates [product brief](product-brief.md) §7 as an operational
+reference. Where the two differ, the brief is canonical.
+
+---
+
+## The ladder
+
+| Level | One-line claim | Reachable today? |
+|---|---|---|
+| **Integrated** | The tool's *startup posture* is governed and its actions are attributable. | **Yes.** |
+| **Gateway Protected** | Model-bound and tool-bound traffic is inspected, redacted and allow/deny-enforced in flight. | **Mechanism proven; not reportable on a default build** — see [below](#why-gateway-protected-is-not-reportable-today). |
+| **Host Enforced** | The *machine* is constrained, so a process cannot escape by launching outside the managed path. | **No.** Reported as *unavailable on this platform*, never omitted. |
+
+Two reporting rules apply at every rung:
+
+* **Report the highest level whose criteria are *currently* met**, re-derived on
+  read rather than cached. A level earned at install time is not still true after
+  the core stops — AAASM-5276 measured ~0.07 ms from core stop to connections
+  being refused, so a cached level would be displaying protection that no longer
+  exists.
+* **Report the mechanisms behind the level**, split into *exercised* and *read
+  back*. A user who can see which is which can reason about their own risk; a
+  user shown a single word cannot.
+
+---
+
+## Integrated
+
+| | |
+|---|---|
+| **What it protects** | The tool's startup posture. The managed settings constrain what Claude Code will agree to do — permission allow/deny lists, `permissionMode`, and which MCP servers it may load — and the tool is registered with the gateway so its actions are attributable and auditable. |
+| **Testable entry criteria** | **All four** must hold: (1) a valid installation receipt exists; (2) every managed key read back from the live config equals the planned value by content hash; (3) the detected tool version is at or above the adapter's minimum; (4) the tool has been launched at least once through the managed path *and* the gateway observed the resulting registration event. Criterion 4 is what makes this a behavioural claim — (1)–(3) alone are configuration and are explicitly **not** sufficient. |
+| **What it does *not* protect** | Anything on the model-bound path. **Nothing is inspecting model-bound content at this level**, so `Integrated` carries no sensitive-data claim at all. |
+| **Bypasses that remain** | Launching the tool outside the managed path. Editing the managed config by hand (detectable as drift, but only at the next status check). All model-bound traffic. Anything the tool's own config surface cannot express. |
+| **Maps to L0–L3** | `L1Observe` as a floor, rising to `L3Native` **for the individual capability dimensions the tool's own configuration genuinely governs** — for Claude Code, the MCP enable/disable lists and the permission keys. See the [capability matrix](../governance/capability-matrix.md). |
+| **Honest limit** | Cannot claim host-level bypass prevention. Cannot claim sensitive-data protection. |
+
+## Gateway Protected
+
+| | |
+|---|---|
+| **What it protects** | Model-bound and tool-bound traffic in flight. Requests traverse the Agent Assembly proxy, so the runtime scanner inspects them, detected secrets are redacted before egress, egress allowlists are enforced, approvals can halt an action, and every decision is audited. |
+| **Testable entry criteria** | Everything required for `Integrated`, **plus a completed protection exercise within the current configuration**: a synthetic secret placed in a model-bound path resulted in (a) the controlled endpoint receiving no raw secret, (b) a redaction finding recorded, and (c) the agent receiving a semantics-preserving placeholder. A reachable gateway is not sufficient. A configured proxy address is not sufficient. **Traffic must have been observed and acted on.** |
+| **What it does *not* protect** | Traffic from tools other than the governed one. Content the deterministic scanner does not match — detection is pattern-based, so *unknown* secret shapes pass through. Anything at all if the core is stopped. |
+| **Bypasses that remain** | Direct provider connections that do not honour the injected proxy — an unmanaged launch, a redirected base URL, a separate credential. Certificate-pinned clients that reject the proxy CA. See [Limitations](limitations.md). |
+| **Maps to L0–L3** | `L2Enforce` — allow/deny, approval, redaction and budget enforcement, which is precisely what traversal of the gateway provides. |
+| **Honest limit** | Also cannot claim host-level bypass prevention. It protects the paths it sees. A user or agent able to start a process outside the managed path is outside its scope by construction. |
+
+### Why `Gateway Protected` is not reportable today
+
+> **`aasm integrations verify claude-code` exits `6` on a default build, so the
+> level stays at `Integrated`.**
+>
+> Raising the level requires *exercised* evidence, and exercised means traffic
+> was produced **and adjudicated**. Adjudicating means knowing what the provider
+> actually received — which **a client on the near side of the proxy cannot
+> see**. The shipped default probe, `UnadjudicatedProbe`, therefore reports
+> `Inconclusive` with its reason and produces no traffic at all
+> (`aa-devtool-claude-code/src/probe.rs`).
+>
+> This is not a broken installation, and it is not the protection failing. It is
+> the evidence model refusing a vacuous pass: a probe that reported `Redacted`
+> because nothing obviously failed would be exactly the claim this system exists
+> to prevent.
+>
+> **The mechanism itself was measured working.** AAASM-5276 ran the real
+> `claude 2.1.220` binary against a TLS-terminating mock provider: all four
+> upstream requests traversed the proxy, the deterministic scanner matched the
+> synthetic secret, and the forwarded body carried `[REDACTED:AnthropicKey]`
+> while remaining valid Messages JSON — at sub-millisecond added cost.
+>
+> **Planned:** a deployment that can observe the forwarded payload supplies a
+> probe that adjudicates. The probe is an injected capability precisely so this
+> can land without changing the evidence model. Until it does, read exit `6` on
+> an otherwise-clean install as *not measured*, not as *measured and failed*.
+
+## Host Enforced
+
+| | |
+|---|---|
+| **What it would protect** | The machine, not the integration. Enforcement at the operating-system boundary, so a process could not escape by unsetting an environment variable, launching the tool directly, or opening its own socket. |
+| **Testable entry criteria** | An OS-level enforcement facility is installed, active, and **demonstrated to block a deliberately unmanaged launch** — the bypass that defeats both levels above must be shown to fail. |
+| **Availability** | **Not available.** macOS Endpoint Security and Network Extension are explicit non-goals; Windows and Linux host enforcement are out of scope. `aa-ebpf` is Linux-only and is a *detection* layer — it observes SSL and exec/file syscalls but cannot modify traffic in flight, so it cannot supply this level either. |
+| **Reporting requirement** | The level is **named and reported as unavailable**, not hidden. Silence reads as "there is nothing above what I have", which is the over-claim this whole model exists to prevent. |
+| **Maps to L0–L3** | Nothing. It is *not* `L3Native`: `L3Native` means Agent Assembly writes the tool's own native configuration so governance survives Agent Assembly going offline — a property of `Integrated`. Host enforcement is orthogonal to the L0–L3 scale, which describes what a tool adapter achieves, not what the OS enforces. |
+
+> **No non-overridable-enforcement claim is made anywhere in this product.** The
+> strongest available bypass counters live in Claude Code's endpoint
+> managed-settings file, that file was deliberately never written to, and its
+> managed-only keys remain **unmeasured**. See
+> [Limitations](limitations.md#the-managed-settings-path-is-unmeasured).
+
+---
+
+## Evidence: exercised versus read-back
+
+This split is the whole mechanism by which a level stays honest, so `status`
+prints it rather than summarising it.
+
+| Evidence kind | What it establishes | Highest level it can justify |
+|---|---|---|
+| **Exercised** | Traffic was produced on the protected path and the core adjudicated what happened to it. | `Gateway Protected` |
+| **Read-back** | A managed value on disk matches what the receipt says was written. Proves a file is correct; proves nothing about traffic. | `Integrated` |
+| **Absent** | A check could not be made. Recorded so the gap is legible. Absent readings only ever *lower* a state. | — |
+
+A detected bypass becomes **Absent** evidence rather than a silent pass. With
+`defaultMode: "bypassPermissions"` in effect, for instance, Agent Assembly's
+permission rules are still written and still read back — but nothing can be
+concluded from them about what the tool will actually do
+(`aa-devtool-claude-code/src/bypass.rs`).
+
+Every status carries `observed_at_unix_secs`. The claim is **"verified at T"**,
+not "true now".
+
+---
+
+## How a profile interacts with a level
+
+| | `recommended` | `strict` | `observe-only` |
+|---|---|---|---|
+| Highest level attainable | `Gateway Protected` | `Gateway Protected` | **None.** |
+| What status says | The achieved level plus its evidence | The achieved level plus its evidence | *Monitoring*, with a standing not-enforcing warning |
+
+**`observe-only` must never be displayed as protection.** Under
+`EnforcementMode::Observe` the payload is forwarded unchanged — AAASM-5276
+measured the synthetic secret reaching the provider — which is correct behaviour
+and precisely why the profile that does not protect must not be able to look like
+the one that does.
+
+---
+
+## Failure and degradation
+
+Default posture is **fail closed**: when Agent Assembly cannot establish that
+protection is active, it reports *not protected* and, where a decision is
+required, denies. Failing closed does not mean bricking your tool — the tool
+stays usable; what fails closed is the *protection claim*.
+
+| Situation | Reported as |
+|---|---|
+| Core stopped or unreachable | *Not protected* — never "protection status unknown". Say when protection ended if it stopped mid-session. |
+| Partial install | *Not protected*, rolled back. Never a reduced protection level. |
+| Drift detected | Level drops **before** repair is attempted. |
+| Protection test failed (synthetic secret reached the endpoint) | A **hard failure**, never a warning. The level stays at most `Integrated`. |
+| Tool launched outside the managed path | A **bypass**, not an Agent Assembly error. The remedy is different, and blaming the system trains users to ignore real failures. |
+
+---
+
+## Status vocabulary
+
+Use these words verbatim in any client. A user comparing the CLI, the dashboard
+and an editor extension must see one word for one thing.
+
+* **Profiles:** `Recommended`, `Strict`, `Observe`
+* **Levels:** `Integrated`, `Gateway Protected`, `Host Enforced`
+* **Overriding states:** `Drifted`, `Degraded`, `Incompatible`
+
+---
+
+## References
+
+* [Onboarding a Developer Integration](onboarding.md)
+* [Limitations and known bypasses](limitations.md)
+* [Product Capability Brief](product-brief.md) §6 (profiles), §7 (levels), §8
+  (guarantees), §9 (failure journeys)
+* [L0–L3 Capability Matrix](../governance/capability-matrix.md)
+* [ADR 0030 — Developer Integration boundaries and trust model](../adr/0030-developer-integration-boundaries-and-trust-model.md)
+* [Protection and enforcement](../security/protection-model.md)

--- a/docs/src/governance/capability-matrix.md
+++ b/docs/src/governance/capability-matrix.md
@@ -83,6 +83,17 @@ A cell answers: *"At this tier, is this capability available?"*
 - VS Code settings sync writes `settings.json` at the workspace level; a user can override at the user-settings level. Enterprise-grade enforcement requires VS Code managed device policies (outside AAASM scope).
 - Network-egress block via proxy does not cover VS Code's built-in Copilot HTTPS calls unless the proxy CA is trusted by the VS Code process.
 
+> **Why the per-capability rows above were left unchanged when `AAASM-5274` normalised Copilot's
+> overall level to `L2Enforce`.** `AAASM-5274` §3 resolved the *tool-wide* `governance_level()`
+> declaration in favour of the dedicated `aa-devtool-copilot` crate (`L2Enforce`) over the deleted
+> minimal stub (`L1Observe`). That same section states explicitly that `governance_level()` is the
+> tool's **overall** declaration and that per-capability tiers belong in this matrix — the two are
+> not the same number, which is why Codex declares `L2Enforce` overall while holding L3 on three
+> dimensions. Raising the rows here would require per-capability evidence for Copilot, and no
+> Copilot Spike exists: unlike Claude Code, its tiers come from the adapter's own declarations. The
+> rows therefore stay as `AAASM-1064` set them, and the inconsistency is recorded here rather than
+> resolved by a guess. A Copilot equivalent of `AAASM-5276` is what would settle it.
+
 ---
 
 ### Windsurf Cascade

--- a/docs/src/governance/capability-matrix.md
+++ b/docs/src/governance/capability-matrix.md
@@ -6,8 +6,10 @@ single source of truth for "what does L2 mean for this tool" — adapter impleme
 reference this document rather than defining tiers ad hoc.
 
 > **Status:** Codex, GitHub Copilot, and Windsurf Cascade tiers are final (adapters merged).
-> Claude Code (`AAASM-201`) and SaaS coding-agent (`AAASM-918`) rows are placeholders pending
-> those adapters landing.
+> The Claude Code row is now filled from measured evidence — the `AAASM-5276` mechanism matrix
+> plus the adapter productized in `AAASM-5281` — and is the only row backed by a Spike rather
+> than by an adapter's own declaration. The SaaS coding-agent (`AAASM-918`) row remains a
+> placeholder.
 
 ---
 
@@ -106,17 +108,56 @@ A cell answers: *"At this tier, is this capability available?"*
 
 ### Claude Code
 
-> **Adapter:** `AAASM-201` — **Pending** (in backlog) · _Placeholder — do not rely on these declarations until AAASM-201 is merged_
+> **Adapter:** `aa-devtool-claude-code` (`AAASM-201` implementation, productized by `AAASM-5281`) ·
+> **Mechanism:** managed settings + proxy CA trust injection + MitM interception + MCP governance ·
+> **Overall declared `governance_level()`:** **`L2Enforce`** (`aa-devtool-claude-code/src/lib.rs`)
+
+The overall declaration was resolved by `AAASM-5274` §3. Claude Code writes **native** managed
+settings, which is an L3-shaped capability, but it cannot natively enforce exec, file or network
+policy — those still require `aa-proxy` (Layer 2). A tool-wide `L3Native` would therefore
+over-claim, while individual dimensions below genuinely reach L3. This is the same shape as Codex,
+which declares `L2Enforce` overall while achieving L3 on individual capabilities.
 
 | Capability | Tier | Notes |
 |---|---|---|
-| Audit log capture | TBD | — |
-| Policy decision visibility | TBD | — |
-| MCP server allowlist | TBD | — |
-| Terminal-exec block | TBD | — |
-| File-write block | TBD | — |
-| Network-egress block | TBD | — |
-| Sub-agent governance | TBD | — |
+| Audit log capture | **L2** | The managed launch injects `AA_AGENT_ID` / `AA_TEAM_ID` into the child process, so actions are attributable (`aa-devtool-claude-code/src/lib.rs`, `build_launch_command`). `AAASM-5276` measured one headless `claude -p` run producing **four** upstream requests — two `/v1/messages` POSTs, an MCP-registry `GET` and a 130 KB `POST /api/event_logging/v2/batch` telemetry payload — and **all four** traversed the proxy and passed through the scanner. Not L3: nothing written into Claude Code's own config keeps emitting audit events, and an **unmanaged launch emits nothing** (measured). |
+| Policy decision visibility | **L2** | Policy is evaluated by the runtime on intercepted traffic; the decision and the evidence behind it are surfaced by `aasm integrations status`, split into *exercised* and *read-back*. Requires the core to be running and is **re-derived on read, never cached** — `AAASM-5276` measured ~0.07 ms from core stop to connections being refused. |
+| MCP server allowlist | **L3** | `apply_mcp_governance_at` writes `enabledMcpjsonServers` / `disabledMcpjsonServers` into Claude Code's **own** `settings.json`, idempotently and preserving every unmanaged key (`aa-devtool-claude-code/src/apply.rs`; idempotence and preservation measured in `AAASM-5276` scenarios 11.1–11.2). Those keys cap what the tool loads at startup whether or not Agent Assembly is running. Bounded: at `user`/`project` scope the file is user-writable, so this **constrains, it does not prevent**. |
+| Terminal-exec block | **L3‡** | Policy rules are mapped to `permissions.allow` / `permissions.deny` tool patterns (e.g. `Bash`) and to `permissionMode` (`plan` / `default` / `acceptEdits`) and written into the tool's own config (`aa-devtool-claude-code/src/settings.rs`, `apply.rs`). ‡ **The write path was measured; a block was never exercised** — `AAASM-5276` classified managed settings as tool-governance and measured only their idempotence and footprint. Fully overridden by `bypassPermissions` or `--dangerously-skip-permissions`, which are **detected, not prevented**. |
+| File-write block | **L3‡** | Same mechanism and the same ‡ caveat: `Edit` / `Write` tool patterns land in the same two managed keys, and the same permission-mode bypass switches them off wholesale. |
+| Network-egress block | **L2** | The strongest measured dimension. `aa-proxy` MitM with the CA injected via `NODE_EXTRA_CA_CERTS` intercepted 4/4 real-binary requests; the scanner matched the synthetic secret and the forwarded body carried `[REDACTED:AnthropicKey]` while remaining valid Messages JSON, at sub-millisecond added cost. Interception is scoped per-integration to `api.anthropic.com` / `*.anthropic.com` so the binary's side channels are covered without flipping `llm_only` globally. Not L3: Claude Code exposes no native network-restriction config, and enforcement ends when the core stops. |
+| Sub-agent governance | **L0** | Nothing in the adapter handles sub-agents: the managed launch injects **one** `AA_AGENT_ID` per process, and there is no registration, topology entry or per-child policy scope. Sub-agent model traffic is covered *incidentally* because it shares the launched process's proxy environment — that is egress coverage, not sub-agent governance, and claiming L1 would require them to appear in the topology tree. |
+
+‡ **Declared from the write path, not from an exercised block.** The mechanism is native and
+survives Agent Assembly going offline, which is what L3 denotes; the *effect* was not measured by
+`AAASM-5276`, and the endpoint managed-settings keys that would make it non-overridable are
+unmeasured (see below).
+
+**Honest boundaries for Claude Code:**
+- **No non-overridable-enforcement claim is made.**
+  `/Library/Application Support/ClaudeCode/managed-settings.json` is root-owned; the Spike
+  deliberately made no privileged writes, so its managed-only keys
+  (`allowManagedPermissionRulesOnly`, `disableBypassPermissionsMode`, …) — the strongest available
+  bypass counters — remain **unmeasured** (`AAASM-5276` condition C6). `--scope managed` is
+  refused, and the path is resolved only so a refusal can name it. Measuring it on a managed macOS
+  device is tracked by `AAASM-5298`.
+- **`Gateway Protected` is not reportable on a default build.** The shipped `UnadjudicatedProbe`
+  reports `Inconclusive` because a client on the near side of the proxy cannot see the forwarded
+  body, so `aasm integrations verify claude-code` exits `6` and the level stays at `Integrated` —
+  even though the interception itself was proven end-to-end. An adjudicating probe is *planned*.
+  See [Limitations](../devtools/limitations.md#verify-cannot-adjudicate-so-it-exits-6).
+- **All L2 dimensions require the managed launch.** A `claude` started directly inherits neither
+  the proxy nor `NODE_EXTRA_CA_CERTS` and is unprotected — measured, not theoretical. Worse, it
+  fails *silently*: a proxy that cannot terminate TLS still lets the connection through, which is
+  why CA injection is a first-class, receipted plan step.
+- **`ANTHROPIC_BASE_URL` redirection is unsuitable for protection.** Measured delivering the raw
+  synthetic secret to the provider with **no Agent Assembly component in the path**. It is routing,
+  not protection, and it is deliberately not offered as a mechanism.
+- **Hooks carry no sensitive-data claim.** They govern tool and action execution and cannot see or
+  modify model-bound prompt content.
+- **Three bypasses are demonstrated and eleven more are inferred but undemonstrated.** The split is
+  published in full at [Limitations](../devtools/limitations.md#known-bypasses-demonstrated-versus-inferred);
+  neither list is asserted to be exhaustive.
 
 ---
 
@@ -148,11 +189,19 @@ A cell answers: *"At this tier, is this capability available?"*
 | **Codex** | L2 | L2 | L3 | L3 | L3 | L2 | L2 |
 | **GitHub Copilot** | L1 | L1 | L3 | L0† | L0† | L1 | L0 |
 | **Windsurf Cascade** | L1 | L1 | L3 | L1† | L1† | L1 | L1 |
-| **Claude Code** | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| **Claude Code** | L2† | L2† | L3 | L3‡ | L3‡ | L2† | L0 |
 | **SaaS Coding-Agent** | L1 | L1 | L0 | L0 | L0 | L0 | L0 |
 
 † These capabilities require `aa-proxy` (Layer 2) running alongside the tool for enforcement.
-Without the proxy, the declared tier drops to L0 (discovery/inventory only).
+Without the proxy, the declared tier drops to L0 (discovery/inventory only). For Claude Code they
+additionally require the **managed launch** (`aasm run claude`), which is what injects the proxy
+environment and the CA trust the interception depends on.
+
+‡ Declared from the native write path, not from an exercised block — see the Claude Code
+declarations above.
+
+Only the Claude Code row is backed by a measured Spike (`AAASM-5276`). Every other row states what
+its adapter declares.
 
 ---
 
@@ -177,7 +226,13 @@ requiring a new adapter.
 ## References
 
 - `AAASM-199` — Agent Assembly SDK interception overview (`DevToolAdapter` trait + `GovernanceLevel` enum)
-- `AAASM-201` — Claude Code adapter (pending; will update Claude Code row above)
+- `AAASM-201` — Claude Code adapter (`aa-devtool-claude-code`)
+- `AAASM-5274` — DevTool reconciliation; resolved Claude Code's overall `governance_level()` to `L2Enforce`
+- `AAASM-5276` — Claude Code lifecycle Spike; the measured evidence behind the Claude Code row
+- `AAASM-5281` — Claude Code productization (CA trust injection, side-channel scoping, explicit scope)
+- `AAASM-5298` — measure the endpoint managed-settings path on a managed macOS device (open)
+- `docs/src/devtools/protection-levels.md` — `Integrated` / `Gateway Protected` / `Host Enforced`
+- `docs/src/devtools/limitations.md` — demonstrated-versus-inferred bypasses and other honest limits
 - `AAASM-202` — Codex adapter
 - `AAASM-203` — GitHub Copilot adapter
 - `AAASM-204` — Windsurf Cascade adapter


### PR DESCRIPTION
## Description

Publishes the user-facing Developer Integration documentation and fills the Claude Code row of the
L0–L3 capability matrix — the truthful-claims deliverable for Epic AAASM-5272.

New: `docs/src/devtools/{onboarding,protection-levels,limitations}.md`.
Changed: `docs/src/governance/capability-matrix.md`, `docs/src/SUMMARY.md`,
`docs/src/devtools/{cli,product-brief}.md` (cross-links). **No non-`docs/**` file touched.**

Every claim traces to `verification-reports/AAASM-5276-claude-code-mechanism-matrix.md` or to shipped
code. The section below on what was *cut* is the more useful half of this PR.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

## Related Issues

- Jira: [AAASM-5284](https://lightning-dust-mite.atlassian.net/browse/AAASM-5284)
  (Epic [AAASM-5272](https://lightning-dust-mite.atlassian.net/browse/AAASM-5272))
- Consumes evidence from: AAASM-5276 (#1820), AAASM-5281 (#1828), AAASM-5274 (#1819)
- References: AAASM-5298 (unmeasured managed-settings path), AAASM-5300 (adjudicating probe)
- GitHub issues: N/A

## The Claude Code capability-matrix row

Previously entirely `TBD`. Overall governance level is `L2Enforce` per AAASM-5274 §3.

| Capability | Tier | Evidence |
|---|---|---|
| Audit log capture | **L2** | `build_launch_command` injects `AA_AGENT_ID`/`AA_TEAM_ID`; AAASM-5276 measured 4/4 upstream requests traversing the proxy. Not L3 — an unmanaged launch emits nothing (measured). |
| Policy decision visibility | **L2** | Evaluated on intercepted traffic; re-derived on read (~0.07 ms core-stop → refused). |
| MCP server allowlist | **L3** | `apply_mcp_governance_at` writes `enabled/disabledMcpjsonServers` into the tool's own settings; idempotence and preservation measured (11.1/11.2). |
| Terminal-exec block | **L3‡** | `settings.rs` maps policy → `permissions.allow/deny` + `permissionMode`, natively written. **‡ = write path measured, block never exercised**; `bypassPermissions` overrides. |
| File-write block | **L3‡** | Same keys, same caveat. |
| Network-egress block | **L2** | Strongest evidence: real binary, 4/4 intercepted, `[REDACTED:AnthropicKey]` forwarded, side-channel scoping (C5). No native network config → not L3. |
| Sub-agent governance | **L0** | One `AA_AGENT_ID` per process; grep confirms **zero** sub-agent handling in the crate. Incidental egress coverage is not governance. |

The `‡` marker was introduced specifically so the two L3s cannot be misread as measured blocks.

## Claims cut or qualified rather than published

This is the substance of a truthful-marketing ticket:

- **A count discrepancy in the Spike report was published, not smoothed.** AAASM-5276 says "ten bypasses
  remain inferred" while its own list enumerates **eleven**. The list is published verbatim with a
  footnote that the list — not the count — is the claim.
- **Unqualified `L3` for terminal-exec and file-write was cut** → `L3‡`. The Codex precedent supports L3,
  but the Spike classified managed settings as *tool governance* and never exercised a block.
- **`L1` for sub-agent governance was cut** → `L0`. L1 requires topology-tree registration; nothing does that.
- **No Copilot row change** — see below.
- **A plausible remedy was cut**: *"verify will pass once you launch through `aasm run`"*. On a default
  build it will not.
- **All wording implying managed settings *prevent* rather than *constrain*** was removed; the doc notes
  the user-scope file is user-writable.
- **`strict` blocking on findings is marked _planned_** (AAASM-5277/5281) — today it redacts like
  `recommended`.

## Copilot's row: deliberately unchanged, with the reasoning recorded

AAASM-5274 §3 normalised only the **tool-wide** `governance_level()`, and that same section states the
overall value is *not* a per-capability tier (Codex is the precedent — L2 overall, L3 on some
capabilities). No Copilot Spike exists, so its rows are adapter *declarations*, not measurements.
Raising them would be a guess. The discrepancy is now written down rather than silently inherited.

## The `verify` limitation is surfaced five times, not buried

`aasm integrations verify claude-code` exits **6** in production. Each mention states it is
**not measured**, *not* "measured and failed", names `UnadjudicatedProbe` and the near-side-of-proxy
cause, and points at the planned adjudicating probe (AAASM-5300):

onboarding's opening bullet · onboarding Step 6 as a `⚠` callout · onboarding's troubleshooting table ·
protection-levels' *"Why `Gateway Protected` is not reportable today"* · limitations' own H2. `cli.md`
now names the exit code too.

## The bypass split is published verbatim

Two separately headed subsections under one H2 — **"Demonstrated by the AAASM-5276 harness"** (3 items)
and **"Inferred, not demonstrated"** (11 items) — plus a third table, *"Which of these the shipped
integration can actually see"*, mapping each to detected/not-detected from `bypass.rs`.

That third table exists because **detection is not prevention**, and `UNOBSERVABLE_BYPASSES` names what
cannot be seen at all.

## Security impact

Documentation-only, and the impact is that the product's public claims now match measured reality:

- **No non-overridable-enforcement claim is made** (Spike condition C6). `/Library/Application
  Support/ClaudeCode/managed-settings.json` is root-owned, was deliberately never attempted, and its
  managed-only keys remain unmeasured — tracked by AAASM-5298.
- **`ANTHROPIC_BASE_URL` redirection is documented as unsuitable for protection** — measured: the raw
  secret reached the provider with no AASM component in the path.
- Semantics-exact (not byte-exact) restore is documented as the accepted constraint ADR 0030 records.
- The deterministic scanner is stated to recognise only the shapes it knows.

## Tests executed

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (explain why)

Documentation-only; there is no executable surface.

```
$ mdbook build docs
 INFO Book building has started
Warning: The mdbook-mermaid preprocessor was built against version 0.5.0 of mdbook,
         but we're being called from version 0.5.2
 INFO Running the html backend
 INFO HTML book written to .../docs/book
EXIT=0
```

The mermaid version warning is pre-existing and not from this change. All 7 pages render.

**Every relative link and anchor was checked by script against the real generated files: 0 bad.** One
anchor was genuinely wrong on the first pass — `#step-6-verify…` versus mdbook's `step-6--verify…`,
which an em-dash produces — found by grepping the generated HTML ids, fixed, and re-verified.

`markdownlint` is **not installed on this machine**, so no lint run was possible. Not asserting it passes.

## Acceptance-criteria evidence

| AC | Status |
|---|---|
| A new user can install/verify/status/repair/remove from the docs alone | ✅ onboarding Steps 1–9, real flags, exit codes, troubleshooting |
| Three profiles with concrete enforcement behaviour | ✅ five-column table plus the three load-bearing caveats |
| Three levels with evidence requirements and honest limitations | ✅ `protection-levels.md` |
| Coverage and bypasses match AAASM-5276/5281/5283 | ⚠️ satisfied for 5276 and 5281. **5283 not consulted** — it is running in parallel and owns the test tree this branch must not touch; nothing here depends on it |
| Local-first and raw-content logging prohibitions stated | ✅ including the type-shape enforcement and the edge case (the tool's own transcripts) |
| Plugin / adapter / core responsibilities separated | ✅ onboarding "Who is responsible for what" |
| MCP presented as optional | ✅ same section, plus the reference-client link |
| Troubleshooting covers runtime unavailable, version mismatch, drift, verification failure, rollback conflict | ✅ 12-row matrix with exit codes |
| Contributor docs define lifecycle/conformance for future tools | ⚠️ **partial** — responsibilities and the DI-API client contract are covered by pointer; the normative conformance requirements live in ADR 0030, the DI-API page and the reference client, which are linked rather than duplicated. No new contributor-architecture page was written, as it would duplicate three existing pages |
| Supported / Experimental / Planned / Unsupported vocabulary used | ✅ legend plus a 14-row status table |

## Known limitations

- AAASM-5283's conformance evidence is not reflected here; if that suite disproves a claim, this
  documentation must be revised rather than the suite relaxed.
- `markdownlint` was not run (not installed locally); CI covers the mdBook build.

## Dependencies / stacked PRs

Cut from `main` @ `66983e10`; independently mergeable. Developed in parallel with AAASM-5283, which owns
`aa-integration-tests/**` and `conformance/**` — no file is touched by both.

## Documentation and migration impact

This PR *is* the documentation. All new pages are registered in `docs/src/SUMMARY.md` under the existing
`# Developer Integrations` chapter. No migration.

## Checklist

- [x] Code follows project style guidelines — N/A, no code changed
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (7 commits)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5284]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-5272]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ