### PR TITLE
[AAASM-5326] 🚨 (ci): Fix the conformance workflow failing to parse on main

### DIFF
--- a/.github/workflows/claude-code-conformance.yml
+++ b/.github/workflows/claude-code-conformance.yml
@@ -109,7 +109,7 @@ jobs:
           - lane: macos
             os: macos-latest
     env:
-      AA_CONFORMANCE_OUTCOME_DIR: ${{ runner.temp }}/conformance-outcomes
+      AA_CONFORMANCE_OUTCOME_DIR: ${{ github.workspace }}/.conformance-outcomes
 
     steps:
       - name: Checkout
@@ -164,7 +164,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     env:
-      AA_CONFORMANCE_OUTCOME_DIR: ${{ runner.temp }}/conformance-outcomes
+      AA_CONFORMANCE_OUTCOME_DIR: ${{ github.workspace }}/.conformance-outcomes
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ docs/ci/__pycache__/
 
 # Python bytecode cache from the scripts/ generators + their tests (AAASM-4910)
 scripts/__pycache__/
+
+# Conformance outcome ledger, written under the workspace by the conformance
+# workflow so job-level `env:` can name it — `runner.temp` is a steps-only
+# context and cannot be used there (AAASM-5326).
+/.conformance-outcomes/


### PR DESCRIPTION
## Description

Repairs a workflow I broke. `main`'s conformance workflow has **failed to parse on every push since #1865 merged** — six consecutive runs producing **zero jobs**.

```
failed to parse workflow: (Line: 112, Col: 35): Unrecognized named-value: 'runner'.
Located at position 1 within expression: runner.temp
```

`runner` is a **steps-only** expression context. Job-level `env:` cannot see it. Both lanes used `${{ runner.temp }}/conformance-outcomes` there, so the file was unloadable.

## Why review and two subsequent merges missed it

**A workflow that fails to parse produces no check runs at all.** So `gh pr checks` on #1865 showed green, and so did #1863 and #1866 after it — none of them was wrong, the conformance workflow simply wasn't in the list, because it had never started.

That is the same failure this programme keeps finding: absence of failure read as presence of coverage. A green check list is evidence about the checks that ran, and says nothing about a check that could not start.

## The fix

`github.workspace` is valid at job level. Nothing else changes: the Rust writer already does `create_dir_all`, and the directory is now gitignored so it cannot dirty a checkout mid-run.

Verified: `yaml.safe_load` parses, `actionlint` clean.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No — restores intended behaviour.

## Related Issues

- Related Jira ticket: AAASM-5326 (regression in `c3c5166a`, PR #1865)

## Testing

- [x] Manual testing performed
- [x] No tests required (explain why)

The proof is the workflow loading at all. Before: `HTTP 422 … failed to parse workflow` on dispatch, and six push runs with zero jobs. After: `actionlint` clean and `yaml.safe_load` succeeds. The dispatch attempt that surfaces it is the same one AAASM-1112's conformance rerun needs, so that rerun is the end-to-end check — it could not have produced evidence while this was broken.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Not fixed here — worth its own ticket

**Nothing prevents the next unparseable workflow from being invisible.** `actionlint` runs in this repo's CI but evidently did not gate this file on #1865, so a syntax error in a `workflow_dispatch`-only workflow can merge without any check going red. Widening this PR to fix that would be scope creep; it needs deciding on its own terms — whether `actionlint` should run on every workflow file on every PR that touches `.github/workflows/**`, and whether a workflow producing zero check runs should itself be a signal.
