### PR TITLE
[AAASM-5313] 🐛 (aa-integration-tests): Fix loaderd path lookup and pin the eBPF nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -871,6 +871,20 @@ jobs:
         run: sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly branch @ 2026-06-27
         with:
+          # AAASM-5311: pin the actual nightly *release* date, not just the
+          # wrapper action commit above — the action SHA only pins which
+          # version of the GitHub Action runs; without an explicit `toolchain`
+          # input it still installs whatever nightly is current on the day the
+          # job runs. That floating nightly is what silently broke this job
+          # (a Cargo build-directory-layout change landed between 2026-07-26
+          # and 2026-07-30) with no repository change, and the AAASM-3446
+          # weekly schedule means the next `schedule` run would have hit it
+          # again with nothing to bisect. Bump this date **in its own PR**
+          # when a newer nightly feature is needed, and confirm CI is green
+          # on that PR before merging it — a stale pin fails safe (an older
+          # but working toolchain keeps building); a silent/untested bump
+          # does not.
+          toolchain: nightly-2026-07-30
           # Do NOT add bpfel-unknown-none to targets: there is no precompiled rust-std
           # for this target. BPF programs are built from source via -Zbuild-std=core
           # (configured in aa-ebpf-probes/.cargo/config.toml). Only rust-src is needed.
@@ -981,6 +995,11 @@ jobs:
           sudo apt-get install -y curl
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly branch @ 2026-06-27
         with:
+          # AAASM-5311: pin the nightly release date — same rationale as the
+          # `ebpf-build` job above (this job runs the very `e2e_ebpf` test
+          # that a floating nightly's layout change broke). Bump in its own
+          # PR, verified green, when a newer nightly feature is needed.
+          toolchain: nightly-2026-07-30
           # Same justification as the `ebpf-build` job: bpfel-unknown-none has
           # no precompiled rust-std, so the BPF probes build via
           # `-Zbuild-std=core` which needs rust-src on nightly.

--- a/aa-integration-tests/tests/e2e_ebpf.rs
+++ b/aa-integration-tests/tests/e2e_ebpf.rs
@@ -129,6 +129,11 @@ use aya::Ebpf;
 use tokio::net::UnixListener;
 use tokio::time::timeout;
 
+// AAASM-5311: pure path-resolution helpers, shared with the cross-platform
+// regression test in `tests/loaderd_bin_path.rs` — see that module's doc
+// comment for why this lives outside this (Linux-only) file.
+mod loaderd_path_support;
+
 // =============================================================================
 // Helpers — shared across the six tests
 // =============================================================================
@@ -538,44 +543,72 @@ async fn ebpf_load_and_unload_clean() {
 // AAASM-4033 — runtime → loaderd orchestration helpers (tests 7 & 8)
 // =============================================================================
 
-/// Resolve the `aa-ebpf-loaderd` binary: an explicit override, the sibling build
-/// artifact next to the test executable, or a one-shot `cargo build`.
+/// Name of the daemon binary this function locates.
+const LOADERD_BIN_NAME: &str = "aa-ebpf-loaderd";
+
+/// Resolve the `aa-ebpf-loaderd` binary: an explicit override, a fast
+/// sibling-search near the test executable, or the authoritative artifact
+/// path Cargo itself reports for a one-shot build.
 ///
 /// `cargo +nightly test -p aa-integration-tests` (the CI invocation) does not
 /// build sibling-crate binaries, so the daemon may not exist yet. The build
 /// fallback reuses the already-compiled `aa-ebpf` lib artifacts, so it is
 /// incremental.
+///
+/// AAASM-5311: this used to derive the daemon's directory from
+/// `current_exe().parent().parent()`, assuming `current_exe()` was always
+/// `<target>/<profile>/deps/e2e_ebpf-<hash>`. A Cargo nightly build-directory
+/// layout change moved the test binary itself elsewhere
+/// (`<target>/<profile>/build/aa-integration-tests/<hash>/out/...`), so that
+/// fixed two-`.parent()` chain silently pointed at the wrong directory and
+/// the subsequent `candidate.exists()` check failed even though the earlier
+/// `cargo build` fallback had *already* placed the binary at the real
+/// `<target>/<profile>/aa-ebpf-loaderd`. `current_exe()`-relative `target/`
+/// layout is a Cargo implementation detail, not a stable contract — it has
+/// moved before and will move again, so do not reintroduce a fixed-depth
+/// `.parent()` chain here. [`loaderd_path_support::find_sibling_binary`]
+/// tolerates any depth, and the `cargo build` fallback below now asks Cargo
+/// directly (via `--message-format=json-render-diagnostics`) where it put
+/// the artifact instead of re-deriving the path, so it stays correct under
+/// any future layout too.
 fn loaderd_bin_path() -> PathBuf {
     if let Some(p) = std::env::var_os("AA_EBPF_LOADERD_BIN") {
         return PathBuf::from(p);
     }
-    // current_exe() is `<target>/<profile>/deps/e2e_ebpf-<hash>`; the daemon
-    // binary lands at `<target>/<profile>/aa-ebpf-loaderd`.
     let exe = std::env::current_exe().expect("current_exe");
-    let profile_dir = exe
-        .parent()
-        .and_then(|deps| deps.parent())
-        .expect("target profile dir")
-        .to_path_buf();
-    let candidate = profile_dir.join("aa-ebpf-loaderd");
-    if candidate.exists() {
+    if let Some(candidate) = loaderd_path_support::find_sibling_binary(&exe, LOADERD_BIN_NAME) {
         return candidate;
     }
+
     let cargo = option_env!("CARGO").unwrap_or("cargo");
-    let status = Command::new(cargo)
-        .args(["build", "-p", "aa-ebpf", "--bin", "aa-ebpf-loaderd"])
-        .status()
+    let output = Command::new(cargo)
+        .args([
+            "build",
+            "-p",
+            "aa-ebpf",
+            "--bin",
+            LOADERD_BIN_NAME,
+            "--message-format=json-render-diagnostics",
+        ])
+        .output()
         .expect("failed to invoke cargo to build aa-ebpf-loaderd");
+    // Distinct failure mode #1: the build itself failed — surface stderr so
+    // this reads differently from "build succeeded but we couldn't find it".
     assert!(
-        status.success(),
-        "`cargo build -p aa-ebpf --bin aa-ebpf-loaderd` failed"
+        output.status.success(),
+        "`cargo build -p aa-ebpf --bin {LOADERD_BIN_NAME}` failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
     );
-    assert!(
-        candidate.exists(),
-        "aa-ebpf-loaderd missing at {} after build",
-        candidate.display()
-    );
-    candidate
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Distinct failure mode #2: the build succeeded but Cargo's own JSON
+    // output doesn't mention the artifact — a lookup/parsing bug, not a
+    // build failure.
+    loaderd_path_support::parse_executable_from_cargo_json(&stdout, LOADERD_BIN_NAME).unwrap_or_else(|| {
+        panic!(
+            "cargo build -p aa-ebpf --bin {LOADERD_BIN_NAME} succeeded but no matching \
+             compiler-artifact executable was found in its JSON output"
+        )
+    })
 }
 
 /// A spawned `aa-ebpf-loaderd` daemon bound to a private control socket, killed

--- a/aa-integration-tests/tests/loaderd_bin_path.rs
+++ b/aa-integration-tests/tests/loaderd_bin_path.rs
@@ -1,0 +1,130 @@
+//! AAASM-5311 — cross-platform regression tests for the `aa-ebpf-loaderd`
+//! path-resolution helpers used by `e2e_ebpf.rs::loaderd_bin_path()`.
+//!
+//! `e2e_ebpf.rs` is `#![cfg(all(target_os = "linux", feature = "integration-test"))]`
+//! (it links `aa-ebpf`/`aya`, which don't build off Linux), so it cannot run
+//! its own `#[test]`s on a macOS dev machine. This file is unconditional —
+//! no `cfg` gate, no Linux-only dependency — and `mod`-includes the exact
+//! same `loaderd_path_support` module that `e2e_ebpf.rs` calls in
+//! production, so what's tested here is what actually runs in CI.
+//!
+//! The case this exists to guard: a Cargo nightly build-directory layout
+//! change moved the test binary itself out from under `target/<profile>/deps/`,
+//! which broke a fixed `current_exe().parent().parent()` assumption even
+//! though the sibling `aa-ebpf-loaderd` binary was built correctly. See the
+//! module doc on `loaderd_path_support` and the comment on
+//! `e2e_ebpf::loaderd_bin_path` for the full history.
+
+mod loaderd_path_support;
+
+use std::fs;
+use std::path::PathBuf;
+
+/// The exact failure mode AAASM-5311 fixed: the "current test executable" is
+/// several directories above the profile dir that holds the sibling binary —
+/// not exactly two, as the old `.parent().parent()` chain assumed. Walking
+/// ancestors must still find it.
+#[test]
+fn find_sibling_binary_locates_binary_under_new_nightly_layout() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let profile_dir = tmp.path().join("target").join("debug");
+    // Mirrors target/debug/build/aa-integration-tests/<hash>/out/e2e_ebpf-<hash>
+    let nested_exe_dir = profile_dir
+        .join("build")
+        .join("aa-integration-tests")
+        .join("abcd1234")
+        .join("out");
+    fs::create_dir_all(&nested_exe_dir).expect("mkdir nested (new-layout) exe dir");
+    let fake_exe = nested_exe_dir.join("e2e_ebpf-deadbeef");
+    fs::write(&fake_exe, b"").expect("write fake test exe");
+
+    let real_bin = profile_dir.join("aa-ebpf-loaderd");
+    fs::write(&real_bin, b"").expect("write fake aa-ebpf-loaderd");
+
+    let found = loaderd_path_support::find_sibling_binary(&fake_exe, "aa-ebpf-loaderd")
+        .expect("should locate aa-ebpf-loaderd by walking ancestors of a deeply-nested exe path");
+    assert_eq!(found, real_bin);
+}
+
+/// The old layout (`target/<profile>/deps/<name>-<hash>`, two levels above
+/// the daemon binary) must still resolve — the fix must not regress it.
+#[test]
+fn find_sibling_binary_locates_binary_under_old_deps_layout() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let profile_dir = tmp.path().join("target").join("debug");
+    let deps_dir = profile_dir.join("deps");
+    fs::create_dir_all(&deps_dir).expect("mkdir deps dir");
+    let fake_exe = deps_dir.join("e2e_ebpf-5fafa8cfcc64d109");
+    fs::write(&fake_exe, b"").expect("write fake test exe");
+
+    let real_bin = profile_dir.join("aa-ebpf-loaderd");
+    fs::write(&real_bin, b"").expect("write fake aa-ebpf-loaderd");
+
+    let found = loaderd_path_support::find_sibling_binary(&fake_exe, "aa-ebpf-loaderd")
+        .expect("should still locate aa-ebpf-loaderd under the old deps/ layout");
+    assert_eq!(found, real_bin);
+}
+
+/// When the binary genuinely isn't anywhere above the exe (not yet built),
+/// resolution must report absence rather than panicking or fabricating a path
+/// — the caller relies on `None` to trigger the `cargo build` fallback.
+#[test]
+fn find_sibling_binary_returns_none_when_absent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let exe_dir = tmp.path().join("target").join("debug").join("deps");
+    fs::create_dir_all(&exe_dir).expect("mkdir");
+    let fake_exe = exe_dir.join("e2e_ebpf-deadbeef");
+    fs::write(&fake_exe, b"").expect("write fake test exe");
+
+    assert!(loaderd_path_support::find_sibling_binary(&fake_exe, "aa-ebpf-loaderd").is_none());
+}
+
+/// The authoritative fallback: parsing real `cargo build
+/// --message-format=json-render-diagnostics` stdout must pick out the
+/// `executable` field of the matching `compiler-artifact` message and ignore
+/// unrelated artifacts (e.g. the `aa-ebpf` lib target built as a dependency).
+#[test]
+fn parse_executable_from_cargo_json_extracts_matching_artifact() {
+    let stdout = concat!(
+        r#"{"reason":"compiler-artifact","target":{"name":"aa-ebpf"},"executable":null}"#,
+        "\n",
+        r#"{"reason":"compiler-artifact","target":{"name":"aa-ebpf-loaderd"},"executable":"/repo/target/debug/aa-ebpf-loaderd"}"#,
+        "\n",
+        r#"{"reason":"build-finished","success":true}"#,
+        "\n",
+    );
+
+    let found = loaderd_path_support::parse_executable_from_cargo_json(stdout, "aa-ebpf-loaderd");
+    assert_eq!(found, Some(PathBuf::from("/repo/target/debug/aa-ebpf-loaderd")));
+}
+
+/// No message for the requested target name — e.g. the build was invoked for
+/// the wrong package — must report absence rather than picking an unrelated
+/// artifact.
+#[test]
+fn parse_executable_from_cargo_json_returns_none_when_target_absent() {
+    let stdout = concat!(
+        r#"{"reason":"compiler-artifact","target":{"name":"aa-ebpf"},"executable":"/repo/target/debug/aa-ebpf"}"#,
+        "\n",
+    );
+
+    assert_eq!(
+        loaderd_path_support::parse_executable_from_cargo_json(stdout, "aa-ebpf-loaderd"),
+        None
+    );
+}
+
+/// Non-JSON / malformed lines (Cargo interleaves plain-text warnings even
+/// under `--message-format=json-render-diagnostics` in some versions) must be
+/// skipped rather than panicking the parser.
+#[test]
+fn parse_executable_from_cargo_json_skips_malformed_lines() {
+    let stdout = concat!(
+        "warning: unused import\n",
+        r#"{"reason":"compiler-artifact","target":{"name":"aa-ebpf-loaderd"},"executable":"/repo/target/debug/aa-ebpf-loaderd"}"#,
+        "\n",
+    );
+
+    let found = loaderd_path_support::parse_executable_from_cargo_json(stdout, "aa-ebpf-loaderd");
+    assert_eq!(found, Some(PathBuf::from("/repo/target/debug/aa-ebpf-loaderd")));
+}

--- a/aa-integration-tests/tests/loaderd_path_support/mod.rs
+++ b/aa-integration-tests/tests/loaderd_path_support/mod.rs
@@ -1,0 +1,67 @@
+//! AAASM-5311 — pure, platform-independent helpers for locating a
+//! cargo-built binary artifact, factored out of `e2e_ebpf.rs::loaderd_bin_path()`
+//! so they can be unit-tested without Linux, root, or `aa-ebpf`/`aya`.
+//!
+//! `e2e_ebpf.rs` (the production consumer of these helpers) is
+//! `#![cfg(target_os = "linux")]`-gated because it links `aa-ebpf`/`aya`,
+//! which don't build off Linux — so it can't run its own `#[test]`s on a
+//! macOS dev machine. This module has no such dependency (std + `serde_json`
+//! only, both available on every platform this crate builds on) and is
+//! `mod`-included by both `e2e_ebpf.rs` and `../loaderd_bin_path.rs` (the
+//! cross-platform regression test), so the code under test is the exact
+//! code that ships to CI, not a parallel reimplementation that could drift.
+//!
+//! ## Why this exists
+//!
+//! A Cargo nightly build-directory-layout change (observed between
+//! 2026-07-26 and 2026-07-30) moved test binaries from
+//! `target/<profile>/deps/<name>-<hash>` to
+//! `target/<profile>/build/<crate>/<hash>/out/<name>-<hash>`. The old lookup
+//! assumed `current_exe().parent().parent()` was always exactly the
+//! `<profile>` directory — true only under the old layout. `current_exe()`-
+//! relative `target/` layout is a Cargo implementation detail, not a stable
+//! contract (it has changed before and will change again); do not reintroduce
+//! a fixed-depth `.parent()` chain here or elsewhere.
+
+use std::path::{Path, PathBuf};
+
+/// Walk upward from `start` (inclusive of `start`'s own directory) looking
+/// for a sibling file named `bin_name` in each ancestor directory.
+///
+/// This tolerates any `target/` layout depth between the current test
+/// executable and the sibling binary, unlike a fixed `.parent().parent()`
+/// chain. It is a fast, cargo-free pre-check; the authoritative source of
+/// truth (immune to *future* layout changes too, since it asks Cargo
+/// directly) is [`parse_executable_from_cargo_json`].
+pub(crate) fn find_sibling_binary(start: &Path, bin_name: &str) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .map(|dir| dir.join(bin_name))
+        .find(|candidate| candidate.exists())
+}
+
+/// Parse `cargo build --message-format=json-render-diagnostics` stdout
+/// (newline-delimited JSON messages) for the `executable` path reported by
+/// the `compiler-artifact` message whose target name is `target_name`.
+///
+/// This is authoritative regardless of `target/` directory layout, present
+/// or future, because it asks Cargo directly where it placed the artifact
+/// rather than guessing from `current_exe()`.
+pub(crate) fn parse_executable_from_cargo_json(stdout: &str, target_name: &str) -> Option<PathBuf> {
+    for line in stdout.lines() {
+        let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if msg.get("reason").and_then(|r| r.as_str()) != Some("compiler-artifact") {
+            continue;
+        }
+        let name_matches = msg.get("target").and_then(|t| t.get("name")).and_then(|n| n.as_str()) == Some(target_name);
+        if !name_matches {
+            continue;
+        }
+        if let Some(exe) = msg.get("executable").and_then(|e| e.as_str()) {
+            return Some(PathBuf::from(exe));
+        }
+    }
+    None
+}


### PR DESCRIPTION
## Description

`e2e — Layer 3 eBPF (Linux)` broke with **no repository change**. A Cargo build-directory layout change landed in nightly between 2026-07-26 and 2026-07-30, moving test binaries out of `target/<profile>/deps/`:

```
was: target/debug/deps/e2e_ebpf-5fafa8cfcc64d109                              # nightly dc3f85158 (07-26) — green
now: target/debug/build/aa-integration-tests/<hash>/out/e2e_ebpf-<hash>        # nightly 8ab9fdff5 (07-30) — red
```

`aa-integration-tests/tests/e2e_ebpf.rs:552-558` derived the target profile directory with `exe.parent().parent()`, hardcoding the `<target>/<profile>/deps/<name>` assumption in a comment at `:552`. Under the new layout that lands in the build-script output directory instead, so the lookup failed at `:573`.

**The build was never the problem.** The fallback `cargo build -p aa-ebpf --bin aa-ebpf-loaderd` at `:566` succeeded and wrote the binary to the real `target/debug/` — no panic at `:568`. Only the *lookup* was wrong, so the assertion fired against a correctly-built binary. The fix preserves that distinction: build failure and lookup failure now panic with **different** messages.

## The fix

New `aa-integration-tests/tests/loaderd_path_support/mod.rs` — pure, dependency-light resolution helpers:

1. **Fast path** — walk `exe.ancestors()` for the first directory containing `aa-ebpf-loaderd`. Tolerates any layout depth, costs nothing.
2. **Authoritative fallback** — run the existing `cargo build` with `--message-format=json-render-diagnostics` and read the `executable` field from the matching `compiler-artifact` message. Correct under any layout, present or future.

A comment records **why** no `current_exe()`-relative `target/` layout assumption may be reintroduced: they are not stable across Cargo versions, as this incident demonstrates.

## Nightly is now actually pinned

Both eBPF jobs now pass `toolchain: nightly-2026-07-30` to `dtolnay/rust-toolchain`.

**Previously only the wrapper Action's SHA was pinned — which pins the Action, not the Rust release.** The job has been floating on whatever nightly resolved that morning, so this class of breakage was going to arrive eventually regardless of the path bug.

The pin is deliberately set to **`2026-07-30`, the nightly that exposed the bug** — not back to `07-26`. CI therefore runs against the *new* layout and proves the fix, rather than masking it by reverting to the old one. The update procedure is documented in a comment: bump the date in its own PR, verified green before merge, since a stale pin is its own failure mode.

## This would have broken `main` on its own

The job also runs on a **weekly schedule** (`ci.yml:117-124`) and has passed six consecutive Mondays — 07-27, 07-20, 07-13, 07-06, 06-29, 06-22, most recently SHA `dab8a70b`. **The next scheduled run, Monday 2026-08-03, would have failed identically on `main`** without this.

Worth recording because it was the first hypothesis and it is wrong: eBPF coverage has **not** been silently skipped behind the path gate. Six consecutive green weekly runs; the only gap is the ~4-day nightly-drift window.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Test infrastructure and CI configuration only. No product code.

## Related Issues

- Jira: [AAASM-5313](https://lightning-dust-mite.atlassian.net/browse/AAASM-5313)
- **Exposed by** PR #1843 (AAASM-5309), which is causally unrelated: its comment-only edit to `.github/workflows/release.yml` flipped the `ebpf` dorny filter true (`ci.yml:255-260` lists that file), un-skipping an already-broken job.
- GitHub issues: N/A

## Tests executed

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

**The regression is now covered by tests that run on every platform**, not only on the Linux-only e2e lane. `aa-integration-tests/tests/loaderd_bin_path.rs` — 6 tests covering new-layout resolution, old-layout resolution, absence, and JSON parsing including malformed lines.

### Proved load-bearing

Reverted `find_sibling_binary` to the old `parent().parent()` chain and re-ran:

```
test find_sibling_binary_locates_binary_under_new_nightly_layout ... FAILED
panicked at loaderd_bin_path.rs:45:10:
  should locate aa-ebpf-loaderd by walking ancestors of a deeply-nested exe path
Summary: 6 tests run: 5 passed, 1 failed
```

Exactly the intended test failed; the old-layout and negative tests stayed green. Reverted; 6/6 pass.

### `current_exe` sweep — 4 other sites, none share the bug

Checked for the *pattern*, not the function name. All four correctly left alone:

| Site | Why it is not affected |
|---|---|
| `aa-gateway/src/dashboard_server.rs:64` | Production install layout (`bin/` beside `dashboard/dist/`); already has a hermetic-test seam |
| `aa-cli/src/commands/integrations/session.rs:101` | Single `.parent()` sibling lookup for an installed binary |
| `aa-cli/src/commands/gateway/start.rs:161` | Same pattern |
| `aa-storage-sqlite-buffer/tests/kill_restart.rs:50` | Re-execs itself; derives no sibling path |

### Validation

`cargo fmt --all` clean · `cargo clippy -p aa-integration-tests --all-targets -- -D warnings` **exit 0** · full-workspace `cargo clippy --all-targets --all-features -- -D warnings` **exit 0** · `cargo build --workspace` succeeds · `cargo nextest run -p aa-integration-tests --test loaderd_bin_path` → **6/6 pass**.

**Could not verify locally, and CI must confirm:** the actual Linux `e2e_ebpf` run needs root, `CAP_BPF`/`CAP_PERFMON`, and a Linux kernel — none available on macOS, where the test compiles to an empty crate and reports "0 tests run" (unchanged, expected). `cargo check -p aa-integration-tests --target x86_64-unknown-linux-gnu` also failed for lack of a cross-linker (`x86_64-linux-gnu-gcc` not found) — a missing toolchain here, not a code issue.

## Acceptance-criteria evidence

| AC | Evidence |
|---|---|
| The test passes under the current nightly | CI must confirm on Linux; the resolution logic is unit-proved on macOS |
| The binary is located without assuming a `target/` layout | Ancestor walk + cargo JSON `executable` field |
| The fix is proved against the failure mode | Old logic reinstated → the new-layout test failed; output above |
| A comment prevents reintroducing the assumption | In `loaderd_path_support/mod.rs`, with the WHY |
| Decide whether to pin nightly | **Pinned**, to the nightly that exposed the bug, with a documented update procedure |

## Known limitations

The pin means a future Cargo layout change will be caught on a deliberate bump rather than on a Monday morning — which is the intent, but it does mean the eBPF lane no longer exercises the newest nightly continuously. That trade is recorded in the workflow comment.

## Dependencies / stacked PRs

Cut from `main`. **PR #1843 (AAASM-5309) should be rebased onto this once it merges**, so its red eBPF check clears honestly rather than by admin override.

## Documentation and migration impact

None — test infrastructure and CI config.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — comment recorded in-code
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (4 commits)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5313]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ