### PR TITLE
[AAASM-5315] 🐛 (release): Ship required files in published crates and gate the packaged artifact

### DIFF
--- a/.github/workflows/release-completeness.yml
+++ b/.github/workflows/release-completeness.yml
@@ -25,6 +25,16 @@ on:
       - "scripts/check-publish-surface.sh"
       - "aa-cli/src/commands/mod.rs"
       - "aa-runtime/src/runtime.rs"
+      # AAASM-5315/5316: the packaged-artifact gate below is decided by what
+      # cargo's file enumeration sees, so it must run when anything that moves
+      # that boundary moves — a crate's `include`/manifest, a .gitignore that
+      # can silently drop a staged directory, the offline query cache that has
+      # to be staged into a crate, or either staging script.
+      - "**/Cargo.toml"
+      - "**/.gitignore"
+      - ".sqlx/**"
+      - ".ci/**"
+      - "scripts/**"
   workflow_dispatch:
 
 jobs:
@@ -54,3 +64,49 @@ jobs:
 
       - name: Run published-surface coherence gate
         run: bash scripts/check-publish-surface.sh
+
+  packaged-artifacts:
+    # AAASM-5315/5316: the two gates above reason about the SOURCE tree. This one
+    # reasons about the tarball. `release.yml` publishes with `--no-verify`
+    # (it has to — see the comment on that call), so nothing ever unpacked a
+    # crate and compiled it in isolation, and two defects of exactly that class
+    # shipped: aa-cli with no dashboard, aa-gateway that could not compile for
+    # any consumer. This job reconstructs what verify would have proved.
+    #
+    # It lives on `pull_request`, not on the tag: a packaging defect found at
+    # tag-cut time is already a broken release with a burned version number.
+    name: Packaged-artifact gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # aa-proto's build.rs (which stages _embedded/proto/) compiles protobuf.
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      # Same dashboard build release.yml runs before staging into
+      # aa-cli/_embedded — the gate asserts the real bundle ships, not a stub.
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.9.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+
+      - name: Build dashboard
+        working-directory: dashboard
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Run packaged-artifact gate
+        run: bash scripts/check-packaged-artifacts.sh

--- a/.github/workflows/release-completeness.yml
+++ b/.github/workflows/release-completeness.yml
@@ -73,8 +73,12 @@ jobs:
     # shipped: aa-cli with no dashboard, aa-gateway that could not compile for
     # any consumer. This job reconstructs what verify would have proved.
     #
-    # It lives on `pull_request`, not on the tag: a packaging defect found at
-    # tag-cut time is already a broken release with a burned version number.
+    # It lives on `pull_request` so a packaging defect surfaces before the tag
+    # — one found at tag-cut time is already a broken release with a burned
+    # version number. `release.yml` runs the same script again as a
+    # `packaged-artifact-gate` job that `publish-crates` needs, because this
+    # run is path-filtered and sees a PR head rather than the tree that ships,
+    # so it cannot itself be the precondition of an irreversible publish.
     name: Packaged-artifact gate
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -480,6 +480,56 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
 
+  packaged-artifact-gate:
+    # AAASM-5315/5316: the LAST thing standing between a tag and crates.io.
+    #
+    # The same gate also runs on every PR (release-completeness.yml), which is
+    # where a packaging defect *should* be caught. This run exists because that
+    # one cannot be a precondition of publishing: it is path-filtered, it runs
+    # against a PR head rather than the merge result, and a tag can be cut from
+    # a commit whose PR never triggered it at all. Something that decides what
+    # ships has to have looked at the tree that ships.
+    #
+    # Publishing is irreversible — crates.io does not allow re-uploading a
+    # version — so the ~8 minutes this costs is bounded and the failure it
+    # prevents is not.
+    name: Packaged-artifact gate (pre-publish)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # aa-proto's build.rs (which stages _embedded/proto/) compiles protobuf.
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.9.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+
+      # The gate asserts the real bundle ships, so it needs the same dashboard
+      # build publish-crates stages into aa-cli/_embedded.
+      - name: Build dashboard
+        working-directory: dashboard
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Run packaged-artifact gate
+        run: bash scripts/check-packaged-artifacts.sh
+
   publish-crates:
     # Publishes the workspace to crates.io in topological order via
     # cargo-workspaces. AAASM-2340 (resolves AAASM-2094).
@@ -514,7 +564,10 @@ jobs:
     # binary with only a stub "dashboard not built" page.
     name: Publish workspace to crates.io
     runs-on: ubuntu-latest
-    needs: publish
+    # AAASM-5315/5316: packaged-artifact-gate is a hard precondition, not
+    # advisory — nothing reaches crates.io that has not been packaged, had its
+    # tarball contents asserted, and been built back out of those tarballs.
+    needs: [publish, packaged-artifact-gate]
     if: github.event_name == 'push'
     # AAASM-4016: gate this publish behind a protected GitHub Environment so a
     # required-reviewer approval is needed before CRATES_IO_TOKEN is exposed and
@@ -645,10 +698,13 @@ jobs:
           # proves the workspace builds" — was false: a workspace build never
           # separates a crate from its siblings, which is exactly the defect
           # class verify exists to catch, and two such defects (5315, 5316)
-          # shipped through it. `scripts/check-packaged-artifacts.sh` now runs
-          # on every PR and reconstructs what verify would have proved —
-          # package, assert tarball contents, then build the real binaries out
-          # of the unpacked tarballs — without re-entering the aa-ebpf failure.
+          # shipped through it. `scripts/check-packaged-artifacts.sh` now
+          # reconstructs what verify would have proved — package, assert
+          # tarball contents, then build the real binaries out of the unpacked
+          # tarballs — without re-entering the aa-ebpf failure. It runs on
+          # every PR for early feedback AND as the `packaged-artifact-gate`
+          # job this one `needs`, so it is a precondition of this publish and
+          # not merely something that ran earlier on some other tree.
           cargo workspaces publish \
             --from-git \
             --no-git-push \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,6 +599,22 @@ jobs:
              aa-ebpf/_embedded/aa-ebpf-probes/Cargo.toml.embedded
           echo "✓ aa-ebpf/_embedded/aa-ebpf-probes/ staged ($(find aa-ebpf/_embedded -type f | wc -l) files)"
 
+      - name: Stage .sqlx offline query cache into aa-gateway for crates.io publish
+        # AAASM-5315: aa-gateway expands `sqlx::query!` at compile time in
+        # `approval/sqlite_repo.rs` + `approval/db_escalation_scheduler.rs`.
+        # Without a DATABASE_URL those macros read the offline cache, which
+        # lives at the WORKSPACE root — outside the package, and cargo's
+        # `include` cannot escape the package directory. Mirror it in so the
+        # published crate compiles for a consumer who has no database at all.
+        # Kept as a staged copy (not a committed second copy) so the root
+        # `.sqlx/` stays the only thing `cargo sqlx prepare` has to regenerate.
+        run: |
+          set -euo pipefail
+          rm -rf aa-gateway/.sqlx
+          cp -r .sqlx aa-gateway/.sqlx
+          test -n "$(ls -A aa-gateway/.sqlx)"
+          echo "✓ aa-gateway/.sqlx/ staged ($(find aa-gateway/.sqlx -type f | wc -l) files)"
+
       - name: Strip held-back surface from aa-cli for crates.io publish
         # AAASM-2340: removes the `aa-devtool*` deps and the source files
         # that consume them (`aasm run` + `aasm tools` subcommands) before
@@ -618,6 +634,21 @@ jobs:
           # --no-git-push avoids creating/pushing tags (we already
           # have one from the upstream tag push), --yes skips
           # confirmation prompts.
+          #
+          # --no-verify (AAASM-2463, re-justified by AAASM-5315/5316):
+          # cargo's per-crate verify step unpacks each tarball and compiles it
+          # in isolation. It CANNOT be turned on here: aa-ebpf/build.rs's
+          # `restore_manifest_from_stage` renames `Cargo.toml.embedded` back
+          # during that compile, which trips cargo's "Source directory was
+          # modified by build.rs during cargo publish" guard and aborts the
+          # release. The flag's original rationale — "pre-tag CI already
+          # proves the workspace builds" — was false: a workspace build never
+          # separates a crate from its siblings, which is exactly the defect
+          # class verify exists to catch, and two such defects (5315, 5316)
+          # shipped through it. `scripts/check-packaged-artifacts.sh` now runs
+          # on every PR and reconstructs what verify would have proved —
+          # package, assert tarball contents, then build the real binaries out
+          # of the unpacked tarballs — without re-entering the aa-ebpf failure.
           cargo workspaces publish \
             --from-git \
             --no-git-push \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,7 +44,23 @@ cargo deny check
 # 6. Verify aasm binary builds and embeds the dashboard
 cargo build --release -p aa-cli
 ./target/release/aasm --version
+
+# 7. Verify what will actually be PUBLISHED, not just what builds here
+bash scripts/check-packaged-artifacts.sh
 ```
+
+> **Why step 7 is not covered by steps 3–6.** Everything above builds inside the
+> Cargo workspace, where each crate can see its siblings, the workspace-root
+> `.sqlx/` cache and `dashboard/dist/`. A crates.io consumer gets one crate on
+> its own, and `cargo workspaces publish` runs with `--no-verify` (it has to —
+> see the comment on that call in `release.yml`), so nothing else ever compiles a
+> crate in isolation. Two defects shipped straight through steps 3–6 that way:
+> the published `aa-cli` carried no dashboard at all (AAASM-5316) and the
+> published `aa-gateway` could not compile for any consumer (AAASM-5315).
+> `check-packaged-artifacts.sh` packages every crate, asserts the tarball
+> contents, builds the binaries out of the tarballs, and runs the result. It also
+> runs on every PR (`.github/workflows/release-completeness.yml`); step 7 is here
+> so a release cut is never the first time anyone looks.
 
 ## Tagging and triggering the release workflow
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,9 +58,17 @@ bash scripts/check-packaged-artifacts.sh
 > the published `aa-cli` carried no dashboard at all (AAASM-5316) and the
 > published `aa-gateway` could not compile for any consumer (AAASM-5315).
 > `check-packaged-artifacts.sh` packages every crate, asserts the tarball
-> contents, builds the binaries out of the tarballs, and runs the result. It also
-> runs on every PR (`.github/workflows/release-completeness.yml`); step 7 is here
-> so a release cut is never the first time anyone looks.
+> contents, builds the binaries out of the tarballs, and runs the result.
+>
+> It runs in three places, and all three are wanted. On every PR
+> (`.github/workflows/release-completeness.yml`) for early feedback; here, so a
+> release cut is never the first time anyone looks; and as the
+> `packaged-artifact-gate` job that `publish-crates` **needs**, which is the only
+> one of the three that is a precondition of anything. The PR run is
+> path-filtered and sees a PR head rather than the merge result, so it cannot
+> speak for the tree a tag is cut from — and crates.io will not accept a second
+> upload of a version, so the artifact itself has to be looked at before the
+> upload, not before the merge.
 
 ## Tagging and triggering the release workflow
 

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -6,6 +6,24 @@ license.workspace = true
 repository.workspace = true
 description = "aasm — command-line tool for Agent Assembly"
 
+# AAASM-5316: explicit include list lets `_embedded/dashboard/dist/` (the
+# publish-staged copy of `dashboard/dist/`, see release.yml and build.rs) ship in
+# the published tarball even though `aa-cli/.gitignore` lists `_embedded/`.
+# cargo's default file-enumeration is git-aware and silently drops gitignored
+# paths, so up to and including v0.0.1-rc.6 every published aa-cli tarball
+# carried ZERO `_embedded` files and `cargo install aasm` produced a binary whose
+# `aasm dashboard` served only build.rs's "Dashboard not built" stub. `aa-ebpf`
+# and `aa-proto` already carry the same override for the same reason; this is
+# the third instance of the pattern, not a new one.
+include = [
+    "src/**",
+    "tests/**",
+    "build.rs",
+    "Cargo.toml",
+    "README.md",
+    "_embedded/dashboard/dist/**",
+]
+
 [[bin]]
 name = "aasm"
 path = "src/main.rs"

--- a/aa-gateway/.gitignore
+++ b/aa-gateway/.gitignore
@@ -1,0 +1,6 @@
+# AAASM-5315: publish-staging mirror of the workspace-root `.sqlx/` offline
+# query cache, copied in by release.yml right before `cargo workspaces publish`
+# (and by scripts/check-packaged-artifacts.sh). The workspace-root copy stays
+# the single source of truth; this one exists only so cargo's `include` can
+# reach it, since `include` cannot escape the package directory.
+.sqlx/

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -6,6 +6,31 @@ license.workspace = true
 repository.workspace = true
 description = "Control plane — policy enforcement engine and agent registry for Agent Assembly"
 
+# AAASM-5315: `src/approval/sqlite_repo.rs` and
+# `src/approval/db_escalation_scheduler.rs` expand `sqlx::query!` at COMPILE
+# time. Both are un-feature-gated `pub mod`s reached from `src/server.rs` and
+# both gRPC services, so every consumer of a default `cargo add aa-gateway`
+# compiles them. With no live DATABASE_URL the macros fall back to the offline
+# cache, which lives at the WORKSPACE root `.sqlx/` — outside this package, so
+# no tarball up to v0.0.1-rc.6 carried it and the published crate could not
+# build for anyone.
+#
+# `include` paths cannot escape the package directory, hence the staged
+# `aa-gateway/.sqlx/` mirror (gitignored; see .gitignore) that release.yml
+# copies in before publishing. Adding `include` at all means every other shipped
+# path must be listed explicitly — cargo ignores the git-aware default once this
+# key is present.
+include = [
+    "src/**",
+    "tests/**",
+    "benches/**",
+    "migrations/**",
+    "Cargo.toml",
+    "Dockerfile",
+    "README.md",
+    ".sqlx/**",
+]
+
 [dependencies]
 aa-core      = { path = "../aa-core", version = "0.0.1-rc.6", features = ["serde"] }
 # AAASM-3907: the shared HTTP auth framework (AuthConfig / ApiKeyStore /

--- a/scripts/check-packaged-artifacts.sh
+++ b/scripts/check-packaged-artifacts.sh
@@ -174,7 +174,8 @@ while IFS= read -r pkg; do
 done <<EOF
 $PUBLISHABLE
 EOF
-[ "$fail" -eq 0 ] && echo "  ✓ every internal aa-* pin matches the workspace version"
+[ "$fail" -eq 0 ] || { echo "packaged-artifact gate: FAILED (version-pin drift)" >&2; exit 1; }
+echo "  ✓ every internal aa-* pin matches the workspace version"
 
 # ---------------------------------------------------------------------------
 # 3. Package every publishable crate.

--- a/scripts/check-packaged-artifacts.sh
+++ b/scripts/check-packaged-artifacts.sh
@@ -59,8 +59,9 @@
 # `dashboard/`), exactly as release.yml builds it before staging.
 #
 # Usage: scripts/check-packaged-artifacts.sh
-#   PACKAGED_GATE_WORKDIR=<dir>     reuse a scratch dir across runs (dev only)
-#   PACKAGED_GATE_TARGET_DIR=<dir>  persist/cache the packaged build's target dir
+#   PACKAGED_GATE_WORKDIR=<dir>        reuse a scratch dir across runs (dev only)
+#   PACKAGED_GATE_STAGE_TARGET_DIR=<d> persist/cache the staging+packaging target dir
+#   PACKAGED_GATE_TARGET_DIR=<dir>     persist/cache the packaged build's target dir
 #   PACKAGED_GATE_SKIP_BUILD=1      stop after step 4 (fast contents-only check)
 set -euo pipefail
 
@@ -89,6 +90,11 @@ fi
 # refuses to build a package that sits under a workspace it is not a member of.
 TREE="$WORK/tree"
 mkdir -p "$TREE"
+
+# The tree copy is throwaway, so its `target/` is rebuilt from scratch every
+# run unless it is pointed somewhere that survives — which CI's cache action and
+# a developer iterating both want.
+export CARGO_TARGET_DIR="${PACKAGED_GATE_STAGE_TARGET_DIR:-$TREE/target}"
 
 echo "packaged-artifact gate: staging a throwaway copy of the tree in $TREE"
 ( cd "$REPO_ROOT" && git ls-files -z | tar --null -T - -cf - ) | tar -xf - -C "$TREE"
@@ -255,7 +261,7 @@ step "5/6 build aasm + aa-gateway + aa-proxy from the unpacked tarballs"
 
 UNPACK="$WORK/unpacked"
 mkdir -p "$UNPACK"
-for crate in "$TREE"/target/package/*.crate; do
+for crate in "$CARGO_TARGET_DIR"/package/*.crate; do
     tar -xzf "$crate" -C "$UNPACK"
 done
 echo "  unpacked $(find "$UNPACK" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ') crates into $UNPACK"

--- a/scripts/check-packaged-artifacts.sh
+++ b/scripts/check-packaged-artifacts.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# AAASM-5315 / AAASM-5316: packaged-artifact gate.
+#
+# WHY
+# ---
+# `release.yml` publishes with `cargo workspaces publish --no-verify`. That flag
+# is not optional: cargo's verify step unpacks each tarball and compiles it in
+# isolation, and `aa-ebpf/build.rs`'s `restore_manifest_from_stage` renames
+# `Cargo.toml.embedded` back during that compile, tripping cargo's "Source
+# directory was modified by build.rs during cargo publish" guard and aborting
+# the release (AAASM-2463, commit 72fd24ec). The rationale recorded with the
+# flag — "pre-tag CI already validates the workspace builds cleanly, so the
+# per-crate verify step is redundant" — is false. A workspace build never
+# separates a crate from its siblings, and separation is the entire defect class
+# verify exists to catch:
+#
+#   * AAASM-5316 — `aa-cli/.gitignore` lists `_embedded/`, cargo's default file
+#     enumeration is git-aware, so every published aa-cli tarball shipped ZERO
+#     dashboard files. Workspace builds never noticed: build.rs mirrors the
+#     sibling `dashboard/dist/` in.
+#   * AAASM-5315 — aa-gateway's `sqlx::query!` macros read the offline cache at
+#     the WORKSPACE root, which is outside the package, so the published crate
+#     could not compile for any consumer. Workspace builds never noticed: the
+#     root cache is right there.
+#
+# This gate reconstructs what `--verify` would have proved, without re-entering
+# the aa-ebpf failure: package every publishable crate, assert the tarball
+# CONTENTS, then build the real binaries out of the unpacked tarballs.
+#
+# WHY NOT `cargo publish --dry-run`
+# ---------------------------------
+# Per-crate `--dry-run` is structurally unusable here. It resolves each crate's
+# internal deps against the ALREADY-PUBLISHED release, so `aa-runtime` fails
+# with `unresolved import 'aa_core::integration'` — 13 errors — purely because
+# the published `aa-core` predates that module (verified: `git ls-tree
+# v0.0.1-rc.6 aa-core/src/`). That is a false negative about the previous
+# release, not a fact about this tree.
+#
+# Step 5 avoids the trap by unpacking ALL the tarballs and adding a
+# `[patch.crates-io]` block that points every `aa-*` dep at its unpacked
+# sibling. Every internal dep then resolves to the artifact this run just
+# produced — which is precisely what a topological publish yields, and what
+# `cargo publish --verify` gets wrong.
+#
+# WHAT IT RUNS
+# ------------
+#   1. Publish-staging on a throwaway copy of the tree, mirroring release.yml
+#      step-for-step (aa-cli/_embedded, aa-proto/_embedded, aa-ebpf/_embedded,
+#      aa-gateway/.sqlx) and then the real `.ci/strip-for-publish.sh`.
+#   2. Internal-dep version-pin drift check.
+#   3. `cargo package --no-verify --allow-dirty` for every publishable crate.
+#   4. Required-file assertions read from `cargo package --list` — the tarball
+#      manifest, never the working directory.
+#   5. Build `aasm`, `aa-gateway` and `aa-proxy` from the unpacked tarballs.
+#   6. Run the packaged `aasm`: `--version`, `--help`, and every top-level
+#      subcommand it advertises must actually dispatch.
+#
+# PREREQUISITE: `dashboard/dist/` must already be built (`pnpm build` in
+# `dashboard/`), exactly as release.yml builds it before staging.
+#
+# Usage: scripts/check-packaged-artifacts.sh
+#   PACKAGED_GATE_WORKDIR=<dir>     reuse a scratch dir across runs (dev only)
+#   PACKAGED_GATE_TARGET_DIR=<dir>  persist/cache the packaged build's target dir
+#   PACKAGED_GATE_SKIP_BUILD=1      stop after step 4 (fast contents-only check)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+fail=0
+err() { echo "::error::$*" >&2; fail=1; }
+step() { echo ""; echo "── $* ─────────────────────────────────────────"; }
+
+# ---------------------------------------------------------------------------
+# Throwaway copy of the tracked working tree (not HEAD), so a developer sees
+# the effect of edits they have not committed yet — same convention as
+# scripts/check-publish-surface.sh.
+# ---------------------------------------------------------------------------
+if [ -n "${PACKAGED_GATE_WORKDIR:-}" ]; then
+    WORK="$PACKAGED_GATE_WORKDIR"
+    rm -rf "$WORK"
+    mkdir -p "$WORK"
+else
+    WORK="$(mktemp -d)"
+    trap 'rm -rf "$WORK"' EXIT
+fi
+
+# The tree copy lives in a SUBdirectory of the scratch root, so that step 5 can
+# unpack the tarballs as a sibling rather than inside the workspace — cargo
+# refuses to build a package that sits under a workspace it is not a member of.
+TREE="$WORK/tree"
+mkdir -p "$TREE"
+
+echo "packaged-artifact gate: staging a throwaway copy of the tree in $TREE"
+( cd "$REPO_ROOT" && git ls-files -z | tar --null -T - -cf - ) | tar -xf - -C "$TREE"
+
+# ---------------------------------------------------------------------------
+# 1. Publish staging — mirrors .github/workflows/release.yml's publish-crates
+#    job. Keep these steps in lockstep with that workflow: a divergence here
+#    means the gate stops describing what actually ships.
+# ---------------------------------------------------------------------------
+step "1/6 publish staging (mirrors release.yml)"
+
+# release.yml: "Build dashboard for crates.io bundling" (pnpm build). Done by
+# the caller so this gate stays a pure shell script with no Node dependency.
+if [ ! -f "$REPO_ROOT/dashboard/dist/index.html" ]; then
+    echo "::error::dashboard/dist/index.html not found. release.yml runs \`pnpm build\` in dashboard/ before staging; do the same before running this gate." >&2
+    exit 1
+fi
+
+# release.yml: "Stage dashboard/dist into aa-cli/_embedded for crates.io tarball"
+rm -rf "$TREE/aa-cli/_embedded"
+mkdir -p "$TREE/aa-cli/_embedded/dashboard"
+cp -r "$REPO_ROOT/dashboard/dist" "$TREE/aa-cli/_embedded/dashboard/dist"
+test -f "$TREE/aa-cli/_embedded/dashboard/dist/index.html"
+echo "  ✓ aa-cli/_embedded staged ($(find "$TREE/aa-cli/_embedded" -type f | wc -l | tr -d ' ') files)"
+
+# release.yml: "Populate aa-proto _embedded/proto/ mirror via build.rs"
+( cd "$TREE" && cargo check -p aa-proto ) >/dev/null 2>&1
+test -f "$TREE/aa-proto/_embedded/proto/common.proto"
+echo "  ✓ aa-proto/_embedded staged ($(find "$TREE/aa-proto/_embedded" -type f | wc -l | tr -d ' ') files)"
+
+# release.yml: "Stage aa-ebpf/_embedded/aa-ebpf-probes/ for crates.io publish".
+# `perl -i` rather than release.yml's `sed -i` only because this script also has
+# to run on a developer's macOS box, where BSD sed's -i takes a mandatory arg.
+rm -rf "$TREE/aa-ebpf/_embedded"
+mkdir -p "$TREE/aa-ebpf/_embedded"
+cp -r "$TREE/aa-ebpf-probes" "$TREE/aa-ebpf/_embedded/aa-ebpf-probes"
+rm -rf "$TREE/aa-ebpf/_embedded/aa-ebpf-probes/target"
+perl -i -pe 's|aa-ebpf-common = \{ path = "\.\./aa-ebpf-common" \}|aa-ebpf-common = "0.0.1-alpha.3"|' \
+    "$TREE/aa-ebpf/_embedded/aa-ebpf-probes/Cargo.toml"
+grep -q 'aa-ebpf-common = "0.0.1-alpha.3"' "$TREE/aa-ebpf/_embedded/aa-ebpf-probes/Cargo.toml" \
+    || { echo "::error::path-dep rewrite produced unexpected result"; exit 1; }
+mv "$TREE/aa-ebpf/_embedded/aa-ebpf-probes/Cargo.toml" \
+   "$TREE/aa-ebpf/_embedded/aa-ebpf-probes/Cargo.toml.embedded"
+echo "  ✓ aa-ebpf/_embedded staged ($(find "$TREE/aa-ebpf/_embedded" -type f | wc -l | tr -d ' ') files)"
+
+# release.yml: "Stage .sqlx offline query cache into aa-gateway" (AAASM-5315)
+rm -rf "$TREE/aa-gateway/.sqlx"
+cp -r "$TREE/.sqlx" "$TREE/aa-gateway/.sqlx"
+echo "  ✓ aa-gateway/.sqlx staged ($(find "$TREE/aa-gateway/.sqlx" -type f | wc -l | tr -d ' ') files)"
+
+# release.yml: "Strip held-back surface from aa-cli for crates.io publish".
+# VERIFY=0 skips the script's own `cargo check`s; step 5 below compiles far more
+# than they do, out of the tarballs rather than out of the workspace.
+STRIP_FOR_PUBLISH_VERIFY=0 bash "$TREE/.ci/strip-for-publish.sh" >/dev/null
+echo "  ✓ held-back surface stripped"
+
+# ---------------------------------------------------------------------------
+# 2. Version-pin drift. `[patch.crates-io]` in step 5 only takes effect when the
+#    patched path's version satisfies the dependency requirement; a stale pin
+#    would silently fall through to crates.io and "prove" the wrong artifact
+#    builds. Assert the pins first so step 5's result means what it claims.
+# ---------------------------------------------------------------------------
+step "2/6 internal dependency version-pin drift"
+
+WS_VERSION="$( cd "$TREE" && cargo metadata --no-deps --format-version=1 \
+    | jq -r '.packages[] | select(.name == "aa-core") | .version' )"
+echo "  workspace version: $WS_VERSION"
+
+PUBLISHABLE="$( cd "$TREE" && cargo metadata --no-deps --format-version=1 \
+    | jq -r '.packages[] | select(.publish != []) | .name' | sort )"
+
+while IFS= read -r pkg; do
+    [ -n "$pkg" ] || continue
+    while IFS=$'\t' read -r dep req; do
+        [ -n "$dep" ] || continue
+        if [ "$req" != "^$WS_VERSION" ] && [ "$req" != "$WS_VERSION" ] && [ "$req" != "=$WS_VERSION" ]; then
+            err "$pkg pins internal dep '$dep' at '$req', but the workspace publishes $WS_VERSION. A published crate whose sibling pin lags resolves against the PREVIOUS release, not this one."
+        fi
+    done < <( cd "$TREE" && cargo metadata --no-deps --format-version=1 \
+        | jq -r --arg p "$pkg" '.packages[] | select(.name == $p) | .dependencies[]
+                 | select(.name | startswith("aa-")) | select(.kind == null)
+                 | [.name, .req] | @tsv' )
+done <<EOF
+$PUBLISHABLE
+EOF
+[ "$fail" -eq 0 ] && echo "  ✓ every internal aa-* pin matches the workspace version"
+
+# ---------------------------------------------------------------------------
+# 3. Package every publishable crate.
+# ---------------------------------------------------------------------------
+step "3/6 cargo package (--no-verify, see header for why verify cannot run)"
+
+while IFS= read -r pkg; do
+    [ -n "$pkg" ] || continue
+    ( cd "$TREE" && cargo package -p "$pkg" --no-verify --allow-dirty ) >/dev/null 2>&1 \
+        || { err "cargo package -p $pkg failed"; continue; }
+    echo "  ✓ packaged $pkg"
+done <<EOF
+$PUBLISHABLE
+EOF
+[ "$fail" -eq 0 ] || { echo "packaged-artifact gate: FAILED (packaging)" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 4. Required tarball contents. Read from `cargo package --list` — the tarball
+#    manifest — so a file that exists on disk but is filtered out by cargo's
+#    git-aware enumeration (the AAASM-5315/5316 shape exactly) still fails.
+#
+#    Format: <package> <literal-path-or-glob>. A glob entry must match at least
+#    one listed path.
+# ---------------------------------------------------------------------------
+step "4/6 required files present in the tarball manifest"
+
+REQUIRED_FILES="
+aa-cli _embedded/dashboard/dist/index.html
+aa-cli _embedded/dashboard/dist/assets/*
+aa-proto _embedded/proto/common.proto
+aa-proto _embedded/proto/*.proto
+aa-ebpf _embedded/aa-ebpf-probes/Cargo.toml.embedded
+aa-ebpf _embedded/aa-ebpf-probes/src/*
+aa-gateway .sqlx/query-*.json
+aa-gateway migrations/*
+"
+
+listing_of() { ( cd "$TREE" && cargo package -p "$1" --list --allow-dirty 2>/dev/null ); }
+
+prev_pkg=""
+listing=""
+while read -r pkg pattern; do
+    [ -n "$pkg" ] || continue
+    if [ "$pkg" != "$prev_pkg" ]; then
+        listing="$(listing_of "$pkg")"
+        prev_pkg="$pkg"
+    fi
+    matched=0
+    while IFS= read -r entry; do
+        # shellcheck disable=SC2254  # $pattern is a deliberate glob
+        case "$entry" in
+            $pattern) matched=1; break ;;
+        esac
+    done <<EOF
+$listing
+EOF
+    if [ "$matched" -eq 1 ]; then
+        echo "  ✓ $pkg: $pattern"
+    else
+        err "$pkg tarball does not contain '$pattern'. \`cargo package --list\` is the authority here — the file may well exist in the working tree and still be dropped, which is how AAASM-5315 and AAASM-5316 shipped. Check the crate's \`include\` in $pkg/Cargo.toml and the staging step in .github/workflows/release.yml."
+    fi
+done <<EOF
+$REQUIRED_FILES
+EOF
+[ "$fail" -eq 0 ] || { echo "packaged-artifact gate: FAILED (tarball contents)" >&2; exit 1; }
+
+if [ "${PACKAGED_GATE_SKIP_BUILD:-0}" = "1" ]; then
+    echo ""
+    echo "packaged-artifact gate: PACKAGED_GATE_SKIP_BUILD=1 — stopping after contents checks"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Build the release binaries out of the unpacked tarballs.
+# ---------------------------------------------------------------------------
+step "5/6 build aasm + aa-gateway + aa-proxy from the unpacked tarballs"
+
+UNPACK="$WORK/unpacked"
+mkdir -p "$UNPACK"
+for crate in "$TREE"/target/package/*.crate; do
+    tar -xzf "$crate" -C "$UNPACK"
+done
+echo "  unpacked $(find "$UNPACK" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ') crates into $UNPACK"
+
+TOP="$UNPACK/aa-cli-$WS_VERSION"
+[ -d "$TOP" ] || { echo "::error::expected unpacked $TOP" >&2; exit 1; }
+
+# Point every internal dep at the sibling that was just unpacked. Without this
+# they resolve to the PREVIOUS crates.io release and the build tests the wrong
+# artifact (see the header's dry-run note).
+{
+    echo ""
+    echo "# Injected by scripts/check-packaged-artifacts.sh — resolve every internal"
+    echo "# dep to the tarball produced by this run, not the previous release."
+    echo "[patch.crates-io]"
+    for d in "$UNPACK"/aa-*/; do
+        name="$(basename "$d")"
+        name="${name%-"$WS_VERSION"}"
+        [ "$name" = "aa-cli" ] && continue
+        echo "$name = { path = \"../$(basename "$d")\" }"
+    done
+} >> "$TOP/Cargo.toml"
+
+# Kept out of $TOP so it survives PACKAGED_GATE_WORKDIR being recreated and so
+# CI can cache it: the third-party half of this build is identical run to run.
+PACKAGED_TARGET_DIR="${PACKAGED_GATE_TARGET_DIR:-$WORK/packaged-target}"
+
+build_from_tarball() {
+    local desc="$1"; shift
+    echo "  building $desc ..."
+    if ! ( cd "$TOP" && CARGO_TARGET_DIR="$PACKAGED_TARGET_DIR" cargo build "$@" ) 2> "$WORK/build-$desc.log"; then
+        echo "  ✗ $desc FAILED — last 40 lines:" >&2
+        tail -40 "$WORK/build-$desc.log" >&2
+        err "the packaged artifact does not build: $desc. The workspace build passing proves nothing about this — that is the whole point of the gate."
+        return 1
+    fi
+    echo "  ✓ $desc"
+}
+
+build_from_tarball aasm --bin aasm
+build_from_tarball aa-gateway -p aa-gateway --bins
+build_from_tarball aa-proxy -p aa-proxy --bins
+[ "$fail" -eq 0 ] || { echo "packaged-artifact gate: FAILED (packaged build)" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 6. Run the packaged binary. check-publish-surface.sh approximates this by
+#    reading the stripped dispatch table as text; this asserts it against the
+#    artifact a `cargo install aasm` user actually receives.
+# ---------------------------------------------------------------------------
+step "6/6 run the packaged aasm"
+
+AASM="$PACKAGED_TARGET_DIR/debug/aasm"
+[ -x "$AASM" ] || { echo "::error::packaged aasm binary not at $AASM" >&2; exit 1; }
+
+version_out="$("$AASM" --version 2>&1)" \
+    || err "packaged \`aasm --version\` exited non-zero: $version_out"
+echo "  aasm --version → $version_out"
+case "$version_out" in
+    *"$WS_VERSION"*) ;;
+    *) err "packaged \`aasm --version\` reports '$version_out', which does not carry the published version $WS_VERSION." ;;
+esac
+
+help_out="$("$AASM" --help 2>&1)" || err "packaged \`aasm --help\` exited non-zero"
+
+# Top-level subcommands the packaged binary ADVERTISES, straight out of its own
+# help. Not a hardcoded list: a command added tomorrow is covered.
+advertised="$(printf '%s\n' "$help_out" \
+    | awk '/^Commands:/{c=1;next} c && /^[A-Za-z]/{exit} c && NF {print $1}' \
+    | grep -v '^help$' || true)"
+
+[ -n "$advertised" ] || err "packaged \`aasm --help\` advertises no subcommands at all"
+echo "  advertised: $(printf '%s' "$advertised" | tr '\n' ' ')"
+
+while IFS= read -r cmd; do
+    [ -n "$cmd" ] || continue
+    if out="$("$AASM" "$cmd" --help 2>&1)"; then
+        printf '  ✓ aasm %s\n' "$cmd"
+    else
+        err "packaged \`aasm $cmd\` is advertised by --help but does not dispatch: $(printf '%s' "$out" | head -3 | tr '\n' ' ')"
+    fi
+done <<EOF
+$advertised
+EOF
+
+echo ""
+if [ "$fail" -ne 0 ]; then
+    echo "packaged-artifact gate: FAILED" >&2
+    exit 1
+fi
+echo "packaged-artifact gate: OK"
+echo "  every publishable crate packages, carries its required files, builds from"
+echo "  its own tarball, and the packaged aasm dispatches every command it advertises."


### PR DESCRIPTION
## Description

Closes two **live defects in already-published `0.0.1-rc.6` artifacts**, and adds the gate that would have caught them.

Both were found by auditing the real registry, not by reasoning about the workflow. Neither is caused by the AAASM-5272 programme — they are pre-existing, and the published crates are broken today.

### AAASM-5316 — `aa-cli` ships without the dashboard

Live tarball: 147 files, **zero** `_embedded` entries, despite `release.yml:547-561` staging `dashboard/dist` into `aa-cli/_embedded`. Cause: `aa-cli/.gitignore:1` lists `_embedded/` and `aa-cli/Cargo.toml` had **no `include = [...]`**, so cargo's git file-enumeration drops the staged directory. `include_dir!` on a missing directory is a hard compile error, so the published crate cannot build.

`aa-ebpf` survives the identical staging pattern only because it declares an explicit `include`. **Fix:** give `aa-cli` the same treatment.

### AAASM-5315 — `aa-gateway` does not compile for any consumer

A scratch crate depending on `aa-gateway = "=0.0.1-rc.6"` from the real registry fails with 7 errors:
`set DATABASE_URL to use query macros online, or run cargo sqlx prepare` at `src/approval/sqlite_repo.rs:129`.
The sqlx offline cache lives at the **workspace root** `.sqlx/`; `tar tzf … | grep -i sqlx` → 0 hits.

**Fix: include, not feature-gate — and the obvious fix would not have worked.** `sqlite_repo.rs` is not the only `sqlx::query!` user: `approval/db_escalation_scheduler.rs` is too, and `DbEscalationScheduler` is wired into `server.rs` and both gRPC services. Gating `sqlite_repo` alone leaves the other file's macros expanding; gating the feature off by default would gut `aasm gateway` in the published build. The cache genuinely has to ship.

Since `include` cannot escape the package directory: the workspace-root `.sqlx/` stays the single source of truth, `release.yml` stages a gitignored `aa-gateway/.sqlx/` mirror beside the existing `_embedded` staging, and `include` rescues it. `cargo add aa-gateway` works with default features; no behaviour change.

## The gate

`scripts/check-packaged-artifacts.sh`, run by a new `packaged-artifacts` job in `release-completeness.yml` **on every pull request** (paths widened to `**/Cargo.toml`, `**/.gitignore`, `.sqlx/**`, `.ci/**`, `scripts/**`).

Six steps: mirror `release.yml`'s staging → version-pin drift → `cargo package --no-verify` ×16 → **required files asserted from `cargo package --list`** → build `aasm`/`aa-gateway`/`aa-proxy` **from the unpacked tarballs** → run the packaged `aasm` and assert every advertised subcommand dispatches.

**Why it does not use `cargo publish --dry-run`.** Per-crate dry-run is structurally blocked in this workspace: it resolves path-deps against the *already-published* rc.6, so `aa-runtime` fails with `unresolved import 'aa_core::integration' … could not find 'integration' in 'aa_core'` (13 errors) purely because rc.6 predates that module — confirmed via `git ls-tree v0.0.1-rc.6 aa-core/src/`. That is a false negative, and a permanently-red gate is one people learn to ignore.

Instead the gate unpacks **all** tarballs and appends `[patch.crates-io] aa-* = { path = <unpacked sibling> }`, so every internal dep resolves to *this run's artifact*. That is exactly what topological publish produces, and precisely what `cargo publish --verify` gets wrong here.

**`--no-verify` stays on the publish call, with the reason recorded in a comment.** Commit `72fd24ec` (AAASM-2463) added it because `aa-ebpf/build.rs` renames `Cargo.toml.embedded`, tripping cargo's *"Source directory was modified by build.rs"* guard. That trigger is still live. The flag was never the bug — the missing compensating gate was. Its old rationale ("pre-tag CI already validates the workspace builds cleanly, so the per-crate verify step is redundant") is exactly the assumption these two defects falsify.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Packaging metadata and CI only. No product code, no public API. Using `include` in `aa-cli` also stops two junk files shipping (`.gitignore`, `AAASM-4457-error-message-audit.md`).

## Related Issues

- Jira: [AAASM-5315](https://lightning-dust-mite.atlassian.net/browse/AAASM-5315), [AAASM-5316](https://lightning-dust-mite.atlassian.net/browse/AAASM-5316)
- Hardens the gap identified by [AAASM-5309](https://lightning-dust-mite.atlassian.net/browse/AAASM-5309)
- Context: AAASM-2463 (why `--no-verify` exists)

## Falsification — all five planted, observed, reverted

A guard nobody has watched fail is a guard nobody can trust.

| Plant | Observed failure |
|---|---|
| Advertised-but-undispatchable subcommand (`disable_help_flag` on `TopologyArgs`) | step 6 — `::error::packaged 'aasm topology' is advertised by --help but does not dispatch`; 21 other commands passed |
| `_embedded` removed from `aa-cli` include, assertion intact | step 4 — `::error::aa-cli tarball does not contain '_embedded/dashboard/dist/index.html'` |
| `.sqlx` removed from `aa-gateway` include, assertion intact | step 4 — `::error::aa-gateway tarball does not contain '.sqlx/query-*.json'` |
| Version drift: `aa-gateway` pin rc.6→rc.5 | step 2 — `::error::aa-cli pins internal dep 'aa-gateway' at '^0.0.1-rc.5', but the workspace publishes 0.0.1-rc.6` |
| **Workspace green, packaged artifact broken** | step 5 — 7 × `set DATABASE_URL to use query macros online` → `::error::the packaged artifact does not build` |

On the last row, the step-4 assertion was removed **deliberately to isolate step 5** — with it intact, step 4 short-circuits and step 5 is never reached. The row above already proves step 4 with its assertion in place, and the same step-5 failure was independently reproduced by hiding `.sqlx` inside the already-unpacked tarball (7 identical errors), then restored → clean build in 9.85 s.

### A real bug found in the gate itself

Commit `3afb21aa`. The version-pin check read `[ "$fail" -eq 0 ] && echo "✓ …"` — it *printed* success when there was no drift and did **nothing** when there was. It could never fail the build. Found only by watching it fail. That it appeared in the very gate written to catch checks-that-do-not-check is the argument for mandatory falsification.

## Proof the defects are fixed — `cargo package --list`

- **`aa-cli`**: 164 → 266 entries; **104** `_embedded/` files including `_embedded/dashboard/dist/index.html` (was **0**).
- **`aa-gateway`**: 239 → 247, exactly +8; all 8 `.sqlx/query-*.json` present, every previously-shipped path preserved.

## The packaged binary actually runs

Built from the tarball. `aasm --version` → `aasm 0.0.1-rc.6`. All 22 advertised subcommands dispatch:
`admin agent alerts audit logs policy context config completion status version trace approvals cost dashboard gateway sandbox topology proxy start stop uninstall`.
`run` / `tools` / `integrations` correctly **absent** (stripped per AAASM-5309). `aa-gateway` and `aa-proxy` also built from their tarballs.

## Tests executed

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required

`cargo fmt --all -- --check` 0 · `cargo build --workspace` 0 · `cargo clippy --all-targets --all-features -- -D warnings` 0 · `check-release-completeness.sh` 0 · `check-publish-surface.sh` 0 · **`check-packaged-artifacts.sh` full clean run** (16 crates packaged, required files present, three binaries built from tarballs, 22 subcommands dispatch) · `shellcheck` clean.

**Could not run locally:** the CI job's Linux lane (ubuntu runner, apt protoc, pnpm dashboard build) — verified by YAML parse and by mirroring `release.yml`'s steps; the gate itself ran on macOS/arm64. eBPF probes degrade to stubs on macOS, as in any normal workspace build.

## Release safety

**Nothing was published, tagged or released.** No `cargo publish` was run in any form — `cargo package` only. Tag count unchanged at 19, all pre-existing. No version bump.

## Known limitations

The gate proves the packaged artifact **builds and dispatches**; it does not exercise runtime behaviour of every subcommand. It also cannot detect a defect that only manifests on a platform CI does not run.

## Dependencies / stacked PRs

Cut from `main` @ `2e543884`; independently mergeable. Developed alongside two parallel workstreams on disjoint files — documentation (`docs/**`, `CHANGELOG`, `README`, `SECURITY.md`) and conformance evidence (`aa-integration-tests/**`). No file overlaps.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`, `shellcheck`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — `RELEASING.md` checklist entry added
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (8 commits)
- [ ] Commits are signed off (`git commit -s`) — advisory, not enforced


[AAASM-5315]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ