### PR TITLE
[AAASM-5318] 📝 (docs): Document native-auth, SMTP, policy-cascade & trust env vars

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -50,6 +50,7 @@
   - [Observe in the dashboard](usage-guide/observe-in-dashboard.md)
   - [Choosing interception layers](usage-guide/interception-layers.md)
   - [Self-hosting (open source)](usage-guide/self-hosting.md)
+  - [Authentication](usage-guide/authentication.md)
   - [Container base images](usage-guide/container-base-images.md)
   - [Runnable examples](usage-guide/examples.md)
   - [Troubleshooting](usage-guide/troubleshooting.md)

--- a/docs/src/quick-start/configuration.md
+++ b/docs/src/quick-start/configuration.md
@@ -116,6 +116,52 @@ value, the precedence is noted.
 > `AA_GATEWAY_URL` (used by the Windsurf devtool). Only
 > `AA_PROXY_GATEWAY_ENDPOINT` affects `aasm proxy start`.
 
+### `aa-api` server environment variables
+
+The REST API server (`aa-api`) — the process the dashboard reads through — reads
+its own set of `AA_*` variables at boot. These configure the server itself, not
+the CLI.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AA_POLICY` | _(unset)_ | Policy source for the API's dashboard projections. See [Policy source](#policy-source-for-aa-api) below. |
+| `AA_AUTH_OPEN_REGISTRATION` | `false` | Opt into open self-registration for [native accounts](../usage-guide/authentication.md#opening-self-registration-optional). Only `1` / `true` / `yes` (case-insensitive) enable it; the default is closed (first-user-then-invite). |
+| `AA_SMTP_HOST` | _(unset)_ | SMTP relay host. Its presence switches on real password-reset email delivery; when unset, `aa-api` falls back to a logging mailer that sends nothing. See [Password-reset email](../usage-guide/authentication.md#password-reset-email-smtp). |
+| `AA_SMTP_PORT` | `587` | SMTP port (submission with STARTTLS). |
+| `AA_SMTP_USER` | _(unset)_ | Username for authenticated SMTP submission. Optional. |
+| `AA_SMTP_PASS` | _(unset)_ | Password for authenticated SMTP submission. Optional. |
+| `AA_SMTP_FROM` | `no-reply@localhost` | The `From:` address stamped on outbound mail. |
+
+> Native email/password accounts also require a **Postgres-backed** deployment.
+> The `AA_SMTP_*` and `AA_AUTH_OPEN_REGISTRATION` variables only take effect once
+> native accounts are available. See [Authentication](../usage-guide/authentication.md).
+
+#### Policy source for `aa-api`
+
+`aa-api` reads `AA_POLICY` the same way `aa-gateway` does — routing on the
+**shape** of the path it points at — to decide what the dashboard's
+capability-matrix, topology-chain, and team-policy projections display:
+
+| `AA_POLICY` | What `aa-api` loads | What the projections show |
+|---|---|---|
+| **A directory** | The multi-document [policy cascade](../operations/policy-cascade-loader.md) (Global / Org / Team / Agent scopes) | Real cascade data — the enforced org/team/agent rules |
+| **A single file** | That one policy document | The single policy's rules only (no cascade) |
+| _(unset / empty / non-existent path)_ | A generated budget-only bootstrap policy | `Unknown` / `Unconfigured` — never a fabricated allow |
+
+When `AA_POLICY` is unset, the projections render an honest "Unconfigured"
+signal rather than presenting the generated bootstrap as though it were an
+operator-authored policy. Point `AA_POLICY` at a directory to see the full
+cascade in the dashboard.
+
+#### Trust score tuning
+
+The dashboard's per-agent **trust score** (a policy-friction score served at
+`GET /api/v1/analytics/trust`) needs no configuration to work — every tenant
+starts on sensible defaults. Its penalty-signal weights are optionally tunable
+per tenant at runtime via `GET` / `PUT /api/v1/analytics/trust/config`; there is
+no environment variable for it. An agent with fewer than the minimum number of
+governed actions shows `—` (not enough data) rather than a misleading number.
+
 ## Output format
 
 Most list/get commands accept `--output table|json|yaml` (default `table`). Use

--- a/docs/src/usage-guide/authentication.md
+++ b/docs/src/usage-guide/authentication.md
@@ -1,0 +1,149 @@
+# Authentication
+
+Agent Assembly's `aa-api` supports **two credential paths**, side by side:
+
+- **API keys** — for machines. SDKs, agents, and scripts authenticate
+  programmatically with an API key. This path is unchanged and is available on
+  every deployment.
+- **Native email/password accounts** — for human operators at the dashboard.
+  This is an *additive* path for people; it never replaces the API key. It is
+  **only available on a Postgres-backed deployment** (see below).
+
+Both paths mint the **same scoped JWT** that every RBAC gate already reads, so
+enabling accounts changes nothing about how authorization works — it only adds a
+second way for a human to obtain that token.
+
+## Which methods a deployment offers
+
+A deployment advertises its available credential methods through a public
+endpoint, so the dashboard never presents a login form the backend cannot serve:
+
+```console
+$ curl http://localhost:7700/api/v1/auth/methods
+{"methods":["api_key"]}                 # in-memory deployment (API key only)
+
+$ curl http://localhost:7700/api/v1/auth/methods
+{"methods":["api_key","password"]}      # Postgres-backed deployment
+```
+
+`password` appears only when a Postgres account store is configured. On an
+in-memory deployment the native-auth endpoints below respond `503 Service
+Unavailable` and the dashboard shows only the API-key path.
+
+> **Native accounts require Postgres.** Passwords must be stored durably and
+> safely, which an in-memory map cannot do across a restart, so the account
+> endpoints are Postgres-gated. In-memory deployments stay API-key-only. This is
+> a deliberate, surfaced limitation — not a hidden failure.
+
+## The API-key path (machines)
+
+Unchanged. A caller exchanges an API key for a scoped JWT:
+
+```console
+$ curl -X POST http://localhost:7700/api/v1/auth/token \
+    -H "Authorization: Bearer <api-key>"
+```
+
+Use this for SDKs and agents. It works on every deployment, with or without
+Postgres.
+
+## The native-account path (human operators)
+
+When a Postgres store is configured, `aa-api` mounts a set of account endpoints
+under `/api/v1/auth`:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/v1/auth/methods` | `GET` | Advertise the available methods (`api_key`, and `password` when Postgres-backed). Public. |
+| `/api/v1/auth/login` | `POST` | Email + password → access token (+ refresh cookie). |
+| `/api/v1/auth/register` | `POST` | Register the first (bootstrap) account, or a self-registered account when open registration is enabled. |
+| `/api/v1/auth/invite` | `POST` | Create a single-use invite for a new account. **Admin scope required.** |
+| `/api/v1/auth/invite/accept` | `POST` | Set the initial password and activate an invited account. |
+| `/api/v1/auth/refresh` | `POST` | Exchange the refresh cookie for a fresh access token. |
+| `/api/v1/auth/logout` | `POST` | Revoke the refresh session and clear the cookie. |
+| `/api/v1/auth/password/reset` | `POST` | Request a password-reset email. Requires the [SMTP mailer](#password-reset-email-smtp) to deliver mail. |
+| `/api/v1/auth/password/reset/confirm` | `POST` | Consume a reset token and set a new password. |
+
+The access token is short-lived (15 minutes) and returned in the response body;
+the refresh token is delivered as an `HttpOnly; Secure; SameSite=Strict` cookie
+scoped to `/api/v1/auth`, and is rotated on every refresh. `remember_me` on login
+extends the refresh lifetime from 12 hours to 30 days.
+
+### First user is admin, then invite-only
+
+On a fresh instance the `users` table is empty, so registration bootstraps:
+
+1. **Bootstrap.** The **first** account created via `POST /api/v1/auth/register`
+   becomes the `owner` of the single default workspace. Registration is open
+   only for this first account.
+2. **After bootstrap.** Once any account exists, `register` returns `403`
+   (registration closed). New accounts are created by an admin:
+   `POST /api/v1/auth/invite` (admin scope) mints a single-use, expiring invite
+   token; the invitee sets their password via `POST /api/v1/auth/invite/accept`.
+
+An invite token is returned to the inviting admin exactly once (only its hash is
+stored) and expires after 7 days. Deliver it to the invitee out of band.
+
+### Opening self-registration (optional)
+
+To let anyone self-register (not just the first user), set:
+
+```bash
+AA_AUTH_OPEN_REGISTRATION=true
+```
+
+The default is `false` (closed — first-user-then-invite). Only the truthy
+spellings `1`, `true`, or `yes` (case-insensitive) enable it; any other value or
+leaving it unset keeps registration closed. When open registration is enabled,
+accounts created after the bootstrap owner receive the `developer` role.
+
+### Password policy
+
+Passwords are hashed with **argon2id** and must be at least **12 characters**.
+A shorter password is rejected with `422`. Login is enumeration-safe: an unknown
+email and a wrong password both return a uniform `401`, and repeated failures
+lock the account (`423` with a `Retry-After` header) after 5 attempts for
+15 minutes.
+
+## Password-reset email (SMTP)
+
+Password reset (`POST /api/v1/auth/password/reset`) needs to deliver a reset
+token to the account owner by email. `aa-api` ships a pluggable SMTP mailer
+configured entirely through environment variables:
+
+| Variable | Required | Default | Meaning |
+|---|---|---|---|
+| `AA_SMTP_HOST` | yes, to send mail | _(unset)_ | SMTP relay host. **Its presence is what switches on real email delivery.** |
+| `AA_SMTP_PORT` | no | `587` | SMTP port (submission with STARTTLS). |
+| `AA_SMTP_USER` | no | _(unset)_ | Username for authenticated submission. Omit for an unauthenticated relay. |
+| `AA_SMTP_PASS` | no | _(unset)_ | Password for authenticated submission. |
+| `AA_SMTP_FROM` | no | `no-reply@localhost` | The `From:` address stamped on outbound mail. |
+
+When `AA_SMTP_HOST` is set, `aa-api` builds a real SMTP transport (STARTTLS,
+authenticated when a user + pass are supplied) and password-reset emails are
+delivered.
+
+### When SMTP is not configured
+
+When `AA_SMTP_HOST` is **unset**, `aa-api` falls back to a **logging mailer**: it
+does not send anything, it logs that an email *would* have been sent (recipient
+and subject only — never the token). The deployment still boots and the reset
+endpoint still behaves correctly:
+
+- `POST /api/v1/auth/password/reset` always returns `202 Accepted`, whether or
+  not the email exists and whether or not mail can be delivered. This is
+  deliberate — the response must never reveal which addresses are registered.
+- With no SMTP configured, **no reset email is actually sent**; the operator sees
+  the log line instead. Users cannot self-serve a password reset until SMTP is
+  wired up.
+
+The same fallback applies if `AA_SMTP_HOST` is set but the transport cannot be
+built (a bad host or credential): `aa-api` logs a warning and falls back to the
+logging mailer rather than refusing to start.
+
+## Related
+
+- [Configuration](../quick-start/configuration.md) — environment-variable
+  reference, including the auth and SMTP variables.
+- [Self-hosting](self-hosting.md) — the Postgres-backed stack that unlocks native
+  accounts.

--- a/docs/src/usage-guide/self-hosting.md
+++ b/docs/src/usage-guide/self-hosting.md
@@ -193,6 +193,28 @@ image, keep `AA_AGENT_ID` identical to `aa-runtime`, and keep the
 [README](https://github.com/ai-agent-assembly/agent-assembly/blob/HEAD/examples/docker-compose/README.md)
 for details.
 
+## Configuring the `aa-api` service
+
+Once you grow the stack past the runtime-only quickstart and run the **`aa-api`**
+control-plane service (the one the dashboard reads), a few `AA_*` environment
+variables on that service shape what operators see and how they sign in. The full
+reference lives in [Configuration → aa-api server environment
+variables](../quick-start/configuration.md#aa-api-server-environment-variables);
+the self-host essentials:
+
+| Variable | Set it to | Effect |
+|---|---|---|
+| `AA_POLICY` | a **directory** of scoped policy documents | The dashboard's capability-matrix, topology-chain, and team-policy projections show the real [policy cascade](../operations/policy-cascade-loader.md). A single **file** shows one policy; leaving it **unset** makes the projections render `Unknown` / `Unconfigured` — never a fabricated allow. |
+| `AA_AUTH_OPEN_REGISTRATION` | `true` (optional) | Opens self-registration for native accounts. Default is closed: the first account bootstraps as `owner`, then it is invite-only. |
+| `AA_SMTP_HOST` (+ `AA_SMTP_PORT` / `USER` / `PASS` / `FROM`) | your SMTP relay | Enables password-reset email delivery. When unset, resets still return `202` but no email is sent (a logging-mailer fallback). |
+
+> **Native email/password login requires a Postgres-backed deployment.** The
+> in-memory / runtime-only quickstart above stays API-key-only. Once `aa-api`
+> is backed by Postgres, human operators can sign in with accounts —
+> `GET /api/v1/auth/methods` advertises whether the password path is available,
+> and the login page degrades honestly when it is not. See
+> [Authentication](authentication.md) for the account, invite, and reset flows.
+
 ## When you want it fully managed
 
 If you would rather not run and maintain the infrastructure yourself — and want the


### PR DESCRIPTION
## Description

The features shipped this cycle had no user/operator docs (only ADRs). This documents them so operators can actually enable them. **Docs-only.** Every fact verified against source, not invented.

- **New `docs/src/usage-guide/authentication.md`** — native email/password auth: API-key vs native-account coexistence, Postgres gating, `GET /api/v1/auth/methods` capability signal, first-user-is-admin→invite-only bootstrap, `AA_AUTH_OPEN_REGISTRATION` opt-in, the `/api/v1/auth` endpoint table, argon2id/12-char/lockout policy, and the `AA_SMTP_*` mailer + logging-mailer fallback. Registered in `SUMMARY.md`.
- **`configuration.md`** — new "aa-api server environment variables" section: `AA_AUTH_OPEN_REGISTRATION`, `AA_SMTP_*`, `AA_POLICY` (dir→cascade / file→single / unset→Unknown), trust-score tuning note.
- **`self-hosting.md`** — "Configuring the aa-api service": `AA_POLICY`, `AA_AUTH_OPEN_REGISTRATION`, `AA_SMTP_*`, Postgres requirement for native accounts.

### Correction caught during authoring
The ticket assumed `self-hosting.md` already listed `AA_POLICY` — it actually listed `AA_POLICY_PATH` (a *different* var, for the aa-runtime sidecar). The agent did **not** conflate them: the aa-api-server `AA_POLICY` behaviour is a distinct new section; the runtime's `AA_POLICY_PATH` rows are untouched.

## Type of Change
- [x] 📝 Documentation update

## Breaking Changes
- [x] No

## Related Issues
- Related Jira ticket: AAASM-5318 (Epic AAASM-3545; documents 5299/5301/5306/5083)

## Testing
- [x] No tests required (explain why)

Docs-only. `mdbook build docs` green (same toolchain as `.github/workflows/docs.yml`); all added cross-links + anchors verified against the generated HTML. Exact env-var names/defaults confirmed against `aa-api/src/mailer.rs`, `native_auth.rs`, `state.rs`, `trust.rs`.

## Checklist
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)