### PR TITLE
[AAASM-5083] 📝 (adr): Ratify ADR-0019 as Option D — tenant-configurable trust weights

### DIFF
--- a/docs/src/adr/0019-agent-trust-score-derivation.md
+++ b/docs/src/adr/0019-agent-trust-score-derivation.md
@@ -245,9 +245,75 @@ denials and redactions over a selectable window, with a sparkline.
   fleet; two counts are harder to rank by. "Which of my 400 agents should I look at
   first" is a real operator question that a score answers and counts do not.
 
+### Option D — Option A's formula as a default, with tenant-configurable weights (ACCEPTED)
+
+Ship Option A's clean-rate formula as the **product-owned default**, and make each
+penalty signal **operator-configurable at the tenant layer**. This is the accepted
+option; it did not exist in the original draft and was added on 2026-07-30 after the
+product discussion below.
+
+The insight it resolves: every objection to Option A (§Con) — *should
+`CredentialLeakBlocked` be penalised at all?*, *is a redaction 1.5× a violation?*, *is
+this "friction" or "risk"?* — is a **tenant-specific value judgement**, not a
+derivation. A security-conservative tenant may want a blocked credential leak to hurt
+the score; a tenant whose whole thesis is "the LLM works fine never seeing the secret"
+may consider the DLP layer doing its job and want it to count for nothing. Both are
+correct *for that tenant*. So the weight is not a universal constant to be discovered —
+it is a policy each tenant sets.
+
+```
+# Per-tenant config (defaults = Option A, which every tenant inherits until they change it):
+[trust]
+window            = "7d"         # default; v1 keeps this fixed
+min_actions       = 20           # default; cold-start floor, not tenant-tunable in v1
+[trust.signals.policy_violation]      enabled = true  weight = 1.0   # default
+[trust.signals.credential_redaction]  enabled = true  weight = 1.5   # a tenant may disable or reweight
+[trust.signals.approval_rejection]    enabled = true  weight = 0.5
+
+# Score is then Option A's arithmetic over only the ENABLED signals, with the tenant's weights:
+penalty = Σ (weight_i × count_i)   for each enabled signal i
+trust   = clamp(round(100 * (1 - penalty / D)), 0, 100)
+```
+
+- **Scope of configurability (v1, deliberately narrow):** per-signal **on/off** + **weight**
+  only. Bucket thresholds (60/80) and the window (`7d`) stay at sensible defaults — they
+  are not tenant-tunable in v1, to avoid shipping an over-complex first version. A later
+  ADR can widen the surface if operators ask for it.
+- **Where config lives:** the **tenant layer** (per team/org), because different teams
+  have different security postures. This requires a durable per-tenant config store and
+  reuses the existing tenant-confinement path (`scope_entries`); a trust endpoint must
+  never read another tenant's config or another tenant's audit entries.
+- **Guardrail 1 — the score is labelled with the weight-set that produced it.** A
+  `trust: 78` computed under tenant A's weights is not comparable to a `78` under tenant
+  B's. The API response carries the effective config (or a hash/version of it) and the
+  UI states the score is "a policy-friction score under your configured weights", never
+  a universal objective measure. Cross-tenant ranking of raw scores is therefore not
+  offered as if the numbers were commensurable.
+- **Guardrail 2 — configurability never manufactures certainty.** Cold start
+  (`D < min_actions`) and a truncated window both return `null`, *regardless of how the
+  weights are set*. No weight configuration can turn "not enough data" into a number.
+  Disabling every signal yields a constant `100` only when `D ≥ min_actions` — and the
+  UI labels that as "no penalty signals enabled", not as "fully trusted".
+- **Pro:** puts the value judgement where it belongs — with the tenant who owns the
+  security posture — which is the cleanest possible answer to this ADR's founding
+  concern that an *unowned* weight is an invented derivation. A tenant-set weight is, by
+  construction, owned.
+- **Pro:** every deployment still gets a working score on day one from the defaults; the
+  configurability is opt-in.
+- **Con:** more work than plain Option A — needs a per-tenant config store, config
+  read/write endpoints, and the labelling plumbing. Accepted, because the flexibility
+  directly serves the product's multi-tenant governance thesis.
+- **Con:** two tenants' scores are not comparable, and that limitation must be surfaced
+  honestly (Guardrail 1) rather than hidden.
+
 ---
 
 ## Recommendation
+
+> **Superseded by the 2026-07-30 decision (Option D).** The original recommendation
+> below (Option A with three conditions) stands as the *default* Option D ships; Option
+> D wraps it with tenant-configurable weights. The three conditions remain binding and
+> are folded into Option D's guardrails. Retained verbatim for the reasoning trail.
 
 **Option A**, with three conditions.
 

--- a/docs/src/adr/0019-agent-trust-score-derivation.md
+++ b/docs/src/adr/0019-agent-trust-score-derivation.md
@@ -381,20 +381,35 @@ The three conditions:
 - The capability-matrix `trust <= N` filter
   (`dashboard/src/features/capability/filters.ts:28-30`).
 
-## Decision required from: product
+<a id="decision-2026-07-30"></a>
+## Decision (2026-07-30, product)
 
-1. **Which option** — a score (A), a richer score (B), or components only (C)?
-2. **If A: are the weights owned?** `1.0` violation / `1.5` credential-redaction /
-   `0.5` approval-rejection, and the `MIN_ACTIONS = 20` floor. These are the product
-   decision; they should be ratified explicitly, not inherited from this draft.
-3. **Bucketing** — adopt the shipped code bands (60/80) or the mock's (50/75)? They
-   currently disagree.
-4. **Cold start** — `null` (recommended) or the 50 the UI copy already promises?
-5. **Window** — is `7d` the right default, and should it be operator-selectable per
-   the existing `1h|24h|7d|30d` presets?
+The questions this ADR raised are now answered. Product owns the decision below;
+implementation of AAASM-5083 is authorised against it.
 
-Until items 1–2 are answered, **no implementation ticket should be opened**. Merging
-this ADR does not authorise any of the options.
+1. **Which option** — **Option D**: Option A's clean-rate formula as the default, with
+   tenant-configurable weights. Not plain A (the weights are contested and tenant-specific)
+   and not C (a single sortable score is the affordance Fleet triage needs).
+2. **Are the weights owned?** — **Yes, by each tenant.** The defaults (`1.0` violation /
+   `1.5` credential-redaction / `0.5` approval-rejection, `MIN_ACTIONS = 20`) are
+   product-owned starting values; each tenant may then toggle a signal off or reweight it.
+   A tenant-set weight is owned by construction, which is the cleanest answer to this
+   ADR's founding concern. The `credential_redaction` penalty in particular is
+   configurable precisely because whether "the DLP layer worked" should hurt the score is
+   a per-tenant posture question.
+3. **Bucketing** — adopt the **shipped code bands (60/80)**; correct the mock's 50/75 text.
+   Not tenant-tunable in v1.
+4. **Cold start** — **`null`, never 50.** The `—` placeholder is already correct; the
+   `EmptyState.tsx:110` "initialized at 50" copy is corrected to describe the
+   minimum-activity threshold. This holds regardless of configured weights (Guardrail 2).
+5. **Window** — **`7d` default**, fixed in v1 (not tenant-tunable yet). Widening to the
+   `1h|24h|7d|30d` presets is a later-ADR question.
+
+**Authorised for implementation** under AAASM-5083. Two adjacent defects the ADR
+surfaced are already handled: the dead `policy_violations_count` / permanently-false
+`flagged` badge was fixed in AAASM-5103 (derived from audit), and the `trust`
+type/serialization reconciliation (`Option<u8>`, explicit `null`) is condition 3 of the
+Option A block, to be done first.
 
 ## Reconsideration triggers
 

--- a/docs/src/adr/0019-agent-trust-score-derivation.md
+++ b/docs/src/adr/0019-agent-trust-score-derivation.md
@@ -1,7 +1,7 @@
 # ADR 0019: Agent Trust-Score Derivation
 
-**Status**: Proposed — **requires product sign-off before any implementation**
-**Date**: 2026-07
+**Status**: Accepted (2026-07-30, **Option D — Option A with tenant-configurable weights**). Product owns the default weights and the configuration surface: the clean-rate formula of Option A ships as the default, and each penalty signal is operator-configurable at the tenant layer (toggle on/off + adjust weight); bucket thresholds and window stay at sensible defaults for v1. The two truthfulness guardrails are binding: the score is labelled with which weight-set produced it, and cold-start / truncated-window still return `null` regardless of the configured weights. See [§ Decision](#decision-2026-07-30) below.
+**Date**: 2026-07 (accepted 2026-07-30)
 **Ticket**: [AAASM-5083](https://lightning-dust-mite.atlassian.net/browse/AAASM-5083) (Epic [AAASM-5082](https://lightning-dust-mite.atlassian.net/browse/AAASM-5082))
 
 This ADR proposes options for deriving the per-agent `trust` score the dashboard

--- a/docs/src/adr/README.md
+++ b/docs/src/adr/README.md
@@ -25,7 +25,7 @@ The format follows a lightweight variant of [Michael Nygard's template](https://
 | [0016](0016-default-branch-master-to-main-migration.md) | Organization-wide Default Branch — `master` → `main` | Accepted |
 | [0017](0017-dashboard-design-parity-ratified-evolutions.md) | Dashboard Design-Parity — Ratified Evolutions | Accepted |
 | [0018](0018-canonical-runtime-verdict-and-enriched-decision-record.md) | Canonical Runtime Verdict & Enriched Decision Record | Accepted |
-| [0019](0019-agent-trust-score-derivation.md) | Agent Trust-Score Derivation | Proposed |
+| [0019](0019-agent-trust-score-derivation.md) | Agent Trust-Score Derivation | Accepted |
 | [0020](0020-rolling-monthly-budget-window.md) | Rolling vs Calendar Monthly Budget Windows — and the Missing Team Tier | Proposed |
 | [0021](0021-topology-enforcement-mode-mutation-safety.md) | Topology Enforcement-Mode Mutation — Authorization, Blast Radius & Reversibility | Proposed |
 | [0022](0022-agent-config-projection-and-quantified-recommendations.md) | Agent-Detail Config Projection & Quantified Posture Recommendations | Proposed |


### PR DESCRIPTION
## Description

Ratifies **ADR-0019 (Agent Trust-Score Derivation)** with a new **Option D**: Option A's clean-rate formula as the **product-owned default**, plus **per-tenant configurable weights** (each penalty signal can be toggled on/off and reweighted). This resolves the ADR's founding concern — an *unowned* weight is an invented derivation — by putting the value judgement where it belongs: with the tenant that owns the security posture. A tenant-set weight is owned by construction.

**Docs-only.** No code, schema, or scoring rule is introduced by this PR. It records the 2026-07-30 product decision so the AAASM-5083 implementation can proceed against a ratified design.

### Why Option D over plain A or C
The contested points in Option A (should a *successful* `CredentialLeakBlocked` defence penalise the score? is a redaction 1.5× a violation? is this "friction" or "risk"?) are all **tenant-specific value judgements**, not universal constants. A security-conservative tenant and a "the LLM never sees the secret anyway" tenant can both be right — for themselves. So the weight is a per-tenant policy, not a number to discover.

### v1 scope (deliberately narrow)
- Configurable: per-signal **on/off + weight**, at the **tenant layer**.
- Fixed at sensible defaults: bucket thresholds (60/80) and window (`7d`). Widening is a later-ADR question.
- Defaults = Option A verbatim (`1.0` violation / `1.5` redaction / `0.5` approval-rejection, `MIN_ACTIONS=20`), so every deployment gets a working score on day one.

### Two binding truthfulness guardrails
1. The score is **labelled with the weight-set that produced it** — a `78` under tenant A's weights isn't comparable to a `78` under tenant B's; the UI never presents it as a universal objective measure, and raw cross-tenant ranking isn't offered as if commensurable.
2. Configurability **never manufactures certainty** — cold-start (`D < min_actions`) and truncated-window still return `null` regardless of weights.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5083 (Epic AAASM-5082)

## Testing

- [x] No tests required (explain why)

Docs-only ADR ratification. Verified: the Status-line anchor resolves to the new `#decision-2026-07-30` section, the ADR index (`README.md`) status updated Proposed→Accepted, and no `SUMMARY.md` drift (0019 already indexed). Implementation + tests land under AAASM-5083 in follow-up PRs.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — N/A, docs-only
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off (`git commit -s`) — DCO optional/advisory here

🤖 Generated with [Claude Code](https://claude.com/claude-code)