### PR TITLE
[AAASM-5326] 🐛 (conformance): Fail the real-tool lane when it measures nothing

### DIFF
--- a/.github/workflows/claude-code-conformance.yml
+++ b/.github/workflows/claude-code-conformance.yml
@@ -26,20 +26,34 @@ permissions:
 #    `claude` binary and points `AA_SPIKE_CLAUDE_BIN` at it, so the one
 #    assertion a mock cannot make (does Claude Code's embedded Node runtime
 #    accept the Agent Assembly certificate authority through
-#    `NODE_EXTRA_CA_CERTS`) is actually taken. Not required: it depends on a
-#    third-party npm package whose availability this repository does not
-#    control. It uses no credentials and reaches no external model provider —
-#    every request is redirected to an in-process mock.
+#    `NODE_EXTRA_CA_CERTS`) is actually taken. Not required for a merge, but it
+#    can fail: see below. It uses no credentials and reaches no external model
+#    provider — every request is redirected to an in-process mock.
 #
 # The security-regression assertions are not a separate lane. They live in the
 # same binary as the scenarios they guard, because a regression set that can be
 # skipped independently of the suite it protects will eventually be skipped.
 #
-# Skipping vs passing
-# -------------------
+# Skipping vs passing vs measuring
+# --------------------------------
 # Scenarios that need the real binary print `SKIP [...]` with the reason and
 # return. `--no-capture` is deliberate: a skip must be legible in the log rather
-# than indistinguishable from a green assertion.
+# than indistinguishable from a green assertion. But a runner counts a skip as a
+# pass, so the summary line alone cannot tell a lane that measured from one that
+# declined to — which is why every lane sets `AA_CONFORMANCE_OUTCOME_DIR` and
+# renders the resulting ledger into the job summary, and why the real-tool lane
+# asserts its scenario recorded `measured`.
+#
+# Where the tolerance lives
+# -------------------------
+# This lane used to carry a job-level `continue-on-error`, on the grounds that a
+# third-party npm package this repository does not control must not read as a
+# product regression. That tolerance was far too wide: it also swallowed a
+# genuine failure of the one assertion the lane exists to make, leaving the run
+# green either way. The tolerance now sits on the single step that depends on
+# the third party. If that step fails the lane reports, loudly, that it did not
+# run — an honest absence of evidence. Everything after it is the product, and
+# fails the job.
 
 on:
   push:
@@ -94,6 +108,8 @@ jobs:
             os: ubuntu-latest
           - lane: macos
             os: macos-latest
+    env:
+      AA_CONFORMANCE_OUTCOME_DIR: ${{ runner.temp }}/conformance-outcomes
 
     steps:
       - name: Checkout
@@ -121,14 +137,34 @@ jobs:
         # a skipped scenario reads exactly like a passing one.
         run: cargo nextest run -p aa-integration-tests --test conformance_claude_code --no-capture
 
+      - name: Report what this lane measured
+        # `always()`: a lane that failed still has an outcome worth reading, and
+        # the ledger is most useful exactly when something went wrong.
+        if: always()
+        env:
+          LANE: ${{ matrix.lane }}
+        run: |
+          set -uo pipefail
+          {
+            echo "### Conformance (${LANE})"
+            echo
+            if compgen -G "${AA_CONFORMANCE_OUTCOME_DIR}/*.json" > /dev/null; then
+              jq -r '"- `\(.scenario)` — **\(.outcome)** — \(.detail)"' "${AA_CONFORMANCE_OUTCOME_DIR}"/*.json
+            else
+              echo "- no scenario recorded an outcome"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   real-tool:
     name: Conformance (real Claude Code)
-    # Opt-in only. Depends on a third-party npm package; a transient
-    # unavailability there must not read as a product regression.
+    # Opt-in only. Not required for a merge — but it is allowed to fail, so that
+    # a run someone deliberately asked for cannot report green having measured
+    # nothing. The third-party tolerance sits on the install step below.
     if: github.event_name == 'workflow_dispatch' && inputs.real_tool
     runs-on: macos-latest
     timeout-minutes: 30
-    continue-on-error: true
+    env:
+      AA_CONFORMANCE_OUTCOME_DIR: ${{ runner.temp }}/conformance-outcomes
 
     steps:
       - name: Checkout
@@ -136,16 +172,6 @@ jobs:
 
       - name: Install protobuf compiler
         run: brew install protobuf
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
-
-      - name: Install Claude Code
-        # No credential is configured and none is needed: every request the
-        # binary makes is redirected onto an in-process mock provider by the
-        # proxy under test.
-        run: npm install -g @anthropic-ai/claude-code
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
@@ -156,14 +182,72 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@83c419a40a2e48673b2c523337e57f602dfe53c9 # cargo-nextest
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Install Claude Code
+        # The one step that depends on something this repository does not
+        # control, and therefore the only step allowed to fail without failing
+        # the lane. No credential is configured and none is needed: every
+        # request the binary makes is redirected onto an in-process mock
+        # provider by the proxy under test.
+        id: install_tool
+        continue-on-error: true
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Report that the lane could not run
+        if: steps.install_tool.outcome == 'failure'
+        run: |
+          set -euo pipefail
+          note="the real-tool lane did not run: @anthropic-ai/claude-code could not be installed, so no measurement was taken. This is an absence of evidence, not a passing measurement."
+          echo "::warning title=Real-tool lane not run::${note}"
+          printf '### Conformance (real Claude Code)\n\n- **not run** — %s\n' "${note}" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Report the tool version under test
+        if: steps.install_tool.outcome == 'success'
         run: claude --version
 
       - name: Run the conformance suite against the real binary
+        if: steps.install_tool.outcome == 'success'
         run: |
           set -euo pipefail
           AA_SPIKE_CLAUDE_BIN="$(command -v claude)" \
             cargo nextest run -p aa-integration-tests --test conformance_claude_code --no-capture
+
+      - name: Report what this lane measured
+        if: always() && steps.install_tool.outcome == 'success'
+        run: |
+          set -uo pipefail
+          {
+            echo "### Conformance (real Claude Code)"
+            echo
+            if compgen -G "${AA_CONFORMANCE_OUTCOME_DIR}/*.json" > /dev/null; then
+              jq -r '"- `\(.scenario)` — **\(.outcome)** — \(.detail)"' "${AA_CONFORMANCE_OUTCOME_DIR}"/*.json
+            else
+              echo "- no scenario recorded an outcome"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Assert the lane actually measured the real binary
+        # The suite's own zero-traffic failure covers a scenario that ran and
+        # established nothing. This covers the other way the lane can be green
+        # without evidence: the scenario declining, because the binary this lane
+        # provisioned was not where it was looked for. A skip is an honest
+        # outcome on a developer laptop and a broken lane here.
+        if: steps.install_tool.outcome == 'success'
+        run: |
+          set -euo pipefail
+          record="${AA_CONFORMANCE_OUTCOME_DIR}/real-tool-lane.json"
+          if [ ! -f "${record}" ]; then
+            echo "::error title=Real-tool lane measured nothing::the real-tool scenario recorded no outcome at ${record}; the lane exists to take one measurement and did not take it."
+            exit 1
+          fi
+          if ! jq -e '.outcome == "measured"' "${record}" > /dev/null; then
+            echo "::error title=Real-tool lane measured nothing::$(jq -r '"the real-tool scenario recorded `\(.outcome)`: \(.detail)"' "${record}")"
+            exit 1
+          fi
+          jq -r '"the real-tool scenario measured: \(.detail)"' "${record}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/aa-integration-tests/tests/conformance_claude_code.rs
+++ b/aa-integration-tests/tests/conformance_claude_code.rs
@@ -56,8 +56,16 @@
 //! scenario that needs the real `claude` binary
 //! ([`the_real_binary_launched_through_the_installed_environment_is_protected`])
 //! prints `SKIP [...]` with the reason and returns, so a skip is visible in the
-//! output rather than looking like a pass — and a run that captures no traffic
-//! prints `NOT MEASURED` rather than passing on an empty capture set.
+//! output rather than looking like a pass.
+//!
+//! There are exactly two things that scenario may decline on — a host that is
+//! not macOS, and a host with no `claude`. Past that pair it has **committed to
+//! measuring**: a run that then captures no traffic is a failed measurement,
+//! not an opt-out, and it fails. Every outcome — measured, skipped, not
+//! measured — is also written to the machine-readable ledger described in
+//! [`conformance_support::outcome`], because a runner counts a skip as a pass
+//! and the summary line alone cannot otherwise distinguish a lane that measured
+//! from one that declined to.
 //!
 //! # Safety
 //!
@@ -81,7 +89,7 @@ use aa_devtool_claude_code::lifecycle::{CA_ENV_VAR, MANAGED_KEYS, STEP_NODE_EXTR
 use aa_devtool_claude_code::probe::ProtectionProbe as _;
 use aa_devtool_claude_code::ProxyAdjudicatedProbe;
 use aa_runtime::devint::IntegrationLifecycle;
-use conformance_support::{ConformanceHarness, SYNTHETIC_SECRET};
+use conformance_support::{ConformanceHarness, Measurement, SYNTHETIC_SECRET};
 use spike_support::proxy_harness::{drive_direct, drive_emulated_client};
 use spike_support::{assert_recorded_and_secret_absent, assert_recorded_and_secret_present, AnthropicMock};
 
@@ -1580,6 +1588,11 @@ fn the_probe_and_the_proxy_agree_on_the_correlation_contract() {
 ///
 /// Skips with a printed reason where the binary is absent (Linux CI) or the host
 /// is not macOS. `AA_SPIKE_CLAUDE_BIN` opts a lane in explicitly.
+///
+/// Those two are the whole of what this scenario may decline on. Once both hold
+/// it has committed to measuring, so observing no traffic **fails**: the
+/// question the lane exists to answer went unanswered, and a green run that
+/// answered nothing is exactly the outcome the suite's design rule forbids.
 #[tokio::test(flavor = "multi_thread")]
 async fn the_real_binary_launched_through_the_installed_environment_is_protected() -> anyhow::Result<()> {
     const SCENARIO: &str = "real-tool lane";
@@ -1630,14 +1643,29 @@ async fn the_real_binary_launched_through_the_installed_environment_is_protected
     println!("MEASURED real-binary requests reaching the provider: {observed}");
     println!("MEASURED real-binary request lines: {:?}", h.upstream.request_lines());
     if observed == 0 {
-        println!(
-            "NOT MEASURED [{SCENARIO}]: the real binary produced no upstream traffic through the \
-             installed endpoint (exit={:?}, stopped_by_harness={}). This is a gap in the evidence, \
-             not a pass — nothing about the tool was established.",
-            run.exit_code, run.timed_out
+        // Both opt-outs are behind us: the host is macOS and the binary exists,
+        // so the scenario committed to measuring. Zero traffic here is a failed
+        // measurement — the tool did not reach the endpoint the install
+        // produced — and a failed measurement is a failure. Returning `Ok(())`
+        // with an explanatory line was indistinguishable from a pass to
+        // everything except a human reading `--no-capture` stdout.
+        let detail = format!(
+            "no upstream traffic through the installed endpoint (exit={:?}, stopped_by_harness={}, \
+             elapsed={:?})",
+            run.exit_code, run.timed_out, run.elapsed
         );
+        conformance_support::outcome::record(SCENARIO, Measurement::NotMeasured, &detail);
+        // The launch's own output is the only evidence distinguishing "the tool
+        // refused to start" from "the product's launch environment is wrong",
+        // and it is gone once the child is reaped.
+        println!("NOT MEASURED stdout tail: {}", tail(&run.stdout));
+        println!("NOT MEASURED stderr tail: {}", tail(&run.stderr));
         h.finish(SCENARIO);
-        return Ok(());
+        anyhow::bail!(
+            "NOT MEASURED [{SCENARIO}]: the real binary produced {detail}. This is a gap in the \
+             evidence, not a pass — nothing about the tool was established, so the lane that exists \
+             to establish it has failed."
+        );
     }
 
     let bodies = h.upstream.bodies();
@@ -1657,11 +1685,30 @@ async fn the_real_binary_launched_through_the_installed_environment_is_protected
          nothing"
     );
 
+    conformance_support::outcome::record(
+        SCENARIO,
+        Measurement::Measured,
+        &format!(
+            "{observed} request(s) observed, {redacted} of {} carried the redaction placeholder",
+            bodies.len()
+        ),
+    );
     h.finish(SCENARIO);
     Ok(())
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// The last 2 KiB of a launch's output, with the synthetic secret masked.
+///
+/// Masking is not for confidentiality — the value is a compile-time constant in
+/// this repository — but because it matches `sk-ant-`, and a CI log carrying a
+/// credential-shaped literal trips secret scanners on every run that prints it.
+fn tail(output: &str) -> String {
+    let masked = output.replace(SYNTHETIC_SECRET, "[SYNTHETIC-SECRET]");
+    let start = masked.len().saturating_sub(2048);
+    masked[masked.char_indices().find(|(i, _)| *i >= start).map_or(0, |(i, _)| i)..].to_string()
+}
 
 /// A rustls client trusting exactly the certificate authority at `pem`.
 ///

--- a/aa-integration-tests/tests/conformance_support/mod.rs
+++ b/aa-integration-tests/tests/conformance_support/mod.rs
@@ -27,10 +27,12 @@
 //! * `NODE_TLS_REJECT_UNAUTHORIZED` is never set. A TLS failure is a finding.
 
 pub mod harness;
+pub mod outcome;
 pub mod probe;
 pub mod proxy;
 
 pub use harness::{walk, ConformanceHarness, HarnessOptions, MEASURED_TOOL_VERSION};
+pub use outcome::Measurement;
 pub use probe::AdjudicatingProbe;
 pub use proxy::RestartableProxy;
 

--- a/aa-integration-tests/tests/conformance_support/mod.rs
+++ b/aa-integration-tests/tests/conformance_support/mod.rs
@@ -62,14 +62,18 @@ pub fn assert_no_raw_secret(surfaces: &[(String, String)], needle: &str, scenari
 /// A skip must be legible in the output. A test that quietly returns having
 /// asserted nothing is indistinguishable from a pass, which is the failure mode
 /// this whole suite exists to rule out.
+///
+/// The skip is recorded in the [`outcome`] ledger as well as printed, so a lane
+/// that exists *to take* this measurement can fail on a skip it never asked
+/// for. Recording here rather than at the call site means no opt-out path can
+/// forget to declare itself.
 pub fn require_macos(scenario: &str) -> bool {
     if cfg!(target_os = "macos") {
         return true;
     }
-    println!(
-        "SKIP [{scenario}]: macOS-only scenario; this host is {}",
-        std::env::consts::OS
-    );
+    let reason = format!("macOS-only scenario; this host is {}", std::env::consts::OS);
+    println!("SKIP [{scenario}]: {reason}");
+    outcome::record(scenario, Measurement::Skipped, &reason);
     false
 }
 
@@ -77,16 +81,20 @@ pub fn require_macos(scenario: &str) -> bool {
 ///
 /// `AA_SPIKE_CLAUDE_BIN` overrides the `PATH` lookup, so the optional real-tool
 /// CI lane can point at an installation it provisioned itself.
+///
+/// As with [`require_macos`], the skip is recorded in the [`outcome`] ledger:
+/// the real-tool lane provisions the binary itself, so a skip *there* is a
+/// broken lane rather than an honest opt-out, and only a machine-readable
+/// record makes that difference assertable.
 pub fn require_claude(scenario: &str) -> Option<std::path::PathBuf> {
     if let Some(explicit) = std::env::var_os("AA_SPIKE_CLAUDE_BIN") {
         let path = std::path::PathBuf::from(explicit);
         if path.exists() {
             return Some(path);
         }
-        println!(
-            "SKIP [{scenario}]: AA_SPIKE_CLAUDE_BIN points at {}, which does not exist",
-            path.display()
-        );
+        let reason = format!("AA_SPIKE_CLAUDE_BIN points at {}, which does not exist", path.display());
+        println!("SKIP [{scenario}]: {reason}");
+        outcome::record(scenario, Measurement::Skipped, &reason);
         return None;
     }
     let found = std::process::Command::new("which")
@@ -98,9 +106,9 @@ pub fn require_claude(scenario: &str) -> Option<std::path::PathBuf> {
         .map(|s| std::path::PathBuf::from(s.trim()))
         .filter(|p| p.exists());
     if found.is_none() {
-        println!(
-            "SKIP [{scenario}]: no `claude` binary on PATH (expected on Linux CI); set AA_SPIKE_CLAUDE_BIN to opt in"
-        );
+        let reason = "no `claude` binary on PATH (expected on Linux CI); set AA_SPIKE_CLAUDE_BIN to opt in";
+        println!("SKIP [{scenario}]: {reason}");
+        outcome::record(scenario, Measurement::Skipped, reason);
     }
     found
 }

--- a/aa-integration-tests/tests/conformance_support/outcome.rs
+++ b/aa-integration-tests/tests/conformance_support/outcome.rs
@@ -1,0 +1,96 @@
+//! A machine-readable ledger of whether a scenario *measured* anything.
+//!
+//! # The problem this exists for
+//!
+//! A scenario that opts out prints `SKIP [...]` and returns `Ok(())`, which the
+//! test runner counts as a pass — by design, and documented. But the summary
+//! line a reviewer actually reads (`26 tests run: 26 passed`) is then identical
+//! whether the optional real-tool scenario took its measurement or declined to.
+//! The distinction survives only in `--no-capture` stdout, which nothing
+//! asserts on, so "the lane was green" cannot be read as "the lane measured".
+//!
+//! This writes the distinction somewhere a workflow step can assert on: the
+//! real-tool lane, whose entire reason to exist is the one assertion a mock
+//! cannot make, fails if its scenario recorded anything other than
+//! [`Measurement::Measured`].
+//!
+//! # Opt-in by design
+//!
+//! Recording happens only when `AA_CONFORMANCE_OUTCOME_DIR` names a directory,
+//! so a local `cargo nextest run` behaves exactly as before and leaves nothing
+//! behind. A lane that wants the ledger sets the variable. When it *is* set, a
+//! write failure panics rather than degrading quietly — a ledger that silently
+//! did not get written would restore the very invisibility it is here to fix.
+
+/// The environment variable naming the directory the ledger is written into.
+pub const OUTCOME_DIR_ENV: &str = "AA_CONFORMANCE_OUTCOME_DIR";
+
+/// What a scenario established about the product.
+///
+/// The three states are deliberately distinct: a scenario that never ran and a
+/// scenario that ran and established nothing are different failures of
+/// evidence, and collapsing them is what lets an unmeasured lane read as a
+/// measured one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Measurement {
+    /// The scenario ran and its assertions were taken against observed
+    /// behaviour.
+    Measured,
+    /// A precondition the scenario is allowed to decline on was absent — the
+    /// host is the wrong platform, or the tool under test is not installed.
+    Skipped,
+    /// Every precondition held, so the scenario committed to measuring, and
+    /// then produced no evidence. This is a failed measurement, not an opt-out.
+    NotMeasured,
+}
+
+impl Measurement {
+    /// The token written to the ledger and matched by the workflow.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Measured => "measured",
+            Self::Skipped => "skipped",
+            Self::NotMeasured => "not_measured",
+        }
+    }
+}
+
+/// Print the outcome and, when the ledger is enabled, record it as JSON.
+///
+/// `detail` is free text for a human reading the ledger; the workflow asserts
+/// on `outcome` alone. One file per scenario, so scenarios running in parallel
+/// processes never contend for the same path.
+///
+/// # Panics
+///
+/// When `AA_CONFORMANCE_OUTCOME_DIR` is set and the record cannot be written.
+pub fn record(scenario: &str, measurement: Measurement, detail: &str) {
+    println!("OUTCOME [{scenario}]: {} — {detail}", measurement.as_str());
+    let Some(dir) = std::env::var_os(OUTCOME_DIR_ENV) else {
+        return;
+    };
+    let dir = std::path::PathBuf::from(dir);
+    std::fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("{} could not be created: {e}", dir.display()));
+    let body = serde_json::json!({
+        "scenario": scenario,
+        "outcome": measurement.as_str(),
+        "detail": detail,
+    });
+    let path = dir.join(format!("{}.json", slug(scenario)));
+    let rendered = serde_json::to_string_pretty(&body).expect("a three-field object always serialises");
+    std::fs::write(&path, rendered).unwrap_or_else(|e| panic!("{} could not be written: {e}", path.display()));
+}
+
+/// A filename-safe form of a scenario name.
+fn slug(scenario: &str) -> String {
+    scenario
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}


### PR DESCRIPTION
## Description

Implements **AAASM-5326**: the real-binary conformance scenario **fails when it measures nothing**, instead of printing "this is not a pass" and then returning a pass.

### The defect

After `require_claude` and `require_macos` had both been satisfied — i.e. the harness had committed to measuring — zero observed traffic printed an accurate `NOT MEASURED` message and then `return Ok(())`. nextest counted it as a pass, and nothing asserted on stdout. Compounding it, the lane carried job-level `continue-on-error: true`, so even a hard failure could not have changed the run's conclusion.

### Fix, and a second hole it exposed

The zero-traffic path now `bail!`s. Justification is the ticket's own: past the two legitimate opt-outs, zero traffic is a *failed measurement*, not an opt-out. The repo-wide `retries = 2` already absorbs non-deterministic flakes and reports recovered tests as FLAKY, so this is only reached deterministically.

Separately — and this is the part the ticket only gestured at — `require_claude` / `require_macos` also `return Ok(())`, so **a skip and a measurement were indistinguishable**. In the real-tool lane, which provisions the binary itself, a skip is a *broken lane*, not an opt-out.

A machine-readable ledger (`measured` / `skipped` / `not_measured`) is now written per scenario, and the recording lives **inside the `require_*` helpers** so no future opt-out path can forget to declare itself. Writing is opt-in via `AA_CONFORMANCE_OUTCOME_DIR`; a local `cargo nextest run` is byte-for-byte unchanged and leaves nothing behind. Every lane renders the ledger into the job summary; the real-tool lane additionally asserts `outcome == "measured"`.

**No scenario's tolerance was widened.** The only assertion change is `return Ok(())` → `bail!`.

### `continue-on-error` narrowed to the step that earns it

Removed from the job, applied to `npm install -g @anthropic-ai/claude-code` alone. The flag's stated justification is a third-party package the repo does not control — that is one step, not the whole job, and job-level scope also swallowed failure of the single assertion the lane exists to make.

If npm fails, the lane emits a `::warning::` and a summary line saying it did not run and took no measurement, and the remaining steps are guarded off. That is an honest absence of evidence rather than a green measurement. Everything after that step is the product, and fails the job.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5326

## Testing

**Forced zero traffic** via a binary that satisfies both preconditions and emits nothing (`AA_SPIKE_CLAUDE_BIN=/usr/bin/true`):

```
MEASURED real-binary requests reaching the provider: 0
Error: NOT MEASURED [real-tool lane]: ... nothing about the tool was established, so the
lane that exists to establish it has failed.
Summary  1 test run: 0 passed, 1 failed, 25 skipped
```

It burned all three nextest attempts — deterministic, as intended.

The workflow's assertion step, extracted from the YAML and run verbatim, goes red on all three evidence-free states — `not_measured`, `skipped`, and an **empty ledger** (the lane ran but recorded nothing). The `skipped` case was also falsified end to end against the real binary, which is the "also in scope" hole: nextest reports `1 passed` having measured nothing, and the ledger assertion catches it.

**Normal run still measures and passes** — real `claude 2.1.220`:

```
MEASURED real-binary requests reaching the provider: 3
MEASURED real-binary bodies carrying the placeholder: 2 of 3
OUTCOME [real-tool lane]: measured — 3 request(s) observed, 2 of 3 carried the redaction placeholder
Summary  26 tests run: 26 passed, 0 skipped
```

Gates: `cargo fmt --all -- --check` clean; `cargo clippy -p aa-integration-tests --all-targets --all-features -- -D warnings` → 0 errors.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Notes

- **The lane remains `workflow_dispatch`-only.** Deliberate: making it run on every PR puts a third-party npm dependency in the merge path. It now *can* fail when dispatched, which is what the ticket asked. Whether to schedule it (e.g. nightly, so tool-version drift is caught without someone remembering) is a separate decision.
- A 2 KiB tail of the launch's stdout/stderr is added to the failure path, with the synthetic secret masked — it matches `sk-ant-`, and printing it on every failing CI run would trip secret scanners. Added diagnostics, not changed tolerance; without it a zero-traffic failure is undiagnosable because the child is reaped.
- `spike_support::require_claude` / `require_macos` have the same skip-counts-as-pass shape and are used by the superseded Spike suite. Untouched — out of scope, but worth extending the ledger there if that suite stays.
