### PR TITLE
[AAASM-5349] 🐛 (aa-cli): Refuse a governed launch when no effective policy resolves

### DIFF
--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub mod policy;
 pub mod proxy;
 // strip-for-publish:begin devtool
 pub mod run;
+pub mod run_policy;
 pub mod run_registration;
 // strip-for-publish:end devtool
 pub mod sandbox;

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -399,7 +399,9 @@ fn dry_run_handle(args: &RunArgs) -> RegistrationHandle {
 /// inferred later from what the tool was or was not stopped from doing.
 fn resolve_policy(args: &RunArgs) -> run_policy::PolicyResolution {
     let resolution = run_policy::resolve(args.policy.as_deref());
-    eprintln!("policy={} — {}", resolution.state_token(), resolution.summary());
+    // `summary()` already opens with the state token, so the `policy=<token>`
+    // prefix an audit scraper matches on falls out of it without repeating it.
+    eprintln!("policy={}", resolution.summary());
     resolution
 }
 

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -1583,6 +1583,88 @@ mod tests {
         );
     }
 
+    /// The four effective-policy states must survive as far as the artefact an
+    /// operator actually reads.
+    ///
+    /// This is the assertion that a four-variant enum on its own does not
+    /// satisfy: a consumer that renders every state the same way — or that
+    /// collapses them into "a policy loaded" / "it did not" — passes the type
+    /// checker and fails the contract. So the check is on the rendered receipt,
+    /// and it is pairwise: `enforced` and `permissive` both launch, and are the
+    /// pair most likely to be flattened into each other.
+    #[test]
+    fn the_dry_run_receipt_distinguishes_all_four_policy_states() {
+        let handle = stub_handle(None);
+        let cmd = std::process::Command::new("mock-tool");
+        let env = HashMap::new();
+
+        let states = [
+            run_policy::PolicyResolution::Enforced {
+                source: PathBuf::from("/p.yaml"),
+                document: PolicyDocument {
+                    version: 1,
+                    name: "p".into(),
+                    rules: vec![aa_core::PolicyRule {
+                        action_pattern: "bash".into(),
+                        decision: aa_core::PolicyDecision::Deny,
+                    }],
+                    enforcement_mode: aa_core::EnforcementMode::default(),
+                },
+            },
+            run_policy::PolicyResolution::Permissive {
+                source: PathBuf::from("/p.yaml"),
+                document: PolicyDocument {
+                    version: 1,
+                    name: "p".into(),
+                    rules: vec![aa_core::PolicyRule {
+                        action_pattern: "*".into(),
+                        decision: aa_core::PolicyDecision::Allow,
+                    }],
+                    enforcement_mode: aa_core::EnforcementMode::default(),
+                },
+            },
+            run_policy::PolicyResolution::Unconfigured(run_policy::Unconfigured::NoSource { searched: vec![] }),
+            run_policy::PolicyResolution::LoadFailed {
+                source: PathBuf::from("/p.yaml"),
+                detail: "bad".into(),
+            },
+        ];
+
+        let sections: Vec<String> = states
+            .iter()
+            .map(|state| {
+                let output = format_dry_run_output(&handle, state, "{}", &cmd, &env);
+                let start = output
+                    .find("--- policy ---")
+                    .expect("receipt must carry a policy section");
+                let rest = &output[start..];
+                let end = rest.find("--- managed settings ---").unwrap_or(rest.len());
+                rest[..end].to_string()
+            })
+            .collect();
+
+        for (state, section) in states.iter().zip(&sections) {
+            assert!(
+                section.contains(state.state_token()),
+                "the receipt must name the state it is reporting; {} is missing from:\n{section}",
+                state.state_token()
+            );
+        }
+
+        for (i, a) in sections.iter().enumerate() {
+            for (j, b) in sections.iter().enumerate().skip(i + 1) {
+                assert_ne!(
+                    a,
+                    b,
+                    "states {} and {} render an identical policy receipt, so an operator cannot \
+                     tell them apart",
+                    states[i].state_token(),
+                    states[j].state_token()
+                );
+            }
+        }
+    }
+
     #[test]
     fn dry_run_masks_secret_and_connection_url_env_vars() {
         let handle = RegistrationHandle {

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -10,8 +10,9 @@ use uuid::Uuid;
 #[cfg(unix)]
 use tokio::signal::unix::SignalKind;
 
-use aa_core::{DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel, PolicyDocument, PolicyRule};
+use aa_core::{DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel};
 
+use crate::commands::run_policy;
 use crate::commands::run_registration::{self, GovernedRegistration};
 use crate::commands::status::models::redact_database_url;
 use crate::config::ResolvedContext;
@@ -51,6 +52,15 @@ pub struct RunArgs {
     /// proxy endpoint (AAASM-5323) — it never launches unproxied by accident.
     #[arg(long)]
     pub no_proxy: bool,
+
+    /// Policy YAML file this session runs under.
+    ///
+    /// When absent the policy is resolved from `$AA_POLICY` and the default
+    /// locations, in the same order `aasm gateway start` uses. A governed
+    /// launch refuses when no effective policy resolves — an unconfigured
+    /// policy is not an implicit allow-all (AAASM-5349).
+    #[arg(long)]
+    pub policy: Option<std::path::PathBuf>,
 
     /// Show the launch command and settings without executing.
     #[arg(long)]
@@ -378,14 +388,19 @@ fn dry_run_handle(args: &RunArgs) -> RegistrationHandle {
     }
 }
 
-/// Construct a default policy document used until a real loader is wired in.
-fn load_policy() -> PolicyDocument {
-    PolicyDocument {
-        version: 1,
-        name: "default".into(),
-        rules: Vec::<PolicyRule>::new(),
-        enforcement_mode: aa_core::EnforcementMode::default(),
-    }
+/// Resolve the effective policy for this launch, and announce which of the four
+/// states it landed in.
+///
+/// This used to be a `load_policy()` that returned a hard-coded empty rule set,
+/// which meant every `aasm run` delivered an intercepted, registered, monitored
+/// launch enforcing nothing — and reported that as success. The banner is
+/// unconditional for the same reason the observe-mode banner is: the posture a
+/// session actually runs under has to be visible at the top of its output, not
+/// inferred later from what the tool was or was not stopped from doing.
+fn resolve_policy(args: &RunArgs) -> run_policy::PolicyResolution {
+    let resolution = run_policy::resolve(args.policy.as_deref());
+    eprintln!("policy={} — {}", resolution.state_token(), resolution.summary());
+    resolution
 }
 
 /// Mask a credential-bearing env value before it is printed in the dry-run
@@ -425,8 +440,15 @@ fn mask_value(key: &str, value: &str) -> String {
 }
 
 /// Build the structured dry-run output string.
+///
+/// The `--- policy ---` section is the preview's receipt of which of the four
+/// effective-policy states this launch resolved to. It is printed for all four,
+/// including the two that would refuse: a preview that showed a policy section
+/// only when one loaded would make "no policy at all" look like a formatting
+/// quirk rather than the reason the live run stops.
 fn format_dry_run_output(
     handle: &RegistrationHandle,
+    policy: &run_policy::PolicyResolution,
     settings: &str,
     cmd: &std::process::Command,
     env: &HashMap<String, String>,
@@ -455,11 +477,14 @@ fn format_dry_run_output(
         .collect();
 
     format!(
-        "--- aasm run dry-run ---\nagent_id:    {}\nagent_did:   {}\ntrace_id:    {}\nsession_id:  {}\n\n--- managed settings ---\n{}\n\n--- launch command ---\n{}\n\n--- environment ---\n{}",
+        "--- aasm run dry-run ---\nagent_id:    {}\nagent_did:   {}\ntrace_id:    {}\nsession_id:  {}\n\n--- policy ---\nstate:  {}\nsource: {}\ndetail: {}\n\n--- managed settings ---\n{}\n\n--- launch command ---\n{}\n\n--- environment ---\n{}",
         handle.agent_id,
         handle.registration_did,
         handle.trace_id,
         handle.session_id,
+        policy.state_token(),
+        policy.source().map_or("<none>".to_string(), |p| p.display().to_string()),
+        policy.summary(),
         truncated_settings,
         cmd_line,
         env_lines,
@@ -598,12 +623,25 @@ pub async fn execute_with_adapters(args: &RunArgs, adapters: &HashMap<&str, Box<
                 None
             }
         };
-        let child_env = build_child_env(&handle, proxy.as_deref(), args.no_proxy, mode);
+        // A preview reports the policy state rather than refusing on it, for the
+        // same reason it reports an unresolvable proxy: the operator ran this to
+        // find out what a live run would do, and the answer "it would refuse"
+        // is only useful if they are shown it.
+        let resolution = resolve_policy(args);
+        if let Err(e) = resolution.clone().into_enforceable() {
+            eprintln!("warning: {e}");
+            eprintln!("warning: a live `aasm run` with these flags would refuse to launch.");
+        }
+        let mut child_env = build_child_env(&handle, proxy.as_deref(), args.no_proxy, mode);
+        resolution.annotate_env(&mut child_env);
         let settings = "<dry-run: managed settings not generated>".to_string();
         let mut cmd = std::process::Command::new(&args.tool);
         cmd.args(&args.tool_args);
         cmd.envs(&child_env);
-        print!("{}", format_dry_run_output(&handle, &settings, &cmd, &child_env));
+        print!(
+            "{}",
+            format_dry_run_output(&handle, &resolution, &settings, &cmd, &child_env)
+        );
         return Ok(0);
     }
 
@@ -623,14 +661,22 @@ pub async fn execute_with_adapters(args: &RunArgs, adapters: &HashMap<&str, Box<
     // refused should not first create a gateway registration it then abandons.
     let proxy = resolve_launch_proxy(args.no_proxy)?;
 
+    // Same reason, and the same ordering rule: a session with no effective
+    // policy is refused here, before any registration exists, because a
+    // registered session that never launched is a governed identity with no
+    // process behind it — and because there is nothing to govern a tool with.
+    // An absent policy is not permission (AAASM-5349).
+    let resolution = resolve_policy(args);
+    let policy = resolution.clone().into_enforceable()?;
+
     // Fatal on failure, and fatal *before* anything is launched: a session the
     // gateway did not accept has no governed identity, and a tool started under
     // no identity is an ungoverned process wearing a governed launch's name.
     let registration = register_with_gateway(&info, args).await?;
     let handle = RegistrationHandle::of(&registration);
-    let child_env = build_child_env(&handle, proxy.as_deref(), args.no_proxy, mode);
+    let mut child_env = build_child_env(&handle, proxy.as_deref(), args.no_proxy, mode);
+    resolution.annotate_env(&mut child_env);
 
-    let policy = load_policy();
     let settings = adapter
         .generate_managed_settings(&policy)
         .await
@@ -704,7 +750,7 @@ mod tests {
 
     // Stub adapters below implement DevToolAdapter, so the test module carries
     // the trait-object plumbing the production path no longer needs.
-    use aa_core::{AdapterError, DevToolInfo, DevToolKind, McpServerInfo};
+    use aa_core::{AdapterError, DevToolInfo, DevToolKind, McpServerInfo, PolicyDocument};
     use async_trait::async_trait;
     use clap::Parser;
 
@@ -984,6 +1030,23 @@ mod tests {
             trace_id: "test-trace".into(),
             session_id: "test-session".into(),
             team_id: team_id.map(String::from),
+        }
+    }
+
+    /// A resolved-and-enforced policy, for tests whose subject is not the
+    /// policy state itself.
+    fn stub_resolution() -> run_policy::PolicyResolution {
+        run_policy::PolicyResolution::Enforced {
+            source: PathBuf::from("/tmp/test-policy.yaml"),
+            document: PolicyDocument {
+                version: 1,
+                name: "test".into(),
+                rules: vec![aa_core::PolicyRule {
+                    action_pattern: "bash".into(),
+                    decision: aa_core::PolicyDecision::Deny,
+                }],
+                enforcement_mode: aa_core::EnforcementMode::default(),
+            },
         }
     }
 
@@ -1329,6 +1392,7 @@ mod tests {
             root_agent: None,
             governance_level: None,
             no_proxy: false,
+            policy: None,
             dry_run: false,
             enforcement_mode: None,
             observe: false,
@@ -1483,7 +1547,7 @@ mod tests {
         env.insert("MY_API_KEY".into(), "secret123".into());
         env.insert("NORMAL_VAR".into(), "hello".into());
 
-        let output = format_dry_run_output(&handle, settings, &cmd, &env);
+        let output = format_dry_run_output(&handle, &stub_resolution(), settings, &cmd, &env);
 
         assert!(output.contains("agent_id:"), "missing identity section: {output}");
         assert!(output.contains("agent-xyz"), "missing agent_id value: {output}");
@@ -1534,7 +1598,7 @@ mod tests {
         env.insert("AA_JWT_SECRET".into(), "super-secret-signing-key".into());
         env.insert("DATABASE_URL".into(), "postgresql://aasm:hunter2@db:5432/aasm".into());
 
-        let output = format_dry_run_output(&handle, "{}", &cmd, &env);
+        let output = format_dry_run_output(&handle, &stub_resolution(), "{}", &cmd, &env);
 
         assert!(
             !output.contains("super-secret-signing-key"),
@@ -1573,7 +1637,7 @@ mod tests {
         let mut env = HashMap::new();
         env.insert("MONGODB_URI".into(), "mongodb://user:p4ss@host:27017/db".into());
 
-        let output = format_dry_run_output(&handle, "{}", &cmd, &env);
+        let output = format_dry_run_output(&handle, &stub_resolution(), "{}", &cmd, &env);
 
         assert!(
             !output.contains("p4ss"),

--- a/aa-cli/src/commands/run_policy.rs
+++ b/aa-cli/src/commands/run_policy.rs
@@ -270,7 +270,7 @@ fn search_path(explicit: Option<&Path>) -> Vec<(String, PathBuf)> {
     // not exist is an operator error worth reporting, not a cue to fall back to
     // an ambient policy they did not ask for.
     if let Some(path) = explicit {
-        return vec![("--policy".to_string(), path.to_path_buf())];
+        return vec![(format!("--policy {}", path.display()), path.to_path_buf())];
     }
 
     let mut out = Vec::new();
@@ -420,5 +420,342 @@ fn project_rules(doc: &aa_gateway::policy::PolicyDocument) -> PolicyDocument {
         name: doc.name.clone().unwrap_or_else(|| "policy".to_string()),
         rules,
         enforcement_mode: aa_core::EnforcementMode::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &tempfile::TempDir, name: &str, body: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, body).expect("write policy");
+        path
+    }
+
+    /// The defect this module exists to fix, stated as an assertion: a policy
+    /// that governs nothing must not present as a policy that governs.
+    #[test]
+    fn an_empty_document_is_unconfigured_not_allow_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(&dir, "p.yaml", "budget:\n  daily_limit_usd: 5.0\n");
+
+        let resolution = load(&path);
+
+        assert_eq!(
+            resolution.state_token(),
+            "unconfigured",
+            "a document with no tool rule governs nothing and must not read as governance; got {resolution:?}"
+        );
+        assert!(
+            resolution.into_enforceable().is_err(),
+            "an empty effective policy must not produce a launchable policy"
+        );
+    }
+
+    #[test]
+    fn a_missing_artifact_is_unconfigured() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.yaml");
+
+        let resolution = resolve(Some(&missing));
+
+        assert_eq!(resolution.state_token(), "unconfigured");
+        assert!(resolution.into_enforceable().is_err());
+    }
+
+    /// A broken policy and an absent one are different operator problems and
+    /// must not collapse into one another — the remedy differs, and so does
+    /// what the audit trail should record.
+    #[test]
+    fn a_malformed_artifact_is_load_failed_not_unconfigured() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(&dir, "p.yaml", "tools: [[[ not: valid\n");
+
+        let resolution = load(&path);
+
+        assert_eq!(
+            resolution.state_token(),
+            "load_failed",
+            "a policy that cannot be parsed is a broken artifact, not an absent one; got {resolution:?}"
+        );
+    }
+
+    /// A typo'd section is the dangerous shape of the case above: it parses as
+    /// YAML, so the only thing standing between it and a silently-dropped
+    /// restriction is that it lands in `load_failed` rather than in a state
+    /// that launches.
+    #[test]
+    fn a_typoed_section_is_load_failed_and_does_not_launch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(&dir, "p.yaml", "capabilties:\n  deny:\n    - file_delete\n");
+
+        let resolution = load(&path);
+
+        assert_eq!(resolution.state_token(), "load_failed");
+        assert!(
+            resolution.into_enforceable().is_err(),
+            "a policy whose section name is misspelled must not launch as if it applied"
+        );
+    }
+
+    #[test]
+    fn a_directory_is_load_failed_rather_than_silently_half_loaded() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let resolution = load(dir.path());
+
+        assert_eq!(resolution.state_token(), "load_failed");
+        assert!(
+            resolution.summary().contains("directory"),
+            "the operator must be told the source was a directory: {}",
+            resolution.summary()
+        );
+    }
+
+    #[test]
+    fn the_allow_all_template_resolves_to_permissive_and_launches() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(&dir, "p.yaml", ALLOW_ALL_TEMPLATE);
+
+        let resolution = load(&path);
+
+        assert_eq!(
+            resolution.state_token(),
+            "permissive",
+            "the documented allow-all artifact must resolve to the permissive state; got {resolution:?}"
+        );
+        assert!(
+            resolution.into_enforceable().is_ok(),
+            "an operator who explicitly asked for allow-all must be able to launch"
+        );
+    }
+
+    #[test]
+    fn a_policy_with_rules_is_enforced() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(&dir, "p.yaml", "tools:\n  bash:\n    allow: false\n");
+
+        let resolution = load(&path);
+
+        assert_eq!(resolution.state_token(), "enforced");
+        assert!(resolution.into_enforceable().is_ok());
+    }
+
+    /// Permissive means *nothing* is restricted. A wildcard-allow tool section
+    /// sitting next to an egress allowlist still enforces something, and
+    /// labelling it permissive would understate the governance in place.
+    #[test]
+    fn wildcard_allow_beside_another_restriction_is_enforced_not_permissive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            &dir,
+            "p.yaml",
+            "network:\n  allowlist:\n    - api.anthropic.com\ntools:\n  \"*\":\n    allow: true\n",
+        );
+
+        let resolution = load(&path);
+
+        assert_eq!(
+            resolution.state_token(),
+            "enforced",
+            "a policy that still restricts egress is not permissive; got {resolution:?}"
+        );
+    }
+
+    /// The refusal has to be actionable. An operator who is told only "no"
+    /// works around the check, and a worked-around fail-closed default is how
+    /// the empty policy survived three verification runs.
+    #[test]
+    fn the_unconfigured_refusal_names_every_way_to_supply_a_policy() {
+        let err = PolicyResolution::Unconfigured(Unconfigured::NoSource { searched: vec![] })
+            .into_enforceable()
+            .expect_err("unconfigured must refuse")
+            .to_string();
+
+        assert!(err.contains("--policy"), "refusal must name the flag: {err}");
+        assert!(err.contains("AA_POLICY"), "refusal must name the env var: {err}");
+        assert!(
+            err.contains("~/.aasm/policy.yaml"),
+            "refusal must name the default location: {err}"
+        );
+        assert!(
+            err.contains("aasm policy validate"),
+            "refusal must name how to check a candidate: {err}"
+        );
+        assert!(
+            err.contains("tools:") && err.contains("allow: true"),
+            "refusal must show the allow-all artifact, or permissive execution is undiscoverable: {err}"
+        );
+        assert!(
+            err.contains("An absent policy is not permission"),
+            "refusal must say why absence is not permission: {err}"
+        );
+    }
+
+    /// An operator whose file is broken must be sent to that file, not to the
+    /// concept of configuring a policy they already configured.
+    #[test]
+    fn the_load_failure_refusal_points_at_the_file_not_the_concept() {
+        let err = PolicyResolution::LoadFailed {
+            source: PathBuf::from("/etc/aasm/policy.yaml"),
+            detail: "budget.daily_limit_usd: must be > 0".into(),
+        }
+        .into_enforceable()
+        .expect_err("a broken policy must refuse")
+        .to_string();
+
+        assert!(
+            err.contains("/etc/aasm/policy.yaml"),
+            "the refusal must name the broken file: {err}"
+        );
+        assert!(
+            err.contains("budget.daily_limit_usd"),
+            "the refusal must carry the underlying reason: {err}"
+        );
+        assert!(
+            !err.contains("An absent policy is not permission"),
+            "a broken policy must not be described as an absent one: {err}"
+        );
+    }
+
+    /// The trap this ticket names: four variants nothing reads are worth
+    /// nothing. `annotate_env` is the machine-readable consumer, so the four
+    /// must arrive at a child process as four distinct values.
+    #[test]
+    fn all_four_states_reach_the_child_environment_distinctly() {
+        let dir = tempfile::tempdir().unwrap();
+        let states = [
+            load(&write(&dir, "enforced.yaml", "tools:\n  bash:\n    allow: false\n")),
+            load(&write(&dir, "permissive.yaml", ALLOW_ALL_TEMPLATE)),
+            load(&write(&dir, "empty.yaml", "budget:\n  daily_limit_usd: 5.0\n")),
+            load(&write(&dir, "broken.yaml", "tools: [[[ not: valid\n")),
+        ];
+
+        let mut seen = Vec::new();
+        for state in &states {
+            let mut env = HashMap::new();
+            state.annotate_env(&mut env);
+            seen.push(env.get(POLICY_STATE_ENV).cloned().unwrap_or_default());
+        }
+
+        assert_eq!(
+            seen,
+            vec!["enforced", "permissive", "unconfigured", "load_failed"],
+            "the four states must be four distinct values in {POLICY_STATE_ENV}, not collapsed into ok/not-ok"
+        );
+    }
+
+    #[test]
+    fn the_summary_line_differs_for_every_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let summaries: Vec<String> = [
+            load(&write(&dir, "enforced.yaml", "tools:\n  bash:\n    allow: false\n")),
+            load(&write(&dir, "permissive.yaml", ALLOW_ALL_TEMPLATE)),
+            load(&write(&dir, "empty.yaml", "budget:\n  daily_limit_usd: 5.0\n")),
+            load(&write(&dir, "broken.yaml", "tools: [[[ not: valid\n")),
+        ]
+        .iter()
+        .map(|r| r.summary())
+        .collect();
+
+        for (i, a) in summaries.iter().enumerate() {
+            for b in summaries.iter().skip(i + 1) {
+                assert_ne!(a, b, "two states render the same operator-facing summary");
+            }
+        }
+    }
+
+    /// The rendered managed settings must not churn between identical runs.
+    /// The source is a `HashMap`, so without an explicit sort the tool's
+    /// settings file would be rewritten with reordered lists on every launch.
+    #[test]
+    fn rules_are_ordered_deterministically() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            &dir,
+            "p.yaml",
+            "tools:\n  zsh:\n    allow: false\n  bash:\n    allow: true\n  fish:\n    allow: false\n",
+        );
+
+        let patterns = |r: PolicyResolution| -> Vec<String> {
+            r.into_enforceable()
+                .unwrap()
+                .rules
+                .iter()
+                .map(|rule| rule.action_pattern.clone())
+                .collect()
+        };
+
+        assert_eq!(patterns(load(&path)), vec!["bash", "fish", "zsh"]);
+        assert_eq!(patterns(load(&path)), vec!["bash", "fish", "zsh"], "unstable ordering");
+    }
+
+    #[test]
+    fn tool_decisions_are_projected_faithfully() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            &dir,
+            "p.yaml",
+            "tools:\n  allowed:\n    allow: true\n  denied:\n    allow: false\n  \
+             gated:\n    allow: true\n    requires_approval_if: \"true\"\n",
+        );
+
+        let doc = load(&path).into_enforceable().expect("policy loads");
+        let decision = |name: &str| {
+            doc.rules
+                .iter()
+                .find(|r| r.action_pattern == name)
+                .map(|r| r.decision.clone())
+                .unwrap_or_else(|| panic!("no rule for {name}"))
+        };
+
+        assert_eq!(decision("allowed"), PolicyDecision::Allow);
+        assert_eq!(decision("denied"), PolicyDecision::Deny);
+        assert_eq!(
+            decision("gated"),
+            PolicyDecision::RequireApproval,
+            "an approval gate must not be flattened into a plain allow"
+        );
+    }
+
+    /// `aasm run` and `aasm gateway start` must look in the same places, or a
+    /// host ends up governed by one document and previewed against another.
+    #[test]
+    fn the_search_order_matches_the_gateway_convention() {
+        let _guard = crate::test_support::env_guard();
+        let prior = std::env::var("AA_POLICY").ok();
+        std::env::set_var("AA_POLICY", "/from/env.yaml");
+
+        let labels: Vec<String> = search_path(None).into_iter().map(|(label, _)| label).collect();
+
+        match prior {
+            Some(v) => std::env::set_var("AA_POLICY", v),
+            None => std::env::remove_var("AA_POLICY"),
+        }
+
+        assert_eq!(labels.first().map(String::as_str), Some("$AA_POLICY"));
+        assert!(
+            labels.iter().any(|l| l == "~/.aasm/policy.yaml"),
+            "the home-directory default must be searched: {labels:?}"
+        );
+        assert!(
+            labels.iter().any(|l| l == "/etc/aasm/policy.yaml"),
+            "the system default must be searched: {labels:?}"
+        );
+    }
+
+    #[test]
+    fn an_explicit_path_is_the_whole_search() {
+        let labels: Vec<String> = search_path(Some(Path::new("/named.yaml")))
+            .into_iter()
+            .map(|(label, _)| label)
+            .collect();
+
+        assert_eq!(
+            labels,
+            vec!["--policy /named.yaml"],
+            "a named artifact must not fall back to an ambient policy the operator did not ask for"
+        );
     }
 }

--- a/aa-cli/src/commands/run_policy.rs
+++ b/aa-cli/src/commands/run_policy.rs
@@ -1,0 +1,424 @@
+//! Effective-policy resolution for `aasm run` (AAASM-5349).
+//!
+//! # Why absence of configuration is not permission
+//!
+//! `aasm run` used to hand its adapter a hard-coded `PolicyDocument` with an
+//! empty rule list. That is not a neutral placeholder. The Claude Code adapter
+//! maps an empty rule list to `permissions: {allow: [], deny: []}` and
+//! `permissionMode: "acceptEdits"` — so the session it produced was not merely
+//! ungoverned, it was *more* permissive than the tool's own default, and it
+//! reported itself as a successfully governed launch while being so.
+//!
+//! The rule this module exists to enforce is that an empty effective policy is
+//! a statement about the **operator**, not about the agent: it means nobody has
+//! said what this agent may do. "Nobody has said" is not "everything is
+//! allowed". A governed launch therefore refuses, and the refusal names the
+//! remedy — because a fail-closed default that an operator cannot act on gets
+//! worked around, and a workaround is how the empty policy got here.
+//!
+//! Permissive execution remains available, but it has to be *said*: an operator
+//! who wants an agent with no restrictions writes an allow-all artifact (see
+//! [`ALLOW_ALL_TEMPLATE`]) and selects it. The difference between "I chose to
+//! restrict nothing" and "I never chose anything" is the entire point, and it
+//! is why [`PolicyResolution`] has four variants rather than an `Option`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use aa_core::{PolicyDecision, PolicyDocument, PolicyRule};
+
+/// A minimal policy artifact that permits everything.
+///
+/// This is the *whole* shape of an explicit allow-all: a policy whose tool
+/// ruleset is exactly the wildcard, allowed, and which restricts nothing on any
+/// other dimension. There is no dedicated `permissive: true` switch, because a
+/// switch is easy to set without reading what it turns off — writing the
+/// wildcard out is the smallest thing that is unambiguously deliberate, and it
+/// validates through the same [`aa_gateway::policy::PolicyValidator`] as every
+/// other policy rather than through a bypass.
+pub const ALLOW_ALL_TEMPLATE: &str = r#"apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: allow-all
+spec:
+  tools:
+    "*":
+      allow: true
+"#;
+
+/// Environment variable carrying the resolved policy state into the child.
+///
+/// Exported so anything downstream of the launch — an SDK inside the tool, a
+/// log scraper joining child output to a session — can tell an enforced session
+/// from a deliberately permissive one without re-deriving it. The two refusing
+/// states never reach a child, but they do reach `--dry-run`, which is where an
+/// operator checks what a live run would do.
+pub const POLICY_STATE_ENV: &str = "AA_POLICY_STATE";
+
+/// Environment variable carrying the path the policy was resolved from.
+pub const POLICY_SOURCE_ENV: &str = "AA_POLICY_SOURCE";
+
+/// The outcome of resolving an effective policy for a launch.
+///
+/// # Why four variants and not `Option<PolicyDocument>`
+///
+/// Each variant is a different fact about the operator's configuration, and
+/// each one obliges a different response:
+///
+/// * [`Enforced`](Self::Enforced) — rules exist and will be applied. Launch.
+/// * [`Permissive`](Self::Permissive) — the operator wrote down that nothing is
+///   restricted. Launch, but say so loudly: a reader of the audit trail must
+///   not mistake this for the case above.
+/// * [`Unconfigured`](Self::Unconfigured) — no effective policy resolved.
+///   Refuse, and explain how to supply one.
+/// * [`LoadFailed`](Self::LoadFailed) — an artifact was selected and is broken.
+///   Refuse, and explain how to fix *that file*.
+///
+/// The last two must not collapse into each other. An operator whose YAML has a
+/// typo has already made a decision about governance and needs to be sent to
+/// their file; an operator with no policy at all needs to be sent to the
+/// concept. Merging them produces a message that is wrong for both, and — worse
+/// — makes a broken policy indistinguishable from an absent one in the audit
+/// trail, which is precisely the confusion an attacker who corrupts a policy
+/// file would want.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PolicyResolution {
+    /// An effective policy resolved and carries at least one enforceable rule.
+    Enforced {
+        /// The artifact it was read from.
+        source: PathBuf,
+        /// The projection handed to the dev-tool adapter.
+        document: PolicyDocument,
+    },
+    /// The operator explicitly selected an allow-all artifact.
+    Permissive {
+        /// The artifact it was read from.
+        source: PathBuf,
+        /// The projection handed to the dev-tool adapter.
+        document: PolicyDocument,
+    },
+    /// No effective policy resolved.
+    Unconfigured(Unconfigured),
+    /// An artifact was selected but could not be turned into a policy.
+    LoadFailed {
+        /// The artifact that could not be loaded.
+        source: PathBuf,
+        /// Why it could not be loaded, for the operator to act on.
+        detail: String,
+    },
+}
+
+/// Why no effective policy resolved.
+///
+/// Both are [`PolicyResolution::Unconfigured`] — contract point 1 is that an
+/// empty effective policy *is* the unconfigured state — but the remedy differs,
+/// so the refusal text does too.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Unconfigured {
+    /// Nothing existed at any searched location.
+    NoSource {
+        /// Human-readable locations that were searched, in order.
+        searched: Vec<String>,
+    },
+    /// An artifact parsed cleanly but declares no tool rule, so it governs
+    /// nothing. Distinct from `NoSource` only in the remedy: the operator has a
+    /// file and needs to put rules in it.
+    EmptyDocument {
+        /// The artifact that turned out to be empty.
+        source: PathBuf,
+    },
+}
+
+impl PolicyResolution {
+    /// Stable machine-readable token for this state.
+    ///
+    /// Stable on purpose: it lands in [`POLICY_STATE_ENV`], in the dry-run
+    /// preview and in the launch banner, and audit tooling matches on it.
+    pub fn state_token(&self) -> &'static str {
+        match self {
+            Self::Enforced { .. } => "enforced",
+            Self::Permissive { .. } => "permissive",
+            Self::Unconfigured(_) => "unconfigured",
+            Self::LoadFailed { .. } => "load_failed",
+        }
+    }
+
+    /// The artifact this resolution came from, when there was one.
+    pub fn source(&self) -> Option<&Path> {
+        match self {
+            Self::Enforced { source, .. }
+            | Self::Permissive { source, .. }
+            | Self::LoadFailed { source, .. }
+            | Self::Unconfigured(Unconfigured::EmptyDocument { source }) => Some(source),
+            Self::Unconfigured(Unconfigured::NoSource { .. }) => None,
+        }
+    }
+
+    /// One-line operator-facing summary, distinct per state.
+    ///
+    /// Every state names itself, so the four are told apart by reading the line
+    /// rather than by inferring from what is missing from it.
+    pub fn summary(&self) -> String {
+        match self {
+            Self::Enforced { source, document } => {
+                format!("enforced — {} rule(s) from {}", document.rules.len(), source.display())
+            }
+            Self::Permissive { source, .. } => format!(
+                "permissive — explicit allow-all artifact at {} (nothing is restricted)",
+                source.display()
+            ),
+            Self::Unconfigured(Unconfigured::NoSource { .. }) => {
+                "unconfigured — no policy artifact found; a governed launch is refused".to_string()
+            }
+            Self::Unconfigured(Unconfigured::EmptyDocument { source }) => format!(
+                "unconfigured — {} declares no tool rule; a governed launch is refused",
+                source.display()
+            ),
+            Self::LoadFailed { source, detail } => {
+                format!("load_failed — {} could not be loaded: {detail}", source.display())
+            }
+        }
+    }
+
+    /// Record this state in the child environment.
+    ///
+    /// Deliberately a mutation of an already-built map rather than a parameter
+    /// of `build_child_env`: the policy state is orthogonal to the identity and
+    /// proxy wiring that function exists to assemble.
+    pub fn annotate_env(&self, env: &mut HashMap<String, String>) {
+        env.insert(POLICY_STATE_ENV.into(), self.state_token().into());
+        match self.source() {
+            Some(source) => {
+                env.insert(POLICY_SOURCE_ENV.into(), source.display().to_string());
+            }
+            None => {
+                env.remove(POLICY_SOURCE_ENV);
+            }
+        }
+    }
+
+    /// Consume this resolution into the policy a launch may proceed under, or
+    /// refuse with an explanation the operator can act on.
+    ///
+    /// The two refusing states produce different text on purpose — see the type
+    /// docs. Both refuse *before* anything is launched, because a tool that has
+    /// already started under no policy cannot be retroactively governed.
+    pub fn into_enforceable(self) -> Result<PolicyDocument> {
+        match self {
+            Self::Enforced { document, .. } | Self::Permissive { document, .. } => Ok(document),
+            Self::Unconfigured(Unconfigured::NoSource { searched }) => Err(anyhow::anyhow!(
+                "refusing to launch ungoverned: no effective policy is configured, so this session \
+                 would run under no rules at all. An absent policy is not permission.\n\
+                 \n\
+                 Searched, in order: {}\n\
+                 \n\
+                 Supply a policy, then re-run:\n\
+                 \x20 aasm run --policy <FILE> <tool>\n\
+                 \x20 AA_POLICY=<FILE> aasm run <tool>\n\
+                 \x20 install one at ~/.aasm/policy.yaml (or /etc/aasm/policy.yaml)\n\
+                 Check it first with: aasm policy validate <FILE>\n\
+                 \n\
+                 If you intend this agent to be unrestricted, say so explicitly with an \
+                 allow-all artifact:\n\
+                 {}",
+                searched.join(", "),
+                indent(ALLOW_ALL_TEMPLATE),
+            )),
+            Self::Unconfigured(Unconfigured::EmptyDocument { source }) => Err(anyhow::anyhow!(
+                "refusing to launch ungoverned: the policy at {} parsed cleanly but declares no \
+                 tool rule, so it would govern nothing. An empty policy is unconfigured, not \
+                 allow-all.\n\
+                 \n\
+                 Add the tool rules this agent should run under, then re-run.\n\
+                 Check the file with: aasm policy validate {}\n\
+                 \n\
+                 If you intend this agent to be unrestricted, say so explicitly — an empty \
+                 `tools:` section does not mean that, this does:\n\
+                 {}",
+                source.display(),
+                source.display(),
+                indent(ALLOW_ALL_TEMPLATE),
+            )),
+            Self::LoadFailed { source, detail } => Err(anyhow::anyhow!(
+                "refusing to launch: the policy at {} could not be loaded — {detail}\n\
+                 \n\
+                 This is a broken policy artifact, not an absent one: the file was selected as \
+                 this session's policy, so guessing what it meant is not safe.\n\
+                 Fix it, then re-check with: aasm policy validate {}\n\
+                 \x20 or select a different one with: aasm run --policy <FILE> <tool>",
+                source.display(),
+                source.display(),
+            )),
+        }
+    }
+}
+
+/// Indent a block so it reads as a quoted artifact inside an error message.
+fn indent(block: &str) -> String {
+    block.lines().map(|l| format!("    {l}\n")).collect()
+}
+
+/// The locations `aasm run` looks in, in order.
+///
+/// Deliberately the same order `aasm gateway start` uses, so the two commands
+/// agree about where an operator's policy lives. Diverging here would let a
+/// host be governed by one document and previewed against another.
+fn search_path(explicit: Option<&Path>) -> Vec<(String, PathBuf)> {
+    // An explicitly named artifact is the whole search: naming a file that does
+    // not exist is an operator error worth reporting, not a cue to fall back to
+    // an ambient policy they did not ask for.
+    if let Some(path) = explicit {
+        return vec![("--policy".to_string(), path.to_path_buf())];
+    }
+
+    let mut out = Vec::new();
+    if let Ok(env_path) = std::env::var("AA_POLICY") {
+        if !env_path.is_empty() {
+            out.push(("$AA_POLICY".to_string(), PathBuf::from(env_path)));
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        out.push((
+            "~/.aasm/policy.yaml".to_string(),
+            home.join(".aasm").join("policy.yaml"),
+        ));
+        out.push(("~/.aasm/policies/".to_string(), home.join(".aasm").join("policies")));
+    }
+    out.push((
+        "/etc/aasm/policy.yaml".to_string(),
+        PathBuf::from("/etc/aasm/policy.yaml"),
+    ));
+    out.push(("/etc/aasm/policies/".to_string(), PathBuf::from("/etc/aasm/policies")));
+    out
+}
+
+/// Resolve the effective policy for this launch.
+///
+/// Never returns an "empty but fine" policy: every path out of here is one of
+/// the four states, and two of them refuse.
+pub fn resolve(explicit: Option<&Path>) -> PolicyResolution {
+    let candidates = search_path(explicit);
+    for (_, path) in &candidates {
+        if path.exists() {
+            return load(path);
+        }
+    }
+    PolicyResolution::Unconfigured(Unconfigured::NoSource {
+        searched: candidates.into_iter().map(|(label, _)| label).collect(),
+    })
+}
+
+/// Load and classify a single policy artifact.
+pub fn load(source: &Path) -> PolicyResolution {
+    // A directory is the gateway's multi-document cascade. `aasm run` renders
+    // one tool's managed settings and has no cascade merger, so it says so
+    // rather than picking a file out of the directory and calling that the
+    // effective policy.
+    if source.is_dir() {
+        return PolicyResolution::LoadFailed {
+            source: source.to_path_buf(),
+            detail: "it is a directory. `aasm run` resolves a single effective policy document \
+                     and does not merge the multi-document cascade that `aasm gateway start` \
+                     accepts; point --policy at one file"
+                .to_string(),
+        };
+    }
+
+    let yaml = match std::fs::read_to_string(source) {
+        Ok(yaml) => yaml,
+        Err(e) => {
+            return PolicyResolution::LoadFailed {
+                source: source.to_path_buf(),
+                detail: e.to_string(),
+            }
+        }
+    };
+    classify(source, &yaml)
+}
+
+/// Parse `yaml` and place it in one of the four states.
+///
+/// Split out from [`load`] so classification is testable without a filesystem.
+pub fn classify(source: &Path, yaml: &str) -> PolicyResolution {
+    let validated = match aa_gateway::policy::PolicyValidator::from_yaml(yaml) {
+        Ok(output) => output.document,
+        Err(errors) => {
+            return PolicyResolution::LoadFailed {
+                source: source.to_path_buf(),
+                detail: errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("; "),
+            }
+        }
+    };
+
+    let document = project_rules(&validated);
+    if document.rules.is_empty() {
+        return PolicyResolution::Unconfigured(Unconfigured::EmptyDocument {
+            source: source.to_path_buf(),
+        });
+    }
+    if is_explicit_allow_all(&validated) {
+        return PolicyResolution::Permissive {
+            source: source.to_path_buf(),
+            document,
+        };
+    }
+    PolicyResolution::Enforced {
+        source: source.to_path_buf(),
+        document,
+    }
+}
+
+/// True when this artifact restricts nothing at all.
+///
+/// Both halves matter. A wildcard-allow `tools:` section alongside a network
+/// allowlist or a capability denial is *not* permissive — something is still
+/// enforced — and labelling it permissive would understate the governance in
+/// place. The check is therefore conservative in the safe direction: it says
+/// "permissive" only when there is genuinely nothing left to enforce.
+fn is_explicit_allow_all(doc: &aa_gateway::policy::PolicyDocument) -> bool {
+    let tools_are_wildcard_allow = doc.tools.len() == 1
+        && doc
+            .tools
+            .get("*")
+            .is_some_and(|t| t.allow && t.requires_approval_if.is_none() && t.limit_per_hour.is_none());
+
+    tools_are_wildcard_allow
+        && doc.network.is_none()
+        && doc.schedule.is_none()
+        && doc.budget.is_none()
+        && doc.capabilities.is_none()
+        && doc.data.as_ref().map_or(true, |d| d.sensitive_patterns.is_empty())
+}
+
+/// Project the gateway's validated document onto the rule list the dev-tool
+/// adapter consumes.
+///
+/// Only the `tools:` dimension crosses over: a dev-tool adapter writes tool
+/// permissions into the tool's own settings file and has nowhere to put a spend
+/// cap or an egress allowlist — those are enforced by the gateway and the proxy.
+/// Rules are sorted so the rendered settings are byte-stable across runs; the
+/// source is a `HashMap` and would otherwise reorder on every launch.
+fn project_rules(doc: &aa_gateway::policy::PolicyDocument) -> PolicyDocument {
+    let mut rules: Vec<PolicyRule> = doc
+        .tools
+        .iter()
+        .map(|(name, tool)| PolicyRule {
+            action_pattern: name.clone(),
+            decision: match (tool.allow, tool.requires_approval_if.is_some()) {
+                (true, true) => PolicyDecision::RequireApproval,
+                (true, false) => PolicyDecision::Allow,
+                (false, _) => PolicyDecision::Deny,
+            },
+        })
+        .collect();
+    rules.sort_by(|a, b| a.action_pattern.cmp(&b.action_pattern));
+
+    PolicyDocument {
+        version: 1,
+        name: doc.name.clone().unwrap_or_else(|| "policy".to_string()),
+        rules,
+        enforcement_mode: aa_core::EnforcementMode::default(),
+    }
+}

--- a/aa-cli/tests/run_command.rs
+++ b/aa-cli/tests/run_command.rs
@@ -286,6 +286,36 @@ async fn run_command_refuses_a_lineage_the_gateway_will_not_accept() {
     );
 }
 
+/// A real policy artifact on disk, shared by every test in this binary.
+///
+/// Since AAASM-5349 a governed launch refuses when no effective policy
+/// resolves, so a spawn/deregistration test has to supply one — the same way it
+/// has to supply a gateway. Pinning it with `--policy` rather than leaning on
+/// `$AA_POLICY` or `~/.aasm/policy.yaml` keeps these tests hermetic: they
+/// measure the same thing on a host that happens to have an operator policy
+/// installed and on one that does not.
+fn test_policy_path() -> &'static std::path::Path {
+    static POLICY: std::sync::OnceLock<(tempfile::TempDir, PathBuf)> = std::sync::OnceLock::new();
+    let (_dir, path) = POLICY.get_or_init(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("policy.yaml");
+        std::fs::write(
+            &path,
+            "apiVersion: agent-assembly/v1\n\
+             kind: Policy\n\
+             metadata:\n\
+             \x20 name: run-command-test\n\
+             spec:\n\
+             \x20 tools:\n\
+             \x20   bash:\n\
+             \x20     allow: false\n",
+        )
+        .expect("write policy");
+        (dir, path)
+    });
+    path
+}
+
 /// Args shared by every test here.
 ///
 /// `--no-proxy`: these tests measure child-process spawn and deregistration, not
@@ -302,6 +332,7 @@ fn run_args(tool: &str) -> RunArgs {
         root_agent: None,
         governance_level: None,
         no_proxy: true,
+        policy: Some(test_policy_path().to_path_buf()),
         dry_run: false,
         enforcement_mode: None,
         observe: false,

--- a/aa-cli/tests/run_policy_fail_closed.rs
+++ b/aa-cli/tests/run_policy_fail_closed.rs
@@ -1,0 +1,274 @@
+//! Falsification tests for AAASM-5349: an empty effective policy is
+//! unconfigured, and a governed launch refuses on it.
+//!
+//! These drive the whole `aasm run` path — detect, resolve policy, register,
+//! launch — rather than the resolver in isolation, because the defect being
+//! fixed was not in a resolver. It was that the launch path never asked: it
+//! synthesized an empty `PolicyDocument` inline and carried on. An assertion
+//! that only exercises the resolver would still pass against that bug.
+//!
+//! Every launch here is measured with a [`RecordingAdapter`], so "did not
+//! launch" is an observation rather than an inference from an exit code: a
+//! refusal that happened *after* the tool started would be indistinguishable
+//! from a real refusal if all we checked was the returned `Err`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use aa_cli::commands::run::{execute_with_adapters, RunArgs};
+use aa_core::{AdapterError, DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel, McpServerInfo, PolicyDocument};
+use async_trait::async_trait;
+
+mod gateway_support;
+use gateway_support::{GatewayEnv, TestGateway};
+
+/// Adapter that records whether a launch command was ever built, and what
+/// policy the managed settings were generated from.
+struct RecordingAdapter {
+    launched: Arc<AtomicBool>,
+    rules_seen: Arc<std::sync::Mutex<Option<usize>>>,
+}
+
+impl RecordingAdapter {
+    fn new() -> (Self, Arc<AtomicBool>, Arc<std::sync::Mutex<Option<usize>>>) {
+        let launched = Arc::new(AtomicBool::new(false));
+        let rules_seen = Arc::new(std::sync::Mutex::new(None));
+        (
+            Self {
+                launched: launched.clone(),
+                rules_seen: rules_seen.clone(),
+            },
+            launched,
+            rules_seen,
+        )
+    }
+}
+
+#[async_trait]
+impl DevToolAdapter for RecordingAdapter {
+    fn detect(&self) -> Option<DevToolInfo> {
+        Some(DevToolInfo {
+            kind: DevToolKind::ClaudeCode,
+            version: Some("1.0.0".into()),
+            install_path: PathBuf::from("/usr/bin/echo"),
+            governance_level: GovernanceLevel::L2Enforce,
+            supports_mcp: false,
+            supports_managed_settings: true,
+        })
+    }
+
+    async fn generate_managed_settings(&self, p: &PolicyDocument) -> Result<String, AdapterError> {
+        *self.rules_seen.lock().unwrap() = Some(p.rules.len());
+        Ok("{}".into())
+    }
+
+    async fn apply_settings(&self, _s: &str) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    fn build_launch_command(
+        &self,
+        _args: &[String],
+        _agent_id: &str,
+        _team_id: Option<&str>,
+        _proxy_addr: Option<&str>,
+    ) -> Result<std::process::Command, AdapterError> {
+        self.launched.store(true, Ordering::SeqCst);
+        let mut cmd = std::process::Command::new("echo");
+        cmd.arg("hello");
+        Ok(cmd)
+    }
+
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+        Ok(vec![])
+    }
+
+    async fn apply_mcp_governance(&self, _a: &[String], _d: &[String]) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    fn governance_level(&self) -> GovernanceLevel {
+        GovernanceLevel::L2Enforce
+    }
+}
+
+/// `--policy` is always pinned at a path under this test's own temp dir, so a
+/// developer machine with a real `~/.aasm/policy.yaml` measures the same thing
+/// as a bare CI runner.
+fn args_with_policy(path: PathBuf) -> RunArgs {
+    RunArgs {
+        tool: "echo".into(),
+        tool_args: vec![],
+        agent_id: None,
+        team_id: None,
+        root_agent: None,
+        governance_level: None,
+        no_proxy: true,
+        policy: Some(path),
+        dry_run: false,
+        enforcement_mode: None,
+        observe: false,
+    }
+}
+
+async fn run_with(policy: PathBuf) -> (anyhow::Result<i32>, bool, Option<usize>) {
+    let gateway = TestGateway::start().await.expect("start gateway");
+    let _env = GatewayEnv::point_at(gateway.endpoint());
+
+    let (adapter, launched, rules_seen) = RecordingAdapter::new();
+    let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
+    adapters.insert("echo", Box::new(adapter));
+
+    let result = execute_with_adapters(&args_with_policy(policy), &adapters).await;
+    let seen = *rules_seen.lock().unwrap();
+    (result, launched.load(Ordering::SeqCst), seen)
+}
+
+/// The headline contract: no effective policy, no launch.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_governed_launch_with_no_policy_refuses_and_never_starts_the_tool() {
+    let dir = tempfile::tempdir().unwrap();
+    let (result, launched, rules_seen) = run_with(dir.path().join("absent.yaml")).await;
+
+    let err = result.expect_err("a launch with no effective policy must refuse");
+    assert!(
+        err.to_string().contains("refusing to launch ungoverned"),
+        "the operator must be told the launch was refused; got: {err}"
+    );
+    assert!(
+        !launched,
+        "the tool was started for a session with no policy — the launch is ungoverned"
+    );
+    assert!(
+        rules_seen.is_none(),
+        "managed settings were generated from a policy that does not exist"
+    );
+}
+
+/// An empty-but-valid policy is the exact shape the old `load_policy()`
+/// produced. It must refuse for the same reason an absent one does.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_policy_with_no_rules_refuses_rather_than_launching_permissively() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty.yaml");
+    std::fs::write(&path, "budget:\n  daily_limit_usd: 5.0\n").unwrap();
+
+    let (result, launched, rules_seen) = run_with(path).await;
+
+    let err = result.expect_err("an empty effective policy must refuse");
+    assert!(
+        err.to_string()
+            .contains("An empty policy is unconfigured, not allow-all"),
+        "the refusal must say why an empty policy is not permission; got: {err}"
+    );
+    assert!(!launched, "a policy that governs nothing launched a governed session");
+    assert!(rules_seen.is_none(), "an empty rule list reached the adapter");
+}
+
+/// Refusing is only half the contract — the operator has to be able to act on
+/// it without going to read the source.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_refusal_names_the_remedy() {
+    let dir = tempfile::tempdir().unwrap();
+    let (result, _, _) = run_with(dir.path().join("absent.yaml")).await;
+    let err = result.expect_err("must refuse").to_string();
+
+    assert!(err.contains("--policy"), "must name the flag that supplies one: {err}");
+    assert!(err.contains("AA_POLICY"), "must name the env var: {err}");
+    assert!(
+        err.contains("~/.aasm/policy.yaml"),
+        "must name where an installed policy lives: {err}"
+    );
+    assert!(
+        err.contains("aasm policy validate"),
+        "must name how to check a candidate before re-running: {err}"
+    );
+    assert!(
+        err.contains("allow: true"),
+        "must show the allow-all artifact, or the escape hatch is undiscoverable: {err}"
+    );
+}
+
+/// Permissive execution stays reachable — but only for an operator who wrote
+/// the artifact that says so.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_explicit_allow_all_artifact_launches() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("allow-all.yaml");
+    std::fs::write(&path, aa_cli::commands::run_policy::ALLOW_ALL_TEMPLATE).unwrap();
+
+    let (result, launched, rules_seen) = run_with(path).await;
+
+    assert_eq!(
+        result.expect("an explicit allow-all policy must launch"),
+        0,
+        "the child ran and exited cleanly"
+    );
+    assert!(launched, "an explicitly permissive session must still start the tool");
+    assert_eq!(
+        rules_seen,
+        Some(1),
+        "the wildcard rule must reach the adapter, not an empty list"
+    );
+}
+
+/// A policy with real rules launches and carries those rules to the adapter —
+/// the over-rejection guard for the fail-closed default.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_enforced_policy_launches_and_its_rules_reach_the_adapter() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("enforced.yaml");
+    std::fs::write(
+        &path,
+        "tools:\n  bash:\n    allow: false\n  read_file:\n    allow: true\n",
+    )
+    .unwrap();
+
+    let (result, launched, rules_seen) = run_with(path).await;
+
+    assert_eq!(result.expect("a policy with rules must launch"), 0);
+    assert!(launched);
+    assert_eq!(
+        rules_seen,
+        Some(2),
+        "both tool rules must reach the adapter that renders managed settings"
+    );
+}
+
+/// A broken policy and an absent one are different operator problems. If the
+/// launch path collapsed them, an operator whose file has a typo would be told
+/// to configure a policy they already configured — and the audit trail would
+/// record a corrupted policy as if none had ever been set.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_malformed_policy_refuses_with_a_different_message_than_an_absent_one() {
+    let dir = tempfile::tempdir().unwrap();
+    let broken = dir.path().join("broken.yaml");
+    std::fs::write(&broken, "capabilties:\n  deny:\n    - file_delete\n").unwrap();
+
+    let (broken_result, launched, _) = run_with(broken.clone()).await;
+    let broken_err = broken_result.expect_err("a broken policy must refuse").to_string();
+
+    let (absent_result, _, _) = run_with(dir.path().join("absent.yaml")).await;
+    let absent_err = absent_result.expect_err("an absent policy must refuse").to_string();
+
+    assert!(!launched, "a session with an unloadable policy must not start the tool");
+    assert!(
+        broken_err.contains("could not be loaded"),
+        "a broken policy must be reported as broken; got: {broken_err}"
+    );
+    assert!(
+        broken_err.contains(&broken.display().to_string()),
+        "the refusal must name the file to fix; got: {broken_err}"
+    );
+    assert_ne!(
+        broken_err, absent_err,
+        "a broken policy and an absent one produced the same refusal, so the operator cannot \
+         tell which problem they have"
+    );
+    assert!(
+        !broken_err.contains("An absent policy is not permission"),
+        "a broken policy must not be described as an absent one; got: {broken_err}"
+    );
+}

--- a/aa-integration-tests/tests/cli_run_claude_governed_launch.rs
+++ b/aa-integration-tests/tests/cli_run_claude_governed_launch.rs
@@ -33,6 +33,20 @@
 //! gRPC. So the expectations below are *derived* the way the CLI derives them
 //! rather than picked, and the monitoring claim is read off a real registry.
 //!
+//! # The gates a governed launch passes, and why they are ordered
+//!
+//! `aasm run` refuses on three separate grounds, checked in order: it cannot
+//! vouch for a local proxy (AAASM-5323), no effective policy resolves
+//! (AAASM-5349), or the gateway will not accept the session. Every scenario here
+//! therefore supplies a verified proxy, a policy, and a live gateway — except
+//! the one that is *about* a gate, which supplies the other two so the refusal
+//! it measures is attributable to the gate it names rather than to whichever
+//! check happened to fire first.
+//!
+//! The policies are narrow and enforcing rather than allow-all: this file's
+//! claim is about a *governed* launch, and a session running under a policy that
+//! restricts nothing would make that claim untrue.
+//!
 //! # Safety
 //!
 //! `ClaudeCodeAdapter::new()` resolves its binary with `which claude` and its
@@ -86,6 +100,40 @@ mod governed_launch {
     /// values the session ends up with are derived from them below.
     const AGENT_ID: &str = "aaasm1112-agent";
     const TEAM_ID: &str = "aaasm1112-team";
+
+    /// Write the policy this host's sessions run under and return its path.
+    ///
+    /// Since AAASM-5349 a governed launch refuses when no effective policy
+    /// resolves, so every run here has to supply one — the same way it has to
+    /// supply a gateway and a verified proxy. It is a precondition of the
+    /// scenario, not part of what the scenario measures.
+    ///
+    /// Deliberately a **narrow, enforced** policy rather than the allow-all
+    /// artifact: these tests claim to exercise a *governed* launch, and a
+    /// session running under a policy that restricts nothing would make that
+    /// claim untrue. One real allow and one real deny is the smallest policy
+    /// that is honestly enforcing something.
+    ///
+    /// Passed with `--policy` rather than installed at `$HOME/.aasm/policy.yaml`
+    /// so the run measures the same thing on a developer machine that happens to
+    /// have an operator policy installed and on a bare CI runner.
+    fn write_test_policy(dir: &Path) -> std::io::Result<PathBuf> {
+        let path = dir.join("policy.yaml");
+        std::fs::write(
+            &path,
+            "apiVersion: agent-assembly/v1\n\
+             kind: Policy\n\
+             metadata:\n\
+             \x20 name: aaasm1112-governed-launch\n\
+             spec:\n\
+             \x20 tools:\n\
+             \x20   read_file:\n\
+             \x20     allow: true\n\
+             \x20   shell:\n\
+             \x20     allow: false\n",
+        )?;
+        Ok(path)
+    }
 
     /// A `claude` stand-in that answers `--version` with a supported version and,
     /// when launched, writes the governance variables it can see to a file.
@@ -161,6 +209,7 @@ exit 0
         std::fs::create_dir_all(home.join(".claude"))?;
         std::fs::create_dir_all(&project)?;
         let stub = write_stub_binary(root)?;
+        let policy = write_test_policy(root)?;
         let dump = root.join("child-env.txt");
 
         // `PATH` is prefixed rather than replaced: `build_launch_command`'s
@@ -192,6 +241,8 @@ exit 0
             .args([
                 "run",
                 "claude",
+                "--policy",
+                &policy.to_string_lossy(),
                 "--agent-id",
                 AGENT_ID,
                 "--team-id",
@@ -344,6 +395,7 @@ exit 0
         std::fs::create_dir_all(home.join(".claude"))?;
         std::fs::create_dir_all(&project)?;
         let stub = write_stub_binary(root)?;
+        let policy = write_test_policy(root)?;
         let dump = root.join("child-env.txt");
 
         let path_var = {
@@ -363,7 +415,14 @@ exit 0
             .env("AA_DATA_DIR", proxy.data_dir())
             .env("AA_TEST_ENV_DUMP", &dump)
             .env("AA_GATEWAY_ENDPOINT", format!("http://{dead}"))
-            .args(["run", "claude", "--agent-id", AGENT_ID])
+            .args([
+                "run",
+                "claude",
+                "--policy",
+                &policy.to_string_lossy(),
+                "--agent-id",
+                AGENT_ID,
+            ])
             .output()
             .expect("aasm run claude should execute");
 
@@ -372,10 +431,32 @@ exit 0
             !out.status.success(),
             "a session the gateway never accepted must not exit successfully\nstderr:\n{stderr}",
         );
+
+        // Every gate ahead of registration must be *passed*, not merely present.
+        //
+        // `aasm run` refuses on several grounds, and they are checked in order:
+        // proxy trust, then effective policy, then registration. A run that
+        // tripped an earlier gate would still exit non-zero and still launch
+        // nothing — so it would satisfy this test's other two assertions while
+        // establishing nothing about the registration gate this test is named
+        // for. Pinning the resolved policy state is what makes the refusal below
+        // attributable: the run got past policy resolution, so registration is
+        // the gate that stopped it.
+        assert!(
+            stderr.contains("policy=enforced"),
+            "the run must reach registration with an effective policy in hand; if it refused on \
+             policy instead, the assertion below would pass for the wrong reason and this test \
+             would no longer test what it names:\n{stderr}",
+        );
         assert!(
             stderr.contains("refusing to launch unregistered"),
             "the operator must be told the launch was refused and why, not left to infer it from \
              an exit code:\n{stderr}",
+        );
+        assert!(
+            !stderr.contains("refusing to launch ungoverned"),
+            "the refusal names a policy or proxy failure, not the registration failure this test \
+             exists to measure:\n{stderr}",
         );
         assert!(
             !dump.exists(),
@@ -559,6 +640,33 @@ mod real_binary_governed_launch {
         std::fs::create_dir_all(&project)?;
         std::fs::create_dir_all(&ca_dir)?;
 
+        // ── the policy the session runs under ──────────────────────────────
+        //
+        // A precondition since AAASM-5349, alongside the gateway and the
+        // verified proxy: a launch that resolves no effective policy refuses,
+        // and a refused launch emits no upstream traffic — so without this the
+        // scenario reports NOT MEASURED rather than failing on its own subject.
+        //
+        // Narrow and enforcing rather than allow-all, for the same reason as in
+        // the stub scenario: this file's claim is about a *governed* launch. The
+        // rules name tool permissions, which the adapter renders into Claude's
+        // settings file; they do not gate the provider request whose
+        // interception and redaction is what this test actually measures.
+        let real_policy = root.join("policy.yaml");
+        std::fs::write(
+            &real_policy,
+            "apiVersion: agent-assembly/v1\n\
+             kind: Policy\n\
+             metadata:\n\
+             \x20 name: aaasm1112-real-governed-launch\n\
+             spec:\n\
+             \x20 tools:\n\
+             \x20   read_file:\n\
+             \x20     allow: true\n\
+             \x20   shell:\n\
+             \x20     allow: false\n",
+        )?;
+
         // ── the provider, behind the proxy's own certificate authority ─────
         //
         // One CA for three roles: the mock's leaf is signed by it, the proxy
@@ -655,7 +763,17 @@ mod real_binary_governed_launch {
             .stderr(std::fs::File::create(&stderr_path)?)
             // Its own group, so the tool it launches can be reaped with it.
             .process_group(0)
-            .args(["run", "claude", "--agent-id", AGENT_ID, "--", "-p", &prompt]);
+            .args([
+                "run",
+                "claude",
+                "--policy",
+                &real_policy.to_string_lossy(),
+                "--agent-id",
+                AGENT_ID,
+                "--",
+                "-p",
+                &prompt,
+            ]);
         let mut child = cmd.spawn().expect("aasm run claude should execute");
         let pgid = child.id() as i32;
         let _reaper = GroupReaper(pgid);

--- a/aa-integration-tests/tests/cli_run_claude_launch_env.rs
+++ b/aa-integration-tests/tests/cli_run_claude_launch_env.rs
@@ -58,6 +58,18 @@
 //! register does not happen at all, so these tests would measure nothing without
 //! one. Registration itself is not this file's subject — see
 //! `aa-cli/tests/run_registration_gateway.rs`.
+//!
+//! # The policy is a precondition too
+//!
+//! Since AAASM-5349 a governed launch refuses when no effective policy resolves,
+//! because an unconfigured policy means nobody has said what the agent may do —
+//! which is not the same as everything being permitted. So each run supplies one
+//! with `--policy`, alongside the gateway and the verified proxy. It is narrow
+//! and enforcing rather than allow-all: this file measures a *governed* launch,
+//! and a session under a policy that restricts nothing would not be one. What
+//! the policy says has no bearing on the launch environment asserted below —
+//! tool permissions are rendered into Claude's settings file, not into the
+//! child's environment — so it is a precondition, not a variable.
 
 // `RealHomeGuard` is reused rather than reimplemented: it fingerprints the live
 // settings file on length+mtime and never reads its contents.
@@ -157,6 +169,8 @@ exit 0
         project: PathBuf,
         state_dir: PathBuf,
         dump: PathBuf,
+        /// The effective policy every run of this host launches under.
+        policy: PathBuf,
         path_var: std::ffi::OsString,
     }
 
@@ -177,10 +191,40 @@ exit 0
             parts.extend(std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()));
             let path_var = std::env::join_paths(parts)?;
 
+            // A governed launch refuses when no effective policy resolves
+            // (AAASM-5349), so the host carries one — a precondition of this
+            // scenario in the same way the gateway and the verified proxy are.
+            //
+            // Narrow and enforcing rather than allow-all: this file measures a
+            // *governed* launch, and a session under a policy that restricts
+            // nothing would not be one. The rules name tool permissions, which
+            // the adapter renders into Claude's settings file; they have no
+            // bearing on the launch environment this file actually asserts on.
+            //
+            // Written into the host's own temp root and passed with `--policy`
+            // rather than installed at `$HOME/.aasm/policy.yaml`, so the run
+            // measures the same thing on a developer machine that happens to
+            // have an operator policy installed and on a bare CI runner.
+            let policy = root.join("policy.yaml");
+            std::fs::write(
+                &policy,
+                "apiVersion: agent-assembly/v1\n\
+                 kind: Policy\n\
+                 metadata:\n\
+                 \x20 name: aaasm5327-launch-env\n\
+                 spec:\n\
+                 \x20 tools:\n\
+                 \x20   read_file:\n\
+                 \x20     allow: true\n\
+                 \x20   shell:\n\
+                 \x20     allow: false\n",
+            )?;
+
             Ok(Self {
                 _tmp: tmp,
                 state_dir: root.join("state"),
                 dump: root.join("child-env.txt"),
+                policy,
                 root,
                 home,
                 project,
@@ -224,7 +268,16 @@ exit 0
                 // before anything is launched, so a run that measured nothing
                 // here would be a run that never got past the gate.
                 .env("AA_GATEWAY_ENDPOINT", gateway.endpoint())
-                .args(["run", "claude", "--agent-id", AGENT_ID, "--team-id", TEAM_ID])
+                .args([
+                    "run",
+                    "claude",
+                    "--policy",
+                    &self.policy.to_string_lossy(),
+                    "--agent-id",
+                    AGENT_ID,
+                    "--team-id",
+                    TEAM_ID,
+                ])
                 .output()
                 .expect("aasm run claude should execute");
 


### PR DESCRIPTION
## Description

Implements **AAASM-5349** (owner Decision 4, Option A): an empty effective policy means **unconfigured** and a governed launch **fails closed**.

## The defect was worse than the ticket said

`load_policy()` returned a hard-coded empty rule set. I wrote that up as "enforces no policy rules." It is worse than that.

`aa-devtool-claude-code/src/settings.rs:51-58` derives the mode from the rules:

```rust
let permission_mode = if has_require_approval { "plan" }
                      else if has_deny        { "default" }
                      else                    { "acceptEdits" };
```

An empty policy has neither, so `aasm run` shipped **`permissionMode: "acceptEdits"`** to Claude Code — which auto-accepts file edits, where the tool's own default prompts. **A user running `aasm run` got *less* protection than running `claude` directly, while the receipt reported a successful governed launch.**

That is not "governance absent." It is governance actively loosening the tool's built-in posture and claiming credit for it.

## The four states

New `aa-cli/src/commands/run_policy.rs`:

```rust
enum PolicyResolution {
    Enforced { source, document },
    Permissive { source, document },
    Unconfigured(Unconfigured),   // NoSource{searched} | EmptyDocument{source}
    LoadFailed { source, detail },
}
```

Neither a bare rule list nor `Option<PolicyDocument>` can carry this: each variant obliges a different response, and the two refusing ones need different text. `Unconfigured` sub-splits because an operator who never configured a policy needs sending to the concept, while one whose file is empty needs sending to their file. `LoadFailed` stays top-level deliberately — **a corrupted policy presenting as "never configured" is exactly what an attacker corrupting a policy file would want.**

The adapter still receives `aa_core::PolicyDocument`; the trait signature is untouched, so blast radius stays inside `aa-cli`.

## The explicit allow-all artifact

No new config surface — an ordinary policy YAML whose tool ruleset is the wildcard:

```yaml
apiVersion: agent-assembly/v1
kind: Policy
metadata: {name: allow-all}
spec: {tools: {"*": {allow: true}}}
```

Selected by `--policy FILE` → `$AA_POLICY` → `~/.aasm/policy.yaml` → `~/.aasm/policies/` → `/etc/aasm/policy.yaml` → `/etc/aasm/policies/` — **the exact order `aasm gateway start` already uses**, so the two commands cannot disagree about where a host's policy lives.

Deliberately **not** a `permissive: true` switch: a switch is easy to flip without reading what it turns off. Writing the wildcard out is the smallest unambiguously deliberate act, and it validates through the same `PolicyValidator` as any other policy. Permissive also requires the *conjunction* — a wildcard-allow beside a network allowlist classifies as `enforced`, never `permissive`.

## The refusal an operator sees

```
policy=unconfigured — no policy artifact found; a governed launch is refused
error: refusing to launch ungoverned: no effective policy is configured, so this
session would run under no rules at all. An absent policy is not permission.

Searched, in order: --policy /does/not/exist.yaml

Supply a policy, then re-run:
  aasm run --policy <FILE> <tool>
  AA_POLICY=<FILE> aasm run <tool>
  install one at ~/.aasm/policy.yaml (or /etc/aasm/policy.yaml)
Check it first with: aasm policy validate <FILE>

If you intend this agent to be unrestricted, say so explicitly with an allow-all artifact:
    apiVersion: agent-assembly/v1
    kind: Policy
    ...
```

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature (four-state resolution)

## Breaking Changes

- [x] Yes — **`aasm run` now refuses when no policy resolves.** Previously it launched with an empty policy and a loosened `permissionMode`. Nothing that was genuinely governed stops working; what stops is a launch that reported governance it did not have.

## Related Issues

- Related Jira ticket: AAASM-5349

## Testing

**16 mutations, all killed.** Highlights:

| Mutation | Verbatim failure |
|---|---|
| **M13 — regress to the original defect** | kills all 6 fail-closed tests: `a launch with no effective policy must refuse: 0` · `the wildcard rule must reach the adapter, not an empty list` |
| **M4 — collapse four states into ok/not_ok** | `the four states must be four distinct values in AA_POLICY_STATE, not collapsed into ok/not-ok` |
| **M12b — receipt flattens enforced/permissive** | `states enforced and enforced render an identical policy receipt, so an operator cannot tell them apart` |
| M2 — LoadFailed→Unconfigured | `a policy that cannot be parsed is a broken artifact, not an absent one` |
| M17 — over-rejection | `an explicit allow-all policy must launch` |

**Worth reading M4 closely.** It killed the env-var test but **not** the receipt test, because the receipt's detail line still differed. That was not accepted as sufficient — M12 and M12b were added to prove the receipt test load-bearing in both directions (state named; states pairwise distinct). A four-variant enum that every consumer collapses into "ok / not ok" satisfies the type system and not the contract, and that was the specific trap here.

Gates: `cargo fmt --all` clean; `cargo clippy -p aa-cli --all-targets --all-features -- -D warnings` clean; `aa-cli` **951/951**.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Contract point 6 — partially met, reported not faked

Audit and receipt distinguish all four states, verified live: stderr banner, dry-run `--- policy ---` receipt, and `AA_POLICY_STATE` / `AA_POLICY_SOURCE` in the child environment.

**`aasm status` and `aasm integrations verify` are not covered.** `status` has no per-session effective-policy field at all today — it reports gateway-side aggregates — and adding one needs `status/{models,fetch,render}.rs` plus a gateway-side source of truth, all outside this lane. `verify` is about integration-receipt drift, an unrelated axis. Stopped and reported rather than reaching into another lane's files. **That residue wants its own ticket.**

## Sequencing

The `--no-proxy` lane (**AAASM-5350**) changes the same protection-reporting surface and lands behind this. Contact points were deliberately minimised: `build_child_env`'s signature is unchanged — the policy env is applied by `resolution.annotate_env(&mut child_env)` after it returns — so the overlap is one added `RunArgs` field and one line at each of two call sites.

## Found, not fixed

- **Directory cascade is refused, not merged.** `~/.aasm/policies/` is searched so `run` and `gateway start` agree on locations, but a directory source resolves to `load_failed` explaining that `run` renders one effective document. Fail-closed and honest; an operator using the cascade must pass `--policy FILE`.
- **Only the `tools:` dimension reaches managed settings.** `network`/`budget`/`capabilities` are validated and gate the permissive classification, but a dev-tool adapter has nowhere to put them — the gateway and proxy enforce those. Pre-existing.
- **Branch name carries `AAASM-5344`**, a placeholder key I supplied before the ticket existed. All four commit trailers say `AAASM-5349`; the remote branch is named correctly. Not rewritten, because that would need a force-push.
- **Unrelated environmental failure:** `aa-gateway … apply_good_succeeds_and_is_idempotent_on_postgres` fails with `initdb: … pg_wal: No space left on device`. The Docker VM is out of disk. This diff touches zero `aa-gateway` files.
