### PR TITLE
[AAASM-5299] ✨ (state): Wire aa-api to load the policy cascade from $AA_POLICY

### DIFF
--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -263,44 +263,70 @@ impl AppState {
         let uniq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let pid = std::process::id();
 
-        let policy_dir = std::env::temp_dir().join(format!("aa-api-local-policy-{pid}-{uniq}"));
-        std::fs::create_dir_all(&policy_dir).map_err(|source| LocalStateError::PolicyWrite {
-            path: policy_dir.clone(),
-            source,
-        })?;
-        let policy_path = policy_dir.join("local-policy.yaml");
-        std::fs::write(
-            &policy_path,
-            // Minimal valid section-based envelope. AAASM-3351 made the
-            // validator fail closed on the legacy rule-list schema, so this
-            // must use the `spec:` section form.
-            "apiVersion: agent-assembly/v1\n\
-             kind: Policy\n\
-             metadata:\n  \
-             name: local-policy\n  \
-             version: \"0.1.0\"\n\
-             spec:\n  \
-             budget:\n    \
-             daily_limit_usd: 100.0\n",
-        )
-        .map_err(|source| LocalStateError::PolicyWrite {
-            path: policy_path.clone(),
-            source,
-        })?;
-
         let events = Arc::new(EventBroadcast::default());
         let budget_alert_tx = events.budget_sender();
-        // AAASM-5102: the engine adopts the *same* registry the AppState
-        // exposes. Without `with_registry`, `PolicyEngine::registry` stays
-        // `None`, and every lineage-less cascade read (`collect_cascade` →
-        // `effective_permissions`, behind `GET /agents/{id}/capabilities`)
-        // resolves `Lineage::default()` and walks only Global and Agent —
-        // silently dropping every Org- and Team-scoped allow *and* deny.
-        // Enforcement was never affected: it resolves tenancy itself via
-        // `authoritative_lineage` (AAASM-3729).
+
+        // AAASM-5299 (ADR-0023 Option a): route on the operator-configured
+        // `$AA_POLICY` source, mirroring what `aa-gateway` does with its
+        // `--policy` / `$AA_POLICY` input. A directory populates the scope-index
+        // cascade so the dashboard projections reflect the enforced policy
+        // source; a file keeps today's primary-slot behaviour; unset synthesises
+        // the budget-only bootstrap policy as before, leaving the cascade empty
+        // (`cascade_loaded() == false`) so a generated bootstrap is never
+        // presented as an operator-authored cascade (ADR-0024).
+        //
+        // AAASM-5102: whichever loader runs, the engine adopts the *same*
+        // registry the AppState exposes. Without `with_registry`,
+        // `PolicyEngine::registry` stays `None`, and every lineage-less cascade
+        // read (`collect_cascade` → `effective_permissions`, behind
+        // `GET /agents/{id}/capabilities`) resolves `Lineage::default()` and
+        // walks only Global and Agent — silently dropping every Org- and
+        // Team-scoped allow *and* deny. Enforcement was never affected: it
+        // resolves tenancy itself via `authoritative_lineage` (AAASM-3729).
+        let engine = match resolve_policy_source(|k| std::env::var(k).ok()) {
+            PolicySource::Directory(dir) => {
+                aa_gateway::engine::PolicyEngine::load_cascade_from_dir(&dir, budget_alert_tx)
+                    .map_err(|e| LocalStateError::PolicyLoad(format!("{e:?}")))?
+            }
+            PolicySource::File(file) => {
+                aa_gateway::engine::PolicyEngine::load_from_file(&file, budget_alert_tx)
+                    .map_err(|e| LocalStateError::PolicyLoad(format!("{e:?}")))?
+            }
+            PolicySource::Unset => {
+                // No operator policy configured: synthesise the budget-only
+                // bootstrap envelope into a per-process temp file and load it
+                // via the single-file loader. This leaves the scope-index
+                // cascade empty (`cascade_loaded() == false`).
+                let policy_dir = std::env::temp_dir().join(format!("aa-api-local-policy-{pid}-{uniq}"));
+                std::fs::create_dir_all(&policy_dir).map_err(|source| LocalStateError::PolicyWrite {
+                    path: policy_dir.clone(),
+                    source,
+                })?;
+                let policy_path = policy_dir.join("local-policy.yaml");
+                std::fs::write(
+                    &policy_path,
+                    // Minimal valid section-based envelope. AAASM-3351 made the
+                    // validator fail closed on the legacy rule-list schema, so
+                    // this must use the `spec:` section form.
+                    "apiVersion: agent-assembly/v1\n\
+                     kind: Policy\n\
+                     metadata:\n  \
+                     name: local-policy\n  \
+                     version: \"0.1.0\"\n\
+                     spec:\n  \
+                     budget:\n    \
+                     daily_limit_usd: 100.0\n",
+                )
+                .map_err(|source| LocalStateError::PolicyWrite {
+                    path: policy_path.clone(),
+                    source,
+                })?;
+                aa_gateway::engine::PolicyEngine::load_from_file(&policy_path, budget_alert_tx)
+                    .map_err(|e| LocalStateError::PolicyLoad(format!("{e:?}")))?
+            }
+        };
         let policy_engine = Arc::new(
-            aa_gateway::engine::PolicyEngine::load_from_file(&policy_path, budget_alert_tx)
-                .map_err(|e| LocalStateError::PolicyLoad(format!("{e:?}")))?
+            engine
                 .with_registry(Arc::clone(&agent_registry))
                 .with_invalidation_hub(aa_gateway::invalidation::InvalidationHub::new()),
         );
@@ -610,6 +636,57 @@ impl AppState {
         }
 
         Ok(state)
+    }
+}
+
+/// The operator-configured policy source for `aa-api`, resolved from
+/// `$AA_POLICY` (AAASM-5299 / ADR-0023 Option a).
+///
+/// This mirrors the resolution semantics `aa-gateway` already uses for its
+/// `--policy` / `$AA_POLICY` input (`aa-cli::commands::gateway::start::resolve_policy`
+/// → `aa-gateway::server::load_policy_engine`): the value is routed on the
+/// *shape* of the path it points at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PolicySource {
+    /// `$AA_POLICY` is unset (or empty, or points at a non-existent path).
+    /// `aa-api` synthesises its budget-only bootstrap policy and loads it via
+    /// the single-file loader, exactly as it did before AAASM-5299. The
+    /// scope-index cascade stays empty, so `PolicyEngine::cascade_loaded()`
+    /// reports `false` — the "unconfigured / Unknown" signal the dashboard
+    /// projections rely on (ADR-0024). A generated bootstrap policy must never
+    /// be presented as an operator-authored cascade.
+    Unset,
+    /// `$AA_POLICY` points at a single YAML file. Loaded via
+    /// `PolicyEngine::load_from_file` — the primary slot only, matching today's
+    /// behaviour. The cascade stays empty (`cascade_loaded() == false`).
+    File(std::path::PathBuf),
+    /// `$AA_POLICY` points at a directory of scoped `*.yaml` documents. Loaded
+    /// via `PolicyEngine::load_cascade_from_dir`, which populates the scope
+    /// index so the cascade-derived projections reflect the enforced source
+    /// (`cascade_loaded() == true`).
+    Directory(std::path::PathBuf),
+}
+
+/// Resolve the operator policy source from `$AA_POLICY` (AAASM-5299).
+///
+/// Matches `aa-gateway`'s `$AA_POLICY` semantics: an existing file resolves to
+/// [`PolicySource::File`], an existing directory to [`PolicySource::Directory`],
+/// and an unset / empty / non-existent value to [`PolicySource::Unset`]. The
+/// caller supplies the env lookup so tests can inject a value without poisoning
+/// the real process environment.
+pub(crate) fn resolve_policy_source(env_lookup: impl Fn(&str) -> Option<String>) -> PolicySource {
+    match env_lookup("AA_POLICY") {
+        Some(raw) if !raw.is_empty() => {
+            let path = std::path::PathBuf::from(raw);
+            if path.is_dir() {
+                PolicySource::Directory(path)
+            } else if path.is_file() {
+                PolicySource::File(path)
+            } else {
+                PolicySource::Unset
+            }
+        }
+        _ => PolicySource::Unset,
     }
 }
 

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -288,10 +288,8 @@ impl AppState {
                 aa_gateway::engine::PolicyEngine::load_cascade_from_dir(&dir, budget_alert_tx)
                     .map_err(|e| LocalStateError::PolicyLoad(format!("{e:?}")))?
             }
-            PolicySource::File(file) => {
-                aa_gateway::engine::PolicyEngine::load_from_file(&file, budget_alert_tx)
-                    .map_err(|e| LocalStateError::PolicyLoad(format!("{e:?}")))?
-            }
+            PolicySource::File(file) => aa_gateway::engine::PolicyEngine::load_from_file(&file, budget_alert_tx)
+                .map_err(|e| LocalStateError::PolicyLoad(format!("{e:?}")))?,
             PolicySource::Unset => {
                 // No operator policy configured: synthesise the budget-only
                 // bootstrap envelope into a per-process temp file and load it

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -846,4 +846,43 @@ mod tests {
         let rate = LocalStateError::RateLimit("abc".to_string());
         assert_eq!(rate.to_string(), "invalid AA_RATE_LIMIT_RPM: abc");
     }
+
+    /// AAASM-5299 — `resolve_policy_source` routes on the *shape* of the
+    /// `$AA_POLICY` value exactly like `aa-gateway`: an existing directory is a
+    /// cascade source, an existing file is a single-policy source, and an
+    /// unset / empty / non-existent value is `Unset` (bootstrap-synthesis).
+    /// The env lookup is injected so this test never touches the real
+    /// process environment.
+    #[test]
+    fn resolve_policy_source_routes_on_path_shape() {
+        let dir = std::env::temp_dir().join(format!("aa-api-resolve-src-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let file = dir.join("policy.yaml");
+        std::fs::write(&file, "x").expect("temp file");
+
+        let dir_str = dir.to_string_lossy().into_owned();
+        let file_str = file.to_string_lossy().into_owned();
+
+        // Directory → Directory.
+        assert_eq!(
+            resolve_policy_source(|_| Some(dir_str.clone())),
+            PolicySource::Directory(dir.clone()),
+        );
+        // File → File.
+        assert_eq!(
+            resolve_policy_source(|_| Some(file_str.clone())),
+            PolicySource::File(file.clone()),
+        );
+        // Unset → Unset.
+        assert_eq!(resolve_policy_source(|_| None), PolicySource::Unset);
+        // Empty string → Unset.
+        assert_eq!(resolve_policy_source(|_| Some(String::new())), PolicySource::Unset);
+        // Non-existent path → Unset (never presented as an operator source).
+        assert_eq!(
+            resolve_policy_source(|_| Some("/nonexistent-aa-policy-path-xyz".to_string())),
+            PolicySource::Unset,
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/aa-api/tests/policy_source_directory.rs
+++ b/aa-api/tests/policy_source_directory.rs
@@ -1,0 +1,61 @@
+//! AAASM-5299 — a `$AA_POLICY` **directory** source must populate the
+//! scope-index cascade, so `AppState`'s engine reports `cascade_loaded() ==
+//! true` and a cascade-derived read returns the operator's scoped documents.
+//!
+//! This is the ADR-0023 Option (a) acceptance evidence: before this wiring,
+//! `AppState` always built the engine via `load_from_file` (primary slot only),
+//! leaving the cascade empty in every shipped deployment.
+//!
+//! `$AA_POLICY` is process-wide, so this scenario lives in its own test binary
+//! (one env-mutating `#[test]` per file) to avoid racing sibling tests under
+//! either `cargo test` or nextest.
+
+use aa_api::AppState;
+use aa_gateway::policy::PolicyScope;
+
+#[test]
+fn directory_source_populates_the_cascade() {
+    let dir = tempfile::tempdir().expect("temp policy dir");
+
+    // A Global allow-all plus a narrower Team-scoped document. The Team doc is
+    // what proves the *cascade* (scope index) was populated — `load_from_file`
+    // could never insert it.
+    std::fs::write(
+        dir.path().join("000-global.yaml"),
+        "apiVersion: agent-assembly.dev/v1alpha1\n\
+         kind: GovernancePolicy\n\
+         metadata:\n  name: local-global\n  version: \"0.1.0\"\n\
+         spec:\n  tools: {}\n",
+    )
+    .expect("write global doc");
+    std::fs::write(
+        dir.path().join("100-team-alpha.yaml"),
+        "apiVersion: agent-assembly.dev/v1alpha1\n\
+         kind: GovernancePolicy\n\
+         metadata:\n  name: local-team-alpha\n  version: \"0.1.0\"\n\
+         spec:\n  scope: team:team-alpha\n  tools:\n    bash:\n      allow: false\n",
+    )
+    .expect("write team doc");
+
+    std::env::set_var("AA_POLICY", dir.path());
+    let state = AppState::local_in_memory().expect("in-memory state builds from a cascade directory");
+    std::env::remove_var("AA_POLICY");
+
+    // The scope index carries at least one scoped document: the unconfigured
+    // signal is now `true` for cascade-derived projections.
+    assert!(
+        state.policy_engine.cascade_loaded(),
+        "a directory source must populate the cascade — cascade_loaded() must be true"
+    );
+
+    // And a cascade-derived read returns the operator's real Team document,
+    // not the empty result every shipped deployment saw before AAASM-5299.
+    let team_policies = state
+        .policy_engine
+        .policies_for_scope(&PolicyScope::Team("team-alpha".to_string()));
+    assert_eq!(
+        team_policies.len(),
+        1,
+        "the Team-scoped document must be present in the loaded cascade"
+    );
+}

--- a/aa-api/tests/policy_source_file.rs
+++ b/aa-api/tests/policy_source_file.rs
@@ -1,0 +1,34 @@
+//! AAASM-5299 — a `$AA_POLICY` **file** source must keep today's primary-slot
+//! behaviour: the operator's single document loads via `load_from_file`, so the
+//! scope-index cascade stays empty and `cascade_loaded() == false`.
+//!
+//! `$AA_POLICY` is process-wide, so this scenario lives in its own test binary
+//! (one env-mutating `#[test]` per file) to avoid racing sibling tests under
+//! either `cargo test` or nextest.
+
+use aa_api::AppState;
+
+#[test]
+fn file_source_keeps_primary_slot_behaviour() {
+    let dir = tempfile::tempdir().expect("temp policy dir");
+    let file = dir.path().join("policy.yaml");
+    std::fs::write(
+        &file,
+        "apiVersion: agent-assembly.dev/v1alpha1\n\
+         kind: GovernancePolicy\n\
+         metadata:\n  name: local-file-policy\n  version: \"0.1.0\"\n\
+         spec:\n  tools: {}\n",
+    )
+    .expect("write policy file");
+
+    std::env::set_var("AA_POLICY", &file);
+    let state = AppState::local_in_memory().expect("in-memory state builds from a single file");
+    std::env::remove_var("AA_POLICY");
+
+    // A single-file source uses the primary slot only — the cascade is never
+    // populated, matching the pre-AAASM-5299 behaviour.
+    assert!(
+        !state.policy_engine.cascade_loaded(),
+        "a file source must leave the cascade empty — cascade_loaded() must be false"
+    );
+}

--- a/aa-api/tests/policy_source_unset.rs
+++ b/aa-api/tests/policy_source_unset.rs
@@ -1,0 +1,26 @@
+//! AAASM-5299 — an **unset** `$AA_POLICY` must keep synthesising the budget-only
+//! bootstrap policy, leaving the scope-index cascade empty so
+//! `cascade_loaded() == false`. This is the ADR-0024 unconfigured / Unknown
+//! signal: a generated bootstrap policy must never be presented as an
+//! operator-authored cascade.
+//!
+//! `$AA_POLICY` is process-wide, so this scenario lives in its own test binary
+//! (one env-mutating `#[test]` per file) to avoid racing sibling tests under
+//! either `cargo test` or nextest.
+
+use aa_api::AppState;
+
+#[test]
+fn unset_source_leaves_cascade_empty() {
+    std::env::remove_var("AA_POLICY");
+
+    let state = AppState::local_in_memory().expect("in-memory state builds with no policy source");
+
+    // No operator source: the bootstrap policy loads via the single-file loader
+    // and the cascade stays empty, so the dashboard projections render the
+    // Unknown / Unconfigured state rather than inferring permission.
+    assert!(
+        !state.policy_engine.cascade_loaded(),
+        "an unset source must leave the cascade empty — cascade_loaded() must be false"
+    );
+}


### PR DESCRIPTION
## Description

The real-fix half of AAASM-5106 (ADR-0023 Option a, Accepted). `aa-api` now loads a policy cascade from an operator-settable source using the **same `$AA_POLICY` semantics and the same `load_cascade_from_dir` loader that `aa-gateway` uses**, so the dashboard's cascade-derived projections (capability matrix, topology permission chain, Teams active-policies) reflect the policy source the gateway actually enforces.

**Read-only projection change — no enforcement path touched.** Before this, `AppState` built the engine via `load_from_file` (primary slot only) and the scope index was empty in every deployment, so those projections read empty; the interim truthfulness fix (AAASM-5106 / #1825) made that render honestly as *Unknown*. This PR makes the data real.

### Source resolution (matches aa-gateway)
- **Directory** → `load_cascade_from_dir` (scope index populated → `cascade_loaded() == true`, projections show real data).
- **File** → `load_from_file` (primary slot, today's behaviour → `cascade_loaded() == false`).
- **Unset / empty / missing** → budget-only bootstrap as before (`cascade_loaded() == false`) — the generated bootstrap is **never** presented as an operator-authored cascade, so the ADR-0024 Unknown state holds.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5299 (completes AAASM-5106; ADR-0023 / ADR-0024)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`resolve_policy_source` path-shape routing unit test; three env-isolated integration tests (directory populates cascade / file keeps primary-slot / unset leaves cascade empty). Local gates: `cargo clippy --all-targets` clean, `cargo fmt --check` clean, `cargo test -p aa-api` lib+new tests green (2 pre-existing webhook-egress flakes in `tests/destinations.rs`, unrelated — verified failing on HEAD independently). Authoritative full build runs in CI.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off — DCO optional/advisory here

🤖 Generated with [Claude Code](https://claude.com/claude-code)