### PR TITLE
[AAASM-5334] 🔧 (ci): Report every failing test, not just the first binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,22 @@ jobs:
           # in-test command builders honour AASM_BIN_PATH; absent it they
           # fall back to cargo run for local dev.
           AASM_BIN_PATH: ${{ github.workspace }}/target/debug/aasm
-        run: cargo nextest run --workspace --no-tests=pass --exclude aa-ebpf
+        # AAASM-5334: `--no-fail-fast` so a red run reports EVERY failing test,
+        # not just the ones that happened to be dispatched before nextest
+        # cancelled. Without it the reported blast radius is arbitrary and
+        # misleadingly small: run 30689213155 (main, 2026-08-01) cancelled after
+        # `1681/6267 tests run` — 73% of the suite, including every integration
+        # binary, never executed, so the job reported 1 failure out of an unknown
+        # true total. A reviewer reasonably reads that as "localised" and it may
+        # not be.
+        #
+        # The runner-minute cost is small and bounded, because fail-fast cannot
+        # skip the expensive part. nextest compiles all 328 test binaries before
+        # running any test; on that run compilation was ~8m30s of the 8m43s step.
+        # Only the test phase is truncated, and a complete test phase is 191.7s
+        # (run 30686659787) against 13.2s truncated — so the worst case is ~3
+        # extra minutes, paid only on runs that are already failing.
+        run: cargo nextest run --workspace --no-tests=pass --exclude aa-ebpf --no-fail-fast
 
   coverage:
     name: Coverage


### PR DESCRIPTION
## Description

Implements **AAASM-5334**: the `Test` job now runs with `--no-fail-fast`, so a failing run reports every failing test instead of stopping at the first failing binary.

## The premise, measured rather than assumed

The ticket cited PR #1861 — 4 failures reported, 8 actually broken. **`main` today is worse.** Run `30689213155`, job `91340914613`:

```
  Cancelling due to test failure: 3 tests still running
     Summary [  13.182s] 1681/6267 tests run: 1680 passed, 1 failed, 11 skipped
```

**1681 of 6267 tests ran — 73% of the suite, including every integration binary, never executed**, and the job reported exactly one failure out of an unknown true total. Cancellation came 13.2s into a test phase that normally runs 191.7s, while still inside `aa-cli`'s unit tests.

## The runner-minute argument does not survive measurement

| | complete run `30686659787` | cancelled run `30689213155` |
|---|---|---|
| `Run tests` step total | 9m00s | 8m43s |
| ...compile | 5m48s | ~8m30s |
| ...test phase | 191.7s | **13.2s** |

Fail-fast saved **17 seconds**. nextest compiles all 328 test binaries *before* running any test, so the flag cannot touch the expensive part. Worst case for `--no-fail-fast` is bounded by the full test phase minus the truncated one — **≈178s, under 3 minutes, paid only on runs that are already red.**

That cost and both run IDs are written into the workflow comment beside the flag, so the next person weighing this has the numbers rather than the intuition.

### Options rejected, and why

- **Split unit / integration.** Two nextest invocations. `&&`-chained, the integration half doesn't run when the unit half fails — reinstating exactly this bug. `;`-separated, the step's exit code needs hand-management. Either way it needs a hand-maintained binary filterset that silently rots: a new integration binary added later lands in the fail-fast half and goes unreported. Real complexity and a new failure mode, to save ≤3 min.
- **Conditional on draft/ready.** The misleading picture hurts during draft iteration too, and each branch would only ever be half-exercised.
- **`--max-fail=N`.** Supported by nextest 0.9.133, but still truncates arbitrarily — fails AC 1 at a higher watermark.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-5334

## Testing

A full-suite local run is impractical (6267 tests, Postgres service, sibling `node-sdk` native build, prebuilt dashboard assets), so **the flag's behaviour was validated on a real subset** — `-p aa-core -p aa-security -p aa-devtool-contract`, 579 real tests across 9 binaries, same command shape and same `.config/nextest.toml` (`retries = 2`). Stated plainly rather than implying a full-suite validation.

No tracked `.rs` was modified. Two *new, untracked* probe files reproduced the ticket's shape — an early failing binary and a later one with 4 broken cases standing in for `cli_run_trusted_proxy` — then were deleted.

**BEFORE:**
```
    Starting 590 tests across 11 binaries
  TRY 3 FAIL (411/590) aa-core::aaa_blast_radius_probe early_binary_failure_that_ci_does_report
  Cancelling due to test failure: 15 tests still running
     Summary [   0.361s] 426/590 tests run: 425 passed, 1 failed, 0 skipped
```

**AFTER:**
```
    Starting 590 tests across 11 binaries
  TRY 3 FAIL (411/590) aa-core::aaa_blast_radius_probe early_binary_failure_that_ci_does_report
  TRY 3 FAIL (585/590) aa-security::zzz_blast_radius_probe launch_refuses_a_non_loopback_endpoint
  TRY 3 FAIL (586/590) aa-security::zzz_blast_radius_probe launch_refuses_when_nothing_is_listening...
  TRY 3 FAIL (588/590) aa-security::zzz_blast_radius_probe launch_refuses_when_the_recorded_pid_runs...
  TRY 3 FAIL (589/590) aa-security::zzz_blast_radius_probe launch_refuses_when_the_recorded_pid_is...
     Summary [   0.466s] 590 tests run: 585 passed, 5 failed, 0 skipped
```

426/590 with 1 failure → 590/590 with all 5, across two different binaries. Subset cost: 0.361s → 0.466s.

`actionlint .github/workflows/ci.yml` clean, exit 0 — validated rather than eyeballed, since this repo recently merged an unparseable workflow.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Same truncation property elsewhere — reported, not fixed

1. **`conformance` job, line 1152: `cargo test -p conformance`** — the worst remaining. That crate has **six** integration test targets; `cargo test` runs them strictly sequentially and aborts at the first non-zero exit, so a failure in `credential_detection` hides all five later suites **unconditionally**, not probabilistically. `--no-fail-fast` is a `cargo test` flag too.
2. **`coverage` job (~line 597)** — same missing flag, plus a `run: |` block where a first-invocation failure skips both the `-p aa-devtool-claude-code` run and LCOV generation, so a partial failure yields no report at all.
3. **`timescaledb-tests` (682) and `migration-drift-check` (701)** — also lack the flag; low impact (9 tests, single binary).
4. **`dashboard-typecheck` (1235/1237)** — `pnpm type-check` and `pnpm lint` are separate steps, so a type error skips lint entirely. Step-level rather than test-level, same reviewer-facing effect.

`dashboard-test` is **not** affected — vitest's `bail` defaults to 0 and the config doesn't set it.
