### PR TITLE
[AAASM-5319] ✅ (e2e): Playwright login/auth specs — methods-gating, two-tab, reset

### DIFF
--- a/dashboard/tests/e2e/verify-aaasm-5319-login.spec.ts
+++ b/dashboard/tests/e2e/verify-aaasm-5319-login.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * End-to-end coverage of the native-auth login surface (AAASM-5319, exercising
+ * the UI shipped by AAASM-5307).
+ *
+ * The login page reads `GET /api/v1/auth/methods` on mount and renders honestly
+ * from that signal (ADR 0031 §Q5), never a guess:
+ *   - `["api_key","password"]` → the two-tab email/password UI, with the API-key
+ *     path reachable and NO social login (Google/GitHub) and NO "or continue
+ *     with email" divider (ADR 0031 D4);
+ *   - `["api_key"]` → the API-key-only surface with a "needs Postgres" note and
+ *     no password form the backend cannot serve.
+ *
+ * This spec drives, all APIs mocked via `page.route` (FE-only, no backend):
+ *   1. methods-gating — password available → two-tab UI, no social/divider;
+ *   2. methods-gating — api_key only → no password form, API-key path + note;
+ *   3. the sign-in ↔ sign-up tab switch (sign-up has email + password, no
+ *      workspace-name field — OSS is single-workspace);
+ *   4. the sign-in happy path — `POST /api/v1/auth/login` → access token, then
+ *      navigate into the app with the token committed to sessionStorage.
+ *
+ * Harness conventions copied from the existing review/verify specs
+ * (e.g. review-aaasm-5104): a permissive API fallback route is registered
+ * first, specific fixtures after (Playwright matches most-recently-added
+ * first); the token is NOT pre-seeded here (these flows are the
+ * unauthenticated login surface), and routing happens at the network layer
+ * because openapi-fetch captures globalThis.fetch at module load. No console
+ * errors / pageerrors across any flow.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+type AuthMethod = 'api_key' | 'password'
+
+interface Harness {
+  errors: string[]
+}
+
+const TOKEN_KEY = 'aa_token'
+
+/** A JWT-shaped access token so `parseScopesFromJwt` has three dot-segments to split. */
+const ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOltdfQ.e2e-5319-signature'
+
+async function bootstrap(page: Page, methods: AuthMethod[]): Promise<Harness> {
+  const errors: string[] = []
+  page.on('console', (m) => {
+    if (m.type() !== 'error') return
+    const text = m.text()
+    // Aborted WS upgrades / unmocked resources are the fixture's doing, not the app's.
+    if (!text.startsWith('Failed to load resource')) errors.push(text)
+  })
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+
+  // Permissive fallback first (least specific); specific fixtures registered
+  // afterwards win, since Playwright matches most-recently-added first.
+  await page.route('**/api/**', (r) => r.fulfill({ json: {} }))
+  // The honest-degradation signal the login page renders from (ADR 0031 §Q5).
+  await page.route('**/api/v1/auth/methods**', (r) => r.fulfill({ json: { methods } }))
+  await page.route('**/api/v1/ws/events**', (r) => r.abort())
+  await page.route('**/api/v1/alerts/ws**', (r) => r.abort())
+
+  return { errors }
+}
+
+test.describe('AAASM-5319 — native-auth login surface', () => {
+  test('methods-gating: password available renders the two-tab UI and no social/divider', async ({
+    page,
+  }) => {
+    const harness = await bootstrap(page, ['api_key', 'password'])
+    await page.goto('/login')
+
+    // The two-tab email/password UI is the password-enabled shape.
+    const tablist = page.getByRole('tablist', { name: 'Sign in or sign up' })
+    await expect(tablist).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Sign in' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Sign up' })).toBeVisible()
+    await expect(page.getByLabel('Work email')).toBeVisible()
+    await expect(page.getByLabel('Password', { exact: true })).toBeVisible()
+
+    // ADR 0031 D4: no social login and no "or continue with email" divider.
+    await expect(page.getByRole('button', { name: /google/i })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /github/i })).toHaveCount(0)
+    await expect(page.getByText(/continue with email/i)).toHaveCount(0)
+
+    // The API-key path is still reachable (but not the default surface).
+    await expect(
+      page.getByRole('button', { name: 'Sign in with an API key instead' }),
+    ).toBeVisible()
+
+    expect(harness.errors, 'no console errors or uncaught exceptions').toEqual([])
+  })
+
+  test('methods-gating: api_key only renders the API-key path with a needs-Postgres note', async ({
+    page,
+  }) => {
+    const harness = await bootstrap(page, ['api_key'])
+    await page.goto('/login')
+
+    // No two-tab password UI at all when the deployment advertises only api_key.
+    await expect(page.getByRole('tablist', { name: 'Sign in or sign up' })).toHaveCount(0)
+    await expect(page.getByRole('tab', { name: 'Sign up' })).toHaveCount(0)
+
+    // The honest-degradation note explains why account login is unavailable.
+    await expect(page.getByText(/needs a Postgres-backed deployment/i)).toBeVisible()
+
+    // The API-key form (the OSS path that always survives) is present.
+    await expect(page.getByLabel('API key')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Sign in with API key' })).toBeVisible()
+
+    expect(harness.errors, 'no console errors or uncaught exceptions').toEqual([])
+  })
+
+  test('the sign-in ↔ sign-up tab switch: sign-up has email + password, no workspace field', async ({
+    page,
+  }) => {
+    const harness = await bootstrap(page, ['api_key', 'password'])
+    await page.goto('/login')
+
+    const signIn = page.getByRole('tab', { name: 'Sign in' })
+    const signUp = page.getByRole('tab', { name: 'Sign up' })
+
+    // Sign-in is the default selected tab and offers the "Forgot?" link.
+    await expect(signIn).toHaveAttribute('aria-selected', 'true')
+    await expect(page.getByRole('link', { name: 'Forgot?' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible()
+
+    // Switch to sign-up.
+    await signUp.click()
+    await expect(signUp).toHaveAttribute('aria-selected', 'true')
+    await expect(signIn).toHaveAttribute('aria-selected', 'false')
+    await expect(page.getByRole('button', { name: 'Create account' })).toBeVisible()
+
+    // Sign-up collects exactly email + password.
+    await expect(page.getByLabel('Work email')).toBeVisible()
+    await expect(page.getByLabel('Password', { exact: true })).toBeVisible()
+
+    // OSS is single-workspace: there is NO workspace/tenant/organisation field.
+    await expect(page.getByLabel(/workspace|tenant|organi[sz]ation|company name/i)).toHaveCount(0)
+    await expect(page.getByPlaceholder(/workspace|tenant|organi[sz]ation/i)).toHaveCount(0)
+
+    // Switch back to sign-in restores the "Forgot?" affordance.
+    await signIn.click()
+    await expect(signIn).toHaveAttribute('aria-selected', 'true')
+    await expect(page.getByRole('link', { name: 'Forgot?' })).toBeVisible()
+
+    expect(harness.errors, 'no console errors or uncaught exceptions').toEqual([])
+  })
+
+  test('sign-in happy path: valid credentials commit a token and navigate into the app', async ({
+    page,
+  }) => {
+    const harness = await bootstrap(page, ['api_key', 'password'])
+
+    // `POST /api/v1/auth/login` → the access-token envelope (ADR 0031 §5). The
+    // refresh token would ride an HttpOnly cookie the FE never reads.
+    await page.route('**/api/v1/auth/login**', (r) =>
+      r.fulfill({ json: { access_token: ACCESS_TOKEN, expires_in: 900 } }),
+    )
+    // Landing on the protected app after auth pulls the overview surface; keep
+    // those calls quiet so the flow doesn't error post-navigation.
+    await page.route('**/api/v1/fleet/active-sessions**', (r) => r.fulfill({ json: [] }))
+    await page.route('**/api/v1/logs**', (r) => r.fulfill({ json: { items: [], total: 0 } }))
+    await page.route('**/api/v1/agents**', (r) => r.fulfill({ json: { items: [], total: 0 } }))
+
+    await page.goto('/login')
+
+    await page.getByLabel('Work email').fill('operator@example.com')
+    await page.getByLabel('Password', { exact: true }).fill('correct-horse-battery')
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click()
+
+    // Success navigates off /login. `/` redirects to /overview (App.tsx).
+    await page.waitForURL((url) => !url.pathname.endsWith('/login'))
+    await expect(page).not.toHaveURL(/\/login$/)
+
+    // The app signals success by committing the access token to sessionStorage
+    // via the tokenStorage tier (key `aa_token`, AAASM-4322).
+    const stored = await page.evaluate((key) => sessionStorage.getItem(key), TOKEN_KEY)
+    expect(stored).toBe(ACCESS_TOKEN)
+
+    // The login card is gone — we are inside the authenticated shell.
+    await expect(page.getByRole('tablist', { name: 'Sign in or sign up' })).toHaveCount(0)
+
+    expect(harness.errors, 'no console errors or uncaught exceptions').toEqual([])
+  })
+})

--- a/dashboard/tests/e2e/verify-aaasm-5319-reset.spec.ts
+++ b/dashboard/tests/e2e/verify-aaasm-5319-reset.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * End-to-end coverage of the enumeration-safe password-reset flow (AAASM-5319,
+ * exercising the UI shipped by AAASM-5307), reachable from the login page's
+ * "Forgot?" link (ADR 0031 §Q4).
+ *
+ * Two forms on one `/forgot-password` route:
+ *   1. Request — enter an email → `POST /api/v1/auth/password/reset`. The
+ *      response is enumeration-safe by contract (`202` regardless of whether the
+ *      email matches an account), so the UI always shows the SAME neutral "if
+ *      that email matches an account…" message and never signals existence.
+ *   2. Confirm — enter the reset token + a new password →
+ *      `POST /api/v1/auth/password/reset/confirm` → the "password has been
+ *      reset" confirmation.
+ *
+ * Both reset endpoints use a raw `fetch` (they are not in the merged OpenAPI
+ * spec yet), so — like the openapi-fetch calls — they must be routed at the
+ * network layer via `page.route`. All APIs mocked, FE-only, no backend. Harness
+ * conventions copied from the existing verify specs; no console errors /
+ * pageerrors across the flow.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const NEUTRAL_RESET_MESSAGE = /if that email matches an account/i
+
+interface Harness {
+  errors: string[]
+  resetRequests: Array<Record<string, unknown>>
+  confirmRequests: Array<Record<string, unknown>>
+}
+
+async function bootstrap(page: Page): Promise<Harness> {
+  const errors: string[] = []
+  const resetRequests: Array<Record<string, unknown>> = []
+  const confirmRequests: Array<Record<string, unknown>> = []
+
+  page.on('console', (m) => {
+    if (m.type() !== 'error') return
+    const text = m.text()
+    if (!text.startsWith('Failed to load resource')) errors.push(text)
+  })
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+
+  // Permissive fallback first; specific fixtures registered afterwards win.
+  await page.route('**/api/**', (r) => r.fulfill({ json: {} }))
+
+  // Register the more-specific `/confirm` route AFTER the base reset route so it
+  // wins for the confirm path (most-recently-added match).
+  await page.route('**/api/v1/auth/password/reset', (r) => {
+    try {
+      resetRequests.push(JSON.parse(r.request().postData() ?? '{}'))
+    } catch {
+      resetRequests.push({})
+    }
+    // Enumeration-safe: 202 no matter what email was submitted.
+    return r.fulfill({ status: 202, json: {} })
+  })
+  await page.route('**/api/v1/auth/password/reset/confirm', (r) => {
+    try {
+      confirmRequests.push(JSON.parse(r.request().postData() ?? '{}'))
+    } catch {
+      confirmRequests.push({})
+    }
+    return r.fulfill({ status: 200, json: {} })
+  })
+
+  await page.route('**/api/v1/ws/events**', (r) => r.abort())
+  await page.route('**/api/v1/alerts/ws**', (r) => r.abort())
+
+  return { errors, resetRequests, confirmRequests }
+}
+
+test.describe('AAASM-5319 — enumeration-safe password reset', () => {
+  test('request form always shows the neutral message; confirm form accepts token + new password', async ({
+    page,
+  }) => {
+    const harness = await bootstrap(page)
+    await page.goto('/forgot-password')
+
+    // --- Step 1: request a reset link. The outcome is enumeration-safe. ---
+    await page.getByLabel('Work email').fill('someone@example.com')
+    await page.getByRole('button', { name: 'Send reset link' }).click()
+
+    // The neutral status is shown regardless of account existence, and it does
+    // NOT disclose whether the email matched (no "sent"/"not found" branch).
+    const notice = page.getByRole('status')
+    await expect(notice).toBeVisible()
+    await expect(notice).toHaveText(NEUTRAL_RESET_MESSAGE)
+    expect(harness.resetRequests).toEqual([{ email: 'someone@example.com' }])
+
+    // --- Step 2: move to the confirm form via "Enter it here". ---
+    await page.getByRole('button', { name: 'Enter it here' }).click()
+
+    // The confirm form takes a reset token + a new password.
+    const tokenField = page.getByLabel('Reset token')
+    const newPassword = page.getByLabel('New password')
+    await expect(tokenField).toBeVisible()
+    await expect(newPassword).toBeVisible()
+
+    await tokenField.fill('reset-token-abc123')
+    await newPassword.fill('brand-new-passphrase')
+    await page.getByRole('button', { name: 'Reset password' }).click()
+
+    // A successful confirm surfaces the done state with a sign-in link.
+    await expect(page.getByRole('status')).toHaveText(/your password has been reset/i)
+    await expect(page.getByRole('link', { name: 'Sign in', exact: true })).toBeVisible()
+    expect(harness.confirmRequests).toEqual([
+      { token: 'reset-token-abc123', new_password: 'brand-new-passphrase' },
+    ])
+
+    expect(harness.errors, 'no console errors or uncaught exceptions').toEqual([])
+  })
+
+  test('a non-matching email yields the identical neutral message (enumeration-safe)', async ({
+    page,
+  }) => {
+    const harness = await bootstrap(page)
+    await page.goto('/forgot-password')
+
+    // A different (presumed non-existent) email must produce the SAME outcome —
+    // the UI never branches on account existence.
+    await page.getByLabel('Work email').fill('nobody@no-such-domain.invalid')
+    await page.getByRole('button', { name: 'Send reset link' }).click()
+
+    const notice = page.getByRole('status')
+    await expect(notice).toBeVisible()
+    await expect(notice).toHaveText(NEUTRAL_RESET_MESSAGE)
+    // Nothing on screen distinguishes a hit from a miss.
+    await expect(page.getByText(/no account|not found|does not exist|unknown email/i)).toHaveCount(0)
+
+    expect(harness.errors, 'no console errors or uncaught exceptions').toEqual([])
+  })
+
+  test('the confirm form prefills the token from an emailed ?token= link', async ({ page }) => {
+    const harness = await bootstrap(page)
+    // Following the emailed link lands directly on the confirm form (ADR 0031 §Q4).
+    await page.goto('/forgot-password?token=link-token-xyz')
+
+    const tokenField = page.getByLabel('Reset token')
+    await expect(tokenField).toBeVisible()
+    await expect(tokenField).toHaveValue('link-token-xyz')
+
+    await page.getByLabel('New password').fill('another-strong-passphrase')
+    await page.getByRole('button', { name: 'Reset password' }).click()
+
+    await expect(page.getByRole('status')).toHaveText(/your password has been reset/i)
+    expect(harness.confirmRequests).toEqual([
+      { token: 'link-token-xyz', new_password: 'another-strong-passphrase' },
+    ])
+
+    expect(harness.errors, 'no console errors or uncaught exceptions').toEqual([])
+  })
+})


### PR DESCRIPTION
## Description

Closes the e2e gap: the native-auth login surface (AAASM-5307) had unit tests + screenshots but no Playwright e2e. Adds two FE-only specs (all APIs mocked via `page.route`), 7 tests total.

- **`verify-aaasm-5319-login.spec.ts`** (4): methods-gating with `["api_key","password"]` → two-tab UI + **asserts no Google/GitHub buttons and no "or continue with email" divider**; methods-gating with `["api_key"]` → no password form, API-key path + Postgres note; two-tab sign-in↔sign-up switch (sign-up has no workspace-name field); sign-in happy path (token lands in `sessionStorage`, URL leaves `/login`).
- **`verify-aaasm-5319-reset.spec.ts`** (3): enumeration-safe reset (neutral "if that email matches…" message; identical outcome for non-matching email), confirm form + `?token=` prefill.

Assertions use real ARIA roles/labels (no new `data-testid` needed); console/pageerror asserted empty. Harness copied from the existing e2e specs verbatim.

## Type of Change
- [x] ✅ Tests

## Breaking Changes
- [x] No

## Related Issues
- Related Jira ticket: AAASM-5319 (Epic AAASM-4522; covers AAASM-5307)

## Testing
- [x] Integration tests added / updated

`pnpm build` ✓, the two new specs `7 passed`, `tsc --noEmit` clean, `eslint .` clean. No app-source changes, no new deps. Reverted unrelated regenerated screenshot byproducts before commit.

## Checklist
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)