### PR TITLE
[AAASM-5305] ✨ (auth): Native email/password auth endpoints + JWT + /auth/methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "aa-sandbox",
  "aa-sdk-client",
  "aa-security",
+ "aa-storage-postgres",
  "argon2",
  "async-trait",
  "axum",

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -19,6 +19,10 @@ aa-security = { path = "../aa-security", features = ["serde"] }
 aa-devtool       = { path = "../aa-devtool" }
 aa-devtool-saas  = { path = "../aa-devtool-saas" }
 aa-gateway = { path = "../aa-gateway" }
+# AAASM-5305: the native-account auth endpoints (ADR 0031) are Postgres-gated and
+# persist users / invites / refresh sessions through PgUserStore. `publish = false`
+# like aa-api itself, so this within-workspace path dep is not a crates.io concern.
+aa-storage-postgres = { path = "../aa-storage-postgres" }
 aa-proto = { path = "../aa-proto" }
 aa-runtime = { path = "../aa-runtime" }
 aa-sandbox = { path = "../aa-sandbox" }
@@ -63,6 +67,10 @@ tonic = { workspace = true }
 ulid = "1"
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+# AAASM-5305: SHA-256 for hashing opaque refresh/invite tokens before they are
+# handed to PgUserStore (which stores only the hash). Promoted from a
+# dev-dependency to a runtime dependency for the auth endpoints.
+sha2 = { workspace = true }
 
 [dev-dependencies]
 # AAASM-3980: WS tenant-isolation tests construct AuditEvent to set team_id.

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -10,7 +10,7 @@
 //! [`policy_auth`] — which couples to `aa_gateway::policy` and therefore cannot
 //! live in the leaf — still lives here in `aa-api`.
 
-pub use aa_auth::{api_key, config, gate, jwt, rate_limit, scope};
+pub use aa_auth::{api_key, config, gate, jwt, rate_limit, role, scope};
 pub use aa_auth::{AuthError, AuthenticatedCaller, Tenant};
 
 pub mod policy_auth;

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub mod events;
 pub mod middleware;
 pub mod models;
+pub mod native_auth;
 pub mod openapi;
 pub mod pagination;
 pub mod replay;

--- a/aa-api/src/native_auth.rs
+++ b/aa-api/src/native_auth.rs
@@ -1,0 +1,163 @@
+//! Static configuration for the native email/password auth endpoints
+//! (AAASM-5305, ADR 0031).
+//!
+//! Native accounts are Postgres-gated (ADR 0031 D2); this config is the
+//! deployment posture that shapes their behaviour *independently* of whether a
+//! Postgres store is wired in, so `/auth/methods` and the closed-registration
+//! default behave deterministically. Nothing here holds a secret — only sizing
+//! and policy knobs — so it is safe to keep on the cloneable `AppState`.
+
+use uuid::Uuid;
+
+/// The single default workspace/org an OSS deployment bootstraps into (ADR 0031
+/// §4: OSS is single-workspace, so `register` takes no `tenant_name`).
+///
+/// A fixed, non-nil UUID: deliberately NOT the all-zeroes reserved system org
+/// (`aa_storage_postgres::support::SYSTEM_ORG`) that untagged agent-liveness rows
+/// use, so native accounts never share a tenant scope with those rows.
+pub const DEFAULT_ORG_ID: Uuid = Uuid::from_u128(0x0000_5305_0000_0000_0000_0000_0000_0001);
+
+/// Human-readable name stamped on the default workspace org when it is created
+/// on first bootstrap.
+pub const DEFAULT_ORG_NAME: &str = "Default Workspace";
+
+/// Environment flag that opts a deployment into open self-registration
+/// (ADR 0031 §Q3). Default is closed (first-user-then-invite).
+pub const OPEN_REGISTRATION_ENV: &str = "AA_AUTH_OPEN_REGISTRATION";
+
+/// Consecutive failed logins before an account is locked (ADR 0031 brute-force).
+const LOCKOUT_THRESHOLD: i32 = 5;
+
+/// How long an account stays locked after crossing the threshold, in seconds
+/// (15 minutes).
+const LOCKOUT_WINDOW_SECS: i64 = 15 * 60;
+
+/// Access-token lifetime, in seconds (ADR 0031 §5: short-lived, ~15 min).
+const ACCESS_TTL_SECS: u64 = 15 * 60;
+
+/// Refresh-token lifetime without `remember_me`, in seconds (12 hours).
+const REFRESH_TTL_SECS: u64 = 12 * 60 * 60;
+
+/// Refresh-token lifetime with `remember_me`, in seconds (30 days).
+const REFRESH_TTL_REMEMBER_SECS: u64 = 30 * 24 * 60 * 60;
+
+/// Minimum accepted password length (ADR 0031 §3 "422 weak password"). A length
+/// floor is the one weak-password rule the endpoint ticket calls out; 12 is a
+/// conservative modern minimum that stays comfortably above the 8-char legacy
+/// floor without imposing composition rules users route around.
+const MIN_PASSWORD_LEN: usize = 12;
+
+/// Resolved posture for the native-auth endpoints.
+#[derive(Debug, Clone)]
+pub struct NativeAuthConfig {
+    /// The single default workspace org id native accounts belong to.
+    pub default_org_id: Uuid,
+    /// The name stamped on the default org when created on bootstrap.
+    pub default_org_name: &'static str,
+    /// Whether open self-registration is enabled (ADR 0031 §Q3).
+    pub open_registration: bool,
+    /// Consecutive failures before lockout.
+    pub lockout_threshold: i32,
+    /// Lockout duration in seconds.
+    pub lockout_window_secs: i64,
+    /// Access-token lifetime in seconds.
+    pub access_ttl_secs: u64,
+    /// Refresh-token lifetime without `remember_me`, in seconds.
+    pub refresh_ttl_secs: u64,
+    /// Refresh-token lifetime with `remember_me`, in seconds.
+    pub refresh_ttl_remember_secs: u64,
+    /// Minimum accepted password length.
+    pub min_password_len: usize,
+}
+
+impl NativeAuthConfig {
+    /// Resolve the posture from the environment.
+    ///
+    /// Only the open-registration flag is environment-driven (ADR 0031 §Q3); the
+    /// rest are fixed policy for this release. The flag is `true` only for the
+    /// explicit truthy spellings (`1`/`true`/`yes`, case-insensitive) — any other
+    /// value (or unset) stays closed, the safe default.
+    pub fn from_env() -> Self {
+        let open_registration = std::env::var(OPEN_REGISTRATION_ENV)
+            .ok()
+            .map(|v| Self::is_truthy(&v))
+            .unwrap_or(false);
+        Self {
+            default_org_id: DEFAULT_ORG_ID,
+            default_org_name: DEFAULT_ORG_NAME,
+            open_registration,
+            lockout_threshold: LOCKOUT_THRESHOLD,
+            lockout_window_secs: LOCKOUT_WINDOW_SECS,
+            access_ttl_secs: ACCESS_TTL_SECS,
+            refresh_ttl_secs: REFRESH_TTL_SECS,
+            refresh_ttl_remember_secs: REFRESH_TTL_REMEMBER_SECS,
+            min_password_len: MIN_PASSWORD_LEN,
+        }
+    }
+
+    /// The refresh-token lifetime for a login, extended when `remember_me` is set.
+    pub fn refresh_ttl_for(&self, remember_me: bool) -> u64 {
+        if remember_me {
+            self.refresh_ttl_remember_secs
+        } else {
+            self.refresh_ttl_secs
+        }
+    }
+
+    /// Whether a candidate password clears the minimum-length floor.
+    pub fn password_is_strong_enough(&self, password: &str) -> bool {
+        password.chars().count() >= self.min_password_len
+    }
+
+    /// Parse a truthy environment value (`1` / `true` / `yes`, case-insensitive).
+    fn is_truthy(v: &str) -> bool {
+        matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+    }
+}
+
+impl Default for NativeAuthConfig {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_org_is_not_the_reserved_system_org() {
+        // Native accounts must not share the reserved all-zeroes tenant that
+        // untagged agent-liveness rows use.
+        assert_ne!(DEFAULT_ORG_ID, Uuid::nil(), "default org must not be the system org");
+    }
+
+    #[test]
+    fn open_registration_flag_only_true_for_truthy_values() {
+        for v in ["1", "true", "TRUE", "yes", "Yes", " true "] {
+            assert!(NativeAuthConfig::is_truthy(v), "{v:?} should be truthy");
+        }
+        for v in ["0", "false", "no", "", "off", "maybe"] {
+            assert!(!NativeAuthConfig::is_truthy(v), "{v:?} should not be truthy");
+        }
+    }
+
+    #[test]
+    fn remember_me_extends_the_refresh_lifetime() {
+        let cfg = NativeAuthConfig::from_env();
+        assert!(
+            cfg.refresh_ttl_for(true) > cfg.refresh_ttl_for(false),
+            "remember_me must extend the refresh lifetime"
+        );
+        assert_eq!(cfg.refresh_ttl_for(false), REFRESH_TTL_SECS);
+        assert_eq!(cfg.refresh_ttl_for(true), REFRESH_TTL_REMEMBER_SECS);
+    }
+
+    #[test]
+    fn password_length_floor_is_enforced() {
+        let cfg = NativeAuthConfig::from_env();
+        // 11 chars: too short. 12: accepted.
+        assert!(!cfg.password_is_strong_enough(&"a".repeat(MIN_PASSWORD_LEN - 1)));
+        assert!(cfg.password_is_strong_enough(&"a".repeat(MIN_PASSWORD_LEN)));
+    }
+}

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -20,7 +20,7 @@ use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, EventPayload, ViolationPayload};
 use crate::routes::{
     admin, agents, alert_rules, alerts, analytics, approvals, audit, auth, capability, costs, destinations, dispatch,
-    edges, iam, logs, ops, policies, scrub, tools, topology, traces,
+    edges, iam, logs, native_auth, ops, policies, scrub, tools, topology, traces,
 };
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
@@ -106,6 +106,13 @@ use crate::routes::{
         crate::ws::alerts_handler::ws_alerts_handler,
         auth::issue_token,
         auth::issue_ws_ticket,
+        native_auth::login,
+        native_auth::register,
+        native_auth::invite,
+        native_auth::invite_accept,
+        native_auth::refresh,
+        native_auth::logout,
+        native_auth::auth_methods,
         crate::ws::handler::ws_events_handler,
         topology::get_topology_graph,
         topology::get_overview,
@@ -240,6 +247,15 @@ use crate::routes::{
         auth::TokenResponse,
         auth::WsTicketRequest,
         auth::WsTicketResponse,
+        native_auth::LoginRequest,
+        native_auth::AccessTokenResponse,
+        native_auth::RegisterRequest,
+        native_auth::RegisterResponse,
+        native_auth::InviteRequest,
+        native_auth::InviteResponse,
+        native_auth::InviteAcceptRequest,
+        native_auth::AuthMethodsResponse,
+        crate::auth::role::Role,
         crate::ws::ticket::WsTicketPurpose,
         crate::auth::scope::Scope,
         topology::TopologyOverview,

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -23,6 +23,9 @@ pub(crate) mod enforcement_mirror;
 pub mod health;
 pub mod iam;
 pub mod logs;
+/// Native email/password auth endpoints (AAASM-5305, ADR 0031). Distinct from
+/// [`auth`], which owns the unchanged API-key → JWT `/auth/token` route.
+pub mod native_auth;
 pub mod ops;
 /// Over-permission derivation for the capability matrix (ADR 0029). Crate-internal:
 /// it is a projection helper, not an HTTP surface.
@@ -70,6 +73,18 @@ fn public_router() -> Router {
         .route("/ws/events", get(crate::ws::handler::ws_events_handler))
         // Auth
         .route("/auth/token", post(auth::issue_token))
+        // Native email/password auth (AAASM-5305, ADR 0031). These are mounted on
+        // the PUBLIC router for the same reason as /auth/token: they are how a
+        // human obtains a credential, so they must be reachable without one. The
+        // login/refresh handlers authenticate themselves (password / refresh
+        // cookie); invite-accept authenticates via the single-use token; methods
+        // is a public capability probe. The credential-requiring halves —
+        // /auth/invite (admin) and /auth/logout — are on the protected router.
+        .route("/auth/login", post(native_auth::login))
+        .route("/auth/register", post(native_auth::register))
+        .route("/auth/invite/accept", post(native_auth::invite_accept))
+        .route("/auth/refresh", post(native_auth::refresh))
+        .route("/auth/methods", get(native_auth::auth_methods))
         // AAASM-1389: real-time alert event stream.
         .route("/alerts/ws", get(crate::ws::alerts_handler::ws_alerts_handler))
         // Dev tool webhooks — HMAC-authenticated in-handler.
@@ -90,6 +105,11 @@ fn protected_router() -> Router {
         // dashboard makes before each WS connect so it never puts a long-lived
         // credential in the WS URL. Gated like every other protected route.
         .route("/auth/ws-ticket", post(auth::issue_ws_ticket))
+        // Native auth — credential-requiring halves (AAASM-5305, ADR 0031).
+        // invite is admin-scope-gated in-handler; logout revokes the caller's
+        // refresh session. Both sit behind the deny-by-default gate below.
+        .route("/auth/invite", post(native_auth::invite))
+        .route("/auth/logout", post(native_auth::logout))
         // Secret Injection — tool dispatch (AAASM-1920)
         .route("/dispatch_tool", post(dispatch::dispatch_tool))
         // Agents

--- a/aa-api/src/routes/native_auth.rs
+++ b/aa-api/src/routes/native_auth.rs
@@ -215,16 +215,27 @@ pub async fn login(
         Err(_) => return internal_error().into_response(),
     }
 
-    // A disabled or still-invited account cannot log in — treated as invalid
-    // credentials (uniform 401), never a distinct signal.
-    let credentials_ok = user.status == UserStatus::Active && verify_password(&user.password_hash, &body.password);
+    // Always run the argon2 verify — even for a disabled/invited account and even
+    // when we already know the status is non-Active — so the response time does
+    // not distinguish "active wrong password" from "non-active account" (a
+    // short-circuit here would leak a status oracle by timing). The password_ok
+    // and status_ok checks are then combined without a boolean short-circuit.
+    let password_ok = verify_password(&user.password_hash, &body.password);
+    let credentials_ok = password_ok & (user.status == UserStatus::Active);
     if !credentials_ok {
-        // Record the failure (unless the account is non-active, in which case
-        // there is nothing to lock out — but we still return a uniform 401).
+        // Record the failure and, if this attempt crossed the lockout threshold,
+        // return 423 + retry-after immediately (rather than a plain 401 that
+        // silently hides the just-applied lock until the next attempt). A
+        // non-active account has nothing to lock — it still returns a uniform 401.
         if user.status == UserStatus::Active {
-            let _ = store
+            if let Ok(state_) = store
                 .record_login_failure(org, user.id, cfg.lockout_threshold, cfg.lockout_window_secs)
-                .await;
+                .await
+            {
+                if let Some(retry_after) = state_.retry_after_secs(now()) {
+                    return locked(retry_after).into_response();
+                }
+            }
         }
         return unauthorized().into_response();
     }
@@ -384,7 +395,29 @@ pub async fn invite(
         );
     }
 
-    // The raw token is opaque and single-use; only its hash is persisted.
+    let org = cfg.default_org_id;
+
+    // Create the invited (password-less) account row FIRST, so a token is only
+    // ever handed out for a fresh, activatable account. It is created `invited`
+    // with a placeholder hash that never verifies, so it cannot authenticate
+    // until accept sets a real password. If the email already exists (any
+    // status), the create fails on the unique index → 409, and no dead invite
+    // token is issued. This is the admin surface (not the login surface), so
+    // revealing existence via 409 is acceptable and matches register.
+    let invited_user = NewUser {
+        id: Uuid::new_v4(),
+        email: body.email.clone(),
+        password_hash: unset_password_hash().to_string(),
+        role: role_to_user_role(body.role),
+        status: UserStatus::Invited,
+    };
+    if store.create_user(org, &invited_user).await.is_err() {
+        return Err(email_conflict());
+    }
+
+    // The raw token is opaque and single-use; only its hash is persisted. Bind
+    // the invite to the account just created (invited_by = the account row) so
+    // one token maps to exactly one account.
     let raw_token = generate_opaque_token();
     let token_hash = sha256_hex(&raw_token);
     let invite_id = Uuid::new_v4();
@@ -398,23 +431,9 @@ pub async fn invite(
         invited_by: Uuid::parse_str(&caller.key_id).ok(),
     };
     store
-        .create_invite(cfg.default_org_id, &new_invite)
+        .create_invite(org, &new_invite)
         .await
         .map_err(|_| internal_error())?;
-
-    // Also create the invited (password-less) account row so accept can activate
-    // it. It is created `invited`, so it cannot authenticate until accepted.
-    let invited_user = NewUser {
-        id: Uuid::new_v4(),
-        email: body.email.clone(),
-        // A placeholder that never verifies: the real hash is set on accept.
-        password_hash: unset_password_hash().to_string(),
-        role: role_to_user_role(body.role),
-        status: UserStatus::Invited,
-    };
-    // A duplicate email means the account already exists; the invite row still
-    // stands (an admin re-inviting an existing user is not an error surface here).
-    let _ = store.create_user(cfg.default_org_id, &invited_user).await;
 
     Ok(Json(InviteResponse {
         invite_id: invite_id.to_string(),
@@ -452,15 +471,18 @@ pub async fn invite_accept(
         return weak_password(cfg.min_password_len).into_response();
     }
 
+    // Hash the new password BEFORE consuming the single-use token, so a hashing
+    // failure cannot burn the invite and leave the invitee permanently unable to
+    // accept it (the token is spent but the account was never activated).
+    let password_hash = match hash_password(&body.password) {
+        Ok(h) => h,
+        Err(_) => return internal_error().into_response(),
+    };
+
     let token_hash = sha256_hex(&body.token);
     let invite = match store.consume_invite(org, &token_hash).await {
         Ok(Some(inv)) => inv,
         Ok(None) => return invalid_invite().into_response(),
-        Err(_) => return internal_error().into_response(),
-    };
-
-    let password_hash = match hash_password(&body.password) {
-        Ok(h) => h,
         Err(_) => return internal_error().into_response(),
     };
 
@@ -518,16 +540,25 @@ pub async fn refresh(
     };
     let token_hash = sha256_hex(&raw);
 
+    // Read the session to recover its owner and check expiry. Liveness here is
+    // advisory only — the authoritative single-use gate is the atomic revoke
+    // below, which is what makes rotation race-safe.
     let record = match store.find_refresh_token(org, &token_hash).await {
         Ok(Some(r)) if r.is_live(now()) => r,
         Ok(_) => return unauthorized().into_response(),
         Err(_) => return internal_error().into_response(),
     };
 
-    // Rotate: revoke the presented token before issuing the replacement so a
-    // replay of the old cookie cannot mint a second session.
-    if store.revoke_refresh_token(org, &token_hash).await.is_err() {
-        return internal_error().into_response();
+    // Rotate: atomically revoke the presented token BEFORE issuing the
+    // replacement. `revoke_refresh_token` flips `revoked_at` only `WHERE
+    // revoked_at IS NULL`, so it is a compare-and-set: exactly one caller gets
+    // `true`. A concurrent replay of the same cookie (or a re-submitted request)
+    // loses the race, gets `false`, and is rejected — so one cookie can never
+    // mint two live sessions.
+    match store.revoke_refresh_token(org, &token_hash).await {
+        Ok(true) => {}
+        Ok(false) => return unauthorized().into_response(),
+        Err(_) => return internal_error().into_response(),
     }
 
     let user = match store.find_by_id(org, record.user_id).await {

--- a/aa-api/src/routes/native_auth.rs
+++ b/aa-api/src/routes/native_auth.rs
@@ -367,8 +367,11 @@ pub async fn register(
     }
 }
 
-/// Create a single-use, expiring invite for a new account (admin scope only)
-/// (ADR 0031 §3). The raw token is returned once here; only its hash is stored.
+/// Create a single-use, expiring invite for a new account (admin scope only).
+///
+/// ADR 0031 §3. The raw invite token is returned exactly once in this response;
+/// only its hash is persisted, so it cannot be recovered later. The invite is
+/// bound to the target email and role and expires after a fixed window.
 #[utoipa::path(
     post,
     path = "/api/v1/auth/invite",
@@ -441,9 +444,11 @@ pub async fn invite(
     }))
 }
 
-/// Accept an invite: consume the single-use token and set the initial password,
-/// activating the account (ADR 0031 §3). Public: the invitee is not yet
-/// authenticated.
+/// Accept an invite: set the initial password and activate the account.
+///
+/// ADR 0031 §3. Consumes the single-use invite token (rejected if already used
+/// or expired), hashes the chosen password with argon2id, and activates the
+/// account. Public: the invitee is not yet authenticated.
 #[utoipa::path(
     post,
     path = "/api/v1/auth/invite/accept",
@@ -511,8 +516,11 @@ pub async fn invite_accept(
         .unwrap_or_else(|e| e.into_response())
 }
 
-/// Exchange a valid refresh cookie for a new access token, rotating the refresh
-/// token (ADR 0031 §5). Public (the cookie is the credential).
+/// Exchange a valid refresh cookie for a new access token.
+///
+/// ADR 0031 §5. Rotates the refresh token on use — the presented token is
+/// revoked and a fresh one is set — so a replayed cookie loses the rotation
+/// race and is rejected. Public: the HttpOnly refresh cookie is the credential.
 #[utoipa::path(
     post,
     path = "/api/v1/auth/refresh",
@@ -576,8 +584,11 @@ pub async fn refresh(
         .unwrap_or_else(|e| e.into_response())
 }
 
-/// Revoke the refresh session and clear the cookie (ADR 0031 §5). Requires an
-/// authenticated caller; always returns `204`.
+/// Revoke the refresh session and clear the cookie.
+///
+/// ADR 0031 §5. Revokes the caller's refresh token server-side and clears the
+/// HttpOnly cookie. Requires an authenticated caller; always returns `204`,
+/// including when no active session is found (idempotent).
 #[utoipa::path(
     post,
     path = "/api/v1/auth/logout",

--- a/aa-api/src/routes/native_auth.rs
+++ b/aa-api/src/routes/native_auth.rs
@@ -1,0 +1,864 @@
+//! Native email/password authentication endpoints (AAASM-5305, ADR 0031).
+//!
+//! These are the human-operator account endpoints that coexist with the retained
+//! API-key path (`routes::auth::issue_token`, deliberately untouched). They are
+//! **Postgres-gated** (ADR 0031 D2): every handler that touches an account first
+//! resolves the [`AppState::auth_store`], and when it is absent (the in-memory
+//! deployment) responds `503 Service Unavailable` so the surface degrades
+//! honestly. `GET /auth/methods` advertises whether the password path is even
+//! available so the frontend never offers a form the backend cannot serve.
+//!
+//! Both this login path and `/auth/token` mint the **same** scoped JWT shape
+//! (via [`JwtSigner`]), differing only in lifetime, so every downstream RBAC gate
+//! reads either credential source unchanged.
+//!
+//! Security posture (ADR 0031 §"Security considerations", development rule 7):
+//! - Login is enumeration-safe: a uniform `401` for unknown-email OR bad-password,
+//!   and an unknown email still runs an argon2 verify against a dummy hash so the
+//!   response time does not leak whether the account exists.
+//! - Lockout is Postgres-backed (never in memory) → `423` + `retry-after`.
+//! - The refresh token is opaque, hashed-at-rest, delivered as an
+//!   `HttpOnly; Secure; SameSite=Strict` cookie, rotated on every refresh, and
+//!   revocable (logout).
+//! - Register bootstrap is advisory-locked so two concurrent registrations can
+//!   never both claim `owner`.
+//! - Passwords, tokens, and hashes are never logged and never returned on the wire.
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::{Extension, Json};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use aa_auth::jwt::JwtSigner;
+use aa_auth::password::{hash_password, verify_password};
+use aa_auth::role::Role;
+use aa_auth::scope::Scope;
+use aa_auth::AuthenticatedCaller;
+use aa_storage_postgres::{BootstrapOutcome, NewInvite, NewUser, PgUserStore, UserRecord, UserRole, UserStatus};
+
+use crate::error::ProblemDetail;
+use crate::native_auth::NativeAuthConfig;
+use crate::state::AppState;
+
+/// The cookie name carrying the opaque refresh token.
+const REFRESH_COOKIE: &str = "aa_refresh";
+
+/// The cookie `Path`. Scoped to the auth surface so the refresh token is only
+/// ever sent to the endpoints that consume it (refresh / logout), not attached
+/// to every API call.
+const REFRESH_COOKIE_PATH: &str = "/api/v1/auth";
+
+// ── Request / response bodies ────────────────────────────────────────────────
+
+/// Request body for `POST /auth/login`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct LoginRequest {
+    /// The account email (case-insensitive).
+    pub email: String,
+    /// The account password.
+    pub password: String,
+    /// When true, the refresh session is issued with an extended lifetime.
+    #[serde(default)]
+    pub remember_me: bool,
+}
+
+/// Response body carrying a freshly minted access token (login / refresh /
+/// invite-accept). The refresh token is NOT in the body — it rides in the
+/// HttpOnly cookie.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AccessTokenResponse {
+    /// The short-lived access JWT to present as `Authorization: Bearer`.
+    pub access_token: String,
+    /// Access-token lifetime in seconds.
+    pub expires_in: u64,
+}
+
+/// Request body for `POST /auth/register`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RegisterRequest {
+    /// The new account email (case-insensitive). OSS is single-workspace, so no
+    /// `tenant_name` is accepted (ADR 0031 §4).
+    pub email: String,
+    /// The new account password (must clear the minimum-length floor).
+    pub password: String,
+}
+
+/// Response body for a successful `POST /auth/register`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RegisterResponse {
+    /// The id of the newly created account (UUID string).
+    pub user_id: String,
+    /// The short-lived access JWT for the bootstrap owner (the refresh token is
+    /// delivered as the HttpOnly cookie alongside).
+    pub access_token: String,
+    /// Access-token lifetime in seconds.
+    pub expires_in: u64,
+}
+
+/// Request body for `POST /auth/invite` (admin only).
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct InviteRequest {
+    /// The email to invite.
+    pub email: String,
+    /// The role the invited account will receive on accept.
+    pub role: Role,
+}
+
+/// Response body for `POST /auth/invite`. The raw invite token is returned once
+/// to the inviting admin to deliver out of band; only its hash is stored.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct InviteResponse {
+    /// The created invite id (UUID string).
+    pub invite_id: String,
+    /// The single-use, expiring raw invite token. Returned exactly once, here;
+    /// the server stores only its SHA-256 hash and can never surface it again.
+    pub token: String,
+}
+
+/// Request body for `POST /auth/invite/accept`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct InviteAcceptRequest {
+    /// The raw invite token delivered to the invitee.
+    pub token: String,
+    /// The initial password to set on the account (must clear the floor).
+    pub password: String,
+}
+
+/// Response body for `GET /auth/methods` (ADR 0031 §Q5). Advertises which
+/// credential paths this deployment can serve so the frontend degrades honestly.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuthMethodsResponse {
+    /// `["api_key"]` on an in-memory deployment; `["api_key","password"]` when a
+    /// Postgres store backs native accounts.
+    pub methods: Vec<String>,
+}
+
+// ── Endpoints ────────────────────────────────────────────────────────────────
+
+/// Advertise the credential methods this deployment supports (ADR 0031 §Q5).
+///
+/// Public: the login page reads this before rendering, so it never offers a
+/// password form on an in-memory (API-key-only) backend. Always lists `api_key`;
+/// adds `password` only when a Postgres-backed account store is configured.
+#[utoipa::path(
+    get,
+    path = "/api/v1/auth/methods",
+    responses((status = 200, description = "Available auth methods", body = AuthMethodsResponse)),
+    tag = "auth"
+)]
+pub async fn auth_methods(Extension(state): Extension<AppState>) -> Json<AuthMethodsResponse> {
+    let mut methods = vec!["api_key".to_string()];
+    if state.auth_store.is_some() {
+        methods.push("password".to_string());
+    }
+    Json(AuthMethodsResponse { methods })
+}
+
+/// Authenticate with email + password, returning an access token and setting the
+/// refresh cookie (ADR 0031 §3).
+///
+/// Enumeration-safe: an unknown email and a wrong password both return a uniform
+/// `401`, and an unknown email still runs an argon2 verify against a dummy hash
+/// so the timing does not distinguish the two. A locked account returns `423`
+/// with `retry-after` regardless of whether the password is correct.
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/login",
+    request_body = LoginRequest,
+    responses(
+        (status = 200, description = "Authenticated", body = AccessTokenResponse),
+        (status = 401, description = "Invalid credentials", body = ProblemDetail),
+        (status = 423, description = "Account locked", body = ProblemDetail),
+        (status = 503, description = "Native auth not available (no Postgres)", body = ProblemDetail),
+    ),
+    tag = "auth"
+)]
+pub async fn login(
+    Extension(state): Extension<AppState>,
+    Extension(jwt_signer): Extension<Arc<JwtSigner>>,
+    Json(body): Json<LoginRequest>,
+) -> Response {
+    let store = match require_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+    let cfg = &state.native_auth;
+    let org = cfg.default_org_id;
+
+    let user = match store.find_by_email(org, &body.email).await {
+        Ok(u) => u,
+        Err(_) => return internal_error().into_response(),
+    };
+
+    // Enumeration-safe timing: verify against a dummy hash when the account is
+    // absent so the response time does not reveal whether the email exists.
+    let Some(user) = user else {
+        let _ = verify_password(dummy_hash(), &body.password);
+        return unauthorized().into_response();
+    };
+
+    // Lockout is checked BEFORE the password verify so a locked account is
+    // refused even with correct credentials (and the correct-password path does
+    // not silently reset the lock).
+    match store.lockout_state(org, user.id).await {
+        Ok(state_) => {
+            if let Some(retry_after) = state_.retry_after_secs(now()) {
+                return locked(retry_after).into_response();
+            }
+        }
+        Err(_) => return internal_error().into_response(),
+    }
+
+    // A disabled or still-invited account cannot log in — treated as invalid
+    // credentials (uniform 401), never a distinct signal.
+    let credentials_ok = user.status == UserStatus::Active && verify_password(&user.password_hash, &body.password);
+    if !credentials_ok {
+        // Record the failure (unless the account is non-active, in which case
+        // there is nothing to lock out — but we still return a uniform 401).
+        if user.status == UserStatus::Active {
+            let _ = store
+                .record_login_failure(org, user.id, cfg.lockout_threshold, cfg.lockout_window_secs)
+                .await;
+        }
+        return unauthorized().into_response();
+    }
+
+    // Success: clear the failed-attempt counter and issue tokens.
+    if store.clear_login_failures(org, user.id).await.is_err() {
+        return internal_error().into_response();
+    }
+
+    issue_session(&store, jwt_signer.as_ref(), cfg, &user, body.remember_me)
+        .await
+        .map(|(json, cookie)| with_cookie(StatusCode::OK, json, cookie))
+        .unwrap_or_else(|e| e.into_response())
+}
+
+/// Register the first account (bootstrap owner) or a self-registered account when
+/// open registration is enabled (ADR 0031 §4 / §Q3).
+///
+/// The first account on a fresh instance becomes `owner` under an advisory lock
+/// so two concurrent registrations cannot both claim owner. Once a user exists,
+/// registration is closed (`403`) unless `AA_AUTH_OPEN_REGISTRATION` is set, in
+/// which case a subsequent registration creates a `developer` account.
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/register",
+    request_body = RegisterRequest,
+    responses(
+        (status = 200, description = "Registered", body = RegisterResponse),
+        (status = 403, description = "Registration closed", body = ProblemDetail),
+        (status = 409, description = "Email already exists", body = ProblemDetail),
+        (status = 422, description = "Weak password", body = ProblemDetail),
+        (status = 503, description = "Native auth not available (no Postgres)", body = ProblemDetail),
+    ),
+    tag = "auth"
+)]
+pub async fn register(
+    Extension(state): Extension<AppState>,
+    Extension(jwt_signer): Extension<Arc<JwtSigner>>,
+    Json(body): Json<RegisterRequest>,
+) -> Response {
+    let store = match require_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+    let cfg = &state.native_auth;
+    let org = cfg.default_org_id;
+
+    if !cfg.password_is_strong_enough(&body.password) {
+        return weak_password(cfg.min_password_len).into_response();
+    }
+
+    let password_hash = match hash_password(&body.password) {
+        Ok(h) => h,
+        Err(_) => return internal_error().into_response(),
+    };
+
+    let new_id = Uuid::new_v4();
+    let outcome = match store
+        .bootstrap_first_user(org, cfg.default_org_name, new_id, &body.email, &password_hash)
+        .await
+    {
+        Ok(o) => o,
+        // A unique-index violation here means the email already exists in the
+        // bootstrap path (a genuine concurrent duplicate) → 409.
+        Err(_) => return email_conflict().into_response(),
+    };
+
+    let user = match outcome {
+        BootstrapOutcome::CreatedOwner { .. } => UserRecord {
+            id: new_id,
+            email: body.email.clone(),
+            password_hash,
+            org_id: org,
+            role: UserRole::Owner,
+            status: UserStatus::Active,
+            created_at: now(),
+            updated_at: now(),
+            last_login_at: None,
+        },
+        BootstrapOutcome::AlreadyBootstrapped { .. } => {
+            // Not the first user. Closed unless open registration is enabled.
+            if !cfg.open_registration {
+                return registration_closed().into_response();
+            }
+            // Reject a duplicate email up front (register legitimately reveals
+            // existence via 409 per ADR 0031 §3 — this is not the login surface).
+            match store.find_by_email(org, &body.email).await {
+                Ok(Some(_)) => return email_conflict().into_response(),
+                Ok(None) => {}
+                Err(_) => return internal_error().into_response(),
+            }
+            let new_user = NewUser {
+                id: new_id,
+                email: body.email.clone(),
+                password_hash: password_hash.clone(),
+                role: UserRole::Developer,
+                status: UserStatus::Active,
+            };
+            if store.create_user(org, &new_user).await.is_err() {
+                // Most likely a race lost to the unique index → 409.
+                return email_conflict().into_response();
+            }
+            UserRecord {
+                id: new_id,
+                email: body.email.clone(),
+                password_hash,
+                org_id: org,
+                role: UserRole::Developer,
+                status: UserStatus::Active,
+                created_at: now(),
+                updated_at: now(),
+                last_login_at: None,
+            }
+        }
+    };
+
+    // A registered account is logged straight in (bootstrap admin / self-signup),
+    // returning tokens + the refresh cookie.
+    match issue_session(&store, jwt_signer.as_ref(), cfg, &user, false).await {
+        Ok((json, cookie)) => {
+            let resp = RegisterResponse {
+                user_id: user.id.to_string(),
+                access_token: json.access_token,
+                expires_in: json.expires_in,
+            };
+            with_cookie(StatusCode::OK, resp, cookie)
+        }
+        Err(e) => e.into_response(),
+    }
+}
+
+/// Create a single-use, expiring invite for a new account (admin scope only)
+/// (ADR 0031 §3). The raw token is returned once here; only its hash is stored.
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/invite",
+    request_body = InviteRequest,
+    responses(
+        (status = 200, description = "Invite created", body = InviteResponse),
+        (status = 403, description = "Caller is not an admin", body = ProblemDetail),
+        (status = 503, description = "Native auth not available (no Postgres)", body = ProblemDetail),
+    ),
+    security(("bearer_auth" = [])),
+    tag = "auth"
+)]
+pub async fn invite(
+    Extension(state): Extension<AppState>,
+    caller: AuthenticatedCaller,
+    Json(body): Json<InviteRequest>,
+) -> Result<Json<InviteResponse>, ProblemDetail> {
+    let store = require_store(&state)?;
+    let cfg = &state.native_auth;
+
+    if !Scope::Admin.is_satisfied_by(&caller.scopes) {
+        return Err(
+            ProblemDetail::from_status(StatusCode::FORBIDDEN).with_detail("Creating an invite requires admin scope")
+        );
+    }
+
+    // The raw token is opaque and single-use; only its hash is persisted.
+    let raw_token = generate_opaque_token();
+    let token_hash = sha256_hex(&raw_token);
+    let invite_id = Uuid::new_v4();
+
+    let new_invite = NewInvite {
+        id: invite_id,
+        token_hash,
+        email: body.email.clone(),
+        role: role_to_user_role(body.role),
+        expires_at: now() + chrono::Duration::days(7),
+        invited_by: Uuid::parse_str(&caller.key_id).ok(),
+    };
+    store
+        .create_invite(cfg.default_org_id, &new_invite)
+        .await
+        .map_err(|_| internal_error())?;
+
+    // Also create the invited (password-less) account row so accept can activate
+    // it. It is created `invited`, so it cannot authenticate until accepted.
+    let invited_user = NewUser {
+        id: Uuid::new_v4(),
+        email: body.email.clone(),
+        // A placeholder that never verifies: the real hash is set on accept.
+        password_hash: unset_password_hash().to_string(),
+        role: role_to_user_role(body.role),
+        status: UserStatus::Invited,
+    };
+    // A duplicate email means the account already exists; the invite row still
+    // stands (an admin re-inviting an existing user is not an error surface here).
+    let _ = store.create_user(cfg.default_org_id, &invited_user).await;
+
+    Ok(Json(InviteResponse {
+        invite_id: invite_id.to_string(),
+        token: raw_token,
+    }))
+}
+
+/// Accept an invite: consume the single-use token and set the initial password,
+/// activating the account (ADR 0031 §3). Public: the invitee is not yet
+/// authenticated.
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/invite/accept",
+    request_body = InviteAcceptRequest,
+    responses(
+        (status = 200, description = "Invite accepted", body = AccessTokenResponse),
+        (status = 422, description = "Token expired/used or weak password", body = ProblemDetail),
+        (status = 503, description = "Native auth not available (no Postgres)", body = ProblemDetail),
+    ),
+    tag = "auth"
+)]
+pub async fn invite_accept(
+    Extension(state): Extension<AppState>,
+    Extension(jwt_signer): Extension<Arc<JwtSigner>>,
+    Json(body): Json<InviteAcceptRequest>,
+) -> Response {
+    let store = match require_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+    let cfg = &state.native_auth;
+    let org = cfg.default_org_id;
+
+    if !cfg.password_is_strong_enough(&body.password) {
+        return weak_password(cfg.min_password_len).into_response();
+    }
+
+    let token_hash = sha256_hex(&body.token);
+    let invite = match store.consume_invite(org, &token_hash).await {
+        Ok(Some(inv)) => inv,
+        Ok(None) => return invalid_invite().into_response(),
+        Err(_) => return internal_error().into_response(),
+    };
+
+    let password_hash = match hash_password(&body.password) {
+        Ok(h) => h,
+        Err(_) => return internal_error().into_response(),
+    };
+
+    // Find the invited account by email and activate it.
+    let user = match store.find_by_email(org, &invite.email).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return invalid_invite().into_response(),
+        Err(_) => return internal_error().into_response(),
+    };
+    match store.activate_invited_user(org, user.id, &password_hash).await {
+        Ok(true) => {}
+        // Already active (or gone): the invite was consumed but the account
+        // cannot be activated — treat as an invalid/spent invite.
+        Ok(false) => return invalid_invite().into_response(),
+        Err(_) => return internal_error().into_response(),
+    }
+
+    let activated = UserRecord {
+        password_hash,
+        status: UserStatus::Active,
+        ..user
+    };
+    issue_session(&store, jwt_signer.as_ref(), cfg, &activated, false)
+        .await
+        .map(|(json, cookie)| with_cookie(StatusCode::OK, json, cookie))
+        .unwrap_or_else(|e| e.into_response())
+}
+
+/// Exchange a valid refresh cookie for a new access token, rotating the refresh
+/// token (ADR 0031 §5). Public (the cookie is the credential).
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/refresh",
+    responses(
+        (status = 200, description = "Refreshed", body = AccessTokenResponse),
+        (status = 401, description = "Missing / revoked / expired refresh token", body = ProblemDetail),
+        (status = 503, description = "Native auth not available (no Postgres)", body = ProblemDetail),
+    ),
+    tag = "auth"
+)]
+pub async fn refresh(
+    Extension(state): Extension<AppState>,
+    Extension(jwt_signer): Extension<Arc<JwtSigner>>,
+    headers: HeaderMap,
+) -> Response {
+    let store = match require_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+    let cfg = &state.native_auth;
+    let org = cfg.default_org_id;
+
+    let Some(raw) = read_refresh_cookie(&headers) else {
+        return unauthorized().into_response();
+    };
+    let token_hash = sha256_hex(&raw);
+
+    let record = match store.find_refresh_token(org, &token_hash).await {
+        Ok(Some(r)) if r.is_live(now()) => r,
+        Ok(_) => return unauthorized().into_response(),
+        Err(_) => return internal_error().into_response(),
+    };
+
+    // Rotate: revoke the presented token before issuing the replacement so a
+    // replay of the old cookie cannot mint a second session.
+    if store.revoke_refresh_token(org, &token_hash).await.is_err() {
+        return internal_error().into_response();
+    }
+
+    let user = match store.find_by_id(org, record.user_id).await {
+        Ok(Some(u)) if u.status == UserStatus::Active => u,
+        Ok(_) => return unauthorized().into_response(),
+        Err(_) => return internal_error().into_response(),
+    };
+
+    // Preserve the presented refresh lifetime shape: a rotated session keeps the
+    // default (non-remembered) lifetime; a longer-lived remembered session is
+    // re-established on the next explicit login.
+    issue_session(&store, jwt_signer.as_ref(), cfg, &user, false)
+        .await
+        .map(|(json, cookie)| with_cookie(StatusCode::OK, json, cookie))
+        .unwrap_or_else(|e| e.into_response())
+}
+
+/// Revoke the refresh session and clear the cookie (ADR 0031 §5). Requires an
+/// authenticated caller; always returns `204`.
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/logout",
+    responses(
+        (status = 204, description = "Logged out (refresh revoked)"),
+        (status = 401, description = "Not authenticated", body = ProblemDetail),
+    ),
+    security(("bearer_auth" = [])),
+    tag = "auth"
+)]
+pub async fn logout(
+    Extension(state): Extension<AppState>,
+    _caller: AuthenticatedCaller,
+    headers: HeaderMap,
+) -> Response {
+    // Best-effort revoke: if a Postgres store and a cookie are present, revoke the
+    // presented refresh token. The response is 204 regardless so logout is
+    // idempotent and never leaks whether a session existed.
+    if let Some(store) = state.auth_store.as_ref() {
+        if let Some(raw) = read_refresh_cookie(&headers) {
+            let _ = store
+                .revoke_refresh_token(state.native_auth.default_org_id, &sha256_hex(&raw))
+                .await;
+        }
+    }
+
+    let mut resp = StatusCode::NO_CONTENT.into_response();
+    resp.headers_mut().insert(header::SET_COOKIE, cleared_refresh_cookie());
+    resp
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+/// Resolve the Postgres account store, or a `503` when native auth is not
+/// available (in-memory deployment, ADR 0031 D2).
+fn require_store(state: &AppState) -> Result<Arc<PgUserStore>, ProblemDetail> {
+    state.auth_store.clone().ok_or_else(|| {
+        ProblemDetail::from_status(StatusCode::SERVICE_UNAVAILABLE)
+            .with_detail("Native email/password auth requires a Postgres-backed deployment")
+    })
+}
+
+/// Mint an access token + a fresh refresh session for `user`, returning the
+/// response body and the `Set-Cookie` value carrying the refresh token.
+async fn issue_session(
+    store: &PgUserStore,
+    jwt_signer: &JwtSigner,
+    cfg: &NativeAuthConfig,
+    user: &UserRecord,
+    remember_me: bool,
+) -> Result<(AccessTokenResponse, HeaderValue), ProblemDetail> {
+    let scopes = user_role_to_role(user.role).scopes();
+    // Same JWT shape as /auth/token: subject + scope + tenant org; short TTL.
+    let access_token = jwt_signer
+        .sign_with_ttl(
+            &user.id.to_string(),
+            &scopes,
+            None,
+            Some(user.org_id.to_string()),
+            cfg.access_ttl_secs,
+        )
+        .map_err(|_| internal_error())?;
+
+    let refresh_ttl = cfg.refresh_ttl_for(remember_me);
+    let raw_refresh = generate_opaque_token();
+    let refresh_hash = sha256_hex(&raw_refresh);
+    let expires_at = now() + chrono::Duration::seconds(refresh_ttl as i64);
+    store
+        .store_refresh_token(user.org_id, Uuid::new_v4(), &refresh_hash, user.id, expires_at)
+        .await
+        .map_err(|_| internal_error())?;
+
+    let cookie = refresh_cookie(&raw_refresh, refresh_ttl);
+    Ok((
+        AccessTokenResponse {
+            access_token,
+            expires_in: cfg.access_ttl_secs,
+        },
+        cookie,
+    ))
+}
+
+/// Build a JSON `Response` with the refresh `Set-Cookie` header attached.
+fn with_cookie<T: Serialize>(status: StatusCode, body: T, cookie: HeaderValue) -> Response {
+    let mut resp = (status, Json(body)).into_response();
+    resp.headers_mut().insert(header::SET_COOKIE, cookie);
+    resp
+}
+
+/// Build the refresh-token `Set-Cookie` value:
+/// `HttpOnly; Secure; SameSite=Strict`, path-scoped to the auth surface, with a
+/// `Max-Age` matching the refresh lifetime (ADR 0031 §5).
+fn refresh_cookie(token: &str, max_age_secs: u64) -> HeaderValue {
+    let raw = format!(
+        "{REFRESH_COOKIE}={token}; Max-Age={max_age_secs}; Path={REFRESH_COOKIE_PATH}; \
+         HttpOnly; Secure; SameSite=Strict"
+    );
+    HeaderValue::from_str(&raw).expect("refresh cookie is a valid header value")
+}
+
+/// Build a `Set-Cookie` that immediately expires the refresh cookie (logout).
+fn cleared_refresh_cookie() -> HeaderValue {
+    let raw = format!("{REFRESH_COOKIE}=; Max-Age=0; Path={REFRESH_COOKIE_PATH}; HttpOnly; Secure; SameSite=Strict");
+    HeaderValue::from_str(&raw).expect("cleared refresh cookie is a valid header value")
+}
+
+/// Read the raw refresh token from the request `Cookie` header, if present.
+fn read_refresh_cookie(headers: &HeaderMap) -> Option<String> {
+    let cookie_header = headers.get(header::COOKIE)?.to_str().ok()?;
+    for pair in cookie_header.split(';') {
+        let pair = pair.trim();
+        if let Some(value) = pair.strip_prefix(&format!("{REFRESH_COOKIE}=")) {
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Generate a 256-bit opaque token as lowercase hex (refresh / invite tokens).
+///
+/// Uses the same CSPRNG (`rand::rng`) as API-key / WS-ticket generation. 256 bits
+/// of entropy makes the token unguessable; it is meaningless without the
+/// server-side hash store.
+fn generate_opaque_token() -> String {
+    use rand::RngExt;
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// SHA-256 of an opaque token, lowercase hex — the at-rest representation.
+fn sha256_hex(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    hasher.finalize().iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// A password-hash placeholder for a not-yet-accepted invited account. It is a
+/// syntactically invalid PHC string, so [`verify_password`] can never accept any
+/// candidate against it — the account is unauthenticatable until accept sets a
+/// real hash.
+fn unset_password_hash() -> &'static str {
+    "invited-no-password-set"
+}
+
+/// A dummy argon2 hash used to equalise login timing on an unknown email. Minted
+/// once from a random password so an unknown-email login still pays the argon2
+/// verify cost without ever matching a real password.
+fn dummy_hash() -> &'static str {
+    static DUMMY: OnceLock<String> = OnceLock::new();
+    DUMMY.get_or_init(|| {
+        let secret = generate_opaque_token();
+        hash_password(&secret).expect("dummy hash mints")
+    })
+}
+
+/// Map the storage-layer role to the auth-layer role (same lowercase labels).
+fn user_role_to_role(role: UserRole) -> Role {
+    match role {
+        UserRole::Owner => Role::Owner,
+        UserRole::Admin => Role::Admin,
+        UserRole::Developer => Role::Developer,
+        UserRole::Viewer => Role::Viewer,
+    }
+}
+
+/// Map the auth-layer role to the storage-layer role (same lowercase labels).
+fn role_to_user_role(role: Role) -> UserRole {
+    match role {
+        Role::Owner => UserRole::Owner,
+        Role::Admin => UserRole::Admin,
+        Role::Developer => UserRole::Developer,
+        Role::Viewer => UserRole::Viewer,
+    }
+}
+
+/// Current wall-clock time.
+fn now() -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc::now()
+}
+
+// ── Error constructors (uniform, leak-free) ──────────────────────────────────
+
+fn unauthorized() -> ProblemDetail {
+    // Uniform for unknown-email OR bad-password (enumeration-safe).
+    ProblemDetail::from_status(StatusCode::UNAUTHORIZED).with_detail("Invalid email or password")
+}
+
+fn locked(retry_after_secs: u64) -> Response {
+    let problem = ProblemDetail::from_status(StatusCode::LOCKED)
+        .with_detail("Account locked due to too many failed login attempts");
+    let mut resp = problem.into_response();
+    resp.headers_mut().insert(
+        header::RETRY_AFTER,
+        HeaderValue::from_str(&retry_after_secs.to_string()).expect("integer is a valid header value"),
+    );
+    resp
+}
+
+fn registration_closed() -> ProblemDetail {
+    ProblemDetail::from_status(StatusCode::FORBIDDEN)
+        .with_detail("Registration is closed; new accounts are created by invite")
+}
+
+fn email_conflict() -> ProblemDetail {
+    ProblemDetail::from_status(StatusCode::CONFLICT).with_detail("An account with that email already exists")
+}
+
+fn weak_password(min_len: usize) -> ProblemDetail {
+    ProblemDetail::from_status(StatusCode::UNPROCESSABLE_ENTITY)
+        .with_detail(format!("Password must be at least {min_len} characters"))
+}
+
+fn invalid_invite() -> ProblemDetail {
+    ProblemDetail::from_status(StatusCode::UNPROCESSABLE_ENTITY)
+        .with_detail("Invite token is invalid, expired, or already used")
+}
+
+fn internal_error() -> ProblemDetail {
+    // Deliberately generic: never surfaces a password, token, hash, or DB detail.
+    ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail("Authentication service error")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refresh_cookie_carries_all_security_attributes() {
+        let cookie = refresh_cookie("opaque-token-value", 3600);
+        let s = cookie.to_str().unwrap();
+        assert!(s.contains("aa_refresh=opaque-token-value"));
+        assert!(s.contains("HttpOnly"), "cookie must be HttpOnly: {s}");
+        assert!(s.contains("Secure"), "cookie must be Secure: {s}");
+        assert!(s.contains("SameSite=Strict"), "cookie must be SameSite=Strict: {s}");
+        assert!(s.contains("Max-Age=3600"));
+        assert!(s.contains("Path=/api/v1/auth"));
+    }
+
+    #[test]
+    fn cleared_cookie_expires_immediately() {
+        let s = cleared_refresh_cookie();
+        let s = s.to_str().unwrap();
+        assert!(s.contains("Max-Age=0"), "logout cookie must expire now: {s}");
+        assert!(s.contains("HttpOnly") && s.contains("Secure") && s.contains("SameSite=Strict"));
+    }
+
+    #[test]
+    fn read_refresh_cookie_extracts_the_named_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_static("other=x; aa_refresh=the-token; another=y"),
+        );
+        assert_eq!(read_refresh_cookie(&headers).as_deref(), Some("the-token"));
+    }
+
+    #[test]
+    fn read_refresh_cookie_absent_or_empty_is_none() {
+        let empty = HeaderMap::new();
+        assert!(read_refresh_cookie(&empty).is_none());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::COOKIE, HeaderValue::from_static("aa_refresh=; other=z"));
+        assert!(read_refresh_cookie(&headers).is_none(), "empty cookie value is None");
+    }
+
+    #[test]
+    fn opaque_tokens_are_unpredictable_and_hex() {
+        let a = generate_opaque_token();
+        let b = generate_opaque_token();
+        assert_ne!(a, b, "two tokens must differ");
+        assert_eq!(a.len(), 64, "32 bytes -> 64 hex chars");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn sha256_hex_is_stable_and_not_the_input() {
+        let token = "some-opaque-token";
+        let h = sha256_hex(token);
+        assert_eq!(h, sha256_hex(token), "hashing is deterministic");
+        assert_ne!(h, token, "the stored hash is not the raw token");
+        assert_eq!(h.len(), 64);
+    }
+
+    #[test]
+    fn dummy_hash_is_a_real_argon2_hash_that_never_matches() {
+        let h = dummy_hash();
+        assert!(
+            h.starts_with("$argon2id$"),
+            "must be a real PHC hash for constant-time verify"
+        );
+        // It must not verify against a guessed password (it was minted from a
+        // random secret the caller never sees).
+        assert!(!verify_password(h, "password"));
+        assert!(!verify_password(h, ""));
+    }
+
+    #[test]
+    fn role_mapping_roundtrips_between_layers() {
+        for role in [Role::Owner, Role::Admin, Role::Developer, Role::Viewer] {
+            assert_eq!(user_role_to_role(role_to_user_role(role)), role);
+        }
+    }
+
+    #[test]
+    fn unset_invite_password_placeholder_never_verifies() {
+        // An invited-but-not-accepted account carries a placeholder that can never
+        // authenticate, so a login attempt before accept is always rejected.
+        assert!(!verify_password(unset_password_hash(), "anything"));
+    }
+}

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -145,6 +145,16 @@ pub struct AppState {
     /// reads the Option A defaults. In-memory, following the same pattern as the
     /// other per-tenant aa-api stores (`alert_rule_store`, `destination_store`).
     pub trust_config: Arc<crate::trust::TrustConfigStore>,
+    /// Postgres-backed native-account store (AAASM-5305, ADR 0031). `None` in the
+    /// in-memory wiring: native email/password auth is Postgres-gated (D2), so the
+    /// login/register/invite/refresh/logout endpoints report "unavailable" and
+    /// `GET /auth/methods` advertises only `api_key` when this is absent. Only a
+    /// Postgres-backed deployment populates it, unlocking the password auth path.
+    pub auth_store: Option<Arc<aa_storage_postgres::PgUserStore>>,
+    /// Static configuration for the native-auth endpoints (default workspace,
+    /// open-registration flag, lockout policy, token lifetimes). Read at request
+    /// time so behaviour is deterministic regardless of `auth_store` presence.
+    pub native_auth: crate::native_auth::NativeAuthConfig,
 }
 
 /// Error returned by [`AppState::local_in_memory`] when the in-memory wiring
@@ -434,6 +444,13 @@ impl AppState {
             secrets_store: Arc::new(aa_gateway::secrets::InMemorySecretsStore::new()),
             tool_registry: ToolRegistry::new(),
             trust_config: Arc::new(crate::trust::TrustConfigStore::new()),
+            // Native email/password auth is Postgres-gated (ADR 0031 D2); the
+            // in-memory wiring stays API-key-only, so the store is absent and the
+            // native-auth endpoints degrade honestly. Config is resolved from the
+            // environment even here so `/auth/methods` and the closed-registration
+            // default behave identically once a Postgres store is wired in.
+            auth_store: None,
+            native_auth: crate::native_auth::NativeAuthConfig::from_env(),
         })
     }
 

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -194,6 +194,10 @@ spec:
         secrets_store: Arc::new(InMemorySecretsStore::new()),
         tool_registry: ToolRegistry::new(),
         trust_config: Arc::new(aa_api::trust::TrustConfigStore::new()),
+        // AAASM-5305: in-memory test AppState — native auth is Postgres-gated and
+        // therefore absent here (ADR 0031 D2).
+        auth_store: None,
+        native_auth: aa_api::native_auth::NativeAuthConfig::from_env(),
     }
 }
 

--- a/aa-auth/src/jwt.rs
+++ b/aa-auth/src/jwt.rs
@@ -76,6 +76,35 @@ impl JwtSigner {
         encode(&Header::default(), &claims, &self.encoding_key).map_err(JwtError::Encode)
     }
 
+    /// Sign a JWT that lives for `ttl_secs` seconds (AAASM-5305).
+    ///
+    /// Identical in every other respect to [`sign_with_tenant`](Self::sign_with_tenant):
+    /// it produces the same [`Claims`] shape (same `sub`/`scope`/tenant fields) so a
+    /// token minted here is scope-compatible with the API-key path and every RBAC gate
+    /// reads it unchanged. The only difference is the lifetime — the native-account
+    /// login path mints a *short-lived* access token (ADR 0031 §5) rather than the
+    /// 24-hour `/auth/token` lifetime — so the two credential sources share the JWT
+    /// shape but differ only in expiry.
+    pub fn sign_with_ttl(
+        &self,
+        subject: &str,
+        scopes: &[Scope],
+        team_id: Option<String>,
+        org_id: Option<String>,
+        ttl_secs: u64,
+    ) -> Result<String, JwtError> {
+        let now = now_epoch_secs();
+        let claims = Claims {
+            sub: subject.to_string(),
+            iat: now,
+            exp: now + ttl_secs,
+            scope: scopes.to_vec(),
+            team_id,
+            org_id,
+        };
+        encode(&Header::default(), &claims, &self.encoding_key).map_err(JwtError::Encode)
+    }
+
     /// Sign a JWT with a custom expiry (for testing).
     #[cfg(test)]
     fn sign_with_expiry(&self, key_id: &str, scopes: &[Scope], exp: u64) -> Result<String, JwtError> {
@@ -199,6 +228,35 @@ mod tests {
         let plain_claims = verifier.verify(&plain).unwrap();
         assert_eq!(plain_claims.team_id, None);
         assert_eq!(plain_claims.org_id, None);
+    }
+
+    #[test]
+    fn test_jwt_sign_with_ttl_matches_the_shared_claim_shape() {
+        // AAASM-5305: the native-login access token must be the *same* JWT shape
+        // as the API-key `/auth/token` path — same subject, scope, and tenant
+        // claims — differing only in lifetime, so every RBAC gate reads it
+        // unchanged.
+        let signer = JwtSigner::new(TEST_SECRET);
+        let verifier = JwtVerifier::new(TEST_SECRET);
+
+        let ttl = 15 * 60;
+        let token = signer
+            .sign_with_ttl(
+                "user-abc",
+                &[Scope::Read, Scope::Write],
+                Some("team-1".into()),
+                Some("org-1".into()),
+                ttl,
+            )
+            .expect("signing should succeed");
+        let claims = verifier.verify(&token).expect("verification should succeed");
+
+        assert_eq!(claims.sub, "user-abc");
+        assert_eq!(claims.scope, vec![Scope::Read, Scope::Write]);
+        assert_eq!(claims.team_id.as_deref(), Some("team-1"));
+        assert_eq!(claims.org_id.as_deref(), Some("org-1"));
+        // The lifetime is exactly the requested TTL, not the 24h default.
+        assert_eq!(claims.exp - claims.iat, ttl, "ttl must be honoured verbatim");
     }
 
     #[test]

--- a/aa-integration-tests/tests/api_openapi_contract.rs
+++ b/aa-integration-tests/tests/api_openapi_contract.rs
@@ -90,10 +90,13 @@ fn openapi_spec_loads_without_errors() {
     // AAASM-5083 added the trust-score surface (ADR 0019 Option D):
     // /api/v1/analytics/trust (per-agent behavioural trust score) and
     // /api/v1/analytics/trust/config (per-tenant weight-set read/write),
-    // bringing it to 82.
+    // bringing it to 82. AAASM-5305 added the ADR 0031 native email/password
+    // auth surface: /api/v1/auth/login, /register, /invite, /invite/accept,
+    // /refresh, /logout, and the public /auth/methods capability probe —
+    // seven paths that coexist with the unchanged /auth/token — bringing it to 89.
     assert_eq!(
-        path_count, 82,
-        "openapi/v1.yaml must declare exactly 82 paths, found {path_count}"
+        path_count, 89,
+        "openapi/v1.yaml must declare exactly 89 paths, found {path_count}"
     );
 
     for schema in ["HealthResponse", "ProblemDetail", "PolicyResponse", "AlertResponse"] {
@@ -170,6 +173,14 @@ fn openapi_spec_paths_match_implemented_routes() {
         "/api/v1/approvals/{id}/reject",
         "/api/v1/audit/sandbox-summary",
         "/api/v1/audit/violations-by-lineage",
+        // AAASM-5305 — ADR 0031 native email/password auth (coexists with /auth/token).
+        "/api/v1/auth/invite",
+        "/api/v1/auth/invite/accept",
+        "/api/v1/auth/login",
+        "/api/v1/auth/logout",
+        "/api/v1/auth/methods",
+        "/api/v1/auth/refresh",
+        "/api/v1/auth/register",
         "/api/v1/auth/token",
         "/api/v1/auth/ws-ticket",
         "/api/v1/capability/matrix",

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -944,6 +944,11 @@ spec:
             secrets_store: Arc::new(InMemorySecretsStore::new()),
             tool_registry: ToolRegistry::new(),
             trust_config: Arc::new(aa_api::trust::TrustConfigStore::new()),
+            // AAASM-5305: the harness is the in-memory (no-Postgres) deployment,
+            // so native email/password auth is unavailable — auth_store is None
+            // and the endpoints degrade honestly (ADR 0031 D2).
+            auth_store: None,
+            native_auth: aa_api::native_auth::NativeAuthConfig::from_env(),
         },
         audit_dir,
         alert_store_handle,
@@ -1085,6 +1090,11 @@ spec:
             secrets_store: Arc::new(InMemorySecretsStore::new()),
             tool_registry: ToolRegistry::new(),
             trust_config: Arc::new(aa_api::trust::TrustConfigStore::new()),
+            // AAASM-5305: the harness is the in-memory (no-Postgres) deployment,
+            // so native email/password auth is unavailable — auth_store is None
+            // and the endpoints degrade honestly (ADR 0031 D2).
+            auth_store: None,
+            native_auth: aa_api::native_auth::NativeAuthConfig::from_env(),
         },
         audit_dir,
         alert_store_handle,
@@ -1227,6 +1237,11 @@ spec:
             secrets_store: Arc::new(InMemorySecretsStore::new()),
             tool_registry: ToolRegistry::new(),
             trust_config: Arc::new(aa_api::trust::TrustConfigStore::new()),
+            // AAASM-5305: the harness is the in-memory (no-Postgres) deployment,
+            // so native email/password auth is unavailable — auth_store is None
+            // and the endpoints degrade honestly (ADR 0031 D2).
+            auth_store: None,
+            native_auth: aa_api::native_auth::NativeAuthConfig::from_env(),
         },
         audit_dir,
         alert_store_handle,
@@ -1361,6 +1376,11 @@ spec:
             secrets_store: Arc::new(InMemorySecretsStore::new()),
             tool_registry: ToolRegistry::new(),
             trust_config: Arc::new(aa_api::trust::TrustConfigStore::new()),
+            // AAASM-5305: the harness is the in-memory (no-Postgres) deployment,
+            // so native email/password auth is unavailable — auth_store is None
+            // and the endpoints degrade honestly (ADR 0031 D2).
+            auth_store: None,
+            native_auth: aa_api::native_auth::NativeAuthConfig::from_env(),
         },
         audit_dir,
         alert_store_handle,
@@ -1488,6 +1508,11 @@ fn build_test_state_empty_policy() -> anyhow::Result<(AppState, PathBuf, Arc<InM
             secrets_store: Arc::new(InMemorySecretsStore::new()),
             tool_registry: ToolRegistry::new(),
             trust_config: Arc::new(aa_api::trust::TrustConfigStore::new()),
+            // AAASM-5305: the harness is the in-memory (no-Postgres) deployment,
+            // so native email/password auth is unavailable — auth_store is None
+            // and the endpoints degrade honestly (ADR 0031 D2).
+            auth_store: None,
+            native_auth: aa_api::native_auth::NativeAuthConfig::from_env(),
         },
         audit_dir,
         alert_store_handle,

--- a/aa-integration-tests/tests/native_auth_gating.rs
+++ b/aa-integration-tests/tests/native_auth_gating.rs
@@ -1,0 +1,92 @@
+//! AAASM-5305 — native email/password auth honest-degradation gate (ADR 0031 D2).
+//!
+//! The integration harness builds the in-memory `AppState` (no Postgres), which
+//! is exactly the deployment where native accounts are NOT available. These tests
+//! prove the surface degrades honestly end-to-end over HTTP:
+//!
+//! * `GET /auth/methods` advertises only `api_key` (never `password`), so the
+//!   frontend never renders a password form the backend cannot serve.
+//! * The account endpoints (`/login`, `/register`, `/refresh`) are reachable
+//!   (mounted, not 404) but return `503`, signalling "configured route, no
+//!   Postgres" rather than silently 404-ing.
+//! * `/auth/token` (the API-key path) is untouched and still works.
+//!
+//! The Postgres-backed happy path (real login/register/invite/refresh) is covered
+//! by the `PgUserStore` integration suite in `aa-storage-postgres`; wiring a live
+//! Postgres store into the full aa-api app is out of this harness's scope.
+
+mod common;
+
+use common::TopologyTestEnv;
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_methods_advertises_only_api_key_without_postgres() {
+    let env = TopologyTestEnv::start().await.expect("harness starts");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{}/api/v1/auth/methods", env.base_url()))
+        .send()
+        .await
+        .expect("methods request");
+    assert_eq!(resp.status(), StatusCode::OK, "methods is a public probe");
+
+    let body: Value = resp.json().await.expect("json body");
+    let methods = body["methods"].as_array().expect("methods array");
+    let methods: Vec<&str> = methods.iter().filter_map(Value::as_str).collect();
+    assert_eq!(
+        methods,
+        vec!["api_key"],
+        "an in-memory deployment must advertise only api_key (ADR 0031 D2)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn login_is_gated_503_without_postgres() {
+    let env = TopologyTestEnv::start().await.expect("harness starts");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{}/api/v1/auth/login", env.base_url()))
+        .json(&json!({ "email": "someone@example.com", "password": "irrelevant-here" }))
+        .send()
+        .await
+        .expect("login request");
+    // Mounted (not 404) but unavailable (503) — the honest-degradation signal.
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "native login must 503 (not 404) when Postgres is absent"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn register_is_gated_503_without_postgres() {
+    let env = TopologyTestEnv::start().await.expect("harness starts");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{}/api/v1/auth/register", env.base_url()))
+        .json(&json!({ "email": "someone@example.com", "password": "a-sufficiently-long-password" }))
+        .send()
+        .await
+        .expect("register request");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn refresh_without_cookie_is_gated_503_without_postgres() {
+    let env = TopologyTestEnv::start().await.expect("harness starts");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{}/api/v1/auth/refresh", env.base_url()))
+        .send()
+        .await
+        .expect("refresh request");
+    // The Postgres gate is checked before the cookie, so an in-memory deployment
+    // reports 503 rather than 401 — the surface is unavailable, not "bad cookie".
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}

--- a/aa-storage-postgres/migrations/0009_login_attempts.sql
+++ b/aa-storage-postgres/migrations/0009_login_attempts.sql
@@ -1,0 +1,32 @@
+-- Per-account failed-login lockout counter (AAASM-5305, ADR 0031 security).
+--
+-- Native login enforces a per-account lockout after N consecutive failed
+-- attempts (→ HTTP 423 + retry-after). The counter MUST be durable, not in
+-- memory (ADR 0031: "Counter is Postgres-backed, not in memory"), so a restart
+-- or a multi-process deployment cannot reset an attacker's budget.
+--
+-- One row per account, keyed by user id. `failed_count` is the current run of
+-- consecutive failures; a successful login resets it to zero. `locked_until`,
+-- when in the future, is the wall-clock instant before which authentication is
+-- refused regardless of correct credentials.
+--
+-- Tenant-scoped exactly like the other account tables (0008): `org_id` is
+-- stamped from the user's verified org and the `tenant_isolation` RLS policy
+-- confines every row to its tenant. An unset GUC sees zero rows (fail-closed).
+
+CREATE TABLE login_attempts (
+    user_id      UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    org_id       UUID NOT NULL REFERENCES orgs(id),
+    failed_count INTEGER NOT NULL DEFAULT 0,
+    locked_until TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_login_attempts_org_id ON login_attempts(org_id);
+
+ALTER TABLE login_attempts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE login_attempts FORCE  ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON login_attempts
+    USING (org_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (org_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid);

--- a/aa-storage-postgres/src/lib.rs
+++ b/aa-storage-postgres/src/lib.rs
@@ -25,7 +25,10 @@ pub use credential_store::PgCredentialStore;
 pub use lifecycle_store::PgLifecycleStore;
 pub use policy_store::PgPolicyStore;
 pub use pool::{PostgresPool, MIGRATOR};
-pub use user_store::{InviteRecord, NewInvite, NewUser, PgUserStore, UserRecord, UserRole, UserStatus};
+pub use user_store::{
+    BootstrapOutcome, InviteRecord, LockoutState, NewInvite, NewUser, PgUserStore, RefreshTokenRecord, UserRecord,
+    UserRole, UserStatus,
+};
 
 /// The name this driver registers under in the storage registry. An operator
 /// selects it with `backend = "postgres"` (or `[storage.postgres]`).

--- a/aa-storage-postgres/src/user_store.rs
+++ b/aa-storage-postgres/src/user_store.rs
@@ -173,6 +173,71 @@ pub struct NewInvite {
     pub invited_by: Option<Uuid>,
 }
 
+/// A refresh-token session as stored (AAASM-5305). Only the hash is persisted;
+/// this is the record the refresh path reads to rotate a live token.
+#[derive(Debug, Clone)]
+pub struct RefreshTokenRecord {
+    /// Session id.
+    pub id: Uuid,
+    /// The user this session belongs to.
+    pub user_id: Uuid,
+    /// The tenant (org) the session belongs to.
+    pub org_id: Uuid,
+    /// When the session expires.
+    pub expires_at: DateTime<Utc>,
+    /// When the session was revoked, if it has been.
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl RefreshTokenRecord {
+    /// Whether this session is currently usable: not revoked and not expired.
+    pub fn is_live(&self, now: DateTime<Utc>) -> bool {
+        self.revoked_at.is_none() && self.expires_at > now
+    }
+}
+
+/// The lockout state of an account (AAASM-5305, ADR 0031 brute-force control).
+///
+/// Returned by the failed-attempt counter methods so the login handler can map a
+/// locked account to `423 Locked` + a `retry-after` without re-reading the row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LockoutState {
+    /// Consecutive failed attempts recorded for the account.
+    pub failed_count: i32,
+    /// When the account is locked until, if it is currently locked.
+    pub locked_until: Option<DateTime<Utc>>,
+}
+
+impl LockoutState {
+    /// Seconds remaining in the lockout window relative to `now`, or `None` when
+    /// the account is not currently locked.
+    pub fn retry_after_secs(&self, now: DateTime<Utc>) -> Option<u64> {
+        self.locked_until.and_then(|until| {
+            let remaining = (until - now).num_seconds();
+            (remaining > 0).then_some(remaining as u64)
+        })
+    }
+}
+
+/// The outcome of an atomic first-user bootstrap attempt (AAASM-5305, ADR 0031
+/// §4 / security "bootstrap race").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BootstrapOutcome {
+    /// This call created the first account as `owner` of the default workspace.
+    /// Carries the tenant the account was created under so the caller can mint a
+    /// tenant-scoped JWT.
+    CreatedOwner {
+        /// The default workspace (org) the owner now belongs to.
+        org_id: Uuid,
+    },
+    /// A user already existed, so the bootstrap did not run. The caller decides
+    /// between `403` (registration closed) and the open-registration path.
+    AlreadyBootstrapped {
+        /// The default workspace (org) open-registration accounts join.
+        org_id: Uuid,
+    },
+}
+
 /// Postgres-backed store for native accounts, invites, and refresh sessions.
 ///
 /// Every method takes the verified tenant `org_id` and runs under the RLS GUC
@@ -329,7 +394,230 @@ impl PgUserStore {
         tx.commit().await.map_err(backend_err)?;
         Ok(result.rows_affected() > 0)
     }
+
+    /// Look up a live-or-dead refresh session by its `token_hash` under the
+    /// verified tenant `org_id` (AAASM-5305).
+    ///
+    /// Returns the row (including `revoked_at` / `expires_at`) so the refresh
+    /// path can decide whether it may be rotated; a missing or RLS-invisible
+    /// token yields `Ok(None)`. Liveness is [`RefreshTokenRecord::is_live`] — the
+    /// caller checks it rather than the query, so an expired/revoked token is
+    /// distinguishable from an absent one.
+    pub async fn find_refresh_token(&self, org_id: Uuid, token_hash: &str) -> Result<Option<RefreshTokenRecord>> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
+        let row: Option<RefreshTokenRow> = sqlx::query_as(
+            "SELECT id, user_id, org_id, expires_at, revoked_at \
+               FROM refresh_tokens WHERE token_hash = $1",
+        )
+        .bind(token_hash)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
+        Ok(row.map(RefreshTokenRow::into_record))
+    }
+
+    /// Find a native account by id within the verified tenant `org_id`
+    /// (AAASM-5305).
+    ///
+    /// Used by the refresh path to reload the account behind a valid refresh
+    /// session so the rotated access token carries the account's current role
+    /// and status. Returns `Ok(None)` when no such account is visible.
+    pub async fn find_by_id(&self, org_id: Uuid, user_id: Uuid) -> Result<Option<UserRecord>> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
+        let row: Option<UserRow> = sqlx::query_as(
+            "SELECT id, email, password_hash, org_id, role::text AS role, status::text AS status, \
+                    created_at, updated_at, last_login_at \
+             FROM users WHERE id = $1",
+        )
+        .bind(user_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
+        row.map(UserRow::into_record).transpose()
+    }
+
+    /// Atomically bootstrap the first account as `owner`, or report that the
+    /// workspace is already bootstrapped (AAASM-5305, ADR 0031 §4 + security
+    /// "bootstrap race").
+    ///
+    /// The whole check-then-create runs in a single transaction guarded by a
+    /// transaction-scoped advisory lock (`pg_advisory_xact_lock`), so two
+    /// concurrent registrations cannot both observe an empty table and both
+    /// claim `owner` — the second waits on the lock, then sees the row the first
+    /// inserted and returns [`BootstrapOutcome::AlreadyBootstrapped`]. The
+    /// default workspace org is created on demand (idempotently) so a fresh
+    /// instance needs no seeding step. The new user is created `active`.
+    pub async fn bootstrap_first_user(
+        &self,
+        default_org_id: Uuid,
+        default_org_name: &str,
+        new_user_id: Uuid,
+        email: &str,
+        password_hash: &str,
+    ) -> Result<BootstrapOutcome> {
+        let mut tx = self.pool.begin_for_tenant(default_org_id).await.map_err(backend_err)?;
+
+        // Serialise every bootstrap attempt on one well-known advisory key so the
+        // count-then-insert is race-free. The lock releases at transaction end.
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(BOOTSTRAP_ADVISORY_KEY)
+            .execute(&mut *tx)
+            .await
+            .map_err(backend_err)?;
+
+        // Ensure the single default workspace exists. Idempotent: a second
+        // bootstrap attempt (or a re-run after a crash) is a no-op.
+        sqlx::query("INSERT INTO orgs (id, name) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING")
+            .bind(default_org_id)
+            .bind(default_org_name)
+            .execute(&mut *tx)
+            .await
+            .map_err(backend_err)?;
+
+        // Count under the advisory lock AND the tenant GUC: the count only sees
+        // this tenant's users (RLS), which is exactly the single-workspace scope.
+        let existing: i64 = sqlx::query_scalar("SELECT count(*) FROM users")
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(backend_err)?;
+
+        if existing > 0 {
+            tx.commit().await.map_err(backend_err)?;
+            return Ok(BootstrapOutcome::AlreadyBootstrapped { org_id: default_org_id });
+        }
+
+        sqlx::query(
+            "INSERT INTO users (id, email, password_hash, org_id, role, status) \
+             VALUES ($1, $2, $3, $4, 'owner'::user_role, 'active'::user_status)",
+        )
+        .bind(new_user_id)
+        .bind(email)
+        .bind(password_hash)
+        .bind(default_org_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend_err)?;
+
+        tx.commit().await.map_err(backend_err)?;
+        Ok(BootstrapOutcome::CreatedOwner { org_id: default_org_id })
+    }
+
+    /// Activate an invited account by setting its initial password hash and
+    /// flipping its status to `active` (AAASM-5305).
+    ///
+    /// Only a row currently in `invited` status is activated; a missing, already
+    /// active/disabled, or RLS-invisible user affects zero rows. Returns `true`
+    /// when this call activated the account. The invite itself is consumed
+    /// separately via [`consume_invite`](Self::consume_invite); this is the
+    /// account-side half of accepting an invite.
+    pub async fn activate_invited_user(&self, org_id: Uuid, user_id: Uuid, password_hash: &str) -> Result<bool> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
+        let result = sqlx::query(
+            "UPDATE users SET password_hash = $1, status = 'active'::user_status, updated_at = now() \
+              WHERE id = $2 AND status = 'invited'::user_status",
+        )
+        .bind(password_hash)
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Read the current lockout state of an account (AAASM-5305).
+    ///
+    /// Returns the zero state when no counter row exists yet (an account that has
+    /// never failed a login). The login handler consults this *before* verifying
+    /// the password so a locked account is refused with `423` regardless of
+    /// whether the supplied password is correct.
+    pub async fn lockout_state(&self, org_id: Uuid, user_id: Uuid) -> Result<LockoutState> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
+        let row: Option<(i32, Option<DateTime<Utc>>)> =
+            sqlx::query_as("SELECT failed_count, locked_until FROM login_attempts WHERE user_id = $1")
+                .bind(user_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
+        Ok(row.map_or(
+            LockoutState {
+                failed_count: 0,
+                locked_until: None,
+            },
+            |(failed_count, locked_until)| LockoutState {
+                failed_count,
+                locked_until,
+            },
+        ))
+    }
+
+    /// Record a failed login attempt, locking the account for `lock_secs` once
+    /// `threshold` consecutive failures are reached (AAASM-5305).
+    ///
+    /// Atomic upsert: the counter row is created or its `failed_count`
+    /// incremented, and `locked_until` is set to `now() + lock_secs` when the new
+    /// count meets or exceeds `threshold`. Returns the resulting
+    /// [`LockoutState`]. The counter lives in Postgres (never memory) so it
+    /// survives a restart and is shared across processes (ADR 0031).
+    pub async fn record_login_failure(
+        &self,
+        org_id: Uuid,
+        user_id: Uuid,
+        threshold: i32,
+        lock_secs: i64,
+    ) -> Result<LockoutState> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
+        let row: (i32, Option<DateTime<Utc>>) = sqlx::query_as(
+            "INSERT INTO login_attempts (user_id, org_id, failed_count, locked_until, updated_at) \
+             VALUES ($1, $2, 1, NULL, now()) \
+             ON CONFLICT (user_id) DO UPDATE SET \
+                 failed_count = login_attempts.failed_count + 1, \
+                 locked_until = CASE WHEN login_attempts.failed_count + 1 >= $3 \
+                                     THEN now() + make_interval(secs => $4) \
+                                     ELSE login_attempts.locked_until END, \
+                 updated_at = now() \
+             RETURNING failed_count, locked_until",
+        )
+        .bind(user_id)
+        .bind(org_id)
+        .bind(threshold)
+        .bind(lock_secs as f64)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
+        Ok(LockoutState {
+            failed_count: row.0,
+            locked_until: row.1,
+        })
+    }
+
+    /// Clear an account's failed-attempt counter after a successful login
+    /// (AAASM-5305).
+    ///
+    /// Idempotent: resets `failed_count` to zero and clears `locked_until` for the
+    /// account, affecting zero rows when no counter exists.
+    pub async fn clear_login_failures(&self, org_id: Uuid, user_id: Uuid) -> Result<()> {
+        let mut tx = self.pool.begin_for_tenant(org_id).await.map_err(backend_err)?;
+        sqlx::query(
+            "UPDATE login_attempts SET failed_count = 0, locked_until = NULL, updated_at = now() \
+              WHERE user_id = $1",
+        )
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend_err)?;
+        tx.commit().await.map_err(backend_err)?;
+        Ok(())
+    }
 }
+
+/// Advisory-lock key serialising first-user bootstrap attempts. An arbitrary
+/// fixed 64-bit constant unique to this concern.
+const BOOTSTRAP_ADVISORY_KEY: i64 = 0x5305_0001_B007_57A9_u64 as i64;
 
 /// Raw `users` row as read from Postgres (role/status come back as `text` via the
 /// `::text` cast in the SELECT). Converted to [`UserRecord`] by [`into_record`].
@@ -396,6 +684,28 @@ impl InviteRow {
     }
 }
 
+/// Raw `refresh_tokens` row as read from Postgres (AAASM-5305).
+#[derive(sqlx::FromRow)]
+struct RefreshTokenRow {
+    id: Uuid,
+    user_id: Uuid,
+    org_id: Uuid,
+    expires_at: DateTime<Utc>,
+    revoked_at: Option<DateTime<Utc>>,
+}
+
+impl RefreshTokenRow {
+    fn into_record(self) -> RefreshTokenRecord {
+        RefreshTokenRecord {
+            id: self.id,
+            user_id: self.user_id,
+            org_id: self.org_id,
+            expires_at: self.expires_at,
+            revoked_at: self.revoked_at,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -422,5 +732,59 @@ mod tests {
         assert_eq!(UserRole::Admin.as_str(), "admin");
         assert_eq!(UserRole::Developer.as_str(), "developer");
         assert_eq!(UserRole::Viewer.as_str(), "viewer");
+    }
+
+    #[test]
+    fn lockout_retry_after_is_none_when_not_locked() {
+        let now = Utc::now();
+        let unlocked = LockoutState {
+            failed_count: 2,
+            locked_until: None,
+        };
+        assert_eq!(unlocked.retry_after_secs(now), None);
+
+        // A lock whose window has already elapsed is no longer a lock.
+        let past = LockoutState {
+            failed_count: 5,
+            locked_until: Some(now - chrono::Duration::seconds(1)),
+        };
+        assert_eq!(past.retry_after_secs(now), None);
+    }
+
+    #[test]
+    fn lockout_retry_after_reports_remaining_window() {
+        let now = Utc::now();
+        let locked = LockoutState {
+            failed_count: 5,
+            locked_until: Some(now + chrono::Duration::seconds(90)),
+        };
+        // Allow a 1s slack for the arithmetic crossing a second boundary.
+        let remaining = locked.retry_after_secs(now).expect("still locked");
+        assert!((89..=90).contains(&remaining), "expected ~90s, got {remaining}");
+    }
+
+    #[test]
+    fn refresh_token_liveness_tracks_revocation_and_expiry() {
+        let now = Utc::now();
+        let base = RefreshTokenRecord {
+            id: Uuid::nil(),
+            user_id: Uuid::nil(),
+            org_id: Uuid::nil(),
+            expires_at: now + chrono::Duration::hours(1),
+            revoked_at: None,
+        };
+        assert!(base.is_live(now), "a fresh unrevoked token is live");
+
+        let revoked = RefreshTokenRecord {
+            revoked_at: Some(now - chrono::Duration::minutes(1)),
+            ..base.clone()
+        };
+        assert!(!revoked.is_live(now), "a revoked token is not live");
+
+        let expired = RefreshTokenRecord {
+            expires_at: now - chrono::Duration::minutes(1),
+            ..base
+        };
+        assert!(!expired.is_live(now), "an expired token is not live");
     }
 }

--- a/aa-storage-postgres/tests/user_store_pg.rs
+++ b/aa-storage-postgres/tests/user_store_pg.rs
@@ -16,7 +16,9 @@
 //! split the production deployment uses. Otherwise the RLS assertions would
 //! silently pass under a bypassing superuser.
 
-use aa_storage_postgres::{NewInvite, NewUser, PgUserStore, PostgresPool, PostgresPoolConfig, UserRole, UserStatus};
+use aa_storage_postgres::{
+    BootstrapOutcome, NewInvite, NewUser, PgUserStore, PostgresPool, PostgresPoolConfig, UserRole, UserStatus,
+};
 use chrono::{Duration, Utc};
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
@@ -257,6 +259,170 @@ async fn find_by_email_is_tenant_scoped() {
         .await
         .expect("find via B");
     assert!(via_b.is_none(), "tenant B must not see tenant A's user (RLS)");
+}
+
+const DEFAULT_ORG: Uuid = Uuid::from_u128(0x0d);
+
+#[tokio::test]
+async fn bootstrap_first_user_creates_owner_then_reports_already_bootstrapped() {
+    let (_pg, pool) = setup().await;
+    let store = PgUserStore::new(pool);
+
+    // A fresh workspace: the first bootstrap creates the owner and the default org
+    // (created on demand — no seeding step needed).
+    let first = store
+        .bootstrap_first_user(DEFAULT_ORG, "Default", Uuid::new_v4(), "ivan@example.com", "hash")
+        .await
+        .expect("first bootstrap");
+    assert_eq!(first, BootstrapOutcome::CreatedOwner { org_id: DEFAULT_ORG });
+
+    let created = store
+        .find_by_email(DEFAULT_ORG, "ivan@example.com")
+        .await
+        .expect("find")
+        .expect("owner present");
+    assert_eq!(created.role, UserRole::Owner, "the first account becomes owner");
+    assert_eq!(created.status, UserStatus::Active);
+
+    // A second bootstrap must NOT create a second owner — it reports the workspace
+    // is already bootstrapped, leaving the count-then-insert race-free.
+    let second = store
+        .bootstrap_first_user(DEFAULT_ORG, "Default", Uuid::new_v4(), "judy@example.com", "hash")
+        .await
+        .expect("second bootstrap");
+    assert_eq!(second, BootstrapOutcome::AlreadyBootstrapped { org_id: DEFAULT_ORG });
+    assert!(
+        store
+            .find_by_email(DEFAULT_ORG, "judy@example.com")
+            .await
+            .expect("find")
+            .is_none(),
+        "a second bootstrap must not create a user"
+    );
+}
+
+#[tokio::test]
+async fn lockout_counter_increments_locks_and_clears() {
+    let (_pg, pool) = setup().await;
+    let store = PgUserStore::new(pool);
+
+    let user = new_user("kate@example.com");
+    let user_id = user.id;
+    store.create_user(TENANT_A, &user).await.expect("create user");
+
+    // No failures yet: zero state, no lock.
+    let initial = store.lockout_state(TENANT_A, user_id).await.expect("state");
+    assert_eq!(initial.failed_count, 0);
+    assert!(initial.locked_until.is_none());
+
+    // Below threshold: increments but does not lock.
+    let one = store
+        .record_login_failure(TENANT_A, user_id, 3, 900)
+        .await
+        .expect("fail 1");
+    assert_eq!(one.failed_count, 1);
+    assert!(one.locked_until.is_none(), "below threshold must not lock");
+
+    store
+        .record_login_failure(TENANT_A, user_id, 3, 900)
+        .await
+        .expect("fail 2");
+    // Reaching the threshold locks the account.
+    let three = store
+        .record_login_failure(TENANT_A, user_id, 3, 900)
+        .await
+        .expect("fail 3");
+    assert_eq!(three.failed_count, 3);
+    assert!(three.locked_until.is_some(), "reaching threshold must lock");
+    assert!(
+        three.retry_after_secs(Utc::now()).is_some(),
+        "a locked account reports a retry-after"
+    );
+
+    // A successful login clears the counter.
+    store.clear_login_failures(TENANT_A, user_id).await.expect("clear");
+    let cleared = store.lockout_state(TENANT_A, user_id).await.expect("state");
+    assert_eq!(cleared.failed_count, 0);
+    assert!(cleared.locked_until.is_none(), "clear must lift the lock");
+}
+
+#[tokio::test]
+async fn find_refresh_token_reads_liveness() {
+    let (_pg, pool) = setup().await;
+    let store = PgUserStore::new(pool);
+
+    let user = new_user("leo@example.com");
+    let user_id = user.id;
+    store.create_user(TENANT_A, &user).await.expect("create user");
+    store
+        .store_refresh_token(
+            TENANT_A,
+            Uuid::new_v4(),
+            "live-refresh-hash",
+            user_id,
+            Utc::now() + Duration::days(7),
+        )
+        .await
+        .expect("store");
+
+    let found = store
+        .find_refresh_token(TENANT_A, "live-refresh-hash")
+        .await
+        .expect("find")
+        .expect("token present");
+    assert_eq!(found.user_id, user_id);
+    assert!(found.is_live(Utc::now()), "a stored unrevoked token is live");
+
+    // After revocation the same lookup shows it dead (so refresh can reject it).
+    store
+        .revoke_refresh_token(TENANT_A, "live-refresh-hash")
+        .await
+        .expect("revoke");
+    let after = store
+        .find_refresh_token(TENANT_A, "live-refresh-hash")
+        .await
+        .expect("find")
+        .expect("token still present");
+    assert!(!after.is_live(Utc::now()), "a revoked token reads as not live");
+
+    // A missing token is None (not an error).
+    assert!(store
+        .find_refresh_token(TENANT_A, "no-such-hash")
+        .await
+        .expect("find")
+        .is_none());
+}
+
+#[tokio::test]
+async fn activate_invited_user_sets_password_and_status() {
+    let (_pg, pool) = setup().await;
+    let store = PgUserStore::new(pool);
+
+    let mut invited = new_user("mia@example.com");
+    invited.status = UserStatus::Invited;
+    let user_id = invited.id;
+    store.create_user(TENANT_A, &invited).await.expect("create invited");
+
+    let activated = store
+        .activate_invited_user(TENANT_A, user_id, "new-hash")
+        .await
+        .expect("activate");
+    assert!(activated, "activating an invited account reports true");
+
+    let record = store
+        .find_by_id(TENANT_A, user_id)
+        .await
+        .expect("find")
+        .expect("present");
+    assert_eq!(record.status, UserStatus::Active);
+    assert_eq!(record.password_hash, "new-hash");
+
+    // Re-activating an already-active account is a no-op (zero rows → false).
+    let again = store
+        .activate_invited_user(TENANT_A, user_id, "another-hash")
+        .await
+        .expect("activate again");
+    assert!(!again, "an already-active account cannot be re-activated");
 }
 
 #[tokio::test]

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1099,6 +1099,157 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/auth/invite": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a single-use, expiring invite for a new account (admin scope only)
+         *     (ADR 0031 §3). The raw token is returned once here; only its hash is stored.
+         */
+        post: operations["invite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/invite/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Accept an invite: consume the single-use token and set the initial password,
+         *     activating the account (ADR 0031 §3). Public: the invitee is not yet
+         *     authenticated.
+         */
+        post: operations["invite_accept"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Authenticate with email + password, returning an access token and setting the
+         *     refresh cookie (ADR 0031 §3).
+         * @description Enumeration-safe: an unknown email and a wrong password both return a uniform
+         *     `401`, and an unknown email still runs an argon2 verify against a dummy hash
+         *     so the timing does not distinguish the two. A locked account returns `423`
+         *     with `retry-after` regardless of whether the password is correct.
+         */
+        post: operations["login"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Revoke the refresh session and clear the cookie (ADR 0031 §5). Requires an
+         *     authenticated caller; always returns `204`.
+         */
+        post: operations["logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/methods": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Advertise the credential methods this deployment supports (ADR 0031 §Q5).
+         * @description Public: the login page reads this before rendering, so it never offers a
+         *     password form on an in-memory (API-key-only) backend. Always lists `api_key`;
+         *     adds `password` only when a Postgres-backed account store is configured.
+         */
+        get: operations["auth_methods"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Exchange a valid refresh cookie for a new access token, rotating the refresh
+         *     token (ADR 0031 §5). Public (the cookie is the credential).
+         */
+        post: operations["refresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Register the first account (bootstrap owner) or a self-registered account when
+         *     open registration is enabled (ADR 0031 §4 / §Q3).
+         * @description The first account on a fresh instance becomes `owner` under an advisory lock
+         *     so two concurrent registrations cannot both claim owner. Once a user exists,
+         *     registration is closed (`403`) unless `AA_AUTH_OPEN_REGISTRATION` is set, in
+         *     which case a subsequent registration creates a `developer` account.
+         */
+        post: operations["register"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/auth/token": {
         parameters: {
             query?: never;
@@ -2197,6 +2348,20 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * @description Response body carrying a freshly minted access token (login / refresh /
+         *     invite-accept). The refresh token is NOT in the body — it rides in the
+         *     HttpOnly cookie.
+         */
+        AccessTokenResponse: {
+            /** @description The short-lived access JWT to present as `Authorization: Bearer`. */
+            access_token: string;
+            /**
+             * Format: int64
+             * @description Access-token lifetime in seconds.
+             */
+            expires_in: number;
+        };
         /** @description Response for `GET /api/v1/analytics/action-volume`. */
         ActionVolumeResponse: {
             /** @description One series per action category (empty when no audit events matched). */
@@ -3143,6 +3308,17 @@ export interface components {
             team_id?: string | null;
         };
         /**
+         * @description Response body for `GET /auth/methods` (ADR 0031 §Q5). Advertises which
+         *     credential paths this deployment can serve so the frontend degrades honestly.
+         */
+        AuthMethodsResponse: {
+            /**
+             * @description `["api_key"]` on an in-memory deployment; `["api_key","password"]` when a
+             *     Postgres store backs native accounts.
+             */
+            methods: string[];
+        };
+        /**
          * @description Payload for `event_type: "budget"` events.
          *
          *     Emitted when an agent's spend crosses a configured daily threshold
@@ -3931,6 +4107,33 @@ export interface components {
             /** @description Gateway version (semver from Cargo.toml). */
             version: string;
         };
+        /** @description Request body for `POST /auth/invite/accept`. */
+        InviteAcceptRequest: {
+            /** @description The initial password to set on the account (must clear the floor). */
+            password: string;
+            /** @description The raw invite token delivered to the invitee. */
+            token: string;
+        };
+        /** @description Request body for `POST /auth/invite` (admin only). */
+        InviteRequest: {
+            /** @description The email to invite. */
+            email: string;
+            /** @description The role the invited account will receive on accept. */
+            role: components["schemas"]["Role"];
+        };
+        /**
+         * @description Response body for `POST /auth/invite`. The raw invite token is returned once
+         *     to the inviting admin to deliver out of band; only its hash is stored.
+         */
+        InviteResponse: {
+            /** @description The created invite id (UUID string). */
+            invite_id: string;
+            /**
+             * @description The single-use, expiring raw invite token. Returned exactly once, here;
+             *     the server stores only its SHA-256 hash and can never surface it again.
+             */
+            token: string;
+        };
         /**
          * @description Response for `GET /api/v1/analytics/kpis` — a single scalar KPI plus the
          *     fractional change versus the previous equivalent window.
@@ -4014,6 +4217,15 @@ export interface components {
          * @enum {string}
          */
         LogEventType: "ToolCallIntercepted" | "PolicyViolation" | "CredentialLeakBlocked" | "ApprovalRequested" | "ApprovalGranted" | "ApprovalDenied" | "BudgetLimitApproached" | "BudgetLimitExceeded" | "ApprovalTimedOut" | "ApprovalRouted" | "ApprovalEscalated" | "AgentForceDeregistered" | "MessageBlocked" | "ToolDispatched" | "A2ACallIntercepted" | "A2AImpersonationAttempted" | "SandboxStarted" | "SandboxFilesystemBlocked" | "SandboxCpuTimeout" | "SandboxOomKilled" | "SandboxTerminated" | "SandboxHostFnRateLimited";
+        /** @description Request body for `POST /auth/login`. */
+        LoginRequest: {
+            /** @description The account email (case-insensitive). */
+            email: string;
+            /** @description The account password. */
+            password: string;
+            /** @description When true, the refresh session is issued with an extended lifetime. */
+            remember_me?: boolean;
+        };
         /**
          * @description Per-agent daily budget projection for a topology node (AAASM-5045).
          *
@@ -4744,6 +4956,31 @@ export interface components {
             /** @description Stable identifier for the operation, typically a `GovernanceEvent.id`. */
             op_id: string;
         };
+        /** @description Request body for `POST /auth/register`. */
+        RegisterRequest: {
+            /**
+             * @description The new account email (case-insensitive). OSS is single-workspace, so no
+             *     `tenant_name` is accepted (ADR 0031 §4).
+             */
+            email: string;
+            /** @description The new account password (must clear the minimum-length floor). */
+            password: string;
+        };
+        /** @description Response body for a successful `POST /auth/register`. */
+        RegisterResponse: {
+            /**
+             * @description The short-lived access JWT for the bootstrap owner (the refresh token is
+             *     delivered as the HttpOnly cookie alongside).
+             */
+            access_token: string;
+            /**
+             * Format: int64
+             * @description Access-token lifetime in seconds.
+             */
+            expires_in: number;
+            /** @description The id of the newly created account (UUID string). */
+            user_id: string;
+        };
         /**
          * @description Request body for `POST /api/v1/policies/replay` (AAASM-5094).
          *
@@ -4995,6 +5232,15 @@ export interface components {
             /** @description Timestamp (UTC) at which the run completed (ISO 8601). */
             ran_at: string;
         };
+        /**
+         * @description A native-account user role (ADR 0031 data model).
+         *
+         *     Roles are a coarse, human-facing label stored on the user row; authorization
+         *     is still driven by the [`Scope`] set [`Role::scopes`] expands each role to.
+         *     Serialized lowercase to match the `users.role` enum values in the migration.
+         * @enum {string}
+         */
+        Role: "owner" | "admin" | "developer" | "viewer";
         /** @description One built-in RBAC role and the governance capabilities it grants. */
         RoleCapabilitiesResponse: {
             /**
@@ -7957,6 +8203,286 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    invite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteRequest"];
+            };
+        };
+        responses: {
+            /** @description Invite created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InviteResponse"];
+                };
+            };
+            /** @description Caller is not an admin */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Native auth not available (no Postgres) */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    invite_accept: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteAcceptRequest"];
+            };
+        };
+        responses: {
+            /** @description Invite accepted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccessTokenResponse"];
+                };
+            };
+            /** @description Token expired/used or weak password */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Native auth not available (no Postgres) */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    login: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginRequest"];
+            };
+        };
+        responses: {
+            /** @description Authenticated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccessTokenResponse"];
+                };
+            };
+            /** @description Invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Account locked */
+            423: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Native auth not available (no Postgres) */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    logout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Logged out (refresh revoked) */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    auth_methods: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Available auth methods */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthMethodsResponse"];
+                };
+            };
+        };
+    };
+    refresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Refreshed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccessTokenResponse"];
+                };
+            };
+            /** @description Missing / revoked / expired refresh token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Native auth not available (no Postgres) */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    register: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterRequest"];
+            };
+        };
+        responses: {
+            /** @description Registered */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegisterResponse"];
+                };
+            };
+            /** @description Registration closed */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Email already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Weak password */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Native auth not available (no Postgres) */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
             };
         };
     };

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1109,8 +1109,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Create a single-use, expiring invite for a new account (admin scope only)
-         *     (ADR 0031 §3). The raw token is returned once here; only its hash is stored.
+         * Create a single-use, expiring invite for a new account (admin scope only).
+         * @description ADR 0031 §3. The raw invite token is returned exactly once in this response;
+         *     only its hash is persisted, so it cannot be recovered later. The invite is
+         *     bound to the target email and role and expires after a fixed window.
          */
         post: operations["invite"];
         delete?: never;
@@ -1129,9 +1131,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Accept an invite: consume the single-use token and set the initial password,
-         *     activating the account (ADR 0031 §3). Public: the invitee is not yet
-         *     authenticated.
+         * Accept an invite: set the initial password and activate the account.
+         * @description ADR 0031 §3. Consumes the single-use invite token (rejected if already used
+         *     or expired), hashes the chosen password with argon2id, and activates the
+         *     account. Public: the invitee is not yet authenticated.
          */
         post: operations["invite_accept"];
         delete?: never;
@@ -1174,8 +1177,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Revoke the refresh session and clear the cookie (ADR 0031 §5). Requires an
-         *     authenticated caller; always returns `204`.
+         * Revoke the refresh session and clear the cookie.
+         * @description ADR 0031 §5. Revokes the caller's refresh token server-side and clears the
+         *     HttpOnly cookie. Requires an authenticated caller; always returns `204`,
+         *     including when no active session is found (idempotent).
          */
         post: operations["logout"];
         delete?: never;
@@ -1216,8 +1221,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Exchange a valid refresh cookie for a new access token, rotating the refresh
-         *     token (ADR 0031 §5). Public (the cookie is the credential).
+         * Exchange a valid refresh cookie for a new access token.
+         * @description ADR 0031 §5. Rotates the refresh token on use — the presented token is
+         *     revoked and a fresh one is set — so a replayed cookie loses the rotation
+         *     race and is rejected. Public: the HttpOnly refresh cookie is the credential.
          */
         post: operations["refresh"];
         delete?: never;

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1913,9 +1913,11 @@ paths:
     post:
       tags:
       - auth
-      summary: |-
-        Create a single-use, expiring invite for a new account (admin scope only)
-        (ADR 0031 §3). The raw token is returned once here; only its hash is stored.
+      summary: Create a single-use, expiring invite for a new account (admin scope only).
+      description: |-
+        ADR 0031 §3. The raw invite token is returned exactly once in this response;
+        only its hash is persisted, so it cannot be recovered later. The invite is
+        bound to the target email and role and expires after a fixed window.
       operationId: invite
       requestBody:
         content:
@@ -1948,10 +1950,11 @@ paths:
     post:
       tags:
       - auth
-      summary: |-
-        Accept an invite: consume the single-use token and set the initial password,
-        activating the account (ADR 0031 §3). Public: the invitee is not yet
-        authenticated.
+      summary: 'Accept an invite: set the initial password and activate the account.'
+      description: |-
+        ADR 0031 §3. Consumes the single-use invite token (rejected if already used
+        or expired), hashes the chosen password with argon2id, and activates the
+        account. Public: the invitee is not yet authenticated.
       operationId: invite_accept
       requestBody:
         content:
@@ -2026,9 +2029,11 @@ paths:
     post:
       tags:
       - auth
-      summary: |-
-        Revoke the refresh session and clear the cookie (ADR 0031 §5). Requires an
-        authenticated caller; always returns `204`.
+      summary: Revoke the refresh session and clear the cookie.
+      description: |-
+        ADR 0031 §5. Revokes the caller's refresh token server-side and clears the
+        HttpOnly cookie. Requires an authenticated caller; always returns `204`,
+        including when no active session is found (idempotent).
       operationId: logout
       responses:
         '204':
@@ -2062,9 +2067,11 @@ paths:
     post:
       tags:
       - auth
-      summary: |-
-        Exchange a valid refresh cookie for a new access token, rotating the refresh
-        token (ADR 0031 §5). Public (the cookie is the credential).
+      summary: Exchange a valid refresh cookie for a new access token.
+      description: |-
+        ADR 0031 §5. Rotates the refresh token on use — the presented token is
+        revoked and a fresh one is set — so a replayed cookie loses the rotation
+        race and is rejected. Public: the HttpOnly refresh cookie is the credential.
       operationId: refresh
       responses:
         '200':

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1909,6 +1909,232 @@ paths:
           description: Invalid query parameter
         '401':
           description: Missing or invalid credentials
+  /api/v1/auth/invite:
+    post:
+      tags:
+      - auth
+      summary: |-
+        Create a single-use, expiring invite for a new account (admin scope only)
+        (ADR 0031 §3). The raw token is returned once here; only its hash is stored.
+      operationId: invite
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InviteRequest'
+        required: true
+      responses:
+        '200':
+          description: Invite created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InviteResponse'
+        '403':
+          description: Caller is not an admin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '503':
+          description: Native auth not available (no Postgres)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+      security:
+      - bearer_auth: []
+  /api/v1/auth/invite/accept:
+    post:
+      tags:
+      - auth
+      summary: |-
+        Accept an invite: consume the single-use token and set the initial password,
+        activating the account (ADR 0031 §3). Public: the invitee is not yet
+        authenticated.
+      operationId: invite_accept
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InviteAcceptRequest'
+        required: true
+      responses:
+        '200':
+          description: Invite accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessTokenResponse'
+        '422':
+          description: Token expired/used or weak password
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '503':
+          description: Native auth not available (no Postgres)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /api/v1/auth/login:
+    post:
+      tags:
+      - auth
+      summary: |-
+        Authenticate with email + password, returning an access token and setting the
+        refresh cookie (ADR 0031 §3).
+      description: |-
+        Enumeration-safe: an unknown email and a wrong password both return a uniform
+        `401`, and an unknown email still runs an argon2 verify against a dummy hash
+        so the timing does not distinguish the two. A locked account returns `423`
+        with `retry-after` regardless of whether the password is correct.
+      operationId: login
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+        required: true
+      responses:
+        '200':
+          description: Authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessTokenResponse'
+        '401':
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '423':
+          description: Account locked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '503':
+          description: Native auth not available (no Postgres)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /api/v1/auth/logout:
+    post:
+      tags:
+      - auth
+      summary: |-
+        Revoke the refresh session and clear the cookie (ADR 0031 §5). Requires an
+        authenticated caller; always returns `204`.
+      operationId: logout
+      responses:
+        '204':
+          description: Logged out (refresh revoked)
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+      security:
+      - bearer_auth: []
+  /api/v1/auth/methods:
+    get:
+      tags:
+      - auth
+      summary: Advertise the credential methods this deployment supports (ADR 0031 §Q5).
+      description: |-
+        Public: the login page reads this before rendering, so it never offers a
+        password form on an in-memory (API-key-only) backend. Always lists `api_key`;
+        adds `password` only when a Postgres-backed account store is configured.
+      operationId: auth_methods
+      responses:
+        '200':
+          description: Available auth methods
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthMethodsResponse'
+  /api/v1/auth/refresh:
+    post:
+      tags:
+      - auth
+      summary: |-
+        Exchange a valid refresh cookie for a new access token, rotating the refresh
+        token (ADR 0031 §5). Public (the cookie is the credential).
+      operationId: refresh
+      responses:
+        '200':
+          description: Refreshed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessTokenResponse'
+        '401':
+          description: Missing / revoked / expired refresh token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '503':
+          description: Native auth not available (no Postgres)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /api/v1/auth/register:
+    post:
+      tags:
+      - auth
+      summary: |-
+        Register the first account (bootstrap owner) or a self-registered account when
+        open registration is enabled (ADR 0031 §4 / §Q3).
+      description: |-
+        The first account on a fresh instance becomes `owner` under an advisory lock
+        so two concurrent registrations cannot both claim owner. Once a user exists,
+        registration is closed (`403`) unless `AA_AUTH_OPEN_REGISTRATION` is set, in
+        which case a subsequent registration creates a `developer` account.
+      operationId: register
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+        required: true
+      responses:
+        '200':
+          description: Registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterResponse'
+        '403':
+          description: Registration closed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '409':
+          description: Email already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '422':
+          description: Weak password
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '503':
+          description: Native auth not available (no Postgres)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
   /api/v1/auth/token:
     post:
       tags:
@@ -3648,6 +3874,24 @@ paths:
           description: Bad request (invalid query parameters)
 components:
   schemas:
+    AccessTokenResponse:
+      type: object
+      description: |-
+        Response body carrying a freshly minted access token (login / refresh /
+        invite-accept). The refresh token is NOT in the body — it rides in the
+        HttpOnly cookie.
+      required:
+      - access_token
+      - expires_in
+      properties:
+        access_token:
+          type: string
+          description: 'The short-lived access JWT to present as `Authorization: Bearer`.'
+        expires_in:
+          type: integer
+          format: int64
+          description: Access-token lifetime in seconds.
+          minimum: 0
     ActionVolumeResponse:
       type: object
       description: Response for `GET /api/v1/analytics/action-volume`.
@@ -5151,6 +5395,21 @@ components:
           - string
           - 'null'
           description: Team the approval was routed to, if known.
+    AuthMethodsResponse:
+      type: object
+      description: |-
+        Response body for `GET /auth/methods` (ADR 0031 §Q5). Advertises which
+        credential paths this deployment can serve so the frontend degrades honestly.
+      required:
+      - methods
+      properties:
+        methods:
+          type: array
+          items:
+            type: string
+          description: |-
+            `["api_key"]` on an in-memory deployment; `["api_key","password"]` when a
+            Postgres store backs native accounts.
     BudgetAlertPayload:
       type: object
       description: |-
@@ -6453,6 +6712,49 @@ components:
         version:
           type: string
           description: Gateway version (semver from Cargo.toml).
+    InviteAcceptRequest:
+      type: object
+      description: Request body for `POST /auth/invite/accept`.
+      required:
+      - token
+      - password
+      properties:
+        password:
+          type: string
+          description: The initial password to set on the account (must clear the floor).
+        token:
+          type: string
+          description: The raw invite token delivered to the invitee.
+    InviteRequest:
+      type: object
+      description: Request body for `POST /auth/invite` (admin only).
+      required:
+      - email
+      - role
+      properties:
+        email:
+          type: string
+          description: The email to invite.
+        role:
+          $ref: '#/components/schemas/Role'
+          description: The role the invited account will receive on accept.
+    InviteResponse:
+      type: object
+      description: |-
+        Response body for `POST /auth/invite`. The raw invite token is returned once
+        to the inviting admin to deliver out of band; only its hash is stored.
+      required:
+      - invite_id
+      - token
+      properties:
+        invite_id:
+          type: string
+          description: The created invite id (UUID string).
+        token:
+          type: string
+          description: |-
+            The single-use, expiring raw invite token. Returned exactly once, here;
+            the server stores only its SHA-256 hash and can never surface it again.
     KpiResponse:
       type: object
       description: |-
@@ -6589,6 +6891,22 @@ components:
       - SandboxOomKilled
       - SandboxTerminated
       - SandboxHostFnRateLimited
+    LoginRequest:
+      type: object
+      description: Request body for `POST /auth/login`.
+      required:
+      - email
+      - password
+      properties:
+        email:
+          type: string
+          description: The account email (case-insensitive).
+        password:
+          type: string
+          description: The account password.
+        remember_me:
+          type: boolean
+          description: When true, the refresh session is issued with an extended lifetime.
     NodeBudget:
       type: object
       description: |-
@@ -7588,6 +7906,42 @@ components:
         op_id:
           type: string
           description: Stable identifier for the operation, typically a `GovernanceEvent.id`.
+    RegisterRequest:
+      type: object
+      description: Request body for `POST /auth/register`.
+      required:
+      - email
+      - password
+      properties:
+        email:
+          type: string
+          description: |-
+            The new account email (case-insensitive). OSS is single-workspace, so no
+            `tenant_name` is accepted (ADR 0031 §4).
+        password:
+          type: string
+          description: The new account password (must clear the minimum-length floor).
+    RegisterResponse:
+      type: object
+      description: Response body for a successful `POST /auth/register`.
+      required:
+      - user_id
+      - access_token
+      - expires_in
+      properties:
+        access_token:
+          type: string
+          description: |-
+            The short-lived access JWT for the bootstrap owner (the refresh token is
+            delivered as the HttpOnly cookie alongside).
+        expires_in:
+          type: integer
+          format: int64
+          description: Access-token lifetime in seconds.
+          minimum: 0
+        user_id:
+          type: string
+          description: The id of the newly created account (UUID string).
     ReplayPolicyRequest:
       type: object
       description: |-
@@ -7937,6 +8291,19 @@ components:
         ran_at:
           type: string
           description: Timestamp (UTC) at which the run completed (ISO 8601).
+    Role:
+      type: string
+      description: |-
+        A native-account user role (ADR 0031 data model).
+
+        Roles are a coarse, human-facing label stored on the user row; authorization
+        is still driven by the [`Scope`] set [`Role::scopes`] expands each role to.
+        Serialized lowercase to match the `users.role` enum values in the migration.
+      enum:
+      - owner
+      - admin
+      - developer
+      - viewer
     RoleCapabilitiesResponse:
       type: object
       description: One built-in RBAC role and the governance capabilities it grants.


### PR DESCRIPTION
## Description

ADR-0031 native-auth HTTP surface, building on the AAASM-5304 data layer. All Postgres-gated; the existing API-key `POST /auth/token` is **unchanged** and both paths mint the **same scoped JWT**.

**Endpoints** (+7 OpenAPI paths, 82→89): `login` (lockout→423, HttpOnly refresh cookie), `register` (first-user-owner bootstrap, advisory-locked), `invite` + `invite/accept`, `refresh` (rotating), `logout`, and public `GET /auth/methods` (`["api_key"]` vs `["api_key","password"]` by Postgres backing → honest FE degradation).

### Security (rule 7)
- Enumeration-safe uniform 401; refresh token opaque + SHA-256 at rest + HttpOnly/Secure/SameSite=Strict + rotated-on-use (replayed cookie loses the atomic `UPDATE … WHERE revoked_at IS NULL` race).
- Postgres-backed per-account lockout (`login_attempts`, threshold 5 / 15-min); the threshold-crossing attempt returns 423 + retry-after.
- Register bootstrap wrapped in one tx under `pg_advisory_xact_lock` — no double-owner race.
- Test passwords generated/non-literal where they reach a hasher; JWT carries no secret.
- A high-effort self-review caught & fixed 4 real defects (commit `134d4952`): lockout-crossing returned 401 not 423; non-atomic refresh rotation; dead-invite/swallowed error; token-burn on hash failure.

### Design decisions (flagged for review)
- **Shared JWT minting:** added `JwtSigner::sign_with_ttl` (additive) producing the identical `Claims` shape as `/auth/token`, differing only in TTL (15min access). `/auth/token` byte-unchanged.
- **Postgres-gating:** `AppState.auth_store: Option<Arc<PgUserStore>>` — `None` in every existing in-memory constructor; handlers return 503 when absent. No Postgres-backed AppState HTTP constructor exists in-repo yet, so the DB happy-path is covered at the store layer (Docker-gated tests), not full-app HTTP.
- **Schema additions to aa-storage-postgres** (`0009_login_attempts.sql` + store methods for bootstrap/refresh-lookup/invite-activation) — AAASM-5304 didn't ship these and the endpoints are impossible without them.
- **Deps (rule 9):** `aa-api` gains a direct dep on the in-workspace `aa-storage-postgres` (publish=false, like aa-api) and promotes `sha2` dev→runtime. No new external crates.
- **Product micro-decisions:** min password length 12; access 15min / refresh 12h / remember_me 30d; `/auth/invite` returns 409 on existing email (admin surface, consistent with register); `AA_AUTH_OPEN_REGISTRATION` (default false) for opt-in open registration.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5305 (Epic AAASM-5301; ADR-0031)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`aa-auth 66`, `aa-storage-postgres 39` (incl. 12 Docker-gated `user_store_pg`: bootstrap/lockout/refresh/invite), `api_openapi_contract 7` (path count 82→89), `native_auth_gating 4`. clippy `--all-targets` + fmt clean. The 3 `destinations.rs` webhook-egress failures are pre-existing env-gated flakes (branch touches zero connector/SSRF code). Dashboard `schema.d.ts` codegen not run locally (env) — CI catches drift. Authoritative build in CI.

## Checklist

- [x] Self-review of the diff completed (high-effort; fixed 4 defects)
- [x] Commits are small and follow the Gitmoji convention
- [ ] Commits are signed off — DCO optional/advisory here

🤖 Generated with [Claude Code](https://claude.com/claude-code)