### PR TITLE
[AAASM-5309] 🐛 (aa-cli): Strip integrations from the published CLI and gate the surface

### DIFF
--- a/.ci/strip-for-publish.sh
+++ b/.ci/strip-for-publish.sh
@@ -69,6 +69,13 @@ DELETED_FILES=(
     "${REPO_ROOT}/aa-cli/src/commands/tools.rs"
     "${REPO_ROOT}/aa-cli/tests/run_command.rs"
     "${REPO_ROOT}/aa-integration-tests/tests/cli_run.rs"
+    # AAASM-5309: the `aasm integrations` CLI suites. `integrations_command.rs`
+    # drives the subcommand that no longer exists post-strip;
+    # `integrations_claude_code.rs` additionally imports
+    # `aa_runtime::devint::adapters`, which is deleted just below — it would
+    # fail to compile, not merely fail to pass.
+    "${REPO_ROOT}/aa-cli/tests/integrations_command.rs"
+    "${REPO_ROOT}/aa-cli/tests/integrations_claude_code.rs"
     # AAASM-2388: the audit consumer module + its integration test.
     "${REPO_ROOT}/aa-gateway/src/audit_consumer.rs"
     "${REPO_ROOT}/aa-gateway/tests/audit_consumer_e2e.rs"

--- a/.ci/strip-for-publish.sh
+++ b/.ci/strip-for-publish.sh
@@ -3,9 +3,12 @@
 #
 # WHY this exists.
 # ----------------
-# `aa-cli` wires `aasm run` + `aasm tools` to the `aa-devtool*` adapter
-# crates. The dev-tool subsystem isn't ready to ship in v0.0.1-alpha, so
-# the `aa-devtool*` crates are `publish = false`. Cargo's publish
+# `aa-cli` wires `aasm run`, `aasm tools` and `aasm integrations` to the
+# dev-tool subsystem — the first two directly to the `aa-devtool*` adapter
+# crates, the third (AAASM-5309) to the runtime's Developer Integration
+# API, whose bring-up this script also strips. The subsystem isn't ready to
+# ship in v0.0.1-alpha, so the `aa-devtool*` crates are
+# `publish = false`. Cargo's publish
 # verification rejects every dep with a `version = "..."` literal whose
 # target isn't on crates.io — including optional, feature-gated, and
 # target-cfg-conditional deps (empirically verified — see PR #843
@@ -56,8 +59,18 @@ MARKED_FILES=(
     "${REPO_ROOT}/aa-integration-tests/Cargo.toml"
     # AAASM-5280: the DI-API lifecycle service registers the built-in dev-tool
     # adapters through `aa-devtool` (publish = false). Removed so the published
-    # runtime has no held-back deps; it still binds the DI-API and simply has
-    # an empty integration registry.
+    # runtime has no held-back deps.
+    #
+    # AAASM-5309: what is removed here is the WHOLE DI-API bring-up — the
+    # `spawn_devint` definition in `runtime.rs` and its only call site — so a
+    # published aa-runtime never binds the DI-API socket. Nothing else does:
+    # after the strip the only surviving `DevIntServer::bind` is in
+    # `devint/testkit.rs`, which is `#[cfg(test)]`. That is precisely why
+    # `aasm integrations` — the CLI client of that socket — must be stripped
+    # from aa-cli too, and it is (region `devtool` in
+    # `aa-cli/src/commands/mod.rs`). Keeping the bind and shipping an honest
+    # empty registry was considered and rejected: no built-in adapter crate
+    # publishes, so that surface could only ever answer "no tools detected".
     "${REPO_ROOT}/aa-runtime/Cargo.toml"
     "${REPO_ROOT}/aa-runtime/src/devint/mod.rs"
     "${REPO_ROOT}/aa-runtime/src/runtime.rs"

--- a/.ci/strip-for-publish.sh
+++ b/.ci/strip-for-publish.sh
@@ -37,6 +37,12 @@
 # ------
 #   bash .ci/strip-for-publish.sh
 #
+# Set `STRIP_FOR_PUBLISH_VERIFY=0` to skip the trailing `cargo check`s.
+# Only `scripts/check-publish-surface.sh` does that: it runs this script on a
+# throwaway copy of the tree to *inspect* the stripped result, and the checks
+# would cost it several minutes of compilation. The release workflow never sets
+# it — the publish path always verifies.
+#
 # Exits 0 on success, non-zero on any failure. Idempotent: re-running on
 # an already-stripped tree is a no-op.
 
@@ -134,6 +140,12 @@ for f in "${DELETED_FILES[@]}"; do
         echo "  - deleted ${f#$REPO_ROOT/}"
     fi
 done
+
+if [[ "${STRIP_FOR_PUBLISH_VERIFY:-1}" != "1" ]]; then
+    echo ""
+    echo "strip-for-publish: STRIP_FOR_PUBLISH_VERIFY=0 — skipping the cargo checks"
+    exit 0
+fi
 
 # Sanity check: aa-cli must still compile without dev-tool surface.
 echo ""

--- a/.github/workflows/release-completeness.yml
+++ b/.github/workflows/release-completeness.yml
@@ -18,6 +18,13 @@ on:
       - ".github/workflows/release.yml"
       - ".github/workflows/release-completeness.yml"
       - "scripts/check-release-completeness.sh"
+      # AAASM-5309: the publish-surface gate reads the post-strip shape of the
+      # CLI's dispatch table and the runtime's DI-API bring-up, so it must run
+      # when either of those — or the strip itself — changes.
+      - ".ci/strip-for-publish.sh"
+      - "scripts/check-publish-surface.sh"
+      - "aa-cli/src/commands/mod.rs"
+      - "aa-runtime/src/runtime.rs"
   workflow_dispatch:
 
 jobs:
@@ -34,3 +41,16 @@ jobs:
 
       - name: Run release-artifact completeness gate
         run: bash scripts/check-release-completeness.sh
+
+  publish-surface:
+    # AAASM-5309: the sibling gate above proves the release *ships* what it
+    # should. This one proves what ships is coherent — that the published CLI
+    # does not advertise a command family whose server the strip removes. No
+    # toolchain: the gate strips a throwaway copy of the tree and reads it.
+    name: Published-surface coherence gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run published-surface coherence gate
+        run: bash scripts/check-publish-surface.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,9 +496,13 @@ jobs:
     #   * aa-devtool, aa-devtool-codex, aa-devtool-windsurf,
     #     aa-devtool-claude-code, aa-devtool-copilot, aa-devtool-saas
     #     — dev-tool subsystem held back from this alpha (user
-    #     directive: not feature-complete). aa-cli omits the related
-    #     `aasm run` / `aasm tools` subcommands accordingly; they
-    #     return once the subsystem is finished in a future PR.
+    #     directive: not feature-complete). aa-cli omits its whole
+    #     front door accordingly — `aasm run`, `aasm tools` AND
+    #     `aasm integrations` (AAASM-5309) — and aa-runtime omits the
+    #     Developer Integration API bring-up that `aasm integrations`
+    #     talks to, so nothing published advertises a surface nothing
+    #     published can serve. All of it returns together once the
+    #     subsystem is finished.
     #   * aa-api, conformance, aa-integration-tests, examples/* —
     #     cloud/enterprise consumers and workspace-internal tooling.
     #

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -20,7 +20,9 @@ pub mod cost;
 pub mod dashboard;
 pub mod gateway;
 pub mod gw_probe;
+// strip-for-publish:begin devtool
 pub mod integrations;
+// strip-for-publish:end devtool
 pub mod logs;
 pub mod permissions;
 pub mod pidfile;
@@ -76,9 +78,9 @@ pub enum Commands {
     Dashboard(dashboard::DashboardArgs),
     /// Manage the aa-gateway governance daemon — agent registry, policy engine, audit log.
     Gateway(gateway::GatewayArgs),
+    // strip-for-publish:begin devtool
     /// Install, verify, repair and remove Developer Integrations for AI dev tools.
     Integrations(integrations::IntegrationsArgs),
-    // strip-for-publish:begin devtool
     /// Launch an AI dev tool (claude, codex, copilot, windsurf) with governance wiring.
     Run(run::RunArgs),
     // strip-for-publish:end devtool
@@ -120,8 +122,8 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Cost(args) => cost::dispatch(args, ctx, output),
         Commands::Dashboard(args) => dashboard::dispatch(args, ctx),
         Commands::Gateway(args) => gateway::dispatch(args),
-        Commands::Integrations(args) => integrations::dispatch(args, output),
         // strip-for-publish:begin devtool
+        Commands::Integrations(args) => integrations::dispatch(args, output),
         Commands::Run(args) => run::dispatch(args, ctx, output),
         // strip-for-publish:end devtool
         Commands::Sandbox(args) => sandbox::dispatch(args),

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -27,8 +27,15 @@ aa-core                     = { path = "../aa-core", version = "0.0.1-rc.6", fea
 # implementation backs a tool). `aa-devtool*` are `publish = false`
 # (AAASM-2340), and cargo's publish verification rejects any dep whose target
 # is not on crates.io, so `.ci/strip-for-publish.sh` removes this region and
-# `src/devint/adapters.rs` before `cargo workspaces publish`. A published
-# aa-runtime still binds the DI-API; its integration registry is simply empty.
+# `src/devint/adapters.rs` before `cargo workspaces publish`.
+#
+# AAASM-5309: a published aa-runtime does NOT bind the DI-API. The same script
+# also removes `spawn_devint` and its call site from `src/runtime.rs`, leaving
+# `devint/testkit.rs` (`#[cfg(test)]`) as the only `DevIntServer::bind` in the
+# tree — so no published binary opens the socket, and the CLI's client for it,
+# `aasm integrations`, is stripped alongside. Binding anyway with an empty
+# registry was rejected: no built-in adapter crate publishes, so it could only
+# ever report "no tools detected".
 aa-devtool                  = { path = "../aa-devtool" }
 # AAASM-5281: Claude Code is the first natively migrated adapter, and its
 # registration needs three surfaces the registry's `Box<dyn DevToolAdapter>`

--- a/scripts/check-publish-surface.sh
+++ b/scripts/check-publish-surface.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# AAASM-5309: published-surface coherence gate.
+#
+# WHY: every other release gate is mechanical — `cargo metadata` resolves,
+# `cargo build --workspace` compiles, check-release-completeness.sh counts
+# binaries, the version-drift check compares strings. All of them passed, on
+# every rc, while the published `aasm` advertised `integrations` — a command
+# family whose server (`spawn_devint` in aa-runtime) `.ci/strip-for-publish.sh`
+# removes. The published CLI held the client, the published runtime held only
+# the server *type*, and nothing bound the socket. A `cargo install aasm` user
+# got a subcommand that autostarts a runtime, polls for a socket that never
+# appears, times out, and prints a hint pointing at code that was stripped.
+#
+# A build cannot catch that: the stripped tree compiles perfectly. It is a
+# coherence defect between two independently-stripped crates, so the check has
+# to be about the *shape of the published surface*, not about compilation.
+#
+# WHAT IT ASSERTS
+# ---------------
+# On the post-strip tree, for the Developer Integration API specifically:
+#
+#   If no published binary binds the DI-API socket, then no command the
+#   published CLI still advertises may be a client of it.
+#
+# Deliberately not a hardcoded list of held-back command names: the reachable
+# command set is read out of the stripped `aa-cli/src/commands/mod.rs` and the
+# client usage out of each surviving module's own sources, so a *new* DI-API
+# command added tomorrow is covered without anyone remembering to list it. The
+# implication also runs the other way — re-enable `spawn_devint` in the
+# published runtime and the gate stops objecting, which is the correct answer.
+#
+# HOW: runs the real `.ci/strip-for-publish.sh` (not a reimplementation of it)
+# over a throwaway copy of the tracked working tree, with the script's own
+# cargo verification switched off. No compilation; ~1 second.
+#
+# Usage: scripts/check-publish-surface.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# The DI-API client path. A CLI module that names this is talking to the socket
+# `spawn_devint` opens; nothing else in aa-cli has a reason to.
+DEVINT_CLIENT_PATH="aa_runtime::devint"
+# The runtime's DI-API bring-up. Present in the stripped tree => a published
+# aa-runtime binds the socket.
+DEVINT_BRINGUP="spawn_devint"
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# Copy the tracked working tree (not HEAD) so a developer running this locally
+# sees the effect of edits they have not committed yet.
+( cd "$REPO_ROOT" && git ls-files -z | tar --null -T - -cf - ) | tar -xf - -C "$WORK"
+
+echo "publish-surface gate: stripping a throwaway copy of the tree"
+STRIP_FOR_PUBLISH_VERIFY=0 bash "$WORK/.ci/strip-for-publish.sh" >/dev/null
+
+CLI_MOD="$WORK/aa-cli/src/commands/mod.rs"
+RUNTIME_RS="$WORK/aa-runtime/src/runtime.rs"
+
+for f in "$CLI_MOD" "$RUNTIME_RS"; do
+    [[ -f "$f" ]] || { echo "::error::expected file missing after strip: ${f#$WORK/}" >&2; exit 1; }
+done
+
+# Does anything in the published runtime actually bring the DI-API up? Comment
+# lines are excluded so a leftover mention in prose cannot vouch for a bind.
+if grep -v '^[[:space:]]*//' "$RUNTIME_RS" | grep -q "$DEVINT_BRINGUP"; then
+    echo "publish-surface gate: OK"
+    echo "  the published aa-runtime brings the DI-API up (${DEVINT_BRINGUP} survives the strip);"
+    echo "  published CLI clients of it are therefore coherent."
+    exit 0
+fi
+
+echo "  published aa-runtime does NOT bind the DI-API (${DEVINT_BRINGUP} is stripped)"
+
+fail=0
+# Command modules the published CLI still advertises, straight out of the
+# stripped dispatch table.
+while IFS= read -r m; do
+    [[ -n "$m" ]] || continue
+    src="$WORK/aa-cli/src/commands/$m.rs"
+    [[ -f "$src" ]] || src="$WORK/aa-cli/src/commands/$m"
+    [[ -e "$src" ]] || continue
+    if grep -rq "$DEVINT_CLIENT_PATH" "$src"; then
+        echo "::error::published \`aasm $m\` is a client of the Developer Integration API (${DEVINT_CLIENT_PATH}), but no published binary binds its socket — .ci/strip-for-publish.sh removes ${DEVINT_BRINGUP} from aa-runtime. A \`cargo install aasm\` user would get an advertised command that can only time out. Either wrap \`$m\` in a strip-for-publish region in aa-cli/src/commands/mod.rs, or stop stripping the runtime's DI-API bring-up (AAASM-5309)." >&2
+        fail=1
+    fi
+done < <(sed -n 's/^pub mod \([a-z_][a-z0-9_]*\);$/\1/p' "$CLI_MOD")
+
+if [ "$fail" -ne 0 ]; then
+    echo "publish-surface gate: FAILED" >&2
+    exit 1
+fi
+
+echo "publish-surface gate: OK"
+echo "  no command the published aa-cli advertises depends on the unbound DI-API"


### PR DESCRIPTION
## Description

The published `aasm` crate shipped a `--help`-advertised, fully-documented command family that **nothing in the published build could serve**.

`aasm integrations {list,plan,install,status,verify,repair,remove}` survived into the published crate, while `.ci/strip-for-publish.sh` removed both the `spawn_devint` definition (`aa-runtime/src/runtime.rs:11-191`) **and** its only call site (`:1023-1031`). After the strip the sole surviving `DevIntServer::bind` was in test-only `devint/testkit.rs`.

A `cargo install aasm` user ran any subcommand, the CLI autostarted `aa-runtime`, polled for a socket that never appeared, timed out, and was told to set `AA_DEVINT_ENABLED=1` — advice that **cannot** work, because the code reading that variable was stripped.

## The fix

**Strip `aasm integrations` from the published CLI, alongside `aasm run` and `aasm tools`**, because it is the same held-back subsystem's front door. AAASM-2340 deliberately holds the dev-tool subsystem back from this alpha — which is exactly why `run.rs` and `tools.rs` are already deleted on publish.

The alternative — keep the bind and ship an honest empty registry — was **considered and rejected**: no built-in adapter crate publishes (`aa-devtool*` are all `publish = false`), so that surface could only ever report "no tools detected". That is a differently-shaped false impression, not a fix. The rejection is recorded in the script so the next person doesn't rediscover it.

## Post-strip evidence, from a real stripped build

```
$ grep -rn "mod integrations" aa-cli/src/commands/mod.rs
(exit 1, no output)

$ grep -rn "DevIntServer::bind" aa-runtime/src/
aa-runtime/src/devint/testkit.rs:298      # #[cfg(test)] only

$ ./target/debug/aasm --help
… gateway / sandbox / topology / proxy / start / stop / uninstall / help
(no integrations, no run, no tools)

$ ./target/debug/aasm integrations list
error: unrecognized subcommand 'integrations'
```

## Two comments asserted the opposite and are now corrected

Both `.ci/strip-for-publish.sh:57-60` and `aa-runtime/Cargo.toml:31` claimed:

> *"A published aa-runtime still binds the DI-API; its integration registry is simply empty."*

It does not bind at all — the same script removes `spawn_devint` and its call site. Anyone reasoning about the release from those comments was being misled. Replaced with what is actually true, plus the considered-and-rejected alternative.

`.github/workflows/release.yml`'s omitted-surface note now lists all three subcommands and the runtime's omitted DI-API bring-up.

## The guard — because every existing gate was blind to this

This defect coexisted with green `cargo metadata`, workspace build, release-artifact completeness, version-drift and metadata-drift gates, plus 25–53 CI checks per PR. All of them are mechanical; **none examines the published surface.**

New `scripts/check-publish-surface.sh`, wired as a `publish-surface` job in `release-completeness.yml`. It runs the *real* strip over a throwaway copy of the tracked tree and asserts:

> **if no published binary binds the DI-API, then no command the published CLI still advertises may be a client of `aa_runtime::devint`.**

Both sides are **read out of the stripped tree, not from a hardcoded name list** — so a future DI-API command is covered automatically, and re-enabling `spawn_devint` correctly makes the objection disappear. ~1 s, no compilation.

**Proved load-bearing.** Clean → `publish-surface gate: OK … EXIT=0`. Unwrapped the `pub mod integrations;` region to make the defect reappear:

```
::error::published `aasm integrations` is a client of the Developer Integration API
(aa_runtime::devint), but no published binary binds its socket …
Either wrap `integrations` in a strip-for-publish region … (AAASM-5309)
publish-surface gate: FAILED
EXIT=1
```

Reverted with `git checkout HEAD -- …` (no stash) → OK / EXIT=0 again.

## A second, pre-existing latent break found on the way

`aa-cli/tests/integrations_claude_code.rs` imports `aa_runtime::devint::adapters`, which the strip already deleted — so the stripped tree could not compile its test targets. It survived because the strip script runs `cargo check -p aa-cli`, **not** `--all-targets`. Both `integrations_*` CLI suites are now in `DELETED_FILES`.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

No change to the development build — `aasm integrations` works exactly as before from source. The change is to what the **published** crate exposes, and it removes a command that could not function there.

## Related Issues

- Jira: [AAASM-5309](https://lightning-dust-mite.atlassian.net/browse/AAASM-5309)
  (Epic [AAASM-5272](https://lightning-dust-mite.atlassian.net/browse/AAASM-5272))
- Caused by: AAASM-5280 (#1827) · Governed by the standing decision in AAASM-2340

## Security impact

Truthfulness of the published surface. A CLI that advertises governance commands it cannot perform, and then blames the user's environment, is the same class of defect as over-claiming a protection level — the product asserting a capability it does not have. The new gate makes that assertion structurally checkable rather than a review convention.

## Tests executed

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required

**Stripped scratch copy:** `.ci/strip-for-publish.sh` exit 0 · `cargo metadata --no-deps` **exit 0** · `cargo build --workspace` **exit 0** (572 crates) · `aasm --help` verified · `scripts/check-release-completeness.sh` **OK** · `scripts/check-publish-surface.sh` **OK**, and **FAILED** as designed when the defect was reintroduced.

**Unstripped worktree:** `cargo fmt --all -- --check` **exit 0** · `cargo clippy --all-targets --all-features -- -D warnings` **exit 0** · `cargo nextest run -p aa-cli` (with `AASM_BIN_PATH` pinned) → **874 passed, 0 skipped** · `cargo build --workspace` **exit 0**.

The 6 remaining warnings are pre-existing `default-features` manifest notes.

## Acceptance-criteria evidence

| AC | Evidence |
|---|---|
| Published `aasm` exposes no `integrations` in `--help` or dispatch | Real stripped build, output above |
| Strip still yields `cargo metadata` + `cargo build --workspace` exit 0 | Both exit 0 |
| The two false comments corrected | `.ci/strip-for-publish.sh`, `aa-runtime/Cargo.toml` |
| `release.yml` omitted-surface comment lists `integrations` | Now lists all three plus the runtime bring-up |
| A check exists that catches this class again | `scripts/check-publish-surface.sh` + CI job, **proved failing** |

## Known limitations / reviewer question

`aa-cli/src/commands/integrations/**` remains in the publish tarball as **unreferenced, uncompiled source** — only the wiring is removed. That matches the script's stated "keep the source in tree" philosophy; `run.rs`/`tools.rs` are deleted because they are single whole modules rather than a directory. Happy to delete the directory on publish too if reviewers prefer strict symmetry.

The gate asserts a *coherence* property, not a functional one — it proves the published CLI does not advertise an unservable DI-API command. It does not prove the published tarballs compile against each other; `release.yml` publishes with `--no-verify`, which remains a broader pre-existing gap worth its own ticket.

## Dependencies / stacked PRs

Cut from `main` @ `6632daf6`; independently mergeable. Developed in parallel with AAASM-5310, which owns `docs/**` — no file overlaps.

## Documentation and migration impact

No user-facing docs change here (`docs/**` deliberately untouched). Note that the documentation describing `aasm integrations` remains correct for a **source build**, which is the only context in which the command exists.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (6 commits)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5309]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ