### PR TITLE
[AAASM-5300] ✨ (aa-proxy): Adjudicate the protection probe so verify can pass on evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,11 +197,14 @@ dependencies = [
  "async-trait",
  "axum",
  "insta",
+ "rustls",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-rustls",
+ "uuid",
 ]
 
 [[package]]

--- a/aa-devtool-claude-code/Cargo.toml
+++ b/aa-devtool-claude-code/Cargo.toml
@@ -13,6 +13,20 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+# AAASM-5300: the shipped protection probe drives one real request down the
+# protected path — CONNECT through the proxy, then TLS against the MitM-issued
+# leaf, trusting only the certificate authority the install materialised. That
+# handshake *is* the AAASM-5276 condition-C1 measurement, so it cannot be
+# emulated with a plain HTTP client. `ring` mirrors the provider `aa-proxy`
+# selects, so the two ends of the handshake agree and no new crypto backend
+# enters the tree.
+rustls = { workspace = true, features = ["ring"] }
+tokio = { workspace = true, features = ["fs", "io-util", "net", "time"] }
+tokio-rustls = { workspace = true }
+# Correlation identifiers only: a v4 UUID's `simple` form is 32 lowercase hex
+# characters of OS entropy, which is exactly the opaque, payload-independent
+# identifier the probe protocol requires.
+uuid = { workspace = true, features = ["v4"] }
 
 [features]
 docker-integration = []

--- a/aa-devtool-claude-code/src/adjudicating_probe.rs
+++ b/aa-devtool-claude-code/src/adjudicating_probe.rs
@@ -315,12 +315,9 @@ async fn exchange(
             .await
             .map_err(|e| format!("the probe request to {host} could not be flushed ({e})"))?;
 
-        let mut buf = Vec::new();
-        tls.take(MAX_RESPONSE_BYTES as u64)
-            .read_to_end(&mut buf)
+        read_http_message(&mut tls)
             .await
-            .map_err(|e| format!("the response to the probe request to {host} could not be read ({e})"))?;
-        Ok(String::from_utf8_lossy(&buf).into_owned())
+            .map_err(|e| format!("the response to the probe request to {host} could not be read ({e})"))
     };
 
     match tokio::time::timeout(EXCHANGE_TIMEOUT, attempt).await {
@@ -330,6 +327,55 @@ async fn exchange(
             EXCHANGE_TIMEOUT.as_secs()
         )),
     }
+}
+
+/// Read one HTTP response: the head, then exactly the `Content-Length` bytes it
+/// declares, then stop.
+///
+/// Reading to end-of-stream instead would block on any peer that keeps the
+/// connection open — which every ordinary provider response does — and turn a
+/// perfectly legible "that was not an adjudication" into a timeout. The whole
+/// read stays bounded by [`MAX_RESPONSE_BYTES`]; a response with no
+/// `Content-Length` is read until the peer closes or the budget runs out.
+async fn read_http_message<S>(stream: &mut S) -> std::io::Result<String>
+where
+    S: tokio::io::AsyncRead + Unpin,
+{
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    let mut want: Option<usize> = None;
+    loop {
+        if let Some(total) = want {
+            if buf.len() >= total {
+                break;
+            }
+        }
+        if buf.len() >= MAX_RESPONSE_BYTES {
+            break;
+        }
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if want.is_none() {
+            if let Some(head_len) = find_head_end(&buf) {
+                let head = String::from_utf8_lossy(&buf[..head_len]).to_ascii_lowercase();
+                let body_len = head
+                    .lines()
+                    .find_map(|line| line.strip_prefix("content-length:"))
+                    .and_then(|v| v.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                want = Some(head_len.saturating_add(body_len));
+            }
+        }
+    }
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Index just past the blank line ending an HTTP head.
+fn find_head_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|i| i + 4)
 }
 
 /// The Anthropic Messages request the probe sends, shaped like the traffic the

--- a/aa-devtool-claude-code/src/adjudicating_probe.rs
+++ b/aa-devtool-claude-code/src/adjudicating_probe.rs
@@ -1,0 +1,564 @@
+//! The shipped protection probe: produce traffic on the protected path, and
+//! report only what the core adjudicated about it.
+//!
+//! # What makes this evidence rather than an inference
+//!
+//! [`UnadjudicatedProbe`](crate::probe::UnadjudicatedProbe) is honest and
+//! useless: a client on the **near** side of the proxy sees its request go out
+//! and nothing obviously fail, and neither fact says what the provider would
+//! have received. This probe does not try to infer it. It marks its own request
+//! with an opaque correlation identifier, and the proxy — the component that
+//! runs the scanner and constructs the bytes that would leave the machine —
+//! answers with the verdict for *that* request, including a re-inspection of the
+//! payload it resolved to forward. `Redacted` is reported only when the proxy
+//! says it scrubbed the body **and** that the scrubbed bytes carry no
+//! credential.
+//!
+//! # Why two exchanges
+//!
+//! The adjudication request carries a synthetic credential on purpose. A proxy
+//! that does not speak the probe protocol would forward that body to the real
+//! provider — measuring the deployment by leaking to it. So the probe first
+//! sends a **preflight** whose body carries nothing sensitive and whose only job
+//! is to prove that the thing on the other end adjudicates and answers. Only
+//! after that does the second exchange carry the secret. Every failure of the
+//! first exchange ends the run before anything sensitive is written to a socket.
+//!
+//! # Why it cannot read anyone else's verdict
+//!
+//! There is no verdict store and no query. A verdict arrives only as the
+//! response to the request that produced it, on the probe's own TLS connection,
+//! and is accepted only when it echoes the identifier this run minted. The probe
+//! gains no audit read of any kind.
+//!
+//! # Fail-closed, everywhere
+//!
+//! Unreachable proxy, unreadable trust material, a refused tunnel, an untrusted
+//! MitM certificate, a peer that does not answer with an adjudication, a verdict
+//! for a different request, a timeout — every one of them is
+//! [`Inconclusive`](aa_devtool_contract::ExerciseOutcome::Inconclusive). "Cannot
+//! tell" is never rendered as "fine".
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_devtool_contract::ExerciseOutcome;
+use async_trait::async_trait;
+use rustls::pki_types::pem::PemObject as _;
+use rustls::pki_types::{CertificateDer, ServerName};
+use rustls::{ClientConfig, RootCertStore};
+use serde::Deserialize;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+
+use crate::probe::{ProbeReport, ProbeRequest, ProtectionProbe};
+
+/// Header the probe marks its own request with. Mirrors
+/// `aa_proxy::probe_adjudication::PROBE_CORRELATION_HEADER`.
+pub const PROBE_CORRELATION_HEADER: &str = "x-agent-assembly-probe";
+
+/// Schema tag the probe requires on an adjudication. Mirrors
+/// `aa_proxy::probe_adjudication::PROBE_ADJUDICATION_SCHEMA`.
+pub const PROBE_ADJUDICATION_SCHEMA: &str = "agent-assembly.probe-adjudication/1";
+
+/// Ceiling on one CONNECT + TLS + request/response exchange.
+const EXCHANGE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Ceiling on the adjudication document the probe will read.
+const MAX_RESPONSE_BYTES: usize = 64 * 1024;
+
+/// The probe the product ships for Claude Code.
+///
+/// Stateless: every run mints fresh correlation identifiers and holds nothing
+/// between runs.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProxyAdjudicatedProbe;
+
+#[async_trait]
+impl ProtectionProbe for ProxyAdjudicatedProbe {
+    async fn run(&self, request: &ProbeRequest) -> ProbeReport {
+        let Some(addr) = proxy_addr(&request.proxy_url) else {
+            return inconclusive(format!(
+                "the receipted proxy endpoint {} is not an address this probe can dial, so nothing \
+                 was exercised",
+                request.proxy_url
+            ));
+        };
+        let config = match client_trusting_pem(&request.ca_pem).await {
+            Ok(config) => Arc::new(config),
+            Err(reason) => {
+                return inconclusive(format!(
+                    "the trust material at {} could not be read ({reason}), so the model path was \
+                     never exercised",
+                    request.ca_pem.display()
+                ))
+            }
+        };
+
+        // Exchange 1 — capability preflight. Nothing sensitive is in this body,
+        // and nothing sensitive is sent at all unless it comes back adjudicated.
+        let preflight_id = correlation_id();
+        let preflight = exchange(
+            addr,
+            Arc::clone(&config),
+            &request.target_host,
+            &preflight_id,
+            "agent assembly protection probe: capability preflight, no credential in this body",
+        )
+        .await;
+        if let Err(reason) = preflight
+            .and_then(|raw| adjudication_for(&preflight_id, &raw).map_err(|e| e.into_reason(&request.proxy_url)))
+        {
+            return inconclusive(format!(
+                "{reason}; the probe therefore sent nothing down the {} path and cannot report on it",
+                request.target_host
+            ));
+        }
+
+        // Exchange 2 — the adjudicated one.
+        let id = correlation_id();
+        let raw = match exchange(
+            addr,
+            Arc::clone(&config),
+            &request.target_host,
+            &id,
+            &format!(
+                "agent assembly protection probe: please audit this synthetic credential: {}",
+                request.synthetic_secret
+            ),
+        )
+        .await
+        {
+            Ok(raw) => raw,
+            Err(reason) => return inconclusive(reason),
+        };
+        match adjudication_for(&id, &raw) {
+            Ok(adjudication) => report_for(&adjudication, &request.target_host),
+            Err(e) => inconclusive(e.into_reason(&request.proxy_url)),
+        }
+    }
+}
+
+/// The adjudication document, as the probe reads it.
+///
+/// Deliberately a **mirror** of `aa_proxy::probe_adjudication::ProbeAdjudication`
+/// rather than the type itself: `aa-proxy` depends (transitively) on this crate,
+/// so the dependency cannot be reversed. `decision` and `forwarded_payload` stay
+/// `String` so a token this build does not know is inconclusive rather than a
+/// deserialization error that reads the same as an unreachable proxy. A
+/// cross-crate conformance test pins the two shapes together.
+#[derive(Debug, Clone, Deserialize)]
+struct Adjudication {
+    schema: String,
+    correlation_id: String,
+    decision: String,
+    findings: usize,
+    forwarded_payload: String,
+}
+
+/// Why a response was not usable as evidence about this probe's request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NotEvidence {
+    /// The peer answered, but not with an adjudication.
+    NotAnAdjudication,
+    /// The peer adjudicated a *different* request.
+    ForAnotherRequest,
+}
+
+impl NotEvidence {
+    fn into_reason(self, proxy_url: &str) -> String {
+        match self {
+            Self::NotAnAdjudication => format!(
+                "the endpoint at {proxy_url} did not answer with a protection adjudication, so no \
+                 component reported what it did with the probe traffic"
+            ),
+            Self::ForAnotherRequest => format!(
+                "the endpoint at {proxy_url} answered with an adjudication of a different request; a \
+                 verdict the probe did not produce is not evidence about the probe"
+            ),
+        }
+    }
+}
+
+/// The adjudication in `response`, when it is one and when it is *this* run's.
+///
+/// The correlation check is the reason a probe cannot pass on someone else's
+/// verdict, and is the only thing binding the returned document to the request
+/// this probe sent.
+fn adjudication_for(expected_id: &str, response: &str) -> Result<Adjudication, NotEvidence> {
+    let body = response.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or(response);
+    let adjudication: Adjudication = serde_json::from_str(body.trim()).map_err(|_| NotEvidence::NotAnAdjudication)?;
+    if adjudication.schema != PROBE_ADJUDICATION_SCHEMA {
+        return Err(NotEvidence::NotAnAdjudication);
+    }
+    if adjudication.correlation_id != expected_id {
+        return Err(NotEvidence::ForAnotherRequest);
+    }
+    Ok(adjudication)
+}
+
+/// What an adjudication means for the protection ladder.
+///
+/// `forwarded_redacted` is protective **only** with a clean re-inspection of the
+/// forwarded bytes: a proxy that decided to redact and produced a payload still
+/// carrying the credential protected nothing, and a proxy with no scanner cannot
+/// say what it produced.
+fn report_for(adjudication: &Adjudication, host: &str) -> ProbeReport {
+    let findings = adjudication.findings;
+    match adjudication.decision.as_str() {
+        "blocked" => ProbeReport {
+            outcome: ExerciseOutcome::Blocked,
+            detail: format!(
+                "the core refused the probe request to {host} on {findings} credential finding(s); \
+                 nothing was forwarded"
+            ),
+        },
+        "forwarded_redacted" => match adjudication.forwarded_payload.as_str() {
+            "clean" => ProbeReport {
+                outcome: ExerciseOutcome::Redacted,
+                detail: format!(
+                    "the core redacted {findings} credential finding(s) from the probe request to \
+                     {host}, and re-inspection of the bytes it resolved to forward found none"
+                ),
+            },
+            other => ProbeReport {
+                outcome: ExerciseOutcome::Leaked,
+                detail: format!(
+                    "the core redacted the probe request to {host}, but the payload it resolved to \
+                     forward was reported as `{other}` rather than clean"
+                ),
+            },
+        },
+        "alerted_and_forwarded" => ProbeReport {
+            outcome: ExerciseOutcome::ObservedOnly,
+            detail: format!(
+                "the core recorded {findings} credential finding(s) on the probe request to {host} \
+                 and would have forwarded the payload unmodified; observing is not protecting"
+            ),
+        },
+        "forwarded" => ProbeReport {
+            outcome: ExerciseOutcome::Leaked,
+            detail: format!(
+                "the core would have forwarded the probe request to {host} unmodified, so the \
+                 synthetic credential the probe planted was not acted on"
+            ),
+        },
+        other => inconclusive(format!(
+            "the core reported a decision this build cannot read (`{other}`), so the probe traffic \
+             is unadjudicated as far as this client is concerned"
+        )),
+    }
+}
+
+/// One CONNECT + TLS + request/response against the proxy, returning the raw
+/// response text.
+///
+/// Every failure is returned as a user-facing reason rather than an error type:
+/// the caller's only response to any of them is the same inconclusive report.
+async fn exchange(
+    proxy: SocketAddr,
+    config: Arc<ClientConfig>,
+    host: &str,
+    correlation_id: &str,
+    text: &str,
+) -> Result<String, String> {
+    let attempt = async {
+        let mut tcp = TcpStream::connect(proxy)
+            .await
+            .map_err(|e| format!("the Agent Assembly proxy at {proxy} is not accepting connections ({e})"))?;
+        let target = format!("{host}:443");
+        tcp.write_all(format!("CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n").as_bytes())
+            .await
+            .map_err(|e| format!("the tunnel request to {proxy} could not be written ({e})"))?;
+
+        let mut reader = BufReader::new(tcp);
+        let mut status = String::new();
+        reader
+            .read_line(&mut status)
+            .await
+            .map_err(|e| format!("the proxy at {proxy} closed before answering the tunnel request ({e})"))?;
+        loop {
+            let mut header = String::new();
+            let n = reader
+                .read_line(&mut header)
+                .await
+                .map_err(|e| format!("the proxy at {proxy} closed mid-response ({e})"))?;
+            if n == 0 || header.trim().is_empty() {
+                break;
+            }
+        }
+        if !status.contains("200") {
+            return Err(format!(
+                "the proxy refused the tunnel to {host} ({}), so no traffic was adjudicated",
+                status.trim()
+            ));
+        }
+
+        let server_name = ServerName::try_from(host.to_owned())
+            .map_err(|e| format!("{host} is not a name this probe can request a certificate for ({e})"))?;
+        let mut tls = TlsConnector::from(config)
+            .connect(server_name, reader.into_inner())
+            .await
+            .map_err(|e| {
+                format!(
+                    "the intercepting proxy's certificate for {host} was not trusted ({e}), so the \
+                     model path was never inspected"
+                )
+            })?;
+
+        tls.write_all(request_bytes(host, correlation_id, text).as_bytes())
+            .await
+            .map_err(|e| format!("the probe request to {host} could not be written ({e})"))?;
+        tls.flush()
+            .await
+            .map_err(|e| format!("the probe request to {host} could not be flushed ({e})"))?;
+
+        let mut buf = Vec::new();
+        tls.take(MAX_RESPONSE_BYTES as u64)
+            .read_to_end(&mut buf)
+            .await
+            .map_err(|e| format!("the response to the probe request to {host} could not be read ({e})"))?;
+        Ok(String::from_utf8_lossy(&buf).into_owned())
+    };
+
+    match tokio::time::timeout(EXCHANGE_TIMEOUT, attempt).await {
+        Ok(result) => result,
+        Err(_) => Err(format!(
+            "the probe exchange with {proxy} did not complete within {}s, so nothing was adjudicated",
+            EXCHANGE_TIMEOUT.as_secs()
+        )),
+    }
+}
+
+/// The Anthropic Messages request the probe sends, shaped like the traffic the
+/// tool produces so the proxy's pattern detection, extraction and scanner all
+/// see production-shaped bytes.
+fn request_bytes(host: &str, correlation_id: &str, text: &str) -> String {
+    let body = serde_json::json!({
+        "model": "claude-sonnet-4-5",
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": text}]}],
+    })
+    .to_string();
+    format!(
+        "POST /v1/messages HTTP/1.1\r\nHost: {host}\r\nContent-Type: application/json\r\n\
+         anthropic-version: 2023-06-01\r\n{PROBE_CORRELATION_HEADER}: {correlation_id}\r\n\
+         Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    )
+}
+
+/// A fresh opaque correlation identifier: 32 lowercase hex characters of OS
+/// entropy, generated here and derived from nothing about the payload.
+fn correlation_id() -> String {
+    uuid::Uuid::new_v4().simple().to_string()
+}
+
+fn inconclusive(detail: impl Into<String>) -> ProbeReport {
+    ProbeReport {
+        outcome: ExerciseOutcome::Inconclusive,
+        detail: detail.into(),
+    }
+}
+
+/// The address behind a `http://host:port` proxy URL.
+fn proxy_addr(url: &str) -> Option<SocketAddr> {
+    url.strip_prefix("http://")
+        .unwrap_or(url)
+        .trim_end_matches('/')
+        .parse()
+        .ok()
+}
+
+/// A rustls client trusting exactly the certificate authority the install
+/// materialised — and nothing else, not even the host's own root store.
+///
+/// That narrowness is the point: this handshake is the condition-C1
+/// measurement, so it must fail when the PEM is not the authority the proxy is
+/// presenting leaves from. The crypto provider is passed explicitly rather than
+/// installed process-wide, because a library has no business deciding a
+/// process-global default for its host.
+async fn client_trusting_pem(pem_path: &std::path::Path) -> Result<ClientConfig, String> {
+    let pem = tokio::fs::read(pem_path).await.map_err(|e| e.to_string())?;
+    let certs = CertificateDer::pem_slice_iter(&pem)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    if certs.is_empty() {
+        return Err("it contains no certificate".to_owned());
+    }
+    let mut roots = RootCertStore::empty();
+    for cert in certs {
+        roots.add(cert).map_err(|e| e.to_string())?;
+    }
+    let config = ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+        .with_safe_default_protocol_versions()
+        .map_err(|e| e.to_string())?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::probe::SYNTHETIC_SECRET;
+
+    const ID: &str = "0123456789abcdef0123456789abcdef";
+    const OTHER_ID: &str = "fedcba9876543210fedcba9876543210";
+
+    fn wire(id: &str, decision: &str, payload: &str) -> String {
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n\
+             {{\"schema\":\"{PROBE_ADJUDICATION_SCHEMA}\",\"correlation_id\":\"{id}\",\
+             \"decision\":\"{decision}\",\"findings\":1,\"forwarded_payload\":\"{payload}\"}}"
+        )
+    }
+
+    #[test]
+    fn correlation_ids_are_opaque_fresh_and_not_derived_from_anything() {
+        let a = correlation_id();
+        let b = correlation_id();
+        assert_ne!(a, b, "every run must mint a fresh identifier");
+        assert_eq!(a.len(), 32);
+        assert!(a.bytes().all(|c| c.is_ascii_digit() || (b'a'..=b'f').contains(&c)));
+        assert!(
+            !SYNTHETIC_SECRET.contains(&a) && !a.contains(&SYNTHETIC_SECRET[..8]),
+            "the identifier must not be derived from the payload"
+        );
+    }
+
+    /// The load-bearing guard: a verdict this probe did not produce is not
+    /// evidence about this probe, however protective it reads.
+    #[test]
+    fn a_verdict_for_another_request_is_not_evidence() {
+        let err = adjudication_for(ID, &wire(OTHER_ID, "blocked", "not_forwarded"))
+            .expect_err("an adjudication of another request must be refused");
+        assert_eq!(err, NotEvidence::ForAnotherRequest);
+        let report = inconclusive(err.into_reason("http://127.0.0.1:8899"));
+        assert!(!report.outcome.is_protective());
+        assert!(report.detail.contains("different request"), "{}", report.detail);
+    }
+
+    /// The other load-bearing guard: with no adjudication in hand there is
+    /// nothing to pass on.
+    #[test]
+    fn a_response_that_is_not_an_adjudication_cannot_pass() {
+        for response in [
+            "HTTP/1.1 200 OK\r\n\r\n{\"id\":\"msg_1\",\"content\":[{\"text\":\"hello\"}]}",
+            "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n",
+            "",
+            "HTTP/1.1 200 OK\r\n\r\n{\"schema\":\"something.else/1\",\"correlation_id\":\"0123456789abcdef0123456789abcdef\",\"decision\":\"blocked\",\"findings\":1,\"forwarded_payload\":\"not_forwarded\"}",
+        ] {
+            let err = adjudication_for(ID, response).expect_err("must not be read as evidence: {response}");
+            assert_eq!(err, NotEvidence::NotAnAdjudication, "{response}");
+        }
+    }
+
+    #[test]
+    fn a_block_is_protective() {
+        let a = adjudication_for(ID, &wire(ID, "blocked", "not_forwarded")).expect("adjudicated");
+        let report = report_for(&a, "api.anthropic.com");
+        assert_eq!(report.outcome, ExerciseOutcome::Blocked);
+        assert!(report.outcome.is_protective());
+    }
+
+    #[test]
+    fn a_redaction_is_protective_only_when_the_forwarded_bytes_were_clean() {
+        let clean = adjudication_for(ID, &wire(ID, "forwarded_redacted", "clean")).expect("adjudicated");
+        assert_eq!(
+            report_for(&clean, "api.anthropic.com").outcome,
+            ExerciseOutcome::Redacted
+        );
+
+        for payload in ["carries_credential", "not_inspected", "not_forwarded"] {
+            let dirty = adjudication_for(ID, &wire(ID, "forwarded_redacted", payload)).expect("adjudicated");
+            let report = report_for(&dirty, "api.anthropic.com");
+            assert!(
+                !report.outcome.is_protective(),
+                "`{payload}` must not read as protection: {report:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn observing_is_not_protecting_and_forwarding_is_a_leak() {
+        let observed = adjudication_for(ID, &wire(ID, "alerted_and_forwarded", "carries_credential")).expect("ok");
+        assert_eq!(
+            report_for(&observed, "api.anthropic.com").outcome,
+            ExerciseOutcome::ObservedOnly
+        );
+
+        let forwarded = adjudication_for(ID, &wire(ID, "forwarded", "carries_credential")).expect("ok");
+        assert_eq!(
+            report_for(&forwarded, "api.anthropic.com").outcome,
+            ExerciseOutcome::Leaked
+        );
+    }
+
+    /// A decision token from a newer core is not a licence to guess.
+    #[test]
+    fn an_unreadable_decision_is_inconclusive() {
+        let a = adjudication_for(ID, &wire(ID, "quarantined_for_review", "clean")).expect("adjudicated");
+        let report = report_for(&a, "api.anthropic.com");
+        assert_eq!(report.outcome, ExerciseOutcome::Inconclusive);
+    }
+
+    #[test]
+    fn no_report_this_probe_produces_may_carry_the_secret() {
+        let details = [
+            report_for(
+                &adjudication_for(ID, &wire(ID, "forwarded_redacted", "clean")).expect("ok"),
+                "api.anthropic.com",
+            )
+            .detail,
+            report_for(
+                &adjudication_for(ID, &wire(ID, "forwarded", "carries_credential")).expect("ok"),
+                "api.anthropic.com",
+            )
+            .detail,
+            NotEvidence::ForAnotherRequest.into_reason("http://127.0.0.1:8899"),
+            NotEvidence::NotAnAdjudication.into_reason("http://127.0.0.1:8899"),
+        ];
+        for detail in details {
+            assert!(
+                !detail.contains(SYNTHETIC_SECRET),
+                "SECURITY INVARIANT VIOLATED: {detail}"
+            );
+            assert!(!detail.contains("sk-ant-"), "{detail}");
+        }
+    }
+
+    /// The request the probe writes carries the correlation header and the
+    /// secret only in the body — never in the identifier and never in a header.
+    #[test]
+    fn the_correlation_header_never_carries_the_payload() {
+        let wire = request_bytes("api.anthropic.com", ID, &format!("audit this: {SYNTHETIC_SECRET}"));
+        let (head, body) = wire.split_once("\r\n\r\n").expect("head then body");
+        assert!(head.contains(&format!("{PROBE_CORRELATION_HEADER}: {ID}")));
+        assert!(!head.contains(SYNTHETIC_SECRET), "the head must not carry the secret");
+        assert!(body.contains(SYNTHETIC_SECRET), "the body is what gets adjudicated");
+    }
+
+    /// The preflight body is what the probe sends before it knows anything about
+    /// the peer, so it must be free of the credential.
+    #[test]
+    fn the_preflight_body_carries_no_credential() {
+        let wire = request_bytes(
+            "api.anthropic.com",
+            ID,
+            "agent assembly protection probe: capability preflight, no credential in this body",
+        );
+        assert!(!wire.contains("sk-ant-"), "{wire}");
+    }
+
+    #[test]
+    fn a_proxy_url_that_is_not_dialable_is_rejected() {
+        assert!(proxy_addr("http://127.0.0.1:8899").is_some());
+        assert!(proxy_addr("127.0.0.1:8899").is_some());
+        assert!(proxy_addr("http://proxy.internal:8899").is_none());
+        assert!(proxy_addr("").is_none());
+    }
+}

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -21,6 +21,7 @@
 mod apply;
 mod settings;
 
+pub mod adjudicating_probe;
 pub mod bypass;
 pub mod executor;
 pub mod launch_env;
@@ -28,6 +29,7 @@ pub mod lifecycle;
 pub mod probe;
 pub mod scope;
 
+pub use adjudicating_probe::ProxyAdjudicatedProbe;
 pub use executor::ClaudeCodeStepExecutor;
 pub use lifecycle::ClaudeCodeIntegration;
 pub use probe::{ProbeReport, ProbeRequest, ProtectionProbe};

--- a/aa-devtool-claude-code/src/lifecycle.rs
+++ b/aa-devtool-claude-code/src/lifecycle.rs
@@ -60,9 +60,10 @@ use aa_devtool_contract::{
 };
 use async_trait::async_trait;
 
+use crate::adjudicating_probe::ProxyAdjudicatedProbe;
 use crate::bypass::{self, BypassFinding, LaunchEnvironment};
 use crate::executor::ClaudeCodeStepExecutor;
-use crate::probe::{ProbeRequest, ProtectionProbe, UnadjudicatedProbe, SYNTHETIC_SECRET};
+use crate::probe::{ProbeRequest, ProtectionProbe, SYNTHETIC_SECRET};
 use crate::scope::{ClaudeCodePaths, ScopeError};
 use crate::{ClaudeCodeAdapter, MIN_VERSION};
 
@@ -142,7 +143,7 @@ impl Default for ClaudeCodeIntegration {
 
 impl ClaudeCodeIntegration {
     /// The production integration: roots from the environment, the real
-    /// detection path, and no adjudicating probe.
+    /// detection path, and the shipped adjudicating probe.
     pub fn new() -> Self {
         Self::with_paths(ClaudeCodePaths::from_env())
     }
@@ -155,7 +156,12 @@ impl ClaudeCodeIntegration {
             paths,
             adapter,
             proxy_url: default_proxy_url(),
-            probe: Arc::new(UnadjudicatedProbe),
+            // AAASM-5300: the shipped default adjudicates. It produces traffic on
+            // the protected path and reports only the verdict the proxy returns
+            // for that request, which is what makes `GatewayProtected`
+            // reachable at all — and it still reports `Inconclusive` on every
+            // path it cannot measure, so nothing passes on configuration alone.
+            probe: Arc::new(ProxyAdjudicatedProbe),
             freshness_window_secs: DEFAULT_FRESHNESS_WINDOW_SECS,
         }
     }
@@ -176,10 +182,13 @@ impl ClaudeCodeIntegration {
         self
     }
 
-    /// Supply a probe that can adjudicate what the provider received.
+    /// Replace the probe that adjudicates what became of the model-bound
+    /// traffic.
     ///
-    /// Without one, `verify` reports the model path as configured but never
-    /// exercised, and the protection level does not rise past `Integrated`.
+    /// The default is [`ProxyAdjudicatedProbe`]. A probe that cannot adjudicate
+    /// — [`UnadjudicatedProbe`](crate::probe::UnadjudicatedProbe) — makes
+    /// `verify` report the model path as configured but never exercised, and the
+    /// protection level does not rise past `Integrated`.
     #[must_use]
     pub fn with_probe(mut self, probe: Arc<dyn ProtectionProbe>) -> Self {
         self.probe = probe;

--- a/aa-devtool-claude-code/src/probe.rs
+++ b/aa-devtool-claude-code/src/probe.rs
@@ -13,13 +13,19 @@
 //! obviously failed would be exactly the vacuous pass the evidence model exists
 //! to prevent.
 //!
-//! So the probe is an injected capability. The default,
-//! [`UnadjudicatedProbe`], reports
+//! So the probe is an injected capability, and the trait below is the seam.
+//! The shipped default is
+//! [`ProxyAdjudicatedProbe`](crate::adjudicating_probe::ProxyAdjudicatedProbe)
+//! (AAASM-5300): it produces the traffic and then reads back the verdict the
+//! proxy — the component that constructs the forwarded bytes — returns for that
+//! exact request. That is what makes `GatewayProtected` reachable.
+//!
+//! [`UnadjudicatedProbe`] remains as the honest floor for any deployment with no
+//! adjudicating component in the path: it reports
 //! [`Inconclusive`](aa_devtool_contract::ExerciseOutcome::Inconclusive) with the
-//! reason — which is not protective, so `verify` does not pass and the level
-//! does not rise. A deployment that *can* observe the forwarded payload supplies
-//! a probe that adjudicates, and only then does `GatewayProtected` become
-//! reachable.
+//! reason, which is not protective, so `verify` does not pass and the level does
+//! not rise. It is also the guard the evidence model is pinned by — a build in
+//! which an unadjudicated probe starts passing has broken the rule, not fixed it.
 
 use std::path::PathBuf;
 
@@ -68,10 +74,12 @@ pub trait ProtectionProbe: Send + Sync {
     async fn run(&self, request: &ProbeRequest) -> ProbeReport;
 }
 
-/// The default probe: honest about what it cannot establish.
+/// The floor probe: honest about what it cannot establish.
 ///
 /// It produces no traffic, because producing traffic it cannot adjudicate would
-/// send a synthetic secret to a real provider for no evidential gain.
+/// send a synthetic secret to a real provider for no evidential gain. Supplied
+/// deliberately (via [`with_probe`](crate::ClaudeCodeIntegration::with_probe))
+/// where no component in the path can report on the forwarded payload.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct UnadjudicatedProbe;
 
@@ -106,8 +114,10 @@ mod tests {
         }
     }
 
+    /// The rule the whole evidence model rests on: a probe that adjudicated
+    /// nothing must never read as protection, whatever else changes around it.
     #[tokio::test]
-    async fn the_default_probe_is_never_protective() {
+    async fn an_unadjudicated_probe_must_not_pass() {
         let report = UnadjudicatedProbe.run(&request()).await;
         assert_eq!(report.outcome, ExerciseOutcome::Inconclusive);
         assert!(

--- a/aa-integration-tests/tests/conformance_claude_code.rs
+++ b/aa-integration-tests/tests/conformance_claude_code.rs
@@ -46,6 +46,7 @@
 //! | 11.10 observe-only is never protection | [`observe_only_forwards_the_secret_and_never_claims_protection`] |
 //! | 11.11 unmanaged launch is a bypass | [`an_unmanaged_launch_is_unprotected_and_reported_as_a_bypass`] |
 //! | C1 CA trust is load-bearing | [`without_the_injected_certificate_authority_protection_cannot_pass`] |
+//! | AAASM-5300 adjudicated verification | [`the_shipped_probe_passes_verification_on_an_adjudicated_model_path`] |
 //!
 //! # Portability
 //!
@@ -73,9 +74,12 @@ mod spike_support;
 use std::time::Duration;
 
 use aa_core::integration::{
-    ExerciseOutcome, ProtectionLevel, ProtectionProfile, ProtectionState, SettingsScope, VerificationOutcome,
+    EvidenceKind, ExerciseOutcome, ProtectionLevel, ProtectionProfile, ProtectionState, SettingsScope,
+    VerificationOutcome,
 };
 use aa_devtool_claude_code::lifecycle::{CA_ENV_VAR, MANAGED_KEYS, STEP_NODE_EXTRA_CA_CERTS, STEP_PROXY_CA};
+use aa_devtool_claude_code::probe::ProtectionProbe as _;
+use aa_devtool_claude_code::ProxyAdjudicatedProbe;
 use aa_runtime::devint::IntegrationLifecycle;
 use conformance_support::{ConformanceHarness, SYNTHETIC_SECRET};
 use spike_support::proxy_harness::{drive_direct, drive_emulated_client};
@@ -1239,34 +1243,114 @@ async fn repair_restores_every_managed_key_and_touches_no_user_key() -> anyhow::
     Ok(())
 }
 
-// ── The known limitation, encoded deliberately ──────────────────────────────
+// ── What now observes the forwarded payload (AAASM-5300) ────────────────────
+//
+// AAASM-5283 shipped a scenario here named
+// `the_shipped_probe_cannot_pass_verification_and_the_cli_exits_six`. It
+// asserted that the shipped `UnadjudicatedProbe` reports `Inconclusive` on a
+// correctly installed integration, so `aasm integrations verify claude-code`
+// exits 6 for every real user, and it said in its own doc comment that when an
+// adjudicating probe landed this was the thing to update deliberately, "by
+// someone who has to state what now observes the forwarded payload".
+//
+// This is that update, and the answer is: **the proxy does**. It is the
+// component that runs the credential scanner and that constructs the bytes
+// which would leave the machine, so it — not a client on the near side — is the
+// authority on the forwarded payload. `ProxyAdjudicatedProbe` marks its own
+// request with an opaque correlation identifier, and the proxy answers on that
+// request's own connection with what it decided *and* with a re-inspection of
+// the payload it resolved to forward. Nothing is inferred from "the request went
+// out and nothing failed".
+//
+// The rule the old scenario protected is unchanged and is asserted below:
+// without an adjudicated verdict, verification still cannot pass and the CLI
+// still exits 6.
 
-/// `verify` cannot pass in production today, and that is correct-for-now.
-///
-/// The shipped [`UnadjudicatedProbe`] reports `Inconclusive` because a client on
-/// the near side of the proxy cannot see the forwarded body, and reporting
-/// `Redacted` without observing it is the vacuous pass the evidence model
-/// forbids. So `aasm integrations verify claude-code` exits **6**
-/// (`verification_failed`) on a correctly installed integration.
-///
-/// This test asserts that behaviour rather than asserting a green verify that
-/// does not exist. It fails if `verify` ever starts passing without adjudicated
-/// evidence — which is the point: when an adjudicating probe lands, this is the
-/// thing that gets updated deliberately, by someone who has to state what now
-/// observes the forwarded payload.
-///
-/// The CLI half is pinned by reading the shipped mapping, because
-/// `aa-integration-tests` cannot link `aa-cli`'s private exit module and a
-/// hard-coded `6` here would assert nothing about the binary.
+/// A correctly installed integration, exercised and adjudicated, now passes —
+/// and passes for the one reason the evidence model accepts.
 #[tokio::test(flavor = "multi_thread")]
-async fn the_shipped_probe_cannot_pass_verification_and_the_cli_exits_six() -> anyhow::Result<()> {
+async fn the_shipped_probe_passes_verification_on_an_adjudicated_model_path() -> anyhow::Result<()> {
+    let h = ConformanceHarness::start().await?;
+    h.write_settings("{}");
+    h.install(ProtectionProfile::Recommended).await?;
+
+    let result = h.verify_as_shipped().await?;
+    assert_eq!(
+        result.outcome,
+        VerificationOutcome::Passed,
+        "the shipped probe must now pass on an adjudicated model path: {:?}",
+        result.outcome
+    );
+
+    // The pass rests on exercised evidence with a protective outcome, and on
+    // nothing else. A `Passed` built from read-back evidence would be the
+    // vacuous pass this whole suite exists to rule out.
+    let exercised: Vec<&aa_core::integration::ProtectionEvidence> =
+        result.evidence.iter().filter(|e| e.kind.is_exercised()).collect();
+    assert!(
+        !exercised.is_empty(),
+        "a pass with nothing exercised is not a measurement"
+    );
+    assert!(
+        exercised.iter().any(|e| matches!(
+            e.kind,
+            EvidenceKind::Exercised {
+                outcome: ExerciseOutcome::Redacted
+            }
+        )),
+        "the protective outcome must be the adjudicated one: {exercised:?}"
+    );
+    // Stated in words a user reads: the claim names the re-inspection, not the
+    // absence of a failure.
+    assert!(
+        exercised
+            .iter()
+            .any(|e| e.detail.contains("re-inspection of the bytes it resolved to forward")),
+        "the evidence must say what observed the forwarded payload: {exercised:?}"
+    );
+
+    // And the ladder rises, which is the headline the Epic could not report.
+    let status = h.status().await?;
+    assert_eq!(
+        status.achieved_level(),
+        ProtectionLevel::GatewayProtected,
+        "adjudicated exercised evidence must reach GatewayProtected: {:?}",
+        status.state
+    );
+
+    // The CLI half, pinned by reading the shipped mapping: `aa-integration-tests`
+    // cannot link `aa-cli`'s private exit module, and a hard-coded `0` here would
+    // assert nothing about the binary.
+    let exit_source = conformance_support::read_repo_file("aa-cli/src/commands/integrations/exit.rs");
+    assert!(
+        exit_source.contains("Outcome::Success => 0"),
+        "a passing verification must still map to exit 0"
+    );
+    assert!(
+        exit_source.contains("Outcome::VerificationFailed => 6"),
+        "the failing exit code a user scripts against must not move"
+    );
+
+    // Nothing the run produced carries the value it was measuring.
+    conformance_support::assert_no_raw_secret(&h.persisted_surfaces(), SYNTHETIC_SECRET, "adjudicated verification");
+
+    h.finish("shipped probe passes on adjudicated evidence");
+    Ok(())
+}
+
+/// The guard the replaced scenario existed for, kept and kept load-bearing.
+///
+/// A probe that adjudicated nothing must never pass, however correctly the
+/// integration is installed. If this ever goes green with a protective outcome,
+/// the evidence model has been broken rather than improved.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unadjudicated_probe_still_cannot_pass_and_the_cli_still_exits_six() -> anyhow::Result<()> {
     use aa_devtool_claude_code::probe::{ProbeRequest, ProtectionProbe, UnadjudicatedProbe};
 
     let h = ConformanceHarness::start().await?;
     h.write_settings("{}");
     h.install(ProtectionProfile::Recommended).await?;
 
-    // The shipped default, run against a correctly installed integration.
     let report = UnadjudicatedProbe
         .run(&ProbeRequest {
             proxy_url: h.proxy.url(),
@@ -1275,11 +1359,7 @@ async fn the_shipped_probe_cannot_pass_verification_and_the_cli_exits_six() -> a
             synthetic_secret: SYNTHETIC_SECRET.to_string(),
         })
         .await;
-    assert_eq!(
-        report.outcome,
-        ExerciseOutcome::Inconclusive,
-        "the shipped probe must stay honest about what it cannot establish"
-    );
+    assert_eq!(report.outcome, ExerciseOutcome::Inconclusive);
     assert!(
         !report.outcome.is_protective(),
         "an unadjudicated outcome must never raise the ladder"
@@ -1290,17 +1370,195 @@ async fn the_shipped_probe_cannot_pass_verification_and_the_cli_exits_six() -> a
         report.detail
     );
 
-    // And the CLI still maps a non-passing verification to exit 6.
     let exit_source = conformance_support::read_repo_file("aa-cli/src/commands/integrations/exit.rs");
     assert!(
         exit_source.contains("Outcome::VerificationFailed => 6"),
-        "the exit code a user scripts against changed; if verification can now pass with \
-         adjudicated evidence, update this test deliberately and say what observes the \
-         forwarded payload"
+        "a verification that establishes nothing must still exit 6"
     );
 
-    h.finish("shipped probe cannot pass verification");
+    h.finish("an unadjudicated probe cannot pass");
     Ok(())
+}
+
+/// Condition C1, measured through the shipped probe: trust material that is not
+/// the authority the proxy issues from means the model path was never inspected.
+#[tokio::test(flavor = "multi_thread")]
+async fn without_a_trusted_certificate_authority_the_shipped_probe_is_inconclusive() -> anyhow::Result<()> {
+    let h = ConformanceHarness::start().await?;
+    h.write_settings("{}");
+    h.install(ProtectionProfile::Recommended).await?;
+
+    // A real, well-formed certificate authority that simply is not this proxy's.
+    // Only the trust material changes; the endpoint, the host and the payload are
+    // exactly the ones that pass above.
+    let foreign = tempfile::tempdir()?;
+    aa_proxy::tls::CaStore::load_or_create(foreign.path())
+        .await
+        .map_err(|e| anyhow::anyhow!("foreign certificate authority: {e}"))?;
+
+    let mut request = h.shipped_probe_request();
+    request.ca_pem = foreign.path().join("ca-cert.pem");
+    let report = ProxyAdjudicatedProbe.run(&request).await;
+
+    assert_eq!(
+        report.outcome,
+        ExerciseOutcome::Inconclusive,
+        "an untrusted MitM certificate cannot yield a protection claim: {}",
+        report.detail
+    );
+    assert!(
+        report.detail.contains("not trusted"),
+        "the reason must name the trust failure: {}",
+        report.detail
+    );
+    assert!(!report.detail.contains(SYNTHETIC_SECRET), "{}", report.detail);
+
+    h.finish("C1 through the shipped probe");
+    Ok(())
+}
+
+/// The core is not running, so there is nothing to adjudicate and nothing to
+/// claim. "Cannot tell" must not become "fine".
+#[tokio::test(flavor = "multi_thread")]
+async fn with_the_core_stopped_the_shipped_probe_is_inconclusive() -> anyhow::Result<()> {
+    let mut h = ConformanceHarness::start().await?;
+    h.write_settings("{}");
+    h.install(ProtectionProfile::Recommended).await?;
+    h.proxy.stop();
+
+    let report = ProxyAdjudicatedProbe.run(&h.shipped_probe_request()).await;
+    assert_eq!(
+        report.outcome,
+        ExerciseOutcome::Inconclusive,
+        "a stopped core must not leave a protection claim standing: {}",
+        report.detail
+    );
+
+    // And the whole verification, not just the probe, refuses to pass.
+    let result = h.verify_as_shipped().await?;
+    assert_ne!(result.outcome, VerificationOutcome::Passed, "{:?}", result.outcome);
+
+    h.finish("stopped core through the shipped probe");
+    Ok(())
+}
+
+/// A path no adjudicating component watches yields no claim — **and receives no
+/// secret**.
+///
+/// The proxy answers the probe protocol only on the model-path handler, so a
+/// request addressed elsewhere is treated as ordinary traffic and forwarded. The
+/// probe's capability preflight is what makes that safe: it carries nothing
+/// sensitive, and because it comes back un-adjudicated the run stops before the
+/// credential-bearing exchange is ever written to a socket. The provider's own
+/// capture set is the proof.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unwatched_path_is_inconclusive_and_never_receives_the_secret() -> anyhow::Result<()> {
+    let h = ConformanceHarness::start().await?;
+    h.write_settings("{}");
+    h.install(ProtectionProfile::Recommended).await?;
+
+    let mut request = h.shipped_probe_request();
+    request.target_host = "side-channel.example".to_string();
+    let before = h.upstream.request_count();
+    let report = ProxyAdjudicatedProbe.run(&request).await;
+
+    assert_eq!(
+        report.outcome,
+        ExerciseOutcome::Inconclusive,
+        "an unadjudicated exchange cannot establish protection: {}",
+        report.detail
+    );
+    assert!(
+        report.detail.contains("did not answer with a protection adjudication"),
+        "the reason must name the missing adjudication: {}",
+        report.detail
+    );
+
+    let bodies: Vec<Vec<u8>> = h.upstream.bodies().into_iter().skip(before).collect();
+    assert!(
+        !bodies.is_empty(),
+        "the preflight must actually have reached the provider, or this proves nothing"
+    );
+    assert!(
+        spike_support::find_secret(&bodies, SYNTHETIC_SECRET).is_none(),
+        "the preflight kept the credential off the wire; something sent it anyway"
+    );
+
+    h.finish("unwatched path through the shipped probe");
+    Ok(())
+}
+
+/// A verdict belongs to the request that produced it, and to no other.
+///
+/// Two exchanges are driven through the proxy with caller-chosen correlation
+/// identifiers and different payloads. Each reply carries its own identifier and
+/// its own decision: there is no surface through which one exchange can obtain
+/// the other's verdict, and holding an identifier you did not send buys nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_verdict_is_bound_to_the_request_that_produced_it() -> anyhow::Result<()> {
+    let h = ConformanceHarness::start().await?;
+    h.write_settings("{}");
+    h.install(ProtectionProfile::Recommended).await?;
+
+    let addr: std::net::SocketAddr = h.proxy.url().trim_start_matches("http://").parse()?;
+    let ca = h.ca_pem_path();
+    const MINE: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const THEIRS: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    let mine = conformance_support::probe::raw_probe_exchange(
+        addr,
+        &ca,
+        MINE,
+        &format!("please audit this credential: {SYNTHETIC_SECRET}"),
+    )
+    .await?;
+    let theirs =
+        conformance_support::probe::raw_probe_exchange(addr, &ca, THEIRS, "nothing sensitive in this body").await?;
+
+    assert!(
+        mine.contains(MINE),
+        "the reply must echo the caller's identifier: {mine}"
+    );
+    assert!(
+        !mine.contains(THEIRS),
+        "one exchange must not be told about another: {mine}"
+    );
+    assert!(theirs.contains(THEIRS), "{theirs}");
+    assert!(!theirs.contains(MINE), "{theirs}");
+
+    // The two verdicts are genuinely different, so "bound to its own request" is
+    // a distinction and not a coincidence of identical answers.
+    assert!(
+        mine.contains("\"decision\":\"forwarded_redacted\""),
+        "the credential-bearing exchange must be adjudicated as redacted: {mine}"
+    );
+    assert!(
+        theirs.contains("\"decision\":\"forwarded\""),
+        "the clean exchange must be adjudicated as clean: {theirs}"
+    );
+
+    // The reply is an outcome vocabulary and an opaque identifier — never the
+    // payload it adjudicated.
+    assert!(!mine.contains(SYNTHETIC_SECRET), "SECURITY INVARIANT VIOLATED: {mine}");
+    assert!(!mine.contains("sk-ant-"), "{mine}");
+
+    h.finish("a verdict is bound to its own request");
+    Ok(())
+}
+
+/// The two ends of the correlation path are separate crates — `aa-proxy` cannot
+/// depend on the adapter, because the adapter is (transitively) its dependency —
+/// so the wire contract is pinned here, where both are linkable.
+#[test]
+fn the_probe_and_the_proxy_agree_on_the_correlation_contract() {
+    assert_eq!(
+        aa_devtool_claude_code::adjudicating_probe::PROBE_CORRELATION_HEADER,
+        aa_proxy::probe_adjudication::PROBE_CORRELATION_HEADER,
+    );
+    assert_eq!(
+        aa_devtool_claude_code::adjudicating_probe::PROBE_ADJUDICATION_SCHEMA,
+        aa_proxy::probe_adjudication::PROBE_ADJUDICATION_SCHEMA,
+    );
 }
 
 // ── The optional real-tool lane ─────────────────────────────────────────────

--- a/aa-integration-tests/tests/conformance_support/harness.rs
+++ b/aa-integration-tests/tests/conformance_support/harness.rs
@@ -34,6 +34,7 @@ use aa_core::integration::{
     RemovalPlan, SettingsScope, VerificationResult,
 };
 use aa_core::DevToolKind;
+use aa_devtool_claude_code::probe::{ProbeRequest, SYNTHETIC_SECRET};
 use aa_devtool_claude_code::{ClaudeCodeAdapter, ClaudeCodeIntegration, ClaudeCodePaths};
 use aa_proxy::audit_jsonl::ProxyAuditEntry;
 use aa_proxy::config::CredentialAction;
@@ -96,6 +97,7 @@ pub struct ConformanceHarness {
     /// Receipts on disk, for the tamper scenario.
     pub store: ReceiptStore,
     ca_trust: Arc<AtomicBool>,
+    tool_version: String,
     guard: RealHomeGuard,
 }
 
@@ -168,6 +170,7 @@ impl ConformanceHarness {
             proxy,
             store,
             ca_trust,
+            tool_version: options.tool_version,
             guard,
         })
     }
@@ -194,6 +197,47 @@ impl ConformanceHarness {
             Arc::new(probe),
             &self.store,
         )
+    }
+
+    /// A second lifecycle service over the *same* installation, driven by the
+    /// **shipped** probe instead of the harness's.
+    ///
+    /// [`AdjudicatingProbe`] adjudicates by reading the mock provider the
+    /// harness owns — an instrument no developer has. This service runs exactly
+    /// what `aasm integrations verify claude-code` runs on a real host, so an
+    /// outcome measured through it is a statement about the product rather than
+    /// about the harness.
+    pub fn service_with_shipped_probe(&self) -> EngineLifecycle {
+        let integration = Arc::new(
+            ClaudeCodeIntegration::with_paths(self.paths.clone())
+                .with_adapter(
+                    ClaudeCodeAdapter::with_overrides(Some(self.stub_binary.clone()), Some(self.home.clone()))
+                        .with_version_override(Some(self.tool_version.clone())),
+                )
+                .through_proxy(self.proxy.url()),
+        );
+        EngineLifecycle::new(vec![claude_code_registration(integration)], self.store.clone())
+    }
+
+    /// Verify through the shipped probe.
+    pub async fn verify_as_shipped(&self) -> anyhow::Result<VerificationResult> {
+        self.service_with_shipped_probe()
+            .verify(&self.tool())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// The probe request a shipped probe is handed for this installation.
+    ///
+    /// Scenarios that turn one condition (an untrusted authority, a stopped
+    /// core) build from this so nothing else about the run differs.
+    pub fn shipped_probe_request(&self) -> ProbeRequest {
+        ProbeRequest {
+            proxy_url: self.proxy.url(),
+            ca_pem: self.ca_pem_path(),
+            target_host: ANTHROPIC_HOST.to_string(),
+            synthetic_secret: SYNTHETIC_SECRET.to_string(),
+        }
     }
 
     /// The tool every operation names.

--- a/aa-integration-tests/tests/conformance_support/probe.rs
+++ b/aa-integration-tests/tests/conformance_support/probe.rs
@@ -27,10 +27,10 @@ use aa_devtool_claude_code::probe::{ProbeReport, ProbeRequest, ProtectionProbe};
 use aa_devtool_contract::ExerciseOutcome;
 use async_trait::async_trait;
 use base64::Engine as _;
-use rustls::pki_types::CertificateDer;
+use rustls::pki_types::{CertificateDer, ServerName};
 use rustls::{ClientConfig, RootCertStore};
 
-use crate::spike_support::proxy_harness::drive_emulated_client;
+use crate::spike_support::proxy_harness::{drive_emulated_client, ANTHROPIC_HOST};
 use crate::spike_support::{find_secret, TlsCapturingUpstream};
 
 /// A probe that reports what the provider actually received.
@@ -145,4 +145,67 @@ async fn client_trusting_pem(pem_path: &std::path::Path) -> anyhow::Result<Clien
     Ok(ClientConfig::builder()
         .with_root_certificates(roots)
         .with_no_client_auth())
+}
+
+// ── Raw probe-protocol exchange (AAASM-5300) ────────────────────────────────
+
+/// Drive one raw probe-protocol exchange through the proxy, with a
+/// caller-chosen correlation identifier, and return the response text.
+///
+/// The shipped probe mints its own identifier and never discloses it, so this
+/// is how a scenario observes the *binding* the probe depends on: that the
+/// verdict the proxy answers with is the verdict for the request that carried
+/// that identifier, and for no other.
+pub async fn raw_probe_exchange(
+    proxy: SocketAddr,
+    ca_pem: &std::path::Path,
+    correlation_id: &str,
+    text: &str,
+) -> anyhow::Result<String> {
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::TcpStream;
+
+    let config = client_trusting_pem(ca_pem).await?;
+    let target = format!("{ANTHROPIC_HOST}:443");
+    let mut tcp = TcpStream::connect(proxy).await?;
+    tcp.write_all(format!("CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n").as_bytes())
+        .await?;
+    let mut reader = BufReader::new(tcp);
+    let mut status = String::new();
+    reader.read_line(&mut status).await?;
+    loop {
+        let mut header = String::new();
+        let n = reader.read_line(&mut header).await?;
+        if n == 0 || header.trim().is_empty() {
+            break;
+        }
+    }
+    anyhow::ensure!(
+        status.contains("200"),
+        "the proxy refused the tunnel: {}",
+        status.trim()
+    );
+
+    let server_name = ServerName::try_from(ANTHROPIC_HOST.to_owned())?;
+    let mut tls = tokio_rustls::TlsConnector::from(Arc::new(config))
+        .connect(server_name, reader.into_inner())
+        .await?;
+    let body = serde_json::json!({
+        "model": "claude-sonnet-4-5",
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": text}]}],
+    })
+    .to_string();
+    let request = format!(
+        "POST /v1/messages HTTP/1.1\r\nHost: {ANTHROPIC_HOST}\r\nContent-Type: application/json\r\n\
+         anthropic-version: 2023-06-01\r\n{}: {correlation_id}\r\nContent-Length: {}\r\n\
+         Connection: close\r\n\r\n{body}",
+        aa_proxy::probe_adjudication::PROBE_CORRELATION_HEADER,
+        body.len(),
+    );
+    tls.write_all(request.as_bytes()).await?;
+    tls.flush().await?;
+    let mut buf = Vec::new();
+    tls.read_to_end(&mut buf).await?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
 }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -231,6 +231,22 @@ impl Interceptor {
         }
     }
 
+    /// Re-inspect the bytes the data path resolved to forward, reporting
+    /// whether they are free of credentials.
+    ///
+    /// Returns `None` when scanning is disabled — the honest answer is then
+    /// "this proxy cannot say", and a caller must not read that as clean.
+    ///
+    /// Exists for the protection-probe reply (AAASM-5300), which has to state a
+    /// fact about the *payload* rather than about the decision: a proxy that
+    /// decided to redact but produced bytes still carrying a credential must not
+    /// read as protection. The ordinary data path has no need to re-scan what it
+    /// just produced.
+    pub fn forwarded_payload_is_clean(&self, bytes: &[u8]) -> Option<bool> {
+        let scanner = self.scanner.as_ref()?;
+        Some(scanner.scan(&String::from_utf8_lossy(bytes)).is_clean())
+    }
+
     /// Redact any credentials embedded in a request target (path + query
     /// string) so it can be persisted in an audit record without leaking a
     /// secret.
@@ -957,6 +973,31 @@ mod tests {
         assert_eq!(verdict.decision, VerdictDecision::Block);
         assert!(!verdict.findings.is_empty());
         assert!(verdict.redacted_body.is_none());
+    }
+
+    // ── forwarded_payload_is_clean (AAASM-5300 probe reply) ─────────────────
+
+    #[test]
+    fn forwarded_payload_is_clean_reports_a_credential_bearing_payload() {
+        let interceptor = make_interceptor();
+        assert_eq!(interceptor.forwarded_payload_is_clean(CRED_BODY), Some(false));
+    }
+
+    #[test]
+    fn forwarded_payload_is_clean_reports_a_scrubbed_payload() {
+        let interceptor = make_interceptor();
+        let verdict = interceptor.intercept_request(CRED_BODY, None, CredentialAction::RedactOnly);
+        let redacted = verdict.redacted_body.expect("redact_only populates the body");
+        assert_eq!(interceptor.forwarded_payload_is_clean(&redacted), Some(true));
+    }
+
+    /// A disabled scanner must say "I cannot tell", never "clean" — a caller
+    /// that read `None` as clean would turn an uninspected payload into a pass.
+    #[test]
+    fn forwarded_payload_is_clean_says_nothing_without_a_scanner() {
+        let (tx, _rx) = broadcast::channel(16);
+        let interceptor = Interceptor::with_scanner(tx, None);
+        assert_eq!(interceptor.forwarded_payload_is_clean(CRED_BODY), None);
     }
 
     // ── redact_response_body ────────────────────────────────────────────────

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod hardening;
 pub mod intercept;
 pub mod mcp_enforce;
+pub mod probe_adjudication;
 pub mod proxy;
 pub mod ssrf;
 pub mod tls;

--- a/aa-proxy/src/probe_adjudication.rs
+++ b/aa-proxy/src/probe_adjudication.rs
@@ -1,0 +1,309 @@
+//! Telling a protection probe what this proxy did with the probe's own request.
+//!
+//! # Why the proxy has to be the one to answer
+//!
+//! A protection probe sits on the **near** side of the MitM. It can observe that
+//! its request went out and that nothing obviously failed, and neither fact is
+//! evidence: reporting protection from them is the vacuous pass the evidence
+//! model exists to prevent (ADR 0030 §4.1). The component that *does* know is
+//! this proxy — it runs [`Interceptor::intercept_request`](crate::intercept::Interceptor::intercept_request),
+//! it decides whether to block, redact or forward, and it constructs the exact
+//! bytes that would leave the machine. So the adjudication is reported from
+//! here, on the probe's own connection.
+//!
+//! # Why the reply, and not a queryable store
+//!
+//! A probe must learn the verdict for **its** request and gain nothing else. A
+//! store keyed by correlation id would need a read endpoint, a retention policy
+//! and an authorisation story, and would hand the probe a general-purpose audit
+//! read it has no business having. Answering in the response to the very request
+//! that was adjudicated makes "only its own verdict" structural: there is no
+//! surface to ask a second question through.
+//!
+//! # Why a probe request is never forwarded upstream
+//!
+//! A probe request carries a synthetic credential on purpose. Under a
+//! non-enforcing policy (`alert_only`, or a disabled scanner) the ordinary data
+//! path would forward that body to the real provider — measuring the deployment
+//! by leaking to it. Recognising the correlation header therefore *terminates*
+//! the request here: it is adjudicated exactly as a real request would be, and
+//! then answered instead of relayed. That can only ever withhold traffic, so an
+//! attacker who guesses the header buys themselves a refusal, not a bypass.
+//!
+//! # What the reply may carry
+//!
+//! An opaque correlation id the caller minted, the decision token, the number of
+//! findings, and a re-inspection verdict for the bytes the proxy resolved to
+//! forward. No body, no target, no host, no finding value — nothing a reader
+//! could use to recover the payload.
+
+use serde::{Deserialize, Serialize};
+
+use crate::intercept::{InterceptVerdict, VerdictDecision};
+
+/// Request header a protection probe marks its own traffic with.
+///
+/// The value is the probe's correlation id; see [`ProbeCorrelation`].
+pub const PROBE_CORRELATION_HEADER: &str = "x-agent-assembly-probe";
+
+/// Schema tag on the reply, so a probe can tell an adjudication from any other
+/// JSON a server might answer with.
+pub const PROBE_ADJUDICATION_SCHEMA: &str = "agent-assembly.probe-adjudication/1";
+
+/// An opaque, caller-minted correlation identifier.
+///
+/// Exactly 32 lowercase hex characters — the `simple` form of a v4 UUID, which
+/// is what the shipped probe mints. The grammar is enforced rather than assumed
+/// so a caller cannot smuggle arbitrary bytes into the reply (or the logs)
+/// through this field, and so a value that is *derived from the payload* is not
+/// silently accepted: a content hash is 64 hex characters and is rejected here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbeCorrelation(String);
+
+impl ProbeCorrelation {
+    /// Parse a header value, returning `None` when it is not the fixed grammar.
+    pub fn parse(raw: &str) -> Option<Self> {
+        let trimmed = raw.trim();
+        if trimmed.len() == 32
+            && trimmed
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        {
+            Some(Self(trimmed.to_owned()))
+        } else {
+            None
+        }
+    }
+
+    /// The identifier, as it will be echoed.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// What the proxy did with an adjudicated probe request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeDecision {
+    /// Refused: upstream was never dialled.
+    Blocked,
+    /// Findings replaced with redaction markers; the redacted bytes are what
+    /// would have been forwarded.
+    ForwardedRedacted,
+    /// Findings recorded and the body would have gone upstream unmodified
+    /// (`alert_only`).
+    AlertedAndForwarded,
+    /// No findings: the body would have gone upstream unmodified.
+    Forwarded,
+}
+
+/// A re-inspection of the exact bytes the proxy resolved to forward.
+///
+/// This is the half a near-side client cannot produce for itself, and it is
+/// deliberately about *bytes*, not about the decision: a proxy that decided to
+/// redact but produced a payload still carrying a credential must not read as
+/// protection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForwardedPayload {
+    /// There were no bytes to inspect — the request was refused.
+    NotForwarded,
+    /// Re-inspected and carrying no credential.
+    Clean,
+    /// Re-inspected and still carrying a credential.
+    CarriesCredential,
+    /// This proxy has no scanner configured, so it cannot say what the payload
+    /// carries. Never protective.
+    NotInspected,
+}
+
+/// The reply a probe request is answered with.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProbeAdjudication {
+    /// Always [`PROBE_ADJUDICATION_SCHEMA`].
+    pub schema: String,
+    /// The caller's correlation id, echoed verbatim.
+    pub correlation_id: String,
+    /// What the proxy did.
+    pub decision: ProbeDecision,
+    /// How many credential findings the scanner produced. A count, never a value.
+    pub findings: usize,
+    /// Re-inspection of the bytes that would have been forwarded.
+    pub forwarded_payload: ForwardedPayload,
+}
+
+impl ProbeAdjudication {
+    /// Adjudicate one probe request.
+    ///
+    /// `forwarded` is the payload re-inspection: `None` when the proxy has no
+    /// scanner and therefore cannot say. It is supplied by the caller because
+    /// only the data path knows which bytes it resolved to forward.
+    pub fn new(correlation: &ProbeCorrelation, verdict: &InterceptVerdict, forwarded: Option<bool>) -> Self {
+        let (decision, forwarded_payload) = match verdict.decision {
+            VerdictDecision::Block => (ProbeDecision::Blocked, ForwardedPayload::NotForwarded),
+            VerdictDecision::ForwardRedacted => (ProbeDecision::ForwardedRedacted, payload(forwarded)),
+            VerdictDecision::AlertAndForward => (ProbeDecision::AlertedAndForwarded, payload(forwarded)),
+            VerdictDecision::Forward => (ProbeDecision::Forwarded, payload(forwarded)),
+        };
+        Self {
+            schema: PROBE_ADJUDICATION_SCHEMA.to_owned(),
+            correlation_id: correlation.as_str().to_owned(),
+            decision,
+            findings: verdict.findings.len(),
+            forwarded_payload,
+        }
+    }
+
+    /// The complete HTTP/1.1 response carrying this adjudication.
+    ///
+    /// `Connection: close` because the probe request is terminated here: nothing
+    /// further may be pipelined onto a connection whose request never reached
+    /// upstream.
+    pub fn http_response(&self) -> Vec<u8> {
+        // Serialising a struct of owned `String`/enum/`usize` cannot fail; the
+        // fallback keeps the data path infallible rather than asserting it.
+        let body = serde_json::to_string(self).unwrap_or_else(|_| "{}".to_owned());
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n{PROBE_CORRELATION_HEADER}: {}\r\n\
+             Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            self.correlation_id,
+            body.len(),
+        )
+        .into_bytes()
+    }
+}
+
+fn payload(forwarded_is_clean: Option<bool>) -> ForwardedPayload {
+    match forwarded_is_clean {
+        Some(true) => ForwardedPayload::Clean,
+        Some(false) => ForwardedPayload::CarriesCredential,
+        None => ForwardedPayload::NotInspected,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use aa_security::CredentialScanner;
+    use bytes::Bytes;
+
+    /// A synthetic Anthropic-shaped key. Not a real credential.
+    const SECRET: &str = "sk-ant-api03-AAASM5300SYNTHETICDONOTUSE0000000000000000000000000000000000AA";
+
+    fn verdict(decision: VerdictDecision, findings: usize) -> InterceptVerdict {
+        let body = format!("carrying {SECRET} here");
+        let scan = CredentialScanner::new().scan(&body);
+        assert!(!scan.findings.is_empty(), "fixture invariant: the scanner matches");
+        InterceptVerdict {
+            decision,
+            findings: scan.findings.into_iter().take(findings).collect(),
+            redacted_body: Some(Bytes::from("redacted")),
+        }
+    }
+
+    fn correlation() -> ProbeCorrelation {
+        ProbeCorrelation::parse("0123456789abcdef0123456789abcdef").expect("valid id")
+    }
+
+    #[test]
+    fn a_correlation_id_must_be_thirty_two_lowercase_hex_characters() {
+        assert!(ProbeCorrelation::parse("0123456789abcdef0123456789abcdef").is_some());
+        assert!(
+            ProbeCorrelation::parse("0123456789ABCDEF0123456789ABCDEF").is_none(),
+            "uppercase"
+        );
+        assert!(
+            ProbeCorrelation::parse("0123456789abcdef0123456789abcde").is_none(),
+            "too short"
+        );
+        assert!(
+            ProbeCorrelation::parse("../../etc/passwd\r\nX-Evil: 1").is_none(),
+            "not hex"
+        );
+        assert!(ProbeCorrelation::parse("").is_none(), "empty");
+    }
+
+    /// A content hash is the correlation value the design forbids: it is derived
+    /// from the payload, so holding it is holding a fingerprint of the secret.
+    /// SHA-256 hex is 64 characters, and the grammar rejects it.
+    #[test]
+    fn a_payload_derived_hash_is_not_a_valid_correlation_id() {
+        let hex = "a".repeat(64);
+        assert!(
+            ProbeCorrelation::parse(&hex).is_none(),
+            "a 64-character digest must not be accepted as a correlation id"
+        );
+    }
+
+    #[test]
+    fn a_block_reports_nothing_forwarded() {
+        let a = ProbeAdjudication::new(&correlation(), &verdict(VerdictDecision::Block, 1), None);
+        assert_eq!(a.decision, ProbeDecision::Blocked);
+        assert_eq!(a.forwarded_payload, ForwardedPayload::NotForwarded);
+    }
+
+    #[test]
+    fn a_redaction_reports_the_reinspection_of_the_forwarded_bytes() {
+        let clean = ProbeAdjudication::new(
+            &correlation(),
+            &verdict(VerdictDecision::ForwardRedacted, 1),
+            Some(true),
+        );
+        assert_eq!(clean.decision, ProbeDecision::ForwardedRedacted);
+        assert_eq!(clean.forwarded_payload, ForwardedPayload::Clean);
+
+        let dirty = ProbeAdjudication::new(
+            &correlation(),
+            &verdict(VerdictDecision::ForwardRedacted, 1),
+            Some(false),
+        );
+        assert_eq!(dirty.forwarded_payload, ForwardedPayload::CarriesCredential);
+    }
+
+    #[test]
+    fn a_proxy_without_a_scanner_says_it_did_not_inspect() {
+        let a = ProbeAdjudication::new(&correlation(), &verdict(VerdictDecision::Forward, 0), None);
+        assert_eq!(a.decision, ProbeDecision::Forwarded);
+        assert_eq!(
+            a.forwarded_payload,
+            ForwardedPayload::NotInspected,
+            "an uninspected payload must never read as clean"
+        );
+    }
+
+    /// The security invariant of the whole correlation path: the reply is an
+    /// outcome vocabulary and an opaque id, and carries no protected content —
+    /// not the secret, not the body, not the target it was addressed to.
+    #[test]
+    fn the_reply_carries_no_protected_content() {
+        let a = ProbeAdjudication::new(
+            &correlation(),
+            &verdict(VerdictDecision::ForwardRedacted, 1),
+            Some(true),
+        );
+        let wire = String::from_utf8(a.http_response()).expect("utf-8 response");
+        assert!(!wire.contains(SECRET), "SECURITY INVARIANT VIOLATED: {wire}");
+        assert!(!wire.contains("sk-ant-"), "no credential prefix may appear: {wire}");
+        assert!(
+            !wire.contains("/v1/messages"),
+            "the reply must not echo the target: {wire}"
+        );
+        assert!(wire.contains(PROBE_ADJUDICATION_SCHEMA));
+        assert!(wire.contains("0123456789abcdef0123456789abcdef"));
+    }
+
+    #[test]
+    fn the_reply_round_trips_through_json() {
+        let a = ProbeAdjudication::new(
+            &correlation(),
+            &verdict(VerdictDecision::AlertAndForward, 1),
+            Some(false),
+        );
+        let wire = String::from_utf8(a.http_response()).expect("utf-8");
+        let body = wire.split_once("\r\n\r\n").expect("headers then body").1;
+        let back: ProbeAdjudication = serde_json::from_str(body).expect("parses");
+        assert_eq!(back, a);
+        assert_eq!(back.decision, ProbeDecision::AlertedAndForwarded);
+    }
+}

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -28,6 +28,7 @@ use crate::intercept::event::ProxyEvent;
 use crate::intercept::mcp::{is_unenforceable_tool_call, parse_mcp_request};
 use crate::intercept::{InterceptVerdict, Interceptor, ResponseScan, VerdictDecision};
 use crate::mcp_enforce::{evaluate_mcp_call, McpDecision};
+use crate::probe_adjudication::{ProbeAdjudication, ProbeCorrelation, PROBE_CORRELATION_HEADER};
 use crate::proxy::http::{
     read_http_request, read_http_response, read_line_capped, serialize_http_request, serialize_http_request_with_auth,
     serialize_http_response, HttpRequest, MAX_BODY_LEN, MAX_HEADER_BYTES, MAX_HEADER_COUNT, MAX_HEADER_LINE_LEN,
@@ -849,6 +850,47 @@ impl ProxyServer {
             timestamp: SystemTime::now(),
         };
         self.interceptor.intercept(&event).await?;
+
+        // AAASM-5300: a protection probe's own request is adjudicated exactly
+        // like any other — the verdict above is the same call the real data path
+        // makes, under the same configured `credential_action` — and is then
+        // *answered* here instead of relayed. See `crate::probe_adjudication`
+        // for why terminating it is the only safe direction: the body carries a
+        // synthetic credential, and under a non-enforcing policy the ordinary
+        // path would forward it to the real provider.
+        //
+        // Only this (LLM-pattern) handler speaks the protocol. A probe request
+        // that lands anywhere else is forwarded like any other request, so a
+        // probe must establish that it is talking to an adjudicating proxy
+        // *before* it sends anything sensitive.
+        if let Some(correlation) = req.header(PROBE_CORRELATION_HEADER).and_then(ProbeCorrelation::parse) {
+            let (audit_decision, forwarded_is_clean) = match verdict.decision {
+                VerdictDecision::Block => (ProxyAuditDecision::Blocked, None),
+                VerdictDecision::ForwardRedacted => {
+                    let bytes = verdict.redacted_body.as_deref().unwrap_or(&req.body);
+                    (
+                        ProxyAuditDecision::ForwardedRedacted,
+                        self.interceptor.forwarded_payload_is_clean(bytes),
+                    )
+                }
+                _ => (
+                    ProxyAuditDecision::Forwarded,
+                    self.interceptor.forwarded_payload_is_clean(&req.body),
+                ),
+            };
+            let adjudication = ProbeAdjudication::new(&correlation, &verdict, forwarded_is_clean);
+            tracing::info!(
+                %host,
+                correlation = %correlation.as_str(),
+                decision = ?adjudication.decision,
+                "adjudicated a protection probe request; answering it instead of forwarding upstream",
+            );
+            self.emit_audit_entry(host, &req, &verdict, audit_decision).await;
+            let mut client_tls = client_reader.into_inner();
+            client_tls.write_all(&adjudication.http_response()).await?;
+            let _ = client_tls.shutdown().await;
+            return Ok(());
+        }
 
         if verdict.decision == VerdictDecision::Block {
             tracing::info!(

--- a/docs/src/devtools/cli.md
+++ b/docs/src/devtools/cli.md
@@ -255,7 +255,7 @@ build has none — a client on the near side of the proxy cannot see the forward
 body — so `verify` reports the model path as configured but never exercised, the
 level stays at `Integrated`, and the command **exits `6`**. That is the honest
 reading: configuration alone is not evidence that anything inspected the traffic.
-See [Limitations](limitations.md#verify-cannot-adjudicate-so-it-exits-6).
+See [Limitations](limitations.md#what-verify-adjudicates-and-when-it-still-exits-6).
 
 ## See also
 

--- a/docs/src/devtools/limitations.md
+++ b/docs/src/devtools/limitations.md
@@ -24,7 +24,7 @@ claim that traces to neither is not on this page.
 |---|---|---|
 | Managed settings write / merge / restore | **Supported** | Four owned keys; every other key preserved. |
 | Proxy CA materialisation + `NODE_EXTRA_CA_CERTS` injection | **Supported** | AAASM-5276 condition C1. |
-| HTTPS interception and redaction on the model path | **Supported** | Measured against the real binary; see [`verify`](#verify-cannot-adjudicate-so-it-exits-6) for why the *level* still does not rise. |
+| HTTPS interception and redaction on the model path | **Supported** | Measured against the real binary; see [`verify`](#what-verify-adjudicates-and-when-it-still-exits-6) for what raises the *level*. |
 | Side-channel scoping (`*.anthropic.com`) | **Supported** | Condition C5. |
 | MCP loading control (`enabledMcpjsonServers` / `disabledMcpjsonServers`) | **Supported** | Optional, defence-in-depth. Never required for protection. |
 | Drift detection and repair | **Supported** | Detected at `status`/`verify` time, not in real time. |
@@ -119,34 +119,50 @@ This is why the lifecycle contract keeps `ModelPathInterception` and
 opposites: the first is a protection capability, the second is routing that
 *removes* protection.
 
-## `verify` cannot adjudicate, so it exits `6`
+## What `verify` adjudicates, and when it still exits `6`
 
-**On a default build, `aasm integrations verify claude-code` exits `6`
-(`verification_failed`) even on a completely correct installation.**
+`aasm integrations verify claude-code` **passes on a correctly installed
+integration** whose protected path was exercised and adjudicated (AAASM-5300).
 
 Raising the level to `Gateway Protected` requires *exercised* evidence, and
 exercised means the traffic was produced **and adjudicated**. Adjudicating means
-knowing what the provider actually received — and a client on the **near side of
-the proxy cannot see the forwarded body**. The shipped default probe,
-`UnadjudicatedProbe`, therefore reports `Inconclusive` with its reason, and
-produces no traffic at all: sending a synthetic secret to a real provider for no
-evidential gain would be worse than saying nothing
-(`aa-devtool-claude-code/src/probe.rs`).
+knowing what the payload leaving the machine actually carries — which a client on
+the **near side of the proxy cannot see for itself**. So the shipped probe does
+not try to. It marks its own request with an opaque correlation identifier, and
+the proxy — the component that runs the credential scanner and constructs the
+bytes that would be forwarded — answers on that request's own connection with
+what it decided, plus a re-inspection of the payload it resolved to forward.
+`Redacted` is reported only when the proxy says it scrubbed the body **and** that
+the scrubbed bytes carry no credential
+(`aa-devtool-claude-code/src/adjudicating_probe.rs`,
+`aa-proxy/src/probe_adjudication.rs`).
+
+Two properties of that exchange are worth knowing:
+
+- **The probe learns nothing but its own verdict.** There is no verdict store and
+  no query surface — a verdict exists only as the response to the request that
+  produced it, and is accepted only when it echoes the identifier that run
+  minted. The correlation identifier is 32 hex characters of OS entropy and is
+  derived from nothing about the payload.
+- **The probe's traffic never reaches the provider.** The proxy terminates a
+  correlated request instead of relaying it, and the probe sends a credential-free
+  preflight first — so a path with nothing adjudicating on it never receives the
+  synthetic secret at all.
 
 A probe that returned `Redacted` because nothing obviously failed would be a
 **vacuous pass**, which is precisely what the evidence model exists to prevent.
+That rule is unchanged, and `verify` still exits `6` (`verification_failed`)
+whenever it cannot measure:
 
-The consequence to be clear about: **you can reach `Integrated` and will
-correctly not be shown `Gateway Protected`, even though the protection genuinely
-works.** AAASM-5276 proved it end to end against the real `claude 2.1.220` binary
-and a TLS-terminating mock provider — every upstream request traversed the proxy,
-the scanner matched, and the forwarded body carried `[REDACTED:AnthropicKey]`
-while remaining valid Messages JSON.
-
-**Planned:** a deployment that can observe the forwarded payload supplies a probe
-that adjudicates, and only then does `GatewayProtected` become reachable. The
-probe is an injected capability specifically so that this can land without
-changing the evidence model.
+| Condition | Why it cannot pass |
+|---|---|
+| The path was never exercised | No trust material in the receipt, so there is no intercepted model path to drive. |
+| The certificate authority is not trusted | The MitM handshake fails, so nothing inspected the traffic. AAASM-5276 condition **C1**. |
+| Nothing adjudicates the path | The peer answered, but not with an adjudication — no component reported what it did. |
+| The core is stopped | Nothing is accepting connections; there is no verdict to read. |
+| The exchange times out | Bounded and reported, never assumed. |
+| A verdict for a different request | A verdict the probe did not produce is not evidence about the probe. |
+| `alert_only` is configured | The finding is recorded and the payload forwarded unchanged — observing is not protecting. |
 
 Read exit `6` on an otherwise-clean install as **"not measured"**, not as
 **"measured and failed"** — and read `status` for which it is.

--- a/docs/src/devtools/onboarding.md
+++ b/docs/src/devtools/onboarding.md
@@ -193,52 +193,45 @@ and **passes the flag through unchanged**. Agent Assembly's interception sits
 below Claude Code's own permission enforcement, so stripping the flag would
 change your session without changing what is protected.
 
-## Step 6 — Verify, and the exit `6` you will see
+## Step 6 — Verify, and the exit `6` that means "not measured"
 
 ```console
 $ aasm integrations verify claude-code
 claude-code — verification passed
   ran at:               1785391172 (unix)
-  protected path exercised: no
+  protected path exercised: yes
 
 Assertions:
-  [--] protected_path_exercised               nothing protective was observed on the model-bound path
+  [ok] protected_path_exercised               the core redacted 1 credential finding(s) from the
+                                              probe request to api.anthropic.com, and re-inspection
+                                              of the bytes it resolved to forward found none
   ...
-
-This is NOT a protection measurement. Configuration that exists is not evidence
-that anything was protected; the protected path must be exercised and adjudicated.
 $ echo $?
-6
+0
 ```
 
-> ### ⚠ On a default build, `verify` exits `6` — and that is correct
+> ### ⚠ Exit `6` means "not measured", not "measured and failed"
 >
 > `verify` succeeds only when the outcome is `passed` **and** the protected path
-> was actually exercised. Exercising it means knowing what the provider
-> *received*, and **a client on the near side of the proxy cannot see the
-> forwarded body**. The shipped default probe, `UnadjudicatedProbe`, therefore
-> reports `Inconclusive` and produces no traffic at all — sending a synthetic
-> secret to a real provider for no evidential gain would be worse than saying
-> nothing (`aa-devtool-claude-code/src/probe.rs`).
+> was actually exercised. Exercising it means knowing what the payload leaving
+> the machine carries, and **a client on the near side of the proxy cannot see
+> that for itself**. So the shipped probe does not guess: it marks its own
+> request with an opaque correlation identifier and reads back the proxy's
+> verdict for that exact request, including a re-inspection of the payload the
+> proxy resolved to forward (`aa-devtool-claude-code/src/adjudicating_probe.rs`).
+> The probe's own traffic is terminated at the proxy and never reaches the
+> provider.
+>
+> **You will see exit `6` when the probe cannot measure** — the certificate
+> authority is not trusted, nothing on the path adjudicates, the core is
+> stopped, the exchange times out, or the deployment is configured `alert_only`
+> (observing is not protecting). In every one of those cases the level correctly
+> stays at `Integrated`.
 >
 > A probe that returned `Redacted` because nothing obviously failed would be a
-> vacuous pass, and the evidence model exists to prevent exactly that.
->
-> **What this means for you:** a correct, fully-applied installation reaches
-> `Integrated` and will correctly **not** show `Gateway Protected` — even though
-> the underlying protection genuinely works. AAASM-5276 proved it end to end
-> against the real `claude 2.1.220` binary and a TLS-terminating mock provider:
-> every upstream request traversed the proxy, the scanner matched the synthetic
-> secret, and the forwarded body carried `[REDACTED:AnthropicKey]` while
-> remaining valid Messages JSON.
->
-> **What is planned:** a deployment that *can* observe the forwarded payload
-> supplies a probe that adjudicates, and only then does `GatewayProtected` become
-> reachable. The probe is an injected capability precisely so that this can land
-> without changing the evidence model. Until it does, treat exit `6` on an
-> otherwise-clean install as *"not measured"*, not as *"measured and failed"* —
-> and read `status` for which is which.
-
+> vacuous pass, and the evidence model exists to prevent exactly that. Read exit
+> `6` on an otherwise-clean install as *"not measured"* — and read `status` for
+> which condition it is.
 The probe uses a **synthetic** secret chosen by the adapter and run by the
 service. No real credential is ever read, sent or printed.
 

--- a/docs/src/devtools/protection-levels.md
+++ b/docs/src/devtools/protection-levels.md
@@ -58,33 +58,33 @@ Two reporting rules apply at every rung:
 | **Maps to L0–L3** | `L2Enforce` — allow/deny, approval, redaction and budget enforcement, which is precisely what traversal of the gateway provides. |
 | **Honest limit** | Also cannot claim host-level bypass prevention. It protects the paths it sees. A user or agent able to start a process outside the managed path is outside its scope by construction. |
 
-### Why `Gateway Protected` is not reportable today
+### How `Gateway Protected` becomes reportable
 
-> **`aasm integrations verify claude-code` exits `6` on a default build, so the
-> level stays at `Integrated`.**
+> **`aasm integrations verify claude-code` exits `0` once the protected path has
+> been exercised and adjudicated (AAASM-5300); until then the level stays at
+> `Integrated`.**
 >
 > Raising the level requires *exercised* evidence, and exercised means traffic
-> was produced **and adjudicated**. Adjudicating means knowing what the provider
-> actually received — which **a client on the near side of the proxy cannot
-> see**. The shipped default probe, `UnadjudicatedProbe`, therefore reports
-> `Inconclusive` with its reason and produces no traffic at all
-> (`aa-devtool-claude-code/src/probe.rs`).
+> was produced **and adjudicated**. Adjudicating means knowing what the payload
+> leaving the machine actually carries — which **a client on the near side of the
+> proxy cannot see for itself**. So the shipped probe does not infer it: it marks
+> its own request with an opaque correlation identifier, and the proxy — the
+> component that runs the scanner and builds the forwarded bytes — answers on
+> that request's own connection with what it decided and with a re-inspection of
+> the payload it resolved to forward. `Redacted` is reported only when both agree
+> (`aa-devtool-claude-code/src/adjudicating_probe.rs`).
 >
-> This is not a broken installation, and it is not the protection failing. It is
-> the evidence model refusing a vacuous pass: a probe that reported `Redacted`
-> because nothing obviously failed would be exactly the claim this system exists
-> to prevent.
+> **Everything it cannot measure still exits `6`**: an untrusted certificate
+> authority, a path nothing adjudicates, a stopped core, a timeout, or a verdict
+> belonging to a different request. A probe that reported `Redacted` because
+> nothing obviously failed would be exactly the vacuous pass this system exists
+> to prevent, and the guard that pins that rule is still in the suite.
 >
 > **The mechanism itself was measured working.** AAASM-5276 ran the real
 > `claude 2.1.220` binary against a TLS-terminating mock provider: all four
 > upstream requests traversed the proxy, the deterministic scanner matched the
 > synthetic secret, and the forwarded body carried `[REDACTED:AnthropicKey]`
 > while remaining valid Messages JSON — at sub-millisecond added cost.
->
-> **Planned:** a deployment that can observe the forwarded payload supplies a
-> probe that adjudicates. The probe is an injected capability precisely so this
-> can land without changing the evidence model. Until it does, read exit `6` on
-> an otherwise-clean install as *not measured*, not as *measured and failed*.
 
 ## Host Enforced
 

--- a/docs/src/governance/capability-matrix.md
+++ b/docs/src/governance/capability-matrix.md
@@ -152,11 +152,13 @@ unmeasured (see below).
   bypass counters — remain **unmeasured** (`AAASM-5276` condition C6). `--scope managed` is
   refused, and the path is resolved only so a refusal can name it. Measuring it on a managed macOS
   device is tracked by `AAASM-5298`.
-- **`Gateway Protected` is not reportable on a default build.** The shipped `UnadjudicatedProbe`
-  reports `Inconclusive` because a client on the near side of the proxy cannot see the forwarded
-  body, so `aasm integrations verify claude-code` exits `6` and the level stays at `Integrated` —
-  even though the interception itself was proven end-to-end. An adjudicating probe is *planned*.
-  See [Limitations](../devtools/limitations.md#verify-cannot-adjudicate-so-it-exits-6).
+- **`Gateway Protected` is reportable only on adjudicated evidence.** The shipped probe drives one
+  request down the protected path and reads back the proxy's verdict for that exact request —
+  including a re-inspection of the payload the proxy resolved to forward — so
+  `aasm integrations verify claude-code` exits `0` on an installation whose path was exercised and
+  adjudicated. Every condition it cannot measure (an untrusted certificate authority, a stopped
+  core, a path nothing adjudicates, a timeout) still exits `6` and leaves the level at `Integrated`.
+  See [Limitations](../devtools/limitations.md#what-verify-adjudicates-and-when-it-still-exits-6).
 - **All L2 dimensions require the managed launch.** A `claude` started directly inherits neither
   the proxy nor `NODE_EXTRA_CA_CERTS` and is unprotected — measured, not theoretical. Worse, it
   fails *silently*: a proxy that cannot terminate TLS still lets the connection through, which is


### PR DESCRIPTION
## Description

Makes `aasm integrations verify claude-code` able to pass — **truthfully, and only truthfully**.

Until now the shipped `UnadjudicatedProbe` sat on the **near** side of the proxy and could not see the
forwarded body. Reporting `Redacted` without observing it would be the vacuous pass the protection-state
model exists to forbid, so it returned `Inconclusive` and `verify` exited **6** for every real user —
meaning `Gateway Protected` was never reportable even though the protection genuinely worked.

`aa-proxy` already adjudicated the request; the probe simply had no way to learn the verdict for **its
own** request. Now it does.

## Design

**Correlation.** A v4 UUID `simple` string — 32 lowercase hex chars of OS entropy — minted **in the
probe, per exchange**, derived from nothing. Carried as the request header `x-agent-assembly-probe`.

**Read back as the HTTP response to that same request**, on the probe's own TLS connection:
`{schema, correlation_id, decision, findings: <count>, forwarded_payload}`.

Four properties make this safe rather than merely convenient:

1. **The identifier cannot be a content hash.** It is randomly generated, and the proxy's grammar
   (`ProbeCorrelation::parse`) accepts *exactly* 32 hex chars — a SHA-256 hex digest is 64 and is
   rejected. A payload-derived identifier is structurally impossible.
2. **There is no verdict store and no query surface.** A verdict exists only as the response to the
   request that produced it, and the probe accepts it only when `correlation_id` matches the id that run
   minted. There is no second question to ask, so no general audit access was created — **no new audit
   read, endpoint or capability exists anywhere in this change.**
3. **A correlated request is terminated at the proxy and never relayed upstream.** Guessing the header
   therefore buys a refusal, not a bypass.
4. **A credential-free preflight goes first**, so a peer that does not adjudicate never receives the
   synthetic secret at all.

The reply carries a decision token, a finding **count**, and a re-inspection verdict — no body, no
target, no finding value.

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Additive. `aa-core` and `aa-runtime` needed **zero** changes — `aa-runtime`'s `claude_code_integration()`
calls `ClaudeCodeIntegration::new()`, which now carries the shipped probe. `aa-api` untouched.

## Related Issues

- Jira: [AAASM-5300](https://lightning-dust-mite.atlassian.net/browse/AAASM-5300)
  (Epic [AAASM-5272](https://lightning-dust-mite.atlassian.net/browse/AAASM-5272))
- Resolves the limitation shipped by AAASM-5281 (#1828) and pinned by AAASM-5283 (#1832)
- GitHub issues: N/A

## What still yields `Inconclusive` / exit 6 — and its test

Failing closed on everything unmeasurable is the point; the pass is the narrow case.

| Condition | Test |
|---|---|
| Path never exercised (no trust material) | pre-existing `probe_request() → None`, unchanged |
| No adjudicating probe configured | `an_unadjudicated_probe_still_cannot_pass_and_the_cli_still_exits_six` |
| CA not trusted | `without_a_trusted_certificate_authority_the_shipped_probe_is_inconclusive` — a real foreign `CaStore`; only the PEM changes |
| Core stopped | `with_the_core_stopped_the_shipped_probe_is_inconclusive` — probe **and** full `verify` both refuse |
| Nothing adjudicates the path | `an_unwatched_path_is_inconclusive_and_never_receives_the_secret` — also asserts the provider recorded the preflight and **never** the secret |
| Verdict belongs to another request | `a_verdict_for_another_request_is_not_evidence` |
| Non-adjudication response · unknown decision token · timeout | `a_response_that_is_not_an_adjudication_cannot_pass`, `an_unreadable_decision_is_inconclusive` |
| `alert_only` | maps to `ObservedOnly`, not protective — `observing_is_not_protecting_and_forwarding_is_a_leak` |

## The AAASM-5283 assertion was replaced deliberately, not deleted

`the_shipped_probe_cannot_pass_verification_and_the_cli_exits_six`
→ `the_shipped_probe_passes_verification_on_an_adjudicated_model_path`.

The replacement asserts `VerificationOutcome::Passed`, that the pass rests on `Exercised{Redacted}`
evidence, that the level reaches `GatewayProtected`, and — critically — that the evidence text **names
what observes the forwarded payload**: *"re-inspection of the bytes it resolved to forward"*. The answer
is the proxy: it runs the scanner, constructs the forwarded bytes, and re-inspects them.

Both exit `0` and exit `6` mappings remain pinned from `exit.rs`. **The old guard survives** as
`an_unadjudicated_probe_still_cannot_pass_and_the_cli_still_exits_six`, so the honest-failure path stays
protected now that the happy path can pass.

## Security impact

- **`Gateway Protected` becomes reachable only on adjudicated exercised evidence.**
  `the_ladder_rises_only_on_adjudicated_exercised_evidence` is unchanged and green.
- No new audit access, endpoint, capability or stored verdict.
- The correlation identifier is random, not payload-derived, and a digest-length value is rejected.
- A guessed header withholds traffic rather than releasing it.
- The synthetic secret is never sent to a peer that has not first proved it adjudicates.

### Two guards proved load-bearing

**The probe cannot read another request's verdict** — removed the `correlation_id != expected_id` check:
```
panicked at aa-devtool-claude-code/src/adjudicating_probe.rs:483:14:
an adjudication of another request must be refused: Adjudication {
  schema: "agent-assembly.probe-adjudication/1",
  correlation_id: "fedcba9876543210fedcba9876543210",
  decision: "blocked", findings: 1, forwarded_payload: "not_forwarded" }
1 test run: 0 passed, 1 failed
```

**A probe with no adjudicated verdict cannot pass** — made `UnadjudicatedProbe` return `Redacted`:
```
panicked at aa-devtool-claude-code/src/probe.rs:123:9: assertion `left == right` failed
  left: Redacted
 right: Inconclusive
…and conformance: an_unadjudicated_probe_still_cannot_pass_and_the_cli_still_exits_six FAILED
```

Both reverted; tree clean.

## Tests executed

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

| Command | Result |
|---|---|
| `cargo nextest run -p aa-devtool-claude-code -p aa-proxy` (post-rebase) | **349 passed, 3 skipped** |
| `cargo nextest run -p aa-devtool-claude-code -p aa-core -p aa-proxy -p aa-runtime` | **1281 passed, 5 skipped** |
| `cargo nextest run -p aa-integration-tests --test conformance_claude_code --test claude_code_integration_lifecycle` | **32 passed** |
| `AASM_BIN_PATH=… cargo nextest run -p aa-cli` | **868 passed** |
| `cargo fmt --all -- --check` | OK |
| `cargo clippy --all-targets --all-features -- -D warnings` | **0 errors** (6 pre-existing manifest warnings) |
| `cargo build --workspace` · `cargo deny check` · `cargo doc -p aa-devtool-claude-code -p aa-proxy --no-deps` | 0 errors · advisories/bans/licenses/sources ok · no new warnings |

## Acceptance-criteria evidence

| AC | Status |
|---|---|
| `verify` exits 0 on a correctly installed integration where protection was exercised and adjudicated | ✅ |
| Still exits 6 when not exercised, CA untrusted, or adjudication unavailable | ✅ — full table above |
| The probe reads only its own request's verdict; no general audit access | ✅ no store, no query surface, response-bound + id check |
| No correlation identifier or verdict payload carries protected content | ✅ random id, 64-hex digest rejected, reply asserted secret-free at both ends |
| The AAASM-5283 assertion is updated deliberately | ✅ replaced, and the old guard retained separately |
| `Gateway Protected` reachable only on adjudicated evidence | ✅ |

## Scope note — documentation outside the owned file set

This branch updates 5 `docs/` pages (`cli.md`, `limitations.md`, `onboarding.md`, `protection-levels.md`,
`capability-matrix.md`). They were outside the file set this work was scoped to, but they stated
`Gateway Protected` is unreachable and `verify` always exits 6 — claims this PR makes false. Shipping
code that contradicts merged documentation would be worse than the scope overrun, so they were corrected
here and are called out rather than slipped in.

## Known limitations

Unchanged by this PR: no host-level bypass prevention; the endpoint managed-settings path remains
unmeasured (AAASM-5298); restore stays semantics-exact rather than byte-exact; the deterministic scanner
still recognises only the shapes it knows.

## Dependencies / stacked PRs

Cut from `main` @ `7e0f878b`, **rebased onto `main`** after AAASM-5296 (#1836) merged. No force-push was
performed at any point. Independently mergeable.

## Documentation and migration impact

The five pages above now describe the shipped behaviour. No migration — no flag, command or schema
changes.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (8 commits)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5300]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ