### PR TITLE
[AAASM-5289] ♻️ (topology): Project node mode from canonical enforcement_mode, not metadata.mode

### DIFF
--- a/aa-api/src/models/topology.rs
+++ b/aa-api/src/models/topology.rs
@@ -856,6 +856,35 @@ mod tests {
         assert_eq!(agent_mode(&record), "enforce");
     }
 
+    /// AAASM-5289 — the divergence test that is the point of the ticket: when the
+    /// free-form `metadata["mode"]` disagrees with the canonical
+    /// `enforcement_mode` the gateway consults, the badge reports the canonical
+    /// one. A stale/spoofed `metadata.mode = "enforce"` must not mask an agent
+    /// whose enforcement is actually in `Observe` (shadow), and vice-versa.
+    #[test]
+    fn agent_mode_prefers_enforcement_mode_over_diverging_metadata() {
+        use aa_core::EnforcementMode;
+        let mut record = make_record();
+
+        // metadata says "enforce" but enforcement is really Observe → shadow.
+        record.metadata.insert("mode".to_string(), "enforce".to_string());
+        record.enforcement_mode = Some(EnforcementMode::Observe);
+        assert_eq!(
+            agent_mode(&record),
+            "shadow",
+            "badge must follow the canonical enforcement_mode, not metadata.mode"
+        );
+
+        // metadata says "shadow" but enforcement is really Enforce → enforce.
+        record.metadata.insert("mode".to_string(), "shadow".to_string());
+        record.enforcement_mode = Some(EnforcementMode::Enforce);
+        assert_eq!(
+            agent_mode(&record),
+            "enforce",
+            "a stale metadata.mode must not claim shadow while enforcement is on"
+        );
+    }
+
     #[test]
     fn agent_node_from_record_leaves_flagged_false_for_handler_enrichment() {
         // AAASM-5103 — the record carries no violation counter, so the

--- a/aa-api/src/models/topology.rs
+++ b/aa-api/src/models/topology.rs
@@ -59,16 +59,38 @@ impl From<&AgentStatus> for AgentNodeStatus {
 
 /// Enforcement-mode badge value for a node — `enforce`, `shadow`, or `off`.
 ///
-/// Read from the agent record's `metadata["mode"]`, mirroring the Fleet page's
-/// `parseMode` exactly: a recognised value is passed through, and anything else
-/// (including an absent key) falls back to `enforce`. Sourcing the badge from the
-/// same `metadata.mode` the Fleet chip uses keeps the two surfaces consistent
-/// rather than introducing a second, divergent notion of an agent's mode.
+/// Derived from the canonical `AgentRecord::enforcement_mode` field — the same
+/// per-agent override the gateway actually consults at
+/// `aa_gateway::engine` (`agent_override.unwrap_or(policy_default)`) — and NOT
+/// the free-form `metadata["mode"]` string (AAASM-5289, ADR 0021 prerequisite).
+/// The badge must not be able to claim "enforce" while enforcement is off, or
+/// vice-versa, which the old `metadata.mode` source allowed because that string
+/// does not drive enforcement.
+///
+/// Mapping mirrors `capability::project_mode` — `Observe` is the server-side
+/// mode the "shadow" UI alias names — but the topology badge has a third value
+/// (`off`) so it can represent `Disabled` truthfully rather than collapsing it:
+///
+/// | `enforcement_mode`       | Badge      |
+/// |--------------------------|------------|
+/// | `Some(Enforce)`          | `enforce`  |
+/// | `Some(Observe)`          | `shadow`   |
+/// | `Some(Disabled)`         | `off`      |
+/// | `None` (no override)     | `enforce`  |
+///
+/// `None` means no per-agent override — the resolver falls through to the policy
+/// default and finally to the server-wide `Enforce` default
+/// (`AgentRecord::enforcement_mode` doc), so `enforce` is the honest badge, not
+/// "unknown". Expiry needs no handling here: an already-expired shadow window is
+/// resolved to the base mode (`enforcement_mode = None`) in the registry
+/// (AAASM-5288), so reading the resolved field is correct.
 pub(crate) fn agent_mode(record: &AgentRecord) -> String {
-    match record.metadata.get("mode").map(String::as_str) {
-        Some(m @ ("enforce" | "shadow" | "off")) => m.to_owned(),
-        _ => "enforce".to_owned(),
+    match record.enforcement_mode {
+        Some(aa_core::EnforcementMode::Observe) => "shadow",
+        Some(aa_core::EnforcementMode::Disabled) => "off",
+        Some(aa_core::EnforcementMode::Enforce) | None => "enforce",
     }
+    .to_owned()
 }
 
 // ---------------------------------------------------------------------------
@@ -298,8 +320,11 @@ pub struct AgentNode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub governance_level: Option<String>,
     /// Enforcement-mode badge: `enforce`, `shadow`, or `off`. Derived from the
-    /// agent record's `metadata["mode"]` (defaulting to `enforce`) so the
-    /// topology mode badge matches the Fleet page's mode chip for the same agent.
+    /// canonical `AgentRecord::enforcement_mode` field the gateway actually
+    /// consults (AAASM-5289) — not the free-form `metadata["mode"]` — so the
+    /// badge cannot show a mode enforcement is not in. `None` (no per-agent
+    /// override) resolves to `enforce`, the server-wide default. See
+    /// [`agent_mode`].
     pub mode: String,
     /// Whether the agent is policy-flagged — it has recorded at least one
     /// `PolicyViolation` audit event (`count > 0`, AAASM-5103). Drives the
@@ -520,8 +545,8 @@ pub struct AgentTree {
     /// Governance level — included only when `show_budget=true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub governance_level: Option<String>,
-    /// Enforcement-mode badge: `enforce`, `shadow`, or `off`. Same
-    /// `metadata["mode"]` derivation as [`AgentNode::mode`].
+    /// Enforcement-mode badge: `enforce`, `shadow`, or `off`. Same canonical
+    /// `enforcement_mode` derivation as [`AgentNode::mode`] (AAASM-5289).
     pub mode: String,
     /// Whether the agent is policy-flagged (`count > 0`). Same derivation and
     /// audit source as [`AgentNode::flagged`] (AAASM-5103).
@@ -812,18 +837,22 @@ mod tests {
     }
 
     #[test]
-    fn agent_mode_reads_metadata_and_defaults_to_enforce() {
+    fn agent_mode_reads_canonical_enforcement_mode() {
+        use aa_core::EnforcementMode;
         let mut record = make_record();
-        // Recognised values pass through.
-        for m in ["enforce", "shadow", "off"] {
-            record.metadata.insert("mode".to_string(), m.to_string());
-            assert_eq!(agent_mode(&record), m);
-        }
-        // Unrecognised value falls back to enforce (mirrors Fleet parseMode).
-        record.metadata.insert("mode".to_string(), "bogus".to_string());
+
+        record.enforcement_mode = Some(EnforcementMode::Enforce);
         assert_eq!(agent_mode(&record), "enforce");
-        // Absent key falls back to enforce.
-        record.metadata.remove("mode");
+        record.enforcement_mode = Some(EnforcementMode::Observe);
+        assert_eq!(agent_mode(&record), "shadow");
+        record.enforcement_mode = Some(EnforcementMode::Disabled);
+        assert_eq!(agent_mode(&record), "off");
+
+        // `None` = no per-agent override → the server-wide `Enforce` default,
+        // the honest base mode (not "unknown"). An expired shadow window is
+        // already resolved to `None` in the registry (AAASM-5288), so this same
+        // branch covers it.
+        record.enforcement_mode = None;
         assert_eq!(agent_mode(&record), "enforce");
     }
 
@@ -840,7 +869,7 @@ mod tests {
     #[test]
     fn agent_node_from_record_derives_badge_fields() {
         let mut record = make_record();
-        record.metadata.insert("mode".to_string(), "shadow".to_string());
+        record.enforcement_mode = Some(aa_core::EnforcementMode::Observe);
         let node = AgentNode::from(&record);
         assert_eq!(node.mode, "shadow");
         // `flagged` is enriched by the handler, not the conversion (AAASM-5103).

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -461,14 +461,19 @@ async fn topology_tree_returns_subtree_for_known_agent() {
 }
 
 /// AAASM-5036 / AAASM-5103 — the overview (AgentNode) and tree (AgentTree)
-/// responses both carry per-node `mode` (from `metadata["mode"]`), `flagged`
-/// (a recorded `PolicyViolation`, count > 0), and a nullable `trust`.
+/// responses both carry per-node `mode` (from the canonical `enforcement_mode`,
+/// AAASM-5289), `flagged` (a recorded `PolicyViolation`, count > 0), and a
+/// nullable `trust`.
 #[tokio::test]
 async fn topology_response_carries_mode_flagged_trust() {
     let state = common::test_state();
-    // Standalone root: shadow mode.
+    // Standalone root: shadow mode. AAASM-5289 — the badge now derives `mode`
+    // from the canonical `enforcement_mode` (Observe → "shadow"), NOT the
+    // free-form `metadata["mode"]`. Set a DIVERGENT metadata.mode too, so this
+    // asserts the canonical field wins over the stale metadata blob.
     let mut root = make_agent(0x01, "shadow-root", 0, None, None);
-    root.metadata.insert("mode".to_string(), "shadow".to_string());
+    root.enforcement_mode = Some(aa_core::EnforcementMode::Observe);
+    root.metadata.insert("mode".to_string(), "enforce".to_string());
     state.agent_registry.register(root).unwrap();
     // AAASM-5103 — flag it by seeding a real PolicyViolation audit event, the
     // canonical source the badge now derives from (the record no longer carries a

--- a/aa-integration-tests/tests/api_topology.rs
+++ b/aa-integration-tests/tests/api_topology.rs
@@ -569,13 +569,17 @@ async fn topology_graph_returns_nodes_with_badges_and_every_edge_kind() {
 
     let env = TopologyTestEnv::start().await.expect("harness should start");
 
-    // B carries metadata.mode=shadow and enough violations to be flagged, so the
-    // node projection's live mode/flagged badges (AAASM-5036) can be asserted.
+    // B carries enforcement_mode=Observe (the canonical shadow mode) and enough
+    // violations to be flagged, so the node projection's live mode/flagged
+    // badges (AAASM-5036) can be asserted. AAASM-5289: the mode badge derives
+    // from the canonical enforcement_mode, NOT metadata["mode"] — a DIVERGENT
+    // metadata.mode is set to prove the canonical field wins.
     env.agent_registry
         .register(root_agent(A, Some(TEAM)))
         .expect("register A");
     let mut b = root_agent(B, Some(TEAM));
-    b.metadata.insert("mode".to_string(), "shadow".to_string());
+    b.enforcement_mode = Some(aa_core::EnforcementMode::Observe);
+    b.metadata.insert("mode".to_string(), "enforce".to_string());
     env.agent_registry.register(b).expect("register B");
     env.agent_registry
         .register(root_agent(C, Some(TEAM)))
@@ -648,7 +652,10 @@ async fn topology_graph_returns_nodes_with_badges_and_every_edge_kind() {
     }
     // B's live badges flow through from the registry record.
     let node_b = nodes.iter().find(|n| n["id"] == hex(&B)).expect("node B present");
-    assert_eq!(node_b["mode"], "shadow", "B's mode badge reflects metadata.mode");
+    assert_eq!(
+        node_b["mode"], "shadow",
+        "B's mode badge reflects the canonical enforcement_mode (Observe), not the divergent metadata.mode"
+    );
     assert_eq!(node_b["flagged"], true, "B is flagged by its recorded PolicyViolation");
 
     // Edges: every stored kind is graphed (AAASM-5099). The two structural kinds

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -2803,8 +2803,11 @@ export interface components {
             id: string;
             /**
              * @description Enforcement-mode badge: `enforce`, `shadow`, or `off`. Derived from the
-             *     agent record's `metadata["mode"]` (defaulting to `enforce`) so the
-             *     topology mode badge matches the Fleet page's mode chip for the same agent.
+             *     canonical `AgentRecord::enforcement_mode` field the gateway actually
+             *     consults (AAASM-5289) — not the free-form `metadata["mode"]` — so the
+             *     badge cannot show a mode enforcement is not in. `None` (no per-agent
+             *     override) resolves to `enforce`, the server-wide default. See
+             *     [`agent_mode`].
              */
             mode: string;
             /** @description Human-readable agent name. */
@@ -2965,8 +2968,8 @@ export interface components {
             /** @description Hex-encoded agent UUID. */
             id: string;
             /**
-             * @description Enforcement-mode badge: `enforce`, `shadow`, or `off`. Same
-             *     `metadata["mode"]` derivation as [`AgentNode::mode`].
+             * @description Enforcement-mode badge: `enforce`, `shadow`, or `off`. Same canonical
+             *     `enforcement_mode` derivation as [`AgentNode::mode`] (AAASM-5289).
              */
             mode: string;
             /** @description Human-readable agent name. */

--- a/dashboard/src/features/topology/mapGraph.test.ts
+++ b/dashboard/src/features/topology/mapGraph.test.ts
@@ -124,6 +124,22 @@ describe('mapTopologyGraph', () => {
     expect(nodes[0].mode).toBeUndefined()
   })
 
+  // AAASM-5289 — the badge reads the canonical `mode` field the server now
+  // derives from `enforcement_mode`, not any `metadata` blob on the node. The
+  // wire node carries no metadata at all; the mapper keys solely on `mode`, so
+  // the rendered badge follows enforcement even when a legacy metadata.mode
+  // would have said otherwise.
+  it('reads the badge from the canonical wire mode, never a metadata blob', () => {
+    const { nodes } = mapTopologyGraph({
+      // `metadata` is not part of the AgentNode wire shape; the server projects
+      // `mode` from enforcement_mode. A shadow `mode` must render as shadow
+      // regardless of any stale metadata a caller might imagine.
+      nodes: [{ ...node({ id: 'x', mode: 'shadow' }), metadata: { mode: 'enforce' } } as never],
+      edges: [],
+    })
+    expect(nodes[0].mode).toBe('shadow')
+  })
+
   it('null trust maps to null (renders the no-data state, not a misleading 0)', () => {
     const { nodes } = mapTopologyGraph({ nodes: [node({ trust: null })], edges: [] })
     expect(nodes[0].trust).toBeNull()

--- a/dashboard/src/features/topology/types.ts
+++ b/dashboard/src/features/topology/types.ts
@@ -68,11 +68,12 @@ export interface NodeEffectivePermissions {
 }
 
 /**
- * Enforcement mode of an agent, matching the Fleet page's `FleetMode`
- * (`features/agents/fleetTypes.ts`), which derives it from the agent record's
- * `metadata.mode`. The topology API now carries this per node (AAASM-5036 —
- * `AgentNode.mode` / `AgentTree.mode`, same derivation as Fleet), so the mode
- * badge renders from real data.
+ * Enforcement mode of an agent, carried per node by the topology API
+ * (`AgentNode.mode` / `AgentTree.mode`). The server derives it from the
+ * canonical `enforcement_mode` field the gateway actually consults, NOT the
+ * free-form `metadata.mode` (AAASM-5289, ADR 0021 prerequisite) — so the badge
+ * cannot show a mode enforcement is not in. `enforce` is the value for an agent
+ * with no per-agent override (the server-wide default).
  */
 export type TopologyMode = 'enforce' | 'shadow' | 'off'
 
@@ -131,8 +132,9 @@ export interface TopologyNode {
   readonly framework?: string
   /**
    * Enforcement mode, surfaced as a badge on the node card. Carried by the
-   * topology API (`AgentNode.mode` / `AgentTree.mode`), mapped from the agent
-   * record's `metadata.mode` exactly as the Fleet page does. Optional so nodes
+   * topology API (`AgentNode.mode` / `AgentTree.mode`), derived server-side from
+   * the canonical `enforcement_mode` the gateway consults (AAASM-5289), not
+   * `metadata.mode`. Optional so nodes
    * from any older/partial payload stay null-safe — the badge renders only when
    * present.
    */

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -4514,8 +4514,11 @@ components:
           type: string
           description: |-
             Enforcement-mode badge: `enforce`, `shadow`, or `off`. Derived from the
-            agent record's `metadata["mode"]` (defaulting to `enforce`) so the
-            topology mode badge matches the Fleet page's mode chip for the same agent.
+            canonical `AgentRecord::enforcement_mode` field the gateway actually
+            consults (AAASM-5289) — not the free-form `metadata["mode"]` — so the
+            badge cannot show a mode enforcement is not in. `None` (no per-agent
+            override) resolves to `enforce`, the server-wide default. See
+            [`agent_mode`].
         name:
           type: string
           description: Human-readable agent name.
@@ -4759,8 +4762,8 @@ components:
         mode:
           type: string
           description: |-
-            Enforcement-mode badge: `enforce`, `shadow`, or `off`. Same
-            `metadata["mode"]` derivation as [`AgentNode::mode`].
+            Enforcement-mode badge: `enforce`, `shadow`, or `off`. Same canonical
+            `enforcement_mode` derivation as [`AgentNode::mode`] (AAASM-5289).
         name:
           type: string
           description: Human-readable agent name.


### PR DESCRIPTION
## Description

ADR-0021 prerequisite **3/3 (final)** + standalone truthfulness fix. The Topology node mode badge was projected from the free-form `metadata["mode"]` string — **not** the `enforcement_mode` field the gateway actually consults — so the UI could show "enforcing" while enforcement was off (or vice-versa).

- **Backend:** `agent_mode()` (the single source feeding both `AgentNode.mode` and `AgentTree.mode`) now derives from the canonical `record.enforcement_mode` (durably persisted per AAASM-5288): `Observe→shadow`, `Disabled→off`, `Enforce|None→enforce`. `None` = no per-agent override → honest server-wide `Enforce` default. Expiry needs no handling here — 5288 already resolves an expired shadow window to `None` on rehydrate, so reading the resolved field is correct.
- **Frontend:** the badge already read the wire `AgentNode.mode` (never `metadata.mode`), so no FE logic change — corrected the stale `types.ts` doc comments that claimed otherwise, and added a mapper test proving the badge follows the canonical wire mode.
- **Divergence test (the point of the ticket):** an agent whose `metadata.mode` disagrees with `enforcement_mode` now shows the canonical one.

**No shadow-mode toggle** (gated 5097); no enforcement-decision-path change; read-only projection.

## Type of Change
- [x] ♻️ Refactoring (truthfulness fix)

## Breaking Changes
- [x] No (mode field type/vocabulary unchanged; description-only OpenAPI delta)

## Related Issues
- Related Jira ticket: AAASM-5289 (ADR-0021 prereq 3/3 — completes the set; unblocks AAASM-5097)

## Testing
- [x] Unit tests added / updated

`aa-api --lib` 550 passed (incl. the metadata-vs-enforcement_mode divergence test); **`cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -- -D warnings` clean** (exact CI command, run locally); `fmt` clean; `api_openapi_contract` 7 passed (path count unchanged 91 — description-only); dashboard `tsc`/`eslint`/`vitest 3161` all pass. The 2 `destinations.rs` webhook failures are pre-existing env flakes (confirmed on base via stash).

## Checklist
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)