### PR TITLE
[AAASM-5323] ✨ (aa-cli): Resolve and verify the proxy endpoint host-side, and fail closed

### DIFF
--- a/aa-cli/src/commands/proxy/identity.rs
+++ b/aa-cli/src/commands/proxy/identity.rs
@@ -273,6 +273,26 @@ mod tests {
         );
     }
 
+    /// A process asking about *itself* is exempt from the ptrace gate
+    /// (`same_thread_group`), so a self-read can never exercise the hidden-process
+    /// path. Pin that the ordinary case is still answered by the authoritative
+    /// source, so a regression that made every read fall through to `argv[0]`
+    /// would be visible here rather than silently downgrading every check.
+    #[test]
+    fn a_process_that_hides_nothing_is_named_by_the_kernel() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let evidence = image(child.id());
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(
+            matches!(evidence, ImageEvidence::Reported(_)),
+            "an ordinary process must be named by the kernel, not by its own argv; got {evidence:?}"
+        );
+    }
+
     #[test]
     fn start_token_is_stable_across_reads_for_the_same_process() {
         let pid = std::process::id();
@@ -307,5 +327,142 @@ mod tests {
         child.wait().expect("wait for `true`");
         assert!(start_token(pid).is_none(), "a dead pid must yield no start token");
         assert!(image(pid).path().is_none(), "a dead pid must yield no executable path");
+    }
+
+    /// AAASM-5323 regression. `aa-proxy` marks itself non-dumpable at startup
+    /// (`prctl(PR_SET_DUMPABLE, 0)`, AAASM-3584), and the Linux kernel then
+    /// refuses `readlink("/proc/<pid>/exe")` to *every* caller without
+    /// `CAP_SYS_PTRACE` — including the user who started it. The first cut of
+    /// this module read only that symlink, so on Linux it reported "no identity"
+    /// for every genuine proxy and `aasm run` refused to launch, always.
+    ///
+    /// macOS has no equivalent, which is exactly why the defect was invisible
+    /// there; the case is therefore pinned on Linux specifically.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_process_that_hides_itself_from_ptrace_is_still_identifiable() {
+        let expected = std::fs::canonicalize(std::env::current_exe().expect("current_exe")).expect("canonicalize");
+        let child = NonDumpableChild::spawn();
+
+        // Precondition, not decoration: if the authoritative source still
+        // answered, the fallback below would never run and this test would pass
+        // while measuring nothing.
+        let denied = std::fs::read_link(format!("/proc/{}/exe", child.pid))
+            .expect_err("the child was supposed to have hidden its image from us");
+        assert_eq!(
+            denied.kind(),
+            std::io::ErrorKind::PermissionDenied,
+            "expected the ptrace gate to refuse the read, got {denied}"
+        );
+
+        let evidence = image(child.pid);
+        assert_eq!(
+            evidence,
+            ImageEvidence::InvokedAs(expected),
+            "a live process that hid itself must still be identifiable, and must be reported as \
+             identified by its argv rather than by the kernel"
+        );
+        assert!(is_alive(child.pid), "the child must still be running");
+        assert!(
+            start_token(child.pid).is_some(),
+            "/proc/<pid>/stat is not behind the ptrace gate, so the start time must still read"
+        );
+    }
+
+    /// The fallback must not be a way in for a process that is *gone*. A zombie
+    /// still answers `kill(pid, 0)` and still has a readable `stat` (so the start
+    /// time alone would wave it through), but its address space is released, so
+    /// it has neither an executable link nor a command line.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_zombie_has_no_image_evidence() {
+        let mut child = std::process::Command::new("true").spawn().expect("spawn `true`");
+        let pid = child.id();
+        wait_for_state(pid, b'Z');
+
+        let evidence = image(pid);
+        child.wait().expect("reap `true`");
+
+        assert!(
+            matches!(evidence, ImageEvidence::Unreadable(_)),
+            "an exited-but-unreaped process must yield no image; got {evidence:?}"
+        );
+    }
+
+    /// Block until `/proc/<pid>/stat` reports `state`, so a test that depends on
+    /// a process having reached it is not racing the scheduler.
+    #[cfg(target_os = "linux")]
+    fn wait_for_state(pid: u32, state: u8) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).unwrap_or_default();
+            if let Some(rest) = stat.rfind(')').and_then(|i| stat.get(i + 2..)) {
+                if rest.as_bytes().first() == Some(&state) {
+                    return;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        panic!("pid {pid} never reached state {}", state as char);
+    }
+
+    /// A child of this process that has applied the same hardening `aa-proxy`
+    /// applies to itself, so the ptrace gate the fix has to survive is the real
+    /// kernel one and not a simulation of it.
+    ///
+    /// It is produced with a bare `fork` rather than `Command`, because
+    /// `execve` resets the dumpable flag: only a process that sets it *after*
+    /// its last exec is non-dumpable, which is precisely the shape `aa-proxy`
+    /// has. The child touches nothing but async-signal-safe calls, so forking
+    /// from libtest's threaded harness is sound; it is killed and reaped on
+    /// drop rather than exiting on its own.
+    #[cfg(target_os = "linux")]
+    struct NonDumpableChild {
+        pid: u32,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl NonDumpableChild {
+        fn spawn() -> Self {
+            // Safety: the child path calls only `prctl`, `pause` and `_exit`,
+            // all async-signal-safe; it never returns into test code.
+            let pid = unsafe { libc::fork() };
+            assert!(pid >= 0, "fork failed: {}", std::io::Error::last_os_error());
+            if pid == 0 {
+                unsafe {
+                    libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0);
+                    loop {
+                        libc::pause();
+                    }
+                }
+            }
+            let child = Self { pid: pid as u32 };
+            child.wait_until_hidden();
+            child
+        }
+
+        /// `fork` returns in the parent before the child has run `prctl`, so the
+        /// parent must not read until the flag is actually set.
+        fn wait_until_hidden(&self) {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                match std::fs::read_link(format!("/proc/{}/exe", self.pid)) {
+                    Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return,
+                    _ => std::thread::sleep(std::time::Duration::from_millis(10)),
+                }
+            }
+            panic!("pid {} never became non-dumpable", self.pid);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    impl Drop for NonDumpableChild {
+        fn drop(&mut self) {
+            // Safety: both calls take the PID by value; the child is ours to reap.
+            unsafe {
+                libc::kill(self.pid as libc::pid_t, libc::SIGKILL);
+                libc::waitpid(self.pid as libc::pid_t, std::ptr::null_mut(), 0);
+            }
+        }
     }
 }

--- a/aa-cli/src/commands/proxy/identity.rs
+++ b/aa-cli/src/commands/proxy/identity.rs
@@ -11,7 +11,7 @@
 //! the tool launches, reports as governed, and is inspected by no one.
 //!
 //! Two facts are therefore pinned in the state file when the proxy is spawned
-//! and re-read from the kernel before the endpoint is trusted:
+//! and read back from the running process before the endpoint is trusted:
 //!
 //! * **the executable behind the PID** — a process that merely inherited the
 //!   number is running some other program, so this alone rejects the
@@ -22,14 +22,35 @@
 //!   process-identity pair for exactly this reason (it is what `pidfd`, systemd
 //!   and every correct pidfile implementation reduce to).
 //!
-//! # Why per-platform, and why `None` is fatal rather than skippable
+//! # Why per-platform, and why absent evidence is fatal rather than skippable
 //!
 //! Neither fact is portable. Each platform reads it natively; a platform with no
-//! implementation returns `None`, which the trust check treats as *cannot
-//! establish identity* and refuses. An unavailable check must never degrade into
-//! a passed check — that is how a guard becomes decoration.
+//! implementation says so, and the trust check treats that as *cannot establish
+//! identity* and refuses. An unavailable check must never degrade into a passed
+//! check — that is how a guard becomes decoration.
+//!
+//! # Why the image evidence is a sum type and not a path
+//!
+//! On Linux the authoritative source for "what is this PID running" is
+//! `/proc/<pid>/exe`, and the kernel gates reading it behind
+//! `ptrace_may_access(PTRACE_MODE_READ)`. That gate rejects **even the process's
+//! own user** once the target has marked itself non-dumpable — which `aa-proxy`
+//! does to itself at startup (`prctl(PR_SET_DUMPABLE, 0)`, AAASM-3584) so that
+//! the provider keys in its address space cannot be scraped or core-dumped by a
+//! same-uid attacker. The proxy is therefore, by design, the one process on the
+//! host that will not name its own image to `aasm run`.
+//!
+//! Two deliberate protections cannot both be satisfied by that one source, so
+//! the evidence records *which* source answered rather than flattening both into
+//! `Option<PathBuf>`. [`ImageEvidence::Reported`] is the kernel naming the image
+//! it loaded; [`ImageEvidence::InvokedAs`] is `argv[0]` — the one image fact the
+//! kernel still publishes for a hidden process — and is only ever produced when
+//! the authoritative read was refused *because* the process hid itself. Being
+//! unable to read a process at all ([`ImageEvidence::Unreadable`], which is what
+//! an exited-but-unreaped zombie yields) stays a refusal, and so does a platform
+//! with no implementation ([`ImageEvidence::Unsupported`]).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Returns `true` when a signal can be delivered to `pid`.
 ///
@@ -50,34 +71,119 @@ pub fn is_alive(_pid: u32) -> bool {
     false
 }
 
-/// Absolute path of the executable image `pid` is running, or `None` when the
-/// process is gone or the platform cannot report it.
-#[cfg(target_os = "linux")]
-pub fn exe_path(pid: u32) -> Option<PathBuf> {
-    // `/proc/<pid>/exe` is a kernel-maintained symlink to the *resolved* image,
-    // so it is immune to the caller's `PATH` and to any symlink the launcher
-    // happened to invoke the binary through.
-    std::fs::read_link(format!("/proc/{pid}/exe")).ok()
+/// What this host will say about the executable image behind a PID.
+///
+/// The variants are ordered by authority, and the trust check must branch on
+/// them rather than reduce them to "some path or nothing": the two failure
+/// variants mean different things to an operator, and the two success variants
+/// were answered by different sources.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImageEvidence {
+    /// The kernel named the image it loaded. Unforgeable by the process itself.
+    Reported(PathBuf),
+    /// The process has hidden itself from same-uid inspection, so the kernel
+    /// refuses to name its image; this is the path it was **invoked with**,
+    /// which the kernel still publishes. See the module docs for why this is
+    /// the strongest evidence obtainable about a hardened `aa-proxy`.
+    InvokedAs(PathBuf),
+    /// Nothing about the image can be read. Carries the reason so the refusal
+    /// can say something true instead of blaming the platform.
+    Unreadable(&'static str),
+    /// This platform has no implementation at all.
+    Unsupported,
 }
 
-/// Absolute path of the executable image `pid` is running, or `None` when the
-/// process is gone or the platform cannot report it.
+impl ImageEvidence {
+    /// The path this host attributes to the process, whichever source answered.
+    /// `None` for both failure variants — callers that only need the path must
+    /// still treat absence as a refusal.
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::Reported(p) | Self::InvokedAs(p) => Some(p),
+            Self::Unreadable(_) | Self::Unsupported => None,
+        }
+    }
+}
+
+/// Evidence about the executable image `pid` is running.
+///
+/// `/proc/<pid>/exe` is a kernel-maintained symlink to the *resolved* image, so
+/// it is immune to the caller's `PATH` and to any symlink the launcher happened
+/// to invoke the binary through. Its three error paths are distinguished
+/// because they mean three different things:
+///
+/// * `EACCES` — the process is alive but non-dumpable, i.e. it has deliberately
+///   made itself unreadable to same-uid inspection (what `aa-proxy` does). Fall
+///   through to `argv[0]`, which the kernel keeps publishing.
+/// * `ENOENT` — the PID exists but has no image: it has exited and is a zombie
+///   awaiting reaping, or `/proc` is not mounted. There is nothing to identify.
+/// * anything else — `/proc` is unreadable; refuse rather than guess.
+#[cfg(target_os = "linux")]
+pub fn image(pid: u32) -> ImageEvidence {
+    match std::fs::read_link(format!("/proc/{pid}/exe")) {
+        Ok(path) => ImageEvidence::Reported(path),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => invoked_as(pid),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => ImageEvidence::Unreadable(
+            "it has no executable image — the process has exited and is awaiting reaping, \
+             or /proc is not mounted",
+        ),
+        Err(_) => ImageEvidence::Unreadable("its /proc entry could not be read"),
+    }
+}
+
+/// `argv[0]` of `pid`, canonicalised so it is directly comparable with the
+/// resolved path `/proc/<pid>/exe` would have given.
+///
+/// Only reached when the kernel refused the authoritative read *because the
+/// target hid itself*, so the two remaining ways to get nothing — a zombie
+/// (whose `cmdline` is empty, its address space already gone) and a binary that
+/// has since been removed from the path it was launched from — both stay
+/// refusals rather than becoming a missing check.
+#[cfg(target_os = "linux")]
+fn invoked_as(pid: u32) -> ImageEvidence {
+    use std::os::unix::ffi::OsStrExt;
+
+    let Ok(cmdline) = std::fs::read(format!("/proc/{pid}/cmdline")) else {
+        return ImageEvidence::Unreadable("its command line could not be read");
+    };
+    // NUL-separated; `argv[0]` is everything up to the first separator.
+    let argv0 = cmdline.split(|b| *b == 0).next().unwrap_or_default();
+    if argv0.is_empty() {
+        return ImageEvidence::Unreadable(
+            "it publishes no command line — the process has exited and is awaiting reaping",
+        );
+    }
+    let argv0 = Path::new(std::ffi::OsStr::from_bytes(argv0));
+    match std::fs::canonicalize(argv0) {
+        Ok(resolved) => ImageEvidence::InvokedAs(resolved),
+        Err(_) => ImageEvidence::Unreadable("the executable it was launched from no longer resolves"),
+    }
+}
+
+/// Evidence about the executable image `pid` is running.
+///
+/// macOS has no `PR_SET_DUMPABLE` equivalent, so `proc_pidpath` answers for any
+/// process this user may signal and there is no second-best source to fall back
+/// to — hence no [`ImageEvidence::InvokedAs`] on this platform.
 #[cfg(target_os = "macos")]
-pub fn exe_path(pid: u32) -> Option<PathBuf> {
+pub fn image(pid: u32) -> ImageEvidence {
     let mut buf = vec![0u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
     // Safety: `buf` is a live allocation of exactly the length passed; the call
     // writes at most that many bytes and returns the count written.
     let written = unsafe { libc::proc_pidpath(pid as libc::c_int, buf.as_mut_ptr().cast(), buf.len() as u32) };
     if written <= 0 {
-        return None;
+        return ImageEvidence::Unreadable("the kernel would not name its executable — the process has exited");
     }
     buf.truncate(written as usize);
-    String::from_utf8(buf).ok().map(PathBuf::from)
+    match String::from_utf8(buf) {
+        Ok(path) => ImageEvidence::Reported(PathBuf::from(path)),
+        Err(_) => ImageEvidence::Unreadable("the kernel reported a non-UTF-8 executable path"),
+    }
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-pub fn exe_path(_pid: u32) -> Option<PathBuf> {
-    None
+pub fn image(_pid: u32) -> ImageEvidence {
+    ImageEvidence::Unsupported
 }
 
 /// An opaque token identifying *this* incarnation of `pid`.
@@ -154,13 +260,16 @@ mod tests {
     }
 
     #[test]
-    fn exe_path_of_this_process_is_the_test_binary() {
-        let seen = exe_path(std::process::id()).expect("this platform must report its own executable");
+    fn the_image_of_this_process_is_the_test_binary() {
+        let evidence = image(std::process::id());
+        let seen = evidence
+            .path()
+            .unwrap_or_else(|| panic!("this platform must report its own executable; got {evidence:?}"));
         let expected = std::env::current_exe().expect("current_exe");
         assert_eq!(
-            std::fs::canonicalize(&seen).unwrap_or(seen.clone()),
-            std::fs::canonicalize(&expected).unwrap_or(expected.clone()),
-            "exe_path must name the running image; saw {seen:?} vs {expected:?}"
+            std::fs::canonicalize(seen).unwrap_or_else(|_| seen.to_path_buf()),
+            std::fs::canonicalize(&expected).unwrap_or_else(|_| expected.clone()),
+            "the image evidence must name the running image; saw {seen:?} vs {expected:?}"
         );
     }
 
@@ -197,6 +306,6 @@ mod tests {
         let pid = child.id();
         child.wait().expect("wait for `true`");
         assert!(start_token(pid).is_none(), "a dead pid must yield no start token");
-        assert!(exe_path(pid).is_none(), "a dead pid must yield no executable path");
+        assert!(image(pid).path().is_none(), "a dead pid must yield no executable path");
     }
 }

--- a/aa-cli/src/commands/proxy/identity.rs
+++ b/aa-cli/src/commands/proxy/identity.rs
@@ -132,3 +132,71 @@ pub fn start_token(pid: u32) -> Option<String> {
 pub fn start_token(_pid: u32) -> Option<String> {
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn this_process_is_alive() {
+        assert!(is_alive(std::process::id()));
+    }
+
+    /// PID 0 is never a signallable user process; `kill(0, 0)` addresses the
+    /// caller's whole process group, so a naive implementation would report it
+    /// alive. Kept as a guard against exactly that mistake.
+    #[test]
+    fn a_reaped_child_is_not_alive() {
+        let mut child = std::process::Command::new("true").spawn().expect("spawn `true`");
+        let pid = child.id();
+        child.wait().expect("wait for `true`");
+        assert!(!is_alive(pid), "a reaped child must not report as alive; pid {pid} did");
+    }
+
+    #[test]
+    fn exe_path_of_this_process_is_the_test_binary() {
+        let seen = exe_path(std::process::id()).expect("this platform must report its own executable");
+        let expected = std::env::current_exe().expect("current_exe");
+        assert_eq!(
+            std::fs::canonicalize(&seen).unwrap_or(seen.clone()),
+            std::fs::canonicalize(&expected).unwrap_or(expected.clone()),
+            "exe_path must name the running image; saw {seen:?} vs {expected:?}"
+        );
+    }
+
+    #[test]
+    fn start_token_is_stable_across_reads_for_the_same_process() {
+        let pid = std::process::id();
+        let first = start_token(pid).expect("this platform must report its own start time");
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let second = start_token(pid).expect("start token must remain readable");
+        assert_eq!(first, second, "a process's start time must not change under it");
+    }
+
+    /// The evidence is worthless if two processes share a token, so pin that a
+    /// separately-started process reports a different one.
+    #[test]
+    fn start_token_differs_between_two_processes() {
+        let mine = start_token(std::process::id()).expect("own start token");
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .expect("spawn sleep");
+        let theirs = start_token(child.id()).expect("child start token");
+        let _ = child.kill();
+        let _ = child.wait();
+        assert_ne!(
+            mine, theirs,
+            "two processes started at different times must not share a start token"
+        );
+    }
+
+    #[test]
+    fn identity_of_a_dead_pid_is_unavailable() {
+        let mut child = std::process::Command::new("true").spawn().expect("spawn `true`");
+        let pid = child.id();
+        child.wait().expect("wait for `true`");
+        assert!(start_token(pid).is_none(), "a dead pid must yield no start token");
+        assert!(exe_path(pid).is_none(), "a dead pid must yield no executable path");
+    }
+}

--- a/aa-cli/src/commands/proxy/identity.rs
+++ b/aa-cli/src/commands/proxy/identity.rs
@@ -1,0 +1,134 @@
+//! Live-process identity evidence for the proxy state file.
+//!
+//! # Why a PID is not an identity
+//!
+//! `kill(pid, 0)` succeeding proves only that *some* process currently owns that
+//! number. PIDs are recycled — on a busy host the wrap-around is minutes, not
+//! days — so a state file that records a PID and nothing else cannot tell "the
+//! proxy is still running" from "the proxy died and an unrelated process
+//! inherited its number". Routing a governed tool's traffic at whatever now
+//! holds the number is the same silent-bypass failure as routing it at nothing:
+//! the tool launches, reports as governed, and is inspected by no one.
+//!
+//! Two facts are therefore pinned in the state file when the proxy is spawned
+//! and re-read from the kernel before the endpoint is trusted:
+//!
+//! * **the executable behind the PID** — a process that merely inherited the
+//!   number is running some other program, so this alone rejects the
+//!   overwhelming majority of reuse; and
+//! * **the process start time** — the field the kernel guarantees distinguishes
+//!   a process from its PID's next occupant, because a successor cannot have
+//!   started before its predecessor exited. `(pid, start_time)` is the standard
+//!   process-identity pair for exactly this reason (it is what `pidfd`, systemd
+//!   and every correct pidfile implementation reduce to).
+//!
+//! # Why per-platform, and why `None` is fatal rather than skippable
+//!
+//! Neither fact is portable. Each platform reads it natively; a platform with no
+//! implementation returns `None`, which the trust check treats as *cannot
+//! establish identity* and refuses. An unavailable check must never degrade into
+//! a passed check — that is how a guard becomes decoration.
+
+use std::path::PathBuf;
+
+/// Returns `true` when a signal can be delivered to `pid`.
+///
+/// `kill(pid, 0)` returns 0 only when the caller is permitted to signal the
+/// target, which on a non-root caller means the process runs as the same user.
+/// A process owned by someone else therefore reports as *not alive* here — the
+/// conservative answer, and the one the trust check wants: a proxy this user did
+/// not start is not this user's proxy.
+#[cfg(unix)]
+pub fn is_alive(pid: u32) -> bool {
+    // Safety: `kill` with signal 0 performs the permission/existence check
+    // without delivering a signal; no memory is dereferenced.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+pub fn is_alive(_pid: u32) -> bool {
+    false
+}
+
+/// Absolute path of the executable image `pid` is running, or `None` when the
+/// process is gone or the platform cannot report it.
+#[cfg(target_os = "linux")]
+pub fn exe_path(pid: u32) -> Option<PathBuf> {
+    // `/proc/<pid>/exe` is a kernel-maintained symlink to the *resolved* image,
+    // so it is immune to the caller's `PATH` and to any symlink the launcher
+    // happened to invoke the binary through.
+    std::fs::read_link(format!("/proc/{pid}/exe")).ok()
+}
+
+/// Absolute path of the executable image `pid` is running, or `None` when the
+/// process is gone or the platform cannot report it.
+#[cfg(target_os = "macos")]
+pub fn exe_path(pid: u32) -> Option<PathBuf> {
+    let mut buf = vec![0u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+    // Safety: `buf` is a live allocation of exactly the length passed; the call
+    // writes at most that many bytes and returns the count written.
+    let written = unsafe { libc::proc_pidpath(pid as libc::c_int, buf.as_mut_ptr().cast(), buf.len() as u32) };
+    if written <= 0 {
+        return None;
+    }
+    buf.truncate(written as usize);
+    String::from_utf8(buf).ok().map(PathBuf::from)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn exe_path(_pid: u32) -> Option<PathBuf> {
+    None
+}
+
+/// An opaque token identifying *this* incarnation of `pid`.
+///
+/// The value is only ever compared for equality against a token captured
+/// earlier for the same PID, so its encoding is private to this module. It is
+/// prefixed with the platform that produced it so a state file carried between
+/// hosts of different kinds can never compare equal by coincidence.
+#[cfg(target_os = "linux")]
+pub fn start_token(pid: u32) -> Option<String> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    // Field 2 (`comm`) is parenthesised and may itself contain spaces and even
+    // ')', so the only safe split point in `/proc/<pid>/stat` is the *last*
+    // ')'. Splitting on whitespace from the left mis-parses any process whose
+    // executable name contains a space — including, deliberately, an attacker's.
+    let rest = stat.get(stat.rfind(')')? + 1..)?;
+    // Tokens after that point start at field 3 (`state`), so field 22
+    // (`starttime`, in clock ticks since boot) is at index 19.
+    let ticks: u64 = rest.split_whitespace().nth(19)?.parse().ok()?;
+    Some(format!("linux-starttime:{ticks}"))
+}
+
+/// An opaque token identifying *this* incarnation of `pid`. See the Linux
+/// variant for the comparison contract.
+#[cfg(target_os = "macos")]
+pub fn start_token(pid: u32) -> Option<String> {
+    // Safety: `proc_pidinfo` fills the caller-provided `proc_bsdinfo` and is
+    // told its exact size; a short return is treated as failure below.
+    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+    let written = unsafe {
+        libc::proc_pidinfo(
+            pid as libc::c_int,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            // `addr_of_mut!` rather than `ptr::from_mut`: the latter is stable
+            // only since 1.76 and this crate's MSRV is 1.75.
+            std::ptr::addr_of_mut!(info).cast(),
+            size,
+        )
+    };
+    if written != size {
+        return None;
+    }
+    Some(format!(
+        "macos-starttime:{}.{:06}",
+        info.pbi_start_tvsec, info.pbi_start_tvusec
+    ))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn start_token(_pid: u32) -> Option<String> {
+    None
+}

--- a/aa-cli/src/commands/proxy/mod.rs
+++ b/aa-cli/src/commands/proxy/mod.rs
@@ -7,6 +7,7 @@ pub mod pid;
 pub mod start;
 pub mod status;
 pub mod stop;
+pub mod trust;
 
 use std::process::ExitCode;
 

--- a/aa-cli/src/commands/proxy/mod.rs
+++ b/aa-cli/src/commands/proxy/mod.rs
@@ -1,6 +1,7 @@
 //! `aasm proxy` — manage the aa-proxy sidecar: lifecycle, CA, and log tailing.
 
 pub mod ca;
+pub mod identity;
 pub mod logs;
 pub mod pid;
 pub mod start;

--- a/aa-cli/src/commands/proxy/pid.rs
+++ b/aa-cli/src/commands/proxy/pid.rs
@@ -1,17 +1,55 @@
-//! PID file helpers for `aasm proxy start` / `stop`.
+//! Proxy state file for `aasm proxy start` / `stop` / `status`, and the record
+//! `aasm run` resolves a trusted proxy endpoint from.
 //!
 //! File location: `$AA_DATA_DIR/proxy.pid` if `AA_DATA_DIR` is set
 //! (used by the integration-test harness to isolate per-test state), otherwise
 //! `~/.local/share/aasm/proxy.pid`.
-//! File format: `<pid>\n<listen_addr>\n`
+//!
+//! # Format, and why it grew
+//!
+//! ```text
+//! <pid>
+//! <listen_addr>
+//! <start_token>
+//! <exe_path>
+//! ```
+//!
+//! The first two lines are the lifecycle record `stop` and `status` have always
+//! used. The last two are process-identity evidence (see [`super::identity`]):
+//! without them a reader can establish that *a* process holds the recorded PID,
+//! but not that it is the proxy that was recorded — and `aasm run` routes a
+//! governed tool's traffic on the strength of that answer (AAASM-5323).
+//!
+//! # Why there are two readers
+//!
+//! [`read_state`] is strict: every field must be present and non-empty, because
+//! a partial record cannot support a trust decision and the only safe response
+//! to one is to refuse. [`read_pid`] is deliberately lenient about the trailing
+//! evidence lines, because `aasm proxy stop` must still be able to reap a proxy
+//! whose record it cannot fully vouch for — refusing to signal a live process
+//! would orphan it, which is strictly worse than stopping it.
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-/// Returns the path to the proxy PID file.
+/// The full proxy state record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyState {
+    pub pid: u32,
+    /// `host:port` the proxy was told to bind. Not validated here — see
+    /// [`super::trust`], which is the only thing entitled to conclude anything
+    /// from it.
+    pub listen_addr: String,
+    /// Opaque process-start token captured at spawn; see [`super::identity`].
+    pub start_token: String,
+    /// Canonical path of the executable that was spawned.
+    pub exe_path: PathBuf,
+}
+
+/// Returns the path to the proxy state file.
 ///
 /// Honors `AA_DATA_DIR` so the `aa-integration-tests` harness can give each
-/// test its own PID-file location, avoiding races on the shared user-home
+/// test its own state-file location, avoiding races on the shared user-home
 /// path when `cargo nextest` runs lifecycle tests in parallel. Falls back to
 /// `dirs::data_local_dir()` for the default production install.
 pub fn pid_path() -> PathBuf {
@@ -26,26 +64,79 @@ pub fn pid_path() -> PathBuf {
         .join("proxy.pid")
 }
 
-/// Write `<pid>\n<listen_addr>\n` to the PID file, creating parent directories as needed.
-pub fn write_pid(listen_addr: &str) -> io::Result<()> {
+/// Write the state record, creating parent directories as needed.
+///
+/// The file is left mode `0600` on Unix. This is not hygiene: the reader in
+/// [`super::trust`] refuses a record that any other principal could have
+/// written, so a group- or world-writable file would make every `aasm run`
+/// fail closed. Permissions are set explicitly rather than left to the process
+/// umask, and applied after the write so an existing looser file is tightened
+/// rather than inherited.
+pub fn write_state(state: &ProxyState) -> io::Result<()> {
     let path = pid_path();
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let content = format!("{}\n{}\n", std::process::id(), listen_addr);
-    std::fs::write(&path, content)
+    let content = format!(
+        "{}\n{}\n{}\n{}\n",
+        state.pid,
+        state.listen_addr,
+        state.start_token,
+        state.exe_path.display(),
+    );
+    std::fs::write(&path, content)?;
+    restrict_permissions(&path)
 }
 
-/// Read `(pid, listen_addr)` from the PID file. Returns `None` if the file is absent or malformed.
+#[cfg(unix)]
+fn restrict_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+/// Read the complete state record. Returns `None` unless every field is present
+/// and non-empty — a half-written or truncated record supports no conclusion,
+/// and the caller's only safe response to `None` is to refuse.
+pub fn read_state() -> Option<ProxyState> {
+    let content = std::fs::read_to_string(pid_path()).ok()?;
+    parse_state(&content)
+}
+
+/// Parse a state record. Split out from [`read_state`] so the field rules are
+/// testable without a filesystem.
+pub fn parse_state(content: &str) -> Option<ProxyState> {
+    let mut lines = content.lines();
+    let pid: u32 = lines.next()?.trim().parse().ok()?;
+    let listen_addr = lines.next()?.trim().to_string();
+    let start_token = lines.next()?.trim().to_string();
+    let exe_path = lines.next()?.trim().to_string();
+    if listen_addr.is_empty() || start_token.is_empty() || exe_path.is_empty() {
+        return None;
+    }
+    Some(ProxyState {
+        pid,
+        listen_addr,
+        start_token,
+        exe_path: PathBuf::from(exe_path),
+    })
+}
+
+/// Read `(pid, listen_addr)` for the lifecycle commands. Tolerates a record
+/// carrying no identity evidence on purpose — see the module docs.
 pub fn read_pid() -> Option<(u32, String)> {
     let content = std::fs::read_to_string(pid_path()).ok()?;
     let mut lines = content.lines();
-    let pid: u32 = lines.next()?.parse().ok()?;
-    let addr = lines.next()?.to_string();
+    let pid: u32 = lines.next()?.trim().parse().ok()?;
+    let addr = lines.next()?.trim().to_string();
     Some((pid, addr))
 }
 
-/// Remove the PID file. Succeeds silently if the file does not exist.
+/// Remove the state file. Succeeds silently if the file does not exist.
 pub fn remove_pid() -> io::Result<()> {
     let path = pid_path();
     if path.exists() {
@@ -86,6 +177,15 @@ mod tests {
         }
     }
 
+    fn sample_state() -> ProxyState {
+        ProxyState {
+            pid: std::process::id(),
+            listen_addr: "127.0.0.1:8899".into(),
+            start_token: "linux-starttime:123456".into(),
+            exe_path: PathBuf::from("/usr/local/bin/aa-proxy"),
+        }
+    }
+
     #[test]
     fn pid_path_honors_aa_data_dir_when_set() {
         let _guard = EnvGuard::set("/tmp/aasm-proxy-pid-test-fixture");
@@ -113,21 +213,78 @@ mod tests {
     }
 
     #[test]
-    fn write_and_read_pid_round_trip() {
+    fn write_and_read_state_round_trip() {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = EnvGuard::set(tmp.path().to_str().unwrap());
 
-        write_pid("127.0.0.1:8899").unwrap();
-        let (pid, addr) = read_pid().expect("pid file should be readable after write");
-        assert_eq!(pid, std::process::id());
-        assert_eq!(addr, "127.0.0.1:8899");
+        let state = sample_state();
+        write_state(&state).unwrap();
+        assert_eq!(read_state().expect("state should be readable after write"), state);
+    }
+
+    /// The trust check refuses a record any other principal could have written,
+    /// so the writer must not leave one behind. A `0644` file (the umask
+    /// default) would make every `aasm run` fail closed.
+    #[cfg(unix)]
+    #[test]
+    fn write_state_leaves_the_file_unreadable_to_group_and_other() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set(tmp.path().to_str().unwrap());
+
+        // Pre-create the file world-writable: the writer must tighten it, not
+        // inherit whatever was already there.
+        std::fs::write(pid_path(), "stale").unwrap();
+        std::fs::set_permissions(pid_path(), std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        write_state(&sample_state()).unwrap();
+
+        let mode = std::fs::metadata(pid_path()).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "state file must be 0600, saw {mode:o}");
     }
 
     #[test]
-    fn read_pid_returns_none_when_file_absent() {
+    fn read_state_returns_none_when_file_absent() {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = EnvGuard::set(tmp.path().to_str().unwrap());
+        assert!(read_state().is_none());
         assert!(read_pid().is_none());
+    }
+
+    /// A record with only the lifecycle fields carries no identity evidence, so
+    /// it must not parse as state a trust decision could rest on.
+    #[test]
+    fn parse_state_rejects_a_record_without_identity_evidence() {
+        assert!(parse_state("4242\n127.0.0.1:8899\n").is_none());
+    }
+
+    #[test]
+    fn parse_state_rejects_empty_fields() {
+        for content in [
+            "4242\n\nlinux-starttime:1\n/usr/local/bin/aa-proxy\n",
+            "4242\n127.0.0.1:8899\n\n/usr/local/bin/aa-proxy\n",
+            "4242\n127.0.0.1:8899\nlinux-starttime:1\n\n",
+        ] {
+            assert!(
+                parse_state(content).is_none(),
+                "a record with an empty field must not parse: {content:?}"
+            );
+        }
+    }
+
+    /// `stop` and `status` must stay able to reap a proxy recorded by a build
+    /// that wrote no evidence lines; orphaning a live proxy is worse than
+    /// stopping one whose identity cannot be vouched for.
+    #[test]
+    fn read_pid_still_reads_a_record_without_identity_evidence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set(tmp.path().to_str().unwrap());
+        std::fs::write(pid_path(), "4242\n127.0.0.1:8899\n").unwrap();
+        assert_eq!(read_pid(), Some((4242, "127.0.0.1:8899".to_string())));
+        assert!(
+            read_state().is_none(),
+            "the same record must not satisfy the trust reader"
+        );
     }
 
     #[test]
@@ -136,8 +293,8 @@ mod tests {
         let _guard = EnvGuard::set(tmp.path().to_str().unwrap());
         // remove when no file exists — must not error
         remove_pid().unwrap();
-        write_pid("127.0.0.1:8899").unwrap();
+        write_state(&sample_state()).unwrap();
         remove_pid().unwrap();
-        assert!(read_pid().is_none());
+        assert!(read_state().is_none());
     }
 }

--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -328,6 +328,35 @@ mod tests {
         assert!(env.contains(&("AA_PROXY_ADDR", "127.0.0.1:8899".to_string())));
     }
 
+    /// The record's executable field and the child's `argv[0]` have to be the
+    /// same string, because on Linux `argv[0]` is the only image fact the kernel
+    /// still publishes once the proxy has hardened itself (AAASM-5323). They are
+    /// the same string only if what gets spawned is already resolved, so a
+    /// symlinked install must be followed here rather than at record time.
+    #[test]
+    fn the_spawned_path_is_resolved_not_the_symlink_it_was_found_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("aa-proxy");
+        std::fs::write(&real, "not really a binary").unwrap();
+        let link = tmp.path().join("aa-proxy-link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert_eq!(
+            canonical_binary(link),
+            std::fs::canonicalize(&real).unwrap(),
+            "a proxy found through a symlink must be spawned from the file the link resolves to"
+        );
+    }
+
+    /// Whatever path the caller spawned is what the record must name — the
+    /// resolution happens before the spawn, not after it, so the two cannot
+    /// disagree.
+    #[test]
+    fn the_record_names_the_path_that_was_spawned() {
+        let state = state_for_child(std::process::id(), Path::new("/opt/aa/aa-proxy"), "127.0.0.1:8899");
+        assert_eq!(state.exe_path, PathBuf::from("/opt/aa/aa-proxy"));
+    }
+
     #[test]
     fn wait_for_port_returns_false_on_unbound_addr() {
         // Port 1 is privileged and never listening in test environments.

--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -1,13 +1,14 @@
 //! `aasm proxy start` — spawn the aa-proxy sidecar as a background process.
 
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{ExitCode, Stdio};
 use std::time::{Duration, Instant};
 
 use clap::Args;
 
-use super::pid;
+use super::pid::{self, ProxyState};
+use super::{identity, trust};
 
 /// Arguments for `aasm proxy start`.
 #[derive(Debug, Args)]
@@ -104,14 +105,32 @@ fn wait_for_port(addr: &str, timeout: Duration) -> bool {
     false
 }
 
-/// Write the child process's PID and listen address to the shared PID file.
-fn write_child_pid(child_pid: u32, listen_addr: &str) -> std::io::Result<()> {
-    let path = pid::pid_path();
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+/// Build the state record for a proxy just spawned as `child_pid` from `binary`.
+///
+/// The record carries process-identity evidence because `aasm run` decides
+/// whether to launch a governed tool from it, and a PID plus an address cannot
+/// support that decision (see [`super::trust`]). The two evidence fields are
+/// captured differently on purpose:
+///
+/// * the **start time** is read back from the kernel for `child_pid`. It is set
+///   at fork and is not changed by the subsequent `exec`, so reading it now is
+///   race-free even though the child may not have exec'd yet.
+/// * the **executable** is the canonicalised path that was spawned, not a
+///   read-back of the live image, because the read-back *does* race the exec.
+///   Canonicalising matches what the kernel will later report (`/proc/<pid>/exe`
+///   and `proc_pidpath` both name the resolved image), so the comparison holds
+///   even when the proxy was invoked through a symlink.
+///
+/// A field the platform cannot supply is left empty, which makes the record
+/// unusable to the trust check — deliberately: an unverifiable proxy must fail
+/// the launch, not silently pass it.
+fn state_for_child(child_pid: u32, binary: &Path, listen_addr: &str) -> ProxyState {
+    ProxyState {
+        pid: child_pid,
+        listen_addr: listen_addr.to_string(),
+        start_token: identity::start_token(child_pid).unwrap_or_default(),
+        exe_path: std::fs::canonicalize(binary).unwrap_or_else(|_| binary.to_path_buf()),
     }
-    let content = format!("{}\n{}\n", child_pid, listen_addr);
-    std::fs::write(&path, content)
 }
 
 pub fn dispatch(args: StartArgs) -> ExitCode {
@@ -188,7 +207,21 @@ pub fn dispatch(args: StartArgs) -> ExitCode {
 
     let child_pid = child.id();
 
-    if let Err(e) = write_child_pid(child_pid, &args.listen) {
+    let state = state_for_child(child_pid, &binary, &args.listen);
+    // A record `aasm run` cannot verify is worth saying out loud here rather
+    // than only at the next launch: the operator is standing in front of this
+    // command, not the one that will refuse.
+    if state.start_token.is_empty() {
+        eprintln!(
+            "warning: this platform ({}) does not report process start times, so `aasm run` \
+             will not be able to verify this proxy and will refuse to launch.",
+            std::env::consts::OS
+        );
+    }
+    if let Err(e) = trust::verify_proxy_binary(&state.exe_path) {
+        eprintln!("warning: {e}; `aasm run` will refuse to launch against this proxy.");
+    }
+    if let Err(e) = pid::write_state(&state) {
         eprintln!("warning: could not write PID file: {e}");
     }
 

--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -115,11 +115,12 @@ fn wait_for_port(addr: &str, timeout: Duration) -> bool {
 /// * the **start time** is read back from the kernel for `child_pid`. It is set
 ///   at fork and is not changed by the subsequent `exec`, so reading it now is
 ///   race-free even though the child may not have exec'd yet.
-/// * the **executable** is the canonicalised path that was spawned, not a
-///   read-back of the live image, because the read-back *does* race the exec.
-///   Canonicalising matches what the kernel will later report (`/proc/<pid>/exe`
-///   and `proc_pidpath` both name the resolved image), so the comparison holds
-///   even when the proxy was invoked through a symlink.
+/// * the **executable** is the path that was spawned, not a read-back of the
+///   live image, because the read-back *does* race the exec. The caller
+///   canonicalises before spawning ([`canonical_binary`]), which matches what
+///   the kernel will later report — `/proc/<pid>/exe` and `proc_pidpath` both
+///   name the resolved image — so the comparison holds even when the proxy was
+///   invoked through a symlink.
 ///
 /// A field the platform cannot supply is left empty, which makes the record
 /// unusable to the trust check — deliberately: an unverifiable proxy must fail
@@ -129,8 +130,21 @@ fn state_for_child(child_pid: u32, binary: &Path, listen_addr: &str) -> ProxySta
         pid: child_pid,
         listen_addr: listen_addr.to_string(),
         start_token: identity::start_token(child_pid).unwrap_or_default(),
-        exe_path: std::fs::canonicalize(binary).unwrap_or_else(|_| binary.to_path_buf()),
+        exe_path: binary.to_path_buf(),
     }
+}
+
+/// The path the proxy must actually be spawned from: the resolved one.
+///
+/// Spawning the canonical path rather than the one `PATH` happened to yield is
+/// what keeps `argv[0]` and the recorded executable the same string. That
+/// matters because `aa-proxy` marks itself non-dumpable at startup (AAASM-3584),
+/// after which the kernel will not name its image to `aasm run` and `argv[0]` is
+/// the only image fact left (see [`super::identity`]). Resolving here also means
+/// the record names the file that was executed rather than a symlink that could
+/// be repointed afterwards.
+fn canonical_binary(binary: PathBuf) -> PathBuf {
+    std::fs::canonicalize(&binary).unwrap_or(binary)
 }
 
 pub fn dispatch(args: StartArgs) -> ExitCode {
@@ -142,6 +156,7 @@ pub fn dispatch(args: StartArgs) -> ExitCode {
         );
         return ExitCode::FAILURE;
     };
+    let binary = canonical_binary(binary);
 
     let mut cmd = std::process::Command::new(&binary);
     for (key, value) in proxy_child_env(&args.listen, args.gateway.as_deref()) {

--- a/aa-cli/src/commands/proxy/trust.rs
+++ b/aa-cli/src/commands/proxy/trust.rs
@@ -73,8 +73,17 @@ pub enum ProxyTrustError {
     MalformedRecord { path: PathBuf },
     /// The recorded PID is not a process this user can signal.
     ProxyNotRunning { pid: u32 },
-    /// The platform cannot supply the identity evidence the check needs.
-    IdentityUnavailable { pid: u32 },
+    /// This host has no way to identify a running process at all.
+    IdentityUnsupportedPlatform { pid: u32 },
+    /// This host can identify processes, but not *this* one: it has exited and
+    /// is awaiting reaping, or its `/proc` entry could not be read. Carries
+    /// which fact was missing and why, because "the platform cannot do it" and
+    /// "this process is gone" are different problems with different fixes.
+    IdentityUnreadable {
+        pid: u32,
+        fact: &'static str,
+        reason: &'static str,
+    },
     /// The PID is live but is not the process that was recorded.
     IdentityMismatch { pid: u32, field: &'static str },
     /// The record names something other than the proxy binary.
@@ -109,11 +118,16 @@ impl fmt::Display for ProxyTrustError {
                 f,
                 "the recorded proxy (PID {pid}) is not running. Re-run `aasm proxy start`"
             ),
-            Self::IdentityUnavailable { pid } => write!(
+            Self::IdentityUnsupportedPlatform { pid } => write!(
                 f,
-                "this platform ({}) cannot report the identity of PID {pid}, so the recorded proxy \
-                 cannot be verified",
+                "this platform ({}) cannot report the identity of any process, so the recorded \
+                 proxy (PID {pid}) cannot be verified",
                 std::env::consts::OS
+            ),
+            Self::IdentityUnreadable { pid, fact, reason } => write!(
+                f,
+                "the {fact} of PID {pid} could not be read: {reason}. The recorded proxy cannot be \
+                 verified — re-run `aasm proxy start`"
             ),
             Self::IdentityMismatch { pid, field } => write!(
                 f,
@@ -251,19 +265,32 @@ pub fn verify_proxy_binary(exe: &std::path::Path) -> Result<(), ProxyTrustError>
 /// precisely what the start time closes: a successor cannot have started before
 /// its predecessor exited, so a matching `(pid, start time)` pair identifies one
 /// incarnation of one process.
+///
+/// The executable comparison accepts either source of image evidence (see
+/// [`identity::ImageEvidence`]) because the proxy deliberately hides its image
+/// from the kernel's authoritative answer; what it must never accept is the
+/// *absence* of evidence, which is why the two non-answers below are distinct
+/// refusals rather than a shared "unavailable" that also covers a live process.
 pub fn verify_identity(state: &ProxyState) -> Result<(), ProxyTrustError> {
     if !identity::is_alive(state.pid) {
         return Err(ProxyTrustError::ProxyNotRunning { pid: state.pid });
     }
 
-    let (Some(exe), Some(token)) = (
-        identity::image(state.pid).path().map(std::path::Path::to_path_buf),
-        identity::start_token(state.pid),
-    ) else {
-        // Either the process vanished between the liveness check and here, or
-        // the platform has no implementation. Both mean "cannot verify", and
-        // cannot-verify is a refusal, never a pass.
-        return Err(ProxyTrustError::IdentityUnavailable { pid: state.pid });
+    let exe = match identity::image(state.pid) {
+        identity::ImageEvidence::Reported(path) | identity::ImageEvidence::InvokedAs(path) => path,
+        // The PID is signallable but has no image: it exited between the
+        // liveness check and here, or it is a zombie whose address space the
+        // kernel has already released. Cannot-verify is a refusal, never a pass.
+        identity::ImageEvidence::Unreadable(reason) => {
+            return Err(ProxyTrustError::IdentityUnreadable {
+                pid: state.pid,
+                fact: "executable",
+                reason,
+            })
+        }
+        identity::ImageEvidence::Unsupported => {
+            return Err(ProxyTrustError::IdentityUnsupportedPlatform { pid: state.pid })
+        }
     };
 
     if exe != state.exe_path {
@@ -272,6 +299,14 @@ pub fn verify_identity(state: &ProxyState) -> Result<(), ProxyTrustError> {
             field: "executable",
         });
     }
+
+    let Some(token) = identity::start_token(state.pid) else {
+        return Err(ProxyTrustError::IdentityUnreadable {
+            pid: state.pid,
+            fact: "start time",
+            reason: "its /proc entry could not be read",
+        });
+    };
     if token != state.start_token {
         return Err(ProxyTrustError::IdentityMismatch {
             pid: state.pid,
@@ -530,7 +565,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                ProxyTrustError::ProxyNotRunning { .. } | ProxyTrustError::IdentityUnavailable { .. }
+                ProxyTrustError::ProxyNotRunning { .. } | ProxyTrustError::IdentityUnreadable { .. }
             ),
             "expected the record to be refused as not-running, got {err:?}"
         );

--- a/aa-cli/src/commands/proxy/trust.rs
+++ b/aa-cli/src/commands/proxy/trust.rs
@@ -256,7 +256,10 @@ pub fn verify_identity(state: &ProxyState) -> Result<(), ProxyTrustError> {
         return Err(ProxyTrustError::ProxyNotRunning { pid: state.pid });
     }
 
-    let (Some(exe), Some(token)) = (identity::exe_path(state.pid), identity::start_token(state.pid)) else {
+    let (Some(exe), Some(token)) = (
+        identity::image(state.pid).path().map(std::path::Path::to_path_buf),
+        identity::start_token(state.pid),
+    ) else {
         // Either the process vanished between the liveness check and here, or
         // the platform has no implementation. Both mean "cannot verify", and
         // cannot-verify is a refusal, never a pass.
@@ -360,7 +363,7 @@ mod tests {
             pid,
             listen_addr: "127.0.0.1:8899".into(),
             start_token: identity::start_token(pid).expect("own start token"),
-            exe_path: identity::exe_path(pid).expect("own exe path"),
+            exe_path: identity::image(pid).path().expect("own exe path").to_path_buf(),
         }
     }
 

--- a/aa-cli/src/commands/proxy/trust.rs
+++ b/aa-cli/src/commands/proxy/trust.rs
@@ -1,0 +1,339 @@
+//! Host-side resolution of the proxy endpoint `aasm run` routes a governed tool
+//! at (AAASM-5323).
+//!
+//! # The failure this exists to remove
+//!
+//! `aasm run` used to take its proxy address from whatever the gateway put in
+//! the `proxy_addr` field of its registration response, and injected
+//! `HTTPS_PROXY` **only when that field was present**. Nothing in the tree ever
+//! set it, so every launch went out completely unproxied and uninspected while
+//! reporting as governed. An absent value must never be able to mean "no
+//! interception, proceed anyway".
+//!
+//! # Why the address is resolved here and not accepted from anyone
+//!
+//! The proxy endpoint is a *local host fact*: it is where the sidecar this user
+//! started is listening. A gateway response, an adapter, the launched tool, and
+//! the ambient environment are all outside the trust boundary for that fact —
+//! each of them is either remote, or writable by the very software the proxy
+//! exists to inspect. Any of them naming the endpoint is an invitation to
+//! redirect a governed session at an attacker's listener, or at nothing.
+//!
+//! So the only accepted source is the state file `aasm proxy start` writes, and
+//! the record is trusted only after every one of these holds:
+//!
+//! 1. the file is a regular file owned by this user and not writable by group
+//!    or other — otherwise someone else could have authored the record;
+//! 2. every field is present (see [`super::pid::read_state`]);
+//! 3. the recorded PID is alive and signallable by this user;
+//! 4. the live process's executable *and* start time match what was recorded —
+//!    liveness alone cannot distinguish the proxy from an unrelated process
+//!    that inherited its recycled PID (see [`super::identity`]);
+//! 5. the recorded executable is the proxy binary, not merely *some* binary;
+//! 6. the endpoint parses as an `http://` URL on a loopback address with a
+//!    non-zero port; and
+//! 7. something is actually accepting connections there.
+//!
+//! Failure at any step is fatal to the launch. There is no fallback, because
+//! every conceivable fallback is a direct unprotected connection.
+
+use std::fmt;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use url::Url;
+
+use super::identity;
+use super::pid::{self, ProxyState};
+
+/// The executable name a trusted record must be for. Establishes that the
+/// record describes the proxy rather than any other live process the user
+/// happens to own — an identity claim, not a liveness one.
+const PROXY_BINARY_NAME: &str = "aa-proxy";
+
+/// How long to wait for the recorded endpoint to accept a connection. Short on
+/// purpose: this is a loopback socket that is either bound or not, and a launch
+/// must not hang on the check.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Why a trusted proxy endpoint could not be established.
+///
+/// Every variant is a refusal. Messages name the offending fact and the file it
+/// came from so an operator can fix it, and carry no environment values, no
+/// process arguments and no file contents beyond the fields listed here — the
+/// diagnostic is printed to a terminal that may be captured into CI logs.
+#[derive(Debug)]
+pub enum ProxyTrustError {
+    /// No state file at all — the usual case: no proxy has been started.
+    NoProxyRecorded { path: PathBuf },
+    /// The state file exists but is not a plain file this user solely controls.
+    UntrustedStateFile { path: PathBuf, reason: String },
+    /// Present but not a complete record.
+    MalformedRecord { path: PathBuf },
+    /// The recorded PID is not a process this user can signal.
+    ProxyNotRunning { pid: u32 },
+    /// The platform cannot supply the identity evidence the check needs.
+    IdentityUnavailable { pid: u32 },
+    /// The PID is live but is not the process that was recorded.
+    IdentityMismatch { pid: u32, field: &'static str },
+    /// The record names something other than the proxy binary.
+    NotTheProxyBinary { exe: PathBuf },
+    /// The recorded address is not a usable loopback proxy endpoint.
+    UnusableEndpoint { addr: String, reason: String },
+    /// Nothing is accepting connections at the recorded address.
+    EndpointNotListening { addr: SocketAddr },
+}
+
+impl std::error::Error for ProxyTrustError {}
+
+impl fmt::Display for ProxyTrustError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoProxyRecorded { path } => write!(
+                f,
+                "no governed proxy is running (no state file at {}). Start one with `aasm proxy start`",
+                path.display()
+            ),
+            Self::UntrustedStateFile { path, reason } => write!(
+                f,
+                "the proxy state file {} cannot be trusted: {reason}. Remove it and re-run `aasm proxy start`",
+                path.display()
+            ),
+            Self::MalformedRecord { path } => write!(
+                f,
+                "the proxy state file {} is not a complete record. Remove it and re-run `aasm proxy start`",
+                path.display()
+            ),
+            Self::ProxyNotRunning { pid } => write!(
+                f,
+                "the recorded proxy (PID {pid}) is not running. Re-run `aasm proxy start`"
+            ),
+            Self::IdentityUnavailable { pid } => write!(
+                f,
+                "this platform ({}) cannot report the identity of PID {pid}, so the recorded proxy \
+                 cannot be verified",
+                std::env::consts::OS
+            ),
+            Self::IdentityMismatch { pid, field } => write!(
+                f,
+                "PID {pid} is live but its {field} does not match the recorded proxy — the proxy \
+                 exited and an unrelated process took its PID. Re-run `aasm proxy start`"
+            ),
+            Self::NotTheProxyBinary { exe } => write!(
+                f,
+                "the proxy state file names {}, which is not `{PROXY_BINARY_NAME}`",
+                exe.display()
+            ),
+            Self::UnusableEndpoint { addr, reason } => {
+                write!(f, "the recorded proxy endpoint `{addr}` is unusable: {reason}")
+            }
+            Self::EndpointNotListening { addr } => write!(
+                f,
+                "nothing is accepting connections at the recorded proxy endpoint {addr}. \
+                 Check `aasm proxy status`"
+            ),
+        }
+    }
+}
+
+/// Resolve the proxy endpoint to route a governed launch through.
+///
+/// Returns the `http://host:port` URL on success. Every error is a refusal —
+/// see the module docs for why there is no fallback.
+pub fn resolve_trusted_endpoint() -> Result<Url, ProxyTrustError> {
+    let path = pid::pid_path();
+
+    let meta = match std::fs::symlink_metadata(&path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(ProxyTrustError::NoProxyRecorded { path }),
+        Err(e) => {
+            return Err(ProxyTrustError::UntrustedStateFile {
+                path,
+                reason: format!("it could not be inspected ({e})"),
+            })
+        }
+    };
+    verify_state_file(&path, &meta, current_uid())?;
+
+    let state = pid::read_state().ok_or(ProxyTrustError::MalformedRecord { path })?;
+    verify_process(&state)?;
+
+    let url = verify_endpoint(&state.listen_addr)?;
+    let addr = socket_addr_of(&url).expect("verify_endpoint only returns URLs with a socket address");
+    verify_listening(addr)?;
+    Ok(url)
+}
+
+/// The effective UID this process runs as, i.e. the only principal entitled to
+/// have authored a record this process will act on.
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    // Safety: `geteuid` takes no arguments and cannot fail.
+    unsafe { libc::geteuid() }
+}
+
+#[cfg(not(unix))]
+fn current_uid() -> u32 {
+    0
+}
+
+/// Constraint: the record must be one only this user could have written.
+///
+/// A symlink is rejected rather than followed: the metadata that was vetted must
+/// be the metadata of the bytes that get read, and following a link opens a
+/// window where the two differ. Group/other write bits are rejected because a
+/// record another principal can rewrite is a record another principal can use to
+/// choose where a governed tool's traffic goes.
+///
+/// `expected_uid` is a parameter rather than read inside, so the rejection path
+/// is reachable in a test — a check that can only ever be exercised with the
+/// running user's own UID cannot be shown to fail.
+pub fn verify_state_file(
+    path: &std::path::Path,
+    meta: &std::fs::Metadata,
+    expected_uid: u32,
+) -> Result<(), ProxyTrustError> {
+    if !meta.is_file() {
+        return Err(ProxyTrustError::UntrustedStateFile {
+            path: path.to_path_buf(),
+            reason: "it is not a regular file".into(),
+        });
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::fs::PermissionsExt;
+        let owner = meta.uid();
+        if owner != expected_uid {
+            return Err(ProxyTrustError::UntrustedStateFile {
+                path: path.to_path_buf(),
+                reason: format!("it is owned by uid {owner}, not by this user (uid {expected_uid})"),
+            });
+        }
+        let mode = meta.permissions().mode() & 0o777;
+        if mode & 0o022 != 0 {
+            return Err(ProxyTrustError::UntrustedStateFile {
+                path: path.to_path_buf(),
+                reason: format!("its mode {mode:04o} lets group or other write to it"),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Constraints: the record names the proxy (5), and the process behind it is
+/// alive (3) and still the one that was recorded (4).
+pub fn verify_process(state: &ProxyState) -> Result<(), ProxyTrustError> {
+    verify_proxy_binary(&state.exe_path)?;
+    verify_identity(state)
+}
+
+/// Constraint 5, as a claim about the record itself: it must describe the proxy
+/// binary and not merely some binary. Without it, a record naming any live
+/// process this user owns — a shell, an editor, an attacker's listener launched
+/// under the user's own account — would satisfy every remaining check.
+pub fn verify_proxy_binary(exe: &std::path::Path) -> Result<(), ProxyTrustError> {
+    if exe.file_name().and_then(|n| n.to_str()) == Some(PROXY_BINARY_NAME) {
+        Ok(())
+    } else {
+        Err(ProxyTrustError::NotTheProxyBinary { exe: exe.to_path_buf() })
+    }
+}
+
+/// Constraints 3 and 4: the recorded PID is alive, and the process holding it
+/// now is the one the record was written about.
+///
+/// The two identity fields are not redundant. The executable rules out the
+/// common case — a recycled PID now running something else entirely — but a
+/// *second* `aa-proxy`, started later, could take the same PID and pass that
+/// check while listening somewhere else or under a different policy. That is
+/// precisely what the start time closes: a successor cannot have started before
+/// its predecessor exited, so a matching `(pid, start time)` pair identifies one
+/// incarnation of one process.
+pub fn verify_identity(state: &ProxyState) -> Result<(), ProxyTrustError> {
+    if !identity::is_alive(state.pid) {
+        return Err(ProxyTrustError::ProxyNotRunning { pid: state.pid });
+    }
+
+    let (Some(exe), Some(token)) = (identity::exe_path(state.pid), identity::start_token(state.pid)) else {
+        // Either the process vanished between the liveness check and here, or
+        // the platform has no implementation. Both mean "cannot verify", and
+        // cannot-verify is a refusal, never a pass.
+        return Err(ProxyTrustError::IdentityUnavailable { pid: state.pid });
+    };
+
+    if exe != state.exe_path {
+        return Err(ProxyTrustError::IdentityMismatch {
+            pid: state.pid,
+            field: "executable",
+        });
+    }
+    if token != state.start_token {
+        return Err(ProxyTrustError::IdentityMismatch {
+            pid: state.pid,
+            field: "start time",
+        });
+    }
+    Ok(())
+}
+
+/// Constraint: scheme, host and port of the resulting address.
+///
+/// The scheme is synthesised rather than read, so the record cannot smuggle in
+/// `https://` (which no MitM proxy speaks) or a non-network scheme. The host
+/// must be a loopback **literal**: a hostname would be resolved by whatever
+/// resolver the child inherits, which puts the destination back under the
+/// control of something outside the trust boundary, and a non-loopback address
+/// means the session's plaintext leaves this machine to a host this check
+/// cannot vouch for.
+pub fn verify_endpoint(listen_addr: &str) -> Result<Url, ProxyTrustError> {
+    let unusable = |reason: &str| ProxyTrustError::UnusableEndpoint {
+        addr: listen_addr.to_string(),
+        reason: reason.to_string(),
+    };
+
+    let socket: SocketAddr = listen_addr
+        .parse()
+        .map_err(|_| unusable("it is not an `ip:port` literal"))?;
+    if !socket.ip().is_loopback() {
+        return Err(unusable(
+            "it is not a loopback address, so intercepted traffic would leave this machine",
+        ));
+    }
+    if socket.port() == 0 {
+        return Err(unusable("port 0 is not a listening port"));
+    }
+
+    let url = Url::parse(&format!("http://{socket}")).map_err(|_| unusable("it does not form a URL"))?;
+    if url.scheme() != "http" {
+        return Err(unusable("only an http:// proxy endpoint is accepted"));
+    }
+    if socket_addr_of(&url) != Some(socket) {
+        return Err(unusable("the URL does not round-trip to the recorded address"));
+    }
+    Ok(url)
+}
+
+/// The socket address a validated endpoint URL denotes, or `None` if its host is
+/// not an IP literal.
+fn socket_addr_of(url: &Url) -> Option<SocketAddr> {
+    match (url.host()?, url.port()) {
+        (url::Host::Ipv4(ip), Some(port)) => Some(SocketAddr::from((ip, port))),
+        (url::Host::Ipv6(ip), Some(port)) => Some(SocketAddr::from((ip, port))),
+        _ => None,
+    }
+}
+
+/// Constraint: a socket is actually bound at the recorded address.
+///
+/// The record says where the proxy was *told* to listen. A proxy that died
+/// during startup, or was killed and had its PID reused by another `aa-proxy`
+/// bound elsewhere, leaves a record that passes every other check while nothing
+/// answers — and a launch routed at a closed port fails in whatever way the tool
+/// chooses, which historically has meant falling back to a direct connection.
+pub fn verify_listening(addr: SocketAddr) -> Result<(), ProxyTrustError> {
+    std::net::TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT)
+        .map(|_| ())
+        .map_err(|_| ProxyTrustError::EndpointNotListening { addr })
+}

--- a/aa-cli/src/commands/proxy/trust.rs
+++ b/aa-cli/src/commands/proxy/trust.rs
@@ -571,6 +571,110 @@ mod tests {
         );
     }
 
+    /// AAASM-5323 regression. `aa-proxy` hides its image from same-uid
+    /// inspection (`prctl(PR_SET_DUMPABLE, 0)`, AAASM-3584), which makes the
+    /// kernel refuse `/proc/<pid>/exe` even to the user who started it. The
+    /// first cut of this check read only that link and refused every genuine
+    /// proxy on Linux — `aasm run` could not launch at all. A truthful record
+    /// about such a process must be accepted.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_truthful_record_about_a_process_that_hides_itself_is_accepted() {
+        let child = hidden_child();
+        let state = ProxyState {
+            pid: child.pid,
+            listen_addr: "127.0.0.1:8899".into(),
+            start_token: identity::start_token(child.pid).expect("the child's start time must read"),
+            exe_path: identity::image(child.pid)
+                .path()
+                .expect("a live process that hid itself must still be identifiable")
+                .to_path_buf(),
+        };
+        verify_identity(&state).expect("a truthful record about a live hardened proxy must be accepted");
+    }
+
+    /// The evidence that survives hardening must not also let a *gone* process
+    /// through. A zombie still answers `kill(pid, 0)` and still has a readable
+    /// start time, so it is refused only if the image evidence refuses it.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_zombie_is_refused() {
+        let mut child = std::process::Command::new("true").spawn().expect("spawn `true`");
+        let pid = child.id();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).unwrap_or_default();
+            if stat.rfind(')').and_then(|i| stat.as_bytes().get(i + 2)) == Some(&b'Z') {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let mut state = truthful_state_for_self();
+        state.pid = pid;
+        // Both reads happen before the child is reaped: the case is only
+        // meaningful while the PID is still signallable, which is exactly what
+        // makes a zombie able to fool a liveness-only check.
+        let signallable = identity::is_alive(pid);
+        let outcome = verify_identity(&state);
+        child.wait().expect("reap `true`");
+
+        assert!(
+            signallable,
+            "a zombie must still answer kill(pid, 0), or this proves nothing"
+        );
+        let err = outcome.expect_err("an exited-but-unreaped process must be refused");
+        assert!(
+            matches!(err, ProxyTrustError::IdentityUnreadable { .. }),
+            "expected IdentityUnreadable for a zombie, got {err:?}"
+        );
+    }
+
+    /// A child of this process carrying the same hardening `aa-proxy` applies to
+    /// itself. `fork` rather than `Command`, because `execve` clears the
+    /// dumpable flag — only a process that sets it after its last exec is
+    /// hidden, which is the shape the proxy has.
+    #[cfg(target_os = "linux")]
+    fn hidden_child() -> HiddenChild {
+        // Safety: the child path calls only `prctl`, `pause` and `_exit`, all
+        // async-signal-safe; it never returns into test code.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed: {}", std::io::Error::last_os_error());
+        if pid == 0 {
+            unsafe {
+                libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0);
+                loop {
+                    libc::pause();
+                }
+            }
+        }
+        let child = HiddenChild { pid: pid as u32 };
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            match std::fs::read_link(format!("/proc/{}/exe", child.pid)) {
+                Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return child,
+                _ => std::thread::sleep(std::time::Duration::from_millis(10)),
+            }
+        }
+        panic!("pid {} never became non-dumpable", child.pid);
+    }
+
+    #[cfg(target_os = "linux")]
+    struct HiddenChild {
+        pid: u32,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl Drop for HiddenChild {
+        fn drop(&mut self) {
+            // Safety: both calls take the PID by value; the child is ours to reap.
+            unsafe {
+                libc::kill(self.pid as libc::pid_t, libc::SIGKILL);
+                libc::waitpid(self.pid as libc::pid_t, std::ptr::null_mut(), 0);
+            }
+        }
+    }
+
     /// PID reuse, executable-visible case: the number is live but is running
     /// some other image. This is the shape of the attack a liveness-only check
     /// waves through.

--- a/aa-cli/src/commands/proxy/trust.rs
+++ b/aa-cli/src/commands/proxy/trust.rs
@@ -337,3 +337,342 @@ pub fn verify_listening(addr: SocketAddr) -> Result<(), ProxyTrustError> {
         .map(|_| ())
         .map_err(|_| ProxyTrustError::EndpointNotListening { addr })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+
+    /// A record that describes this very test process truthfully: alive, real
+    /// executable, current start token. Every identity test starts from a
+    /// record that *passes* and breaks exactly one field, so a test that fails
+    /// names the field that mattered.
+    ///
+    /// The `aa-proxy` file-name rule is asserted separately
+    /// ([`verify_proxy_binary`]) rather than being folded in here: the test
+    /// binary is not named `aa-proxy` and cannot honestly claim to be, and
+    /// faking it would leave the identity comparison measuring a fixture rather
+    /// than the kernel.
+    fn truthful_state_for_self() -> ProxyState {
+        let pid = std::process::id();
+        ProxyState {
+            pid,
+            listen_addr: "127.0.0.1:8899".into(),
+            start_token: identity::start_token(pid).expect("own start token"),
+            exe_path: identity::exe_path(pid).expect("own exe path"),
+        }
+    }
+
+    // ---- constraint 6: scheme / host / port ----
+
+    #[test]
+    fn a_loopback_endpoint_resolves_to_an_http_url() {
+        let url = verify_endpoint("127.0.0.1:8899").expect("loopback endpoint must be accepted");
+        assert_eq!(url.as_str(), "http://127.0.0.1:8899/");
+        assert_eq!(url.scheme(), "http");
+    }
+
+    #[test]
+    fn a_non_loopback_endpoint_is_refused() {
+        let err = verify_endpoint("10.0.0.5:8899").expect_err("a routable address must be refused");
+        assert!(
+            matches!(err, ProxyTrustError::UnusableEndpoint { .. }),
+            "expected UnusableEndpoint, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("loopback"),
+            "the diagnostic must say why: {err}"
+        );
+    }
+
+    #[test]
+    fn a_wildcard_bind_is_refused() {
+        // `0.0.0.0` is reachable from off-box, so a proxy bound there is not a
+        // loopback endpoint even though `aasm proxy start --listen` accepts it.
+        assert!(verify_endpoint("0.0.0.0:8899").is_err());
+    }
+
+    #[test]
+    fn a_hostname_endpoint_is_refused() {
+        // Resolution would be performed by the child's resolver, which is
+        // outside the trust boundary.
+        assert!(verify_endpoint("localhost:8899").is_err());
+        assert!(verify_endpoint("proxy.internal:8899").is_err());
+    }
+
+    #[test]
+    fn port_zero_is_refused() {
+        assert!(verify_endpoint("127.0.0.1:0").is_err());
+    }
+
+    #[test]
+    fn a_bare_url_in_the_address_field_is_refused() {
+        // The scheme is synthesised, never read from the record.
+        assert!(verify_endpoint("http://127.0.0.1:8899").is_err());
+        assert!(verify_endpoint("https://127.0.0.1:8899").is_err());
+    }
+
+    // ---- constraint 2: state-file ownership and permissions ----
+
+    fn write_mode(path: &Path, mode: u32) {
+        std::fs::write(path, "unused").unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[test]
+    fn a_private_file_owned_by_this_user_is_accepted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("proxy.pid");
+        write_mode(&path, 0o600);
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+        verify_state_file(&path, &meta, current_uid()).expect("0600 file owned by us must be accepted");
+    }
+
+    #[test]
+    fn a_file_owned_by_another_user_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("proxy.pid");
+        write_mode(&path, 0o600);
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+        // Chowning to another user needs privileges no test has, so the
+        // *expectation* is moved instead — the comparison under test is the
+        // same one either way.
+        let err = verify_state_file(&path, &meta, current_uid().wrapping_add(1))
+            .expect_err("a file owned by someone else must be refused");
+        assert!(
+            matches!(err, ProxyTrustError::UntrustedStateFile { .. }),
+            "expected UntrustedStateFile, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("owned by uid"),
+            "diagnostic must say why: {err}"
+        );
+    }
+
+    #[test]
+    fn a_group_or_world_writable_file_is_refused() {
+        for mode in [0o620, 0o602, 0o666, 0o777] {
+            let tmp = tempfile::tempdir().unwrap();
+            let path = tmp.path().join("proxy.pid");
+            write_mode(&path, mode);
+            let meta = std::fs::symlink_metadata(&path).unwrap();
+            let Err(err) = verify_state_file(&path, &meta, current_uid()) else {
+                panic!("mode {mode:o} lets another principal rewrite the record; it must be refused");
+            };
+            assert!(
+                matches!(err, ProxyTrustError::UntrustedStateFile { .. }),
+                "mode {mode:o}: expected UntrustedStateFile, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_directory_is_not_a_state_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let meta = std::fs::symlink_metadata(tmp.path()).unwrap();
+        assert!(verify_state_file(tmp.path(), &meta, current_uid()).is_err());
+    }
+
+    #[test]
+    fn a_symlink_is_refused_rather_than_followed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real.pid");
+        write_mode(&real, 0o600);
+        let link = tmp.path().join("proxy.pid");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+        assert!(
+            verify_state_file(&link, &meta, current_uid()).is_err(),
+            "a symlink must be refused; vetting the target's metadata is not vetting the link"
+        );
+    }
+
+    // ---- constraints 3, 4, 5: process liveness and identity ----
+
+    /// The fixture's own honesty check: the record every identity test starts
+    /// from must *pass*, or the tests below would be reporting a refusal that
+    /// the field they broke had nothing to do with.
+    #[test]
+    fn a_truthful_record_about_a_live_process_is_accepted() {
+        verify_identity(&truthful_state_for_self()).expect(
+            "a record describing this live process truthfully must be accepted; if it is not, \
+             every refusal asserted below proves nothing about the field it broke",
+        );
+    }
+
+    #[test]
+    fn a_record_naming_a_binary_other_than_the_proxy_is_refused() {
+        for exe in ["/bin/sh", "/usr/bin/nc", "/tmp/aa-proxy-lookalike"] {
+            let err = verify_proxy_binary(Path::new(exe)).expect_err("only the proxy binary may be trusted");
+            assert!(
+                matches!(err, ProxyTrustError::NotTheProxyBinary { .. }),
+                "{exe}: expected NotTheProxyBinary, got {err:?}"
+            );
+        }
+        verify_proxy_binary(Path::new("/usr/local/bin/aa-proxy")).expect("the proxy binary must be accepted");
+    }
+
+    /// Stale state: the record names a PID whose process has exited. Nothing
+    /// about it is verifiable, so it is refused rather than probed further.
+    #[test]
+    fn a_stale_pid_is_refused() {
+        let mut child = std::process::Command::new("true").spawn().expect("spawn `true`");
+        let pid = child.id();
+        child.wait().expect("reap `true`");
+
+        let mut state = truthful_state_for_self();
+        state.pid = pid;
+        let err = verify_identity(&state).expect_err("a dead PID must be refused");
+        assert!(
+            matches!(
+                err,
+                ProxyTrustError::ProxyNotRunning { .. } | ProxyTrustError::IdentityUnavailable { .. }
+            ),
+            "expected the record to be refused as not-running, got {err:?}"
+        );
+    }
+
+    /// PID reuse, executable-visible case: the number is live but is running
+    /// some other image. This is the shape of the attack a liveness-only check
+    /// waves through.
+    #[test]
+    fn a_live_pid_running_a_different_executable_is_refused() {
+        let mut state = truthful_state_for_self();
+        state.exe_path = PathBuf::from(format!("/opt/{PROXY_BINARY_NAME}"));
+        let err = verify_identity(&state).expect_err("a different executable must be refused");
+        assert!(
+            matches!(
+                err,
+                ProxyTrustError::IdentityMismatch {
+                    field: "executable",
+                    ..
+                }
+            ),
+            "expected an executable mismatch, got {err:?}"
+        );
+    }
+
+    /// PID reuse, executable-invisible case: a *second* proxy took the recycled
+    /// PID, so the image matches and only the start time can tell the two
+    /// incarnations apart. Without this comparison the record would be trusted.
+    #[test]
+    fn a_live_pid_with_a_different_start_time_is_refused() {
+        let mut state = truthful_state_for_self();
+        state.start_token = format!("{}-earlier-incarnation", state.start_token);
+        let err = verify_identity(&state).expect_err("a recycled PID must be refused");
+        assert!(
+            matches!(
+                err,
+                ProxyTrustError::IdentityMismatch {
+                    field: "start time",
+                    ..
+                }
+            ),
+            "expected a start-time mismatch, got {err:?}"
+        );
+    }
+
+    // ---- constraint 4: the socket is actually bound ----
+
+    #[test]
+    fn a_bound_loopback_socket_passes_the_listening_check() {
+        let _lock = crate::test_support::net_guard();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        verify_listening(addr).expect("a bound socket must pass");
+    }
+
+    #[test]
+    fn an_unbound_endpoint_is_refused() {
+        let _lock = crate::test_support::net_guard();
+        // Bind then drop, so the port is one nothing is listening on.
+        let addr = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+            listener.local_addr().expect("local_addr")
+        };
+        let err = verify_listening(addr).expect_err("an unbound port must be refused");
+        assert!(
+            matches!(err, ProxyTrustError::EndpointNotListening { .. }),
+            "expected EndpointNotListening, got {err:?}"
+        );
+    }
+
+    // ---- end to end: the resolver refuses when no proxy has been started ----
+
+    #[test]
+    fn resolution_refuses_when_no_state_file_exists() {
+        let _lock = crate::test_support::env_guard();
+        let prior = std::env::var("AA_DATA_DIR").ok();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("AA_DATA_DIR", tmp.path());
+
+        let result = resolve_trusted_endpoint();
+
+        match prior {
+            Some(v) => std::env::set_var("AA_DATA_DIR", v),
+            None => std::env::remove_var("AA_DATA_DIR"),
+        }
+
+        let err = result.expect_err("with no proxy started there is no endpoint to trust");
+        assert!(
+            matches!(err, ProxyTrustError::NoProxyRecorded { .. }),
+            "expected NoProxyRecorded, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolution_refuses_a_record_without_identity_evidence() {
+        let _lock = crate::test_support::env_guard();
+        let prior = std::env::var("AA_DATA_DIR").ok();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("AA_DATA_DIR", tmp.path());
+        let path = tmp.path().join("proxy.pid");
+        std::fs::write(&path, format!("{}\n127.0.0.1:8899\n", std::process::id())).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let result = resolve_trusted_endpoint();
+
+        match prior {
+            Some(v) => std::env::set_var("AA_DATA_DIR", v),
+            None => std::env::remove_var("AA_DATA_DIR"),
+        }
+
+        let err = result.expect_err("a two-line record carries no identity evidence");
+        assert!(
+            matches!(err, ProxyTrustError::MalformedRecord { .. }),
+            "expected MalformedRecord, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolution_refuses_an_over_permissive_record() {
+        let _lock = crate::test_support::env_guard();
+        let prior = std::env::var("AA_DATA_DIR").ok();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("AA_DATA_DIR", tmp.path());
+        let path = tmp.path().join("proxy.pid");
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n127.0.0.1:8899\nlinux-starttime:1\n/usr/local/bin/{PROXY_BINARY_NAME}\n",
+                std::process::id()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        let result = resolve_trusted_endpoint();
+
+        match prior {
+            Some(v) => std::env::set_var("AA_DATA_DIR", v),
+            None => std::env::remove_var("AA_DATA_DIR"),
+        }
+
+        let err = result.expect_err("a world-writable record must not be trusted");
+        assert!(
+            matches!(err, ProxyTrustError::UntrustedStateFile { .. }),
+            "expected UntrustedStateFile, got {err:?}"
+        );
+    }
+}

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -43,7 +43,12 @@ pub struct RunArgs {
     #[arg(long)]
     pub governance_level: Option<GovernanceLevel>,
 
-    /// Skip proxy injection (not recommended for governed environments).
+    /// Launch WITHOUT routing the tool through the governed proxy.
+    ///
+    /// This is an explicit opt-out of Layer 2 interception: the tool's traffic
+    /// is not inspected and no egress policy applies to it. Without this flag
+    /// `aasm run` refuses to launch unless it can establish a trusted local
+    /// proxy endpoint (AAASM-5323) — it never launches unproxied by accident.
     #[arg(long)]
     pub no_proxy: bool,
 
@@ -125,12 +130,19 @@ fn dev_tool_kind_str(kind: &DevToolKind) -> String {
 }
 
 /// Gateway registration result for a single `aasm run` session.
+///
+/// Deliberately carries no proxy address. The gateway used to return one, and
+/// `aasm run` used to route the launched tool at it; that made a remote,
+/// unauthenticated field the authority on where this machine's traffic goes,
+/// and — because nothing ever populated it — meant every launch went out
+/// unproxied while reporting as governed. The endpoint is now a host fact
+/// resolved by [`crate::commands::proxy::trust`] and is never carried on the
+/// registration path (AAASM-5323).
 struct RegistrationHandle {
     agent_id: String,
     registration_id: String,
     trace_id: String,
     session_id: String,
-    proxy_addr: Option<String>,
     /// Carried from [`RunArgs::team_id`] (or echoed by the gateway) for `AA_TEAM_ID` injection.
     team_id: Option<String>,
 }
@@ -217,13 +229,15 @@ async fn register_with_gateway(
         return Err(anyhow::anyhow!("gateway registration failed: HTTP {}", resp.status()));
     }
 
+    // `proxy_addr` is intentionally absent from this struct: serde ignores the
+    // field if the gateway still sends it, which is the point — the response
+    // must not be able to influence where this session's traffic is routed.
     #[derive(Deserialize)]
     struct RegisterResponse {
         agent_id: Option<String>,
         registration_id: Option<String>,
         trace_id: Option<String>,
         session_id: Option<String>,
-        proxy_addr: Option<String>,
         team_id: Option<String>,
     }
 
@@ -234,7 +248,6 @@ async fn register_with_gateway(
         registration_id: reg.registration_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
         trace_id: reg.trace_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
         session_id: reg.session_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
-        proxy_addr: reg.proxy_addr,
         team_id: reg.team_id.or_else(|| args.team_id.clone()),
     })
 }
@@ -251,8 +264,24 @@ fn emit_observe_banner() {
 /// Build the environment map to be inherited by the child process.
 ///
 /// Starts from the current process environment, then overlays governance
-/// identity variables. `HTTPS_PROXY` / `HTTP_PROXY` are only injected when
-/// `handle.proxy_addr` is set and `no_proxy` is `false`.
+/// identity variables.
+///
+/// # Proxy variables
+///
+/// `proxy` is the endpoint [`crate::commands::proxy::trust`] vouched for, or
+/// `None`. The three cases are distinct and none of them is "leave whatever was
+/// there":
+///
+/// * `Some(url)` — both variables are set to it, overwriting anything the
+///   operator's shell had. An ambient `HTTPS_PROXY` is an environment-supplied
+///   proxy address, which is exactly the class of input this feature exists to
+///   stop treating as authoritative.
+/// * `None` with `no_proxy` — the operator asked for an unproxied launch, so
+///   their own proxy configuration is left alone. This is the documented
+///   opt-out, not a fallback.
+/// * `None` without `no_proxy` — reachable only from `--dry-run`, since a live
+///   launch refuses before it gets here. The variables are *removed* so the
+///   preview cannot show an ambient proxy and read as a governed launch.
 ///
 /// `AA_ENFORCEMENT_MODE` is set whenever `mode` differs from the pre-feature
 /// default (`Enforce`) so tools that branch on the env var see the operator's
@@ -260,6 +289,7 @@ fn emit_observe_banner() {
 /// avoid surprising any tool that does best-effort env sniffing.
 fn build_child_env(
     handle: &RegistrationHandle,
+    proxy: Option<&str>,
     no_proxy: bool,
     mode: aa_core::EnforcementMode,
 ) -> HashMap<String, String> {
@@ -271,16 +301,47 @@ fn build_child_env(
     if let Some(ref team_id) = handle.team_id {
         env.insert("AA_TEAM_ID".into(), team_id.clone());
     }
-    if let Some(ref proxy) = handle.proxy_addr {
-        if !no_proxy {
-            env.insert("HTTPS_PROXY".into(), proxy.clone());
-            env.insert("HTTP_PROXY".into(), proxy.clone());
+    match proxy {
+        Some(url) => {
+            env.insert("HTTPS_PROXY".into(), url.to_string());
+            env.insert("HTTP_PROXY".into(), url.to_string());
         }
+        None if !no_proxy => {
+            env.remove("HTTPS_PROXY");
+            env.remove("HTTP_PROXY");
+        }
+        None => {}
     }
     if mode != aa_core::EnforcementMode::Enforce {
         env.insert("AA_ENFORCEMENT_MODE".into(), enforcement_mode_str(mode).into());
     }
     env
+}
+
+/// Resolve the endpoint this launch will be routed through, or explain why the
+/// launch must not happen.
+///
+/// The only `Ok(None)` is the operator's explicit `--no-proxy`. Every other
+/// outcome is either a vouched-for endpoint or a refusal: there is no path from
+/// "the proxy could not be verified" to "launch anyway", because that path is a
+/// direct, uninspected connection made by a session presenting as governed.
+fn resolve_launch_proxy(no_proxy: bool) -> Result<Option<String>> {
+    if no_proxy {
+        eprintln!(
+            "warning: --no-proxy — launching WITHOUT interception. This session's traffic is not \
+             inspected and no egress policy applies to it."
+        );
+        return Ok(None);
+    }
+    let url = crate::commands::proxy::trust::resolve_trusted_endpoint()
+        .map_err(|e| anyhow::anyhow!("refusing to launch ungoverned: {e}"))?;
+    // `Url` appends a path; a proxy variable wants the bare origin.
+    Ok(Some(format!(
+        "{}://{}:{}",
+        url.scheme(),
+        url.host_str().unwrap_or_default(),
+        url.port().unwrap_or_default()
+    )))
 }
 
 /// Synthesize a `RegistrationHandle` for `--dry-run` without contacting the
@@ -301,7 +362,6 @@ fn dry_run_handle(args: &RunArgs) -> RegistrationHandle {
         registration_id: format!("dry-run-{}", Uuid::new_v4()),
         trace_id: format!("dry-run-{}", Uuid::new_v4()),
         session_id: format!("dry-run-{}", Uuid::new_v4()),
-        proxy_addr: None,
         team_id: args.team_id.clone(),
     }
 }
@@ -522,7 +582,18 @@ pub async fn execute_with_adapters(
 
     if args.dry_run {
         let handle = dry_run_handle(args);
-        let child_env = build_child_env(&handle, args.no_proxy, mode);
+        // A preview launches nothing, so an unresolvable endpoint is reported
+        // rather than fatal — but it is reported, because a preview that
+        // silently omits the proxy reads exactly like a governed one.
+        let proxy = match resolve_launch_proxy(args.no_proxy) {
+            Ok(proxy) => proxy,
+            Err(e) => {
+                eprintln!("warning: {e}");
+                eprintln!("warning: a live `aasm run` with these flags would refuse to launch.");
+                None
+            }
+        };
+        let child_env = build_child_env(&handle, proxy.as_deref(), args.no_proxy, mode);
         let settings = "<dry-run: managed settings not generated>".to_string();
         let mut cmd = std::process::Command::new(&args.tool);
         cmd.args(&args.tool_args);
@@ -543,8 +614,12 @@ pub async fn execute_with_adapters(
         info.governance_level,
     );
 
+    // Resolved before registration on purpose: a launch that is going to be
+    // refused should not first create a gateway registration it then abandons.
+    let proxy = resolve_launch_proxy(args.no_proxy)?;
+
     let handle = register_with_gateway(&info, args, ctx).await?;
-    let child_env = build_child_env(&handle, args.no_proxy, mode);
+    let child_env = build_child_env(&handle, proxy.as_deref(), args.no_proxy, mode);
 
     let policy = load_policy();
     let settings = adapter
@@ -562,7 +637,7 @@ pub async fn execute_with_adapters(
             &args.tool_args,
             &handle.agent_id,
             handle.team_id.as_deref(),
-            handle.proxy_addr.as_deref(),
+            proxy.as_deref(),
         )
         .map_err(|e| anyhow::anyhow!("failed to build launch command: {e}"))?;
     // No `cmd.envs(&child_env)` here: `spawn_and_wait` applies both sources with
@@ -892,21 +967,56 @@ mod tests {
 
     // --- build_child_env tests ---
 
-    fn stub_handle(proxy_addr: Option<&str>, team_id: Option<&str>) -> RegistrationHandle {
+    fn stub_handle(team_id: Option<&str>) -> RegistrationHandle {
         RegistrationHandle {
             agent_id: "test-agent".into(),
             registration_id: "test-reg".into(),
             trace_id: "test-trace".into(),
             session_id: "test-session".into(),
-            proxy_addr: proxy_addr.map(String::from),
             team_id: team_id.map(String::from),
+        }
+    }
+
+    /// Set `HTTPS_PROXY` / `HTTP_PROXY` on this process for the duration of the
+    /// guard, so `build_child_env`'s copy of the ambient environment carries an
+    /// operator-supplied proxy the way a real shell would.
+    struct AmbientProxy {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        prior: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl AmbientProxy {
+        fn set(value: &str) -> Self {
+            let lock = crate::test_support::env_guard();
+            let mut prior = Vec::new();
+            for key in ["HTTPS_PROXY", "HTTP_PROXY"] {
+                prior.push((key, std::env::var(key).ok()));
+                std::env::set_var(key, value);
+            }
+            Self { _lock: lock, prior }
+        }
+    }
+
+    impl Drop for AmbientProxy {
+        fn drop(&mut self) {
+            for (key, prior) in self.prior.drain(..) {
+                match prior {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
         }
     }
 
     #[test]
     fn build_child_env_sets_proxy() {
-        let handle = stub_handle(Some("http://proxy:8080"), None);
-        let env = build_child_env(&handle, false, aa_core::EnforcementMode::Enforce);
+        let handle = stub_handle(None);
+        let env = build_child_env(
+            &handle,
+            Some("http://proxy:8080"),
+            false,
+            aa_core::EnforcementMode::Enforce,
+        );
         assert_eq!(
             env.get("HTTPS_PROXY").map(String::as_str),
             Some("http://proxy:8080"),
@@ -923,31 +1033,73 @@ mod tests {
         assert_eq!(env.get("AA_REGISTRATION_ID").map(String::as_str), Some("test-reg"));
     }
 
+    /// `--no-proxy` is an opt-out of *our* injection, not a scrub of the
+    /// operator's own configuration: a developer behind a corporate proxy who
+    /// asks for an unproxied launch still needs their own proxy to reach the
+    /// network.
     #[test]
-    fn build_child_env_skips_proxy_when_no_proxy() {
-        let handle = stub_handle(Some("http://proxy:8080"), None);
-        let env = build_child_env(&handle, true, aa_core::EnforcementMode::Enforce);
+    fn build_child_env_leaves_the_ambient_proxy_alone_under_no_proxy() {
+        let _ambient = AmbientProxy::set("http://corporate:3128");
+        let handle = stub_handle(None);
+        let env = build_child_env(&handle, None, true, aa_core::EnforcementMode::Enforce);
+        assert_eq!(
+            env.get("HTTPS_PROXY").map(String::as_str),
+            Some("http://corporate:3128"),
+            "--no-proxy must not rewrite the operator's own proxy configuration"
+        );
+    }
+
+    /// An environment-supplied proxy address is not authoritative: whatever the
+    /// operator's shell (or anything that wrote to it) had must lose to the
+    /// endpoint the host-side trust check vouched for.
+    #[test]
+    fn build_child_env_overwrites_an_ambient_proxy_with_the_trusted_endpoint() {
+        let _ambient = AmbientProxy::set("http://attacker.example:8080");
+        let handle = stub_handle(None);
+        let env = build_child_env(
+            &handle,
+            Some("http://127.0.0.1:8899"),
+            false,
+            aa_core::EnforcementMode::Enforce,
+        );
+        for key in ["HTTPS_PROXY", "HTTP_PROXY"] {
+            assert_eq!(
+                env.get(key).map(String::as_str),
+                Some("http://127.0.0.1:8899"),
+                "`{key}` must carry the trusted endpoint, not the ambient one"
+            );
+        }
+    }
+
+    /// The dry-run path: no trusted endpoint and no opt-out. An inherited
+    /// `HTTPS_PROXY` must be dropped rather than shown, or the preview reads as
+    /// a governed launch that the live run would have refused.
+    #[test]
+    fn build_child_env_drops_an_ambient_proxy_when_none_was_vouched_for() {
+        let _ambient = AmbientProxy::set("http://corporate:3128");
+        let handle = stub_handle(None);
+        let env = build_child_env(&handle, None, false, aa_core::EnforcementMode::Enforce);
         assert!(
             !env.contains_key("HTTPS_PROXY"),
-            "HTTPS_PROXY must not be set when no_proxy=true"
+            "an unvouched-for ambient HTTPS_PROXY must not reach the child"
         );
         assert!(
             !env.contains_key("HTTP_PROXY"),
-            "HTTP_PROXY must not be set when no_proxy=true"
+            "an unvouched-for ambient HTTP_PROXY must not reach the child"
         );
     }
 
     #[test]
     fn build_child_env_sets_team_id_when_present() {
-        let handle = stub_handle(None, Some("my-team"));
-        let env = build_child_env(&handle, false, aa_core::EnforcementMode::Enforce);
+        let handle = stub_handle(Some("my-team"));
+        let env = build_child_env(&handle, None, true, aa_core::EnforcementMode::Enforce);
         assert_eq!(env.get("AA_TEAM_ID").map(String::as_str), Some("my-team"));
     }
 
     #[test]
     fn build_child_env_omits_team_id_when_absent() {
-        let handle = stub_handle(None, None);
-        let env = build_child_env(&handle, false, aa_core::EnforcementMode::Enforce);
+        let handle = stub_handle(None);
+        let env = build_child_env(&handle, None, true, aa_core::EnforcementMode::Enforce);
         assert!(
             !env.contains_key("AA_TEAM_ID"),
             "AA_TEAM_ID must not be set when team_id is None"
@@ -959,8 +1111,8 @@ mod tests {
         // Pre-feature behaviour: an enforce-mode launch must not introduce
         // any new env var so tools that env-sniff don't pick up a phantom
         // posture marker.
-        let handle = stub_handle(None, None);
-        let env = build_child_env(&handle, false, aa_core::EnforcementMode::Enforce);
+        let handle = stub_handle(None);
+        let env = build_child_env(&handle, None, true, aa_core::EnforcementMode::Enforce);
         assert!(
             !env.contains_key("AA_ENFORCEMENT_MODE"),
             "AA_ENFORCEMENT_MODE must be absent in plain enforce-mode launches"
@@ -972,14 +1124,14 @@ mod tests {
         // The downstream tool / SDK reads this env var to decide whether to
         // surface a "running under observe mode" badge / banner in its own
         // UX. Locks in the snake_case wire form.
-        let handle = stub_handle(None, None);
-        let observe_env = build_child_env(&handle, false, aa_core::EnforcementMode::Observe);
+        let handle = stub_handle(None);
+        let observe_env = build_child_env(&handle, None, true, aa_core::EnforcementMode::Observe);
         assert_eq!(
             observe_env.get("AA_ENFORCEMENT_MODE").map(String::as_str),
             Some("observe")
         );
 
-        let disabled_env = build_child_env(&handle, false, aa_core::EnforcementMode::Disabled);
+        let disabled_env = build_child_env(&handle, None, true, aa_core::EnforcementMode::Disabled);
         assert_eq!(
             disabled_env.get("AA_ENFORCEMENT_MODE").map(String::as_str),
             Some("disabled")
@@ -1036,7 +1188,6 @@ mod tests {
         assert_eq!(handle.registration_id, "gw-reg-id");
         assert_eq!(handle.trace_id, "gw-trace-id");
         assert_eq!(handle.session_id, "gw-session-id");
-        assert_eq!(handle.proxy_addr.as_deref(), Some("http://gw-proxy:9090"));
         assert_eq!(handle.team_id.as_deref(), Some("my-team"));
 
         // Verify the request body shape
@@ -1297,12 +1448,85 @@ mod tests {
             api_key: None,
         };
 
+        // `--no-proxy`, because this test is about detect + register + spawn.
+        // Without it the launch would (correctly) refuse: no proxy is running
+        // in the test process's data dir. The refusal itself is asserted by
+        // `launch_refuses_when_no_trusted_proxy_can_be_established`.
+        let mut args = run_args("claude");
+        args.no_proxy = true;
+
         assert!(
-            execute_with_adapters(&run_args("claude"), &ctx, &adapters)
-                .await
-                .is_ok(),
+            execute_with_adapters(&args, &ctx, &adapters).await.is_ok(),
             "execute_with_adapters should succeed when detect() returns Some and gateway responds 201"
         );
+    }
+
+    /// The core claim of AAASM-5323: with no trusted proxy on this host, a
+    /// launch is refused — and a `proxy_addr` in the gateway's response cannot
+    /// rescue it, because the response is not a source of truth for where this
+    /// machine's traffic goes.
+    ///
+    /// Not `#[tokio::test]`: the `AA_DATA_DIR` redirection needs the crate's
+    /// environment lock, and holding a `std` guard across an `.await` is a
+    /// deadlock hazard clippy rightly rejects. Driving the async body through a
+    /// local runtime keeps the whole guarded region await-free.
+    #[test]
+    fn launch_refuses_when_no_trusted_proxy_can_be_established() {
+        let _lock = crate::test_support::env_guard();
+        let prior = std::env::var("AA_DATA_DIR").ok();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("AA_DATA_DIR", tmp.path());
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build test runtime");
+        let outcome = rt.block_on(async {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/api/v1/agents"))
+                .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "agent_id": "a1",
+                    "registration_id": "r1",
+                    "trace_id": "t1",
+                    "session_id": "s1",
+                    // A gateway insisting there is a proxy. There isn't.
+                    "proxy_addr": "127.0.0.1:8899"
+                })))
+                .mount(&mock_server)
+                .await;
+
+            let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
+            adapters.insert("claude", Box::new(StubDetected { version: None }));
+            let ctx = ResolvedContext {
+                name: None,
+                api_url: mock_server.uri(),
+                api_key: None,
+            };
+
+            let result = execute_with_adapters(&run_args("claude"), &ctx, &adapters).await;
+            let registered = mock_server.received_requests().await.unwrap().len();
+            (result, registered)
+        });
+
+        match prior {
+            Some(v) => std::env::set_var("AA_DATA_DIR", v),
+            None => std::env::remove_var("AA_DATA_DIR"),
+        }
+
+        let (result, registered) = outcome;
+        let err = result.expect_err(
+            "with no proxy running, `aasm run` must refuse to launch rather than launch \
+             unproxied — a gateway-supplied address is not evidence that a proxy exists",
+        );
+        assert!(
+            err.to_string().contains("refusing to launch ungoverned"),
+            "the refusal must say what it refused and why; got: {err}"
+        );
+
+        // And nothing was registered: the refusal happens before the session
+        // exists, so there is no abandoned registration to reap.
+        assert_eq!(registered, 0, "a refused launch must not have registered a session");
     }
 
     #[tokio::test]
@@ -1385,7 +1609,6 @@ mod tests {
             registration_id: "reg-xyz".into(),
             trace_id: "trace-xyz".into(),
             session_id: "session-xyz".into(),
-            proxy_addr: None,
             team_id: None,
         };
         let settings = r#"{"mode":"strict"}"#;
@@ -1439,7 +1662,6 @@ mod tests {
             registration_id: "reg-xyz".into(),
             trace_id: "trace-xyz".into(),
             session_id: "session-xyz".into(),
-            proxy_addr: None,
             team_id: None,
         };
         let cmd = std::process::Command::new("mock-tool");
@@ -1479,7 +1701,6 @@ mod tests {
             registration_id: "reg-xyz".into(),
             trace_id: "trace-xyz".into(),
             session_id: "session-xyz".into(),
-            proxy_addr: None,
             team_id: None,
         };
         let cmd = std::process::Command::new("mock-tool");

--- a/aa-cli/tests/run_command.rs
+++ b/aa-cli/tests/run_command.rs
@@ -16,7 +16,6 @@ fn registration_response(registration_id: &str) -> serde_json::Value {
         "registration_id": registration_id,
         "trace_id": "trace-1",
         "session_id": "session-1",
-        "proxy_addr": null,
     })
 }
 
@@ -153,7 +152,13 @@ async fn run_command_exits_zero_and_deregisters() {
         team_id: None,
         root_agent: None,
         governance_level: None,
-        no_proxy: false,
+        // These tests measure child-process spawn and deregistration, not
+        // proxy trust. Since AAASM-5323 a launch without `--no-proxy` refuses
+        // unless a verified proxy is running on this host, which is not
+        // something an exit-code test should have to stand up — and refusing is
+        // exactly what `aa-cli`'s own
+        // `launch_refuses_when_no_trusted_proxy_can_be_established` asserts.
+        no_proxy: true,
         dry_run: false,
         enforcement_mode: None,
         observe: false,
@@ -199,7 +204,13 @@ async fn run_command_propagates_nonzero_exit_and_deregisters() {
         team_id: None,
         root_agent: None,
         governance_level: None,
-        no_proxy: false,
+        // These tests measure child-process spawn and deregistration, not
+        // proxy trust. Since AAASM-5323 a launch without `--no-proxy` refuses
+        // unless a verified proxy is running on this host, which is not
+        // something an exit-code test should have to stand up — and refusing is
+        // exactly what `aa-cli`'s own
+        // `launch_refuses_when_no_trusted_proxy_can_be_established` asserts.
+        no_proxy: true,
         dry_run: false,
         enforcement_mode: None,
         observe: false,

--- a/aa-integration-tests/tests/cli_run_claude_governed_launch.rs
+++ b/aa-integration-tests/tests/cli_run_claude_governed_launch.rs
@@ -54,8 +54,12 @@ mod common;
 #[allow(dead_code, unused_imports)]
 mod spike_support;
 
+#[allow(unused_imports)]
+mod proxy_trust_support;
+
 #[cfg(unix)]
 mod governed_launch {
+    use super::proxy_trust_support::{aasm_binary, TrustedProxy};
     use super::spike_support::RealHomeGuard;
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -74,9 +78,10 @@ mod governed_launch {
     const TRACE_ID: &str = "aaasm1112-trace";
     const SESSION_ID: &str = "aaasm1112-session";
     const TEAM_ID: &str = "aaasm1112-team";
-    /// The address the gateway assigns this session. Nothing listens on it — the
-    /// claim under test is that the launcher *routes the child at it*, which is
-    /// observable in the child's environment without a live proxy.
+    /// The address the gateway assigns this session. Nothing listens on it, and
+    /// since AAASM-5323 nothing is supposed to route at it either: the endpoint
+    /// is resolved and verified host-side, so this value is the decoy that makes
+    /// the proxy assertion below mean something.
     const PROXY_ADDR: &str = "127.0.0.1:19999";
 
     /// What the mock gateway saw. Registration and deregistration are the
@@ -149,59 +154,6 @@ exit 0
         Ok(bin)
     }
 
-    /// Absolute path to the `aasm` binary under test.
-    ///
-    /// Deliberately not `common::cli::aasm_command()`: that helper falls back to
-    /// `cargo run`, and this test runs the CLI with its working directory inside
-    /// a temp dir (the settings-path resolver prefers `<cwd>/.claude`, so leaving
-    /// the working directory in the repo would let the run write into the
-    /// checkout). `cargo run` cannot find a manifest from there. An absolute
-    /// path sidesteps the problem and keeps the run hermetic.
-    fn aasm_binary() -> PathBuf {
-        if let Some(explicit) = std::env::var_os("AASM_BIN_PATH") {
-            return std::fs::canonicalize(&explicit)
-                .unwrap_or_else(|e| panic!("AASM_BIN_PATH={explicit:?} could not be resolved: {e}"));
-        }
-        let target = std::env::var_os("CARGO_TARGET_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| {
-                Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .parent()
-                    .expect("aa-integration-tests always has a workspace-root parent")
-                    .join("target")
-            });
-        for profile in ["debug", "release"] {
-            let bin = target.join(profile).join("aasm");
-            if bin.is_file() {
-                return bin;
-            }
-        }
-
-        // `aa-integration-tests` does not depend on `aa-cli`, so nothing builds
-        // the binary for us: `cargo nextest run -p aa-integration-tests` on a
-        // clean target dir would otherwise fail here rather than run. Build it
-        // once. The working directory matters — the test bodies run `aasm` from
-        // inside a temp dir (the settings resolver prefers `<cwd>/.claude`, so
-        // running from the checkout would let it write into the repo), and cargo
-        // cannot find a manifest from there. Building from the manifest dir up
-        // front is what lets the run itself stay hermetic.
-        let status = std::process::Command::new(env!("CARGO"))
-            .args(["build", "--quiet", "-p", "aa-cli", "--bin", "aasm"])
-            .current_dir(env!("CARGO_MANIFEST_DIR"))
-            .status()
-            .expect("failed to invoke cargo to build the aasm binary");
-        assert!(status.success(), "`cargo build -p aa-cli --bin aasm` failed");
-
-        let bin = target.join("debug").join("aasm");
-        assert!(
-            bin.is_file(),
-            "no `aasm` binary at {} even after building it — set AASM_BIN_PATH. Skipping \
-             instead would leave AAASM-201 AC4 unevidenced.",
-            bin.display(),
-        );
-        bin
-    }
-
     /// Parse the `KEY=value` dump the stub wrote.
     fn parse_dump(raw: &str) -> BTreeMap<String, String> {
         raw.lines()
@@ -216,6 +168,13 @@ exit 0
     #[tokio::test(flavor = "multi_thread")]
     async fn run_claude_launches_the_tool_with_identity_proxy_and_a_monitored_session() -> anyhow::Result<()> {
         let real_home = RealHomeGuard::capture();
+
+        // ── a proxy this host can vouch for ────────────────────────────────
+        //
+        // Without one the launch is refused outright (AAASM-5323), so AC4's
+        // "launches Claude Code with identity, proxy and monitoring" has a live
+        // proxy as its precondition rather than a gateway-supplied string.
+        let proxy = TrustedProxy::start()?;
 
         // ── the gateway ────────────────────────────────────────────────────
         let recorder: Shared = Arc::new(Mutex::new(Recorder::default()));
@@ -260,6 +219,7 @@ exit 0
             .env("AASM_STATE_DIR", root.join("state"))
             .env("AA_CA_DIR", root.join("ca"))
             .env("AASM_CLAUDE_MANAGED_ROOT", root.join("managed"))
+            .env("AA_DATA_DIR", proxy.data_dir())
             .env("AA_TEST_ENV_DUMP", &dump)
             .args(["--api-url", &api_url, "run", "claude"]);
         let out = cmd.output().expect("aasm run claude should execute");
@@ -295,28 +255,20 @@ exit 0
 
         // ── proxy, as the launched tool saw it ─────────────────────────────
         //
-        // AAASM-1112 finding (2), pinned here rather than asserted away: the
-        // value the child receives is the gateway's bare `host:port`, **not** a
-        // proxy URL. `ClaudeCodeAdapter::build_launch_command` deliberately
-        // normalises `host:port` to `http://host:port`, but `execute_with_adapters`
-        // applies `build_child_env`'s unnormalised value on top of the command the
-        // adapter built (`cmd.envs(&child_env)`), and `spawn_and_wait` applies it
-        // once more — so the adapter's normalisation never reaches the process.
-        // `aa-cli`'s own `build_child_env_sets_proxy` unit test does not catch
-        // this because it feeds in a value that already carries a scheme.
-        //
-        // This assertion is written against the observed value on purpose: when
-        // the defect is fixed the test fails, which is the forcing function that
-        // makes the verification record get revisited.
+        // AAASM-1112 finding (2) is resolved, and by a route the original note
+        // did not anticipate: the child is routed at the endpoint *this host*
+        // resolved and verified, in normalised URL form. The gateway's
+        // `PROXY_ADDR` is deliberately a different, dead address — a
+        // registration response is remote and unauthenticated, so it is not
+        // entitled to choose where this session's traffic goes (AAASM-5323).
+        let expected_proxy = proxy.expected_proxy_url();
         for key in ["HTTPS_PROXY", "HTTP_PROXY"] {
             assert_eq!(
                 seen.get(key).map(String::as_str),
-                Some(PROXY_ADDR),
-                "the launched tool must be routed at the proxy address the gateway assigned via \
-                 `{key}`. NOTE: this pins the CURRENT, DEFECTIVE value on purpose — the designed \
-                 value is `http://{PROXY_ADDR}` (AAASM-5324, root-caused by AAASM-5327). If this \
-                 now reads `http://{PROXY_ADDR}`, that bug is fixed: change this assertion to the \
-                 designed value and re-derive the AAASM-201 AC4 verdict. Saw:\n{raw}",
+                Some(expected_proxy.as_str()),
+                "the launched tool must be routed at the verified local proxy via `{key}`. \
+                 `{PROXY_ADDR}` or `http://{PROXY_ADDR}` here would mean the gateway's response \
+                 chose the route; an empty value would mean no interception at all. Saw:\n{raw}",
             );
         }
 
@@ -377,6 +329,10 @@ exit 0
     async fn against_the_real_gateway_the_launcher_cannot_register_and_never_starts_the_tool() -> anyhow::Result<()> {
         let fixture = super::common::cli::CliFixture::start().await?;
 
+        // A verified proxy, so the run reaches the registration call this test
+        // is about instead of being refused before it (AAASM-5323).
+        let proxy = TrustedProxy::start()?;
+
         let tmp = tempfile::tempdir()?;
         let root = tmp.path();
         let home = root.join("home");
@@ -400,6 +356,7 @@ exit 0
             .env("AASM_STATE_DIR", root.join("state"))
             .env("AA_CA_DIR", root.join("ca"))
             .env("AASM_CLAUDE_MANAGED_ROOT", root.join("managed"))
+            .env("AA_DATA_DIR", proxy.data_dir())
             .env("AA_TEST_ENV_DUMP", &dump)
             .args(["--api-url", &fixture.base_url(), "run", "claude"])
             .output()

--- a/aa-integration-tests/tests/cli_run_claude_launch_env.rs
+++ b/aa-integration-tests/tests/cli_run_claude_launch_env.rs
@@ -47,7 +47,13 @@
 //! reads its contents, because that file is in daily use and may hold
 //! credentials that an `assert_eq!` would print into a CI log.
 //!
-//! # Independence from AAASM-5323
+//! # The proxy endpoint is the one this host verified, not the one it was told
+//!
+//! Since AAASM-5323 a launch is refused unless `aasm run` can vouch for a local
+//! proxy, so these tests stand up a real one ([`TrustedProxy`]). The mock gateway
+//! still answers with a `proxy_addr`, and it is a **different** address than the
+//! running proxy's — so the assertion below is not merely "the child got a proxy"
+//! but "the child got the verified one and not the one the gateway named".
 //!
 //! `aasm run` registers with `POST /api/v1/agents`, which no shipped gateway
 //! serves yet. The gateway here is a mock that answers it, so this file measures
@@ -58,8 +64,12 @@
 #[allow(dead_code, unused_imports)]
 mod spike_support;
 
+#[allow(unused_imports)]
+mod proxy_trust_support;
+
 #[cfg(unix)]
 mod launch_env {
+    use super::proxy_trust_support::{aasm_binary, TrustedProxy};
     use super::spike_support::RealHomeGuard;
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -73,10 +83,10 @@ mod launch_env {
     use axum::routing::{delete, post};
     use axum::{Json, Router};
 
-    /// The address the mock gateway assigns, in the **bare** `host:port` form a
-    /// gateway actually returns. Nothing listens on it: the claim under test is
-    /// which string the child is routed at, which is observable without a live
-    /// proxy. The adapter is expected to normalise this to a URL.
+    /// The address the mock gateway assigns. Nothing listens on it, and nothing
+    /// is supposed to: it is the decoy that makes the proxy assertion meaningful
+    /// — the child must be routed at the endpoint this host verified, never at
+    /// the one a registration response named (AAASM-5323).
     const PROXY_ADDR: &str = "127.0.0.1:19771";
     const AGENT_ID: &str = "aaasm5327-agent";
     const REGISTRATION_ID: &str = "aaasm5327-registration";
@@ -186,59 +196,6 @@ exit 0
         Ok(bin)
     }
 
-    /// Absolute path to a **freshly built** `aasm` binary under test.
-    ///
-    /// Deliberately not `common::cli::aasm_command()`: that helper falls back to
-    /// `cargo run`, and these tests run the CLI with its working directory inside
-    /// a temp dir (the settings-path resolver prefers `<cwd>/.claude`, so leaving
-    /// the working directory in the repo would let the run write into the
-    /// checkout). `cargo run` cannot find a manifest from there.
-    ///
-    /// `aa-integration-tests` does not depend on `aa-cli`, so `cargo nextest run
-    /// -p aa-integration-tests` builds nothing of the CLI: a stale `aasm` left in
-    /// `target/` by an earlier build would be measured instead of the tree. That
-    /// is a false *pass* for a test whose entire subject is `aa-cli` behaviour —
-    /// it makes the suite silently unable to notice the defect coming back — so
-    /// the build is unconditional rather than a fallback for a missing file. It
-    /// is a no-op when the binary is current.
-    ///
-    /// `AASM_BIN_PATH` is the escape hatch for callers (CI) that built the binary
-    /// themselves and own its freshness. It also picks the debug profile
-    /// unconditionally; a `--release` run wanting the release binary must point
-    /// `AASM_BIN_PATH` at it.
-    fn aasm_binary() -> PathBuf {
-        if let Some(explicit) = std::env::var_os("AASM_BIN_PATH") {
-            return std::fs::canonicalize(&explicit)
-                .unwrap_or_else(|e| panic!("AASM_BIN_PATH={explicit:?} could not be resolved: {e}"));
-        }
-
-        // Built from the manifest dir, which is what lets the run itself stay
-        // hermetic in a temp working directory.
-        let status = std::process::Command::new(env!("CARGO"))
-            .args(["build", "--quiet", "-p", "aa-cli", "--bin", "aasm"])
-            .current_dir(env!("CARGO_MANIFEST_DIR"))
-            .status()
-            .expect("failed to invoke cargo to build the aasm binary");
-        assert!(status.success(), "`cargo build -p aa-cli --bin aasm` failed");
-
-        let target = std::env::var_os("CARGO_TARGET_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| {
-                Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .parent()
-                    .expect("aa-integration-tests always has a workspace-root parent")
-                    .join("target")
-            });
-        let bin = target.join("debug").join("aasm");
-        assert!(
-            bin.is_file(),
-            "no `aasm` binary at {} even after building it — set AASM_BIN_PATH. Skipping instead \
-             would leave the launch environment unmeasured.",
-            bin.display(),
-        );
-        bin
-    }
-
     /// A host whose every Claude Code / Agent Assembly root is inside a temp dir.
     struct GovernedHost {
         _tmp: tempfile::TempDir,
@@ -288,11 +245,14 @@ exit 0
             Ok(LaunchEnvStore::at(paths.launch_env_dir(SettingsScope::User)?))
         }
 
-        /// Run `aasm run claude` against `api_url` and return the child stub's
-        /// self-reported environment.
-        fn run(&self, api_url: &str) -> anyhow::Result<BTreeMap<String, String>> {
+        /// Run `aasm run claude` against `api_url`, routed through `proxy`, and
+        /// return the child stub's self-reported environment.
+        fn run(&self, api_url: &str, proxy: &TrustedProxy) -> anyhow::Result<BTreeMap<String, String>> {
             let out = std::process::Command::new(aasm_binary())
                 .current_dir(&self.project)
+                // Where the verified proxy's state record lives. Without it the
+                // launch refuses and nothing is measured.
+                .env("AA_DATA_DIR", proxy.data_dir())
                 .env("HOME", &self.home)
                 .env("PATH", &self.path_var)
                 .env("CLAUDE_CONFIG_DIR", self.home.join(".claude"))
@@ -342,11 +302,12 @@ exit 0
         let real_home = RealHomeGuard::capture();
         let (api_url, server) = start_mock_gateway().await?;
 
+        let proxy = TrustedProxy::start()?;
         let host = GovernedHost::create()?;
         host.user_launch_env_store()?
             .set("NODE_EXTRA_CA_CERTS", CA_PATH_VALUE)?;
 
-        let seen = host.run(&api_url)?;
+        let seen = host.run(&api_url, &proxy)?;
 
         // ── the variable the whole product depends on ──────────────────────
         //
@@ -361,19 +322,22 @@ exit 0
             render(&seen),
         );
 
-        // ── the adapter's normalisation survives the merge ─────────────────
+        // ── the child is routed at the endpoint this host verified ────────
         //
-        // `build_child_env` also sets these, to the gateway's bare `host:port`,
-        // which is not a proxy URL any HTTP client accepts (AAASM-5324). The
-        // adapter's normalised value has to be the one that lands.
-        let expected_proxy = format!("http://{PROXY_ADDR}");
+        // Not at `PROXY_ADDR`, which the gateway named in its response: a
+        // registration response is remote and unauthenticated, so letting it
+        // choose where a governed session's traffic goes is the bypass
+        // AAASM-5323 closes. The value must also be a URL, not a bare authority
+        // — no HTTP client routes through the latter (AAASM-5324).
+        let expected_proxy = proxy.expected_proxy_url();
         for key in ["HTTPS_PROXY", "HTTP_PROXY"] {
             assert_eq!(
                 seen.get(key).map(String::as_str),
                 Some(expected_proxy.as_str()),
-                "`{key}` must carry the adapter's normalised proxy URL, not `build_child_env`'s \
-                 bare `{PROXY_ADDR}` — a bare authority is not a URL an HTTP client routes \
-                 through. Saw:\n{}",
+                "`{key}` must carry the verified local endpoint. `http://{PROXY_ADDR}` here means \
+                 the gateway's response chose the route; `{PROXY_ADDR}` means a bare authority \
+                 reached the child; `__UNSET__` means the launch was not proxied at all. \
+                 Saw:\n{}",
                 render(&seen),
             );
         }
@@ -411,8 +375,9 @@ exit 0
         let (api_url, server) = start_mock_gateway().await?;
 
         // No launch-env store is written, so nothing injects the CA variable.
+        let proxy = TrustedProxy::start()?;
         let host = GovernedHost::create()?;
-        let seen = host.run(&api_url)?;
+        let seen = host.run(&api_url, &proxy)?;
 
         assert_eq!(
             seen.get("NODE_EXTRA_CA_CERTS").map(String::as_str),

--- a/aa-integration-tests/tests/cli_run_trusted_proxy.rs
+++ b/aa-integration-tests/tests/cli_run_trusted_proxy.rs
@@ -1,0 +1,380 @@
+//! AAASM-5323 — `aasm run` refuses to launch when it cannot establish a proxy
+//! endpoint it can vouch for.
+//!
+//! # What was wrong
+//!
+//! `aasm run` read its proxy address from the `proxy_addr` field of the
+//! gateway's registration response and set `HTTPS_PROXY` **only if that field
+//! was present**. Nothing in the tree ever populated it, so the flag-free
+//! `aasm run claude` an operator actually types launched the tool with no proxy
+//! at all — uninspected, unbounded by egress policy, and reporting as governed.
+//! An absent value could mean "proceed anyway", which is the defining shape of a
+//! silent bypass.
+//!
+//! # What this file measures
+//!
+//! Every case here drives the real `aasm` binary and asserts two things
+//! together: the process exits non-zero, **and** the tool was never started. The
+//! second is what makes the first mean something — an error message printed
+//! after a child has already been launched is not a refusal.
+//!
+//! The refusals are distinguished by the *reason* each one gives, not merely by
+//! being refusals. A test that only asserted "it failed" would pass if a single
+//! early check swallowed every case, which is exactly how a matrix of guards
+//! collapses into one guard wearing five names.
+//!
+//! The complementary claim — that a launch through a *verified* proxy proceeds
+//! and the child is routed at the resolved endpoint — is measured in
+//! `cli_run_claude_launch_env.rs`, which already owns the child-environment dump
+//! machinery.
+
+#[allow(unused_imports)]
+mod proxy_trust_support;
+
+#[cfg(unix)]
+mod refusals {
+    use super::proxy_trust_support::{aasm_binary, prefixed_path, TrustedProxy};
+    use std::path::{Path, PathBuf};
+
+    /// A host whose `claude`, home and state roots are all inside a temp dir, so
+    /// nothing here can read or write the developer's own configuration.
+    struct Host {
+        _tmp: tempfile::TempDir,
+        root: PathBuf,
+        home: PathBuf,
+        project: PathBuf,
+        dump: PathBuf,
+        stub_dir: PathBuf,
+    }
+
+    impl Host {
+        fn create() -> anyhow::Result<Self> {
+            let tmp = tempfile::tempdir()?;
+            let root = tmp.path().to_path_buf();
+            let home = root.join("home");
+            let project = root.join("project");
+            std::fs::create_dir_all(home.join(".claude"))?;
+            std::fs::create_dir_all(&project)?;
+            let stub = write_stub_binary(&root)?;
+            Ok(Self {
+                stub_dir: stub.parent().expect("the stub has a parent").to_path_buf(),
+                dump: root.join("child-env.txt"),
+                _tmp: tmp,
+                root,
+                home,
+                project,
+            })
+        }
+
+        /// Run `aasm run claude` with `data_dir` as the proxy state directory.
+        fn run(&self, data_dir: &Path) -> anyhow::Result<std::process::Output> {
+            Ok(std::process::Command::new(aasm_binary())
+                .current_dir(&self.project)
+                .env("HOME", &self.home)
+                .env("PATH", prefixed_path(&self.stub_dir)?)
+                .env("CLAUDE_CONFIG_DIR", self.home.join(".claude"))
+                .env("AASM_STATE_DIR", self.root.join("state"))
+                .env("AA_CA_DIR", self.root.join("ca"))
+                .env("AASM_CLAUDE_MANAGED_ROOT", self.root.join("managed"))
+                .env("AA_DATA_DIR", data_dir)
+                .env("AASM5323_ENV_DUMP", &self.dump)
+                // A gateway address nothing can be listening on. A refusal
+                // happens before registration, so this is never reached — and if
+                // the refusal ever stopped happening, the run would fail here
+                // instead of quietly launching.
+                .args(["--api-url", "http://127.0.0.1:1", "run", "claude"])
+                .output()?)
+        }
+
+        /// True when the `claude` stand-in ran. Absence of the dump is what
+        /// "refused to launch" actually means.
+        fn tool_was_launched(&self) -> bool {
+            self.dump.exists()
+        }
+    }
+
+    /// A `claude` stand-in: answers `--version` so `detect()` succeeds, and
+    /// records the fact that it ran if it is ever launched.
+    fn write_stub_binary(dir: &Path) -> std::io::Result<PathBuf> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let bin_dir = dir.join("bin");
+        std::fs::create_dir_all(&bin_dir)?;
+        let bin = bin_dir.join("claude");
+        std::fs::write(
+            &bin,
+            r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "2.1.999 (Claude Code)"
+  exit 0
+fi
+printf 'HTTPS_PROXY=%s\n' "${HTTPS_PROXY-__UNSET__}" > "$AASM5323_ENV_DUMP"
+exit 0
+"#,
+        )?;
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))?;
+        Ok(bin)
+    }
+
+    /// Assert the run refused, said why, and started nothing.
+    fn assert_refused(host: &Host, out: &std::process::Output, because: &str) {
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !out.status.success(),
+            "the launch must exit non-zero when no proxy endpoint can be trusted\n\
+             stdout:\n{stdout}\nstderr:\n{stderr}",
+        );
+        assert!(
+            stderr.contains("refusing to launch ungoverned"),
+            "the operator must be told the launch was refused, not left to infer it from an \
+             exit code\nstderr:\n{stderr}",
+        );
+        assert!(
+            stderr.contains(because),
+            "the refusal must name the fact that failed (`{because}`); a single early check \
+             standing in for every case would make this matrix meaningless\nstderr:\n{stderr}",
+        );
+        assert!(
+            !host.tool_was_launched(),
+            "the tool was started anyway — an error message printed after the child exists is \
+             not a refusal\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        );
+    }
+
+    /// Overwrite one line of the state record the harness's `aasm proxy start`
+    /// wrote, leaving everything else — including the live process it names —
+    /// exactly as it was.
+    fn tamper_line(path: &Path, index: usize, replacement: &str) {
+        let content = std::fs::read_to_string(path).expect("state file must exist to be tampered with");
+        let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+        assert!(
+            index < lines.len(),
+            "state record has {} lines; cannot rewrite line {index}. The record format changed \
+             and this test is no longer tampering with the field it names.",
+            lines.len(),
+        );
+        lines[index] = replacement.to_string();
+        std::fs::write(path, format!("{}\n", lines.join("\n"))).expect("rewrite state file");
+    }
+
+    // ── no proxy at all ────────────────────────────────────────────────────
+
+    /// The everyday case, and the one the old code got wrong: an operator who
+    /// has not started a proxy types `aasm run claude`.
+    #[test]
+    fn launch_refuses_when_no_proxy_is_running() -> anyhow::Result<()> {
+        let host = Host::create()?;
+        let data = tempfile::tempdir()?;
+
+        let out = host.run(data.path())?;
+
+        assert_refused(&host, &out, "no governed proxy is running");
+        Ok(())
+    }
+
+    // ── stale state ────────────────────────────────────────────────────────
+
+    /// A record left behind by a proxy that has since exited. The PID is a real
+    /// number that was a real process; it just isn't one any more.
+    #[test]
+    fn launch_refuses_when_the_recorded_process_is_gone() -> anyhow::Result<()> {
+        let host = Host::create()?;
+        let data = tempfile::tempdir()?;
+
+        let mut child = std::process::Command::new("true").spawn()?;
+        let dead_pid = child.id();
+        child.wait()?;
+
+        write_state(
+            data.path(),
+            &format!("{dead_pid}\n127.0.0.1:8899\nstale-token\n/usr/local/bin/aa-proxy\n"),
+        )?;
+
+        let out = host.run(data.path())?;
+
+        assert_refused(&host, &out, "is not running");
+        Ok(())
+    }
+
+    /// A record with no identity evidence at all — the two-line format that
+    /// predates AAASM-5323. It names a live process (this test), so a check that
+    /// stopped at liveness would accept it.
+    #[test]
+    fn launch_refuses_a_record_carrying_no_identity_evidence() -> anyhow::Result<()> {
+        let host = Host::create()?;
+        let data = tempfile::tempdir()?;
+
+        write_state(data.path(), &format!("{}\n127.0.0.1:8899\n", std::process::id()))?;
+
+        let out = host.run(data.path())?;
+
+        assert_refused(&host, &out, "not a complete record");
+        Ok(())
+    }
+
+    // ── an untrustworthy record ────────────────────────────────────────────
+
+    /// A record any other account on the box could rewrite is a record any other
+    /// account could use to choose where this session's traffic goes. The proxy
+    /// behind it is genuinely running, so nothing but the file mode is wrong.
+    #[test]
+    fn launch_refuses_an_over_permissive_state_file() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let host = Host::create()?;
+        let proxy = TrustedProxy::start()?;
+        let state = proxy.data_dir().join("proxy.pid");
+        std::fs::set_permissions(&state, std::fs::Permissions::from_mode(0o666))?;
+
+        let out = host.run(proxy.data_dir())?;
+
+        assert_refused(&host, &out, "lets group or other write to it");
+        Ok(())
+    }
+
+    /// The state path replaced by a symlink. The metadata that gets vetted must
+    /// be the metadata of the bytes that get read.
+    #[test]
+    fn launch_refuses_a_state_file_that_is_a_symlink() -> anyhow::Result<()> {
+        let host = Host::create()?;
+        let proxy = TrustedProxy::start()?;
+        let state = proxy.data_dir().join("proxy.pid");
+        let moved = proxy.data_dir().join("elsewhere.pid");
+        std::fs::rename(&state, &moved)?;
+        std::os::unix::fs::symlink(&moved, &state)?;
+
+        let out = host.run(proxy.data_dir())?;
+
+        assert_refused(&host, &out, "not a regular file");
+        Ok(())
+    }
+
+    // ── PID reuse ──────────────────────────────────────────────────────────
+
+    /// The case liveness cannot see: the recorded PID is alive and is running
+    /// `aa-proxy`, but it is a *different incarnation* than the one recorded —
+    /// the shape a recycled PID takes when the successor happens to be another
+    /// proxy. Only the start time distinguishes them.
+    ///
+    /// Simulated by rewriting the recorded start token while leaving the genuine
+    /// running proxy, its PID, its executable and its bound socket untouched:
+    /// every other check still passes, so a failure here is attributable to the
+    /// start-time comparison and to nothing else.
+    #[test]
+    fn launch_refuses_when_the_recorded_pid_is_a_different_incarnation() -> anyhow::Result<()> {
+        let host = Host::create()?;
+        let proxy = TrustedProxy::start()?;
+        tamper_line(&proxy.data_dir().join("proxy.pid"), 2, "not-the-recorded-incarnation");
+
+        let out = host.run(proxy.data_dir())?;
+
+        assert_refused(&host, &out, "start time");
+        Ok(())
+    }
+
+    /// The visible half of PID reuse: the number is alive but is running some
+    /// other program. Simulated by pointing the record's executable field
+    /// somewhere else while the live proxy keeps the PID.
+    #[test]
+    fn launch_refuses_when_the_recorded_pid_runs_a_different_executable() -> anyhow::Result<()> {
+        let host = Host::create()?;
+        let proxy = TrustedProxy::start()?;
+        tamper_line(&proxy.data_dir().join("proxy.pid"), 3, "/opt/somewhere/else/aa-proxy");
+
+        let out = host.run(proxy.data_dir())?;
+
+        assert_refused(&host, &out, "executable");
+        Ok(())
+    }
+
+    /// A live process this user owns is not automatically a proxy. Points the
+    /// record at this very test binary — alive, signallable, and emphatically
+    /// not `aa-proxy`.
+    #[test]
+    fn launch_refuses_a_record_naming_something_other_than_the_proxy() -> anyhow::Result<()> {
+        let host = Host::create()?;
+        let data = tempfile::tempdir()?;
+        let me = std::env::current_exe()?;
+
+        write_state(
+            data.path(),
+            &format!("{}\n127.0.0.1:8899\nany-token\n{}\n", std::process::id(), me.display()),
+        )?;
+
+        let out = host.run(data.path())?;
+
+        assert_refused(&host, &out, "which is not `aa-proxy`");
+        Ok(())
+    }
+
+    // ── the endpoint itself ────────────────────────────────────────────────
+
+    /// A proxy bound off-loopback would carry this session's decrypted traffic
+    /// off the machine, to a host none of these checks can vouch for.
+    #[test]
+    fn launch_refuses_a_non_loopback_endpoint() -> anyhow::Result<()> {
+        let host = Host::create()?;
+        let proxy = TrustedProxy::start()?;
+        let port = proxy
+            .addr()
+            .rsplit(':')
+            .next()
+            .expect("addr carries a port")
+            .to_string();
+        tamper_line(&proxy.data_dir().join("proxy.pid"), 1, &format!("10.0.0.5:{port}"));
+
+        let out = host.run(proxy.data_dir())?;
+
+        assert_refused(&host, &out, "not a loopback address");
+        Ok(())
+    }
+
+    /// The record's address is where the proxy was *told* to listen. A proxy
+    /// that died during startup leaves a record that can pass every other check
+    /// while nothing answers, and a tool routed at a closed port does whatever
+    /// it likes — historically, connect directly.
+    #[test]
+    fn launch_refuses_when_nothing_is_listening_at_the_recorded_endpoint() -> anyhow::Result<()> {
+        let host = Host::create()?;
+        let proxy = TrustedProxy::start()?;
+
+        // A port nothing holds: bound and released.
+        let free_port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+            listener.local_addr()?.port()
+        };
+        tamper_line(
+            &proxy.data_dir().join("proxy.pid"),
+            1,
+            &format!("127.0.0.1:{free_port}"),
+        );
+
+        let out = host.run(proxy.data_dir())?;
+
+        assert_refused(&host, &out, "nothing is accepting connections");
+        Ok(())
+    }
+
+    /// Write a state record at `data_dir/proxy.pid` with the mode the trust
+    /// check requires, so a test aimed at some other field is not answered by
+    /// the permission check instead.
+    fn write_state(data_dir: &Path, content: &str) -> std::io::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+        let path = data_dir.join("proxy.pid");
+        std::fs::write(&path, content)?;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+    }
+}
+
+/// A skip must be legible in the output; a test binary that silently contains no
+/// tests is indistinguishable from a passing one.
+#[cfg(not(unix))]
+#[test]
+fn proxy_trust_refusals_are_not_measured_on_this_host() {
+    println!(
+        "SKIP [AAASM-5323]: these cases need a POSIX shell stand-in for `claude` and POSIX file \
+         modes; this host is {}.",
+        std::env::consts::OS
+    );
+}

--- a/aa-integration-tests/tests/proxy_trust_support/mod.rs
+++ b/aa-integration-tests/tests/proxy_trust_support/mod.rs
@@ -1,0 +1,208 @@
+// Shared across several `cli_run*` test binaries; not every binary uses every
+// helper, so dead-code warnings here are noise.
+#![allow(dead_code)]
+
+//! A real, verified `aa-proxy` for tests whose subject is what `aasm run` does
+//! *after* it has established one (AAASM-5323).
+//!
+//! # Why a real proxy and not a fixture
+//!
+//! Since AAASM-5323 `aasm run` refuses to launch unless it can resolve a proxy
+//! endpoint it can vouch for: a state file only this user could have written,
+//! naming a live process that is still the `aa-proxy` that was recorded, bound
+//! to a loopback address that accepts connections. Every one of those facts is
+//! read from the kernel, so a hand-written state file cannot satisfy them —
+//! which is the whole point of the design, and the reason this harness stands up
+//! the genuine thing instead.
+//!
+//! Standing it up through `aasm proxy start` rather than by spawning `aa-proxy`
+//! directly is also deliberate: the record under test is the one the production
+//! writer produces, so a change to the format moves this harness with it rather
+//! than leaving it asserting against a format nothing writes.
+
+use std::path::{Path, PathBuf};
+
+/// The workspace `target/` directory, honoring `CARGO_TARGET_DIR`.
+pub fn cargo_target_dir() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("aa-integration-tests always has a workspace-root parent")
+                .join("target")
+        })
+}
+
+/// Absolute path to a **freshly built** binary from this workspace.
+///
+/// `aa-integration-tests` depends on neither `aa-cli` nor the `aa-proxy` binary
+/// target, so `cargo nextest run -p aa-integration-tests` builds neither: a
+/// stale artefact left in `target/` by an earlier build would be measured
+/// instead of the tree. For a test whose entire subject is `aa-cli` behaviour
+/// that is a false *pass* — it makes the suite silently unable to notice a
+/// defect coming back — so the build is unconditional rather than a fallback for
+/// a missing file. It is a no-op when the binary is current.
+///
+/// Memoised per test binary rather than per test: the build must happen after
+/// the tree is what it is, which one build at the start of the run satisfies,
+/// and ten tests each taking cargo's package lock in turn does not make the
+/// result any fresher — it only serialises the suite behind it.
+fn build_binary(package: &str, bin: &str) -> PathBuf {
+    static BUILT: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, PathBuf>>> =
+        std::sync::OnceLock::new();
+    let cache = BUILT.get_or_init(Default::default);
+    let mut cache = cache.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(path) = cache.get(bin) {
+        return path.clone();
+    }
+
+    // Built from the manifest dir, which is what lets the runs themselves stay
+    // hermetic in a temp working directory (cargo cannot find a manifest from
+    // there, so `cargo run`-style resolution is not an option).
+    let status = std::process::Command::new(env!("CARGO"))
+        .args(["build", "--quiet", "-p", package, "--bin", bin])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .status()
+        .unwrap_or_else(|e| panic!("failed to invoke cargo to build {bin}: {e}"));
+    assert!(status.success(), "`cargo build -p {package} --bin {bin}` failed");
+
+    let path = cargo_target_dir().join("debug").join(bin);
+    assert!(
+        path.is_file(),
+        "no `{bin}` binary at {} even after building it. Skipping instead would leave the \
+         behaviour unmeasured.",
+        path.display(),
+    );
+    cache.insert(bin.to_string(), path.clone());
+    path
+}
+
+/// Absolute path to a freshly built `aasm`.
+///
+/// `AASM_BIN_PATH` is the escape hatch for callers (CI) that built the binary
+/// themselves and own its freshness. The default picks the debug profile
+/// unconditionally; a `--release` run wanting the release binary must point
+/// `AASM_BIN_PATH` at it.
+pub fn aasm_binary() -> PathBuf {
+    explicit_binary("AASM_BIN_PATH").unwrap_or_else(|| build_binary("aa-cli", "aasm"))
+}
+
+/// Absolute path to a freshly built `aa-proxy`. `AA_PROXY_BIN_PATH` is the same
+/// escape hatch as [`aasm_binary`]'s.
+pub fn aa_proxy_binary() -> PathBuf {
+    explicit_binary("AA_PROXY_BIN_PATH").unwrap_or_else(|| build_binary("aa-proxy", "aa-proxy"))
+}
+
+fn explicit_binary(var: &str) -> Option<PathBuf> {
+    let explicit = std::env::var_os(var)?;
+    Some(std::fs::canonicalize(&explicit).unwrap_or_else(|e| panic!("{var}={explicit:?} could not be resolved: {e}")))
+}
+
+/// A running `aa-proxy` that `aasm run` will accept, plus the isolated
+/// `AA_DATA_DIR` its state record lives in.
+pub struct TrustedProxy {
+    _tmp: tempfile::TempDir,
+    aasm: PathBuf,
+    data_dir: PathBuf,
+    proxy_bin_dir: PathBuf,
+    addr: String,
+}
+
+impl TrustedProxy {
+    /// Start a proxy on a free loopback port and wait for it to bind.
+    pub fn start() -> anyhow::Result<Self> {
+        let aasm = aasm_binary();
+        let proxy_bin = aa_proxy_binary();
+        let proxy_bin_dir = proxy_bin
+            .parent()
+            .expect("the built binary has a parent directory")
+            .to_path_buf();
+
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path().to_path_buf();
+        let data_dir = root.join("data");
+        std::fs::create_dir_all(&data_dir)?;
+
+        // Bind-and-release to pick a port nothing else holds. `aasm proxy start`
+        // polls the port and fails if the proxy did not bind, so a lost race
+        // surfaces as a failed start here rather than as a confusing refusal
+        // later.
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+            listener.local_addr()?.port()
+        };
+        let addr = format!("127.0.0.1:{port}");
+
+        let out = std::process::Command::new(&aasm)
+            .env("AA_DATA_DIR", &data_dir)
+            .env("PATH", prefixed_path(&proxy_bin_dir)?)
+            .args([
+                "proxy",
+                "start",
+                "--listen",
+                &addr,
+                "--ca-dir",
+                root.join("ca").to_str().expect("temp path is utf-8"),
+                "--log-file",
+                root.join("proxy.log").to_str().expect("temp path is utf-8"),
+            ])
+            .output()?;
+        anyhow::ensure!(
+            out.status.success(),
+            "`aasm proxy start` failed — without a running proxy every `aasm run` in this test \
+             refuses, and the refusal would be mistaken for the behaviour under test\n\
+             stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+
+        Ok(Self {
+            _tmp: tmp,
+            aasm,
+            data_dir,
+            proxy_bin_dir,
+            addr,
+        })
+    }
+
+    /// The `AA_DATA_DIR` to hand to any `aasm` process that must see this proxy.
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
+    /// `host:port` the proxy is listening on.
+    pub fn addr(&self) -> &str {
+        &self.addr
+    }
+
+    /// The endpoint a governed launch must be routed at.
+    pub fn expected_proxy_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    /// Directory holding the `aa-proxy` binary, for callers that build their own
+    /// `PATH` for the child.
+    pub fn proxy_bin_dir(&self) -> &Path {
+        &self.proxy_bin_dir
+    }
+}
+
+impl Drop for TrustedProxy {
+    fn drop(&mut self) {
+        // Best effort: the temp dir goes away regardless, but the proxy is in
+        // its own process group and would outlive the test run.
+        let _ = std::process::Command::new(&self.aasm)
+            .env("AA_DATA_DIR", &self.data_dir)
+            .args(["proxy", "stop"])
+            .output();
+    }
+}
+
+/// `PATH` with `first` prepended, so a `which` probe in a child finds our binary
+/// while the child keeps whatever else it needs from the host.
+pub fn prefixed_path(first: &Path) -> anyhow::Result<std::ffi::OsString> {
+    let mut parts = vec![first.to_path_buf()];
+    parts.extend(std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()));
+    Ok(std::env::join_paths(parts)?)
+}


### PR DESCRIPTION
## Description

Implements **decision 1 of AAASM-5323** (owner-approved): the proxy address a governed launch routes at is resolved **host-side from the canonical proxy state file**, verified, and **failed closed** — never taken from the gateway, an adapter, a tool, or the ambient environment.

### The hole this closes

`aasm run` took its proxy address from `RegistrationHandle::proxy_addr`, populated only from the gateway's registration response. **Nothing in the tree ever sets that field** — `grep -rn proxy_addr` across `aa-api/`, `aa-gateway/`, `aa-proto/`, `proto/`, `openapi/` returns zero hits. And `run.rs` injected `HTTPS_PROXY`/`HTTP_PROXY` only when it was `Some`. So `aasm run claude` has **always launched completely unproxied**, while reporting as governed.

One thing worse than that: `build_child_env` seeds from `std::env::vars()`, so an **ambient `HTTPS_PROXY` from the operator's shell** was already reaching the child and would have been the de-facto route — an unverified proxy masquerading as governance.

### Design

The proxy state record (`aa-cli/src/commands/proxy/pid.rs`) is extended from `<pid>\n<listen_addr>` to four lines: `pid / listen_addr / start_token / exe_path`. New `proxy/trust.rs` resolves and verifies it; new `proxy/identity.rs` reads live-process identity natively per platform.

| Constraint | Implementation |
|---|---|
| No caller/adapter/tool/env-supplied address is authoritative | `proxy_addr` removed from `RegistrationHandle` **and** from the `RegisterResponse` deserialiser. `AA_PROXY_ADDR` is read only by `aasm proxy start` (the writer). Ambient `HTTPS_PROXY` is **overwritten** when an endpoint is vouched for and **removed** when none is |
| State file owned/controlled by the host-side integration | `symlink_metadata` (a symlink is refused, not followed), must be a regular file, `uid == geteuid()`, `mode & 0o022 == 0`. `write_state` now chmods `0600` explicitly after writing, tightening a pre-existing looser file |
| PID alive | `kill(pid, 0)` — which also means signallable by this user, so another user's process reads as not-ours |
| Stale state and **PID reuse** | `(executable image, process start time)` + a live bound socket — see below |
| Process identity is the proxy | the recorded executable's file name must be `aa-proxy`, and the live image must equal the recorded path |
| Scheme/host/port | `ip:port` **literals only** (a hostname is refused — resolution would happen in the child, outside the boundary), `is_loopback()` required, port 0 rejected, and `http://` is *synthesised* rather than read from the record |
| Fail closed | `resolve_launch_proxy` runs **before registration**, so a doomed launch never creates a session it abandons. Any error becomes `refusing to launch ungoverned: …` and exit 1. There is no fallback path |
| Diagnostics without credentials | `ProxyTrustError` carries path, pid, mode, address and a fixed reason — no env values, no file contents, no process args |

**Why `(exe, start time)` is sufficient for PID reuse.** The executable rejects the ordinary case — a recycled PID now running something else. It does *not* reject a second `aa-proxy` taking the same PID; the start time closes exactly that, because a successor cannot have started before its predecessor exited, so `(pid, start_time)` names one incarnation of one process. That is the pair `pidfd` and systemd reduce to. Read natively: Linux `/proc/<pid>/exe` + field 22 of `/proc/<pid>/stat` (split on the **last** `)`, so a space in `comm` cannot fool it); macOS `proc_pidpath` + `PROC_PIDTBSDINFO`. Tokens are platform-prefixed so records cannot collide across hosts. **A platform with no implementation returns a refusal, never a skip.** The TCP connect is the fourth leg — a record can pass everything else while the proxy died during startup.

On the writer side the start time is read back from the kernel for the spawned PID (set at fork, unchanged by exec, so race-free), while the executable is `canonicalize(resolved binary)` rather than a read-back, because the read-back *does* race the exec.

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix

## Breaking Changes

- [x] Yes (describe below)

**`aasm run <tool>` now refuses to launch unless a verified `aa-proxy` is running**, or `--no-proxy` is passed. Previously it always launched.

Nothing that was genuinely governed stops working — what stops is a launch that only *appeared* governed. This is the behaviour constraint 7 asks for, but it is user-visible and is called out here rather than buried.

## Related Issues

- Related Jira ticket: AAASM-5323 (decision 1 of two; decision 2 — gRPC registration — follows in a stacked PR)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

**Twenty mutations, each applied to production code, run, and reverted.** A sample:

```
M13 — fail-open: unresolvable endpoint returns Ok(None) instead of refusing
  refusals:: ... 10 tests run: 0 passed, 10 failed, 0 skipped

M19 — child routed at the gateway-named address instead of the verified one
  assertion `left == right` failed: `HTTPS_PROXY` must carry the verified local endpoint
    left: Some("http://127.0.0.1:19771")
   right: Some("http://127.0.0.1:64559")

M6 — start-time comparison removed (PID reuse, executable-invisible)
  a recycled PID must be refused: ()

M15 — ambient proxy kept when nothing was vouched for
  an unvouched-for ambient HTTPS_PROXY must not reach the child
```

The ten-case refusal matrix was re-run independently before merge: **10 passed, 0 skipped** — no proxy running · recorded process gone · record naming a non-proxy binary · no identity evidence · nothing listening · symlinked state file · non-loopback endpoint · different executable · over-permissive file · different incarnation.

Harness notes: `proxy_trust_support::build_binary` rebuilds `aasm` **and** `aa-proxy` unconditionally, and this PR **removes** `cli_run_claude_governed_launch.rs`'s private `aasm_binary()`, which preferred an existing `target/debug/aasm` over building — that file carried the stale-binary trap that cost the AAASM-5327 work its first mutation result. The `claude` stub uses `${VAR-__UNSET__}` (no colon) so absent is distinguishable from empty, and the refusal fixture proves non-launch by the **absence of the dump file**, not by matching a string.

Gates: `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean workspace-wide; `aa-cli` + `aa-devtool*` 1067 pass; `cli_run_trusted_proxy` 10/10, `cli_run_claude_launch_env` 2/2, `cli_run_claude_governed_launch` 2/2, `cli_run` 5/5.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## For the reviewer to rule on

**Should `--no-proxy` survive?** It is the one remaining route to an unproxied launch. It is pre-existing, explicit, and now loud — `warning: --no-proxy — launching WITHOUT interception. This session's traffic is not inspected and no egress policy applies to it.` — and under it the operator's own `HTTPS_PROXY` is deliberately left untouched, which a corporate-proxy user opting out would need. It therefore satisfies "no silent fallback", but it is a deliberate Layer-2 bypass and whether it should exist at all is a product call.

## Found, not fixed

- **`aasm proxy start --listen 0.0.0.0:PORT` now yields a proxy `aasm run` will refuse.** Rejecting a non-loopback bind at *start* time is a separate product call; today the operator gets a working `aasm proxy status` and a refusing `aasm run`. Worth a follow-up.
- **`AA_DATA_DIR` directory permissions are not checked**, only the file's. An attacker with write access there can delete our record and plant one — but theirs would be owned by them and refused by the uid check.
- **A canonical proxy path whose basename is not literally `aa-proxy`** would be refused. Not observed on any install shape checked (`cargo install`, Homebrew, `target/debug`), so the check is left exact rather than loosened.
- **`aa-integration-tests::cli_proxy proxy_logs_follow_streams_new_entries` fails on this machine, pre-existing and unrelated** — it exercises untouched `proxy/logs.rs`, resolves from `HOME` not the state record, and its fixture sleeps a fixed 1000 ms while falling back to `cargo run`. Against a prebuilt binary the same scenario streams correctly.
- **`build_launch_command` still normalises a bare `host:port`.** Now always handed an already-normalised URL, so the branch is dead on this path — but the trait is public and shared, so left alone.
