### PR TITLE
[AAASM-5310] 📝 (docs): Correct Developer Integration claims that contradict the binary

### DIFF
--- a/docs/src/devtools/cli.md
+++ b/docs/src/devtools/cli.md
@@ -258,12 +258,31 @@ can be **discovered, planned and reported on**, but their plan step names no
 destination file, so the service refuses to apply it rather than reporting a
 success nothing performed.
 
-`verify` needs a probe that can adjudicate what the provider received. A default
-build has none — a client on the near side of the proxy cannot see the forwarded
-body — so `verify` reports the model path as configured but never exercised, the
-level stays at `Integrated`, and the command **exits `6`**. That is the honest
-reading: configuration alone is not evidence that anything inspected the traffic.
-See [Limitations](limitations.md#what-verify-adjudicates-and-when-it-still-exits-6).
+`verify` runs an adjudicated protection exercise and **exits `0`** once that
+exercise proves the protected path was exercised and the outcome was protective
+(AAASM-5300). The shipped probe, `AdjudicatingProbe`, marks its own request with
+a random 32-hex correlation id in the `x-agent-assembly-probe` header; the proxy
+reads that id back on the request it resolved to forward, re-inspects the bytes,
+and answers on that same connection with what it decided. A client on the near
+side of the proxy cannot see the forwarded body for itself, so `verify` never
+guesses at what happened to it — it only reports what the proxy adjudicated.
+
+`verify` still **exits `6`** — and most of the honest truth about this command
+lives in this list, not in the passing case — whenever it cannot measure that:
+
+* the protected path was never exercised;
+* the certificate authority is not trusted;
+* adjudication is unavailable;
+* the core is stopped;
+* the verdict belongs to another request than the one the probe sent;
+* the response it got back is not an adjudication at all;
+* the decision token in the response is one this build does not know;
+* the deployment is configured `alert_only` — observing is not protecting.
+
+Read exit `6` as "not measured", never as "measured and failed". Configuration
+alone is never evidence that anything inspected the traffic — only an
+adjudicated exercise is. See
+[Limitations](limitations.md#what-verify-adjudicates-and-when-it-still-exits-6).
 
 ## See also
 

--- a/docs/src/devtools/limitations.md
+++ b/docs/src/devtools/limitations.md
@@ -28,7 +28,7 @@ claim that traces to neither is not on this page.
 | Side-channel scoping (`*.anthropic.com`) | **Supported** | Condition C5. |
 | MCP loading control (`enabledMcpjsonServers` / `disabledMcpjsonServers`) | **Supported** | Optional, defence-in-depth. Never required for protection. |
 | Drift detection and repair | **Supported** | Detected at `status`/`verify` time, not in real time. |
-| Adjudicating protection probe | **Planned** | The default probe cannot see the forwarded body. |
+| Adjudicating protection probe | **Supported** | Shipped as the default probe (AAASM-5300); see [`verify`](#what-verify-adjudicates-and-when-it-still-exits-6). |
 | `strict` blocking on a high-severity scanner finding | **Planned** | [AAASM-5277](https://lightning-dust-mite.atlassian.net/browse/AAASM-5277), [AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281). Today `strict` redacts, like `recommended`. |
 | Endpoint managed-settings file | **Installable, opt-in and authorized** | [AAASM-5298](https://lightning-dust-mite.atlassian.net/browse/AAASM-5298). `--install-managed-settings`; verified by read-back. |
 | Endpoint managed-settings *enforcement* keys | **Still unmeasured** | Documented as non-overridable; no real override attempt has been measured against a managed device. |

--- a/docs/src/devtools/onboarding.md
+++ b/docs/src/devtools/onboarding.md
@@ -8,10 +8,11 @@ It is deliberately not a marketing walkthrough. Two of the steps below end in a
 state that is **weaker than you might expect**, and both are called out where you
 will hit them rather than in a footnote:
 
-* `aasm integrations verify claude-code` **exits `6` on a default build** — see
-  [Step 6](#step-6--verify-and-the-exit-6-you-will-see).
-* `Gateway Protected` is therefore **not reachable** from a default build, even
-  though the interception it describes was measured working end to end.
+* `aasm integrations verify claude-code` **exits `6` whenever the protected path
+  was never exercised and adjudicated** — see
+  [Step 6](#step-6--verify-and-the-exit-6-that-means-not-measured).
+* `Gateway Protected` **is** reachable on a default build once that exercise has
+  happened (AAASM-5300) — but a file existing is still never enough on its own.
 
 > **Scope.** Claude Code on macOS is the only natively migrated integration
 > ([AAASM-5281](https://lightning-dust-mite.atlassian.net/browse/AAASM-5281)).
@@ -349,7 +350,7 @@ esac
 | `<reason> — upgrade …` on connect | `4` | This `aasm` and the running core do not share a DI-API version. | Upgrade both; they ship as one versioned unit. |
 | A `DEGRADED` negotiation | — | The negotiated DI-API version lacks some verbs; `unavailable_verbs` names them. Never a silent downgrade. | Upgrade the older side. Do not use the missing verbs. |
 | `status` reports drift | `5` | Live state no longer matches the receipt. The reported level drops **before** repair is attempted. | `aasm integrations repair <tool>`. If unrepairable, reinstall. |
-| `this is NOT a protection measurement` | `6` | The protected path was not exercised. On a default build this is the expected outcome — see [Step 6](#step-6--verify-and-the-exit-6-you-will-see). | Launch through `aasm run claude` and verify again; on a default build the level stays `Integrated`. |
+| `this is NOT a protection measurement` | `6` | The protected path was never exercised and adjudicated — see [Step 6](#step-6--verify-and-the-exit-6-that-means-not-measured). | Launch through `aasm run claude` so traffic is produced, then verify again. |
 | `the install is partial — N step(s) failed` | — | Some steps applied, some did not. Never a reduced protection level. | `status`, then `repair` or `remove`. |
 | `no integration receipt records <tool>` | — | Nothing has been installed to act on. | `aasm integrations install <tool>` first. |
 | `the capability token at … is mode 644` | `8` | The token is readable by more than its owner, so it is **refused rather than used** — a filesystem mistake must not become a silent authentication downgrade. | `chmod 600` it and restart the runtime to re-issue. |

--- a/docs/src/devtools/product-brief.md
+++ b/docs/src/devtools/product-brief.md
@@ -627,7 +627,7 @@ because "no" without a reason gets re-litigated.
 
 | Non-goal | Why |
 |---|---|
-| **macOS Endpoint Security / Network Extension** | The only route to `Host Enforced` on macOS, and it carries entitlement, signing and distribution burdens far beyond MVP validation. Its absence is what makes §7.3 unavailable — a stated limitation, not a hidden gap. |
+| **macOS Endpoint Security / Network Extension** | A kernel-level route to host enforcement, and it carries entitlement, signing and distribution burdens far beyond MVP validation. `Host Enforced` (§7.3) is reached instead through an opt-in, authorized, read-back-verified managed-settings install (`AAASM-5298`); ES/NE's absence means that route specifically stays out of scope, not that §7.3 is unreachable. |
 | **Windows / Linux host enforcement** | Same reasoning; different mechanisms. `aa-ebpf` is Linux-only and is a detection layer that cannot modify traffic, so it is not a substitute. |
 | **Marketplace extensions** | Publishing to a tool's extension marketplace is a distribution and review-process problem. A reference shell (`AAASM-5282`) is enough to prove the plugin path. |
 | **Dynamic Rust plugin loading** | Adapters are build-time linked today; there is no `inventory`-style registration and no shared-library loading (`docs/devtools/plugins.md`). Adding dynamic loading would introduce a code-loading trust boundary for no MVP benefit. |

--- a/docs/src/devtools/protection-levels.md
+++ b/docs/src/devtools/protection-levels.md
@@ -20,7 +20,7 @@ reference. Where the two differ, the brief is canonical.
 | Level | One-line claim | Reachable today? |
 |---|---|---|
 | **Integrated** | The tool's *startup posture* is governed and its actions are attributable. | **Yes.** |
-| **Gateway Protected** | Model-bound and tool-bound traffic is inspected, redacted and allow/deny-enforced in flight. | **Mechanism proven; not reportable on a default build** — see [below](#why-gateway-protected-is-not-reportable-today). |
+| **Gateway Protected** | Model-bound and tool-bound traffic is inspected, redacted and allow/deny-enforced in flight. | **Yes, on a default build** — reported once the protected path has been exercised and adjudicated (AAASM-5300); see [below](#how-gateway-protected-becomes-reportable). |
 | **Host Enforced** | The tool's policy lives on a surface the developer cannot rewrite, verified by read-back after an authorized write. | **Opt-in only** — `--install-managed-settings`, macOS. A default install can never reach it. |
 
 Two reporting rules apply at every rung:


### PR DESCRIPTION
## Description

Fixes documentation that **contradicted the shipped binary**, and — as the sweep discovered — in two places contradicted **itself**.

This Epic's premise is that a claim without evidence is a defect. That applies to the documentation at least as much as to the product output, so these are defects rather than tidy-ups.

## Defect 1 — a page that said the opposite of what the binary does

`docs/src/devtools/cli.md:261` claimed:

> *"`verify` needs a probe that can adjudicate what the provider received. A default build has none … so `verify` reports the model path as configured but never exercised, the level stays at `Integrated`, and the command **exits `6`**."*

That became false when AAASM-5300 (#1838, `9081d845`) shipped `AdjudicatingProbe` **as the default**. `limitations.md:125` already said the opposite, so the docs contradicted both the code and each other.

A commit in that same PR set out to fix this exact paragraph — its message argues "a doc that contradicts the binary is worse than no doc" — but touched only the hyperlink on line 267, leaving the prose.

**Replaced with** the shipped behaviour: `AdjudicatingProbe` as default, the `x-agent-assembly-probe` correlation mechanism, exit `0` on protective adjudicated evidence, and the eight exit-`6` cases given **their own bullet list rather than a footnote** — never exercised · CA untrusted · adjudication unavailable · core stopped · verdict belongs to another request · response is not an adjudication · unknown decision token · `alert_only`.

The fail-closed cases are most of the truth about this command, so they get real space.

## Defect 2 — three broken anchors

mdbook's slugging is the trap: an em-dash yields a double hyphen, so an anchor that looks correct in Markdown does not resolve. **Verified against the generated HTML ids, not the Markdown source.**

| File:line | Old target | New target |
|---|---|---|
| `protection-levels.md:23` | `#why-gateway-protected-is-not-reportable-today` | `#how-gateway-protected-becomes-reportable` |
| `onboarding.md:12` | `#step-6--verify-and-the-exit-6-you-will-see` | `#step-6--verify-and-the-exit-6-that-means-not-measured` |
| `onboarding.md:352` | same | same |

Each confirmed by `grep 'id="…"' docs/book/devtools/*.html` → 1 hit.

The prose *adjacent* to those anchors was also still asserting "not reportable" / "not reachable" / "stays `Integrated`" as the default-build outcome — a heading rename does not explain that, it was simply never updated. Fixed too.

## Defect 3 — the sweep, which found two self-contradictions

Grepped all of `docs/src` for `exit 6`, `not reportable`, `not reachable`, `Planned` probe language, and every occurrence of `Host Enforced` / `Gateway Protected`:

1. **`limitations.md:31`** — the capability table listed *"Adjudicating protection probe | **Planned** | The default probe cannot see the forwarded body"*, two headings above the page's own section explaining what that probe adjudicates. → **Supported**.
2. **`product-brief.md:630`** — the §10.3 non-goals table claimed macOS Endpoint Security / Network Extension is *"the only route to `Host Enforced`"* and that its absence *"makes §7.3 unavailable"*, directly contradicting §7.3 and constraint C4 **in the same file**, which correctly describe `Host Enforced` as reachable via the AAASM-5298 managed-settings install. → reworded to keep ES/NE as an out-of-scope kernel-level route without claiming it is the only path.

**Nothing was found and deliberately left.** `governance/capability-matrix.md` and `adr/0030-*.md` already read correctly.

### Why this happened, and what it implies

AAASM-5300 and AAASM-5298 each updated the sections their authors were thinking about, and left the **summary tables, non-goals lists and capability matrices** that referenced the same facts from several screens away. Neither PR was careless — the stale claims were nowhere near the edit.

A link checker would not have caught any of these: they are semantically wrong, not structurally broken. The defence is to sweep the corpus for the **claim**, not just fix the paragraph in front of you.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Documentation only. Nothing outside `docs/**` is touched.

## Related Issues

- Jira: [AAASM-5310](https://lightning-dust-mite.atlassian.net/browse/AAASM-5310)
  (Epic [AAASM-5272](https://lightning-dust-mite.atlassian.net/browse/AAASM-5272))
- Corrects claims left stale by AAASM-5300 (#1838) and AAASM-5298 (#1840)
- Keeps the hedge that AAASM-5308 requires

## Security impact

Truthfulness of published security claims is the impact.

**Nothing was overstated in the other direction** — checked explicitly:

- `Host Enforced` still means *"the policy is installed where you cannot rewrite it"*, **not** *"this bypass was demonstrated to fail"*. AAASM-5308 remains open and the hedge is untouched.
- `Gateway Protected` still requires **adjudicated exercised** evidence; it was not softened to "verify passes".
- "A file existing is still never enough on its own" survives verbatim.

Under-claiming and over-claiming are both defects here. The previous state under-claimed (told users a working feature was unavailable); the risk in fixing it was over-correcting, and that was guarded against deliberately.

## Tests executed

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (explain why)

Documentation-only; no executable surface.

```
$ mdbook build docs
 INFO Book building has started
Warning: The mdbook-mermaid preprocessor was built against version 0.5.0 of mdbook,
         but we're being called from version 0.5.2
 INFO Running the html backend
 INFO HTML book written to `.../docs/book`
```

The mermaid version warning is pre-existing. Every touched anchor verified against generated HTML ids; working tree clean.

## Acceptance-criteria evidence

| AC | Evidence |
|---|---|
| `cli.md` describes current `verify` behaviour incl. all exit-6 cases | §Defect 1 — eight cases, own bullet list |
| The three anchors resolve, verified against generated HTML ids | §Defect 2 table, each `grep`-confirmed |
| Sweep confirms no page still claims verify always exits 6 / Gateway Protected unreachable / Host Enforced unavailable | §Defect 3 — two further self-contradictions found and fixed |
| Nothing overstated in the other direction | §Security impact |
| Consider link checking in the docs workflow | **Not done here** — see below |

## Known limitations

**Link checking was not added to `.github/workflows/docs.yml`.** It is listed as a "consider" in the ticket, and it would have caught Defect 2 but **none** of Defects 1 or 3, which are the more serious ones. Adding a CI gate that catches the least important third of this bug risks reading as coverage it does not provide. Worth doing on its own merits, as its own change, with an honest description of what it does and does not catch.

## Dependencies / stacked PRs

Cut from `main` @ `6632daf6`; independently mergeable. Developed in parallel with AAASM-5309, which owns `.ci/`, `aa-cli/`, `aa-runtime/` and `.github/` — no file overlaps.

## Documentation and migration impact

This PR is the documentation fix. No migration.

## Checklist

- [x] Code follows project style guidelines — N/A, no code changed
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (4 commits)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5310]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ