### PR TITLE
[AAASM-5330] 📝 (aa-core): Make the launch-environment obligation part of the contract

### DIFF
--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -287,6 +287,38 @@ pub trait DevToolAdapter: Send + Sync {
     ///   the wiring.
     /// * Sync (no I/O performed) — the returned `Command` is *built*,
     ///   not spawned. Spawning is the launcher's job.
+    ///
+    /// ### The environment on the returned command is part of the contract
+    ///
+    /// The launcher **must** apply [`Command::get_envs`] to the child it
+    /// spawns. The environment is not advisory decoration on top of a
+    /// program and its arguments: `NODE_EXTRA_CA_CERTS` is the only
+    /// mechanism by which an Electron/Node tool's runtime trusts the
+    /// intercepting proxy's CA, so a launcher that rebuilds the child from
+    /// [`Command::get_program`] and [`Command::get_args`] alone starts a
+    /// tool the proxy cannot terminate TLS for and reports it as governed.
+    /// That is AAASM-5327, and it violated nothing that had been written
+    /// down — which is why it is written down here.
+    ///
+    /// A `None` value from [`Command::get_envs`] means **remove that
+    /// variable from the child**, never "set it to the empty string": an
+    /// adapter unsets a variable to switch a tool behaviour off, and an
+    /// empty-but-present variable is one the tool may still honour.
+    ///
+    /// The child's environment is the union of the launcher's own
+    /// environment and this one, and on a collision **the adapter's value
+    /// wins** — it is the layer that knows the tool's requirements and the
+    /// layer that normalises values (the gateway's bare `host:port` proxy
+    /// address is not a proxy URL an HTTP client accepts). An adapter may
+    /// rely on that, but must not assume it is the sole source of the
+    /// child's variables.
+    ///
+    /// The same obligation is stated at length on the lifecycle successor,
+    /// [`LaunchableTool::build_launch_command`](crate::integration::LaunchableTool::build_launch_command).
+    ///
+    /// [`Command::get_envs`]: std::process::Command::get_envs
+    /// [`Command::get_program`]: std::process::Command::get_program
+    /// [`Command::get_args`]: std::process::Command::get_args
     fn build_launch_command(
         &self,
         tool_args: &[String],

--- a/aa-core/src/integration/contract.rs
+++ b/aa-core/src/integration/contract.rs
@@ -218,6 +218,42 @@ pub trait LaunchableTool: Send + Sync {
     /// [`AdapterError::LaunchFailed`] only for genuine run-time failures (the
     /// binary has moved, an argument cannot be encoded) — "this tool has no
     /// launch command" is a capability declaration, not an error.
+    ///
+    /// # The environment on the returned command is part of the contract
+    ///
+    /// A caller **must** apply [`Command::get_envs`] to the child it spawns.
+    /// What comes back is not "a program and some arguments, plus some advisory
+    /// variables": for an Electron/Node tool `NODE_EXTRA_CA_CERTS` is the *only*
+    /// mechanism by which the tool's runtime trusts the intercepting proxy's CA,
+    /// so a caller that drops the environment launches a tool the proxy cannot
+    /// terminate TLS for — and reports it as governed. AAASM-5327 was exactly
+    /// that: a caller that rebuilt the child from [`Command::get_program`] and
+    /// [`Command::get_args`] alone, violating no contract on paper because none
+    /// was written down. The obligation is stated here so the next occurrence is
+    /// a contract violation rather than an oversight.
+    ///
+    /// A `None` value from [`Command::get_envs`] means **remove that variable
+    /// from the child**, never "set it to the empty string". The two are not
+    /// interchangeable, and flattening them is itself a security bug: an adapter
+    /// unsets a variable to switch a tool behaviour *off*, and an
+    /// empty-but-present variable is one the tool may still read and honour.
+    ///
+    /// # When the adapter's variables collide with the caller's
+    ///
+    /// The child's environment is the union of both sources, and on a collision
+    /// **the adapter's value wins** (the behaviour AAASM-5327 established). The
+    /// adapter is the layer that knows what the tool actually requires, and the
+    /// layer that normalises values — the gateway hands out a bare `host:port`
+    /// proxy address, which is not a proxy URL an HTTP client accepts, and only
+    /// the adapter knows which form its own tool needs. An implementer may
+    /// therefore rely on its values surviving the merge and need not defend
+    /// against a caller overwriting them. It may **not** assume it is the sole
+    /// source of the child's environment: the caller's variables are delivered
+    /// too, and a variable the adapter never mentions is passed through.
+    ///
+    /// [`Command::get_envs`]: std::process::Command::get_envs
+    /// [`Command::get_program`]: std::process::Command::get_program
+    /// [`Command::get_args`]: std::process::Command::get_args
     fn build_launch_command(&self, spec: &LaunchSpec) -> Result<std::process::Command, AdapterError>;
 }
 

--- a/aa-core/src/integration/contract.rs
+++ b/aa-core/src/integration/contract.rs
@@ -251,6 +251,14 @@ pub trait LaunchableTool: Send + Sync {
     /// source of the child's environment: the caller's variables are delivered
     /// too, and a variable the adapter never mentions is passed through.
     ///
+    /// That rule is about the caller's *ambient* environment at spawn time, and
+    /// it is the opposite of the rule for [`LaunchSpec::env`], where the caller
+    /// **wins**. The two are not in tension: `LaunchSpec::env` is an argument to
+    /// this method rather than a competing source, and it is how a caller asks
+    /// for one run to differ — pinning a CA for a test, or overriding a variable
+    /// without editing what the install recorded. An adapter should therefore
+    /// apply `spec.env` last, after its own values.
+    ///
     /// [`Command::get_envs`]: std::process::Command::get_envs
     /// [`Command::get_program`]: std::process::Command::get_program
     /// [`Command::get_args`]: std::process::Command::get_args

--- a/aa-devtool-contract/tests/launch_environment_contract.rs
+++ b/aa-devtool-contract/tests/launch_environment_contract.rs
@@ -1,0 +1,252 @@
+//! The launch-environment obligation, machine-checked (AAASM-5330).
+//!
+//! # Why this file exists
+//!
+//! [`LaunchableTool::build_launch_command`] documents that the environment set
+//! on the returned command is part of the contract and must reach the spawned
+//! child. Prose alone is what the caller in AAASM-5327 was already missing: it
+//! rebuilt the child from the command's program and arguments, discarded every
+//! variable the adapter had set — `NODE_EXTRA_CA_CERTS` included, without which
+//! the proxy cannot terminate the tool's TLS — and broke no rule that had been
+//! written down. Writing the rule down stops the *next* caller only if something
+//! checks it, so this file checks it.
+//!
+//! # Why the harness spawns a real child
+//!
+//! The obligation is about the child's environment, not about the shape of the
+//! `Command` a caller happens to hold. Asserting over
+//! [`Command::get_envs`](std::process::Command::get_envs) would only re-read the
+//! caller's own instructions back to itself, and would in particular be unable
+//! to tell "this variable was removed" from "this variable was never mentioned
+//! and is being inherited". [`CallerBehaviour`] therefore ends in a real spawn
+//! and the assertions are made against what the process actually saw.
+//!
+//! # Why the violations are fixtures rather than a mutation exercise
+//!
+//! [`CallerBehaviour`] carries the two ways a caller gets this wrong as first-
+//! class variants, and the tests assert both that a conforming caller delivers
+//! the environment *and* that each violating one does not. A guard that only
+//! ever exercises the passing path cannot distinguish a conforming caller from a
+//! violating one, which is the failure mode this whole ticket is about.
+//!
+//! Unix-only: the harness reads the child's environment out of `/usr/bin/env`,
+//! and there is no Windows target in this workspace's CI.
+
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::process::Command;
+
+use aa_devtool_contract::{AdapterError, LaunchSpec, LaunchableTool};
+
+/// Prints its own environment, one `NAME=VALUE` per line. Present on every
+/// platform this workspace builds for.
+const ENV_PROGRAM: &str = "/usr/bin/env";
+
+/// Where an earlier plan step materialised the proxy CA. The literal value does
+/// not matter; that the child sees *this* value and not the caller's does.
+const CA_PATH: &str = "/home/dev/.aa/ca/aasm-ca.pem";
+
+/// A variable the fixture adapter removes. Prefixed so a stray value in the
+/// developer's own shell cannot make the removal assertion pass or fail by
+/// accident.
+const DISABLED_VAR: &str = "AASM_5330_TOOL_FEATURE";
+
+/// What the caller sets before the adapter's environment is merged in. Two of
+/// the three collide with the adapter on purpose.
+fn caller_environment() -> BTreeMap<String, String> {
+    BTreeMap::from([
+        // The caller's guess at the CA path is stale — this is the collision
+        // that AAASM-5327 turned into an ungoverned session.
+        (
+            "NODE_EXTRA_CA_CERTS".to_string(),
+            "/etc/ssl/certs/ca-bundle.crt".to_string(),
+        ),
+        // The gateway hands out a bare `host:port`; only the adapter knows its
+        // tool needs a URL (AAASM-5324).
+        ("HTTPS_PROXY".to_string(), "127.0.0.1:8080".to_string()),
+        // The adapter removes this one. A caller that flattens the removal to an
+        // empty value leaves the tool a variable it may still honour.
+        (DISABLED_VAR.to_string(), "1".to_string()),
+        // Nothing touches this one: the adapter is not the sole source of the
+        // child's environment.
+        ("AASM_5330_SESSION_ID".to_string(), "session-42".to_string()),
+    ])
+}
+
+// ---------------------------------------------------------------------------
+// The adapter under contract.
+// ---------------------------------------------------------------------------
+
+/// A `LaunchableTool` shaped like the Claude Code one: it sets the CA variable
+/// its tool's runtime needs, normalises the proxy address into the URL form an
+/// HTTP client accepts, and unsets a variable to switch a tool behaviour off.
+struct EnvBearingTool;
+
+impl LaunchableTool for EnvBearingTool {
+    fn build_launch_command(&self, spec: &LaunchSpec) -> Result<Command, AdapterError> {
+        let mut command = Command::new(ENV_PROGRAM);
+        command.args(&spec.tool_args);
+        command.env("NODE_EXTRA_CA_CERTS", CA_PATH);
+        if let Some(proxy) = &spec.proxy_addr {
+            let url = if proxy.starts_with("http") {
+                proxy.clone()
+            } else {
+                format!("http://{proxy}")
+            };
+            command.env("HTTPS_PROXY", url);
+        }
+        command.env_remove(DISABLED_VAR);
+        for (name, value) in &spec.env {
+            command.env(name, value);
+        }
+        Ok(command)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The caller-shaped harness.
+// ---------------------------------------------------------------------------
+
+/// How a caller treats the environment on the command the adapter handed back.
+#[derive(Debug, Clone, Copy)]
+enum CallerBehaviour {
+    /// Honours the contract: the caller's own environment first, the adapter's
+    /// on top, `None` applied as a removal.
+    Conforming,
+    /// The pre-AAASM-5327 `spawn_and_wait`: rebuild from program and arguments,
+    /// keep the caller's environment, drop the adapter's entirely.
+    DropsAdapterEnvironment,
+    /// Subtler, and the reason `None` is spelled out in the trait docs: every
+    /// name is carried across, but a removal is flattened into an empty value
+    /// the tool may still read.
+    FlattensRemovalToEmpty,
+}
+
+/// Run `command` the way `behaviour` says a caller would, and return the
+/// environment the child process actually observed.
+fn observed_child_environment(command: Command, behaviour: CallerBehaviour) -> BTreeMap<String, String> {
+    // Every variant reconstructs the child the way the real caller does — from
+    // the program and arguments — so that dropping the environment is a state
+    // the harness can genuinely reach rather than one it merely describes.
+    let mut child = Command::new(command.get_program());
+    child.args(command.get_args());
+    child.envs(caller_environment());
+
+    match behaviour {
+        CallerBehaviour::Conforming => {
+            for (name, value) in command.get_envs() {
+                match value {
+                    Some(value) => child.env(name, value),
+                    None => child.env_remove(name),
+                };
+            }
+        }
+        CallerBehaviour::DropsAdapterEnvironment => {}
+        CallerBehaviour::FlattensRemovalToEmpty => {
+            for (name, value) in command.get_envs() {
+                child.env(name, value.unwrap_or_default());
+            }
+        }
+    }
+
+    let output = child.output().expect("the env program must be spawnable");
+    assert!(output.status.success(), "the env program exited with {}", output.status);
+    String::from_utf8(output.stdout)
+        .expect("the env program's output must be UTF-8")
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .map(|(name, value)| (name.to_string(), value.to_string()))
+        .collect()
+}
+
+/// The launch this whole contract exists for: a governed run through a local
+/// proxy, with the CA the plan materialised.
+fn governed_launch(behaviour: CallerBehaviour) -> BTreeMap<String, String> {
+    let spec = LaunchSpec::new("agent-1").through_proxy("127.0.0.1:8080");
+    let command = EnvBearingTool
+        .build_launch_command(&spec)
+        .expect("building the launch command must succeed");
+    observed_child_environment(command, behaviour)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_conforming_caller_delivers_the_adapters_environment_to_the_spawned_child() {
+    let child = governed_launch(CallerBehaviour::Conforming);
+    assert_eq!(
+        child.get("NODE_EXTRA_CA_CERTS").map(String::as_str),
+        Some(CA_PATH),
+        "the CA variable is the only thing that makes the tool's runtime trust \
+         the proxy; without it the launch is inspected by nothing"
+    );
+}
+
+#[test]
+fn a_caller_that_rebuilds_from_program_and_args_alone_is_caught() {
+    // The AAASM-5327 shape. The child still gets a plausible-looking
+    // `NODE_EXTRA_CA_CERTS` from the caller, which is why the bug survived
+    // review: the variable is present, it is simply not the proxy's CA.
+    let child = governed_launch(CallerBehaviour::DropsAdapterEnvironment);
+    assert_eq!(
+        child.get("NODE_EXTRA_CA_CERTS").map(String::as_str),
+        Some("/etc/ssl/certs/ca-bundle.crt"),
+        "this assertion failing would mean the harness cannot express the \
+         violation, and the conforming test above would prove nothing"
+    );
+    assert_eq!(
+        child.get("HTTPS_PROXY").map(String::as_str),
+        Some("127.0.0.1:8080"),
+        "the adapter's normalisation is lost with the rest of its environment"
+    );
+    assert!(
+        child.contains_key(DISABLED_VAR),
+        "and the variable the adapter unset comes back"
+    );
+}
+
+#[test]
+fn a_none_env_value_is_a_removal_and_not_an_empty_value() {
+    let child = governed_launch(CallerBehaviour::Conforming);
+    assert_eq!(
+        child.get(DISABLED_VAR),
+        None,
+        "the adapter unset this to switch a tool behaviour off"
+    );
+
+    // The flattening caller passes the CA assertion and still gets this wrong,
+    // which is why the two are stated separately in the trait docs.
+    let flattened = governed_launch(CallerBehaviour::FlattensRemovalToEmpty);
+    assert_eq!(flattened.get("NODE_EXTRA_CA_CERTS").map(String::as_str), Some(CA_PATH));
+    assert_eq!(
+        flattened.get(DISABLED_VAR).map(String::as_str),
+        Some(""),
+        "an empty-but-present variable is one the tool may still read and honour"
+    );
+}
+
+#[test]
+fn the_adapters_value_wins_where_it_collides_with_the_callers() {
+    let child = governed_launch(CallerBehaviour::Conforming);
+    assert_eq!(
+        child.get("HTTPS_PROXY").map(String::as_str),
+        Some("http://127.0.0.1:8080"),
+        "only the adapter knows its tool needs a URL rather than the gateway's \
+         bare host:port"
+    );
+}
+
+#[test]
+fn the_callers_own_variables_still_reach_the_child() {
+    // The merge is a union, not a replacement: an adapter that assumed it owned
+    // the whole environment would be relying on something the contract does not
+    // promise.
+    let child = governed_launch(CallerBehaviour::Conforming);
+    assert_eq!(
+        child.get("AASM_5330_SESSION_ID").map(String::as_str),
+        Some("session-42")
+    );
+}

--- a/aa-devtool-contract/tests/launch_environment_contract.rs
+++ b/aa-devtool-contract/tests/launch_environment_contract.rs
@@ -240,6 +240,25 @@ fn the_adapters_value_wins_where_it_collides_with_the_callers() {
 }
 
 #[test]
+fn a_launch_spec_variable_overrides_the_adapters_own() {
+    // The other collision axis, and it resolves the other way: `LaunchSpec::env`
+    // is an argument to the adapter rather than a competing source, so it is how
+    // a caller pins a CA for one run without editing what the install recorded.
+    // An adapter that applied its own values last would silently ignore the
+    // request.
+    const PINNED: &str = "/tmp/pinned-ca.pem";
+    let spec = LaunchSpec::new("agent-1")
+        .through_proxy("127.0.0.1:8080")
+        .with_env("NODE_EXTRA_CA_CERTS", PINNED);
+    let command = EnvBearingTool
+        .build_launch_command(&spec)
+        .expect("building the launch command must succeed");
+    let child = observed_child_environment(command, CallerBehaviour::Conforming);
+
+    assert_eq!(child.get("NODE_EXTRA_CA_CERTS").map(String::as_str), Some(PINNED));
+}
+
+#[test]
 fn the_callers_own_variables_still_reach_the_child() {
     // The merge is a union, not a replacement: an adapter that assumed it owned
     // the whole environment would be relying on something the contract does not


### PR DESCRIPTION
## Description

Implements **AAASM-5330**: the obligation that a caller must honour the environment on a returned launch `Command` is now stated in the contract and **machine-checked**, instead of living only in the caller's memory.

That omission is what made AAASM-5327 possible. `spawn_and_wait` rebuilt the command from `get_program()` + `get_args()`, discarded the whole environment — `NODE_EXTRA_CA_CERTS` included — and violated nothing written down. Without that variable the proxy cannot terminate TLS, so the tool launched, reported as governed, and was inspected by nothing.

### The ticket named the wrong trait

Worth stating plainly, because following the AC literally would have left the real path uncovered: **`aa-cli` never touches `LaunchableTool`.** `execute_with_adapters` resolves `Box<dyn DevToolAdapter>` (`aa-cli/src/commands/run.rs:403`) and calls `aa-core/src/dev_tool.rs:290` — which had the *identical* documentation gap.

Both traits are now documented. `LaunchableTool` carries the long-form rationale; `DevToolAdapter` states the same obligation and links to it.

### What the contract now says

- The returned command's environment **must** reach the spawned child.
- `None` is a **removal**, never "set to empty". Flattening the two is itself security-relevant: an adapter that unsets a variable to switch a tool behaviour off must not have that become an empty-but-present variable the tool then honours.
- On collision the **adapter wins against the caller's ambient environment** — it is the layer that knows the tool's requirements and the layer that normalises the gateway's bare `host:port`.
- But **`LaunchSpec::env` wins against the adapter**, because it is an argument rather than a competing source. These are two different axes, and the first wording could be read as conflating them; that was corrected after reviewing `lifecycle.rs` against it.

## Type of Change

- [x] 📝 Documentation update
- [x] ✅ Tests

## Breaking Changes

- [x] No — documentation and a new test only. No behaviour changes.

## Related Issues

- Related Jira ticket: AAASM-5330
- Root cause of AAASM-5327 (fixed in #1855); the latent second site is `aa-devtool-claude-code/src/lifecycle.rs:1351`

## Testing

New `aa-devtool-contract/tests/launch_environment_contract.rs` — 6 tests. A fixture adapter sets `NODE_EXTRA_CA_CERTS`, normalises the proxy address, and `env_remove`s a variable. The harness plays the caller and **really spawns `/usr/bin/env`**, asserting on what the process actually saw. That matters: inspecting `get_envs()` would only read the caller's own instructions back, and could not tell a removed variable from an inherited one.

**Mutation — the `Conforming` arm replaced with `{}` so the harness drops the environment:**

```
assertion `left == right` failed: the CA variable is the only thing that makes the tool's
runtime trust the proxy; without it the launch is inspected by nothing
  left: Some("/etc/ssl/certs/ca-bundle.crt")
 right: Some("/home/dev/.aa/ca/aasm-ca.pem")

assertion `left == right` failed: the adapter unset this to switch a tool behaviour off
  left: Some("1")
 right: None

5 tests run: 2 passed, 3 failed
```

Reverted; suite green (`5 passed, 0 skipped`).

**Read that first failure carefully.** The violating caller does not produce an *absent* variable — it produces a **plausible-looking** one: the OS certificate bundle instead of the proxy CA. That is exactly why AAASM-5327 survived review. A test asserting only "`NODE_EXTRA_CA_CERTS` is set" would pass against the bug.

The two violating behaviours also ship as **permanent `CallerBehaviour` variants** with their own assertions, so every run proves the suite can still distinguish a conforming caller from a violating one — not just that the happy path works.

Gates: `cargo fmt --all` clean; `cargo clippy -p aa-devtool-contract -p aa-core --all-targets --all-features -- -D warnings` exits 0; `cargo nextest run -p aa-core -p aa-devtool-contract -p aa-devtool -p aa-devtool-claude-code -p aa-cli` → **1461 passed, 0 skipped**.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## `lifecycle.rs` reviewed, not changed

`aa-devtool-claude-code/src/lifecycle.rs:1345-1381` conforms as a *producer*: it returns an env-bearing command (`installed_environment` supplies `NODE_EXTRA_CA_CERTS`; the proxy is normalised to `http://` form), it applies `spec.env` **last** as the newly-stated precedence requires, and it removes nothing, so caller variables it does not mention pass through. No change made — reviewing it was in scope, editing it was not.

It has **zero shipping consumers** today (`as_launchable()` resolves only to test callers), which is why the identical bug is latent rather than live there.

## Found, not fixed

**No shipping code ever emits a `None` env value.** `installed_environment` returns `BTreeMap<String, String>`, so a variable an operator unset simply vanishes from the map rather than becoming a removal instruction — and an ambient value therefore still reaches the child. That is not a contract violation as written (a variable the adapter never mentions is passed through by design), but it means the `None`-means-removal clause is currently exercised only by this test fixture. Worth its own ticket rather than widening this one.

Also: two pre-existing rustdoc warnings in `aa-core/src/evaluators.rs:3` (unresolved links to `DenyAllEvaluator` / `PermitAllEvaluator`), identical on `main`, untouched.

The test is `#![cfg(unix)]` because it reads the child environment out of `/usr/bin/env`; this workspace's CI has no Windows target, so nothing is silently skipped.
