### PR TITLE
[AAASM-5287] ✨ (audit): Actor-aware governance-mutation audit for aa-api

### DIFF
--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -8,7 +8,8 @@ use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use aa_core::audit::AuditEntry;
+use aa_core::audit::{AuditEntry, GovernanceMutationAudit};
+use aa_core::SessionId;
 use aa_gateway::registry::{AgentStatus, OrphanMode};
 
 use crate::auth::scope::{RequireRead, RequireWrite, Scope};
@@ -94,6 +95,69 @@ fn parse_agent_id(id: &str) -> Result<[u8; 16], ProblemDetail> {
     })?;
 
     Ok(arr)
+}
+
+/// Emit an actor-attributed [`GovernanceMutationAudit`] for an enforcement- or
+/// authorization-relevant mutation on `agent_id` (AAASM-5287 / ADR 0021
+/// prerequisite 1).
+///
+/// This is the reusable actor-aware audit path the future enforcement-mode
+/// toggle (gated behind AAASM-5097) will reuse. Its security contract: `actor`
+/// and `tenant` are taken **only** from the authenticated `caller` — never the
+/// request body — so a caller cannot forge who performed the action or under
+/// which tenant it is recorded. `reason` is the caller-supplied justification,
+/// which must already be validated non-empty (the audit record rejects an empty
+/// reason as a defence-in-depth backstop).
+///
+/// Emission is best-effort onto the existing `audit_sender` channel, matching
+/// the dispatch path (`dispatch.rs`): a full or disconnected channel drops the
+/// entry rather than failing the mutation the operator already performed. The
+/// `seq` / `previous_hash` are zero because the audit sink re-sequences and
+/// re-chains entries as it persists them.
+fn emit_governance_mutation_audit(
+    state: &AppState,
+    caller: &AuthenticatedCaller,
+    agent_id: &[u8; 16],
+    action: &str,
+    reason: &str,
+    before: &str,
+    after: &str,
+) {
+    let Some(sender) = state.audit_sender.as_ref() else {
+        return;
+    };
+    let record = match GovernanceMutationAudit::new(
+        aa_core::AgentId::from_bytes(*agent_id),
+        // Actor + tenant come from the authenticated identity, NEVER the body.
+        caller.key_id.clone(),
+        caller.tenant.org_id.clone(),
+        caller.tenant.team_id.clone(),
+        action,
+        reason,
+        before,
+        after,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            // The reason was already validated non-empty at the call site; a
+            // failure here means a programming error, not caller input. Log and
+            // skip rather than fail the mutation.
+            tracing::error!(error = %e, "governance mutation audit not emitted");
+            return;
+        }
+    };
+    let entry = record.to_audit_entry(0, unix_now_ns(), SessionId::from_bytes([0u8; 16]), [0u8; 32]);
+    // Best-effort, non-blocking: backpressure is non-fatal for the response.
+    let _ = sender.try_send(entry);
+}
+
+/// Current Unix timestamp in nanoseconds. Mirrors the dispatch-path helper so
+/// governance-mutation audit entries carry a real wall-clock time.
+fn unix_now_ns() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
 }
 
 /// Convert an [`AgentRecord`] into an [`AgentResponse`].
@@ -522,6 +586,13 @@ pub async fn suspend_agent(
     // AAASM-3726: write-scope + tenant ownership before suspending.
     authorize_agent_access(&caller, &state, &agent_id, &id)?;
 
+    // AAASM-5287: a governance mutation must carry a non-empty reason so the
+    // actor-attributed audit record has a justification to record.
+    if body.reason.trim().is_empty() {
+        return Err(ProblemDetail::from_status(StatusCode::UNPROCESSABLE_ENTITY)
+            .with_detail("A non-empty 'reason' is required to suspend an agent"));
+    }
+
     let previous_status = state
         .agent_registry
         .agent_status(&agent_id)
@@ -534,12 +605,25 @@ pub async fn suspend_agent(
         .await
         .map_err(|_| ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {id}")))?;
 
+    let new_status = "Suspended(Manual)".to_string();
+    // AAASM-5287: record who suspended the agent, under which tenant, and why —
+    // actor + tenant from the authenticated identity, never the request body.
+    emit_governance_mutation_audit(
+        &state,
+        &caller,
+        &agent_id,
+        "suspend",
+        &body.reason,
+        &previous_status,
+        &new_status,
+    );
+
     Ok((
         StatusCode::OK,
         Json(SuspendResponse {
             agent_id: id,
             previous_status,
-            new_status: "Suspended(Manual)".to_string(),
+            new_status,
         }),
     ))
 }

--- a/aa-api/src/routes/logs.rs
+++ b/aa-api/src/routes/logs.rs
@@ -45,6 +45,7 @@ pub enum LogEventType {
     SandboxOomKilled,
     SandboxTerminated,
     SandboxHostFnRateLimited,
+    GovernanceMutation,
 }
 
 impl From<AuditEventType> for LogEventType {
@@ -72,6 +73,7 @@ impl From<AuditEventType> for LogEventType {
             AuditEventType::SandboxOomKilled => LogEventType::SandboxOomKilled,
             AuditEventType::SandboxTerminated => LogEventType::SandboxTerminated,
             AuditEventType::SandboxHostFnRateLimited => LogEventType::SandboxHostFnRateLimited,
+            AuditEventType::GovernanceMutation => LogEventType::GovernanceMutation,
         }
     }
 }

--- a/aa-api/tests/governance_mutation_audit.rs
+++ b/aa-api/tests/governance_mutation_audit.rs
@@ -1,0 +1,211 @@
+//! Integration tests for the actor-aware governance-mutation audit path
+//! (AAASM-5287 / ADR 0021 prerequisite 1/3).
+//!
+//! These assert the security-critical contract: when an operator performs an
+//! enforcement-/authorization-relevant mutation (here, agent suspend), the
+//! emitted audit record's actor and tenant come from the *authenticated
+//! identity* and can NOT be spoofed via the request body, the reason is
+//! required, and the before/after governance values are recorded.
+
+mod common;
+
+use std::collections::{BTreeMap, VecDeque};
+
+use aa_core::audit::{AuditEntry, AuditEventType};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tokio::sync::mpsc;
+use tower::ServiceExt;
+
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
+use aa_api::state::AppState;
+use aa_gateway::registry::{AgentRecord, AgentStatus};
+
+const VERIFIED_KEY_ID: &str = "operator-verified";
+const VERIFIED_TEAM: &str = "team-alpha";
+const VERIFIED_ORG: &str = "org-alpha";
+
+fn hex_id(id_byte: u8) -> String {
+    format!("{id_byte:02x}").repeat(16)
+}
+
+fn json_bearer(method: &str, uri: &str, token: &str, body: &str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+/// A root agent record tagged with a team + org tenant, so a matching
+/// tenant-scoped caller passes `authorize_agent_access`.
+fn agent_with_tenant(id_byte: u8, team: &str, org: &str) -> AgentRecord {
+    AgentRecord {
+        agent_id: [id_byte; 16],
+        name: format!("agent-{id_byte}"),
+        framework: "test".to_string(),
+        version: "0".to_string(),
+        risk_tier: 1,
+        tool_names: Vec::new(),
+        public_key: String::new(),
+        credential_token: String::new(),
+        metadata: BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        active_sessions: Vec::new(),
+        recent_events: VecDeque::new(),
+        recent_traces: Vec::new(),
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: Some(team.to_string()),
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: Some([id_byte; 16]),
+        children: Vec::new(),
+        parent_key: None,
+        enforcement_mode: None,
+        org_id: Some(org.to_string()),
+    }
+}
+
+/// Build an auth-enabled state with the audit pipeline wired to a channel the
+/// test drains, plus one agent owned by the verified tenant registered under
+/// `id_byte`. Returns the state and the receiving end of the audit channel.
+fn state_with_audit_channel(id_byte: u8) -> (AppState, mpsc::Receiver<AuditEntry>) {
+    let mut state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    let (tx, rx) = mpsc::channel::<AuditEntry>(16);
+    state.audit_sender = Some(tx);
+    state
+        .agent_registry
+        .register(agent_with_tenant(id_byte, VERIFIED_TEAM, VERIFIED_ORG))
+        .unwrap();
+    (state, rx)
+}
+
+/// A JWT for the verified operator: Write scope, confined to the verified
+/// (team, org). This is the authenticated identity the audit record must
+/// attribute the action to.
+fn verified_operator_token() -> String {
+    common::generate_test_jwt_for_tenant(
+        VERIFIED_KEY_ID,
+        &[Scope::Write],
+        Some(VERIFIED_TEAM),
+        Some(VERIFIED_ORG),
+    )
+}
+
+fn payload_of(entry: &AuditEntry) -> serde_json::Value {
+    serde_json::from_str(entry.payload()).expect("governance-mutation payload is JSON")
+}
+
+// ── The headline security test ────────────────────────────────────────────
+//
+// A caller stuffs actor/org/team into the request body. The audit record must
+// ignore all of it and record the values from the authenticated identity.
+
+#[tokio::test]
+async fn actor_and_tenant_are_taken_from_identity_not_the_request_body() {
+    let (state, mut rx) = state_with_audit_channel(0xC1);
+    let app = aa_api::build_app(state);
+    let token = verified_operator_token();
+
+    // The body tries to spoof actor + tenant. SuspendRequest only reads
+    // `reason`; the spoofed fields are ignored, but even if they were parsed
+    // the handler sources actor/tenant solely from the authenticated caller.
+    let spoof_body = r#"{
+        "reason": "incident-4821 mitigation",
+        "actor": "attacker-key",
+        "org": "evil-org",
+        "team": "evil-team",
+        "key_id": "attacker-key"
+    }"#;
+    let uri = format!("/api/v1/agents/{}/suspend", hex_id(0xC1));
+    let response = app.oneshot(json_bearer("POST", &uri, &token, spoof_body)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "the suspend itself must still succeed");
+
+    let entry = rx.try_recv().expect("a governance-mutation audit entry must have been emitted");
+    assert_eq!(entry.event_type(), AuditEventType::GovernanceMutation);
+
+    let payload = payload_of(&entry);
+    // Actor is the verified JWT subject, NOT the body-supplied "attacker-key".
+    assert_eq!(
+        payload["actor"], VERIFIED_KEY_ID,
+        "actor must be the authenticated identity, never the request body"
+    );
+    assert_ne!(payload["actor"], "attacker-key");
+    // Tenant is the verified caller tenant, NOT the body-supplied "evil-*".
+    assert_eq!(payload["org"], VERIFIED_ORG, "org must be the verified tenant org");
+    assert_eq!(payload["team"], VERIFIED_TEAM, "team must be the verified tenant team");
+    assert_ne!(payload["org"], "evil-org");
+    assert_ne!(payload["team"], "evil-team");
+
+    // The verified tenant also flows into the entry's lineage, so audit-log
+    // tenant scoping applies to operator actions too.
+    assert_eq!(entry.org_id(), Some(VERIFIED_ORG));
+    assert_eq!(entry.team_id(), Some(VERIFIED_TEAM));
+}
+
+// ── Reason is required ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn suspend_with_empty_reason_is_422_and_emits_no_audit() {
+    let (state, mut rx) = state_with_audit_channel(0xC2);
+    let app = aa_api::build_app(state);
+    let token = verified_operator_token();
+
+    let uri = format!("/api/v1/agents/{}/suspend", hex_id(0xC2));
+    let response = app
+        .oneshot(json_bearer("POST", &uri, &token, r#"{"reason":"   "}"#))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "a blank reason must be rejected before any mutation"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "no governance-mutation audit entry may be emitted when the reason is rejected"
+    );
+}
+
+// ── Happy path records reason + before/after ────────────────────────────────
+
+#[tokio::test]
+async fn suspend_records_reason_and_before_after_status() {
+    let (state, mut rx) = state_with_audit_channel(0xC3);
+    let app = aa_api::build_app(state);
+    let token = verified_operator_token();
+
+    let uri = format!("/api/v1/agents/{}/suspend", hex_id(0xC3));
+    let response = app
+        .oneshot(json_bearer("POST", &uri, &token, r#"{"reason":"scheduled maintenance"}"#))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let entry = rx.try_recv().expect("a governance-mutation audit entry must have been emitted");
+    let payload = payload_of(&entry);
+    assert_eq!(payload["action"], "suspend");
+    assert_eq!(payload["reason"], "scheduled maintenance");
+    assert_eq!(payload["before"], "Active");
+    assert_eq!(payload["after"], "Suspended(Manual)");
+    // The mutated agent, not the operator, is the entry's agent_id.
+    assert_eq!(
+        entry.agent_id(),
+        aa_core::AgentId::from_bytes([0xC3; 16]),
+        "the audit entry identifies the mutated agent"
+    );
+    // Defence in depth: no credential-shaped bytes in the payload.
+    assert!(!entry.payload().contains("Bearer"));
+    assert!(!entry.payload().contains("aa_"));
+}

--- a/aa-api/tests/governance_mutation_audit.rs
+++ b/aa-api/tests/governance_mutation_audit.rs
@@ -129,10 +129,19 @@ async fn actor_and_tenant_are_taken_from_identity_not_the_request_body() {
         "key_id": "attacker-key"
     }"#;
     let uri = format!("/api/v1/agents/{}/suspend", hex_id(0xC1));
-    let response = app.oneshot(json_bearer("POST", &uri, &token, spoof_body)).await.unwrap();
-    assert_eq!(response.status(), StatusCode::OK, "the suspend itself must still succeed");
+    let response = app
+        .oneshot(json_bearer("POST", &uri, &token, spoof_body))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "the suspend itself must still succeed"
+    );
 
-    let entry = rx.try_recv().expect("a governance-mutation audit entry must have been emitted");
+    let entry = rx
+        .try_recv()
+        .expect("a governance-mutation audit entry must have been emitted");
     assert_eq!(entry.event_type(), AuditEventType::GovernanceMutation);
 
     let payload = payload_of(&entry);
@@ -188,12 +197,19 @@ async fn suspend_records_reason_and_before_after_status() {
 
     let uri = format!("/api/v1/agents/{}/suspend", hex_id(0xC3));
     let response = app
-        .oneshot(json_bearer("POST", &uri, &token, r#"{"reason":"scheduled maintenance"}"#))
+        .oneshot(json_bearer(
+            "POST",
+            &uri,
+            &token,
+            r#"{"reason":"scheduled maintenance"}"#,
+        ))
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let entry = rx.try_recv().expect("a governance-mutation audit entry must have been emitted");
+    let entry = rx
+        .try_recv()
+        .expect("a governance-mutation audit entry must have been emitted");
     let payload = payload_of(&entry);
     assert_eq!(payload["action"], "suspend");
     assert_eq!(payload["reason"], "scheduled maintenance");

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -123,6 +123,17 @@ pub enum AuditEventType {
     ///
     /// [`SandboxStarted`]: Self::SandboxStarted
     SandboxHostFnRateLimited = 21,
+    /// An operator changed an enforcement- or authorization-relevant governance
+    /// state on an agent through an aa-api mutation endpoint (e.g. suspend /
+    /// resume). Unlike the agent-produced events above, this records an
+    /// *operator* action, so its audit `payload` carries the actor identity
+    /// (`actor` = the authenticated caller's key id), the verified `tenant`
+    /// (`org` / `team`, taken from the authenticated identity — never the
+    /// request body), a required non-empty `reason`, and the `before` / `after`
+    /// governance values. The credential-bearing parts of the identity are
+    /// never included. Emitted via [`GovernanceMutationAudit`]. (AAASM-5287 —
+    /// the actor-attributed audit prerequisite from ADR 0021 / AAASM-237.)
+    GovernanceMutation = 22,
 }
 
 impl AuditEventType {
@@ -153,6 +164,7 @@ impl AuditEventType {
             Self::SandboxOomKilled => "SandboxOomKilled",
             Self::SandboxTerminated => "SandboxTerminated",
             Self::SandboxHostFnRateLimited => "SandboxHostFnRateLimited",
+            Self::GovernanceMutation => "GovernanceMutation",
         }
     }
 }
@@ -811,6 +823,179 @@ pub fn audit_entry_for_tool_dispatch(
 }
 
 // ---------------------------------------------------------------------------
+// Governance mutation audit (AAASM-5287 / ADR 0021 prerequisite 1)
+// ---------------------------------------------------------------------------
+
+/// Error returned by [`GovernanceMutationAudit::new`] when a required field is
+/// missing or blank.
+///
+/// The only currently-modelled failure is an empty `reason`: ADR 0021's
+/// security model requires every enforcement-affecting change to carry a
+/// human-supplied justification, so an operator mutation with no reason is
+/// rejected rather than recorded with an empty one.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GovernanceMutationError {
+    /// The supplied `reason` was empty or whitespace-only.
+    EmptyReason,
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Display for GovernanceMutationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::EmptyReason => write!(f, "governance mutation requires a non-empty reason"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for GovernanceMutationError {}
+
+/// A reusable, actor-attributed record of an enforcement- or authorization-
+/// relevant governance mutation performed by an operator through an aa-api
+/// mutation endpoint (AAASM-5287 / ADR 0021 prerequisite 1).
+///
+/// ADR 0021's ratified security model requires every enforcement-affecting
+/// change to record **actor + tenant + reason + before/after + timestamp**,
+/// and the actor and tenant must be taken from the *authenticated identity* —
+/// never from the request body, which the caller controls and could spoof.
+///
+/// This type does not itself read any request or identity. The calling handler
+/// is responsible for passing `actor`, `org`, and `team` **from the
+/// authenticated caller** (e.g. `AuthenticatedCaller::key_id` and
+/// `AuthenticatedCaller::tenant`), and `reason` from the validated request. By
+/// keeping actor/tenant as explicit parameters sourced by the handler from the
+/// verified identity, the spoofing surface is confined to that one call site
+/// and is directly testable.
+///
+/// ## What is *not* recorded
+///
+/// No credential, token, or API key secret is placed in the payload — only the
+/// caller's `key_id` (a non-secret identifier) and the verified tenant labels.
+/// `before` / `after` are the governance values that changed (e.g. agent
+/// status), not credentials.
+///
+/// Gated on `feature = "std"` because it serialises the payload via
+/// `serde_json`.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernanceMutationAudit {
+    /// The mutated resource — the agent whose governance state changed.
+    pub agent_id: AgentId,
+    /// The authenticated caller's identifier (JWT `sub` / API-key id). This is
+    /// a non-secret principal identifier taken from the verified identity, not
+    /// the request body.
+    pub actor: String,
+    /// The verified organization of the caller, taken from the authenticated
+    /// tenant — never the request body. `None` for a cross-tenant / admin
+    /// caller with no org scope.
+    pub org: Option<String>,
+    /// The verified team of the caller, taken from the authenticated tenant —
+    /// never the request body. `None` for a caller with no team scope.
+    pub team: Option<String>,
+    /// The kind of governance mutation (e.g. `"suspend"`, `"resume"`), so audit
+    /// consumers can filter operator actions by operation.
+    pub action: String,
+    /// The required, non-empty operator-supplied justification.
+    pub reason: String,
+    /// The governance value before the mutation (e.g. the prior agent status).
+    pub before: String,
+    /// The governance value after the mutation (e.g. the new agent status).
+    pub after: String,
+}
+
+#[cfg(feature = "std")]
+impl GovernanceMutationAudit {
+    /// Build a governance-mutation record, validating that `reason` is
+    /// non-empty (ADR 0021's mandatory-reason requirement).
+    ///
+    /// `actor`, `org`, and `team` must be sourced by the caller from the
+    /// authenticated identity, never the request body. Returns
+    /// [`GovernanceMutationError::EmptyReason`] if `reason` is empty or
+    /// whitespace-only.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        agent_id: AgentId,
+        actor: impl Into<String>,
+        org: Option<String>,
+        team: Option<String>,
+        action: impl Into<String>,
+        reason: impl Into<String>,
+        before: impl Into<String>,
+        after: impl Into<String>,
+    ) -> Result<Self, GovernanceMutationError> {
+        let reason = reason.into();
+        if reason.trim().is_empty() {
+            return Err(GovernanceMutationError::EmptyReason);
+        }
+        Ok(Self {
+            agent_id,
+            actor: actor.into(),
+            org,
+            team,
+            action: action.into(),
+            reason,
+            before: before.into(),
+            after: after.into(),
+        })
+    }
+
+    /// Serialise this record to the canonical JSON payload string used as the
+    /// [`AuditEntry`] `payload`.
+    ///
+    /// The payload carries only the non-secret actor identifier, verified
+    /// tenant labels, action, reason, and before/after values — never any
+    /// credential.
+    pub fn to_payload(&self) -> String {
+        let value = serde_json::json!({
+            "actor": self.actor,
+            "org": self.org,
+            "team": self.team,
+            "action": self.action,
+            "reason": self.reason,
+            "before": self.before,
+            "after": self.after,
+        });
+        serde_json::to_string(&value).unwrap_or_else(|_| {
+            // A `serde_json::Value` built from owned strings cannot fail to
+            // serialise; this branch exists only so the method is total and the
+            // audit chain stays well-formed.
+            String::from("{\"error\":\"failed to serialize governance mutation\"}")
+        })
+    }
+
+    /// Build the [`AuditEntry`] for this governance mutation, tagged
+    /// [`AuditEventType::GovernanceMutation`].
+    ///
+    /// The verified tenant `org` / `team` are carried in the entry's
+    /// [`Lineage`] (`org_id` / `team_id`) so the existing audit-log tenant
+    /// scoping applies to operator actions exactly as it does to agent events;
+    /// the actor, reason, and before/after live in the JSON payload.
+    ///
+    /// `seq` / `previous_hash` are supplied by the caller (or `0` / `[0u8; 32]`
+    /// when the entry is emitted onto a channel that re-sequences downstream,
+    /// matching the existing aa-api dispatch pattern).
+    pub fn to_audit_entry(&self, seq: u64, timestamp_ns: u64, session_id: SessionId, previous_hash: [u8; 32]) -> AuditEntry {
+        let lineage = Lineage {
+            team_id: self.team.clone(),
+            org_id: self.org.clone(),
+            ..Lineage::default()
+        };
+        AuditEntry::new_with_lineage(
+            seq,
+            timestamp_ns,
+            AuditEventType::GovernanceMutation,
+            self.agent_id,
+            session_id,
+            self.to_payload(),
+            previous_hash,
+            lineage,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Display
 // ---------------------------------------------------------------------------
 
@@ -1106,6 +1291,7 @@ mod tests {
             AuditEventType::SandboxHostFnRateLimited.as_str(),
             "SandboxHostFnRateLimited"
         );
+        assert_eq!(AuditEventType::GovernanceMutation.as_str(), "GovernanceMutation");
     }
 
     #[test]
@@ -1128,6 +1314,7 @@ mod tests {
         assert_eq!(AuditEventType::SandboxOomKilled as u32, 19);
         assert_eq!(AuditEventType::SandboxTerminated as u32, 20);
         assert_eq!(AuditEventType::SandboxHostFnRateLimited as u32, 21);
+        assert_eq!(AuditEventType::GovernanceMutation as u32, 22);
     }
 
     #[test]
@@ -1151,6 +1338,7 @@ mod tests {
             AuditEventType::SandboxOomKilled,
             AuditEventType::SandboxTerminated,
             AuditEventType::SandboxHostFnRateLimited,
+            AuditEventType::GovernanceMutation,
         ];
         for i in 0..variants.len() {
             for j in (i + 1)..variants.len() {

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -976,7 +976,13 @@ impl GovernanceMutationAudit {
     /// `seq` / `previous_hash` are supplied by the caller (or `0` / `[0u8; 32]`
     /// when the entry is emitted onto a channel that re-sequences downstream,
     /// matching the existing aa-api dispatch pattern).
-    pub fn to_audit_entry(&self, seq: u64, timestamp_ns: u64, session_id: SessionId, previous_hash: [u8; 32]) -> AuditEntry {
+    pub fn to_audit_entry(
+        &self,
+        seq: u64,
+        timestamp_ns: u64,
+        session_id: SessionId,
+        previous_hash: [u8; 32],
+    ) -> AuditEntry {
         let lineage = Lineage {
             team_id: self.team.clone(),
             org_id: self.org.clone(),
@@ -2139,7 +2145,10 @@ mod governance_mutation_tests {
         // only the fields we put there and no bearer-token-shaped bytes.
         let payload = record().to_payload();
         assert!(!payload.contains("aa_"), "payload must not embed an API-key token");
-        assert!(!payload.contains("Bearer"), "payload must not embed an auth header value");
+        assert!(
+            !payload.contains("Bearer"),
+            "payload must not embed an auth header value"
+        );
     }
 }
 

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -2064,6 +2064,86 @@ mod lineage_tests {
 }
 
 #[cfg(all(test, feature = "std", feature = "serde"))]
+mod governance_mutation_tests {
+    use super::*;
+
+    const AGENT: AgentId = AgentId::from_bytes([5u8; 16]);
+    const SESSION: SessionId = SessionId::from_bytes([6u8; 16]);
+
+    fn record() -> GovernanceMutationAudit {
+        GovernanceMutationAudit::new(
+            AGENT,
+            "operator-key-1",
+            Some("org-A".to_string()),
+            Some("team-platform".to_string()),
+            "suspend",
+            "investigating incident",
+            "Active",
+            "Suspended(Manual)",
+        )
+        .expect("non-empty reason is valid")
+    }
+
+    #[test]
+    fn new_rejects_empty_reason() {
+        let err = GovernanceMutationAudit::new(
+            AGENT,
+            "operator-key-1",
+            None,
+            None,
+            "suspend",
+            "",
+            "Active",
+            "Suspended(Manual)",
+        )
+        .unwrap_err();
+        assert_eq!(err, GovernanceMutationError::EmptyReason);
+    }
+
+    #[test]
+    fn new_rejects_whitespace_only_reason() {
+        let err = GovernanceMutationAudit::new(AGENT, "op", None, None, "resume", "   \t\n", "S", "A").unwrap_err();
+        assert_eq!(err, GovernanceMutationError::EmptyReason);
+    }
+
+    #[test]
+    fn payload_carries_actor_tenant_reason_and_before_after() {
+        let payload = record().to_payload();
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(value["actor"], "operator-key-1");
+        assert_eq!(value["org"], "org-A");
+        assert_eq!(value["team"], "team-platform");
+        assert_eq!(value["action"], "suspend");
+        assert_eq!(value["reason"], "investigating incident");
+        assert_eq!(value["before"], "Active");
+        assert_eq!(value["after"], "Suspended(Manual)");
+    }
+
+    #[test]
+    fn to_audit_entry_tags_governance_mutation_and_carries_verified_tenant_in_lineage() {
+        let entry = record().to_audit_entry(0, 1_700_000_000_000_000_000, SESSION, [0u8; 32]);
+        assert_eq!(entry.event_type(), AuditEventType::GovernanceMutation);
+        assert_eq!(entry.agent_id(), AGENT);
+        // The verified tenant flows into the entry's lineage, so the existing
+        // audit-log tenant scoping applies to operator actions too.
+        assert_eq!(entry.org_id(), Some("org-A"));
+        assert_eq!(entry.team_id(), Some("team-platform"));
+        assert!(entry.verify_integrity());
+    }
+
+    #[test]
+    fn payload_never_contains_a_credential_secret() {
+        // The record is built only from a non-secret key id and tenant labels;
+        // a raw credential passed to the endpoint (e.g. as the API-key bearer
+        // token) must never reach the payload. We assert the payload contains
+        // only the fields we put there and no bearer-token-shaped bytes.
+        let payload = record().to_payload();
+        assert!(!payload.contains("aa_"), "payload must not embed an API-key token");
+        assert!(!payload.contains("Bearer"), "payload must not embed an auth header value");
+    }
+}
+
+#[cfg(all(test, feature = "std", feature = "serde"))]
 mod redaction_tests {
     use super::*;
     use aa_security::CredentialScanner;

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -76,6 +76,9 @@ pub use evaluators::{DenyAllEvaluator, PermitAllEvaluator};
 #[cfg(feature = "alloc")]
 pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError, Lineage};
 
+#[cfg(feature = "std")]
+pub use audit::{GovernanceMutationAudit, GovernanceMutationError};
+
 #[cfg(feature = "alloc")]
 pub use capability::{
     action_to_capability, capability_is_denied, merge_capabilities, Capability, CapabilitySet, EffectivePermissions,

--- a/aa-storage-postgres/src/audit_sink.rs
+++ b/aa-storage-postgres/src/audit_sink.rs
@@ -155,7 +155,11 @@ fn decision_label(event_type: AuditEventType) -> &'static str {
         | AuditEventType::ApprovalRequested
         | AuditEventType::ApprovalEscalated
         | AuditEventType::BudgetLimitApproached
-        | AuditEventType::A2ACallIntercepted => "review",
+        | AuditEventType::A2ACallIntercepted
+        // AAASM-5287: an operator governance mutation (suspend/resume, and the
+        // future enforcement-mode toggle) is not an agent-action allow/deny; it
+        // is an operator action auditors review.
+        | AuditEventType::GovernanceMutation => "review",
     }
 }
 

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -4274,7 +4274,7 @@ export interface components {
          *     adding an audit variant without extending this enum is a compile error.
          * @enum {string}
          */
-        LogEventType: "ToolCallIntercepted" | "PolicyViolation" | "CredentialLeakBlocked" | "ApprovalRequested" | "ApprovalGranted" | "ApprovalDenied" | "BudgetLimitApproached" | "BudgetLimitExceeded" | "ApprovalTimedOut" | "ApprovalRouted" | "ApprovalEscalated" | "AgentForceDeregistered" | "MessageBlocked" | "ToolDispatched" | "A2ACallIntercepted" | "A2AImpersonationAttempted" | "SandboxStarted" | "SandboxFilesystemBlocked" | "SandboxCpuTimeout" | "SandboxOomKilled" | "SandboxTerminated" | "SandboxHostFnRateLimited";
+        LogEventType: "ToolCallIntercepted" | "PolicyViolation" | "CredentialLeakBlocked" | "ApprovalRequested" | "ApprovalGranted" | "ApprovalDenied" | "BudgetLimitApproached" | "BudgetLimitExceeded" | "ApprovalTimedOut" | "ApprovalRouted" | "ApprovalEscalated" | "AgentForceDeregistered" | "MessageBlocked" | "ToolDispatched" | "A2ACallIntercepted" | "A2AImpersonationAttempted" | "SandboxStarted" | "SandboxFilesystemBlocked" | "SandboxCpuTimeout" | "SandboxOomKilled" | "SandboxTerminated" | "SandboxHostFnRateLimited" | "GovernanceMutation";
         /** @description Request body for `POST /auth/login`. */
         LoginRequest: {
             /** @description The account email (case-insensitive). */

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -6962,6 +6962,7 @@ components:
       - SandboxOomKilled
       - SandboxTerminated
       - SandboxHostFnRateLimited
+      - GovernanceMutation
     LoginRequest:
       type: object
       description: Request body for `POST /auth/login`.


### PR DESCRIPTION
## Description

ADR-0021 prerequisite 1/3 (direction ratified A1). Builds the reusable actor-aware mutation-audit path the future shadow-mode toggle will reuse. **Does NOT implement shadow mode / any enforcement toggle** (gated 5097).

- New `AuditEventType::GovernanceMutation` + `GovernanceMutationAudit` record (actor, tenant, required reason, before/after, timestamp), emitted via the existing audit sink.
- Wired into `suspend_agent` (an existing `RequireWrite` governance mutation that already carries `reason`) as the demonstrated pattern; suspend's behaviour is otherwise unchanged.
- **Non-spoofable:** actor = `caller.key_id`, tenant = `caller.tenant` — taken only from the authenticated `AuthenticatedCaller`, **never** the request body; reason validated non-empty (422). Test-locked.

### Scope decision (flagged)
`resume` was deliberately NOT wired: it has no `reason` field and adding a required body would break existing callers; per ADR-0021 resume is a strengthening action needing "no ceremony". `suspend` alone correctly demonstrates the reusable pattern.

## Type of Change
- [x] ✨ New feature

## Breaking Changes
- [x] No

## Related Issues
- Related Jira ticket: AAASM-5287 (ADR-0021 prereq 1/3; blocks AAASM-5097)

## Testing
- [x] Unit tests added / updated
- [x] Integration tests added / updated

`aa-core` audit 57 passed; new `governance_mutation_audit` 3 passed (spoof test: body-supplied actor/org/team ignored → record shows verified identity; empty-reason → 422, no audit; happy path records action/reason/before/after, no credential-shaped bytes); `api_openapi_contract` 7 passed (path count unchanged 91; only a new `LogEventType` enum value). `fmt` clean; `clippy` clean on aa-core/aa-storage-postgres. **Note: local `cargo clippy` on aa-api / `--all-targets` hit ENOSPC (disk) and couldn't complete — CI runs the authoritative clippy gate.** Test credentials are runtime-generated (no hardcoded literals).

## Checklist
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)