### PR TITLE
[AAASM-5100] ✨ (gateway): Populate verdict + latency_ms at the decision boundary (Phase 1)

### DIFF
--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -1697,14 +1697,27 @@ mod tests {
         assert_eq!(row.verb.as_deref(), Some("TOOL_CALL"));
         assert_eq!(row.resource.as_deref(), Some("pg.users"));
         assert_eq!(row.matched_policy, None);
-        // No per-decision latency source exists — it must be reported as absent.
+        // A legacy payload carrying no verdict/latency_ms keys (written before
+        // AAASM-5100 capture landed) must still read null — the capture is
+        // additive, never fabricated for rows that lack a source.
         assert_eq!(row.latency_ms, None);
-        // The verdict + trace id are frozen in the schema but not yet captured
-        // at decision time (ADR-0018 hot-path follow-up); they must read null.
         assert_eq!(row.verdict, None);
         assert_eq!(row.trace_id, None);
         assert_eq!(row.seq, 7);
         assert_eq!(row.session_id, "ee".repeat(16));
+    }
+
+    #[test]
+    fn scrubbed_action_records_scrub_verdict_distinct_from_allow() {
+        // AAASM-5100 item A — a DLP-scrubbed action is forwarded (proto Redact,
+        // decision=4) but its captured verdict must be `scrub`, never `allow`,
+        // so scrubbed traffic is visible as distinct from a clean allow.
+        let entry = decision_entry(
+            r#"{"action_type":"TOOL_CALL","decision":4,"verdict":"scrub","latency_ms":3,"detail":{"kind":"tool_call","tool_name":"gmail.send"}}"#,
+        );
+        let row = entry_to_decision_row(&entry).expect("redact carries a decision");
+        assert_eq!(row.verdict, Some(RuntimeVerdict::Scrub));
+        assert_ne!(row.verdict, Some(RuntimeVerdict::Allow));
     }
 
     #[test]

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -1750,6 +1750,19 @@ mod tests {
     }
 
     #[test]
+    fn trace_id_stays_null_item_c_not_implemented() {
+        // AAASM-5100 scope guard — item C (trace-id propagation) is Phase 2 and
+        // NOT implemented here. Even when the payload carries a trace_id (used by
+        // the /traces surface), the decision row's trace_id must stay null so no
+        // consumer assumes item C shipped with items A+B.
+        let entry = decision_entry(
+            r#"{"action_type":"TOOL_CALL","decision":1,"verdict":"allow","latency_ms":2,"trace_id":"abc123"}"#,
+        );
+        let row = entry_to_decision_row(&entry).expect("allow carries a decision");
+        assert_eq!(row.trace_id, None, "trace_id must stay null until Phase 2");
+    }
+
+    #[test]
     fn entry_to_decision_row_skips_entry_without_decision() {
         let entry = decision_entry(r#"{"action_type":"AGENT_SPAWN","detail":{"kind":"spawn"}}"#);
         assert!(entry_to_decision_row(&entry).is_none());

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -1735,6 +1735,21 @@ mod tests {
     }
 
     #[test]
+    fn normal_decision_records_positive_latency_ms() {
+        // AAASM-5100 item B — a normal allow decision now carries the captured
+        // per-decision latency (ms) rather than the frozen null.
+        let entry = decision_entry(
+            r#"{"action_type":"TOOL_CALL","decision":1,"verdict":"allow","latency_ms":5,"detail":{"kind":"tool_call","tool_name":"pg.read"}}"#,
+        );
+        let row = entry_to_decision_row(&entry).expect("allow carries a decision");
+        assert_eq!(row.latency_ms, Some(5));
+        assert!(
+            row.latency_ms.unwrap() > 0,
+            "a measured decision reports positive latency"
+        );
+    }
+
+    #[test]
     fn entry_to_decision_row_skips_entry_without_decision() {
         let entry = decision_entry(r#"{"action_type":"AGENT_SPAWN","detail":{"kind":"spawn"}}"#);
         assert!(entry_to_decision_row(&entry).is_none());

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -1182,6 +1182,19 @@ fn entry_to_decision_row(entry: &AuditEntry) -> Option<AgentDecisionResponse> {
         .filter(|s| !s.is_empty())
         .map(str::to_string);
 
+    // AAASM-5100 / ADR-0018 item A — the 5-way runtime verdict, now captured at
+    // decision time on the audit write path (`policy_service::record_audit`).
+    // Parsed from the payload string into the canonical enum; absent on legacy
+    // rows written before capture landed, which stay `null`.
+    let verdict = payload
+        .get("verdict")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| serde_json::from_value::<RuntimeVerdict>(serde_json::Value::String(s.to_string())).ok());
+
+    // AAASM-5100 / ADR-0018 item B — per-decision latency in ms, now recorded on
+    // the audit write path. Absent on legacy rows, which stay `null`.
+    let latency_ms = payload.get("latency_ms").and_then(serde_json::Value::as_u64);
+
     Some(AgentDecisionResponse {
         timestamp,
         session_id: hex::encode(entry.session_id().as_bytes()),
@@ -1190,18 +1203,12 @@ fn entry_to_decision_row(entry: &AuditEntry) -> Option<AgentDecisionResponse> {
         resource,
         decision,
         decision_label: decision_label(decision),
-        // The 5-way runtime verdict is not captured at decision time yet;
-        // deriving it is the ADR-0018-gated hot-path follow-up. Surface null
-        // rather than lossily mapping the coarse proto `decision` onto it.
-        // populated once decision-capture lands (ADR 0018 / AAASM-5086 follow-up)
-        verdict: None,
+        verdict,
         matched_policy,
-        // No per-decision latency source exists in the audit log (AAASM-5058);
-        // report it honestly as absent rather than inventing a value.
-        latency_ms: None,
-        // No per-decision trace id is recorded on the audit write path yet;
-        // trace-id propagation is the ADR-0018-gated hot-path follow-up.
-        // populated once decision-capture lands (ADR 0018 / AAASM-5086 follow-up)
+        latency_ms,
+        // Item C (trace-id propagation) is NOT implemented — it is gated to a
+        // separate Phase 2 ticket. The audit write records no per-decision trace
+        // id, so this stays null.
         trace_id: None,
     })
 }

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -1721,6 +1721,20 @@ mod tests {
     }
 
     #[test]
+    fn narrowed_action_records_narrow_verdict_distinct_from_deny() {
+        // AAASM-5100 item A — a scoped-but-permitted action (proto Allow,
+        // decision=1, but the gateway flagged it narrowed) records the `narrow`
+        // verdict, distinct from `deny` — the UI shows partial success, not a
+        // block.
+        let entry = decision_entry(
+            r#"{"action_type":"FILE_OPERATION","decision":1,"verdict":"narrow","latency_ms":1,"detail":{"kind":"file_op","path":"/tmp/x"}}"#,
+        );
+        let row = entry_to_decision_row(&entry).expect("allow carries a decision");
+        assert_eq!(row.verdict, Some(RuntimeVerdict::Narrow));
+        assert_ne!(row.verdict, Some(RuntimeVerdict::Deny));
+    }
+
+    #[test]
     fn entry_to_decision_row_skips_entry_without_decision() {
         let entry = decision_entry(r#"{"action_type":"AGENT_SPAWN","detail":{"kind":"spawn"}}"#);
         assert!(entry_to_decision_row(&entry).is_none());

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -69,6 +69,15 @@ pub struct EvaluationResult {
     /// fail-closed deny — those verdicts are produced without a nameable cascade
     /// document, so no digest is attributed rather than a misleading one.
     pub policy_doc_id: Option<String>,
+    /// AAASM-5100 / ADR-0018 item A — `true` when this action was **permitted but
+    /// scoped down** by an in-force policy allow-list rather than blocked: the
+    /// action's capability was admitted only because it fell inside the merged
+    /// cascade's restricted allow-list. Purely observational metadata carried to
+    /// the audit write so the read-side can render the `narrow` runtime verdict
+    /// (distinct from a plain `allow`); it never changes the decision. Always
+    /// `false` for non-`Allow` decisions and for a default-allow with no allow-
+    /// list restriction in force.
+    pub narrowed: bool,
 }
 
 impl EvaluationResult {
@@ -82,6 +91,7 @@ impl EvaluationResult {
             credential_findings: vec![],
             deny_action: None,
             policy_doc_id: None,
+            narrowed: false,
         }
     }
 
@@ -100,6 +110,7 @@ impl EvaluationResult {
             credential_findings,
             deny_action,
             policy_doc_id: None,
+            narrowed: false,
         }
     }
 }
@@ -181,6 +192,9 @@ pub fn transform_for_observe_mode(
         // document still fired; preserve its attribution so the dry-run audit
         // entry still names the document that would have decided in enforce mode.
         policy_doc_id: result.policy_doc_id,
+        // The observe-mode allow masks a would-be deny/pending, not a scoping —
+        // it is a dry-run allow, never a `narrow`.
+        narrowed: false,
     };
 
     (transformed, Some(shadow))
@@ -1193,6 +1207,7 @@ impl PolicyEngine {
                 credential_findings: vec![],
                 deny_action: None,
                 policy_doc_id: None,
+                narrowed: false,
             });
         }
         None
@@ -1342,6 +1357,7 @@ impl PolicyEngine {
                 credential_findings: all_findings,
                 deny_action: None,
                 policy_doc_id: None,
+                narrowed: false,
             });
         }
 
@@ -1451,12 +1467,20 @@ impl PolicyEngine {
             }
         }
 
+        // AAASM-5100 / ADR-0018 item A — the action was permitted; record whether
+        // an in-force allow-list scoped it down (`narrow`) vs. a default allow.
+        let narrowed = policy
+            .capabilities
+            .as_ref()
+            .is_some_and(|caps| Self::capability_narrowed(caps, action));
+
         EvaluationResult {
             decision: aa_core::PolicyResult::Allow,
             redacted_payload,
             credential_findings,
             deny_action: None,
             policy_doc_id: None,
+            narrowed,
         }
     }
 
@@ -1505,6 +1529,24 @@ impl PolicyEngine {
             return Some(EvaluationResult::deny("capability not in allow list"));
         }
         None
+    }
+
+    /// AAASM-5100 / ADR-0018 item A — `true` when `caps` **permits** the action
+    /// but only because it fell inside an in-force allow-list restriction, i.e.
+    /// a policy scoped the action down rather than blocking it.
+    ///
+    /// This is the `narrow` runtime-verdict signal: the action's capability is
+    /// present in a *restricted* merged allow-list (`allow_is_restricted()` — an
+    /// explicit whitelist is in force, not the empty "no restriction" default),
+    /// so it was admitted by a scoping match rather than by default-allow.
+    /// Returns `false` when the action maps to no capability, when no allow-list
+    /// restriction is in force, or when the action would be denied — the caller
+    /// only consults this on a permitted (`capability_guard` → `None`) action.
+    fn capability_narrowed(caps: &aa_core::CapabilitySet, action: &aa_core::GovernanceAction) -> bool {
+        let Some(cap) = aa_core::action_to_capability(action) else {
+            return false;
+        };
+        caps.allow_is_restricted() && caps.allow.contains(&cap)
     }
 
     /// Stage 4 across a cascade: apply the most restrictive (minimum)
@@ -1635,6 +1677,7 @@ impl PolicyEngine {
                 credential_findings: vec![],
                 deny_action: None,
                 policy_doc_id: None,
+                narrowed: false,
             };
         }
 
@@ -1663,6 +1706,7 @@ impl PolicyEngine {
                 credential_findings: vec![],
                 deny_action: None,
                 policy_doc_id,
+                narrowed: false,
             };
         }
 
@@ -1705,12 +1749,21 @@ impl PolicyEngine {
             .filter_map(|doc| doc.budget.as_ref().and_then(Self::budget_deny_action))
             .next_back();
 
+        // AAASM-5100 / ADR-0018 item A — an allowed action was `narrow`ed when the
+        // merged cascade allow-list scoped it down rather than blocking it. Only
+        // an Allow verdict can be narrowed; a surviving RequireApproval is
+        // `pending`, not `narrow`.
+        let decision = verdict.into_policy_result();
+        let narrowed = matches!(decision, aa_core::PolicyResult::Allow)
+            && Self::capability_narrowed(&Self::collect_merged_capabilities(&cascade), action);
+
         EvaluationResult {
-            decision: verdict.into_policy_result(),
+            decision,
             redacted_payload,
             credential_findings,
             deny_action,
             policy_doc_id,
+            narrowed,
         }
     }
 
@@ -4029,6 +4082,57 @@ mod tests {
         );
     }
 
+    // ── narrowed flag (AAASM-5100 / ADR-0018 item A) ──────────────────────────
+
+    #[test]
+    fn allow_admitted_by_restricted_allowlist_sets_narrowed() {
+        // An in-force allow-list (Global {FileRead,FileWrite} ∩ Agent {FileRead})
+        // permits FileRead only because it fell inside the scoped whitelist — a
+        // narrowing, not a default allow. The result must flag `narrowed = true`
+        // so the audit write can render the `narrow` runtime verdict.
+        let agent_id = AgentId::from_bytes([1u8; 16]);
+        let mut engine = make_engine(empty_doc());
+        let global_caps = cap_set_cascade(&[aa_core::Capability::FileRead, aa_core::Capability::FileWrite], &[]);
+        engine.load_policy(scoped_doc(crate::policy::scope::PolicyScope::Global, Some(global_caps)));
+        let agent_caps = cap_set_cascade(&[aa_core::Capability::FileRead], &[]);
+        engine.load_policy(scoped_doc(
+            crate::policy::scope::PolicyScope::Agent(agent_id),
+            Some(agent_caps),
+        ));
+
+        let ctx = make_ctx();
+        let read_action = aa_core::GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: aa_core::FileMode::Read,
+        };
+        let result = engine.evaluate(&ctx, &read_action);
+        assert_eq!(
+            result.decision,
+            PolicyResult::Allow,
+            "FileRead is inside the allow-list"
+        );
+        assert!(result.narrowed, "a scoped allow-list match must flag narrowed");
+    }
+
+    #[test]
+    fn default_allow_with_no_capability_restriction_is_not_narrowed() {
+        // No capabilities block anywhere → the action is permitted by default,
+        // not scoped by any allow-list, so it must NOT be flagged as narrowed.
+        let mut engine = make_engine(empty_doc());
+        engine.load_policy(scoped_doc(crate::policy::scope::PolicyScope::Global, None));
+        let agent_id = AgentId::from_bytes([1u8; 16]);
+        engine.load_policy(scoped_doc(crate::policy::scope::PolicyScope::Agent(agent_id), None));
+
+        let ctx = make_ctx();
+        let action = aa_core::GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: aa_core::FileMode::Write,
+        };
+        let result = engine.evaluate(&ctx, &action);
+        assert_eq!(result.decision, PolicyResult::Allow);
+        assert!(!result.narrowed, "a default allow must not be flagged narrowed");
+    }
+
     // ── Primary-path capability stage regression (AAASM-4123) ─────────────────
 
     /// Load a single-file policy via the same public loader `aasm policy
@@ -4585,6 +4689,7 @@ mod tests {
             credential_findings: vec![],
             deny_action: None,
             policy_doc_id: None,
+            narrowed: false,
         }
     }
 
@@ -4608,6 +4713,7 @@ mod tests {
             credential_findings: vec![],
             deny_action: Some(DenyAction::Block),
             policy_doc_id: None,
+            narrowed: false,
         }
     }
 
@@ -4635,6 +4741,7 @@ mod tests {
             credential_findings: vec![],
             deny_action: None,
             policy_doc_id: None,
+            narrowed: false,
         };
         let (out, shadow) = transform_for_observe_mode(pending, aa_core::EnforcementMode::Observe);
         assert_eq!(out.decision, PolicyResult::Allow);

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -261,6 +261,7 @@ pub fn result_to_response(result: &PolicyResult, latency_us: i64, policy_rule: &
         credential_findings: Vec::new(),
         deny_action: None,
         policy_doc_id: None,
+        narrowed: false,
     };
     eval_result_to_response(&eval, latency_us, policy_rule)
 }
@@ -449,6 +450,7 @@ mod tests {
             credential_findings: vec![aa_security::CredentialFinding::from_regex_match(0, 4)],
             deny_action: None,
             policy_doc_id: None,
+            narrowed: false,
         };
         let resp = eval_result_to_response(&eval, 0, "data_pattern_scan");
         assert_eq!(resp.decision, Decision::Deny as i32);
@@ -467,6 +469,7 @@ mod tests {
             credential_findings: vec![aa_security::CredentialFinding::from_regex_match(0, 4)],
             deny_action: None,
             policy_doc_id: None,
+            narrowed: false,
         };
         let resp = eval_result_to_response(&eval, 0, "");
         assert_eq!(resp.decision, Decision::Allow as i32);

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -580,6 +580,38 @@ mod tests {
     }
 
     #[test]
+    fn held_approval_records_decision_latency_not_the_approval_wait() {
+        // AAASM-5100 item B — semantic guardrail. A held/approval-pending action
+        // may wait minutes for a human, but the recorded latency must be the
+        // scanner's DECISION time (the `latency_us` measured in `evaluate_one`
+        // around `engine.evaluate`, BEFORE the blocking wait), NOT the wall-clock
+        // until the operator responds.
+        //
+        // `approval_decision_to_response` is the sole path that builds the final
+        // response for a resolved approval, and it is called with that
+        // pre-computed decision latency. Whatever the approval wait was, the
+        // response carries exactly the decision latency it was given, and the
+        // derived `latency_ms` (ms floor) follows it — never the human wait.
+        let id: ApprovalRequestId = Uuid::new_v4().to_string().parse().unwrap();
+        let decision_latency_us: i64 = 1_500; // measured decision time: 1.5 ms
+        let approved = ApprovalDecision::Approved {
+            by: "operator".into(),
+            reason: None,
+            conditions: Vec::new(),
+        };
+
+        let resp = approval_decision_to_response(&approved, &id, decision_latency_us, "needs-approval");
+
+        // The recorded latency is the decision time it was handed, not the wait.
+        assert_eq!(resp.decision_latency_us, decision_latency_us);
+        // An approved approval is a permitted, un-narrowed action → `allow`, and
+        // the ms latency floors the decision time (1500us → 1ms), independent of
+        // however long the human took.
+        assert_eq!(runtime_verdict(resp.decision, false), "allow");
+        assert_eq!((resp.decision_latency_us.max(0) as u64) / 1_000, 1);
+    }
+
+    #[test]
     fn decide_request_unspecified_decision_is_an_error() {
         let req = DecideRequest {
             request_id: Uuid::new_v4().to_string(),

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -209,6 +209,47 @@ pub fn eval_result_to_response(eval: &EvaluationResult, latency_us: i64, policy_
     }
 }
 
+/// Derive the canonical 5-way runtime verdict (ADR-0018 item A, AAASM-5100) for
+/// the decision an action actually received, as the lowercase wire string the
+/// read-side deserializes into `aa_api::models::verdict::RuntimeVerdict`.
+///
+/// The verdict is a *finer* label emitted **alongside** the proto
+/// [`Decision`] — it never changes what is allowed or blocked. The proto enum is
+/// intentionally coarse: it folds a scoped-but-permitted action into `Allow` and
+/// a DLP-scrubbed-but-forwarded action into `Redact`; this function recovers the
+/// distinction the dashboard renders.
+///
+/// The verdict is written into the audit payload JSON as a string rather than a
+/// typed field because the `RuntimeVerdict` enum lives in `aa-api`, which depends
+/// on `aa-gateway` (not the reverse) — so the gateway cannot name the type, and
+/// the audit payload is a JSON string in any case. `aa-api`'s read-side
+/// (`entry_to_decision_row`) parses the string back into the enum.
+///
+/// Mapping (from the *recorded* proto `decision`, plus the finer signals the
+/// gateway holds at audit-write time):
+/// * `Deny`    → `"deny"`   — blocked outright.
+/// * `Pending` → `"pending"`— held awaiting human approval.
+/// * `Redact`  → `"scrub"`  — permitted, but the DLP layer rewrote the payload
+///   (secrets/PII stripped, ADR 0015) before forwarding. Distinct from `allow`.
+/// * `Allow` + `narrowed`   → `"narrow"` — permitted, but a policy match scoped
+///   the action down (a narrower cascade allow-list still admitted it) rather
+///   than blocking. Distinct from `deny` so the UI shows partial success.
+/// * `Allow`                → `"allow"` — permitted unchanged.
+/// * anything else (`Unspecified` / out-of-range) → `"deny"`, matching the
+///   fail-closed collapse the enforcement paths already apply to unknown codes.
+pub fn runtime_verdict(decision: i32, narrowed: bool) -> &'static str {
+    match Decision::try_from(decision) {
+        Ok(Decision::Allow) if narrowed => "narrow",
+        Ok(Decision::Allow) => "allow",
+        Ok(Decision::Redact) => "scrub",
+        Ok(Decision::Pending) => "pending",
+        Ok(Decision::Deny) => "deny",
+        // Unspecified, or an out-of-range code from a newer peer — fail closed,
+        // mirroring `normalize_gateway_decision` / `decision_from_response`.
+        _ => "deny",
+    }
+}
+
 /// Convert a [`PolicyResult`] into a [`CheckActionResponse`].
 ///
 /// Convenience wrapper for tests and callers that only have a `PolicyResult`
@@ -430,6 +471,60 @@ mod tests {
         let resp = eval_result_to_response(&eval, 0, "");
         assert_eq!(resp.decision, Decision::Allow as i32);
         assert!(resp.redact.is_none());
+    }
+
+    // ── runtime_verdict — 5-way vocabulary (ADR-0018 item A, AAASM-5100) ──────
+
+    #[test]
+    fn runtime_verdict_maps_each_decision_to_its_wire_label() {
+        // A plain (un-narrowed) allow, a scrub (proto Redact), a pending, and a
+        // deny each map to their distinct 5-way label.
+        assert_eq!(runtime_verdict(Decision::Allow as i32, false), "allow");
+        assert_eq!(runtime_verdict(Decision::Redact as i32, false), "scrub");
+        assert_eq!(runtime_verdict(Decision::Pending as i32, false), "pending");
+        assert_eq!(runtime_verdict(Decision::Deny as i32, false), "deny");
+    }
+
+    #[test]
+    fn runtime_verdict_narrowed_allow_is_narrow_not_allow() {
+        // The `narrowed` signal turns a permitted action into `narrow` — a
+        // policy scoped it down rather than blocking. Distinct from a plain
+        // allow so the UI can render partial success.
+        assert_eq!(runtime_verdict(Decision::Allow as i32, true), "narrow");
+        assert_ne!(
+            runtime_verdict(Decision::Allow as i32, true),
+            runtime_verdict(Decision::Allow as i32, false)
+        );
+    }
+
+    #[test]
+    fn runtime_verdict_scrub_is_distinct_from_allow() {
+        // A DLP-scrubbed action is still forwarded (proto Redact), but its
+        // verdict must be `scrub`, never `allow` — scrubbed traffic is visible.
+        assert_ne!(
+            runtime_verdict(Decision::Redact as i32, false),
+            runtime_verdict(Decision::Allow as i32, false)
+        );
+    }
+
+    #[test]
+    fn runtime_verdict_narrow_is_distinct_from_deny() {
+        // A narrowed action was permitted, not blocked — its verdict must not
+        // collapse onto `deny`.
+        assert_ne!(
+            runtime_verdict(Decision::Allow as i32, true),
+            runtime_verdict(Decision::Deny as i32, false)
+        );
+    }
+
+    #[test]
+    fn runtime_verdict_unknown_decision_fails_closed_to_deny() {
+        // An Unspecified or out-of-range code fails closed, mirroring the
+        // enforcement paths' unknown-decision collapse. `narrowed` on an unknown
+        // code is meaningless and must not upgrade it to `narrow`.
+        assert_eq!(runtime_verdict(Decision::Unspecified as i32, false), "deny");
+        assert_eq!(runtime_verdict(9999, false), "deny");
+        assert_eq!(runtime_verdict(9999, true), "deny");
     }
 
     #[test]

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -945,10 +945,35 @@ impl PolicyServiceImpl {
         // budget engine-level denies, empty cascade) — absent, never a
         // misleading id.
         let policy_doc_id: Option<&str> = eval.policy_doc_id.as_deref();
+
+        // AAASM-5100 / ADR-0018 items A+B — capture the finer 5-way runtime
+        // verdict and the per-decision latency onto the audit payload (the
+        // *source* the read-side `GET /agents/{id}/decisions` projection reads;
+        // its `verdict`/`latencyMs` were frozen nullable under AAASM-5086).
+        //
+        // Item A — verdict: derived alongside the proto `decision`, never
+        // replacing it. Written as a lowercase string because `RuntimeVerdict`
+        // lives in `aa-api` (which depends on `aa-gateway`, not the reverse);
+        // the read-side parses the string back into the enum.
+        //
+        // Item B — latency: `decision_latency_us` is measured with a MONOTONIC
+        // clock (`Instant::now()` / `.elapsed()`) around `engine.evaluate` only
+        // (see `evaluate_one`). For a held / approval-pending action this is the
+        // scanner's DECISION time, NOT the human approval wait — the wait happens
+        // later in `maybe_submit_approval`, outside this measurement window. All
+        // actions are measured (no sampling). Recorded in ms (floor via integer
+        // division; a sub-ms decision floors to 0), matching the read-side's
+        // `latencyMs`. `trace_id` is deliberately left to the existing
+        // (nullable) `trace_id` field — trace-id propagation is ADR-0018 item C,
+        // gated to Phase 2 and NOT implemented here.
+        let verdict = convert::runtime_verdict(response.decision, eval.narrowed);
+        let latency_ms: u64 = (response.decision_latency_us.max(0) as u64) / 1_000;
         let payload = match shadow {
             Some(s) => serde_json::json!({
                 "action_type": req.action_type,
                 "decision": response.decision,
+                "verdict": verdict,
+                "latency_ms": latency_ms,
                 "reason": &response.reason,
                 "policy_rule": &response.policy_rule,
                 "policy_doc_id": policy_doc_id,
@@ -971,6 +996,8 @@ impl PolicyServiceImpl {
             None => serde_json::json!({
                 "action_type": req.action_type,
                 "decision": response.decision,
+                "verdict": verdict,
+                "latency_ms": latency_ms,
                 "reason": &response.reason,
                 "policy_rule": &response.policy_rule,
                 "policy_doc_id": policy_doc_id,

--- a/aa-gateway/tests/service_convert_test.rs
+++ b/aa-gateway/tests/service_convert_test.rs
@@ -291,6 +291,7 @@ fn eval_result_with_credential_findings_returns_redact() {
         credential_findings: vec![aa_security::CredentialFinding::from_regex_match(0, 10)],
         deny_action: None,
         policy_doc_id: None,
+        narrowed: false,
     };
     let resp = eval_result_to_response(&eval, 77, "");
     assert_eq!(resp.decision, Decision::Redact as i32);


### PR DESCRIPTION
## Description

ADR-0018 decision-capture plan, **Phase 1 (items A + B only)** — authorised 2026-07-30. Populates the `verdict` and `latency_ms` fields that AAASM-5086 froze as nullable on the read-side contract. **Item C (trace_id propagation) is NOT implemented** — it stays gated as a separate Phase 2; `trace_id` remains `null` (with a test asserting so).

- **A — 5-way `RuntimeVerdict`:** the finer `allow / narrow / scrub / pending / deny` verdict is derived alongside the proto `Decision` and written onto the audit payload. `scrub` = the DLP layer rewrote the payload; `narrow` = a policy match scoped an otherwise-allowed action.
- **B — per-decision latency:** measured with a monotonic clock around policy evaluation and recorded as `latency_ms`.

### Key design note (differs from the ADR's literal derivation point — please review)
ADR-0018 A/B name `aa-runtime::RuntimeScanner` as the derivation point. In the actual code that scanner is a **DLP-scrub-only** stage and does **not** write the decision audit entry — the gateway's `policy_service::record_audit` does, from `check_action`'s `EvaluationResult`, and that is where the proto decision, the scrub signal, and the **monotonic `decision_latency_us`** already live. So verdict + latency are derived at the gateway `record_audit` boundary. This required **no proto `Decision` change and no tracing work**, staying strictly inside A/B.

- **Latency semantic guardrail:** `latency_ms` measures the **decision** time (around `engine.evaluate`), taken *before* any approval-queue wait — so a held/approval-pending action records the scanner's decision time, **not** the human approval wait. Test-locked.
- **`narrow` source:** added a minimal observational `narrowed: bool` on `EvaluationResult` (capability fell inside an in-force restricted allow-list). It is **metadata on an unchanged Allow — no enforcement decision changes.**
- **`verdict` on the wire:** written as a JSON string by the gateway (which can't name `aa-api`'s `RuntimeVerdict` type) and parsed back on the read-side.

**OpenAPI unchanged** — `RuntimeVerdict`/`AgentDecisionResponse` were already registered (frozen in AAASM-5086); regenerated spec is byte-identical, path count stays 80.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5100 (Phase 1; Phase 2 / trace_id tracked separately)

## Testing

- [x] Unit tests added / updated

9 commits, one test per commit: `verdict = scrub` (not allow), `verdict = narrow` (not deny), positive `latency_ms`, held-approval records decision latency not the wait, and `trace_id` stays null. Local gates on the three touched crates (`aa-runtime`/`aa-gateway`/`aa-api`): `cargo test` green (1 pre-existing Docker/Postgres testcontainer failure, no Docker in env), `clippy --all-targets` zero warnings, `fmt --check` clean. Full-workspace `--all-targets` couldn't link locally (disk); authoritative build runs in CI.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off — DCO optional/advisory here

🤖 Generated with [Claude Code](https://claude.com/claude-code)