### PR TITLE
[AAASM-5331] 🐛 (test): Realign governed-launch proxy assertion to the AAASM-5327 fix (main red)

### DIFF
--- a/aa-integration-tests/tests/cli_run_claude_governed_launch.rs
+++ b/aa-integration-tests/tests/cli_run_claude_governed_launch.rs
@@ -295,28 +295,25 @@ exit 0
 
         // ── proxy, as the launched tool saw it ─────────────────────────────
         //
-        // AAASM-1112 finding (2), pinned here rather than asserted away: the
-        // value the child receives is the gateway's bare `host:port`, **not** a
-        // proxy URL. `ClaudeCodeAdapter::build_launch_command` deliberately
-        // normalises `host:port` to `http://host:port`, but `execute_with_adapters`
-        // applies `build_child_env`'s unnormalised value on top of the command the
-        // adapter built (`cmd.envs(&child_env)`), and `spawn_and_wait` applies it
-        // once more — so the adapter's normalisation never reaches the process.
-        // `aa-cli`'s own `build_child_env_sets_proxy` unit test does not catch
-        // this because it feeds in a value that already carries a scheme.
+        // AAASM-1112 finding (2) is now FIXED (AAASM-5324, via AAASM-5327 / PR
+        // #1855): `ClaudeCodeAdapter::build_launch_command` normalises the
+        // gateway-assigned `host:port` to `http://host:port`, and the launch
+        // path (`execute_with_adapters` / `spawn_and_wait`) now propagates the
+        // adapter's normalised value to the child — so the child's proxy env
+        // carries the scheme-qualified `http://{PROXY_ADDR}`.
         //
-        // This assertion is written against the observed value on purpose: when
-        // the defect is fixed the test fails, which is the forcing function that
-        // makes the verification record get revisited.
+        // This previously pinned the pre-fix defective bare `host:port` as a
+        // forcing function (AAASM-5331: the pin was left stale when #1855
+        // landed). It now asserts the DESIGNED value, confirming AAASM-201 AC4
+        // (the launched tool is routed at the proxy the gateway assigned).
+        let expected_proxy_url = format!("http://{PROXY_ADDR}");
         for key in ["HTTPS_PROXY", "HTTP_PROXY"] {
             assert_eq!(
                 seen.get(key).map(String::as_str),
-                Some(PROXY_ADDR),
-                "the launched tool must be routed at the proxy address the gateway assigned via \
-                 `{key}`. NOTE: this pins the CURRENT, DEFECTIVE value on purpose — the designed \
-                 value is `http://{PROXY_ADDR}` (AAASM-5324, root-caused by AAASM-5327). If this \
-                 now reads `http://{PROXY_ADDR}`, that bug is fixed: change this assertion to the \
-                 designed value and re-derive the AAASM-201 AC4 verdict. Saw:\n{raw}",
+                Some(expected_proxy_url.as_str()),
+                "the launched tool must be routed at the scheme-qualified proxy URL the gateway \
+                 assigned via `{key}` — `{expected_proxy_url}` (AAASM-5324 fixed by AAASM-5327 / \
+                 #1855; AAASM-201 AC4). Saw:\n{raw}",
             );
         }
 


### PR DESCRIPTION
## Description

**Fixes `main` red.** AAASM-5327 (PR #1855) fixed the launch-env proxy defect — the launched tool now correctly receives the scheme-qualified `http://127.0.0.1:19999` on `HTTPS_PROXY`/`HTTP_PROXY`. But #1855 left its own **forcing-function assertion** in `cli_run_claude_governed_launch.rs` pinning the *pre-fix* bare `127.0.0.1:19999`. That assertion's comment explicitly said "when the defect is fixed the test fails … change this assertion to the designed value and re-derive the AAASM-201 AC4 verdict" — but it wasn't updated when the fix landed, so `main` (and every PR branched after) is red.

- Assertion now expects the **designed** value `http://{PROXY_ADDR}` (the child's scheme-qualified proxy URL).
- Comment rewritten: the AAASM-1112 finding is fixed (AAASM-5324 via #1855); **AAASM-201 AC4 is met** (the launched tool is routed at the proxy the gateway assigned).
- `PROXY_ADDR` stays the bare `host:port` (it's still correct as the gateway-assigned address at the registration site).

**Test-only** — the production fix already shipped in #1855; this realigns the test to the fixed behaviour.

## Type of Change
- [x] 🐛 Bug fix (CI/test)

## Breaking Changes
- [x] No

## Related Issues
- Related Jira ticket: AAASM-5331 (unblocks main; relates AAASM-5327 / AAASM-5324 / AAASM-201)

## Testing
- [x] Integration tests added / updated

Ran `cargo test -p aa-integration-tests --test cli_run_claude_governed_launch` locally → **2 passed** (both governed-launch tests, incl. the previously-failing `run_claude_launches_the_tool_with_identity_proxy_and_a_monitored_session`). `fmt --check` clean.

## Checklist
- [x] Self-review of the diff completed
- [x] Reproduced the failure and verified the fix locally
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)