### PR TITLE
[AAASM-5298] ✨ (aa-devtool-claude-code): Install managed settings under opt-in admin authorization

### DIFF
--- a/aa-cli/src/commands/integrations/install.rs
+++ b/aa-cli/src/commands/integrations/install.rs
@@ -54,6 +54,14 @@ pub struct InstallArgs {
     #[arg(long)]
     pub allow_privileged_host_steps: bool,
 
+    /// Install the tool's administrator-managed settings file, asking for
+    /// administrator authorization for that one file write.
+    ///
+    /// Off by default; the default install is fully unprivileged and cannot
+    /// reach `Host Enforced`. See `aasm integrations plan --help`.
+    #[arg(long)]
+    pub install_managed_settings: bool,
+
     /// Apply without asking. Required for non-interactive and `--output json`
     /// runs, which have no way to answer a prompt.
     #[arg(long)]
@@ -74,6 +82,7 @@ pub fn run(args: InstallArgs, options: SessionOptions, output: OutputFormat) -> 
             scope: args.scope,
             policy_profile: args.policy_profile.clone(),
             allow_privileged_host_steps: args.allow_privileged_host_steps,
+            install_managed_settings: args.install_managed_settings,
         };
         let plan = super::plan::author(&mut session, &plan_args).await?;
 
@@ -90,11 +99,16 @@ pub fn run(args: InstallArgs, options: SessionOptions, output: OutputFormat) -> 
             _ => eprint!("{}", plan.render_human()),
         }
 
+        // The prompt names what is being authorized. A privileged step that
+        // reached the confirmation as an unremarkable "Apply this plan?" would
+        // be consent in form and not in substance — the disclosure above is what
+        // makes it informed, and this line is what makes it deliberate.
         let prompt = if plan.required_permissions.is_empty() {
             format!("Apply this plan to {}?", args.tool)
         } else {
             format!(
-                "Apply this plan to {}, including {} permission(s) that change host state?",
+                "Apply this plan to {}, including {} permission(s) that change host state \
+                 and will ask for administrator authorization?",
                 args.tool,
                 plan.required_permissions.len()
             )

--- a/aa-cli/src/commands/integrations/plan.rs
+++ b/aa-cli/src/commands/integrations/plan.rs
@@ -52,6 +52,35 @@ pub struct PlanArgs {
     /// this flag — the plan is the record of what was consented to.
     #[arg(long)]
     pub allow_privileged_host_steps: bool,
+
+    /// Install the tool's administrator-managed settings file, asking for
+    /// administrator authorization for that one file write.
+    ///
+    /// **Off by default, and the default install stays fully unprivileged.**
+    /// This is the only route to `Host Enforced`: it writes the one settings
+    /// surface the tool treats as non-overridable, which is owned by the
+    /// administrator. The plan states the exact path, the exact content, the
+    /// diff against what is there, any conflict, and the backup and rollback
+    /// behaviour — all before you are asked to approve anything.
+    ///
+    /// Implies `--scope managed` and the privileged-step consent, because that
+    /// is precisely what this flag is consent *to*. `aasm integrations remove`
+    /// reverses it.
+    #[arg(long)]
+    pub install_managed_settings: bool,
+}
+
+/// The level a plan asks for, as the wire spells it.
+///
+/// Empty means "the service's default", which is `GatewayProtected`. Only the
+/// explicit managed-settings install asks for higher, and even then the adapter
+/// caps the answer at what it can substantiate.
+fn requested_level(install_managed_settings: bool) -> &'static str {
+    if install_managed_settings {
+        "host_enforced"
+    } else {
+        ""
+    }
 }
 
 /// Run `aasm integrations plan`.
@@ -70,6 +99,7 @@ pub fn run(args: PlanArgs, options: SessionOptions, output: OutputFormat) -> Exi
 /// plan that gets applied — two independent renderings of "what will change"
 /// is how a user ends up consenting to something they were not shown.
 pub(crate) async fn author(session: &mut Session, args: &PlanArgs) -> Result<PlanReport, Failure> {
+    let scope = resolve_scope(args)?;
     resolve_tool(session, &args.tool, true).await?;
     let runtime = RuntimeInfo::from_session(session);
     let view = session
@@ -77,11 +107,79 @@ pub(crate) async fn author(session: &mut Session, args: &PlanArgs) -> Result<Pla
         .plan(
             &args.tool,
             args.profile.as_wire(),
-            args.scope.as_wire(),
+            scope,
             &args.policy_profile,
-            args.allow_privileged_host_steps,
+            // The flag *is* the consent to the one privileged step; requiring a
+            // second flag for the same decision would train users to pass both
+            // without reading either.
+            args.allow_privileged_host_steps || args.install_managed_settings,
+            requested_level(args.install_managed_settings),
         )
         .await
         .map_err(verb_failure)?;
     Ok(PlanReport::from_view(runtime, &view))
+}
+
+/// The scope this plan writes, refusing the administrator surface unless it was
+/// asked for by name.
+///
+/// `--scope managed` on its own is not the explicit opt-in the privileged write
+/// requires: it reads like a third choice alongside `user` and `project`, and
+/// nothing about it says "this will ask for your administrator password".
+fn resolve_scope(args: &PlanArgs) -> Result<&'static str, Failure> {
+    if args.install_managed_settings {
+        return Ok(ScopeArg::Managed.as_wire());
+    }
+    if matches!(args.scope, ScopeArg::Managed) {
+        return Err(Failure::new(
+            Outcome::Aborted,
+            "nothing was changed: writing the administrator-managed settings surface needs an explicit opt-in",
+            "re-run with --install-managed-settings, which shows the exact file, its content, the diff and \
+             the rollback before asking for administrator authorization",
+        ));
+    }
+    Ok(args.scope.as_wire())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(scope: ScopeArg, install_managed_settings: bool) -> PlanArgs {
+        PlanArgs {
+            tool: "claude-code".to_string(),
+            profile: ProfileArg::Recommended,
+            scope,
+            policy_profile: String::new(),
+            allow_privileged_host_steps: false,
+            install_managed_settings,
+        }
+    }
+
+    #[test]
+    fn the_default_plan_is_unprivileged_and_asks_for_no_particular_level() {
+        let args = args(ScopeArg::User, false);
+        assert_eq!(resolve_scope(&args).expect("user scope"), "user");
+        assert_eq!(requested_level(false), "");
+        assert!(
+            !args.allow_privileged_host_steps,
+            "the default install must consent to nothing"
+        );
+    }
+
+    #[test]
+    fn the_managed_surface_needs_the_flag_that_names_it() {
+        // `--scope managed` reads like a third choice next to user and project,
+        // and nothing about it says "this asks for your administrator password".
+        let failure = resolve_scope(&args(ScopeArg::Managed, false)).expect_err("must refuse");
+        assert_eq!(failure.outcome, Outcome::Aborted);
+        assert!(failure.remediation.contains("--install-managed-settings"), "{failure}");
+        assert!(failure.to_string().contains("nothing was changed"), "{failure}");
+    }
+
+    #[test]
+    fn the_flag_selects_the_managed_surface_and_asks_for_host_enforcement() {
+        assert_eq!(resolve_scope(&args(ScopeArg::User, true)).expect("managed"), "managed");
+        assert_eq!(requested_level(true), "host_enforced");
+    }
 }

--- a/aa-cli/tests/integrations_claude_code.rs
+++ b/aa-cli/tests/integrations_claude_code.rs
@@ -87,6 +87,12 @@ impl Harness {
         std::env::set_var("CLAUDE_CONFIG_DIR", &claude_home);
         std::env::set_var("AASM_STATE_DIR", dir.path().join("state"));
         std::env::set_var("AA_CA_DIR", &ca_dir);
+        // AAASM-5298: the endpoint-managed surface is redirected into the temp
+        // directory too. `MacOsAdminAuthority` refuses to elevate for anything
+        // but the canonical `/Library/Application Support/ClaudeCode` path, so
+        // this redirection cannot point an authorized write anywhere — it makes
+        // the write unprivileged, and keeps the smoke run off the real path.
+        std::env::set_var("AASM_CLAUDE_MANAGED_ROOT", dir.path().join("ClaudeCode"));
 
         let lifecycle = Arc::new(EngineLifecycle::new(
             vec![claude_code_integration()],
@@ -319,9 +325,9 @@ fn the_command_family_drives_the_native_claude_code_integration() {
     assert!(restored.get("permissions").is_none(), "{restored}");
 }
 
-/// The endpoint managed-settings surface is refused by name.
+/// `--scope managed` alone is not the explicit opt-in the privileged write needs.
 #[test]
-fn a_managed_scope_install_is_refused_and_says_which_scope_to_use() {
+fn a_managed_scope_install_is_refused_and_names_the_flag_that_opts_in() {
     if !require_claude() {
         return;
     }
@@ -329,6 +335,79 @@ fn a_managed_scope_install_is_refused_and_says_which_scope_to_use() {
     let out = h.aasm(&["plan", "claude-code", "--scope", "managed"]);
     assert!(!out.status.success());
     let message = stderr(&out);
-    assert!(message.contains("Library/Application Support/ClaudeCode"), "{message}");
-    assert!(message.contains("--scope user"), "{message}");
+    assert!(message.contains("explicit opt-in"), "{message}");
+    assert!(message.contains("--install-managed-settings"), "{message}");
+    assert!(
+        !h.dir.path().join("ClaudeCode").join("managed-settings.json").exists(),
+        "a refused plan must write nothing"
+    );
+}
+
+/// The plan discloses everything before anything is authorized — and a plan
+/// still changes nothing.
+#[test]
+fn the_managed_install_plan_discloses_path_content_diff_backup_and_rollback() {
+    if !require_claude() {
+        return;
+    }
+    let h = Harness::start();
+    let out = h.aasm(&["plan", "claude-code", "--install-managed-settings"]);
+    let rendered = format!("{}{}", stdout(&out), stderr(&out));
+    println!("--- aasm integrations plan --install-managed-settings ---\n{rendered}");
+    assert!(out.status.success(), "{rendered}");
+
+    assert!(rendered.contains("settings scope:  managed"), "{rendered}");
+    assert!(rendered.contains("CONSENT REQUIRED"), "{rendered}");
+    assert!(rendered.contains("administrator authorization"), "{rendered}");
+    assert!(rendered.contains("managed-settings.json"), "{rendered}");
+    assert!(rendered.contains("disableBypassPermissionsMode"), "{rendered}");
+    assert!(
+        rendered.contains("the exact content that will be written"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("integrations remove claude-code"), "{rendered}");
+    assert!(rendered.contains("Nothing has been changed"), "{rendered}");
+    assert!(
+        !h.dir.path().join("ClaudeCode").join("managed-settings.json").exists(),
+        "a plan must write nothing"
+    );
+}
+
+/// A non-interactive run fails immediately rather than blocking on a credential
+/// prompt nobody can answer — and reports it as Unavailable, not as a success.
+#[test]
+fn a_non_interactive_managed_install_fails_safely_instead_of_waiting() {
+    if !require_claude() {
+        return;
+    }
+    let h = Harness::start();
+    let out = h.aasm(&["install", "claude-code", "--install-managed-settings", "--yes"]);
+    let message = format!("{}{}", stdout(&out), stderr(&out));
+    println!("--- aasm integrations install --install-managed-settings --yes ---\n{message}");
+    assert!(!out.status.success(), "{message}");
+    assert!(
+        message.contains("Unavailable") || message.contains("Permission Required"),
+        "a refusal must stay a refusal, in those words: {message}"
+    );
+    assert!(
+        !h.dir.path().join("ClaudeCode").join("managed-settings.json").exists(),
+        "nothing may be written when authorization could not be obtained"
+    );
+}
+
+/// And without `--yes`, a non-interactive run does not even reach the service.
+#[test]
+fn a_managed_install_without_confirmation_changes_nothing() {
+    if !require_claude() {
+        return;
+    }
+    let h = Harness::start();
+    let out = h.aasm(&["install", "claude-code", "--install-managed-settings"]);
+    let message = format!("{}{}", stdout(&out), stderr(&out));
+    assert!(!out.status.success(), "{message}");
+    assert!(message.contains("nothing was changed"), "{message}");
+    assert!(
+        !h.dir.path().join("ClaudeCode").join("managed-settings.json").exists(),
+        "{message}"
+    );
 }

--- a/aa-devtool-claude-code/src/executor.rs
+++ b/aa-devtool-claude-code/src/executor.rs
@@ -16,6 +16,18 @@
 //! both backed by [`LaunchEnvStore`]. Nothing else is added — a mechanism this
 //! executor cannot perform still refuses.
 //!
+//! # The one step that is not a file write
+//!
+//! A [`StepAction::WriteManagedSettings`] at [`SettingsScope::Managed`] is the
+//! endpoint managed-settings file: root-owned, above every other scope in
+//! Claude Code's precedence order, and writable only with administrator
+//! authorization. It is routed to [`ManagedSettingsInstaller`] rather than to
+//! [`FilesystemExecutor`], and an executor that was given no installer
+//! **refuses** it. A silent fallback to an ordinary file write would produce a
+//! receipt claiming an endpoint-managed install that never happened — and, on a
+//! host where the user happens to own that directory, an "enforcement" file the
+//! user can delete.
+//!
 //! # Why it is scope-keyed rather than built for one scope
 //!
 //! Applying always has a plan, and a plan always names its scope. Observing and
@@ -27,13 +39,15 @@
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use aa_devtool_contract::{
-    ArtifactObservation, EnvValue, ExecutionError, FilesystemExecutor, IntegrationStep, SettingsScope, StepAction,
-    StepExecutor, StepOutcome, StepReceipt,
+    sha256_hex, ArtifactObservation, EnvValue, ExecutionError, FilesystemExecutor, IntegrationStep, SettingsScope,
+    StepAction, StepExecutor, StepOutcome, StepReceipt,
 };
 
 use crate::launch_env::LaunchEnvStore;
+use crate::managed_settings::{ManagedSettingsError, ManagedSettingsInstaller};
 
 /// Prefix `aa-core` puts on every fingerprint. Reproduced rather than
 /// re-exported: the executor has to produce values `observe` can compare
@@ -64,6 +78,14 @@ fn env_projection(pairs: &[(String, String)]) -> String {
 pub struct ClaudeCodeStepExecutor {
     files: FilesystemExecutor,
     launch_env: BTreeMap<SettingsScope, LaunchEnvStore>,
+    /// The installer for the one privileged step. `None` — the default — makes
+    /// a managed-scope settings write refuse rather than fall back.
+    managed: Option<Arc<ManagedSettingsInstaller>>,
+    /// A second copy of the rendered content, because
+    /// [`FilesystemExecutor`] keeps its own privately and the privileged path
+    /// does not go through it. Two maps rather than one is the cost of the
+    /// managed write not being a file write.
+    rendered: BTreeMap<String, String>,
 }
 
 impl std::fmt::Debug for ClaudeCodeStepExecutor {
@@ -90,8 +112,43 @@ impl ClaudeCodeStepExecutor {
     /// Supply the content a step will write.
     #[must_use]
     pub fn with_content(mut self, step_id: impl Into<String>, content: impl Into<String>) -> Self {
+        let (step_id, content) = (step_id.into(), content.into());
+        self.rendered.insert(step_id.clone(), content.clone());
         self.files = self.files.with_content(step_id, content);
         self
+    }
+
+    /// Give this executor the ability to perform the one privileged step.
+    ///
+    /// Never a default: an executor built without this refuses a managed-scope
+    /// settings write, which is what keeps the endpoint-managed install opt-in
+    /// at the layer that performs it and not only at the layer that asks for it.
+    #[must_use]
+    pub fn with_managed_installer(mut self, installer: Arc<ManagedSettingsInstaller>) -> Self {
+        self.managed = Some(installer);
+        self
+    }
+
+    /// The installer for a managed-scope step, or the refusal.
+    fn managed_installer(&self, path: &std::path::Path) -> Result<&ManagedSettingsInstaller, ExecutionError> {
+        let installer = self.managed.as_deref().ok_or_else(|| ExecutionError::Io {
+            artifact: path.display().to_string(),
+            detail: "writing the endpoint managed-settings file needs administrator authorization, and this \
+                     execution was not given the authority to request it. Re-run \
+                     `aasm integrations install claude-code --install-managed-settings`"
+                .to_string(),
+        })?;
+        if installer.target() != path {
+            return Err(ExecutionError::Io {
+                artifact: path.display().to_string(),
+                detail: format!(
+                    "this step names {} and the authorized installer writes {}",
+                    path.display(),
+                    installer.target().display()
+                ),
+            });
+        }
+        Ok(installer)
     }
 
     /// The launch-environment variables this integration injects at `scope`.
@@ -171,8 +228,75 @@ impl ClaudeCodeStepExecutor {
     }
 }
 
+impl ClaudeCodeStepExecutor {
+    /// The path a managed-scope settings step names, when a step is one.
+    ///
+    /// Matching on the scope rather than on the step id: the id is an adapter
+    /// convention and the scope is what the plan validated.
+    fn managed_settings_target(action: &StepAction) -> Option<(&std::path::Path, &str)> {
+        match action {
+            StepAction::WriteManagedSettings {
+                scope: SettingsScope::Managed,
+                path,
+                content_sha256,
+                ..
+            } => Some((path.as_path(), content_sha256.as_str())),
+            _ => None,
+        }
+    }
+
+    /// Perform the one privileged step: disclose, authorize, write, read back.
+    fn apply_managed_settings(
+        &self,
+        step: &IntegrationStep,
+        path: &std::path::Path,
+        content_sha256: &str,
+    ) -> Result<StepOutcome, ExecutionError> {
+        let installer = self.managed_installer(path)?;
+        let content = self
+            .rendered
+            .get(&step.id)
+            .ok_or_else(|| ExecutionError::ContentMissing {
+                step_id: step.id.clone(),
+            })?;
+        // The digest the user reviewed is what gets written; a mismatch fails
+        // closed rather than elevating for bytes nobody approved.
+        if sha256_hex(content) != content_sha256 {
+            return Err(ExecutionError::ContentMismatch {
+                step_id: step.id.clone(),
+            });
+        }
+
+        let disclosure = installer.disclose(content).map_err(|e| managed_failure(path, &e))?;
+        let outcome = installer.install(&disclosure).map_err(|e| managed_failure(path, &e))?;
+        let fingerprint = format!("{FINGERPRINT_PREFIX}{}", outcome.attestation.sha256);
+        Ok(StepOutcome {
+            fingerprint: Some(fingerprint.clone()),
+            document_fingerprint: Some(fingerprint),
+            // The prior document is preserved as a backup file rather than as an
+            // inline projection: the managed document is replaced wholesale, and
+            // restoring it is the installer's job, not the merge helper's.
+            prior_state: None,
+            mutated: outcome.mutated,
+        })
+    }
+}
+
+/// Turn an installer refusal into an execution error the engine can roll back
+/// on, keeping the `Permission Required` / `Unavailable` wording intact.
+fn managed_failure(path: &std::path::Path, error: &ManagedSettingsError) -> ExecutionError {
+    ExecutionError::Io {
+        artifact: format!("{} ({})", path.display(), error.summary()),
+        detail: error.to_string(),
+    }
+}
+
 impl StepExecutor for ClaudeCodeStepExecutor {
     fn apply(&mut self, step: &IntegrationStep) -> Result<StepOutcome, ExecutionError> {
+        if let Some((path, sha)) = Self::managed_settings_target(&step.action) {
+            let (path, sha) = (path.to_path_buf(), sha.to_string());
+            return self.apply_managed_settings(step, &path, &sha);
+        }
         match Self::assignments(&step.action) {
             Some((scope, pairs)) => self.apply_assignments(scope, &pairs, step.action.kind()),
             None => self.files.apply(step),
@@ -180,6 +304,14 @@ impl StepExecutor for ClaudeCodeStepExecutor {
     }
 
     fn reverse(&mut self, step: &StepReceipt) -> Result<(), ExecutionError> {
+        if let Some((path, _)) = Self::managed_settings_target(&step.action) {
+            let path = path.to_path_buf();
+            return self
+                .managed_installer(&path)?
+                .rollback()
+                .map(|_| ())
+                .map_err(|e| managed_failure(&path, &e));
+        }
         match Self::assignments(&step.action) {
             Some((scope, pairs)) => {
                 let store = self.store(scope)?;
@@ -196,6 +328,18 @@ impl StepExecutor for ClaudeCodeStepExecutor {
     }
 
     fn observe(&self, step: &StepReceipt) -> ArtifactObservation {
+        if let Some((path, _)) = Self::managed_settings_target(&step.action) {
+            // Reading the managed file needs no privilege, so drift is
+            // observable on a host that could not authorize a write.
+            return match std::fs::read_to_string(path) {
+                Ok(raw) => ArtifactObservation::Present {
+                    managed_fingerprint: raw_fingerprint(&raw),
+                    document_fingerprint: Some(raw_fingerprint(&raw)),
+                },
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => ArtifactObservation::Missing,
+                Err(e) => ArtifactObservation::Unreadable { reason: e.to_string() },
+            };
+        }
         match Self::assignments(&step.action) {
             Some((scope, pairs)) => self.observe_assignments(scope, &pairs),
             None => self.files.observe(step),
@@ -309,6 +453,159 @@ mod tests {
 
         assert!(exec.apply(&step).unwrap().mutated);
         assert_eq!(std::fs::read_to_string(&artifact).unwrap(), "hosts\n");
+    }
+
+    /// A managed-scope settings step over a **temporary** root. No test names
+    /// the real `/Library/Application Support/ClaudeCode` path, and the real
+    /// authority refuses any target that is not it.
+    fn managed_step(path: &std::path::Path, content: &str) -> IntegrationStep {
+        IntegrationStep::new(
+            "endpoint-managed-settings",
+            StepAction::WriteManagedSettings {
+                scope: SettingsScope::Managed,
+                path: path.to_path_buf(),
+                managed_keys: crate::managed_settings::MANAGED_ONLY_KEYS
+                    .iter()
+                    .map(|k| (*k).to_string())
+                    .collect(),
+                content_sha256: sha256_hex(content),
+                merge: aa_devtool_contract::SettingsMerge::Replace,
+            },
+            "install the endpoint managed-settings file",
+        )
+        .privileged("Agent Assembly will ask for administrator authorization for one file write.")
+        .with_reversal(StepAction::ManageArtifact {
+            operation: ArtifactOperation::Remove,
+            path: path.to_path_buf(),
+        })
+    }
+
+    fn managed_document() -> String {
+        crate::managed_settings::managed_settings_document(aa_devtool_contract::ProtectionProfile::Recommended)
+            .expect("document")
+    }
+
+    fn installer(
+        dir: &std::path::Path,
+        authority: Arc<dyn crate::managed_settings::PrivilegedFileAuthority>,
+    ) -> (std::path::PathBuf, Arc<ManagedSettingsInstaller>) {
+        use std::os::unix::fs::MetadataExt as _;
+        let target = dir.join("ClaudeCode").join("managed-settings.json");
+        let uid = std::fs::metadata(dir).expect("uid probe").uid();
+        (
+            target.clone(),
+            Arc::new(
+                ManagedSettingsInstaller::new(target, dir.join("managed-state"), authority).expecting_owner_uid(uid),
+            ),
+        )
+    }
+
+    #[test]
+    fn a_managed_settings_step_without_an_authorized_installer_refuses() {
+        // The governing rule, at the layer that performs the mutation: an
+        // ordinary execution cannot write the endpoint-managed file at all.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("ClaudeCode").join("managed-settings.json");
+        let doc = managed_document();
+        let mut exec = ClaudeCodeStepExecutor::new()
+            .with_scope(SettingsScope::User, dir.path().join("launch-env"))
+            .with_content("endpoint-managed-settings", doc.clone());
+
+        let err = exec.apply(&managed_step(&target, &doc)).expect_err("must refuse");
+        assert!(
+            matches!(&err, ExecutionError::Io { detail, .. } if detail.contains("administrator authorization")),
+            "{err}"
+        );
+        assert!(!target.exists(), "a refused step must write nothing");
+    }
+
+    #[test]
+    fn an_authorized_managed_settings_step_is_applied_observed_and_rolled_back() {
+        use crate::managed_settings::testing::FakeAuthority;
+        let dir = tempfile::tempdir().unwrap();
+        let (target, installer) = installer(dir.path(), FakeAuthority::granting());
+        let doc = managed_document();
+        let step = managed_step(&target, &doc);
+
+        let mut exec = ClaudeCodeStepExecutor::new()
+            .with_scope(SettingsScope::User, dir.path().join("launch-env"))
+            .with_content(&step.id, doc.clone())
+            .with_managed_installer(installer);
+
+        let applied = exec.apply(&step).expect("apply");
+        assert!(applied.mutated);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), doc);
+
+        let receipt = StepReceipt::applied(&step, applied.fingerprint.clone());
+        assert_eq!(
+            exec.observe(&receipt),
+            ArtifactObservation::Present {
+                managed_fingerprint: applied.fingerprint.clone().unwrap(),
+                document_fingerprint: applied.fingerprint,
+            }
+        );
+
+        exec.reverse(&receipt).expect("rollback");
+        assert!(!target.exists(), "removal must be symmetric");
+        assert_eq!(exec.observe(&receipt), ArtifactObservation::Missing);
+        exec.reverse(&receipt).expect("rollback twice");
+    }
+
+    #[test]
+    fn a_denied_authorization_fails_the_step_rather_than_downgrading_it() {
+        use crate::managed_settings::testing::FakeAuthority;
+        let dir = tempfile::tempdir().unwrap();
+        let (target, installer) = installer(dir.path(), FakeAuthority::denying());
+        let doc = managed_document();
+        let step = managed_step(&target, &doc);
+        let mut exec = ClaudeCodeStepExecutor::new()
+            .with_content(&step.id, doc)
+            .with_managed_installer(installer);
+
+        let err = exec.apply(&step).expect_err("denied");
+        assert!(
+            matches!(&err, ExecutionError::Io { artifact, .. } if artifact.contains("Permission Required")),
+            "{err}"
+        );
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn a_read_back_mismatch_fails_the_step() {
+        use crate::managed_settings::testing::FakeAuthority;
+        let dir = tempfile::tempdir().unwrap();
+        let (target, installer) = installer(
+            dir.path(),
+            FakeAuthority::corrupting(r#"{"disableBypassPermissionsMode":false}"#),
+        );
+        let doc = managed_document();
+        let step = managed_step(&target, &doc);
+        let mut exec = ClaudeCodeStepExecutor::new()
+            .with_content(&step.id, doc)
+            .with_managed_installer(installer);
+
+        let err = exec.apply(&step).expect_err("read-back must fail");
+        assert!(
+            matches!(&err, ExecutionError::Io { artifact, .. } if artifact.contains("Read-back verification failed")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn content_that_does_not_match_the_reviewed_digest_never_reaches_the_authority() {
+        use crate::managed_settings::testing::FakeAuthority;
+        let dir = tempfile::tempdir().unwrap();
+        let authority = FakeAuthority::granting();
+        let (target, installer) = installer(dir.path(), authority.clone());
+        let doc = managed_document();
+        let step = managed_step(&target, &doc);
+
+        let mut exec = ClaudeCodeStepExecutor::new()
+            .with_content(&step.id, r#"{"disableBypassPermissionsMode":true}"#)
+            .with_managed_installer(installer);
+
+        assert!(matches!(exec.apply(&step), Err(ExecutionError::ContentMismatch { .. })));
+        assert!(authority.calls().is_empty(), "{:?}", authority.calls());
     }
 
     #[test]

--- a/aa-devtool-claude-code/src/launch_env.rs
+++ b/aa-devtool-claude-code/src/launch_env.rs
@@ -156,9 +156,14 @@ impl LaunchEnvStore {
 /// installed produces an empty map and the launch is unchanged.
 pub fn installed_environment(paths: &crate::scope::ClaudeCodePaths) -> BTreeMap<String, String> {
     let mut merged = BTreeMap::new();
+    // Every scope an install can own, `Managed` included: the endpoint-managed
+    // install still needs `NODE_EXTRA_CA_CERTS` and the proxy variables at
+    // launch, and the artifacts that carry them are Agent Assembly's own files
+    // under the state root — not the root-owned settings file.
     for scope in [
         aa_devtool_contract::SettingsScope::User,
         aa_devtool_contract::SettingsScope::Project,
+        aa_devtool_contract::SettingsScope::Managed,
     ] {
         let Ok(dir) = paths.launch_env_dir(scope) else {
             continue;

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -26,12 +26,16 @@ pub mod bypass;
 pub mod executor;
 pub mod launch_env;
 pub mod lifecycle;
+pub mod managed_settings;
 pub mod probe;
 pub mod scope;
 
 pub use adjudicating_probe::ProxyAdjudicatedProbe;
 pub use executor::ClaudeCodeStepExecutor;
 pub use lifecycle::ClaudeCodeIntegration;
+pub use managed_settings::{
+    ConsentDisclosure, ManagedSettingsError, ManagedSettingsInstaller, PrivilegedFileAuthority, MANAGED_SETTINGS_PATH,
+};
 pub use probe::{ProbeReport, ProbeRequest, ProtectionProbe};
 pub use scope::{ClaudeCodePaths, ScopeError};
 

--- a/aa-devtool-claude-code/src/lifecycle.rs
+++ b/aa-devtool-claude-code/src/lifecycle.rs
@@ -556,6 +556,17 @@ impl ClaudeCodeIntegration {
                 now,
                 format!("{}. {HOST_ATTESTATION_CAVEAT}", attestation.detail()),
             ),
+            // A host that simply did not opt in reads as the plain reason. A
+            // host that *did* opt in and no longer verifies is a different
+            // situation, and the summary that says which one it is belongs in
+            // front of the user.
+            Err(managed_settings::ManagedSettingsError::NothingInstalled { .. }) => absent(
+                HOST_ENFORCEMENT_REASON.to_string(),
+                format!(
+                    "known bypasses this integration cannot observe: {}",
+                    bypass::UNOBSERVABLE_BYPASSES
+                ),
+            ),
             Err(e) => absent(
                 format!("{HOST_ENFORCEMENT_REASON} ({})", e.summary()),
                 format!(

--- a/aa-devtool-claude-code/src/lifecycle.rs
+++ b/aa-devtool-claude-code/src/lifecycle.rs
@@ -395,7 +395,7 @@ impl ClaudeCodeIntegration {
     /// project-scoped install as unobservable and refuse to remove it.
     pub fn scoped_executor(&self, rendered: BTreeMap<String, String>) -> ClaudeCodeStepExecutor {
         let mut executor = ClaudeCodeStepExecutor::new();
-        for scope in [SettingsScope::User, SettingsScope::Project] {
+        for scope in [SettingsScope::User, SettingsScope::Project, SettingsScope::Managed] {
             if let Ok(dir) = self.paths.launch_env_dir(scope) {
                 executor = executor.with_scope(scope, dir);
             }

--- a/aa-devtool-claude-code/src/lifecycle.rs
+++ b/aa-devtool-claude-code/src/lifecycle.rs
@@ -42,8 +42,25 @@
 //!   sensitive-data claim.
 //! * `NODE_TLS_REJECT_UNAUTHORIZED` is never set, and its presence is reported
 //!   as a bypass. A TLS failure is a finding.
-//! * The endpoint managed-settings file and the macOS System Keychain are never
-//!   touched. Both are privileged host changes whose behaviour is unmeasured.
+//! * The macOS System Keychain is never touched.
+//!
+//! # The one privileged step, and why a normal install cannot reach it
+//!
+//! AAASM-5298 adds an **opt-in** endpoint managed-settings install
+//! (`--scope managed`, which the CLI exposes as `--install-managed-settings`).
+//! It is the only step in this integration marked
+//! [`StepPrivilege::PrivilegedHost`](aa_devtool_contract::StepPrivilege), the
+//! only one that asks for administrator authorization, and it is absent from
+//! every user- and project-scoped plan. Its evidence is
+//! [`EvidenceKind::HostAttested`] produced by re-reading the installed file and
+//! checking content, ownership and permissions — and
+//! [`StateDerivation`] admits `HostEnforced` from nothing else. A successful
+//! normal installation therefore cannot imply `Host Enforced`; it has no step
+//! that could produce the evidence.
+//!
+//! What the attestation does **not** claim: that Claude Code honours each
+//! managed-only key at runtime. That needs a managed device and remains
+//! unmeasured — see `docs/src/devtools/limitations.md`.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -63,6 +80,9 @@ use async_trait::async_trait;
 use crate::adjudicating_probe::ProxyAdjudicatedProbe;
 use crate::bypass::{self, BypassFinding, LaunchEnvironment};
 use crate::executor::ClaudeCodeStepExecutor;
+use crate::managed_settings::{
+    self, Authorization, MacOsAdminAuthority, ManagedSettingsInstaller, PrivilegedFileAuthority, MANAGED_ONLY_KEYS,
+};
 use crate::probe::{ProbeRequest, ProtectionProbe, SYNTHETIC_SECRET};
 use crate::scope::{ClaudeCodePaths, ScopeError};
 use crate::{ClaudeCodeAdapter, MIN_VERSION};
@@ -79,6 +99,9 @@ pub const STEP_PROXY_ENV: &str = "proxy-env";
 pub const STEP_SIDE_CHANNEL_SCOPE: &str = "side-channel-scope";
 /// Step id for the protection test.
 pub const STEP_PROTECTION_TEST: &str = "protection-test";
+/// Step id for the one privileged step — the endpoint managed-settings install
+/// (AAASM-5298). Present only in a `managed`-scoped plan.
+pub const STEP_ENDPOINT_MANAGED_SETTINGS: &str = "endpoint-managed-settings";
 
 /// The CA-trust variable Claude Code's embedded Node runtime honours.
 ///
@@ -124,6 +147,8 @@ pub struct ClaudeCodeIntegration {
     adapter: ClaudeCodeAdapter,
     proxy_url: String,
     probe: Arc<dyn ProtectionProbe>,
+    /// How the one privileged step obtains administrator authorization.
+    managed_authority: Arc<dyn PrivilegedFileAuthority>,
     freshness_window_secs: u64,
 }
 
@@ -162,8 +187,127 @@ impl ClaudeCodeIntegration {
             // reachable at all — and it still reports `Inconclusive` on every
             // path it cannot measure, so nothing passes on configuration alone.
             probe: Arc::new(ProxyAdjudicatedProbe),
+            // Safe as a default because it refuses to elevate for any target
+            // that is not the canonical managed-settings path, and because no
+            // unprivileged plan contains a step that would call it.
+            managed_authority: Arc::new(MacOsAdminAuthority),
             freshness_window_secs: DEFAULT_FRESHNESS_WINDOW_SECS,
         }
+    }
+
+    /// Replace the authority the one privileged step elevates through.
+    ///
+    /// The seam every test substitutes, so no test can reach a real
+    /// authorization prompt.
+    #[must_use]
+    pub fn with_managed_authority(mut self, authority: Arc<dyn PrivilegedFileAuthority>) -> Self {
+        self.managed_authority = authority;
+        self
+    }
+
+    /// The installer for the endpoint managed-settings file, when this host can
+    /// address one.
+    ///
+    /// Ownership is expected to be root at the canonical path. A redirected
+    /// managed root is a test seam where nothing is root-owned, so the check is
+    /// anchored to whatever this process writes as — live in both cases rather
+    /// than disabled in one.
+    pub fn managed_installer(&self) -> Option<Arc<ManagedSettingsInstaller>> {
+        let target = self.paths.settings_path(SettingsScope::Managed).ok()?;
+        let work_dir = self.paths.owned_root(SettingsScope::Managed).ok()?.join("managed");
+        let installer = ManagedSettingsInstaller::new(target, &work_dir, self.managed_authority.clone());
+        if self.paths.managed_root_is_canonical() {
+            return Some(Arc::new(installer));
+        }
+        std::fs::create_dir_all(&work_dir).ok()?;
+        let uid = managed_settings::owner_uid(&work_dir)?;
+        Some(Arc::new(installer.expecting_owner_uid(uid)))
+    }
+
+    /// Add the one privileged step, plus the warnings that make consenting to it
+    /// informed.
+    ///
+    /// The step is `Required`: an endpoint-managed install whose managed write
+    /// silently did not happen would report an integration that is exactly the
+    /// unprivileged one, under a plan that claimed otherwise.
+    fn with_endpoint_managed_step(
+        &self,
+        plan: IntegrationPlan,
+        profile: ProtectionProfile,
+        path: &std::path::Path,
+    ) -> Result<IntegrationPlan, AdapterError> {
+        let document = managed_settings::managed_settings_document(profile)?;
+        let mut plan = plan
+            .with_step(
+                IntegrationStep::new(
+                    STEP_ENDPOINT_MANAGED_SETTINGS,
+                    StepAction::WriteManagedSettings {
+                        scope: SettingsScope::Managed,
+                        path: path.to_path_buf(),
+                        managed_keys: MANAGED_ONLY_KEYS.iter().map(|k| (*k).to_string()).collect(),
+                        content_sha256: sha256_hex(&document),
+                        merge: SettingsMerge::Replace,
+                    },
+                    format!(
+                        "install Agent Assembly's managed policy at {} — the only settings surface Claude \
+                         Code treats as non-overridable — after backing up whatever is there, and verify it \
+                         by reading it back",
+                        path.display()
+                    ),
+                )
+                .privileged(format!(
+                    "Agent Assembly will ask for administrator authorization once, to place one file at {}. \
+                     Nothing else runs with elevated privileges. Removing the integration reverses it.",
+                    path.display()
+                ))
+                .with_reversal(StepAction::ManageArtifact {
+                    operation: ArtifactOperation::Remove,
+                    path: path.to_path_buf(),
+                }),
+            )
+            .warn(format!(
+                "this plan contains one privileged step. It writes {}, which is owned by the \
+                 administrator; every other step in this plan writes files you already own",
+                path.display()
+            ))
+            .warn(format!(
+                "the managed-only keys this installs ({}) are documented by Anthropic as non-overridable. \
+                 Agent Assembly verifies that the file is installed, owned as expected and not writable by \
+                 you — it does not measure Claude Code's runtime handling of each key",
+                MANAGED_ONLY_KEYS.join(", ")
+            ))
+            .warn(
+                "a managed-settings file Agent Assembly did not write is never replaced. If one is already \
+                 installed — for example by your organisation's device management — this plan refuses \
+                 rather than merging over it"
+                    .to_string(),
+            );
+
+        if !self.paths.managed_root_is_canonical() {
+            plan = plan.warn(format!(
+                "AASM_CLAUDE_MANAGED_ROOT redirects the managed surface to {}. That is a test seam: the \
+                 file written there is not the one Claude Code reads, and no administrator authorization \
+                 is requested for it",
+                path.display()
+            ));
+        }
+
+        match self.managed_authority.availability() {
+            Authorization::Available => {}
+            Authorization::NonInteractive { detail } => {
+                plan = plan.warn(format!(
+                    "administrator authorization cannot be requested here: {detail}. This plan will fail \
+                     rather than wait for credentials — run it from a terminal"
+                ));
+            }
+            Authorization::Unavailable { detail } => {
+                plan = plan.warn(format!(
+                    "administrator authorization is unavailable on this host: {detail}"
+                ));
+            }
+        }
+
+        Ok(plan)
     }
 
     /// Replace the detection adapter, so a test can pin the binary path and the
@@ -224,6 +368,9 @@ impl ClaudeCodeIntegration {
         for (step_id, content) in rendered {
             executor = executor.with_content(step_id, content);
         }
+        if let Some(installer) = self.managed_installer() {
+            executor = executor.with_managed_installer(installer);
+        }
         executor
     }
 
@@ -245,6 +392,12 @@ impl ClaudeCodeIntegration {
                 }
                 STEP_SIDE_CHANNEL_SCOPE => {
                     rendered.insert(step.id.clone(), mitm_hosts_document());
+                }
+                STEP_ENDPOINT_MANAGED_SETTINGS => {
+                    rendered.insert(
+                        step.id.clone(),
+                        managed_settings::managed_settings_document(plan.profile)?,
+                    );
                 }
                 _ => {}
             }
@@ -314,18 +467,68 @@ impl ClaudeCodeIntegration {
             })
             .collect();
 
-        evidence.push(ProtectionEvidence::new(
-            IntegrationCapability::HostEnforcement,
-            EvidenceKind::Absent {
-                reason: HOST_ENFORCEMENT_REASON.to_string(),
-            },
-            now,
-            format!(
-                "known bypasses this integration cannot observe: {}",
-                bypass::UNOBSERVABLE_BYPASSES
-            ),
-        ));
+        evidence.push(self.host_enforcement_evidence(now));
         evidence
+    }
+
+    /// Whether this adapter can offer an endpoint-managed install at all.
+    ///
+    /// A platform without an authorization mechanism is `Unsupported`; a
+    /// terminal-less invocation is not — that is a runtime condition the plan
+    /// warns about and the install refuses on, not a capability the adapter
+    /// lacks.
+    fn host_enforcement_support(&self) -> CapabilitySupport {
+        match self.managed_authority.availability() {
+            Authorization::Unavailable { detail } => CapabilitySupport::unsupported(format!(
+                "endpoint-managed settings cannot be installed on this host: {detail}"
+            )),
+            _ => CapabilitySupport::Supported,
+        }
+    }
+
+    /// The one observation that can raise the ladder to `HostEnforced`.
+    ///
+    /// [`EvidenceKind::HostAttested`] is produced **only** by reading the
+    /// installed managed file back and checking its content, owner and
+    /// permissions against what was authorized. Every other outcome — nothing
+    /// installed, a digest that moved, an owner that is not the expected one, a
+    /// mode that lets someone else rewrite it — is
+    /// [`EvidenceKind::Absent`], which lowers and never raises.
+    fn host_enforcement_evidence(&self, now: u64) -> ProtectionEvidence {
+        let absent = |reason: String, detail: String| {
+            ProtectionEvidence::new(
+                IntegrationCapability::HostEnforcement,
+                EvidenceKind::Absent { reason },
+                now,
+                detail,
+            )
+        };
+
+        let Some(installer) = self.managed_installer() else {
+            return absent(
+                HOST_ENFORCEMENT_REASON.to_string(),
+                format!(
+                    "known bypasses this integration cannot observe: {}",
+                    bypass::UNOBSERVABLE_BYPASSES
+                ),
+            );
+        };
+
+        match installer.verify_recorded() {
+            Ok(attestation) => ProtectionEvidence::new(
+                IntegrationCapability::HostEnforcement,
+                EvidenceKind::HostAttested { healthy: true },
+                now,
+                format!("{}. {HOST_ATTESTATION_CAVEAT}", attestation.detail()),
+            ),
+            Err(e) => absent(
+                format!("{HOST_ENFORCEMENT_REASON} ({})", e.summary()),
+                format!(
+                    "{e}; known bypasses this integration cannot observe: {}",
+                    bypass::UNOBSERVABLE_BYPASSES
+                ),
+            ),
+        }
     }
 
     /// Read every applied, fingerprinted step back off the host and compare it
@@ -400,10 +603,23 @@ impl ClaudeCodeIntegration {
 const PROBE_NOT_RUN_REASON: &str =
     "no probe traffic has been produced and adjudicated on the model path; run `aasm integrations verify claude-code`";
 
-/// Why `HostEnforced` is not reachable for this integration.
-const HOST_ENFORCEMENT_REASON: &str = "host enforcement is unavailable: Agent Assembly does not install its \
-     certificate authority into the macOS system trust store for this integration — trust is established \
-     per-launch through NODE_EXTRA_CA_CERTS — and kernel-level enforcement is Linux-only";
+/// Why `HostEnforced` is not reachable from an unprivileged install.
+///
+/// Stated as a *reason it is not active here*, not as a blanket unavailability:
+/// since AAASM-5298 there is a path to it, and it is opt-in, privileged and
+/// verified. Kernel-level enforcement remains Linux-only and the proxy CA is
+/// still never added to the macOS system trust store — trust is established
+/// per-launch through `NODE_EXTRA_CA_CERTS`.
+const HOST_ENFORCEMENT_REASON: &str = "host enforcement is not active: no endpoint-managed settings file \
+     installed by Agent Assembly was verified on this host. Install it with \
+     `aasm integrations install claude-code --install-managed-settings`, which asks for administrator \
+     authorization for one file write. Kernel-level enforcement remains Linux-only, and Agent Assembly \
+     never adds its certificate authority to the macOS system trust store";
+
+/// What an endpoint-managed attestation does, and does not, claim.
+const HOST_ATTESTATION_CAVEAT: &str = "Agent Assembly verified that the managed policy is installed, owned \
+     as expected and not writable by you; it has not measured Claude Code's runtime handling of each \
+     managed-only key";
 
 /// The mechanism a step's artifact is evidence about.
 fn step_mechanism(action: &StepAction) -> IntegrationCapability {
@@ -544,7 +760,7 @@ impl DevToolIntegration for ClaudeCodeIntegration {
                 "Claude Code is a terminal CLI and has no in-editor surface for status or approval \
                  prompts",
             )
-            .unsupported(IntegrationCapability::HostEnforcement, HOST_ENFORCEMENT_REASON)
+            .declare(IntegrationCapability::HostEnforcement, self.host_enforcement_support())
     }
 
     fn detect(&self) -> Option<DevToolInfo> {
@@ -571,10 +787,16 @@ impl DevToolIntegration for ClaudeCodeIntegration {
         let capabilities = self.capabilities();
 
         let interception_available = capabilities.can_intercept_model_path();
-        let ceiling = if interception_available {
-            ProtectionLevel::GatewayProtected
-        } else {
-            ProtectionLevel::Integrated
+        // The endpoint-managed surface is the only one that can carry a
+        // bypass-resistance claim, so it is the only one whose ceiling is
+        // `HostEnforced`. A user- or project-scoped plan cannot reach it —
+        // which is the governing rule of AAASM-5298 expressed as a number.
+        let host_enforcement_available = scope == SettingsScope::Managed
+            && !matches!(self.managed_authority.availability(), Authorization::Unavailable { .. });
+        let ceiling = match (interception_available, host_enforcement_available) {
+            (true, true) => ProtectionLevel::HostEnforced,
+            (true, false) => ProtectionLevel::GatewayProtected,
+            (false, _) => ProtectionLevel::Integrated,
         };
         let planned_level = request.effective_target_level().min(ceiling);
 
@@ -585,22 +807,31 @@ impl DevToolIntegration for ClaudeCodeIntegration {
             GovernanceLevel::L2Enforce,
         );
 
-        // 1. Managed settings — tool-action governance, not the data path.
-        let settings = managed_settings_json(request.profile)?;
-        plan = plan.with_step(IntegrationStep::new(
-            STEP_MANAGED_SETTINGS,
-            StepAction::WriteManagedSettings {
-                scope,
-                path: settings_path.clone(),
-                managed_keys: MANAGED_KEYS.iter().map(|k| (*k).to_string()).collect(),
-                content_sha256: sha256_hex(&settings),
-                merge: SettingsMerge::MergeManagedKeys,
-            },
-            format!(
-                "merge Agent Assembly's four managed keys into {} and leave every other key alone",
-                settings_path.display()
-            ),
-        ));
+        if scope == SettingsScope::Managed {
+            // 1a. The one privileged step. Every fact the user has to weigh is
+            //     in the plan *and* in the disclosure the CLI renders before the
+            //     confirmation — the plan is what the service checks consent
+            //     against, the disclosure is what makes that consent informed.
+            plan = self.with_endpoint_managed_step(plan, request.profile, &settings_path)?;
+        } else {
+            // 1b. The unprivileged install: tool-action governance in a file the
+            //     developer already owns, and not the data path.
+            let settings = managed_settings_json(request.profile)?;
+            plan = plan.with_step(IntegrationStep::new(
+                STEP_MANAGED_SETTINGS,
+                StepAction::WriteManagedSettings {
+                    scope,
+                    path: settings_path.clone(),
+                    managed_keys: MANAGED_KEYS.iter().map(|k| (*k).to_string()).collect(),
+                    content_sha256: sha256_hex(&settings),
+                    merge: SettingsMerge::MergeManagedKeys,
+                },
+                format!(
+                    "merge Agent Assembly's four managed keys into {} and leave every other key alone",
+                    settings_path.display()
+                ),
+            ));
+        }
 
         if interception_available {
             // 2. Trust material — condition C1, first half.
@@ -916,6 +1147,7 @@ impl DevToolIntegration for ClaudeCodeIntegration {
 
     async fn plan_removal(&self, receipt: &IntegrationReceipt) -> Result<RemovalPlan, AdapterError> {
         let mut plan = RemovalPlan::new(removal_plan_id(receipt), DevToolKind::ClaudeCode);
+        let mut managed_removal_needs_authorization = false;
 
         // A protection test mutated nothing, so there is nothing to undo and
         // nothing a reviewer needs to approve. Listing it would make the
@@ -927,6 +1159,18 @@ impl DevToolIntegration for ClaudeCodeIntegration {
             .filter(|s| s.applied && !s.action.is_protection_test())
         {
             let summary = match &step.action {
+                StepAction::WriteManagedSettings {
+                    scope: SettingsScope::Managed,
+                    path,
+                    ..
+                } => {
+                    managed_removal_needs_authorization = true;
+                    format!(
+                        "restore the managed-settings file at {} to what was there before the install, or \
+                         delete it when there was nothing — asking for administrator authorization again",
+                        path.display()
+                    )
+                }
                 StepAction::WriteManagedSettings { path, .. } => format!(
                     "restore the four Agent Assembly-owned keys in {} to what they held before install, \
                      and leave everything you changed since alone",
@@ -969,6 +1213,15 @@ impl DevToolIntegration for ClaudeCodeIntegration {
                     .to_string(),
             )
             .warn("restart any running Claude Code session for the removal to take effect".to_string());
+
+        if managed_removal_needs_authorization {
+            plan = plan.warn(
+                "this removal reverses a privileged step and will ask for administrator authorization \
+                 once. Removal is symmetric: a file that was there before the install is restored from \
+                 the backup, and a host that had none goes back to having none"
+                    .to_string(),
+            );
+        }
 
         Ok(plan)
     }

--- a/aa-devtool-claude-code/src/lifecycle.rs
+++ b/aa-devtool-claude-code/src/lifecycle.rs
@@ -237,6 +237,18 @@ impl ClaudeCodeIntegration {
         path: &std::path::Path,
     ) -> Result<IntegrationPlan, AdapterError> {
         let document = managed_settings::managed_settings_document(profile)?;
+        // The disclosure the owner's model requires — path, reason, content,
+        // diff, conflict, backup, rollback — travels to the client as plan
+        // warnings, because the client renders the whole plan *before* it asks
+        // for confirmation and never sees the adapter directly. Nothing here is
+        // decorative: an authorization granted without the diff and the conflict
+        // in front of the user is not informed consent.
+        let disclosure = self
+            .managed_installer()
+            .map(|installer| installer.disclose(&document))
+            .transpose()
+            .map_err(|e| AdapterError::SettingsGenerationFailed(e.to_string()))?;
+
         let mut plan = plan
             .with_step(
                 IntegrationStep::new(
@@ -282,6 +294,29 @@ impl ClaudeCodeIntegration {
                  rather than merging over it"
                     .to_string(),
             );
+
+        if let Some(disclosure) = &disclosure {
+            plan = plan.warn(format!(
+                "the exact content that will be written to {} (sha256:{}): {}",
+                disclosure.target.display(),
+                disclosure.proposed_sha256,
+                disclosure.proposed.split_whitespace().collect::<Vec<_>>().join(" ")
+            ));
+            plan = plan.warn(if disclosure.diff.is_empty() {
+                format!(
+                    "{} already holds exactly this content; the install verifies it and asks for no \
+                     authorization",
+                    disclosure.target.display()
+                )
+            } else {
+                format!("changes against what is on this host: {}", disclosure.diff.join("  "))
+            });
+            plan = plan.warn(disclosure.backup.clone());
+            plan = plan.warn(disclosure.rollback.clone());
+            if let Some(conflict) = &disclosure.conflict {
+                plan = plan.warn(format!("CONFLICT — this plan will refuse: {conflict}"));
+            }
+        }
 
         if !self.paths.managed_root_is_canonical() {
             plan = plan.warn(format!(

--- a/aa-devtool-claude-code/src/managed_settings.rs
+++ b/aa-devtool-claude-code/src/managed_settings.rs
@@ -1,0 +1,1680 @@
+//! The endpoint-managed settings file, and the one privileged write that
+//! installs it — AAASM-5298.
+//!
+//! # Why this module exists at all
+//!
+//! Everything else this integration does is reversible by the developer who ran
+//! it, because everything else lives in files that developer already owns. The
+//! macOS endpoint managed-settings file does not: it is root-owned, it sits
+//! above every other settings scope in Claude Code's precedence order, and its
+//! managed-only keys (`allowManagedPermissionRulesOnly`,
+//! `disableBypassPermissionsMode`, `allowManagedMcpServersOnly`,
+//! `allowManagedHooksOnly`) are the only levers that a user cannot turn off from
+//! their own configuration. That is exactly why it is the only surface that can
+//! carry a bypass-resistance claim, and exactly why writing it needs
+//! administrator authorization.
+//!
+//! # The shape of the elevation, and what it is *not*
+//!
+//! The installer is unprivileged. It classifies the existing file, takes the
+//! backup, stages the exact bytes, verifies the result, writes the record and
+//! performs the rollback — all as the invoking user. The **only** elevated
+//! operation is [`PrivilegedFileAuthority::install_file`]: place one
+//! already-written file at one already-named path, owned by root. Nothing else
+//! in the process is elevated, and there is no code path that runs the installer
+//! — let alone `aasm` — as root.
+//!
+//! [`MacOsAdminAuthority`] additionally refuses any target that is not the
+//! canonical [`MANAGED_SETTINGS_PATH`]. A caller that redirects the managed root
+//! (as every test does) therefore cannot reach the real authorization prompt
+//! even by accident: the redirect makes the write unprivileged by construction.
+//!
+//! # Consent is a security control, not a prompt
+//!
+//! [`ConsentDisclosure`] is built *before* authorization is requested and states,
+//! in this order: the exact target path, why the privileged write is required,
+//! the proposed content and its diff against what is there, any existing-file
+//! conflict, and the backup and rollback behaviour. A user who cannot see the
+//! diff cannot meaningfully authorize it, so [`ManagedSettingsInstaller::install`]
+//! takes the disclosure — not the raw content — and refuses when the host has
+//! changed underneath it since the disclosure was rendered.
+//!
+//! # Read-back is what separates a claim from evidence
+//!
+//! [`ManagedSettingsInstaller::install`] does not return success on the strength
+//! of the authority reporting success. It re-reads the file, compares the bytes
+//! to what was authorized, and checks ownership and permissions. A mismatch
+//! rolls back and fails; it never produces an attestation, so it can never
+//! produce `Host Enforced`.
+//!
+//! # What this module does *not* prove
+//!
+//! [`ManagedSettingsAttestation`] attests that the managed policy is installed
+//! at the OS-managed path, owned by the expected principal, and not writable by
+//! the invoking user. It does **not** measure whether Claude Code honours each
+//! managed-only key at runtime — that needs a managed device and a real
+//! privileged write, and remains the open half of AAASM-5298. Every user-facing
+//! surface that reports this attestation has to say so.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use aa_devtool_contract::{sha256_hex, AdapterError, ProtectionProfile};
+
+/// The directory macOS reserves for Claude Code's endpoint-managed settings.
+pub const MANAGED_SETTINGS_DIR: &str = "/Library/Application Support/ClaudeCode";
+
+/// The managed settings file name.
+pub const MANAGED_SETTINGS_FILE: &str = "managed-settings.json";
+
+/// The canonical endpoint managed-settings path.
+///
+/// [`MacOsAdminAuthority`] will not elevate for any other target, so this
+/// constant is a security boundary and not merely a default.
+pub const MANAGED_SETTINGS_PATH: &str = "/Library/Application Support/ClaudeCode/managed-settings.json";
+
+/// The keys Claude Code honours **only** when they arrive from the managed
+/// surface, and ignores everywhere else.
+///
+/// These are the whole reason the privileged write exists. A managed document
+/// that carries none of them is a settings file at a privileged path — an
+/// elevation with no enforcement purpose — and
+/// [`validate_managed_document`] refuses it.
+pub const MANAGED_ONLY_KEYS: [&str; 4] = [
+    "allowManagedHooksOnly",
+    "allowManagedMcpServersOnly",
+    "allowManagedPermissionRulesOnly",
+    "disableBypassPermissionsMode",
+];
+
+/// Top-level keys this integration is willing to write to the managed surface.
+///
+/// An allowlist rather than a denylist: the file is root-owned and
+/// world-readable, and a key this build does not understand is a key this build
+/// cannot promise is safe to put there.
+const WRITABLE_KEYS: [&str; 8] = [
+    "allowManagedHooksOnly",
+    "allowManagedMcpServersOnly",
+    "allowManagedPermissionRulesOnly",
+    "disableBypassPermissionsMode",
+    "disabledMcpjsonServers",
+    "enabledMcpjsonServers",
+    "permissionMode",
+    "permissions",
+];
+
+/// Keys refused outright, whatever else the document contains.
+///
+/// `env` and `apiKeyHelper` are the two managed-settings keys that can carry
+/// credential material, and the managed file is root-owned and readable by every
+/// account on the machine. Writing a token there would turn a governance control
+/// into a credential disclosure.
+const FORBIDDEN_KEYS: [&str; 2] = ["apiKeyHelper", "env"];
+
+/// The file name of the staged copy, inside Agent Assembly's own state.
+const STAGED_FILE: &str = "managed-settings.staged.json";
+/// The file name of the pre-install backup, inside Agent Assembly's own state.
+const BACKUP_FILE: &str = "managed-settings.backup.json";
+/// The file name of the install record, inside Agent Assembly's own state.
+const RECORD_FILE: &str = "managed-settings.install.json";
+
+/// Why a privileged managed-settings operation could not complete.
+///
+/// Every variant is a *refusal*, not a downgrade: nothing here is recoverable by
+/// proceeding with less, because proceeding with less would mean reporting an
+/// enforcement level the host does not have.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ManagedSettingsError {
+    /// Authorization was requested and refused, or the mechanism could not
+    /// obtain it. Truthfully "Permission Required" — never a partial success.
+    #[error("permission required: administrator authorization to write {path} was not granted ({detail})")]
+    PermissionRequired {
+        /// The target that was not written.
+        path: String,
+        /// What the authorization mechanism reported.
+        detail: String,
+    },
+    /// No authorization mechanism exists on this host at all.
+    #[error("unavailable: no administrator authorization mechanism is available on this host ({detail})")]
+    AuthorizationUnavailable {
+        /// Why none is available.
+        detail: String,
+    },
+    /// There is no terminal to authorize on. Fails immediately rather than
+    /// blocking a pipeline on a credential prompt nobody can answer.
+    #[error("unavailable: administrator authorization needs an interactive terminal ({detail})")]
+    NonInteractive {
+        /// What was missing.
+        detail: String,
+    },
+    /// A managed-settings file exists that Agent Assembly did not write.
+    #[error("{path} already holds managed settings Agent Assembly did not write; {detail}")]
+    ConflictingExistingFile {
+        /// The conflicting file.
+        path: String,
+        /// What the user has to decide, in words they can act on.
+        detail: String,
+    },
+    /// The file read back after the write is not the file that was authorized.
+    #[error("the managed settings read back from {path} are not what was authorized: {detail}")]
+    ReadBackMismatch {
+        /// The target that was read back.
+        path: String,
+        /// Which check failed.
+        detail: String,
+    },
+    /// The proposed document is not something this integration will write to a
+    /// root-owned path.
+    #[error("the proposed managed-settings document was refused: {detail}")]
+    SchemaInvalid {
+        /// Which rule it broke.
+        detail: String,
+    },
+    /// The host changed between the disclosure the user reviewed and the write.
+    #[error("what was disclosed is no longer what would be written: {detail}")]
+    ConsentStale {
+        /// What changed.
+        detail: String,
+    },
+    /// An unprivileged filesystem operation failed.
+    #[error("{path}: {detail}")]
+    Io {
+        /// What was being touched.
+        path: String,
+        /// What went wrong.
+        detail: String,
+    },
+}
+
+impl ManagedSettingsError {
+    /// The short, stable classification a status line reports.
+    ///
+    /// `Permission Required` and `Unavailable` are the two words the product
+    /// promises never to soften into a success, so they are produced here rather
+    /// than reconstructed from prose at each call site.
+    pub fn summary(&self) -> &'static str {
+        match self {
+            Self::PermissionRequired { .. } => "Permission Required",
+            Self::AuthorizationUnavailable { .. } | Self::NonInteractive { .. } => "Unavailable",
+            Self::ConflictingExistingFile { .. } => "Conflicting managed settings",
+            Self::ReadBackMismatch { .. } => "Read-back verification failed",
+            Self::SchemaInvalid { .. } => "Refused: invalid managed-settings document",
+            Self::ConsentStale { .. } => "Refused: the host changed after the disclosure",
+            Self::Io { .. } => "Failed",
+        }
+    }
+}
+
+fn io_error(path: &Path, e: &std::io::Error) -> ManagedSettingsError {
+    ManagedSettingsError::Io {
+        path: path.display().to_string(),
+        detail: e.to_string(),
+    }
+}
+
+/// Whether an authorization prompt can be raised at all, asked *before* one is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Authorization {
+    /// A prompt can be raised.
+    Available,
+    /// There is a mechanism, but no terminal to use it on.
+    NonInteractive {
+        /// What is missing.
+        detail: String,
+    },
+    /// There is no mechanism on this host.
+    Unavailable {
+        /// Why not.
+        detail: String,
+    },
+}
+
+impl Authorization {
+    /// Turn a pre-flight reading into the refusal it implies, or `Ok(())`.
+    fn require(&self, path: &Path) -> Result<(), ManagedSettingsError> {
+        match self {
+            Self::Available => Ok(()),
+            Self::NonInteractive { detail } => Err(ManagedSettingsError::NonInteractive { detail: detail.clone() }),
+            Self::Unavailable { detail } => Err(ManagedSettingsError::AuthorizationUnavailable {
+                detail: format!("{detail} (target {})", path.display()),
+            }),
+        }
+    }
+}
+
+/// The elevation seam: one authorized file placement, and its reversal.
+///
+/// Deliberately not "run this command as root" and not "give me a privileged
+/// process". The two operations take a target path and, for an install, a file
+/// whose bytes were already written unprivileged — so the elevated code has no
+/// content to interpret, no policy to evaluate and no branch a caller can steer.
+pub trait PrivilegedFileAuthority: fmt::Debug + Send + Sync {
+    /// How this authority obtains authorization, for the disclosure.
+    fn mechanism(&self) -> &str;
+
+    /// Whether a prompt could be raised. Must never raise one.
+    fn availability(&self) -> Authorization;
+
+    /// Place `staged` at `target`, owned by the administrator, replacing
+    /// whatever is there atomically.
+    fn install_file(&self, target: &Path, staged: &Path) -> Result<(), ManagedSettingsError>;
+
+    /// Delete `target`. Must succeed when `target` is already absent.
+    fn delete_file(&self, target: &Path) -> Result<(), ManagedSettingsError>;
+}
+
+/// The macOS administrator-authorization authority.
+///
+/// # What it runs, and what it refuses to run
+///
+/// One `osascript … with administrator privileges` invocation per operation,
+/// whose script is a single `/usr/bin/install` (or `/bin/rm`) against paths this
+/// process chose. It refuses before spawning anything when the target is not
+/// [`MANAGED_SETTINGS_PATH`], when there is no terminal, and on any non-macOS
+/// host.
+///
+/// The target guard is what makes the whole test suite safe: every test injects
+/// a temporary managed root, so every test's target fails the guard and no test
+/// can reach an authorization prompt.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MacOsAdminAuthority;
+
+impl MacOsAdminAuthority {
+    /// Refuse before doing anything, for a target this authority will not
+    /// elevate for.
+    fn guard(&self, target: &Path) -> Result<(), ManagedSettingsError> {
+        if target != Path::new(MANAGED_SETTINGS_PATH) {
+            return Err(ManagedSettingsError::AuthorizationUnavailable {
+                detail: format!(
+                    "this authority elevates only for {MANAGED_SETTINGS_PATH}; {} is not that path",
+                    target.display()
+                ),
+            });
+        }
+        self.availability().require(target)
+    }
+
+    /// Single-quote a path for `/bin/sh`, so a path containing a space or a
+    /// quote cannot become a second command.
+    fn shell_quote(path: &Path) -> String {
+        format!("'{}'", path.display().to_string().replace('\'', r"'\''"))
+    }
+
+    /// Escape a `/bin/sh` script for embedding in an AppleScript string
+    /// literal.
+    fn applescript_quote(script: &str) -> String {
+        format!("\"{}\"", script.replace('\\', r"\\").replace('"', "\\\""))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn run(&self, script: &str) -> Result<(), ManagedSettingsError> {
+        let literal = Self::applescript_quote(script);
+        let output = std::process::Command::new("/usr/bin/osascript")
+            .arg("-e")
+            .arg(format!("do shell script {literal} with administrator privileges"))
+            .output()
+            .map_err(|e| ManagedSettingsError::AuthorizationUnavailable {
+                detail: format!("the macOS authorization helper could not be started: {e}"),
+            })?;
+        if output.status.success() {
+            return Ok(());
+        }
+        Err(ManagedSettingsError::PermissionRequired {
+            path: MANAGED_SETTINGS_PATH.to_string(),
+            detail: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn run(&self, _script: &str) -> Result<(), ManagedSettingsError> {
+        Err(ManagedSettingsError::AuthorizationUnavailable {
+            detail: "endpoint-managed settings are a macOS mechanism".to_string(),
+        })
+    }
+}
+
+impl PrivilegedFileAuthority for MacOsAdminAuthority {
+    fn mechanism(&self) -> &str {
+        "macOS administrator authorization (one authorized file placement; aasm itself never runs as root)"
+    }
+
+    fn availability(&self) -> Authorization {
+        if !cfg!(target_os = "macos") {
+            return Authorization::Unavailable {
+                detail: "endpoint-managed settings are a macOS mechanism".to_string(),
+            };
+        }
+        use std::io::IsTerminal;
+        if !std::io::stdin().is_terminal() {
+            return Authorization::NonInteractive {
+                detail: "stdin is not a terminal, so an administrator prompt could not be answered".to_string(),
+            };
+        }
+        Authorization::Available
+    }
+
+    fn install_file(&self, target: &Path, staged: &Path) -> Result<(), ManagedSettingsError> {
+        self.guard(target)?;
+        let dir = target.parent().unwrap_or(Path::new(MANAGED_SETTINGS_DIR));
+        // `install(1)` writes a temporary and renames it, so the target is never
+        // observed half-written.
+        let script = format!(
+            "/bin/mkdir -p {dir} && /usr/bin/install -m 644 -o root -g wheel -- {staged} {target}",
+            dir = Self::shell_quote(dir),
+            staged = Self::shell_quote(staged),
+            target = Self::shell_quote(target),
+        );
+        self.run(&script)
+    }
+
+    fn delete_file(&self, target: &Path) -> Result<(), ManagedSettingsError> {
+        self.guard(target)?;
+        self.run(&format!("/bin/rm -f -- {}", Self::shell_quote(target)))
+    }
+}
+
+/// What is already sitting at the managed path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExistingManagedSettings {
+    /// Nothing is there.
+    Absent,
+    /// The file matches the one Agent Assembly recorded installing.
+    WrittenByAgentAssembly {
+        /// Its digest.
+        sha256: String,
+    },
+    /// A file is there that Agent Assembly did not write, or wrote and something
+    /// else has since changed.
+    Foreign {
+        /// Its digest.
+        sha256: String,
+        /// Its top-level keys, so the disclosure can describe it without
+        /// printing values that may not be ours to show.
+        keys: Vec<String>,
+    },
+}
+
+impl ExistingManagedSettings {
+    /// Whether this is a conflict that needs a separate, explicit decision.
+    pub fn is_conflict(&self) -> bool {
+        matches!(self, Self::Foreign { .. })
+    }
+
+    /// The digest of what is there, when anything is.
+    pub fn sha256(&self) -> Option<&str> {
+        match self {
+            Self::Absent => None,
+            Self::WrittenByAgentAssembly { sha256 } | Self::Foreign { sha256, .. } => Some(sha256),
+        }
+    }
+}
+
+/// Everything a user must see before authorization is requested.
+///
+/// Field order is the disclosure order, and [`render`](Self::render) prints them
+/// in it. Nothing here is optional presentation: an authorization granted
+/// without the diff and the conflict in front of the user is not informed
+/// consent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsentDisclosure {
+    /// The exact file that will be written.
+    pub target: PathBuf,
+    /// Why the write needs administrator authorization.
+    pub reason: String,
+    /// The exact bytes that will be placed there.
+    pub proposed: String,
+    /// Their digest, which the install re-checks.
+    pub proposed_sha256: String,
+    /// What is there now.
+    pub existing: ExistingManagedSettings,
+    /// A line-level diff of current against proposed.
+    pub diff: Vec<String>,
+    /// The conflict that blocks this install, when there is one.
+    pub conflict: Option<String>,
+    /// Where the pre-install backup goes, and what happens when there is no
+    /// prior file.
+    pub backup: String,
+    /// How to reverse the install.
+    pub rollback: String,
+    /// How authorization will be obtained.
+    pub mechanism: String,
+    /// Whether it can be obtained at all, read before it is requested.
+    pub authorization: Authorization,
+}
+
+impl ConsentDisclosure {
+    /// Render the disclosure, in the order it must be read.
+    pub fn render(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        let _ = writeln!(out, "administrator authorization is required for one file write");
+        let _ = writeln!(out, "  target:      {}", self.target.display());
+        let _ = writeln!(out, "  why:         {}", self.reason);
+        let _ = writeln!(out, "  authorized:  {}", self.mechanism);
+        let _ = writeln!(out, "  proposed content:");
+        for line in self.proposed.lines() {
+            let _ = writeln!(out, "    {line}");
+        }
+        let _ = writeln!(out, "  currently on this host:");
+        match &self.existing {
+            ExistingManagedSettings::Absent => {
+                let _ = writeln!(out, "    (no managed-settings file)");
+            }
+            ExistingManagedSettings::WrittenByAgentAssembly { sha256 } => {
+                let _ = writeln!(out, "    a file Agent Assembly installed (sha256:{sha256})");
+            }
+            ExistingManagedSettings::Foreign { sha256, keys } => {
+                let _ = writeln!(
+                    out,
+                    "    a file Agent Assembly did not write (sha256:{sha256}), top-level keys: {}",
+                    keys.join(", ")
+                );
+            }
+        }
+        let _ = writeln!(out, "  changes:");
+        if self.diff.is_empty() {
+            let _ = writeln!(out, "    (none — the file already holds exactly this content)");
+        } else {
+            for line in &self.diff {
+                let _ = writeln!(out, "    {line}");
+            }
+        }
+        if let Some(conflict) = &self.conflict {
+            let _ = writeln!(out, "  conflict:    {conflict}");
+        }
+        let _ = writeln!(out, "  backup:      {}", self.backup);
+        let _ = writeln!(out, "  rollback:    {}", self.rollback);
+        match &self.authorization {
+            Authorization::Available => {}
+            Authorization::NonInteractive { detail } | Authorization::Unavailable { detail } => {
+                let _ = writeln!(out, "  blocked:     {detail}");
+            }
+        }
+        out
+    }
+
+    /// Whether this disclosure describes an install that can proceed.
+    pub fn is_installable(&self) -> bool {
+        self.conflict.is_none() && matches!(self.authorization, Authorization::Available)
+    }
+}
+
+/// What was read back off the host after the privileged write.
+///
+/// This is the evidence a `Host Enforced` claim rests on. It records the facts
+/// that were checked rather than a bare boolean, so a status line can say what
+/// was verified instead of asserting that something was.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedSettingsAttestation {
+    /// The file that was read back.
+    pub target: PathBuf,
+    /// Its digest, as read back.
+    pub sha256: String,
+    /// Its owner, when the platform reports one.
+    pub owner_uid: Option<u32>,
+    /// Its permission bits, when the platform reports them.
+    pub mode: Option<u32>,
+    /// Which managed-only keys are actually in the installed document.
+    pub managed_only_keys: Vec<String>,
+    /// Whether anyone other than the owner can rewrite it.
+    pub writable_by_others: bool,
+}
+
+impl ManagedSettingsAttestation {
+    /// One line describing what was verified, for evidence detail.
+    pub fn detail(&self) -> String {
+        format!(
+            "{} verified by read-back: sha256:{}, owner uid {}, mode {}, managed-only keys [{}]",
+            self.target.display(),
+            self.sha256,
+            self.owner_uid.map_or_else(|| "unknown".to_string(), |u| u.to_string()),
+            self.mode.map_or_else(|| "unknown".to_string(), |m| format!("{m:04o}")),
+            self.managed_only_keys.join(", ")
+        )
+    }
+}
+
+/// What an install actually did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedInstallOutcome {
+    /// The verified state of the file afterwards.
+    pub attestation: ManagedSettingsAttestation,
+    /// Whether the host changed. `false` means the file already held exactly
+    /// this content and **no authorization was requested**.
+    pub mutated: bool,
+    /// Where the prior file was backed up, when there was one.
+    pub backup: Option<PathBuf>,
+}
+
+/// What a rollback did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ManagedRollbackOutcome {
+    /// There was nothing installed to roll back.
+    NothingToDo,
+    /// A prior file was restored from the backup.
+    Restored {
+        /// Where it came from.
+        backup: PathBuf,
+    },
+    /// There was no prior file, so the managed file was deleted.
+    Removed,
+}
+
+/// The record Agent Assembly keeps of its own managed-settings install.
+///
+/// Kept in Agent Assembly's unprivileged state rather than as a marker key
+/// inside the managed file: an unrecognised key in `managed-settings.json` makes
+/// Claude Code warn, and a governance tool that provokes a warning in the tool it
+/// governs has made the user's day worse for its own bookkeeping.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+struct InstallRecord {
+    target: PathBuf,
+    installed_sha256: String,
+    /// `None` records "there was no file here before" — the case a rollback has
+    /// to handle by deleting rather than restoring.
+    backup: Option<PathBuf>,
+    installed_at_unix_secs: u64,
+}
+
+/// Installs, verifies and reverses the endpoint-managed settings file.
+///
+/// Unprivileged itself; holds one [`PrivilegedFileAuthority`] and calls it for
+/// exactly one operation per install and one per rollback.
+#[derive(Debug, Clone)]
+pub struct ManagedSettingsInstaller {
+    target: PathBuf,
+    work_dir: PathBuf,
+    authority: Arc<dyn PrivilegedFileAuthority>,
+    expected_owner_uid: u32,
+}
+
+impl ManagedSettingsInstaller {
+    /// An installer writing `target`, keeping its own state under `work_dir`,
+    /// elevating through `authority`.
+    pub fn new(
+        target: impl Into<PathBuf>,
+        work_dir: impl Into<PathBuf>,
+        authority: Arc<dyn PrivilegedFileAuthority>,
+    ) -> Self {
+        Self {
+            target: target.into(),
+            work_dir: work_dir.into(),
+            authority,
+            expected_owner_uid: 0,
+        }
+    }
+
+    /// Expect a different owner than root.
+    ///
+    /// Production always expects uid 0. A test that redirects the managed root
+    /// writes as the test user, so it names that uid instead — and the ownership
+    /// check stays load-bearing in both cases rather than being switched off.
+    #[must_use]
+    pub fn expecting_owner_uid(mut self, uid: u32) -> Self {
+        self.expected_owner_uid = uid;
+        self
+    }
+
+    /// The file this installer writes.
+    pub fn target(&self) -> &Path {
+        &self.target
+    }
+
+    /// How authorization would be obtained, without requesting it.
+    pub fn authorization(&self) -> Authorization {
+        self.authority.availability()
+    }
+
+    fn staged_path(&self) -> PathBuf {
+        self.work_dir.join(STAGED_FILE)
+    }
+
+    fn backup_path(&self) -> PathBuf {
+        self.work_dir.join(BACKUP_FILE)
+    }
+
+    fn record_path(&self) -> PathBuf {
+        self.work_dir.join(RECORD_FILE)
+    }
+
+    fn read_record(&self) -> Option<InstallRecord> {
+        let raw = std::fs::read_to_string(self.record_path()).ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    fn write_record(&self, record: &InstallRecord) -> Result<(), ManagedSettingsError> {
+        let path = self.record_path();
+        std::fs::create_dir_all(&self.work_dir).map_err(|e| io_error(&self.work_dir, &e))?;
+        let body = serde_json::to_string_pretty(record).map_err(|e| ManagedSettingsError::Io {
+            path: path.display().to_string(),
+            detail: e.to_string(),
+        })?;
+        std::fs::write(&path, body).map_err(|e| io_error(&path, &e))
+    }
+
+    /// Read what is currently at the managed path, if anything.
+    ///
+    /// Reading needs no privilege: the managed file is world-readable by design.
+    fn current(&self) -> Result<Option<String>, ManagedSettingsError> {
+        match std::fs::read_to_string(&self.target) {
+            Ok(raw) => Ok(Some(raw)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(io_error(&self.target, &e)),
+        }
+    }
+
+    /// Classify what is at the managed path against Agent Assembly's own record.
+    ///
+    /// # Errors
+    ///
+    /// [`ManagedSettingsError::Io`] when the file exists and cannot be read.
+    pub fn classify_existing(&self) -> Result<ExistingManagedSettings, ManagedSettingsError> {
+        let Some(raw) = self.current()? else {
+            return Ok(ExistingManagedSettings::Absent);
+        };
+        let sha256 = sha256_hex(&raw);
+        let ours = self
+            .read_record()
+            .is_some_and(|record| record.target == self.target && record.installed_sha256 == sha256);
+        if ours {
+            return Ok(ExistingManagedSettings::WrittenByAgentAssembly { sha256 });
+        }
+        Ok(ExistingManagedSettings::Foreign {
+            sha256,
+            keys: top_level_keys(&raw),
+        })
+    }
+
+    /// Build the disclosure a user must read before authorization is requested.
+    ///
+    /// # Errors
+    ///
+    /// [`ManagedSettingsError::SchemaInvalid`] when the proposed document is not
+    /// one this integration will write to a root-owned path, and
+    /// [`ManagedSettingsError::Io`] when the current file cannot be read.
+    pub fn disclose(&self, proposed: &str) -> Result<ConsentDisclosure, ManagedSettingsError> {
+        validate_managed_document(proposed)?;
+        let existing = self.classify_existing()?;
+        let current = self.current()?.unwrap_or_default();
+
+        // A conflict is a refusal to *merge over*, and deliberately not an
+        // option this tool offers to override: the file may be MDM-deployed by
+        // the user's own organisation, and silently replacing an administrator's
+        // policy with ours is the one outcome nothing here can justify. The
+        // separate explicit decision is the user's — move the file aside.
+        let conflict = existing.is_conflict().then(|| {
+            format!(
+                "a managed-settings file Agent Assembly did not write is already installed. \
+                 It may have been deployed by your organisation's device management. Agent Assembly \
+                 will not replace it. Move {} aside yourself and re-run if you intend to replace it",
+                self.target.display()
+            )
+        });
+
+        Ok(ConsentDisclosure {
+            target: self.target.clone(),
+            reason: format!(
+                "{} is owned by the administrator, and it is the only settings surface Claude Code \
+                 treats as non-overridable. Writing it needs one authorized file placement; Agent \
+                 Assembly itself never runs as root",
+                self.target.display()
+            ),
+            proposed_sha256: sha256_hex(proposed),
+            diff: line_diff(&current, proposed),
+            proposed: proposed.to_string(),
+            existing,
+            conflict,
+            backup: match self.current()? {
+                Some(_) => format!(
+                    "the file currently installed is copied to {} before anything is written",
+                    self.backup_path().display()
+                ),
+                None => format!(
+                    "there is no file to back up; removal will delete {} rather than restore anything",
+                    self.target.display()
+                ),
+            },
+            rollback: "`aasm integrations remove claude-code` restores the backed-up file, or deletes \
+                       the managed file when there was none — and asks for authorization again"
+                .to_string(),
+            mechanism: self.authority.mechanism().to_string(),
+            authorization: self.authority.availability(),
+        })
+    }
+
+    /// Install the disclosed content, then read it back and verify it.
+    ///
+    /// The disclosure is the argument rather than the content because it carries
+    /// the classification the user saw. If the host has changed since — the file
+    /// appeared, or changed digest — this refuses rather than writing over
+    /// something the user was never shown.
+    ///
+    /// # Errors
+    ///
+    /// Every variant of [`ManagedSettingsError`]. None of them is a partial
+    /// success: an error here means nothing was installed, or what was installed
+    /// was rolled back.
+    pub fn install(&self, disclosure: &ConsentDisclosure) -> Result<ManagedInstallOutcome, ManagedSettingsError> {
+        if disclosure.target != self.target {
+            return Err(ManagedSettingsError::ConsentStale {
+                detail: format!(
+                    "the disclosure names {} and this installer writes {}",
+                    disclosure.target.display(),
+                    self.target.display()
+                ),
+            });
+        }
+        validate_managed_document(&disclosure.proposed)?;
+        if sha256_hex(&disclosure.proposed) != disclosure.proposed_sha256 {
+            return Err(ManagedSettingsError::ConsentStale {
+                detail: "the disclosed content does not match its own digest".to_string(),
+            });
+        }
+
+        let existing = self.classify_existing()?;
+        if existing != disclosure.existing {
+            return Err(ManagedSettingsError::ConsentStale {
+                detail: format!(
+                    "{} changed after the disclosure was shown; re-run so the change is disclosed",
+                    self.target.display()
+                ),
+            });
+        }
+        if let ExistingManagedSettings::Foreign { sha256, .. } = &existing {
+            return Err(ManagedSettingsError::ConflictingExistingFile {
+                path: self.target.display().to_string(),
+                detail: format!(
+                    "it hashes to sha256:{sha256}, which is not the file Agent Assembly recorded installing. \
+                     Agent Assembly will not overwrite managed settings it did not write — move the file \
+                     aside yourself and re-run if you intend to replace it"
+                ),
+            });
+        }
+
+        // Already exactly right: verify and return without requesting
+        // authorization at all. Prompting for a write that would change nothing
+        // is how a tool trains users to click through prompts.
+        if existing.sha256() == Some(disclosure.proposed_sha256.as_str()) {
+            let attestation = self.verify_read_back(&disclosure.proposed_sha256)?;
+            return Ok(ManagedInstallOutcome {
+                attestation,
+                mutated: false,
+                backup: self.read_record().and_then(|r| r.backup),
+            });
+        }
+
+        // Pre-flight the authorization *before* touching anything, so a host
+        // that cannot authorize fails without having taken a backup or staged a
+        // file it will never install.
+        self.authority.availability().require(&self.target)?;
+
+        std::fs::create_dir_all(&self.work_dir).map_err(|e| io_error(&self.work_dir, &e))?;
+        let backup = match self.current()? {
+            Some(prior) => {
+                let path = self.backup_path();
+                std::fs::write(&path, &prior).map_err(|e| io_error(&path, &e))?;
+                Some(path)
+            }
+            None => {
+                // A stale backup from an earlier install would make a rollback
+                // restore a file that is not what this install displaced.
+                let path = self.backup_path();
+                if path.exists() {
+                    std::fs::remove_file(&path).map_err(|e| io_error(&path, &e))?;
+                }
+                None
+            }
+        };
+
+        let staged = self.staged_path();
+        std::fs::write(&staged, &disclosure.proposed).map_err(|e| io_error(&staged, &e))?;
+        set_mode(&staged, 0o644)?;
+
+        self.authority.install_file(&self.target, &staged)?;
+        let _ = std::fs::remove_file(&staged);
+
+        match self.verify_read_back(&disclosure.proposed_sha256) {
+            Ok(attestation) => {
+                self.write_record(&InstallRecord {
+                    target: self.target.clone(),
+                    installed_sha256: disclosure.proposed_sha256.clone(),
+                    backup: backup.clone(),
+                    installed_at_unix_secs: aa_devtool_contract::now_unix_secs(),
+                })?;
+                Ok(ManagedInstallOutcome {
+                    attestation,
+                    mutated: true,
+                    backup,
+                })
+            }
+            Err(mismatch) => {
+                // Put the host back before reporting. A failed read-back that
+                // left the file in place would be exactly the partial success
+                // this path is not allowed to produce.
+                let restore = match &backup {
+                    Some(path) => std::fs::copy(path, &staged)
+                        .ok()
+                        .and_then(|_| self.authority.install_file(&self.target, &staged).ok())
+                        .is_some(),
+                    None => self.authority.delete_file(&self.target).is_ok(),
+                };
+                let _ = std::fs::remove_file(&staged);
+                let detail = match (&mismatch, restore) {
+                    (ManagedSettingsError::ReadBackMismatch { detail, .. }, true) => {
+                        format!("{detail}; the previous state was restored")
+                    }
+                    (ManagedSettingsError::ReadBackMismatch { detail, .. }, false) => {
+                        format!("{detail}; the previous state could NOT be restored — inspect the file by hand")
+                    }
+                    _ => return Err(mismatch),
+                };
+                Err(ManagedSettingsError::ReadBackMismatch {
+                    path: self.target.display().to_string(),
+                    detail,
+                })
+            }
+        }
+    }
+
+    /// Read the managed file back and check it against `expected_sha256`,
+    /// ownership and permissions.
+    ///
+    /// # Errors
+    ///
+    /// [`ManagedSettingsError::ReadBackMismatch`] for every failed check, so no
+    /// caller can mistake a partial verification for a complete one.
+    pub fn verify_read_back(&self, expected_sha256: &str) -> Result<ManagedSettingsAttestation, ManagedSettingsError> {
+        let mismatch = |detail: String| ManagedSettingsError::ReadBackMismatch {
+            path: self.target.display().to_string(),
+            detail,
+        };
+
+        let Some(raw) = self.current()? else {
+            return Err(mismatch("the file is not there".to_string()));
+        };
+        let sha256 = sha256_hex(&raw);
+        if sha256 != expected_sha256 {
+            return Err(mismatch(format!(
+                "it hashes to sha256:{sha256}, not the authorized sha256:{expected_sha256}"
+            )));
+        }
+        validate_managed_document(&raw).map_err(|e| mismatch(e.to_string()))?;
+
+        let metadata = std::fs::metadata(&self.target).map_err(|e| io_error(&self.target, &e))?;
+        let (owner_uid, mode) = owner_and_mode(&metadata);
+
+        if let Some(uid) = owner_uid {
+            if uid != self.expected_owner_uid {
+                return Err(mismatch(format!(
+                    "it is owned by uid {uid}, not the expected uid {}; a file the invoking user owns \
+                     is a file the invoking user can rewrite",
+                    self.expected_owner_uid
+                )));
+            }
+        }
+        let writable_by_others = mode.is_some_and(|m| m & 0o022 != 0);
+        if writable_by_others {
+            return Err(mismatch(format!(
+                "its mode is {:04o}, which lets an account other than the owner rewrite it",
+                mode.unwrap_or_default()
+            )));
+        }
+
+        Ok(ManagedSettingsAttestation {
+            target: self.target.clone(),
+            sha256,
+            owner_uid,
+            mode,
+            managed_only_keys: present_managed_only_keys(&raw),
+            writable_by_others,
+        })
+    }
+
+    /// Verify whatever this installer last recorded installing, for `status` and
+    /// `verify`.
+    ///
+    /// # Errors
+    ///
+    /// As [`verify_read_back`](Self::verify_read_back); additionally
+    /// [`ManagedSettingsError::ReadBackMismatch`] when nothing was ever
+    /// installed, because an attestation about a file this integration did not
+    /// install would attribute someone else's policy to Agent Assembly.
+    pub fn verify_recorded(&self) -> Result<ManagedSettingsAttestation, ManagedSettingsError> {
+        let record = self
+            .read_record()
+            .ok_or_else(|| ManagedSettingsError::ReadBackMismatch {
+                path: self.target.display().to_string(),
+                detail: "Agent Assembly has no record of installing managed settings on this host".to_string(),
+            })?;
+        self.verify_read_back(&record.installed_sha256)
+    }
+
+    /// Reverse the install: restore the backed-up file, or delete the managed
+    /// file when there was none.
+    ///
+    /// Safe to call twice — removal recovery may.
+    ///
+    /// # Errors
+    ///
+    /// As the authority reports, plus
+    /// [`ManagedSettingsError::ReadBackMismatch`] when the host does not end up
+    /// in the state the rollback intended.
+    pub fn rollback(&self) -> Result<ManagedRollbackOutcome, ManagedSettingsError> {
+        let Some(record) = self.read_record() else {
+            return Ok(ManagedRollbackOutcome::NothingToDo);
+        };
+
+        let outcome = match &record.backup {
+            Some(backup) if backup.exists() => {
+                let prior = std::fs::read_to_string(backup).map_err(|e| io_error(backup, &e))?;
+                if self.current()?.as_deref() == Some(prior.as_str()) {
+                    ManagedRollbackOutcome::Restored { backup: backup.clone() }
+                } else {
+                    self.authority.availability().require(&self.target)?;
+                    let staged = self.staged_path();
+                    std::fs::create_dir_all(&self.work_dir).map_err(|e| io_error(&self.work_dir, &e))?;
+                    std::fs::write(&staged, &prior).map_err(|e| io_error(&staged, &e))?;
+                    set_mode(&staged, 0o644)?;
+                    self.authority.install_file(&self.target, &staged)?;
+                    let _ = std::fs::remove_file(&staged);
+                    if self.current()?.as_deref() != Some(prior.as_str()) {
+                        return Err(ManagedSettingsError::ReadBackMismatch {
+                            path: self.target.display().to_string(),
+                            detail: "the backed-up file was not what was there after the restore".to_string(),
+                        });
+                    }
+                    ManagedRollbackOutcome::Restored { backup: backup.clone() }
+                }
+            }
+            // The no-prior-file case: symmetric removal means the host goes back
+            // to having no managed-settings file at all, not to holding an empty
+            // one Agent Assembly invented.
+            _ => {
+                if self.current()?.is_some() {
+                    self.authority.availability().require(&self.target)?;
+                    self.authority.delete_file(&self.target)?;
+                    if self.current()?.is_some() {
+                        return Err(ManagedSettingsError::ReadBackMismatch {
+                            path: self.target.display().to_string(),
+                            detail: "the managed-settings file is still there after removal".to_string(),
+                        });
+                    }
+                }
+                ManagedRollbackOutcome::Removed
+            }
+        };
+
+        let record_path = self.record_path();
+        if record_path.exists() {
+            std::fs::remove_file(&record_path).map_err(|e| io_error(&record_path, &e))?;
+        }
+        let backup_path = self.backup_path();
+        if backup_path.exists() {
+            std::fs::remove_file(&backup_path).map_err(|e| io_error(&backup_path, &e))?;
+        }
+        Ok(outcome)
+    }
+}
+
+/// The managed-settings document one profile resolves to.
+///
+/// `ObserveOnly` has none, deliberately: a profile that applies no decision has
+/// nothing to enforce, and elevating to install non-overridable enforcement keys
+/// for it would be an elevation with no protective effect.
+///
+/// # Errors
+///
+/// [`AdapterError::SettingsGenerationFailed`] for `ObserveOnly`, and if
+/// serialization fails.
+pub fn managed_settings_document(profile: ProtectionProfile) -> Result<String, AdapterError> {
+    let (default_mode, strict) = match profile {
+        ProtectionProfile::Strict => ("plan", true),
+        ProtectionProfile::Recommended => ("default", false),
+        ProtectionProfile::ObserveOnly => {
+            return Err(AdapterError::SettingsGenerationFailed(
+                "the observe-only profile applies no decision, so there is nothing for endpoint-managed \
+                 settings to enforce; install it with --profile recommended or --profile strict, or \
+                 without --install-managed-settings"
+                    .to_string(),
+            ))
+        }
+    };
+
+    let doc = serde_json::json!({
+        // The bypass this closes is `--dangerously-skip-permissions` and
+        // `defaultMode: "bypassPermissions"`, which no user- or project-scoped
+        // setting can counter.
+        "disableBypassPermissionsMode": true,
+        // Managed permission rules become the only ones in effect, so a user
+        // cannot widen them from their own settings file.
+        "allowManagedPermissionRulesOnly": true,
+        "allowManagedMcpServersOnly": strict,
+        "allowManagedHooksOnly": strict,
+        "permissions": {
+            "allow": [],
+            "deny": [],
+            "defaultMode": default_mode,
+        },
+        "permissionMode": default_mode,
+    });
+    serde_json::to_string_pretty(&doc).map_err(|e| AdapterError::SettingsGenerationFailed(e.to_string()))
+}
+
+/// Refuse a document this integration will not put at a root-owned path.
+///
+/// # Errors
+///
+/// [`ManagedSettingsError::SchemaInvalid`] with the rule that was broken.
+pub fn validate_managed_document(raw: &str) -> Result<(), ManagedSettingsError> {
+    let invalid = |detail: String| ManagedSettingsError::SchemaInvalid { detail };
+
+    let value: serde_json::Value =
+        serde_json::from_str(raw).map_err(|e| invalid(format!("it is not valid JSON: {e}")))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("the top level is not a JSON object".to_string()))?;
+
+    for key in object.keys() {
+        if FORBIDDEN_KEYS.contains(&key.as_str()) {
+            return Err(invalid(format!(
+                "{key:?} can carry credential material and the managed file is root-owned and readable \
+                 by every account on the machine"
+            )));
+        }
+        if !WRITABLE_KEYS.contains(&key.as_str()) {
+            return Err(invalid(format!(
+                "{key:?} is not a key this build knows how to write to the managed surface"
+            )));
+        }
+    }
+
+    for key in MANAGED_ONLY_KEYS {
+        if let Some(value) = object.get(key) {
+            if !value.is_boolean() {
+                return Err(invalid(format!("{key:?} must be a boolean")));
+            }
+        }
+    }
+
+    if present_managed_only_keys(raw).is_empty() {
+        return Err(invalid(format!(
+            "it carries none of the managed-only keys ({}), so installing it at a root-owned path \
+             would be an elevation with no enforcement purpose",
+            MANAGED_ONLY_KEYS.join(", ")
+        )));
+    }
+
+    Ok(())
+}
+
+/// Which managed-only keys a document actually carries.
+fn present_managed_only_keys(raw: &str) -> Vec<String> {
+    let Ok(serde_json::Value::Object(object)) = serde_json::from_str::<serde_json::Value>(raw) else {
+        return Vec::new();
+    };
+    MANAGED_ONLY_KEYS
+        .iter()
+        .filter(|key| object.contains_key(**key))
+        .map(|key| (*key).to_string())
+        .collect()
+}
+
+fn top_level_keys(raw: &str) -> Vec<String> {
+    match serde_json::from_str::<serde_json::Value>(raw) {
+        Ok(serde_json::Value::Object(object)) => object.keys().cloned().collect(),
+        _ => vec!["(not a JSON object)".to_string()],
+    }
+}
+
+/// A line-level diff, enough for a human to see what changes.
+///
+/// Not a minimal edit script: the managed document is a handful of lines, and a
+/// disclosure a user has to decode is not a disclosure.
+fn line_diff(current: &str, proposed: &str) -> Vec<String> {
+    if current == proposed {
+        return Vec::new();
+    }
+    let current_lines: Vec<&str> = current.lines().collect();
+    let proposed_lines: Vec<&str> = proposed.lines().collect();
+    let mut out = Vec::new();
+    for line in &current_lines {
+        if !proposed_lines.contains(line) {
+            out.push(format!("- {line}"));
+        }
+    }
+    for line in &proposed_lines {
+        if !current_lines.contains(line) {
+            out.push(format!("+ {line}"));
+        }
+    }
+    out
+}
+
+#[cfg(unix)]
+fn owner_and_mode(metadata: &std::fs::Metadata) -> (Option<u32>, Option<u32>) {
+    use std::os::unix::fs::MetadataExt;
+    (Some(metadata.uid()), Some(metadata.mode() & 0o7777))
+}
+
+#[cfg(not(unix))]
+fn owner_and_mode(_metadata: &std::fs::Metadata) -> (Option<u32>, Option<u32>) {
+    (None, None)
+}
+
+#[cfg(unix)]
+fn set_mode(path: &Path, mode: u32) -> Result<(), ManagedSettingsError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|e| io_error(path, &e))
+}
+
+#[cfg(not(unix))]
+fn set_mode(_path: &Path, _mode: u32) -> Result<(), ManagedSettingsError> {
+    Ok(())
+}
+
+/// Test doubles for the elevation seam.
+///
+/// Shipped rather than confined to `#[cfg(test)]` because the integration tests,
+/// the CLI's tests and the conformance suite all have to exercise the privileged
+/// path — and the one thing none of them may do is reach a real authorization
+/// prompt.
+#[doc(hidden)]
+pub mod testing {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// What a [`FakeAuthority`] does when asked.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum FakeBehaviour {
+        /// Perform the placement as an ordinary unprivileged file copy.
+        Grant,
+        /// Report that authorization was refused.
+        Deny,
+        /// Report that no mechanism exists.
+        Unavailable,
+        /// Report that there is no terminal to authorize on.
+        NonInteractive,
+        /// Report success, but write different bytes — the read-back-mismatch
+        /// case, which no honest authority produces and every product has to
+        /// survive.
+        GrantButCorrupt(String),
+    }
+
+    /// An authority that never elevates anything.
+    #[derive(Debug)]
+    pub struct FakeAuthority {
+        behaviour: FakeBehaviour,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl FakeAuthority {
+        /// An authority with `behaviour`.
+        pub fn new(behaviour: FakeBehaviour) -> Self {
+            Self {
+                behaviour,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        /// Grants, and performs the write unprivileged.
+        pub fn granting() -> Arc<Self> {
+            Arc::new(Self::new(FakeBehaviour::Grant))
+        }
+
+        /// Refuses authorization.
+        pub fn denying() -> Arc<Self> {
+            Arc::new(Self::new(FakeBehaviour::Deny))
+        }
+
+        /// Has no mechanism.
+        pub fn unavailable() -> Arc<Self> {
+            Arc::new(Self::new(FakeBehaviour::Unavailable))
+        }
+
+        /// Has a mechanism and no terminal.
+        pub fn non_interactive() -> Arc<Self> {
+            Arc::new(Self::new(FakeBehaviour::NonInteractive))
+        }
+
+        /// Reports success while writing `content` instead.
+        pub fn corrupting(content: impl Into<String>) -> Arc<Self> {
+            Arc::new(Self::new(FakeBehaviour::GrantButCorrupt(content.into())))
+        }
+
+        /// Every operation this authority was asked to perform.
+        pub fn calls(&self) -> Vec<String> {
+            self.calls.lock().expect("authority call log").clone()
+        }
+
+        fn record(&self, what: String) {
+            self.calls.lock().expect("authority call log").push(what);
+        }
+
+        fn place(&self, target: &Path, body: &str) -> Result<(), ManagedSettingsError> {
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| io_error(parent, &e))?;
+            }
+            std::fs::write(target, body).map_err(|e| io_error(target, &e))?;
+            set_mode(target, 0o644)
+        }
+    }
+
+    impl PrivilegedFileAuthority for FakeAuthority {
+        fn mechanism(&self) -> &str {
+            "a test double that never elevates"
+        }
+
+        fn availability(&self) -> Authorization {
+            match &self.behaviour {
+                FakeBehaviour::Unavailable => Authorization::Unavailable {
+                    detail: "no mechanism in this test".to_string(),
+                },
+                FakeBehaviour::NonInteractive => Authorization::NonInteractive {
+                    detail: "no terminal in this test".to_string(),
+                },
+                _ => Authorization::Available,
+            }
+        }
+
+        fn install_file(&self, target: &Path, staged: &Path) -> Result<(), ManagedSettingsError> {
+            self.record(format!("install {} <- {}", target.display(), staged.display()));
+            match &self.behaviour {
+                FakeBehaviour::Grant => {
+                    let body = std::fs::read_to_string(staged).map_err(|e| io_error(staged, &e))?;
+                    self.place(target, &body)
+                }
+                FakeBehaviour::GrantButCorrupt(body) => self.place(target, body),
+                FakeBehaviour::Deny => Err(ManagedSettingsError::PermissionRequired {
+                    path: target.display().to_string(),
+                    detail: "the user cancelled the authorization prompt".to_string(),
+                }),
+                other => self.availability().require(target).and_then(|()| {
+                    Err(ManagedSettingsError::AuthorizationUnavailable {
+                        detail: format!("{other:?}"),
+                    })
+                }),
+            }
+        }
+
+        fn delete_file(&self, target: &Path) -> Result<(), ManagedSettingsError> {
+            self.record(format!("delete {}", target.display()));
+            match &self.behaviour {
+                FakeBehaviour::Deny => Err(ManagedSettingsError::PermissionRequired {
+                    path: target.display().to_string(),
+                    detail: "the user cancelled the authorization prompt".to_string(),
+                }),
+                _ => match std::fs::remove_file(target) {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    Err(e) => Err(io_error(target, &e)),
+                },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::testing::{FakeAuthority, FakeBehaviour};
+    use super::*;
+
+    /// Every test writes into a temporary directory. Nothing here ever names
+    /// [`MANAGED_SETTINGS_PATH`] as a write target, and
+    /// [`MacOsAdminAuthority`] refuses any target that is not it — so no test
+    /// can reach an authorization prompt or the real system path.
+    struct Host {
+        _dir: tempfile::TempDir,
+        target: PathBuf,
+        work: PathBuf,
+    }
+
+    impl Host {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let target = dir.path().join("ClaudeCode").join(MANAGED_SETTINGS_FILE);
+            let work = dir.path().join("state");
+            std::fs::create_dir_all(&work).expect("work dir");
+            Self {
+                _dir: dir,
+                target,
+                work,
+            }
+        }
+
+        fn installer(&self, authority: Arc<dyn PrivilegedFileAuthority>) -> ManagedSettingsInstaller {
+            ManagedSettingsInstaller::new(&self.target, &self.work, authority).expecting_owner_uid(current_uid())
+        }
+
+        fn preexisting(&self, body: &str) {
+            std::fs::create_dir_all(self.target.parent().unwrap()).expect("dir");
+            std::fs::write(&self.target, body).expect("write");
+        }
+    }
+
+    /// The uid this process writes files as.
+    ///
+    /// Read off a file the process just created rather than through `libc`, so
+    /// the check stays dependency-free and needs no `unsafe`.
+    #[cfg(unix)]
+    fn current_uid() -> u32 {
+        use std::os::unix::fs::MetadataExt;
+        let probe = tempfile::NamedTempFile::new().expect("probe file");
+        probe.as_file().metadata().expect("probe metadata").uid()
+    }
+
+    #[cfg(not(unix))]
+    fn current_uid() -> u32 {
+        0
+    }
+
+    fn document() -> String {
+        managed_settings_document(ProtectionProfile::Recommended).expect("document")
+    }
+
+    #[test]
+    fn the_real_authority_refuses_any_target_but_the_canonical_one() {
+        // The guard the whole test suite's safety rests on: a redirected managed
+        // root cannot reach an authorization prompt.
+        let host = Host::new();
+        let authority = MacOsAdminAuthority;
+        let err = authority
+            .install_file(&host.target, &host.work.join("staged"))
+            .expect_err("a non-canonical target must be refused");
+        assert!(
+            matches!(&err, ManagedSettingsError::AuthorizationUnavailable { detail } if detail.contains(MANAGED_SETTINGS_PATH)),
+            "{err}"
+        );
+        let err = authority.delete_file(&host.target).expect_err("refused");
+        assert!(matches!(err, ManagedSettingsError::AuthorizationUnavailable { .. }));
+    }
+
+    #[test]
+    fn a_document_without_managed_only_keys_is_refused() {
+        let err = validate_managed_document(r#"{"permissions":{"allow":[]}}"#).expect_err("refused");
+        assert!(
+            matches!(&err, ManagedSettingsError::SchemaInvalid { detail } if detail.contains("managed-only keys")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn credential_bearing_keys_are_refused_at_a_root_owned_path() {
+        for key in ["env", "apiKeyHelper"] {
+            let raw = format!(r#"{{"disableBypassPermissionsMode":true,"{key}":{{}}}}"#);
+            let err = validate_managed_document(&raw).expect_err("refused");
+            assert!(
+                matches!(&err, ManagedSettingsError::SchemaInvalid { detail } if detail.contains(key)),
+                "{key}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_key_is_refused_rather_than_written() {
+        let err =
+            validate_managed_document(r#"{"disableBypassPermissionsMode":true,"whatIsThis":1}"#).expect_err("refused");
+        assert!(
+            matches!(&err, ManagedSettingsError::SchemaInvalid { detail } if detail.contains("whatIsThis")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn observe_only_has_no_managed_document() {
+        let err = managed_settings_document(ProtectionProfile::ObserveOnly).expect_err("refused");
+        assert!(err.to_string().contains("observe-only"), "{err}");
+    }
+
+    #[test]
+    fn every_shipped_profile_document_validates() {
+        for profile in [ProtectionProfile::Recommended, ProtectionProfile::Strict] {
+            let doc = managed_settings_document(profile).expect("document");
+            validate_managed_document(&doc).expect("the document this build writes must be one it accepts");
+            assert!(doc.contains("disableBypassPermissionsMode"), "{doc}");
+        }
+    }
+
+    #[test]
+    fn the_disclosure_states_everything_before_authorization_is_requested() {
+        let host = Host::new();
+        let authority = FakeAuthority::granting();
+        let installer = host.installer(authority.clone());
+        let doc = document();
+        let disclosure = installer.disclose(&doc).expect("disclosure");
+        let rendered = disclosure.render();
+
+        assert!(rendered.contains(&host.target.display().to_string()), "{rendered}");
+        assert!(rendered.contains("why:"), "{rendered}");
+        assert!(rendered.contains("disableBypassPermissionsMode"), "{rendered}");
+        assert!(rendered.contains("backup:"), "{rendered}");
+        assert!(rendered.contains("rollback:"), "{rendered}");
+        // Building a disclosure asks the authority for nothing.
+        assert!(authority.calls().is_empty(), "{:?}", authority.calls());
+    }
+
+    #[test]
+    fn install_writes_verifies_and_is_idempotent() {
+        let host = Host::new();
+        let authority = FakeAuthority::granting();
+        let installer = host.installer(authority.clone());
+        let doc = document();
+
+        let outcome = installer
+            .install(&installer.disclose(&doc).expect("disclosure"))
+            .expect("install");
+        assert!(outcome.mutated);
+        assert_eq!(outcome.backup, None, "there was no prior file to back up");
+        assert_eq!(std::fs::read_to_string(&host.target).unwrap(), doc);
+        assert!(outcome
+            .attestation
+            .managed_only_keys
+            .contains(&"disableBypassPermissionsMode".to_string()));
+
+        // Reapplying changes nothing and asks for no authorization.
+        let before = authority.calls().len();
+        let again = installer
+            .install(&installer.disclose(&doc).expect("disclosure"))
+            .expect("reinstall");
+        assert!(!again.mutated);
+        assert_eq!(authority.calls().len(), before, "a no-op install must not prompt");
+    }
+
+    #[test]
+    fn denied_authorization_is_a_permission_required_refusal_and_writes_nothing() {
+        let host = Host::new();
+        let installer = host.installer(FakeAuthority::denying());
+        let doc = document();
+        let err = installer
+            .install(&installer.disclose(&doc).expect("disclosure"))
+            .expect_err("denied");
+        assert_eq!(err.summary(), "Permission Required");
+        assert!(!host.target.exists(), "a denied install must leave nothing behind");
+    }
+
+    #[test]
+    fn an_unavailable_mechanism_is_reported_as_unavailable() {
+        let host = Host::new();
+        let installer = host.installer(FakeAuthority::unavailable());
+        let doc = document();
+        let err = installer
+            .install(&installer.disclose(&doc).expect("disclosure"))
+            .expect_err("unavailable");
+        assert_eq!(err.summary(), "Unavailable");
+        assert!(matches!(err, ManagedSettingsError::AuthorizationUnavailable { .. }));
+        assert!(!host.target.exists());
+    }
+
+    #[test]
+    fn non_interactive_execution_fails_instead_of_waiting() {
+        let host = Host::new();
+        let installer = host.installer(FakeAuthority::non_interactive());
+        let doc = document();
+        let err = installer
+            .install(&installer.disclose(&doc).expect("disclosure"))
+            .expect_err("non-interactive");
+        assert!(matches!(err, ManagedSettingsError::NonInteractive { .. }), "{err}");
+        assert_eq!(err.summary(), "Unavailable");
+        assert!(!host.target.exists());
+    }
+
+    #[test]
+    fn a_managed_file_agent_assembly_did_not_write_is_refused() {
+        let host = Host::new();
+        host.preexisting(r#"{"disableBypassPermissionsMode":true,"permissions":{"deny":["Bash"]}}"#);
+        let installer = host.installer(FakeAuthority::granting());
+        let doc = document();
+
+        let disclosure = installer.disclose(&doc).expect("disclosure");
+        assert!(disclosure.existing.is_conflict());
+        assert!(disclosure.conflict.is_some(), "the conflict must be disclosed");
+        assert!(!disclosure.is_installable());
+
+        let err = installer.install(&disclosure).expect_err("refused");
+        assert!(
+            matches!(err, ManagedSettingsError::ConflictingExistingFile { .. }),
+            "{err}"
+        );
+        // The third party's policy is exactly as it was.
+        assert!(std::fs::read_to_string(&host.target).unwrap().contains("Bash"));
+    }
+
+    #[test]
+    fn a_read_back_mismatch_prevents_success_and_restores_the_prior_state() {
+        let host = Host::new();
+        let installer = host.installer(FakeAuthority::corrupting(r#"{"disableBypassPermissionsMode":false}"#));
+        let doc = document();
+        let err = installer
+            .install(&installer.disclose(&doc).expect("disclosure"))
+            .expect_err("the read-back must fail");
+        assert!(matches!(err, ManagedSettingsError::ReadBackMismatch { .. }), "{err}");
+        assert_eq!(err.summary(), "Read-back verification failed");
+        assert!(
+            !host.target.exists(),
+            "there was no prior file, so a failed install must leave none"
+        );
+        // Nothing was recorded, so nothing can later be attested.
+        assert!(installer.verify_recorded().is_err());
+    }
+
+    #[test]
+    fn a_user_owned_managed_file_fails_the_ownership_check() {
+        let host = Host::new();
+        // Expect an owner this process is not, which is exactly the production
+        // check (uid 0) seen from an unprivileged test.
+        let installer = ManagedSettingsInstaller::new(&host.target, &host.work, FakeAuthority::granting())
+            .expecting_owner_uid(current_uid().wrapping_add(1));
+        let doc = document();
+        let err = installer
+            .install(&installer.disclose(&doc).expect("disclosure"))
+            .expect_err("ownership must be checked");
+        assert!(
+            matches!(&err, ManagedSettingsError::ReadBackMismatch { detail, .. } if detail.contains("owned by uid")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_world_writable_managed_file_fails_the_permission_check() {
+        let host = Host::new();
+        let installer = host.installer(FakeAuthority::granting());
+        let doc = document();
+        installer
+            .install(&installer.disclose(&doc).expect("disclosure"))
+            .expect("install");
+        set_mode(&host.target, 0o666).expect("chmod");
+        let err = installer
+            .verify_recorded()
+            .expect_err("a writable file is not enforcement");
+        assert!(
+            matches!(&err, ManagedSettingsError::ReadBackMismatch { detail, .. } if detail.contains("other than the owner")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rollback_deletes_when_there_was_no_prior_file() {
+        let host = Host::new();
+        let installer = host.installer(FakeAuthority::granting());
+        let doc = document();
+        installer
+            .install(&installer.disclose(&doc).expect("disclosure"))
+            .expect("install");
+        assert!(host.target.exists());
+
+        assert_eq!(installer.rollback().expect("rollback"), ManagedRollbackOutcome::Removed);
+        assert!(!host.target.exists(), "removal must be symmetric with install");
+        // Safe to run twice.
+        assert_eq!(
+            installer.rollback().expect("rollback"),
+            ManagedRollbackOutcome::NothingToDo
+        );
+    }
+
+    #[test]
+    fn rollback_restores_a_file_agent_assembly_replaced() {
+        let host = Host::new();
+        let authority = FakeAuthority::granting();
+        let installer = host.installer(authority.clone());
+
+        // A file Agent Assembly installed earlier, so the second install is not
+        // a conflict.
+        let first = managed_settings_document(ProtectionProfile::Recommended).expect("document");
+        installer
+            .install(&installer.disclose(&first).expect("disclosure"))
+            .expect("first install");
+
+        let second = managed_settings_document(ProtectionProfile::Strict).expect("document");
+        let outcome = installer
+            .install(&installer.disclose(&second).expect("disclosure"))
+            .expect("second install");
+        assert!(outcome.backup.is_some());
+        assert_eq!(std::fs::read_to_string(&host.target).unwrap(), second);
+
+        match installer.rollback().expect("rollback") {
+            ManagedRollbackOutcome::Restored { .. } => {}
+            other => panic!("expected a restore, got {other:?}"),
+        }
+        assert_eq!(std::fs::read_to_string(&host.target).unwrap(), first);
+    }
+
+    #[test]
+    fn a_host_that_changed_after_the_disclosure_is_refused() {
+        let host = Host::new();
+        let installer = host.installer(FakeAuthority::granting());
+        let doc = document();
+        let disclosure = installer.disclose(&doc).expect("disclosure");
+
+        host.preexisting(r#"{"disableBypassPermissionsMode":true}"#);
+
+        let err = installer.install(&disclosure).expect_err("stale");
+        assert!(matches!(err, ManagedSettingsError::ConsentStale { .. }), "{err}");
+    }
+
+    #[test]
+    fn nothing_is_attested_before_anything_is_installed() {
+        let host = Host::new();
+        let installer = host.installer(FakeAuthority::granting());
+        let err = installer.verify_recorded().expect_err("nothing installed");
+        assert!(matches!(err, ManagedSettingsError::ReadBackMismatch { .. }), "{err}");
+    }
+
+    #[test]
+    fn the_fake_authority_is_the_only_one_the_tests_ever_call() {
+        // A behaviour-by-behaviour sweep, so a future change to `FakeAuthority`
+        // that started elevating would fail here rather than silently.
+        for behaviour in [
+            FakeBehaviour::Grant,
+            FakeBehaviour::Deny,
+            FakeBehaviour::Unavailable,
+            FakeBehaviour::NonInteractive,
+        ] {
+            let authority = FakeAuthority::new(behaviour);
+            assert_eq!(authority.mechanism(), "a test double that never elevates");
+        }
+    }
+}

--- a/aa-devtool-claude-code/src/managed_settings.rs
+++ b/aa-devtool-claude-code/src/managed_settings.rs
@@ -1155,6 +1155,16 @@ fn line_diff(current: &str, proposed: &str) -> Vec<String> {
     out
 }
 
+/// Who owns `path`, when the platform reports owners.
+///
+/// Used to anchor the ownership check to the process's own uid when the managed
+/// root is redirected for a test — so the check stays live in both cases rather
+/// than being switched off for one of them.
+pub fn owner_uid(path: &Path) -> Option<u32> {
+    let metadata = std::fs::metadata(path).ok()?;
+    owner_and_mode(&metadata).0
+}
+
 #[cfg(unix)]
 fn owner_and_mode(metadata: &std::fs::Metadata) -> (Option<u32>, Option<u32>) {
     use std::os::unix::fs::MetadataExt;

--- a/aa-devtool-claude-code/src/managed_settings.rs
+++ b/aa-devtool-claude-code/src/managed_settings.rs
@@ -178,6 +178,15 @@ pub enum ManagedSettingsError {
         /// What changed.
         detail: String,
     },
+    /// Agent Assembly never installed managed settings on this host.
+    ///
+    /// Distinct from a failed verification: there is nothing to verify, which is
+    /// what a host that simply did not opt in looks like.
+    #[error("Agent Assembly has not installed managed settings at {path} on this host")]
+    NothingInstalled {
+        /// The surface that holds no Agent Assembly install.
+        path: String,
+    },
     /// An unprivileged filesystem operation failed.
     #[error("{path}: {detail}")]
     Io {
@@ -199,6 +208,7 @@ impl ManagedSettingsError {
             Self::PermissionRequired { .. } => "Permission Required",
             Self::AuthorizationUnavailable { .. } | Self::NonInteractive { .. } => "Unavailable",
             Self::ConflictingExistingFile { .. } => "Conflicting managed settings",
+            Self::NothingInstalled { .. } => "Not installed",
             Self::ReadBackMismatch { .. } => "Read-back verification failed",
             Self::SchemaInvalid { .. } => "Refused: invalid managed-settings document",
             Self::ConsentStale { .. } => "Refused: the host changed after the disclosure",
@@ -941,15 +951,14 @@ impl ManagedSettingsInstaller {
     /// # Errors
     ///
     /// As [`verify_read_back`](Self::verify_read_back); additionally
-    /// [`ManagedSettingsError::ReadBackMismatch`] when nothing was ever
+    /// [`ManagedSettingsError::NothingInstalled`] when nothing was ever
     /// installed, because an attestation about a file this integration did not
     /// install would attribute someone else's policy to Agent Assembly.
     pub fn verify_recorded(&self) -> Result<ManagedSettingsAttestation, ManagedSettingsError> {
         let record = self
             .read_record()
-            .ok_or_else(|| ManagedSettingsError::ReadBackMismatch {
+            .ok_or_else(|| ManagedSettingsError::NothingInstalled {
                 path: self.target.display().to_string(),
-                detail: "Agent Assembly has no record of installing managed settings on this host".to_string(),
             })?;
         self.verify_read_back(&record.installed_sha256)
     }
@@ -1670,7 +1679,8 @@ mod tests {
         let host = Host::new();
         let installer = host.installer(FakeAuthority::granting());
         let err = installer.verify_recorded().expect_err("nothing installed");
-        assert!(matches!(err, ManagedSettingsError::ReadBackMismatch { .. }), "{err}");
+        assert!(matches!(err, ManagedSettingsError::NothingInstalled { .. }), "{err}");
+        assert_eq!(err.summary(), "Not installed");
     }
 
     #[test]

--- a/aa-devtool-claude-code/src/managed_settings.rs
+++ b/aa-devtool-claude-code/src/managed_settings.rs
@@ -315,6 +315,11 @@ impl MacOsAdminAuthority {
 
     /// Escape a `/bin/sh` script for embedding in an AppleScript string
     /// literal.
+    ///
+    /// Gated to macOS because its only caller is the macOS `run`; on other
+    /// hosts `run` refuses before building a script, so an ungated helper is
+    /// dead code that `-D warnings` rejects on a Linux build.
+    #[cfg(target_os = "macos")]
     fn applescript_quote(script: &str) -> String {
         format!("\"{}\"", script.replace('\\', r"\\").replace('"', "\\\""))
     }

--- a/aa-devtool-claude-code/src/scope.rs
+++ b/aa-devtool-claude-code/src/scope.rs
@@ -27,21 +27,27 @@
 //! * **Project** — `<project root>/.claude/settings.json`. Checked in, shared,
 //!   and workspace-trust gated; selectable, never a default.
 //! * **Managed** — `/Library/Application Support/ClaudeCode/managed-settings.json`.
-//!   Root-owned, absent on an unmanaged host, and **unmeasured**: the AAASM-5276
-//!   spike deliberately made no privileged writes, so its managed-only keys
-//!   (`disableBypassPermissionsMode`, `allowManagedPermissionRulesOnly`, …)
-//!   remain unproven. [`ClaudeCodePaths::settings_path`] resolves it so the
-//!   surface can be *named* in a refusal, and nothing in this crate writes to it.
+//!   Root-owned and absent on an unmanaged host. Since AAASM-5298 this scope
+//!   *resolves* and is writable, but only through the explicitly authorized,
+//!   read-back-verified path in [`managed_settings`](crate::managed_settings) —
+//!   never as part of a default install. A caller that names this scope is
+//!   asking for one administrator-authorized file write, and gets a refusal
+//!   rather than a silent downgrade when that authorization is unavailable.
+//!
+//! # The managed-root test seam
+//!
+//! `AASM_CLAUDE_MANAGED_ROOT` (and [`ClaudeCodePaths::with_managed_root`])
+//! redirect where the managed file is *addressed*. That cannot be used to
+//! escalate: [`MacOsAdminAuthority`](crate::managed_settings::MacOsAdminAuthority)
+//! refuses to elevate for any target that is not the canonical
+//! [`MANAGED_SETTINGS_PATH`], so a redirected root makes the write ordinary and
+//! unprivileged rather than pointing an authorized write somewhere else.
 
 use std::path::{Path, PathBuf};
 
 use aa_devtool_contract::SettingsScope;
 
-/// The macOS endpoint managed-settings file.
-///
-/// Named so a refusal can name it. Deliberately never written to — see the
-/// module docs.
-pub const MANAGED_SETTINGS_PATH: &str = "/Library/Application Support/ClaudeCode/managed-settings.json";
+pub use crate::managed_settings::{MANAGED_SETTINGS_DIR, MANAGED_SETTINGS_FILE, MANAGED_SETTINGS_PATH};
 
 /// Directory Claude Code keeps its user configuration in, relative to `$HOME`.
 pub const DOT_CLAUDE: &str = ".claude";
@@ -89,6 +95,9 @@ pub struct ClaudeCodePaths {
     state: Option<PathBuf>,
     /// The proxy CA certificate this integration copies its trust material from.
     ca_source: Option<PathBuf>,
+    /// The directory the endpoint managed-settings file lives in. `None` means
+    /// the canonical OS location.
+    managed_root: Option<PathBuf>,
 }
 
 impl ClaudeCodePaths {
@@ -103,6 +112,7 @@ impl ClaudeCodePaths {
             project: std::env::current_dir().ok(),
             state: Some(state_root()),
             ca_source: Some(ca_source()),
+            managed_root: non_empty_var("AASM_CLAUDE_MANAGED_ROOT"),
         }
     }
 
@@ -141,13 +151,35 @@ impl ClaudeCodePaths {
         self
     }
 
+    /// Pin the directory the endpoint managed-settings file is addressed in.
+    ///
+    /// A redirected root cannot escalate — see the module docs.
+    #[must_use]
+    pub fn with_managed_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.managed_root = Some(root.into());
+        self
+    }
+
+    /// Whether the managed surface is addressed at its canonical OS location.
+    ///
+    /// The privileged authority elevates only for the canonical path, so a
+    /// redirected root is a test seam and reported as such rather than being
+    /// presented to a user as an endpoint-managed install.
+    pub fn managed_root_is_canonical(&self) -> bool {
+        // `Option::is_none_or` would read better but is stable only from 1.82;
+        // this crate's floor is lower.
+        match self.managed_root.as_deref() {
+            Some(root) => root == Path::new(MANAGED_SETTINGS_DIR),
+            None => true,
+        }
+    }
+
     /// The settings file for `scope`.
     ///
     /// # Errors
     ///
     /// [`ScopeError::Unresolvable`] when the scope's root is unknown on this
-    /// host, and [`ScopeError::Refused`] for
-    /// [`SettingsScope::Managed`] — see the module docs.
+    /// host.
     pub fn settings_path(&self, scope: SettingsScope) -> Result<PathBuf, ScopeError> {
         match scope {
             SettingsScope::User => Ok(self.user_config_dir()?.join(SETTINGS_FILE)),
@@ -158,15 +190,20 @@ impl ClaudeCodePaths {
                 })?;
                 Ok(project.join(DOT_CLAUDE).join(SETTINGS_FILE))
             }
-            SettingsScope::Managed => Err(ScopeError::Refused {
-                scope,
-                detail: format!(
-                    "{MANAGED_SETTINGS_PATH} is administrator-owned and Agent Assembly will not write to it. \
-                     Its enforcement keys are unmeasured and installing them needs a privileged step this \
-                     integration deliberately does not take; choose --scope user or --scope project"
-                ),
-            }),
+            SettingsScope::Managed => Ok(self.managed_settings_path()),
         }
+    }
+
+    /// The endpoint managed-settings file this host addresses.
+    ///
+    /// Always resolvable — the file's *absence* is what an unmanaged host looks
+    /// like, and a path that could not be named could not be shown to a user
+    /// before they authorize a write to it.
+    pub fn managed_settings_path(&self) -> PathBuf {
+        self.managed_root
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(MANAGED_SETTINGS_DIR))
+            .join(MANAGED_SETTINGS_FILE)
     }
 
     /// Claude Code's user configuration directory.
@@ -189,10 +226,7 @@ impl ClaudeCodePaths {
         [SettingsScope::User, SettingsScope::Project, SettingsScope::Managed]
             .into_iter()
             .filter_map(|scope| {
-                let path = match scope {
-                    SettingsScope::Managed => PathBuf::from(MANAGED_SETTINGS_PATH),
-                    other => self.settings_path(other).ok()?,
-                };
+                let path = self.settings_path(scope).ok()?;
                 path.is_file().then_some(DetectedSurface { scope, path })
             })
             .collect()
@@ -345,15 +379,28 @@ mod tests {
     }
 
     #[test]
-    fn the_managed_surface_is_named_and_refused() {
+    fn the_managed_surface_resolves_to_the_canonical_os_path_by_default() {
         let dir = tempfile::tempdir().unwrap();
-        match paths(dir.path()).settings_path(SettingsScope::Managed) {
-            Err(ScopeError::Refused { detail, .. }) => {
-                assert!(detail.contains(MANAGED_SETTINGS_PATH), "{detail}");
-                assert!(detail.contains("--scope user"), "{detail}");
-            }
-            other => panic!("managed scope must be refused, got {other:?}"),
-        }
+        let p = paths(dir.path());
+        assert_eq!(
+            p.settings_path(SettingsScope::Managed).unwrap(),
+            PathBuf::from(MANAGED_SETTINGS_PATH)
+        );
+        assert!(p.managed_root_is_canonical());
+    }
+
+    #[test]
+    fn a_redirected_managed_root_is_reported_as_not_canonical() {
+        // The seam every test uses, and the reason a redirected install can
+        // never be presented as an endpoint-managed one: the privileged
+        // authority elevates only for the canonical path.
+        let dir = tempfile::tempdir().unwrap();
+        let p = paths(dir.path()).with_managed_root(dir.path().join("ClaudeCode"));
+        assert_eq!(
+            p.settings_path(SettingsScope::Managed).unwrap(),
+            dir.path().join("ClaudeCode").join(MANAGED_SETTINGS_FILE)
+        );
+        assert!(!p.managed_root_is_canonical());
     }
 
     #[test]

--- a/aa-devtool-claude-code/tests/claude_code_lifecycle.rs
+++ b/aa-devtool-claude-code/tests/claude_code_lifecycle.rs
@@ -22,7 +22,7 @@ use aa_devtool_claude_code::managed_settings::{PrivilegedFileAuthority, MANAGED_
 use aa_devtool_claude_code::{ClaudeCodeAdapter, ClaudeCodeIntegration, ClaudeCodePaths};
 use aa_devtool_contract::{
     capability_conformance, DevToolIntegration, DevToolKind, EnvValue, IntegrationCapability, IntegrationRequest,
-    LaunchSpec, ProtectionLevel, ProtectionProfile, SettingsScope, StepAction,
+    LaunchSpec, ProtectionLevel, ProtectionProfile, SettingsScope, StepAction, StepPrivilege,
 };
 
 /// A fabricated PEM. Nothing verifies it here; the tests assert it is *copied*,
@@ -372,11 +372,33 @@ async fn the_managed_scope_plan_carries_exactly_one_privileged_step() {
         other => panic!("expected a managed settings write, got {other:?}"),
     }
 
-    // Every fact the owner required before authorization is requested.
+    // Every fact the owner required, disclosed before authorization is
+    // requested: path, why, content, diff, conflict, backup, rollback.
     let warnings = plan.warnings.join("\n");
     assert!(warnings.contains("one privileged step"), "{warnings}");
     assert!(warnings.contains("does not measure Claude Code"), "{warnings}");
     assert!(warnings.contains("never replaced"), "{warnings}");
+    assert!(
+        warnings.contains("the exact content that will be written"),
+        "{warnings}"
+    );
+    assert!(warnings.contains("disableBypassPermissionsMode"), "{warnings}");
+    assert!(warnings.contains("changes against what is on this host"), "{warnings}");
+    assert!(warnings.contains("no file to back up"), "{warnings}");
+    assert!(warnings.contains("integrations remove claude-code"), "{warnings}");
+    match &step.privilege {
+        StepPrivilege::PrivilegedHost { consent_prompt } => {
+            assert!(
+                consent_prompt.contains("administrator authorization"),
+                "{consent_prompt}"
+            );
+            assert!(
+                consent_prompt.contains("Nothing else runs with elevated"),
+                "{consent_prompt}"
+            );
+        }
+        other => panic!("the managed step must be privileged, got {other:?}"),
+    }
     assert!(
         step.render_dry_run().contains("privileged-host"),
         "{}",
@@ -658,4 +680,32 @@ async fn an_injected_probe_reaches_the_verification_result() {
     // The probe seam is exercised end to end (with a receipt) in
     // `aa-integration-tests`; here it is enough that the wiring accepts one.
     assert!(integration.as_launchable().is_some());
+}
+
+#[tokio::test]
+async fn a_conflicting_managed_file_is_disclosed_in_the_plan_as_a_refusal() {
+    // A managed-settings file Agent Assembly did not write — for example one an
+    // organisation's device management deployed — is never merged over. The plan
+    // says so before the user is asked for anything.
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let managed = fixture.settings_path(SettingsScope::Managed);
+    std::fs::create_dir_all(managed.parent().expect("parent")).expect("managed dir");
+    std::fs::write(
+        &managed,
+        r#"{"disableBypassPermissionsMode":true,"permissions":{"deny":["Bash"]}}"#,
+    )
+    .expect("third-party policy");
+
+    let integration = fixture.integration(Some("2.1.220"));
+    let plan = integration
+        .plan_integration(&request(SettingsScope::Managed))
+        .await
+        .expect("plan");
+    let warnings = plan.warnings.join("\n");
+    assert!(warnings.contains("CONFLICT"), "{warnings}");
+    assert!(warnings.contains("device management"), "{warnings}");
+
+    // And the third party's file is untouched by planning.
+    assert!(std::fs::read_to_string(&managed).expect("read").contains("Bash"));
 }

--- a/aa-devtool-claude-code/tests/claude_code_lifecycle.rs
+++ b/aa-devtool-claude-code/tests/claude_code_lifecycle.rs
@@ -14,9 +14,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use aa_devtool_claude_code::lifecycle::{
-    CA_ENV_VAR, MITM_HOSTS, STEP_MANAGED_SETTINGS, STEP_NODE_EXTRA_CA_CERTS, STEP_PROTECTION_TEST, STEP_PROXY_CA,
-    STEP_PROXY_ENV, STEP_SIDE_CHANNEL_SCOPE,
+    CA_ENV_VAR, MITM_HOSTS, STEP_ENDPOINT_MANAGED_SETTINGS, STEP_MANAGED_SETTINGS, STEP_NODE_EXTRA_CA_CERTS,
+    STEP_PROTECTION_TEST, STEP_PROXY_CA, STEP_PROXY_ENV, STEP_SIDE_CHANNEL_SCOPE,
 };
+use aa_devtool_claude_code::managed_settings::testing::FakeAuthority;
+use aa_devtool_claude_code::managed_settings::{PrivilegedFileAuthority, MANAGED_ONLY_KEYS};
 use aa_devtool_claude_code::{ClaudeCodeAdapter, ClaudeCodeIntegration, ClaudeCodePaths};
 use aa_devtool_contract::{
     capability_conformance, DevToolIntegration, DevToolKind, EnvValue, IntegrationCapability, IntegrationRequest,
@@ -59,6 +61,11 @@ impl Fixture {
             .with_project(self.root().join("repo"))
             .with_state(self.root().join("state"))
             .with_ca_source(self.ca_source())
+            // The managed surface is redirected into the fixture, and the real
+            // authority refuses to elevate for anything but the canonical path —
+            // so nothing here can reach an administrator prompt or the real
+            // `/Library/Application Support/ClaudeCode`.
+            .with_managed_root(self.root().join("ClaudeCode"))
     }
 
     /// A stub `claude` binary file. Never executed — the version probe is
@@ -77,9 +84,20 @@ impl Fixture {
     }
 
     fn integration(&self, version: Option<&str>) -> ClaudeCodeIntegration {
+        self.integration_with_authority(version, FakeAuthority::granting())
+    }
+
+    /// An integration whose one privileged step elevates through `authority` —
+    /// always a test double, never the real macOS one.
+    fn integration_with_authority(
+        &self,
+        version: Option<&str>,
+        authority: Arc<dyn PrivilegedFileAuthority>,
+    ) -> ClaudeCodeIntegration {
         ClaudeCodeIntegration::with_paths(self.paths())
             .with_adapter(self.adapter(version))
             .through_proxy("http://127.0.0.1:18899")
+            .with_managed_authority(authority)
     }
 
     fn settings_path(&self, scope: SettingsScope) -> PathBuf {
@@ -122,10 +140,20 @@ fn base_url_redirection_and_hooks_are_declared_unsupported_with_reasons() {
         .expect("hooks must be declared unsupported for protection");
     assert!(hooks.contains("cannot see or modify"), "{hooks}");
 
-    let host = caps
+    // Host enforcement is offered — but only through the opt-in privileged
+    // path. `next_level` is where a status says why it is not active.
+    assert!(
+        caps.unsupported_reason(IntegrationCapability::HostEnforcement)
+            .is_none(),
+        "an authority that can be asked makes host enforcement a declared capability"
+    );
+    let unavailable = fixture
+        .integration_with_authority(Some("2.1.220"), FakeAuthority::unavailable())
+        .capabilities();
+    let host = unavailable
         .unsupported_reason(IntegrationCapability::HostEnforcement)
-        .expect("host enforcement must be reported as unavailable, never omitted");
-    assert!(host.contains("system trust store"), "{host}");
+        .expect("a host with no authorization mechanism must say so, never omit it");
+    assert!(host.contains("cannot be installed on this host"), "{host}");
 }
 
 #[test]
@@ -278,18 +306,99 @@ async fn a_project_scoped_plan_writes_only_the_project_surface() {
     }
 }
 
+// ── The one privileged step (AAASM-5298) ────────────────────────────────────
+
 #[tokio::test]
-async fn the_managed_settings_surface_is_refused_rather_than_written() {
+async fn a_normal_install_contains_no_privileged_step_and_cannot_claim_host_enforcement() {
+    // The governing rule of AAASM-5298, at the plan layer: an unprivileged plan
+    // has no step that could produce host-attested evidence, and says so.
     let fixture = Fixture::new();
     fixture.write_ca();
     let integration = fixture.integration(Some("2.1.220"));
-    let err = integration
-        .plan_integration(&request(SettingsScope::Managed))
+
+    for scope in [SettingsScope::User, SettingsScope::Project] {
+        let plan = integration
+            .plan_integration(&request(scope).requesting_level(ProtectionLevel::HostEnforced))
+            .await
+            .expect("plan");
+        plan.validate().expect("validate");
+        assert_eq!(plan.privileged_steps().count(), 0, "{scope} install must not elevate");
+        assert!(
+            !plan.steps.iter().any(|s| s.id == STEP_ENDPOINT_MANAGED_SETTINGS),
+            "{scope} install must not write the endpoint-managed file"
+        );
+        assert_eq!(
+            plan.planned_level,
+            ProtectionLevel::GatewayProtected,
+            "{scope} install must be capped below HostEnforced even when it is asked for"
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_managed_scope_plan_carries_exactly_one_privileged_step() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration(Some("2.1.220"));
+    let plan = integration
+        .plan_integration(&request(SettingsScope::Managed).requesting_level(ProtectionLevel::HostEnforced))
         .await
-        .expect_err("the endpoint managed-settings file must not be planned for");
-    let message = err.to_string();
-    assert!(message.contains("/Library/Application Support/ClaudeCode"), "{message}");
-    assert!(message.contains("--scope user"), "{message}");
+        .expect("plan");
+    plan.validate().expect("validate");
+
+    let privileged: Vec<&str> = plan.privileged_steps().map(|s| s.id.as_str()).collect();
+    assert_eq!(privileged, vec![STEP_ENDPOINT_MANAGED_SETTINGS]);
+    assert_eq!(plan.planned_level, ProtectionLevel::HostEnforced);
+
+    let step = plan
+        .steps
+        .iter()
+        .find(|s| s.id == STEP_ENDPOINT_MANAGED_SETTINGS)
+        .expect("the managed step");
+    assert!(step.reversal.is_some(), "a privileged step needs a reversal");
+    match &step.action {
+        StepAction::WriteManagedSettings {
+            scope,
+            managed_keys,
+            path,
+            ..
+        } => {
+            assert_eq!(*scope, SettingsScope::Managed);
+            assert_eq!(path, &fixture.settings_path(SettingsScope::Managed));
+            for key in MANAGED_ONLY_KEYS {
+                assert!(managed_keys.contains(&key.to_string()), "{key} is unclaimed");
+            }
+        }
+        other => panic!("expected a managed settings write, got {other:?}"),
+    }
+
+    // Every fact the owner required before authorization is requested.
+    let warnings = plan.warnings.join("\n");
+    assert!(warnings.contains("one privileged step"), "{warnings}");
+    assert!(warnings.contains("does not measure Claude Code"), "{warnings}");
+    assert!(warnings.contains("never replaced"), "{warnings}");
+    assert!(
+        step.render_dry_run().contains("privileged-host"),
+        "{}",
+        step.render_dry_run()
+    );
+}
+
+#[tokio::test]
+async fn a_host_with_no_authorization_mechanism_plans_no_privileged_step() {
+    let fixture = Fixture::new();
+    fixture.write_ca();
+    let integration = fixture.integration_with_authority(Some("2.1.220"), FakeAuthority::unavailable());
+    let plan = integration
+        .plan_integration(&request(SettingsScope::Managed).requesting_level(ProtectionLevel::HostEnforced))
+        .await
+        .expect("plan");
+    plan.validate().expect("validate");
+    assert_eq!(
+        plan.planned_level,
+        ProtectionLevel::GatewayProtected,
+        "an unauthorizable host must not plan for a level it cannot reach"
+    );
 }
 
 #[tokio::test]

--- a/aa-integration-tests/tests/claude_code_integration_lifecycle.rs
+++ b/aa-integration-tests/tests/claude_code_integration_lifecycle.rs
@@ -38,6 +38,8 @@ use aa_core::integration::{
 };
 use aa_core::DevToolKind;
 use aa_devtool_claude_code::lifecycle::{CA_ENV_VAR, STEP_NODE_EXTRA_CA_CERTS, STEP_PROXY_CA};
+use aa_devtool_claude_code::managed_settings::testing::FakeAuthority;
+use aa_devtool_claude_code::managed_settings::PrivilegedFileAuthority;
 use aa_devtool_claude_code::probe::{ProbeReport, ProbeRequest, ProtectionProbe, SYNTHETIC_SECRET};
 use aa_devtool_claude_code::{ClaudeCodeAdapter, ClaudeCodeIntegration, ClaudeCodePaths};
 use aa_devtool_contract::ExerciseOutcome;
@@ -170,6 +172,13 @@ struct Harness {
 
 impl Harness {
     async fn start(trust_injected_ca: bool) -> anyhow::Result<Self> {
+        Self::start_with_authority(trust_injected_ca, FakeAuthority::granting()).await
+    }
+
+    async fn start_with_authority(
+        trust_injected_ca: bool,
+        authority: Arc<dyn PrivilegedFileAuthority>,
+    ) -> anyhow::Result<Self> {
         install_crypto_provider();
         let guard = RealHomeGuard::capture();
 
@@ -194,7 +203,13 @@ impl Harness {
             .with_home(&home)
             .with_project(&repo)
             .with_state(&state)
-            .with_ca_source(ca_dir.join("ca-cert.pem"));
+            .with_ca_source(ca_dir.join("ca-cert.pem"))
+            // AAASM-5298: the endpoint-managed surface is redirected into the
+            // fixture, and the real macOS authority refuses to elevate for
+            // anything but the canonical path — so nothing here can reach an
+            // administrator prompt or the real
+            // `/Library/Application Support/ClaudeCode`.
+            .with_managed_root(dir.path().join("ClaudeCode"));
 
         let stub_binary = dir.path().join("claude");
         std::fs::write(&stub_binary, "")?;
@@ -210,7 +225,8 @@ impl Harness {
                     proxy_addr: proxy.addr,
                     upstream: Arc::clone(&upstream),
                     trust_injected_ca,
-                })),
+                }))
+                .with_managed_authority(authority),
         );
 
         let service = EngineLifecycle::new(
@@ -254,6 +270,43 @@ impl Harness {
             .apply(&DevToolKind::ClaudeCode, &plan.plan_id)
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// The opt-in, administrator-authorized install. Everything about it is
+    /// explicit: the scope, the level it asks for, and the consent to the one
+    /// privileged step.
+    async fn install_managed(&self) -> anyhow::Result<aa_core::integration::IntegrationReceipt> {
+        let request = IntegrationRequest::new(
+            DevToolKind::ClaudeCode,
+            ProtectionProfile::Recommended,
+            SettingsScope::Managed,
+        )
+        .requesting_level(ProtectionLevel::HostEnforced)
+        .allowing_privileged_host_steps();
+        let plan = self.service.plan(request).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        self.service
+            .apply(&DevToolKind::ClaudeCode, &plan.plan_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// The same plan, without the consent the privileged step needs.
+    async fn install_managed_without_consent(&self) -> anyhow::Result<String> {
+        let request = IntegrationRequest::new(
+            DevToolKind::ClaudeCode,
+            ProtectionProfile::Recommended,
+            SettingsScope::Managed,
+        )
+        .requesting_level(ProtectionLevel::HostEnforced);
+        let plan = self.service.plan(request).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        match self.service.apply(&DevToolKind::ClaudeCode, &plan.plan_id).await {
+            Ok(_) => anyhow::bail!("an unconsented privileged step must not be applied"),
+            Err(e) => Ok(e.to_string()),
+        }
+    }
+
+    fn managed_settings_path(&self) -> PathBuf {
+        self.paths.managed_settings_path()
     }
 
     fn ca_pem_path(&self) -> PathBuf {
@@ -635,6 +688,194 @@ async fn the_removal_preview_names_the_trust_material_and_the_variable() -> anyh
     assert!(
         preview.steps.iter().any(|s| s.id.contains(STEP_NODE_EXTRA_CA_CERTS)),
         "{rendered}"
+    );
+    h.finish();
+    Ok(())
+}
+
+// ── AAASM-5298: the one privileged step, end to end ─────────────────────────
+
+/// The governing rule, measured through the engine rather than asserted in a
+/// unit test: a successful **normal** installation, fully verified, with real
+/// adjudicated traffic behind it, still cannot report `Host Enforced`.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_successful_normal_install_cannot_reach_host_enforced() -> anyhow::Result<()> {
+    let h = Harness::start(true).await?;
+    let tool = DevToolKind::ClaudeCode;
+
+    h.install().await?;
+    let verification = h.service.verify(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert_eq!(verification.outcome, VerificationOutcome::Passed);
+
+    let status = h.service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert_eq!(
+        status.achieved_level(),
+        ProtectionLevel::GatewayProtected,
+        "the best an unprivileged install can prove is that traffic was governed"
+    );
+    assert!(
+        !h.managed_settings_path().exists(),
+        "an unprivileged install must not write the endpoint-managed file"
+    );
+    assert!(
+        !status
+            .evidence
+            .iter()
+            .any(aa_core::integration::ProtectionEvidence::is_host_enforcement_grade),
+        "a normal install must produce no host-attested evidence: {:?}",
+        status.evidence
+    );
+    let next = status.next_level.as_ref().expect("the next rung is always reported");
+    assert_eq!(next.level, ProtectionLevel::HostEnforced);
+    assert!(
+        next.blocked_because.contains("--install-managed-settings"),
+        "the reason must name the opt-in: {}",
+        next.blocked_because
+    );
+
+    h.finish();
+    Ok(())
+}
+
+/// The authorized path: one privileged step, read back and verified, and only
+/// then `Host Enforced` — reversed symmetrically on removal.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_authorized_managed_install_reaches_host_enforced_and_is_reversible() -> anyhow::Result<()> {
+    let h = Harness::start(true).await?;
+    let tool = DevToolKind::ClaudeCode;
+
+    let receipt = h.install_managed().await?;
+    assert_eq!(receipt.settings_scope, SettingsScope::Managed);
+    let installed = std::fs::read_to_string(h.managed_settings_path())?;
+    assert!(installed.contains("disableBypassPermissionsMode"), "{installed}");
+
+    // Configuration alone still does not raise the ladder past Integrated.
+    let after_install = h.service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(after_install.achieved_level() <= ProtectionLevel::Integrated);
+
+    let verification = h.service.verify(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert_eq!(verification.outcome, VerificationOutcome::Passed);
+
+    let status = h.service.status(&tool).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert_eq!(
+        status.achieved_level(),
+        ProtectionLevel::HostEnforced,
+        "an authorized, read-back-verified managed install is the only route to this rung: {:?}",
+        status.state
+    );
+    let attested = status
+        .evidence
+        .iter()
+        .find(|e| e.is_host_enforcement_grade())
+        .expect("host-attested evidence");
+    assert!(
+        attested.detail.contains("has not measured Claude Code"),
+        "the attestation must state what it does not claim: {}",
+        attested.detail
+    );
+
+    // ── removal is symmetric, including the no-prior-file case ─────────────
+    let removal = h
+        .service
+        .remove(&tool, Some(&format!("remove-{}", receipt.receipt_id)))
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(removal.residual.is_empty(), "{:?}", removal.residual);
+    assert!(
+        !h.managed_settings_path().exists(),
+        "there was no managed file before the install, so there must be none after the removal"
+    );
+
+    h.finish();
+    Ok(())
+}
+
+/// A privileged step the request did not consent to is refused by the service,
+/// before the authority is ever asked.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_privileged_step_is_refused_without_consent() -> anyhow::Result<()> {
+    let h = Harness::start(true).await?;
+    let message = h.install_managed_without_consent().await?;
+    assert!(message.contains("changes host state"), "{message}");
+    assert!(
+        !h.managed_settings_path().exists(),
+        "an unconsented plan must write nothing"
+    );
+    h.finish();
+    Ok(())
+}
+
+/// Denied authorization is a failure, never a quieter install.
+#[tokio::test(flavor = "multi_thread")]
+async fn denied_authorization_fails_the_install_rather_than_downgrading_it() -> anyhow::Result<()> {
+    let h = Harness::start_with_authority(true, FakeAuthority::denying()).await?;
+    let err = h
+        .install_managed()
+        .await
+        .expect_err("a denied authorization must fail the install");
+    let message = err.to_string();
+    assert!(message.contains("Permission Required"), "{message}");
+    assert!(
+        !h.managed_settings_path().exists(),
+        "a denied install must leave nothing behind"
+    );
+
+    // And nothing claims host enforcement afterwards.
+    let status = h
+        .service
+        .status(&DevToolKind::ClaudeCode)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    assert!(
+        status.achieved_level() < ProtectionLevel::HostEnforced,
+        "{:?}",
+        status.state
+    );
+    h.finish();
+    Ok(())
+}
+
+/// A read-back that does not match what was authorized prevents the success
+/// receipt — the install fails and the host is put back.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_read_back_mismatch_prevents_the_success_receipt() -> anyhow::Result<()> {
+    let h = Harness::start_with_authority(
+        true,
+        FakeAuthority::corrupting(r#"{"disableBypassPermissionsMode":false}"#),
+    )
+    .await?;
+    let err = h
+        .install_managed()
+        .await
+        .expect_err("a read-back mismatch must fail the install");
+    let message = err.to_string();
+    assert!(message.contains("Read-back verification failed"), "{message}");
+    assert!(
+        !h.managed_settings_path().exists(),
+        "the failed write must have been rolled back"
+    );
+    h.finish();
+    Ok(())
+}
+
+/// A managed-settings file Agent Assembly did not write is never merged over.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_third_party_managed_file_is_refused_and_left_alone() -> anyhow::Result<()> {
+    const MDM_POLICY: &str = r#"{"disableBypassPermissionsMode":true,"permissions":{"deny":["Bash"]}}"#;
+    let h = Harness::start(true).await?;
+    let managed = h.managed_settings_path();
+    std::fs::create_dir_all(managed.parent().expect("parent"))?;
+    std::fs::write(&managed, MDM_POLICY)?;
+
+    let err = h
+        .install_managed()
+        .await
+        .expect_err("a file Agent Assembly did not write must not be replaced");
+    assert!(err.to_string().contains("Conflicting managed settings"), "{err}");
+    assert_eq!(
+        std::fs::read_to_string(&managed)?,
+        MDM_POLICY,
+        "the third party's policy must be exactly as it was"
     );
     h.finish();
     Ok(())

--- a/aa-integration-tests/tests/conformance_claude_code.rs
+++ b/aa-integration-tests/tests/conformance_claude_code.rs
@@ -499,8 +499,12 @@ async fn the_ladder_rises_only_on_adjudicated_exercised_evidence() -> anyhow::Re
             "the unreachable rung must be reported, not omitted: {json}"
         );
         assert!(
-            json.contains("host enforcement is unavailable"),
-            "the reason host enforcement is unreachable must be stated, not implied: {json}"
+            json.contains("host enforcement is not active"),
+            "the reason host enforcement is not active must be stated, not implied: {json}"
+        );
+        assert!(
+            json.contains("--install-managed-settings"),
+            "the reason must name the opt-in that would change it: {json}"
         );
     }
 

--- a/aa-integration-tests/tests/conformance_claude_code.rs
+++ b/aa-integration-tests/tests/conformance_claude_code.rs
@@ -1130,7 +1130,10 @@ async fn an_unscoped_client_cannot_drive_the_lifecycle() -> anyhow::Result<()> {
         for (verb, outcome) in [
             (
                 "plan",
-                client.plan("claude-code", "recommended", "user", "", false).await.err(),
+                client
+                    .plan("claude-code", "recommended", "user", "", false, "")
+                    .await
+                    .err(),
             ),
             ("apply", client.apply("claude-code", "any-plan").await.err()),
             ("repair", client.repair("claude-code").await.err()),

--- a/aa-runtime/src/devint/client.rs
+++ b/aa-runtime/src/devint/client.rs
@@ -210,11 +210,12 @@ impl DevIntClient {
         settings_scope: &str,
         policy_profile_id: &str,
         allow_privileged_host_steps: bool,
+        requested_level: &str,
     ) -> Result<wire::PlanView, ClientError> {
         let mut request = self.request(DiVerb::Plan, tool_id);
         request.plan = Some(wire::PlanArgs {
             profile: profile.to_string(),
-            requested_level: String::new(),
+            requested_level: requested_level.to_string(),
             settings_scope: settings_scope.to_string(),
             allow_privileged_host_steps,
             policy_profile_id: policy_profile_id.to_string(),
@@ -345,7 +346,7 @@ mod tests {
         let tool = claude_code_id();
         assert_eq!(client.list_tools().await.expect("list").tools.len(), 1);
         let plan = client
-            .plan(&tool, "recommended", "user", "team-default", false)
+            .plan(&tool, "recommended", "user", "team-default", false, "")
             .await
             .expect("plan");
         assert_eq!(plan.plan_id, "plan-1");
@@ -381,7 +382,7 @@ mod tests {
         let (token, _) = server.enrol("reference-client", TokenScope::full_lifecycle(ToolScope::AllTools));
         let mut client = connected(&server, Some(token.expose().to_string())).await;
         let plan = client
-            .plan(&claude_code_id(), "recommended", "user", "team-default", false)
+            .plan(&claude_code_id(), "recommended", "user", "team-default", false, "")
             .await
             .expect("plan");
         let rendered = format!("{plan:?}");

--- a/docs/src/devtools/cli.md
+++ b/docs/src/devtools/cli.md
@@ -201,10 +201,18 @@ Claude Code is the first natively migrated integration
 `~/.claude/settings.json`); `--scope project` writes
 `<cwd>/.claude/settings.json`. A `.claude/` directory in your working directory
 never redirects a user-scoped install — which file is written is a decision you
-make and the receipt records. `--scope managed` is refused: the endpoint
-managed-settings file is administrator-owned, its enforcement keys are
-unmeasured, and installing them would need a privileged step this integration
-does not take.
+make and the receipt records.
+
+`--scope managed` on its own is refused, because it reads like a third choice
+and says nothing about administrator authorization. The endpoint managed-settings
+file is installed by `--install-managed-settings` instead — an explicit opt-in
+that adds **one** privileged step (placing a single root-owned file) and is the
+only route to `Host Enforced`. The plan shows the exact path, the exact bytes,
+the diff, any conflict, and the backup and rollback before you are asked to
+approve anything; a denied or unavailable authorization is a truthful
+*Permission Required* / *Unavailable* failure, never a quieter install; and a
+non-interactive run fails immediately rather than waiting for credentials. See
+[Protection levels → Host Enforced](protection-levels.md#host-enforced).
 
 ### Protection applies to the managed launch
 

--- a/docs/src/devtools/limitations.md
+++ b/docs/src/devtools/limitations.md
@@ -30,7 +30,8 @@ claim that traces to neither is not on this page.
 | Drift detection and repair | **Supported** | Detected at `status`/`verify` time, not in real time. |
 | Adjudicating protection probe | **Planned** | The default probe cannot see the forwarded body. |
 | `strict` blocking on a high-severity scanner finding | **Planned** | [AAASM-5277](https://lightning-dust-mite.atlassian.net/browse/AAASM-5277), [AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281). Today `strict` redacts, like `recommended`. |
-| Endpoint managed-settings enforcement keys | **Planned / unmeasured** | [AAASM-5298](https://lightning-dust-mite.atlassian.net/browse/AAASM-5298). |
+| Endpoint managed-settings file | **Installable, opt-in and authorized** | [AAASM-5298](https://lightning-dust-mite.atlassian.net/browse/AAASM-5298). `--install-managed-settings`; verified by read-back. |
+| Endpoint managed-settings *enforcement* keys | **Still unmeasured** | Documented as non-overridable; no real override attempt has been measured against a managed device. |
 | Byte-exact configuration restore | **Unsupported** | Semantics-exact by accepted constraint (C3). |
 | `ANTHROPIC_BASE_URL` redirection as a protection mechanism | **Unsupported** | Measured delivering the raw secret. |
 | Host-level bypass prevention | **Unsupported** | Explicit non-goal. |
@@ -167,28 +168,51 @@ whenever it cannot measure:
 Read exit `6` on an otherwise-clean install as **"not measured"**, not as
 **"measured and failed"** — and read `status` for which it is.
 
-## The managed-settings path is unmeasured
+## The managed-settings file can be installed; its enforcement is still unmeasured
 
 `/Library/Application Support/ClaudeCode/managed-settings.json` is the endpoint
 managed-settings file. Its managed-only keys —
-`allowManagedPermissionRulesOnly`, `disableBypassPermissionsMode`, and others —
+`allowManagedPermissionRulesOnly`, `disableBypassPermissionsMode`,
+`allowManagedMcpServersOnly`, `allowManagedHooksOnly` —
 are **the strongest available counters to the bypasses listed above**.
 
-They are **unmeasured**. The directory did not exist on the Spike host, creating
-it requires root, and the Spike deliberately made no privileged writes. Nothing
-in `aa-devtool-claude-code` writes to it; `--scope managed` is refused, and the
-path is resolved only so a refusal can name it
-(`aa-devtool-claude-code/src/scope.rs`).
+Since [AAASM-5298](https://lightning-dust-mite.atlassian.net/browse/AAASM-5298),
+Agent Assembly can install that file — through an **opt-in, explicitly
+authorized** path, never as part of a default install. See
+[`--install-managed-settings`](cli.md) and
+[Protection levels → Host Enforced](protection-levels.md#host-enforced).
 
-> **Therefore: no non-overridable-enforcement claim is made anywhere in this
-> product** (AAASM-5276 condition **C6**). Nothing in these docs, the CLI or any
-> client should be read as implying that a bypass is prevented rather than
-> detected.
+**What Agent Assembly verifies**, by reading the file back after the write:
 
-Measuring this path on a managed/MDM macOS device is tracked as
-[AAASM-5298](https://lightning-dust-mite.atlassian.net/browse/AAASM-5298). It is
-a product decision rather than an engineering default, because it introduces a
-**privileged install step**.
+* its bytes are exactly the bytes you were shown and authorized;
+* it parses as a managed-settings document and carries the managed-only keys;
+* it is owned by the expected principal (root at the canonical path);
+* no account other than its owner can rewrite it.
+
+**What Agent Assembly does not measure**, and will not claim:
+
+* that Claude Code honours each managed-only key at runtime. Anthropic documents
+  these keys as non-overridable; Agent Assembly has **not** measured a real
+  override attempt against a managed device. AAASM-5276 condition **C6** is
+  closed for the *install* half and open for the *enforcement* half.
+
+> Read a `Host Enforced` level as: *"the managed policy is installed at the
+> OS-managed path, owned as expected and not writable by you."* Do not read it as
+> *"this bypass has been demonstrated to fail."* Every status that reports it
+> carries that caveat in the evidence detail.
+
+### What the install will not do
+
+* It will not elevate anything but the single file placement. `aasm` never runs
+  as root, and no other step in any plan asks for authorization.
+* It will not replace a managed-settings file Agent Assembly did not write — for
+  example one deployed by your organisation's device management. That is a
+  refusal, and moving the file aside is your explicit decision to make, not
+  Agent Assembly's.
+* It will not run without a terminal. A non-interactive invocation fails
+  immediately rather than blocking on a credential prompt nobody can answer.
+* It will not report success on the authorization mechanism's word. A read-back
+  that does not match rolls the write back and fails.
 
 ## Restore is semantics-exact, not byte-exact
 

--- a/docs/src/devtools/onboarding.md
+++ b/docs/src/devtools/onboarding.md
@@ -93,7 +93,7 @@ you never have to read the absence of a finding as the absence of a bypass.
 |---|---|---|
 | `user` | `$CLAUDE_CONFIG_DIR/settings.json`, else `~/.claude/settings.json` | The default. |
 | `project` | `<cwd>/.claude/settings.json` | Checked in and shared. Selectable, never a default. |
-| `managed` | — | **Refused.** See below. |
+| `managed` | `/Library/Application Support/ClaudeCode/managed-settings.json` | Administrator-owned. Opt-in only, via `--install-managed-settings`. See below. |
 
 A `.claude/` directory in your working directory never redirects a `user`-scoped
 install. This is deliberate: the underlying `apply` resolver *does* prefer a
@@ -102,11 +102,24 @@ where you happened to `cd` cannot write a receipt it can later compare drift
 against or restore from (AAASM-5276 condition **C2**;
 `aa-devtool-claude-code/src/scope.rs`).
 
-`--scope managed` is refused with the path named:
-`/Library/Application Support/ClaudeCode/managed-settings.json` is
-administrator-owned, its enforcement keys are **unmeasured**, and installing them
-would require a privileged step this integration does not take. See
-[Limitations](limitations.md#the-managed-settings-path-is-unmeasured).
+`--scope managed` on its own is **refused**, and points you at the flag that
+names what it does: `--install-managed-settings`. That is deliberate — `managed`
+reads like a third choice alongside `user` and `project`, and nothing about it
+says *this will ask for your administrator password*.
+
+```console
+$ aasm integrations install claude-code --install-managed-settings
+```
+
+This adds **one** privileged step: placing a single file at
+`/Library/Application Support/ClaudeCode/managed-settings.json`, owned by root.
+`aasm` itself never runs as root. Before you are asked to approve anything, the
+plan states the exact path, the exact bytes, the diff against what is already
+there, any conflict, and the backup and rollback behaviour. It is the only route
+to [`Host Enforced`](protection-levels.md#host-enforced) — and it refuses rather
+than merging over a managed-settings file Agent Assembly did not write. Read
+[Limitations](limitations.md#the-managed-settings-file-can-be-installed-its-enforcement-is-still-unmeasured)
+for what the resulting claim does and does not cover.
 
 ## Step 3 — Choose a profile
 

--- a/docs/src/devtools/product-brief.md
+++ b/docs/src/devtools/product-brief.md
@@ -435,10 +435,11 @@ active`.
 
 | | |
 |---|---|
-| **What it would protect** | The machine, not the integration. Enforcement applied at the operating-system boundary so a process cannot escape by unsetting an environment variable, launching the tool directly, or opening its own socket. |
-| **Testable entry criteria** | An OS-level enforcement facility is installed, active, and demonstrated to block a *deliberately unmanaged* launch — i.e. the bypass that defeats §7.1 and §7.2 must be shown to fail. |
-| **Availability** | **Not available in this MVP.** macOS Endpoint Security and Network Extension are explicit non-goals (§10), and Windows/Linux host enforcement is out of scope. The `aa-ebpf` layer is Linux-only and is a **detection** layer — it observes SSL and exec/file syscalls but cannot modify traffic in flight, so it cannot supply this level either. |
-| **Product requirement** | The level must be **named and reported as unavailable**, not hidden. A user reading status must be able to see that a stronger tier exists and that this machine does not have it. Silence here reads as "there is nothing above what I have", which is the over-claim this whole section exists to prevent. |
+| **What it protects** | The tool's *policy surface*, not just its configuration: the governing document lives where the developer running the tool cannot rewrite it, so unsetting a variable or editing a settings file cannot widen it. |
+| **Testable entry criteria** | §7.2, **plus** an endpoint managed-settings file that Agent Assembly installed under explicit administrator authorization and then read back and verified — exact authorized bytes, valid managed-settings document carrying the managed-only keys, owned by the expected principal, not writable by anyone else. |
+| **Availability** | **Opt-in, macOS, one privileged file write** (`AAASM-5298`). Reached only through `aasm integrations install claude-code --install-managed-settings`; never part of a default install, never implied by a profile, and unreachable at `user` or `project` scope. `aasm` itself never runs as root. Kernel-level enforcement stays out of scope: macOS Endpoint Security and Network Extension remain explicit non-goals (§10), and `aa-ebpf` is Linux-only and is a **detection** layer that cannot modify traffic in flight. |
+| **What it does not claim** | That a bypass was demonstrated to fail. Anthropic documents the managed-only keys as non-overridable; Agent Assembly has **not** measured a real override attempt against a managed device (the open half of `AAASM-5276` condition C6). Every `Host Enforced` reading carries that caveat in its evidence detail. |
+| **Product requirement** | The level must be **named with its reason whenever it is not active**, and **with its caveat whenever it is**. Silence reads as "there is nothing above what I have", which is the over-claim this whole section exists to prevent. |
 | **Maps to `GovernanceLevel`** | Nothing today. It is not `L3Native`: `L3Native` means AASM writes the tool's *own* native configuration so governance survives AASM going offline — that is a property of `Integrated`, not a host-level control. Host enforcement is orthogonal to the L0–L3 scale, which describes what a tool adapter achieves, not what the OS enforces. |
 
 ### 7.4 Level reporting rules
@@ -724,8 +725,9 @@ else on the machine.
 > **When** `status` is invoked in each,
 > **Then** (a) reports at most `Integrated` and explicitly does **not** claim sensitive-data
 > protection; (b) reports `Gateway Protected` and names the mechanisms confirmed by exercise as
-> distinct from those confirmed by read-back; and (c) in every case reports `Host Enforced` as
-> **unavailable on this platform** rather than omitting it.
+> distinct from those confirmed by read-back; and (c) in every case names `Host Enforced` rather
+> than omitting it — with the reason it is not active on a default install, and with the caveat on
+> what the attestation covers when an authorized managed-settings install has been verified.
 
 ### 11.9 Core stopped mid-session fails closed
 
@@ -785,7 +787,7 @@ corresponding section of this document changes rather than being quietly worked 
 | C1 | The security core lives in Agent Assembly; integration surfaces are thin and non-authoritative. | §1. No enforcement logic ships inside a plugin. |
 | C2 | MCP is optional, never the plugin architecture. | §2. No lifecycle stage may require MCP. |
 | C3 | `Integrated` and `Gateway Protected` cannot claim host-level bypass prevention. | §7. Stated in product copy, not only in docs. |
-| C4 | `Host Enforced` is unavailable in this MVP, and its absence is reported rather than hidden. | §7.3, §10.3. |
+| C4 | `Host Enforced` is reachable only through an explicit, authorized, read-back-verified managed-settings install; a successful *normal* installation never implies it, and when it is not active the reason is reported rather than hidden. | §7.3, §10.3. |
 | C5 | Default posture is fail-closed. | §9. |
 | C6 | MVP is macOS + Claude Code; the model stays multi-tool. | §10. |
 | C7 | Detection is the existing deterministic scanner; it is incomplete by nature. | G1. Never claim complete detection. |

--- a/docs/src/devtools/protection-levels.md
+++ b/docs/src/devtools/protection-levels.md
@@ -21,7 +21,7 @@ reference. Where the two differ, the brief is canonical.
 |---|---|---|
 | **Integrated** | The tool's *startup posture* is governed and its actions are attributable. | **Yes.** |
 | **Gateway Protected** | Model-bound and tool-bound traffic is inspected, redacted and allow/deny-enforced in flight. | **Mechanism proven; not reportable on a default build** — see [below](#why-gateway-protected-is-not-reportable-today). |
-| **Host Enforced** | The *machine* is constrained, so a process cannot escape by launching outside the managed path. | **No.** Reported as *unavailable on this platform*, never omitted. |
+| **Host Enforced** | The tool's policy lives on a surface the developer cannot rewrite, verified by read-back after an authorized write. | **Opt-in only** — `--install-managed-settings`, macOS. A default install can never reach it. |
 
 Two reporting rules apply at every rung:
 
@@ -90,17 +90,41 @@ Two reporting rules apply at every rung:
 
 | | |
 |---|---|
-| **What it would protect** | The machine, not the integration. Enforcement at the operating-system boundary, so a process could not escape by unsetting an environment variable, launching the tool directly, or opening its own socket. |
-| **Testable entry criteria** | An OS-level enforcement facility is installed, active, and **demonstrated to block a deliberately unmanaged launch** — the bypass that defeats both levels above must be shown to fail. |
-| **Availability** | **Not available.** macOS Endpoint Security and Network Extension are explicit non-goals; Windows and Linux host enforcement are out of scope. `aa-ebpf` is Linux-only and is a *detection* layer — it observes SSL and exec/file syscalls but cannot modify traffic in flight, so it cannot supply this level either. |
-| **Reporting requirement** | The level is **named and reported as unavailable**, not hidden. Silence reads as "there is nothing above what I have", which is the over-claim this whole model exists to prevent. |
-| **Maps to L0–L3** | Nothing. It is *not* `L3Native`: `L3Native` means Agent Assembly writes the tool's own native configuration so governance survives Agent Assembly going offline — a property of `Integrated`. Host enforcement is orthogonal to the L0–L3 scale, which describes what a tool adapter achieves, not what the OS enforces. |
+| **What it protects** | The tool's *policy surface*, not just its configuration. The governing document lives where the developer running the tool cannot rewrite it, so unsetting a variable or editing a settings file cannot widen it. |
+| **Testable entry criteria** | `Gateway Protected`, **plus** an endpoint managed-settings file that Agent Assembly installed under explicit administrator authorization and then **read back and verified**: exact authorized bytes, valid managed-settings document carrying the managed-only keys, owned by the expected principal, not writable by anyone else. |
+| **Availability** | **Opt-in, macOS only.** Reached only through `aasm integrations install claude-code --install-managed-settings`. Never part of a default install, never implied by a profile, never reachable at `--scope user` or `--scope project`. |
+| **Reporting requirement** | Named and reported with its reason whenever it is *not* active, and reported with its caveat whenever it *is*. |
+| **Maps to L0–L3** | Nothing. It is *not* `L3Native`: `L3Native` means Agent Assembly writes the tool's own native configuration so governance survives Agent Assembly going offline — a property of `Integrated`. Host enforcement is orthogonal to the L0–L3 scale. |
 
-> **No non-overridable-enforcement claim is made anywhere in this product.** The
-> strongest available bypass counters live in Claude Code's endpoint
-> managed-settings file, that file was deliberately never written to, and its
-> managed-only keys remain **unmeasured**. See
-> [Limitations](limitations.md#the-managed-settings-path-is-unmeasured).
+### The one privileged operation
+
+The default install is fully unprivileged. `--install-managed-settings` adds
+**exactly one** step that changes host state: placing a single file at
+`/Library/Application Support/ClaudeCode/managed-settings.json`, owned by root.
+`aasm` itself never runs as root, and no other step in any plan asks for
+authorization.
+
+Before authorization is requested, the plan states the exact target path, why
+the privileged write is required, the exact bytes and their diff against what is
+already there, any existing-file conflict, and the backup and rollback
+behaviour. `aasm integrations remove claude-code` reverses it symmetrically —
+restoring the file that was there before, or leaving a host that had none with
+none.
+
+### What this level does and does not claim
+
+> `Host Enforced` means: **the managed policy is installed at the OS-managed
+> path, owned as expected, and not writable by you.** It does **not** mean a
+> bypass has been demonstrated to fail. Anthropic documents the managed-only
+> keys as non-overridable; Agent Assembly has not measured a real override
+> attempt against a managed device, and the evidence detail behind every
+> `Host Enforced` reading says so. See
+> [Limitations](limitations.md#the-managed-settings-file-can-be-installed-its-enforcement-is-still-unmeasured).
+
+Kernel-level enforcement remains out of scope: macOS Endpoint Security and
+Network Extension are explicit non-goals, and `aa-ebpf` is Linux-only and is a
+*detection* layer — it observes SSL and exec/file syscalls but cannot modify
+traffic in flight.
 
 ---
 
@@ -113,6 +137,7 @@ prints it rather than summarising it.
 |---|---|---|
 | **Exercised** | Traffic was produced on the protected path and the core adjudicated what happened to it. | `Gateway Protected` |
 | **Read-back** | A managed value on disk matches what the receipt says was written. Proves a file is correct; proves nothing about traffic. | `Integrated` |
+| **Host-attested** | An enforcement surface reported on itself and the report was attributed to this tool. For Claude Code this is the read-back of the endpoint managed-settings file after an authorized install — content, owner and permissions. | `Host Enforced` |
 | **Absent** | A check could not be made. Recorded so the gap is legible. Absent readings only ever *lower* a state. | — |
 
 A detected bypass becomes **Absent** evidence rather than a silent pass. With

--- a/docs/src/governance/capability-matrix.md
+++ b/docs/src/governance/capability-matrix.md
@@ -141,17 +141,21 @@ which declares `L2Enforce` overall while achieving L3 on individual capabilities
 
 ‡ **Declared from the write path, not from an exercised block.** The mechanism is native and
 survives Agent Assembly going offline, which is what L3 denotes; the *effect* was not measured by
-`AAASM-5276`, and the endpoint managed-settings keys that would make it non-overridable are
-unmeasured (see below).
+`AAASM-5276`, and the endpoint managed-settings keys that would make it non-overridable remain
+unmeasured even though the file itself can now be installed (see below).
 
 **Honest boundaries for Claude Code:**
-- **No non-overridable-enforcement claim is made.**
-  `/Library/Application Support/ClaudeCode/managed-settings.json` is root-owned; the Spike
-  deliberately made no privileged writes, so its managed-only keys
-  (`allowManagedPermissionRulesOnly`, `disableBypassPermissionsMode`, …) — the strongest available
-  bypass counters — remain **unmeasured** (`AAASM-5276` condition C6). `--scope managed` is
-  refused, and the path is resolved only so a refusal can name it. Measuring it on a managed macOS
-  device is tracked by `AAASM-5298`.
+- **The endpoint managed-settings file is installable; its enforcement is still unmeasured.**
+  `/Library/Application Support/ClaudeCode/managed-settings.json` is root-owned. Since
+  `AAASM-5298`, `aasm integrations install claude-code --install-managed-settings` installs it
+  through one explicitly authorized file write, verified by read-back (exact authorized bytes,
+  expected owner, not writable by anyone else). That is the only route to `HostEnforced`, and a
+  default install cannot reach it. **What is still unmeasured is the other half of `AAASM-5276`
+  condition C6:** the managed-only keys (`allowManagedPermissionRulesOnly`,
+  `disableBypassPermissionsMode`, …) are documented as non-overridable, and no real override
+  attempt has been measured against a managed device. `HostEnforced` therefore claims *the policy
+  is installed where you cannot rewrite it*, not *this bypass was demonstrated to fail*, and every
+  status carries that caveat.
 - **`Gateway Protected` is reportable only on adjudicated evidence.** The shipped probe drives one
   request down the protected path and reads back the proxy's verdict for that exact request —
   including a re-inspection of the payload the proxy resolved to forward — so
@@ -243,7 +247,8 @@ requiring a new adapter.
 - `AAASM-5274` — DevTool reconciliation; resolved Claude Code's overall `governance_level()` to `L2Enforce`
 - `AAASM-5276` — Claude Code lifecycle Spike; the measured evidence behind the Claude Code row
 - `AAASM-5281` — Claude Code productization (CA trust injection, side-channel scoping, explicit scope)
-- `AAASM-5298` — measure the endpoint managed-settings path on a managed macOS device (open)
+- `AAASM-5298` — the authorized endpoint managed-settings install (delivered); measuring the
+  managed-only keys against a real override attempt on a managed macOS device (still open)
 - `docs/src/devtools/protection-levels.md` — `Integrated` / `Gateway Protected` / `Host Enforced`
 - `docs/src/devtools/limitations.md` — demonstrated-versus-inferred bypasses and other honest limits
 - `AAASM-202` — Codex adapter

--- a/verification-reports/AAASM-5276-claude-code-mechanism-matrix.md
+++ b/verification-reports/AAASM-5276-claude-code-mechanism-matrix.md
@@ -126,7 +126,14 @@ Epic children; none requires new architecture, and none contradicts ADR 0030.
 | **C3** | Accept and document **semantics-exact, not byte-exact**, restore — or preserve the original document. | `apply.rs:85` reserialises the whole JSON document, so a user file in non-canonical formatting cannot survive an install→remove cycle byte-for-byte no matter how good the receipt is. This must be an accepted, stated constraint rather than an implied guarantee. | AAASM-5278 |
 | **C4** | Classify `ANTHROPIC_BASE_URL` redirection as **Unsuitable for protection**, in the capability model and in user-facing docs. | Measured: with base-URL redirection the raw secret reached the provider with no AASM component in the path. It is a *routing* feature, not a protection mechanism, and shipping it as one would be a direct over-claim. It additionally suppresses Claude Code's server-managed-settings fetch when set in the shell. | AAASM-5277, AAASM-5284 |
 | **C5** | Ensure the Claude Code integration plan intercepts the binary's **side channels**, not only the model endpoint. | One headless run produced a 130 KB `POST /api/event_logging/v2/batch`. `aa-proxy`'s `llm_only` default (`aa-proxy/src/config.rs`) is `true`, which would leave that channel unscanned. Scope this per-integration rather than by flipping a global default — changing `llm_only` wholesale would MitM every host on the machine. | AAASM-5281 |
-| **C6** | Treat the endpoint **managed-settings file as unproven** until measured on a managed device. | `/Library/Application Support/ClaudeCode/managed-settings.json` is root-owned and was deliberately not attempted (no privileged writes were made during this Spike). Its managed-only keys are the strongest bypass counters available, and they remain unmeasured — so no non-overridable-enforcement claim may be made. | AAASM-5284 + follow-up |
+| **C6** | Treat the endpoint **managed-settings file as unproven** until measured on a managed device. | `/Library/Application Support/ClaudeCode/managed-settings.json` is root-owned and was deliberately not attempted (no privileged writes were made during this Spike). Its managed-only keys are the strongest bypass counters available, and they remain unmeasured — so no non-overridable-enforcement claim may be made. | AAASM-5284 + AAASM-5298 |
+
+> **C6 update (AAASM-5298, 2026-07-31) — half closed.** The *install* half is delivered: an opt-in,
+> explicitly authorized, read-back-verified privileged write installs the managed-settings file, and
+> `HostEnforced` is reachable from nothing else. The *enforcement* half is still open: no real
+> override attempt has been measured against a managed device, so `HostEnforced` claims "the policy
+> is installed where the developer cannot rewrite it", **not** "this bypass was demonstrated to
+> fail", and no non-overridable-enforcement claim is made anywhere.
 
 ## Recommended lifecycle-contract changes (input to AAASM-5277)
 


### PR DESCRIPTION
## Description

Implements installation of the Claude Code **endpoint managed-settings** file under **explicit, opt-in
administrator authorization** — the approved privilege model for AAASM-5298. This is the only mechanism
that survives a user unsetting proxy variables or launching outside the managed path, and it is what
makes `Host Enforced` reachable.

New: `aa-devtool-claude-code/src/managed_settings.rs`. 7 gitmoji commits.

> **The governing rule, honoured throughout: a successful normal installation must not imply
> `Host Enforced`.**

## The elevation seam — one file write, never a privileged process

`trait PrivilegedFileAuthority` has exactly two operations: `install_file(target, staged)` and
`delete_file(target)`.

The bytes are written **unprivileged first**; the elevated code receives a path and a path — **no content
to interpret and no branch a caller can steer**. `MacOsAdminAuthority` runs a single
`osascript … with administrator privileges` wrapping a single
`/usr/bin/install -m 644 -o root -g wheel` (atomic via rename).

`aasm` never runs as root. Classification, backup, staging, read-back, receipt and rollback are all
unprivileged.

**The target guard is what makes the test suite safe by construction, not by discipline.**
`MacOsAdminAuthority` refuses — *before spawning anything* — any target that is not the canonical
`MANAGED_SETTINGS_PATH`, plus any non-macOS host and any session without a terminal. Every test injects
a temporary managed root, so **every test's target fails the guard and no test can reach an
authorization prompt even by accident**.

## Consent is a security control, not a prompt

`ConsentDisclosure::render()` emits, in this order: target path · why the privileged write is required ·
mechanism · proposed content · what is on the host · diff · conflict · backup · rollback ·
blocked-reason.

Enforced at three layers:
1. the CLI prints the whole plan — all of the above as warnings plus the step's `CONSENT REQUIRED` line —
   **before** `confirm()`;
2. the service refuses an unconsented `PrivilegedHost` step at apply;
3. `install()` takes the **disclosure**, not raw bytes, and refuses with `ConsentStale` if the host
   changed since the disclosure was rendered.

A user who cannot see the diff cannot meaningfully authorize it.

## Write mechanics

Backup of the prior file into AASM state (or an explicit no-prior-file record) · staged copy at `0644` ·
one atomic authorized placement · then **read-back** verifying the exact authorized digest, schema
validity, presence of managed-only keys, owner uid, and `mode & 0o022 == 0`.

Schema validation is an **allowlist**. It refuses `env` and `apiKeyHelper` — credential-bearing keys at a
world-readable, root-owned path — and refuses any document carrying **no managed-only key**, on the
grounds that it would be an elevation with no enforcement purpose.

A no-op install verifies and **requests no authorization at all**.

## Every refusal path, each tested at unit, executor and engine level

| Condition | Result |
|---|---|
| Authorization denied | `PermissionRequired`, nothing written |
| Authorization unavailable | `AuthorizationUnavailable` |
| Non-interactive | fails immediately, **never waits for credentials** |
| Conflicting third-party file | `ConflictingExistingFile`, file left **byte-identical** |
| Read-back mismatch | rolls back, `ReadBackMismatch`, **no receipt** |

AASM never replaces a managed policy it did not write — moving that file aside is the user's separate,
explicit decision.

## How `Host Enforced` is gated

Only `EvidenceKind::HostAttested { healthy: true }` on `IntegrationCapability::HostEnforcement` can raise
it, `StateDerivation` requires `GatewayProtected` first, and that evidence is produced **solely** by
`verify_recorded()` succeeding.

A user/project plan has no step that could create the record, and its ceiling is **clamped** to
`GatewayProtected` even when `HostEnforced` is requested — proven by
`a_successful_normal_install_cannot_reach_host_enforced`, which verifies with real adjudicated traffic
and still tops out at `GatewayProtected` with zero host-enforcement-grade evidence.

## ⚠️ What `Host Enforced` means here — and what it does not

**It means: the policy is installed where the user cannot rewrite it.**
**It does not mean: this bypass was demonstrated to fail.**

Three things could not be proven without a real privileged write on a managed device, and **none is
claimed anywhere in the product or the docs**:

1. That the file ends up **root-owned in production** — the ownership check is live, but `uid == 0`
   specifically is unexercised, because tests anchor to the process uid under a redirected root.
2. That `osascript` + `install -o root -g wheel` behaves as intended on a real host — the code path is
   implemented and its target-guard is tested, but its **success path is never executed**.
3. **AAASM-5298's original acceptance criterion** — "each managed-only key is measured against a real
   override attempt" — which needs an MDM-enrolled device.

The caveat is carried in the **evidence detail of every reading**, not just in prose. AAASM-5276
condition **C6 is therefore half-closed**: the installation half is delivered, the
enforcement-measurement half must stay open as a follow-up rather than be marked done on installation
evidence.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Additive and **off by default**. The default install remains fully unprivileged and reaches at most
`GatewayProtected`; the privileged path requires an explicit flag plus granted consent.

## Related Issues

- Jira: [AAASM-5298](https://lightning-dust-mite.atlassian.net/browse/AAASM-5298)
  (Epic [AAASM-5272](https://lightning-dust-mite.atlassian.net/browse/AAASM-5272))
- Closes the installation half of AAASM-5276 condition **C6**
- Builds on AAASM-5300 (#1838), AAASM-5281 (#1828)

## Security impact

This PR adds a privileged operation, so the containment properties are the substance:

- **Elevation is one file write, not a process.** The elevated code gets two paths and no content.
- **The canonical-path guard is a security boundary**, documented as such, and is why no test can reach
  a prompt.
- **Consent precedes authorization**, is stale-checked against the host, and is enforced at three layers.
- **Read-back separates a claim from evidence** — the same discipline `Gateway Protected` gained in
  AAASM-5300 via proxy adjudication.
- **Credential-bearing keys are refused** at a world-readable root-owned path.
- **A document with no managed-only key is refused** as an elevation with no purpose.
- **Rollback is symmetric**, including the no-prior-file case, and idempotent.

### Two guards proved load-bearing

**A normal install cannot report `Host Enforced`** — made `host_enforcement_evidence` fall back to a
synthetic attestation:
```
assertion `left == right` failed: the best an unprivileged install can prove is that traffic was governed
  left: HostEnforced
 right: GatewayProtected
```

**A read-back mismatch cannot produce a success receipt** — made `install()` verify against whatever is
on disk instead of what was authorized:
```
a read-back mismatch must fail the install: IntegrationReceipt { …
  step_id: "endpoint-managed-settings", applied: true,
  fingerprint: Some("sha256:c8b233fe73…") … }
```
— a full success receipt fingerprinting the **corrupt** bytes rather than the authorized
`sha256:51c3ce2f…`. Both reverted; tree clean.

## Tests executed

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

| Command | Result |
|---|---|
| `cargo nextest run -p aa-devtool-claude-code -p aa-core -p aa-cli` | **1408 passed, 0 failed** |
| `cargo nextest run -p aa-integration-tests --test conformance_claude_code --test claude_code_integration_lifecycle` | **38 passed, 0 failed** |
| `cargo fmt --all` | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | 0 errors |
| `cargo build --workspace` · `mdbook build docs` | OK · OK |

One earlier run showed `install_status_verify_drift_repair_and_remove_are_one_cycle` flaky (2/3) — a
pre-existing port/timing-bound harness test; it passed 3/3 in isolation and in the final clean run.

## Safety confirmation

**No `sudo`, no `osascript`, no authorization prompt and no `security add-trusted-cert` was executed at
any point.** `/Library/Application Support/ClaudeCode` **still does not exist** on the development
machine — verified before and after, and independently re-verified during review.
`~/.claude/settings.json` mtime 2026-07-30 09:08 (unchanged), `~/.aasm/*` 2026-07-19–23, `~/.aa`
2026-07-17 — all untouched, with `RealHomeGuard` additionally asserted by the integration suites.

Every test redirects `HOME` / `CLAUDE_CONFIG_DIR` / `AASM_STATE_DIR` / `AA_CA_DIR` /
`AASM_CLAUDE_MANAGED_ROOT` into a temp directory. Secrets are the existing synthetic
`AAASM5281SYNTHETIC` fixtures.

## Acceptance-criteria evidence — against the approved privilege model

| Constraint | Evidence |
|---|---|
| Default install fully unprivileged | no privileged step in a user/project plan; ceiling clamped |
| Never elevate the entire installer | `PrivilegedFileAuthority` — two path-only operations |
| Never prompt silently | explicit flag **and** rendered consent **and** `confirm()` |
| Explicit flag required | `--install-managed-settings` |
| Disclosure before authorization | `ConsentDisclosure::render()`, ten items in order, three enforcement layers |
| Backup + atomic replacement | backup to AASM state; `install` via rename |
| Validate schema, ownership, permissions | allowlist + owner uid + `mode & 0o022 == 0` |
| Read back before success receipt or `Host Enforced` | `verify_recorded()`; mismatch rolls back |
| Denied/unavailable → truthful result | `PermissionRequired` / `AuthorizationUnavailable` |
| Non-interactive fails safely | refuses before spawning; never waits |
| No overwrite of unknown/conflicting settings | `ConflictingExistingFile`, file byte-identical |
| Symmetric rollback/uninstall | `rollback()`, incl. no-prior-file; idempotent |
| **Normal install must not imply `Host Enforced`** | `a_successful_normal_install_cannot_reach_host_enforced` |

## Documentation

`protection-levels.md` (Host Enforced rewritten — opt-in, entry criteria, the one privileged operation,
what it does and does not claim; new *Host-attested* evidence row) · `limitations.md` (split into
verified vs unmeasured, plus "what the install will not do") · `onboarding.md` and `cli.md` (the flag
documented; `--scope managed` now points at it) · `capability-matrix.md` (C6 half-closed) ·
`product-brief.md` §7.3, constraint C4, scenario 11.8 · `verification-reports/AAASM-5276-…md` C6 row with
a dated update note.

## Dependencies / stacked PRs

Cut from `main` @ `9081d845` after AAASM-5300 merged (both change `aa-devtool-claude-code`).
Independently mergeable. **No force-push was performed at any point.**

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (7 commits)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5298]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ