### PR TITLE
[AAASM-5345] 🐛 (aa-security): Normalise full-width digits before Luhn and SSN detection

### DIFF
--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1830,6 +1830,23 @@ mod tests {
         assert!(redacted.contains("[REDACTED:SsnPattern]"));
     }
 
+    // --- AAASM-5345: full-width digits (U+FF10–U+FF19) must not evade the
+    //     credit-card and SSN detectors. All fixtures are synthetic. ---
+
+    #[test]
+    fn detects_fullwidth_credit_card_as_the_same_kind_as_ascii() {
+        // The same synthetic Visa test number in both digit widths must be
+        // classified identically — switching input mode must not change the
+        // verdict.
+        let scanner = CredentialScanner::new();
+        let ascii = scanner.scan("card=4532015112830366");
+        let fullwidth = scanner.scan("card=４５３２０１５１１２８３０３６６");
+
+        let kinds = |r: &ScanResult| r.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>();
+        assert_eq!(kinds(&ascii), vec![CredentialKind::CreditCardLuhn]);
+        assert_eq!(kinds(&fullwidth), kinds(&ascii));
+    }
+
     #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1992,6 +1992,34 @@ mod tests {
     }
 
     #[test]
+    fn digit_run_longer_than_the_segment_budget_stays_clean_in_both_widths() {
+        // Pins `DIGIT_SEGMENT_MAX_CHARS`, the refactor's riskiest invariant.
+        //
+        // The budget decides how much of a long digit run one segment swallows,
+        // and shrinking it fails in the *false positive* direction: a 30-digit
+        // run is not a card number, but its first 19 digits here are
+        // Luhn-valid, so a budget of 19 would truncate the segment exactly onto
+        // that prefix and report a card that is not there. On the enforce path
+        // that means redacting a legitimate payload — worse than the missed
+        // detection a too-large budget would cause.
+        //
+        // The synthetic 19-digit prefix is Luhn-valid by construction; the
+        // trailing zeros only push the run past the budget.
+        let scanner = CredentialScanner::new();
+        let ascii = "num=004532015112830366500000000000";
+        let fullwidth = "num=００４５３２０１５１１２８３０３６６５００００００００００００";
+
+        for text in [ascii, fullwidth] {
+            let result = scanner.scan(text);
+            assert!(
+                !result.findings.iter().any(|f| f.kind == CredentialKind::CreditCardLuhn),
+                "over-long digit run must not yield a card finding: {:?}",
+                result.findings,
+            );
+        }
+    }
+
+    #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("contact: user@example.com for support");

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1946,6 +1946,21 @@ mod tests {
     }
 
     #[test]
+    fn does_not_flag_a_fullwidth_number_that_fails_luhn() {
+        // The point of the fix is to widen what reaches the checksum, not to
+        // weaken the checksum. A full-width number with one digit altered must
+        // be rejected exactly as its ASCII equivalent is
+        // (`does_not_flag_invalid_luhn` above).
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan("num=４５３２０１５１１２８３０３６７");
+        assert!(
+            !result.findings.iter().any(|f| f.kind == CredentialKind::CreditCardLuhn),
+            "Luhn gate must reject a full-width number too: {:?}",
+            result.findings,
+        );
+    }
+
+    #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("contact: user@example.com for support");

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -830,47 +830,103 @@ fn luhn_valid(digits: &str) -> bool {
     sum % 10 == 0
 }
 
+/// Maximum number of characters consumed into one digit segment.
+///
+/// Bounds the per-segment work just above the longest value either detector
+/// recognises (a 19-digit card number, or an 11-character SSN including its two
+/// separators). The budget counts **characters, not bytes**, so it does not
+/// shrink on multi-byte input — a byte budget would truncate a segment written
+/// in multi-byte digits partway through the number and lose the match.
+const DIGIT_SEGMENT_MAX_CHARS: usize = 24;
+
+/// Result of walking one digit segment (see [`digit_segment`]).
+struct DigitSegment {
+    /// Byte offset just past the segment — where the outer scan resumes, and
+    /// the `end` of any finding the segment produces.
+    end: usize,
+    /// The segment's digits and the separators between them, in order.
+    /// Matched against the `DDD-DD-DDDD` SSN shape by [`is_ssn`].
+    normalised: String,
+    /// The segment's digits only, without separators — what [`luhn_valid`]
+    /// computes the checksum over.
+    digits: String,
+}
+
+/// Walk the digit segment beginning at byte offset `start` (which must be the
+/// boundary of a digit character).
+///
+/// The walk advances one whole character at a time, so [`DigitSegment::end`] is
+/// always a valid UTF-8 char boundary of `text`. That is a correctness
+/// requirement rather than a nicety: [`ScanResult::redact`] splices the original
+/// bytes at a finding's offsets, and a bound landing mid-character would make it
+/// fail closed and replace the entire payload with an opaque label.
+fn digit_segment(text: &str, start: usize) -> DigitSegment {
+    let mut normalised = String::new();
+    let mut digits = String::new();
+    let mut chars = 0usize;
+    let mut end = start;
+
+    while chars < DIGIT_SEGMENT_MAX_CHARS {
+        let Some(c) = text[end..].chars().next() else { break };
+
+        if c.is_ascii_digit() {
+            normalised.push(c);
+            digits.push(c);
+            end += c.len_utf8();
+            chars += 1;
+            continue;
+        }
+
+        // Only consume a separator that sits *between* digits. A trailing
+        // separator must not be swallowed into the segment, or an SSN like
+        // "123-45-6789 " would become 12 bytes and fail the exact-11-byte
+        // `is_ssn` check, letting the PII through unredacted (AAASM-4820).
+        if matches!(c, ' ' | '-')
+            && !digits.is_empty()
+            && chars + 1 < DIGIT_SEGMENT_MAX_CHARS
+            && text[end + c.len_utf8()..]
+                .chars()
+                .next()
+                .is_some_and(|next| next.is_ascii_digit())
+        {
+            normalised.push(c);
+            end += c.len_utf8();
+            chars += 1;
+            continue;
+        }
+
+        break;
+    }
+
+    DigitSegment {
+        end,
+        normalised,
+        digits,
+    }
+}
+
 /// Scans `text` for credit card numbers (Luhn-validated) and SSN patterns (`DDD-DD-DDDD`).
 fn scan_digit_sequences(text: &str, findings: &mut Vec<CredentialFinding>) {
-    let bytes = text.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if !bytes[i].is_ascii_digit() {
-            i += 1;
+    let mut i = 0usize;
+    while i < text.len() {
+        // `i` is always on a char boundary: it advances either by one whole
+        // character or to a segment's `end`, which is itself a boundary.
+        let Some(c) = text[i..].chars().next() else { break };
+        if !c.is_ascii_digit() {
+            i += c.len_utf8();
             continue;
         }
 
         let start = i;
-        let mut digits = String::new();
-        let mut j = i;
-        let limit = (start + 24).min(bytes.len());
+        let segment = digit_segment(text, start);
+        let end = segment.end;
 
-        while j < limit {
-            match bytes[j] {
-                b if b.is_ascii_digit() => {
-                    digits.push(b as char);
-                    j += 1;
-                }
-                // Only consume a separator that sits *between* digits. A trailing
-                // separator must not be swallowed into the segment, or an SSN like
-                // "123-45-6789 " would become 12 bytes and fail the exact-11-byte
-                // `is_ssn` check, letting the PII through unredacted (AAASM-4820).
-                b' ' | b'-' if !digits.is_empty() && j + 1 < limit && bytes[j + 1].is_ascii_digit() => {
-                    j += 1;
-                }
-                _ => break,
-            }
-        }
-
-        let end = j;
-        let segment = &text[start..end];
-
-        if is_ssn(segment) {
+        if is_ssn(&segment.normalised) {
             findings.push(CredentialFinding::new(CredentialKind::SsnPattern, start, end));
-        } else if digits.len() >= 13 && digits.len() <= 19 && luhn_valid(&digits) {
+        } else if segment.digits.len() >= 13 && segment.digits.len() <= 19 && luhn_valid(&segment.digits) {
             findings.push(CredentialFinding::new(CredentialKind::CreditCardLuhn, start, end));
         }
-        i = end.max(i + 1);
+        i = end.max(start + c.len_utf8());
     }
 }
 

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1972,6 +1972,26 @@ mod tests {
     }
 
     #[test]
+    fn redact_fails_closed_on_a_span_inside_a_fullwidth_digit() {
+        // The concrete instance of the fail-closed guard this change puts at
+        // risk. `redact` must never emit the payload with the flagged region
+        // intact, so a span landing inside a full-width digit's three bytes has
+        // to collapse the whole value to an opaque label rather than splice.
+        // Exercised rather than assumed, because the guard is the only thing
+        // standing between a mis-computed span and a leak.
+        let text = "card=４５３２０１５１１２８３０３６６";
+        // `card=` is five bytes; the first full-width digit occupies bytes 5..8,
+        // so byte 6 is mid-character.
+        let result = ScanResult {
+            findings: vec![CredentialFinding::new(CredentialKind::CreditCardLuhn, 5, 6)],
+        };
+
+        let redacted = result.redact(text);
+        assert_eq!(redacted, "[REDACTED]");
+        assert!(contains_no_digit(&redacted), "residual digits: {redacted}");
+    }
+
+    #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("contact: user@example.com for support");

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -833,10 +833,17 @@ fn luhn_valid(digits: &str) -> bool {
 /// Maximum number of characters consumed into one digit segment.
 ///
 /// Bounds the per-segment work just above the longest value either detector
-/// recognises (a 19-digit card number, or an 11-character SSN including its two
-/// separators). The budget counts **characters, not bytes**, so it does not
-/// shrink on multi-byte input — a byte budget would truncate a segment written
-/// in multi-byte digits partway through the number and lose the match.
+/// recognises. The binding case is **not** the bare 19-digit card number: it is
+/// a 19-digit card written in separator-delimited groups of four, which is 19
+/// digits plus 4 separators — 23 characters. An 11-character SSN is well under
+/// that. Do not "tidy" this down to 20: doing so truncates a grouped card
+/// mid-number, and, worse, a budget that lands on a Luhn-valid prefix of a
+/// longer digit run reports a card that is not there (see
+/// `digit_run_longer_than_the_segment_budget_stays_clean_in_both_widths`).
+///
+/// The budget counts **characters, not bytes**, so it does not shrink on
+/// multi-byte input — a byte budget would truncate a segment written in
+/// multi-byte digits partway through the number and lose the match.
 const DIGIT_SEGMENT_MAX_CHARS: usize = 24;
 
 /// The ASCII digit equivalent of `c` — `c` itself for `'0'..='9'`, and the

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1875,6 +1875,26 @@ mod tests {
         );
     }
 
+    /// Every digit character a redacted payload must never still contain —
+    /// both widths, so a partial splice cannot hide behind the assertion.
+    fn contains_no_digit(s: &str) -> bool {
+        !s.chars().any(|c| c.is_ascii_digit() || matches!(c, '０'..='９'))
+    }
+
+    #[test]
+    fn redacts_a_fullwidth_credit_card_to_exact_bytes() {
+        // Counting findings is not enough: the failure mode this fix risks is a
+        // span that is off by a byte or two, which still yields one finding but
+        // splices the wrong region and leaves digits in the clear. Assert the
+        // exact output bytes.
+        let scanner = CredentialScanner::new();
+        let text = "card=４５３２０１５１１２８３０３６６";
+        let redacted = scanner.scan(text).redact(text);
+
+        assert_eq!(redacted, "card=[REDACTED:CreditCardLuhn]");
+        assert!(contains_no_digit(&redacted), "residual digits: {redacted}");
+    }
+
     #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1862,6 +1862,20 @@ mod tests {
     }
 
     #[test]
+    fn detects_mixed_width_credit_card() {
+        // A single full-width digit inside an otherwise ASCII number is the
+        // cheapest form of the evasion and the case where the byte-offset
+        // arithmetic is least uniform — one 3-byte character among 15 1-byte
+        // ones.
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan("card=4532０15112830366");
+        assert_eq!(
+            result.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>(),
+            vec![CredentialKind::CreditCardLuhn],
+        );
+    }
+
+    #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("contact: user@example.com for support");

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -839,16 +839,38 @@ fn luhn_valid(digits: &str) -> bool {
 /// in multi-byte digits partway through the number and lose the match.
 const DIGIT_SEGMENT_MAX_CHARS: usize = 24;
 
+/// The ASCII digit equivalent of `c` — `c` itself for `'0'..='9'`, and the
+/// corresponding ASCII digit for the full-width forms `'０'..='９'`
+/// (U+FF10–U+FF19). `None` for anything else.
+///
+/// AAASM-5345: full-width digits render near-identically to ASCII in most
+/// fonts, are one keystroke away on any CJK input method, and round-trip
+/// through JSON unchanged — so a card number or SSN typed in full-width form
+/// was a working evasion of both PII detectors, which compared raw ASCII bytes.
+///
+/// Normalisation is for **matching only**. A full-width digit occupies three
+/// UTF-8 bytes against ASCII's one, so callers must keep every reported offset
+/// in terms of the original text; normalising the text and matching on the
+/// result would yield offsets that index the wrong bytes.
+fn ascii_digit_of(c: char) -> Option<char> {
+    match c {
+        '0'..='9' => Some(c),
+        '\u{FF10}'..='\u{FF19}' => char::from_u32(c as u32 - 0xFF10 + u32::from(b'0')),
+        _ => None,
+    }
+}
+
 /// Result of walking one digit segment (see [`digit_segment`]).
 struct DigitSegment {
     /// Byte offset just past the segment — where the outer scan resumes, and
     /// the `end` of any finding the segment produces.
     end: usize,
-    /// The segment's digits and the separators between them, in order.
-    /// Matched against the `DDD-DD-DDDD` SSN shape by [`is_ssn`].
+    /// The segment's digits — normalised to ASCII by [`ascii_digit_of`] — and
+    /// the separators between them, in order. Matched against the
+    /// `DDD-DD-DDDD` SSN shape by [`is_ssn`].
     normalised: String,
-    /// The segment's digits only, without separators — what [`luhn_valid`]
-    /// computes the checksum over.
+    /// The segment's normalised digits only, without separators — what
+    /// [`luhn_valid`] computes the checksum over.
     digits: String,
 }
 
@@ -869,9 +891,11 @@ fn digit_segment(text: &str, start: usize) -> DigitSegment {
     while chars < DIGIT_SEGMENT_MAX_CHARS {
         let Some(c) = text[end..].chars().next() else { break };
 
-        if c.is_ascii_digit() {
-            normalised.push(c);
-            digits.push(c);
+        if let Some(d) = ascii_digit_of(c) {
+            normalised.push(d);
+            digits.push(d);
+            // Advance by the *original* character's width, never the ASCII
+            // equivalent's, so `end` stays an offset into `text`.
             end += c.len_utf8();
             chars += 1;
             continue;
@@ -887,7 +911,8 @@ fn digit_segment(text: &str, start: usize) -> DigitSegment {
             && text[end + c.len_utf8()..]
                 .chars()
                 .next()
-                .is_some_and(|next| next.is_ascii_digit())
+                .and_then(ascii_digit_of)
+                .is_some()
         {
             normalised.push(c);
             end += c.len_utf8();
@@ -906,13 +931,18 @@ fn digit_segment(text: &str, start: usize) -> DigitSegment {
 }
 
 /// Scans `text` for credit card numbers (Luhn-validated) and SSN patterns (`DDD-DD-DDDD`).
+///
+/// Digits are normalised by [`ascii_digit_of`], so a value written in full-width
+/// digits is detected as the same kind as its ASCII equivalent (AAASM-5345).
+/// Findings still span the **original** text: normalisation never reaches the
+/// offsets, only the strings the two checks are run against.
 fn scan_digit_sequences(text: &str, findings: &mut Vec<CredentialFinding>) {
     let mut i = 0usize;
     while i < text.len() {
         // `i` is always on a char boundary: it advances either by one whole
         // character or to a segment's `end`, which is itself a boundary.
         let Some(c) = text[i..].chars().next() else { break };
-        if !c.is_ascii_digit() {
+        if ascii_digit_of(c).is_none() {
             i += c.len_utf8();
             continue;
         }

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1961,6 +1961,17 @@ mod tests {
     }
 
     #[test]
+    fn does_not_flag_a_short_fullwidth_digit_run() {
+        // An 8-digit run is below the 13-digit card floor and is not SSN-shaped,
+        // so it must stay clean. Full-width digits are ordinary content — order
+        // numbers, dates, quantities — in CJK text, and flagging them would make
+        // the detector unusable in exactly the locales this fix serves.
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan("qty=１２３４５６７８");
+        assert!(result.is_clean(), "short run must stay clean: {:?}", result.findings);
+    }
+
+    #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("contact: user@example.com for support");

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1918,6 +1918,34 @@ mod tests {
     }
 
     #[test]
+    fn fullwidth_finding_spans_are_char_boundaries_of_the_original_text() {
+        // The span contract `redact` depends on, asserted directly rather than
+        // inferred from redaction output: offsets index the *original* text and
+        // land on character boundaries. A span that satisfies this can always be
+        // spliced; one that does not sends `redact` down its fail-closed path.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "card=４５３２０１５１１２８３０３６６",
+            "ssn=１２３-４５-６７８９",
+            "card=4532０15112830366",
+        ] {
+            let result = scanner.scan(text);
+            assert!(!result.findings.is_empty(), "no finding for {text:?}");
+            for f in &result.findings {
+                assert!(
+                    text.is_char_boundary(f.offset),
+                    "offset {} splits a character",
+                    f.offset
+                );
+                assert!(text.is_char_boundary(f.end), "end {} splits a character", f.end);
+                // The span must cover the whole value, not a prefix of it.
+                assert!(contains_no_digit(&text[..f.offset]));
+                assert!(contains_no_digit(&text[f.end..]));
+            }
+        }
+    }
+
+    #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("contact: user@example.com for support");

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1896,6 +1896,18 @@ mod tests {
     }
 
     #[test]
+    fn redacts_a_fullwidth_ssn_to_exact_bytes() {
+        // The SSN span mixes 3-byte digits with 1-byte separators, so its end
+        // offset is the one least likely to survive a width assumption.
+        let scanner = CredentialScanner::new();
+        let text = "ssn=１２３-４５-６７８９";
+        let redacted = scanner.scan(text).redact(text);
+
+        assert_eq!(redacted, "ssn=[REDACTED:SsnPattern]");
+        assert!(contains_no_digit(&redacted), "residual digits: {redacted}");
+    }
+
+    #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("contact: user@example.com for support");

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1848,6 +1848,20 @@ mod tests {
     }
 
     #[test]
+    fn detects_fullwidth_ssn_as_the_same_kind_as_ascii() {
+        // The SSN detector matches an exact `DDD-DD-DDDD` shape, so it is the
+        // detector most likely to be broken by normalisation changing the
+        // string's length — assert it survives in full-width form.
+        let scanner = CredentialScanner::new();
+        let ascii = scanner.scan("ssn=123-45-6789");
+        let fullwidth = scanner.scan("ssn=１２３-４５-６７８９");
+
+        let kinds = |r: &ScanResult| r.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>();
+        assert_eq!(kinds(&ascii), vec![CredentialKind::SsnPattern]);
+        assert_eq!(kinds(&fullwidth), kinds(&ascii));
+    }
+
+    #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("contact: user@example.com for support");

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1908,6 +1908,16 @@ mod tests {
     }
 
     #[test]
+    fn redacts_a_mixed_width_credit_card_to_exact_bytes() {
+        let scanner = CredentialScanner::new();
+        let text = "card=4532０15112830366";
+        let redacted = scanner.scan(text).redact(text);
+
+        assert_eq!(redacted, "card=[REDACTED:CreditCardLuhn]");
+        assert!(contains_no_digit(&redacted), "residual digits: {redacted}");
+    }
+
+    #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();
         let result = scanner.scan("contact: user@example.com for support");


### PR DESCRIPTION
## Description

Full-width digits `U+FF10`–`U+FF19` (`０１２３４５６７８９`) were invisible to the
`CreditCardLuhn` and `SsnPattern` detectors in `aa-security`. Both compared raw ASCII
bytes, so a card number or SSN written in full-width form passed through the scanner
clean while its ASCII equivalent was detected and redacted.

This is a live evasion rather than a cosmetic i18n gap: full-width digits are one
keystroke away on any CJK input method, render near-identically to ASCII in most fonts,
and round-trip through JSON unchanged. Any agent or user could defeat both PII detectors
by switching input mode.

Backlog item **B-3** from the AAASM-5269 Spike report §9, discovered alongside the
`zh-TW` entropy defect (B-2). It is independent of B-2: this one is in the
digit-sequence pass, not the entropy pass.

### Implementation

Two commits of production change, deliberately split:

1. **`♻️ Walk digit segments by character, not by byte`** — the scan indexed raw bytes
   and bounded each segment with a 24-*byte* budget. Both assumptions only hold for
   ASCII: a wider digit character would be stepped over one byte at a time, and the
   byte budget would run out after eight characters — far short of a 13–19 digit card
   number. The walk now advances one whole character at a time and budgets in
   *characters*, with the segment walk lifted into `digit_segment` / `DigitSegment`.
   **No behaviour change** — for ASCII input a character *is* a byte, so segment bounds,
   the separator rule and both detectors see exactly what they saw before.
2. **`🐛 Normalise full-width digits before Luhn and SSN matching`** — `ascii_digit_of`
   maps each digit to its ASCII equivalent as the segment is walked; `is_ssn` and
   `luhn_valid` run against the normalised string.

The normaliser ships in the same commit as its only call site so no intermediate commit
carries an unused function that `-D warnings` would reject.

Plus one documentation commit (`📝 Record what actually sets the digit-segment budget at
24`), added in review: the constant's rationale cited "a 19-digit card, or an
11-character SSN", both of which fit under 20, so the stated reasons invited a future
reader to tidy the value down. The real binding case is a 19-digit card in
separator-delimited groups — 23 characters.

### Since first review

- **S1** — added `digit_run_longer_than_the_segment_budget_stays_clean_in_both_widths`,
  pinning `DIGIT_SEGMENT_MAX_CHARS`. Mutation-verified rather than assumed (details in
  the acceptance table below).
- **S2** — the residual section below is rewritten and expanded; the SSN case is now
  stated as **partially open**, with U+3000 added and measured evidence for each row.
- **N2** — the constant's doc now names the real driver and the failure mode of
  shrinking it.
- No production behaviour changed in response to review; S1 and N2 are a test and a
  comment.

### Span safety — the part worth reviewing

A full-width digit is **three UTF-8 bytes** to ASCII's one. Normalising the text and
matching on the *result* would produce offsets that index the wrong bytes in the
original — `ScanResult::redact` splices the original bytes at a finding's offsets, so
that either trips the char-boundary guard (whole payload collapses to `[REDACTED]`) or,
if the arithmetic happened to land on a boundary, splices the wrong region and leaves
digits in the clear.

So **normalisation is for matching only**. The walk always advances by the *original*
character's `len_utf8()`, never the ASCII equivalent's, which makes every reported
offset a char boundary of the scanned text by construction. `DigitSegment` separates the
two concerns explicitly: `end` is an offset into the original text; `normalised` and
`digits` are match-only strings.

`redact`'s fail-closed branch (`scanner.rs`, the `is_char_boundary` guard) is preserved
untouched and is now **exercised** by a test that hands it a span landing one byte into a
full-width digit — it is the last thing between a mis-computed span and a leaked card
number, so it is asserted rather than assumed.

### ⚠️ What this does NOT close — the SSN evasion remains partially open

This ticket normalises full-width **digits**. It does not touch **separators**, and
measurement shows the separator gap is the load-bearing one for SSNs. Measured scanner
output on this branch:

| Input | Result |
|---|---|
| `ssn=１２３-４５-６７８９` — full-width digits, ASCII hyphen | ✅ `SsnPattern` |
| `ssn=１２３－４５－６７８９` — full-width digits, **U+FF0D** hyphen | ❌ **not detected** |
| `ssn=123－45－6789` — ASCII digits, **U+FF0D** hyphen | ❌ **not detected** |
| `card=４５３２０１５１１２８３０３６６` — contiguous | ✅ `CreditCardLuhn` |
| `card=４５３２　０１５１　１２８３　０３６６` — **U+3000** ideographic space | ❌ **not detected** |
| `card=4532　0151　1283　0366` — ASCII digits, **U+3000** | ❌ **not detected** |

Read plainly:

- **Credit card — closed** for the realistic case. A card number needs no separators, so
  the contiguous full-width form — the one an evader would actually use — is now caught.
- **SSN — partially open.** An SSN *requires* separators. A CJK IME in full-width mode
  emits **U+FF0D** for hyphen, not ASCII `-`, so the spelling this fix catches
  (full-width digits + ASCII hyphen) is a *mixed* spelling, not the one the input method
  naturally produces. **An SSN typed the natural way is still undetected.** This is not
  a minor leftover; it is the majority of the realistic SSN case.
- The last two rows are the scoping evidence: these separator gaps are **pre-existing
  and independent of digit width** — `123－45－6789` and `4532　0151　1283　0366` use
  ASCII digits and were equally undetected before this change. So this is a second,
  distinct evasion class (full-width *separators*), not an unfinished corner of this
  fix. A follow-up ticket is being filed separately; this PR's code scope is unchanged.

### Other digit consumers — investigated

- `is_ssn` and `luhn_valid` are the only digit-consuming detectors in `aa-security`;
  both are reached solely through `scan_digit_sequences` and are covered by this change.
- The hex passes (`scan_long_hex_runs`, `scan_separated_hex_runs`) consume
  `is_ascii_hexdigit`, but they are the `GenericHighEntropy` backstop, not a PII
  detector, and full-width hex would need the letters `ａ`–`ｆ` normalised too — a
  different, wider change. **Not addressed here; flagged for triage.**
- `dashboard/src/features/scrub/detectors.ts` carries an approximate ASCII-only
  credit-card regex, but it is a static catalogue/preview surface that explicitly does
  not run the Luhn checksum (AAASM-5156), not an enforcement path. Left alone — it
  overlaps AAASM-5347's area.

### Merge note

A sibling branch changes the **entropy pass** in this same file. This diff is confined to
the digit-sequence path (`scan_digit_sequences` and the helpers it owns) plus new tests
appended in the PII test section, so the two should merge without conflict.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Additive detection only. No schema, API or wire change; no new `CredentialKind` variant;
no change to redaction labels (ADR 0015's redaction contract is untouched). Payloads
previously passed through untouched may now be redacted — that is the intended fix, and
it is the same class of behaviour change any detector improvement carries.

**ADR references:** ADR 0015 (DLP trust boundary and redaction semantics) — the
fail-closed redaction semantics and the "golden vectors are not edited" rule are both
honoured; ADR 0032 (local-first sensitive-data provider architecture) — this is B-3 of
the AAASM-5269 Spike's §9 backlog.

## Related Issues

- Related Jira ticket: [AAASM-5345](https://lightning-dust-mite.atlassian.net/browse/AAASM-5345)
- Parent Epic: [AAASM-5270](https://lightning-dust-mite.atlassian.net/browse/AAASM-5270)
- Related GitHub issues: N/A

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Eleven new tests, one per commit. All fixtures are synthetic — the card number is the
standard Visa test number already used by the existing ASCII tests and the
`pii_credit_card` vector.

**No conformance vector was added or edited** (ADR 0015). New full-width vectors are B-5,
a separate ticket. All 26 `credential_detection` vectors pass byte-identically.

### `cargo nextest run -p aa-security -p conformance`

```
        PASS [   0.018s] ( 52/192) aa-security scanner::tests::detects_fullwidth_credit_card_as_the_same_kind_as_ascii
        PASS [   0.020s] ( 54/192) aa-security scanner::tests::detects_fullwidth_ssn_as_the_same_kind_as_ascii
        PASS [   0.021s] ( 66/192) aa-security scanner::tests::detects_mixed_width_credit_card
        PASS [   0.017s] ( 80/192) aa-security scanner::tests::does_not_flag_a_fullwidth_number_that_fails_luhn
        PASS [   0.018s] ( 82/192) aa-security scanner::tests::digit_run_longer_than_the_segment_budget_stays_clean_in_both_widths
        PASS [   0.023s] ( 85/192) aa-security scanner::tests::does_not_flag_a_short_fullwidth_digit_run
        PASS [   0.027s] ( 99/192) aa-security scanner::tests::fullwidth_finding_spans_are_char_boundaries_of_the_original_text
        PASS [   0.018s] (114/192) aa-security scanner::tests::redact_fails_closed_on_a_span_inside_a_fullwidth_digit
        PASS [   0.018s] (122/192) aa-security scanner::tests::redacts_a_fullwidth_credit_card_to_exact_bytes
        PASS [   0.016s] (123/192) aa-security scanner::tests::redacts_a_fullwidth_ssn_to_exact_bytes
        PASS [   0.017s] (127/192) aa-security scanner::tests::redacts_a_mixed_width_credit_card_to_exact_bytes
        PASS [   0.018s] (143/192) conformance::credential_detection all_vectors_redact_correctly
        PASS [   0.022s] (144/192) conformance::credential_detection all_vectors_have_correct_finding_count
        PASS [   0.021s] (145/192) conformance::credential_detection all_vectors_have_correct_finding_offsets
        PASS [   0.021s] (146/192) conformance::credential_detection all_vectors_have_correct_finding_kinds
     Summary [   0.354s] 192 tests run: 192 passed, 0 skipped
```

192 tests, up from 181 on the base commit — the eleven new tests, zero regressions.

### `cargo clippy -p aa-security --all-targets --all-features -- -D warnings`

```
    Checking aa-security v0.0.1-rc.6 (…/aa-security)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.85s
```

Clean. The full-workspace `cargo clippy --all-targets --all-features -- -D warnings`
also passes — it ran as a pre-commit hook on every one of the fourteen commits.

### `cargo fmt --all -- --check`

Clean (no output, exit 0).

### `cargo doc --workspace --no-deps`

Passes (pre-push hook, 22.8s) — pre-existing rustdoc warnings only, none from this diff.

## Acceptance criteria evidence

| Criterion | Evidence |
|---|---|
| Full-width card detected with the same `CredentialKind` as ASCII | `detects_fullwidth_credit_card_as_the_same_kind_as_ascii` — compares the two scans against each other, not a hard-coded kind |
| Full-width US SSN detected likewise | `detects_fullwidth_ssn_as_the_same_kind_as_ascii` |
| Mixed half/full-width number detected | `detects_mixed_width_credit_card` (`card=4532０15112830366`) |
| `redact()` correct, no residual digits, no panic — asserted on bytes | `redacts_a_fullwidth_credit_card_to_exact_bytes`, `redacts_a_fullwidth_ssn_to_exact_bytes`, `redacts_a_mixed_width_credit_card_to_exact_bytes` — each asserts the exact output string *and* that no digit of either width survives |
| Spans are valid UTF-8 char boundaries in the original text | `fullwidth_finding_spans_are_char_boundaries_of_the_original_text` — asserts `is_char_boundary` on both bounds, plus that no digit survives outside the span |
| Segment budget cannot be shrunk into a false positive (review S1) | `digit_run_longer_than_the_segment_budget_stays_clean_in_both_widths` — 30-digit run whose first 19 digits are Luhn-valid, both widths. Mutation-verified: with the budget cut to 19 it fails on ASCII (spurious card over bytes 4..23) and on full-width (bytes 4..61) |
| All 26 conformance vectors pass unchanged; no golden vector edited | `git diff --name-only` over the branch lists exactly one file: `aa-security/src/scanner.rs` |
| Negative: full-width string failing Luhn is not reported | `does_not_flag_a_fullwidth_number_that_fails_luhn` (16 digits, one altered) and `does_not_flag_a_short_fullwidth_digit_run` (8 digits) |
| `redact`'s fail-closed guard exercised, not assumed | `redact_fails_closed_on_a_span_inside_a_fullwidth_digit` |

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-5345]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
