### PR TITLE
[AAASM-5346] 🐛 (aa-runtime): Preserve non-UTF-8 and chunk-split payloads on redaction write-back

### DIFF
--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -103,7 +103,15 @@ impl EnforcementConfig {
 /// Carries only finding metadata (kind + offset + redacted label) — never a
 /// raw secret. Consumed by the metrics layer (AAASM-2585) and the verification
 /// suite (AAASM-2587).
+///
+/// `#[non_exhaustive]` because this struct records *what enforcement did*, and
+/// that vocabulary keeps growing — `undecodable_fields` (AAASM-5346) is the
+/// latest, and the ADR 0032 `sensitive_data_disposition` work will add more.
+/// Without it every such addition is a semver break for any out-of-crate struct
+/// literal. Construct it with [`Default`] and functional-update syntax
+/// (`..Default::default()`); field *reads* are unaffected (AAASM-5346).
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct EnforcementOutcome {
     /// Every credential finding across all scanned fields of the event.
     pub findings: Vec<CredentialFinding>,

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -451,6 +451,22 @@ mod tests {
     /// signature of the AAASM-5346 corruption bug.
     const REPLACEMENT_CHAR: &[u8] = "\u{FFFD}".as_bytes();
 
+    /// Traditional-Chinese sample: eight 3-byte characters, so every character
+    /// boundary is a candidate chunk-split point.
+    const CJK: &str = "台北市政府資訊局";
+
+    /// [`CJK`] with its first and last bytes shaved off, so a 3-byte character is
+    /// cut in half at **both** ends — exactly what a stream chunk boundary does
+    /// to multi-byte text. Invalid UTF-8 in isolation, valid in aggregate.
+    fn chunk_split_cjk() -> Vec<u8> {
+        let bytes = CJK.as_bytes();
+        assert!(
+            std::str::from_utf8(&bytes[1..bytes.len() - 1]).is_err(),
+            "fixture must be invalid UTF-8 or it does not exercise the split path"
+        );
+        bytes[1..bytes.len() - 1].to_vec()
+    }
+
     /// Byte-level substring search — the AAASM-5346 assertions must run over raw
     /// `Vec<u8>`, never a lossy `String` view of it, or they would compare the
     /// very decoding that causes the bug and pass either way.
@@ -649,6 +665,33 @@ mod tests {
         assert!(
             !outcome.is_clean(),
             "fail-closed: never reported as a clean pass-through"
+        );
+    }
+
+    /// AAASM-5346: a multi-byte character cut by a chunk boundary makes the
+    /// payload invalid UTF-8. With no finding present nothing may be written
+    /// back, so the bytes must survive exactly — compared as `Vec<u8>`, never as
+    /// a lossy `String`.
+    #[test]
+    fn chunk_split_multibyte_clean_payload_round_trips_byte_identically() {
+        let scanner = RuntimeScanner::new();
+        let original = chunk_split_cjk();
+        let mut event = event_with(Detail::ToolCall(ToolCallDetail {
+            args_json: original.clone(),
+            ..Default::default()
+        }));
+
+        let outcome = scanner.enforce(&mut event);
+
+        assert_eq!(
+            args_json_of(event),
+            original,
+            "a clean split payload must round-trip byte-identically"
+        );
+        assert!(outcome.is_clean());
+        assert_eq!(
+            outcome.undecodable_fields, 0,
+            "a clean payload is not a coarse redaction"
         );
     }
 

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -446,6 +446,36 @@ mod tests {
     /// A GitHub PAT — detected via the `ghp_` literal pattern.
     const GH_PAT: &str = "ghp_0123456789abcdefABCDEF0123456789abcd";
 
+    /// UTF-8 encoding of U+FFFD, the character `from_utf8_lossy` substitutes for
+    /// every byte it cannot decode. Its presence in an output payload is the
+    /// signature of the AAASM-5346 corruption bug.
+    const REPLACEMENT_CHAR: &[u8] = "\u{FFFD}".as_bytes();
+
+    /// Byte-level substring search — the AAASM-5346 assertions must run over raw
+    /// `Vec<u8>`, never a lossy `String` view of it, or they would compare the
+    /// very decoding that causes the bug and pass either way.
+    fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+        !needle.is_empty() && haystack.windows(needle.len()).any(|w| w == needle)
+    }
+
+    /// A genuinely binary payload wrapping a synthetic secret: a PNG signature,
+    /// a `0xFF 0xFE` pair no UTF-8 decoder accepts, and a truncated 2-byte
+    /// sequence plus a lone continuation byte at the tail.
+    fn binary_payload_with_secret() -> Vec<u8> {
+        let mut payload = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0xFF, 0xFE];
+        payload.extend_from_slice(AWS_KEY.as_bytes());
+        payload.extend_from_slice(&[0x00, 0xC3, 0x28, 0x80]);
+        payload
+    }
+
+    /// Extract the `args_json` payload from an event whose detail is a ToolCall.
+    fn args_json_of(event: EnrichedEvent) -> Vec<u8> {
+        let Some(Detail::ToolCall(tc)) = event.inner.detail else {
+            unreachable!("detail was a ToolCall");
+        };
+        tc.args_json
+    }
+
     /// Build an [`EnrichedEvent`] wrapping `detail` with throwaway metadata.
     fn event_with(detail: Detail) -> EnrichedEvent {
         EnrichedEvent {
@@ -586,6 +616,40 @@ mod tests {
         assert!(outcome.is_clean());
         assert!(outcome.findings.is_empty());
         assert_eq!(outcome.scanned_bytes, original.len());
+    }
+
+    /// AAASM-5346: the write-back used to splice a lossy decoding over the
+    /// caller's bytes, so a binary payload carrying a secret came back riddled
+    /// with U+FFFD. It must now be dropped whole instead — fail-closed, and
+    /// never a half-rewritten buffer the caller cannot detect.
+    #[test]
+    fn binary_payload_with_secret_is_dropped_whole_never_corrupted() {
+        let scanner = RuntimeScanner::new();
+        let mut event = event_with(Detail::ToolCall(ToolCallDetail {
+            args_json: binary_payload_with_secret(),
+            ..Default::default()
+        }));
+
+        let outcome = scanner.enforce(&mut event);
+
+        let out = args_json_of(event);
+        assert!(!contains(&out, AWS_KEY.as_bytes()), "raw secret must not survive");
+        assert!(
+            !contains(&out, REPLACEMENT_CHAR),
+            "payload was corrupted: U+FFFD spliced into the output"
+        );
+        assert_eq!(
+            out,
+            UNDECODABLE_MARKER.as_bytes(),
+            "an undecodable dirty payload is replaced whole, not partially rewritten"
+        );
+        assert_eq!(outcome.undecodable_fields, 1, "the coarse redaction is recorded");
+        assert!(outcome.has_undecodable_fields());
+        assert!(!outcome.findings.is_empty(), "the decision was made, not skipped");
+        assert!(
+            !outcome.is_clean(),
+            "fail-closed: never reported as a clean pass-through"
+        );
     }
 
     #[test]

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -891,6 +891,27 @@ mod tests {
         assert!(!rendered.contains(AWS_KEY));
     }
 
+    /// AAASM-5346: dropping a payload whole because it could not be decoded is a
+    /// coarser redaction than configured, so operators get a dedicated counter
+    /// rather than having it disappear into the generic finding metric.
+    #[test]
+    fn enforce_emits_undecodable_metric() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        ::metrics::with_local_recorder(&recorder, || {
+            let scanner = RuntimeScanner::new();
+            let mut event = event_with(Detail::ToolCall(ToolCallDetail {
+                args_json: binary_payload_with_secret(),
+                ..Default::default()
+            }));
+            scanner.enforce(&mut event);
+        });
+
+        let rendered = handle.render();
+        assert!(rendered.contains("aa_runtime_scan_undecodable_total"));
+        assert!(!rendered.contains(AWS_KEY), "the raw secret never reaches a metric");
+    }
+
     #[test]
     fn from_runtime_config_maps_size_cap_and_keeps_fail_closed_policy() {
         let rc = RuntimeConfig {

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -101,7 +101,13 @@ pub struct EnforcementOutcome {
     pub findings: Vec<CredentialFinding>,
     /// Number of fields that hit the size cap and were redacted whole.
     pub oversized_fields: usize,
-    /// Total bytes actually handed to the scanner across all fields.
+    /// Total **input** bytes inspected across all fields.
+    ///
+    /// Counted from the field as it arrived, never from a decoded form of it:
+    /// `String::from_utf8_lossy` expands every invalid byte into a 3-byte
+    /// U+FFFD, so counting the decoded length would inflate this figure — and
+    /// the `aa_runtime_scan_payload_bytes` histogram it feeds — by up to 3x for
+    /// a binary payload (AAASM-5346).
     pub scanned_bytes: usize,
     /// Number of SDK-supplied trust-marker labels (see [`TRUST_MARKER_LABELS`])
     /// that were stripped from the event — i.e. forgery attempts the runtime
@@ -285,9 +291,12 @@ impl RuntimeScanner {
             self.apply_oversized_bytes(field, outcome);
             return;
         }
+        // Count the payload as it arrived. `from_utf8_lossy` below can expand
+        // it (each invalid byte becomes a 3-byte U+FFFD), and the accounting
+        // must describe the payload, not an artefact of decoding it.
+        outcome.scanned_bytes += field.len();
         // Normalize: a `bytes` payload is scanned as lossy UTF-8 text.
         let text = String::from_utf8_lossy(field);
-        outcome.scanned_bytes += text.len();
         let result = self.scanner.scan(&text);
         if !result.is_clean() {
             let redacted = result.redact(&text);

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -733,6 +733,15 @@ mod tests {
             !contains(&out, REPLACEMENT_CHAR),
             "surviving bytes must not carry U+FFFD"
         );
+        // Pin the actual disposition. The U+FFFD assertion above is necessary
+        // but not sufficient: once the field is dropped whole, *nothing*
+        // survives, so that check alone would pass trivially and would keep
+        // passing if the branch silently changed to emit something else.
+        assert_eq!(
+            out,
+            UNDECODABLE_MARKER.as_bytes(),
+            "the split payload is replaced whole, exactly as the binary case is"
+        );
         assert_eq!(outcome.undecodable_fields, 1);
         assert!(!outcome.is_clean());
     }

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -695,6 +695,32 @@ mod tests {
         );
     }
 
+    /// AAASM-5346: the same split payload *with* a synthetic secret. Pre-fix the
+    /// surviving CJK bytes came back as U+FFFD; the flagged payload must now be
+    /// handled without any replacement character reaching the output.
+    #[test]
+    fn chunk_split_multibyte_payload_with_secret_introduces_no_replacement_char() {
+        let scanner = RuntimeScanner::new();
+        let mut payload = chunk_split_cjk();
+        payload.extend_from_slice(format!(" key={AWS_KEY} ").as_bytes());
+        payload.extend_from_slice(&chunk_split_cjk());
+        let mut event = event_with(Detail::ToolCall(ToolCallDetail {
+            args_json: payload,
+            ..Default::default()
+        }));
+
+        let outcome = scanner.enforce(&mut event);
+
+        let out = args_json_of(event);
+        assert!(!contains(&out, AWS_KEY.as_bytes()), "raw secret must not survive");
+        assert!(
+            !contains(&out, REPLACEMENT_CHAR),
+            "surviving bytes must not carry U+FFFD"
+        );
+        assert_eq!(outcome.undecodable_fields, 1);
+        assert!(!outcome.is_clean());
+    }
+
     #[test]
     fn oversized_field_is_redacted_whole_fail_closed() {
         let scanner = RuntimeScanner::with_config(EnforcementConfig {

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -307,11 +307,32 @@ impl RuntimeScanner {
         }
     }
 
-    /// Normalize a `bytes` field to UTF-8, then scan and redact it in place.
+    /// Scan a `bytes` field and redact it in place without ever corrupting it
+    /// (AAASM-5346).
     ///
-    /// The original bytes are left untouched when the field is clean; they are
-    /// rewritten (from the normalized, redacted text) only when a finding is
-    /// present.
+    /// Every payload is scanned — an undecodable one is *never* waved through,
+    /// because skipping the write-back must never mean skipping the decision.
+    /// What differs is how a dirty payload is repaired:
+    ///
+    /// * **Valid UTF-8** — finding offsets are byte offsets into `field` itself,
+    ///   so [`ScanResult::redact`] splices exactly the flagged spans and every
+    ///   other byte survives verbatim.
+    /// * **Not valid UTF-8** (binary body, or a multi-byte character cut by a
+    ///   chunk boundary) — the scan runs against a lossy decoding, in which each
+    ///   invalid byte has become a 3-byte U+FFFD. Those offsets do not map back
+    ///   onto `field`, so no faithful splice exists. Writing the decoded text
+    ///   back would replace the caller's bytes with replacement characters —
+    ///   silent corruption, and the bug this method was rewritten to fix.
+    ///
+    ///   ADR 0015 §1 already decides this case ("caller text ≠ scanned text"):
+    ///   redaction degrades to an opaque whole-value replacement rather than
+    ///   passing the original through. Leaving the payload alone would forward a
+    ///   detected secret in the clear — a fail-open — so the field is dropped
+    ///   whole into [`UNDECODABLE_MARKER`] and counted in
+    ///   [`EnforcementOutcome::undecodable_fields`], mirroring the
+    ///   [`OversizedPolicy::RedactWhole`] precedent.
+    ///
+    /// A clean payload is left byte-identical in both branches.
     fn scan_bytes(&self, field: &mut Vec<u8>, outcome: &mut EnforcementOutcome) {
         if field.is_empty() {
             return;
@@ -320,17 +341,38 @@ impl RuntimeScanner {
             self.apply_oversized_bytes(field, outcome);
             return;
         }
-        // Count the payload as it arrived. `from_utf8_lossy` below can expand
-        // it (each invalid byte becomes a 3-byte U+FFFD), and the accounting
-        // must describe the payload, not an artefact of decoding it.
+        // Count the payload as it arrived. Lossy decoding can expand it (each
+        // invalid byte becomes a 3-byte U+FFFD), and the accounting must
+        // describe the payload, not an artefact of decoding it.
         outcome.scanned_bytes += field.len();
-        // Normalize: a `bytes` payload is scanned as lossy UTF-8 text.
-        let text = String::from_utf8_lossy(field);
-        let result = self.scanner.scan(&text);
-        if !result.is_clean() {
-            let redacted = result.redact(&text);
-            *field = redacted.into_bytes();
-            outcome.findings.extend(result.findings);
+
+        // Computed inside the match so the immutable borrow of `field` taken by
+        // the decode ends before the write-back below.
+        let replacement: Option<Vec<u8>> = match std::str::from_utf8(field) {
+            Ok(text) => {
+                let result = self.scanner.scan(text);
+                if result.is_clean() {
+                    None
+                } else {
+                    let redacted = result.redact(text).into_bytes();
+                    outcome.findings.extend(result.findings);
+                    Some(redacted)
+                }
+            }
+            Err(_) => {
+                let text = String::from_utf8_lossy(field);
+                let result = self.scanner.scan(&text);
+                if result.is_clean() {
+                    None
+                } else {
+                    outcome.findings.extend(result.findings);
+                    outcome.undecodable_fields += 1;
+                    Some(UNDECODABLE_MARKER.as_bytes().to_vec())
+                }
+            }
+        };
+        if let Some(bytes) = replacement {
+            *field = bytes;
         }
     }
 

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -373,6 +373,14 @@ impl RuntimeScanner {
                 if result.is_clean() {
                     None
                 } else {
+                    // These findings are **kind-only**. Their `offset` / `end`
+                    // index the lossy decoding, so they match neither the input
+                    // bytes nor the marker that replaces them. Nothing consumes
+                    // the spans today (the metrics layer reads `kind`, and
+                    // redaction already happened above), but a future consumer
+                    // must not treat them as positions in the payload. They are
+                    // kept rather than dropped because *what kind* of secret was
+                    // found is the audit-relevant fact.
                     outcome.findings.extend(result.findings);
                     outcome.undecodable_fields += 1;
                     Some(UNDECODABLE_MARKER.as_bytes().to_vec())

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -747,6 +747,41 @@ mod tests {
         );
     }
 
+    /// AAASM-5346 guard on the *unchanged* path: a payload that is valid UTF-8
+    /// still gets a precise per-finding splice, so multi-byte text around the
+    /// secret survives byte-for-byte rather than being dropped whole.
+    #[test]
+    fn valid_utf8_multibyte_payload_keeps_surrounding_bytes_on_redaction() {
+        let scanner = RuntimeScanner::new();
+        let payload = format!("{CJK} key={AWS_KEY} {CJK}");
+        let mut event = event_with(Detail::ToolCall(ToolCallDetail {
+            args_json: payload.into_bytes(),
+            ..Default::default()
+        }));
+
+        let outcome = scanner.enforce(&mut event);
+
+        let out = args_json_of(event);
+        assert!(!contains(&out, AWS_KEY.as_bytes()), "raw secret must not survive");
+        assert!(
+            !contains(&out, REPLACEMENT_CHAR),
+            "no lossy substitution on a valid payload"
+        );
+        assert!(
+            contains(&out, CJK.as_bytes()),
+            "CJK bytes either side of the secret must survive verbatim"
+        );
+        assert!(
+            contains(&out, b"[REDACTED:"),
+            "a precise splice, not a whole-field drop"
+        );
+        assert_eq!(
+            outcome.undecodable_fields, 0,
+            "a decodable payload is repaired precisely, not coarsely"
+        );
+        assert!(!outcome.is_clean());
+    }
+
     #[test]
     fn oversized_field_is_redacted_whole_fail_closed() {
         let scanner = RuntimeScanner::with_config(EnforcementConfig {

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -109,6 +109,17 @@ pub struct EnforcementOutcome {
     pub findings: Vec<CredentialFinding>,
     /// Number of fields that hit the size cap and were redacted whole.
     pub oversized_fields: usize,
+    /// Number of `bytes` fields that carried a finding but could not be decoded
+    /// as UTF-8, and so were redacted whole rather than spliced (AAASM-5346).
+    ///
+    /// Records the payload as *inspected but not precisely transformable*. It is
+    /// a counter on this internal outcome, **not** a verdict: decision D-2
+    /// (ADR 0032 §10) freezes [`RuntimeVerdict`], and the finer disposition
+    /// vocabulary belongs to the future additive `sensitive_data_disposition`
+    /// field, which this counter is intended to feed.
+    ///
+    /// [`RuntimeVerdict`]: https://github.com/ai-agent-assembly/agent-assembly/blob/main/docs/src/adr/0018-canonical-runtime-verdict-and-enriched-decision-record.md
+    pub undecodable_fields: usize,
     /// Total **input** bytes inspected across all fields.
     ///
     /// Counted from the field as it arrived, never from a decoded form of it:
@@ -135,8 +146,18 @@ impl EnforcementOutcome {
     }
 
     /// Total number of redactions applied (findings + oversized fields).
+    ///
+    /// `undecodable_fields` is deliberately **not** added: such a field is only
+    /// counted when it produced at least one finding, so it is already included
+    /// via `findings.len()`. Adding it here would double-count (AAASM-5346).
     pub fn redaction_count(&self) -> usize {
         self.findings.len() + self.oversized_fields
+    }
+
+    /// `true` when at least one field was scanned dirty but could not be decoded
+    /// well enough to splice, and was therefore dropped whole.
+    pub fn has_undecodable_fields(&self) -> bool {
+        self.undecodable_fields > 0
     }
 
     /// `true` when at least one forged SDK trust-marker label was stripped.

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -43,6 +43,14 @@ pub const DEFAULT_MAX_FIELD_BYTES: usize = 64 * 1024;
 /// Replacement written into a field that exceeded the configured size cap.
 pub const OVERSIZED_MARKER: &str = "[REDACTED:OVERSIZED]";
 
+/// Replacement written into a `bytes` field that carries a finding but cannot be
+/// decoded as UTF-8, so no faithful per-finding splice exists (AAASM-5346).
+///
+/// Distinct from [`OVERSIZED_MARKER`] because the reason differs and operators
+/// need to tell them apart: oversized means *not fully scanned*, undecodable
+/// means *scanned, found dirty, but not precisely repairable*.
+pub const UNDECODABLE_MARKER: &str = "[REDACTED:UNDECODABLE]";
+
 /// Behaviour when a secret-bearing field exceeds [`EnforcementConfig::max_field_bytes`].
 ///
 /// The runtime is a security gate, so the policy is **fail-closed**: an

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -721,6 +721,32 @@ mod tests {
         assert!(!outcome.is_clean());
     }
 
+    /// AAASM-5346: `scanned_bytes` counted the *lossy* decoding, which expands
+    /// each invalid byte into a 3-byte U+FFFD — over-reporting a binary payload
+    /// by up to 3x in the `aa_runtime_scan_payload_bytes` histogram.
+    #[test]
+    fn scanned_bytes_counts_input_bytes_not_the_lossy_expansion() {
+        let scanner = RuntimeScanner::new();
+        let original = chunk_split_cjk();
+        let lossy_len = String::from_utf8_lossy(&original).len();
+        assert!(
+            lossy_len > original.len(),
+            "fixture must actually expand under lossy decoding, else it proves nothing"
+        );
+        let mut event = event_with(Detail::ToolCall(ToolCallDetail {
+            args_json: original.clone(),
+            ..Default::default()
+        }));
+
+        let outcome = scanner.enforce(&mut event);
+
+        assert_eq!(
+            outcome.scanned_bytes,
+            original.len(),
+            "scanned_bytes must describe the payload, not its decoding"
+        );
+    }
+
     #[test]
     fn oversized_field_is_redacted_whole_fail_closed() {
         let scanner = RuntimeScanner::with_config(EnforcementConfig {

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -421,6 +421,12 @@ fn emit_metrics(outcome: &EnforcementOutcome, elapsed: Duration) {
     if outcome.oversized_fields > 0 {
         ::metrics::counter!("aa_runtime_scan_oversized_total").increment(outcome.oversized_fields as u64);
     }
+    // A payload dropped whole because it could not be decoded is a *coarser*
+    // redaction than the operator asked for, so it must be visible rather than
+    // hidden inside the generic finding counter (AAASM-5346).
+    if outcome.undecodable_fields > 0 {
+        ::metrics::counter!("aa_runtime_scan_undecodable_total").increment(outcome.undecodable_fields as u64);
+    }
     for finding in &outcome.findings {
         ::metrics::counter!("aa_runtime_scan_findings_total", "kind" => finding.kind.as_str()).increment(1);
     }

--- a/docs/src/architecture/workflows.md
+++ b/docs/src/architecture/workflows.md
@@ -192,7 +192,10 @@ Key invariants from `aa-runtime/src/pipeline/enforcement.rs`:
   `already_scanned` / `clean` wire marker, and none is honoured.
 - Enforcement is **fail-closed**: a field larger than `max_field_bytes`
   (default 64 KiB) cannot be fully scanned, so it is redacted *whole*
-  (`[REDACTED:OVERSIZED]`) rather than partially forwarded.
+  (`[REDACTED:OVERSIZED]`) rather than partially forwarded. Likewise a `bytes`
+  field that is not valid UTF-8 is scanned but cannot be spliced faithfully, so a
+  finding redacts it *whole* (`[REDACTED:UNDECODABLE]`); when it is clean it is
+  forwarded byte-identical.
 - The credential scanner / redaction primitives come from the `aa-security`
   leaf crate.
 

--- a/docs/src/devtools/limitations.md
+++ b/docs/src/devtools/limitations.md
@@ -265,7 +265,7 @@ unrecognised — a bespoke internal token, a secret with no distinguishing prefi
 a value split across fields. There is no claim of complete detection, and the
 Spike explicitly does not license one.
 
-Two knock-on limits worth stating:
+Three knock-on limits worth stating:
 
 * **An undetected secret is not absent from audit records.** If the scanner never
   classified a value as a secret, it was never redacted, and it may appear in a

--- a/docs/src/devtools/limitations.md
+++ b/docs/src/devtools/limitations.md
@@ -273,6 +273,26 @@ Two knock-on limits worth stating:
 * **Redaction is not encryption and not a DLP product.** An oversized field that
   cannot be scanned reliably is replaced wholesale with `[REDACTED:OVERSIZED]` —
   the scanner fails closed — but that is a containment behaviour, not detection.
+* **A flagged undecodable payload loses its whole audit content.** A `bytes` field
+  that is not valid UTF-8 — a binary body, or multi-byte text cut by a chunk
+  boundary — is still scanned, but a detected secret cannot be excised precisely,
+  because the finding's offsets index the lossy decoding rather than the payload.
+  The field is therefore replaced *in full* with `[REDACTED:UNDECODABLE]`. The
+  secret is contained, but so is everything else that was in the field: the
+  surrounding content does not reach the audit record. A **clean** undecodable
+  field is unaffected and is forwarded byte-identical (AAASM-5346).
+
+  **This is sharper for `zh-TW` traffic until [AAASM-5344] ships.** That defect
+  makes ordinary Chinese text register as `GenericHighEntropy` findings, so a
+  chunk-split Chinese payload is *dirty by false positive* and loses its entire
+  `args_json` to the 22-byte marker — where previously it was forwarded corrupted
+  but present. Containment is the correct trade, and a corrupted payload was
+  never trustworthy audit content, but the loss is real and it is why ADR 0032's
+  operational guidance treats `zh-TW` traffic as unsafe until AAASM-5344 lands in
+  `v0.0.1-rc.7`. Once it does, benign Chinese text stops producing findings and
+  this path stops being reached by ordinary traffic.
+
+[AAASM-5344]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5344
 
 ## Hooks cannot carry a sensitive-data claim
 

--- a/docs/src/devtools/product-brief.md
+++ b/docs/src/devtools/product-brief.md
@@ -378,6 +378,7 @@ reachable from a profile:
 | **`EnforcementMode`** | `Enforce` | `Enforce` | `Observe` |
 | **Sensitive-data finding on a model-bound path** | **Redact and proceed.** The match is replaced with a `[REDACTED:<kind>]` placeholder and the request continues (`aa-security` `redact()`; policy pipeline Stage 6 redacts and never denies). | **Redact and proceed by default; block the request when the finding is in a configured high-severity class** — _planned_ (`AAASM-5277`, `AAASM-5281`). Blocking on a scanner finding is **not** core behaviour today; Stage 6 redacts unconditionally. Until that lands, `Strict` differs from `Recommended` on the other four rows only. | **Record only.** The finding is audited; the payload is forwarded unchanged. |
 | **Unscannable (oversized) field** | Replaced wholesale with `[REDACTED:OVERSIZED]` — fail-closed (`aa-runtime` `OversizedPolicy::RedactWhole`). | Same. | Recorded; forwarded unchanged, because `Observe` applies nothing. |
+| **Undecodable field with a finding** | A `bytes` field that is not valid UTF-8 (a binary body, or multi-byte text cut by a chunk boundary) is still scanned, but a detected secret cannot be spliced out precisely — the finding's offsets index the lossy decoding, not the payload. The field is replaced wholesale with `[REDACTED:UNDECODABLE]` — fail-closed (`aa-runtime`, ADR 0015 §1). A **clean** undecodable field is forwarded byte-identical. | Same. | Recorded; forwarded unchanged, because `Observe` applies nothing. |
 | **Approval posture** | Approval required only where policy declares it (`requires_approval_if` → `RequireApproval`). Pending halts execution until decided. | Approval required for the declared cases **plus** destructive tool classes; an approval that times out resolves as deny. | No approval prompts. A would-be `RequireApproval` is audited as a shadow decision and the action proceeds. |
 | **Network egress** | Policy allowlist enforced at Stage 2 and at the wire by `aa-proxy`; hosts outside a non-empty allowlist are denied. | Same enforcement, with a narrower default allowlist: model provider endpoints and the local gateway only. | Egress evaluated and audited; nothing blocked. |
 | **Budget** | Enforced (`action_on_exceed`, default `Deny`). | Enforced; `Suspend` available. | Tracked and audited; not enforced. |
@@ -485,7 +486,10 @@ Two words carry weight throughout and are used precisely:
 > **We guarantee:** on supported model-bound paths, content is scanned before it leaves the
 > machine, and every detected secret is replaced with a `[REDACTED:<kind>]` placeholder so the raw
 > value is not transmitted. A field too large to scan reliably is replaced wholesale with
-> `[REDACTED:OVERSIZED]` rather than forwarded — the scanner fails closed. The agent still
+> `[REDACTED:OVERSIZED]` rather than forwarded — the scanner fails closed. A field that cannot
+> be decoded as UTF-8 and carries a finding is likewise replaced wholesale, with
+> `[REDACTED:UNDECODABLE]`, because the secret cannot be excised precisely from bytes the
+> scanner could only read through a lossy decoding. The agent still
 > receives a semantics-preserving placeholder, so the request remains usable.
 
 > **This does NOT guarantee:** that every secret is found. Detection is deterministic and

--- a/docs/src/security/protection-model.md
+++ b/docs/src/security/protection-model.md
@@ -57,6 +57,15 @@ examples:
   forwarded raw — `OversizedPolicy::RedactWhole`, the sole and default variant
   (`aa-runtime/src/pipeline/enforcement.rs`). The doc comment is explicit: *"The
   runtime is a security gate, so the policy is fail-closed."*
+- **Undecodable field with a finding → redact whole.** A `bytes` field that is
+  not valid UTF-8 is still scanned — the *decision* is never skipped — but a
+  detected secret cannot be spliced out faithfully, because the finding's offsets
+  index the lossy decoding rather than the payload. So it is replaced wholesale
+  with `UNDECODABLE_MARKER = "[REDACTED:UNDECODABLE]"` and counted in
+  `EnforcementOutcome::undecodable_fields`. Leaving it untouched would forward a
+  detected secret in the clear; this is the same rule as ADR 0015 §1's
+  "caller text ≠ scanned text ⇒ opaque whole-value redaction". A **clean**
+  undecodable field is forwarded byte-identical (AAASM-5346).
 
 > **Null-as-no-match nuance.** Inside a single policy document, an *unresolvable*
 > graph variable contributes nothing to the decision — a `deny` condition that


### PR DESCRIPTION
## Description

`aa-runtime`'s enforcement stage scanned a `bytes` payload by decoding it with
`String::from_utf8_lossy`, then — when the scan produced a finding — wrote the
decoded text straight back over the original bytes with `into_bytes()`.

`from_utf8_lossy` replaces every invalid sequence with U+FFFD, so the write-back
**destroyed** any payload that was not already valid UTF-8, and nothing recorded
that it had happened. Two concrete cases:

1. **Binary payloads.** A non-UTF-8 body carrying a credential was mangled on the
   way through — the secret was replaced, but so was every other invalid byte.
2. **Chunk-split multi-byte text.** A 3-byte Han character straddling a chunk
   boundary is lossy-decoded to U+FFFD on both sides, so a `zh-TW` payload that
   was valid in aggregate came out corrupted.

This PR makes the write-back byte-faithful, and makes the undecodable case
explicit and fail-closed.

### The design chosen, and why

The ticket offered three options. **Option 1 — never write lossy text back —
hardened to fail closed** is what shipped:

* `scan_bytes` now splits on `std::str::from_utf8`.
  * **Valid UTF-8** → scan and splice against the payload itself. Finding offsets
    are byte offsets into the real bytes, so every unmatched region is preserved
    byte-for-byte. (This is what the old code already did *correctly*; it is now
    explicit rather than incidental, and no longer allocates a lossy copy.)
  * **Not valid UTF-8** → the payload is still scanned (via the lossy decoding),
    so the *decision* is never skipped. If it is clean the original bytes are left
    completely untouched. If it has findings, the whole field is replaced with
    `[REDACTED:UNDECODABLE]` and counted in a new `undecodable_fields` outcome.

**Option 2 (operate on bytes throughout)** would require a byte-oriented API on
`aa-security`'s `CredentialScanner`, which is out of scope for this ticket and
being changed on other branches.

**Option 3 (buffer across chunk boundaries)** has nowhere to live here:
`scan_bytes` receives one whole `args_json` field, not a stream. There is no
chunking seam in `aa-runtime` to buffer across; the "chunk boundary" is a property
of what the *caller* handed us. Making the gate correct for whatever bytes arrive
is the fix that does not depend on a re-architecture.

### Why the undecodable case is a *redaction*, not a skip

This is the fail-open trap the ticket calls out, and ADR 0015 §1 already decides
it:

> When a finding's span cannot be applied faithfully (out-of-range offset,
> non-UTF-8-boundary, **caller text ≠ scanned text**), redaction degrades to an
> opaque whole-value `[REDACTED]` rather than passing the original through.

An undecodable payload is exactly `caller text ≠ scanned text`: the finding offsets
index the *lossy decoding*, where each invalid byte became a 3-byte U+FFFD, so they
do not map onto the original buffer and no faithful splice exists. Skipping the
write-back there would forward a payload with a detected secret intact — a
fail-open. Dropping the whole field is the conservative branch, and it matches the
existing `OversizedPolicy::RedactWhole` precedent one function away: *we could not
prove this payload was scrubbed, so it does not go out.*

Consequently `is_clean()` is still false for such a field (the findings are
recorded), the tamper/metrics layer sees it, and `aa_runtime_scan_undecodable_total`
makes it visible to operators — it is recorded truthfully as "inspected, not
precisely transformable", not reported as a successful surgical redaction.

### `scanned_bytes` was a bug — fixed

It counted `text.len()`, the length of the **lossy decoding**. Because lossy
decoding expands each invalid byte to a 3-byte U+FFFD, a binary payload was
reported at up to 3x its true size, inflating both the outcome field and the
`aa_runtime_scan_payload_bytes` histogram fed from it. It now counts `field.len()`,
matching what `scan_string` has always done. Valid UTF-8 is unaffected — the two
lengths are equal by definition.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

No schema, wire or API change.

* `RuntimeVerdict` is **untouched** — decision **D-2** (ADR 0032 §10) freezes it,
  and nothing here adds, renames or reorders a variant.
* `EnforcementOutcome::undecodable_fields` is a new field on an existing
  `#[derive(Default)]` struct. Every construction site in the tree already uses
  `..Default::default()`, and `0` means exactly what today's absence means.
* `redaction_count()` deliberately does **not** add `undecodable_fields`: an
  undecodable field with findings is already counted through `findings.len()`, so
  adding it would double-count.
* Behaviour changes for payloads that were previously being corrupted — but the
  change is not only "stops corrupting". A flagged undecodable field now loses its
  **entire** content to the 22-byte marker, where before it was forwarded mangled
  but present. Containment is the correct trade (a lossy-decoded payload was never
  trustworthy audit content), but the audit-content loss is real. See the
  limitation below.
* The finer disposition vocabulary stays where D-2 put it — the future additive
  `sensitive_data_disposition` field. `undecodable_fields` is a counter on an
  internal outcome struct, not a new verdict, and is the natural input for a
  `redact` disposition when that field lands.

### Known limitation — sharper for `zh-TW` until AAASM-5344 ships

A flagged undecodable field is replaced *in full*, so the surrounding content does
not reach the audit record either. That is deliberate, but it has a blast radius
worth stating plainly:

**[AAASM-5344] is still open** (In Progress, fixVersion `v0.0.1-rc.7`), so ordinary
Traditional-Chinese text currently registers as `GenericHighEntropy` findings. A
chunk-split `zh-TW` payload is therefore *dirty by false positive*, and under this
PR it loses its whole `args_json` to `[REDACTED:UNDECODABLE]` — where before it was
forwarded corrupted but present. Both outcomes are bad; this one is at least honest
and fail-closed, and a corrupted payload was never usable audit content. But it is a
behaviour regression in audit *completeness* for that traffic, and it interacts with
ADR 0032's existing operational guidance that `zh-TW` traffic is unsafe until 5344
lands.

Once AAASM-5344 ships, benign Chinese text stops producing findings and ordinary
`zh-TW` traffic stops reaching this path at all. This PR is deliberately independent
of it — B-4 and B-2 are listed as independent in the report's §9 dependency graph —
and the fix here is strictly better than the corruption it replaces in the meantime.

This is documented in `docs/src/devtools/limitations.md`, not only here.

[AAASM-5344]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5344

## Related Issues

- Related Jira ticket: [AAASM-5346](https://lightning-dust-mite.atlassian.net/browse/AAASM-5346)
  (backlog item **B-4** from the [AAASM-5269 report §9](https://github.com/ai-agent-assembly/agent-assembly/blob/main/docs/src/research/AAASM-5269-sensitive-data-provider-architecture.md))
- ADRs: [ADR 0015 §1](https://github.com/ai-agent-assembly/agent-assembly/blob/main/docs/src/adr/0015-dlp-trust-boundary-and-redaction-semantics.md) (redaction fails closed — the governing rule here),
  [ADR 0032 §10 D-2](https://github.com/ai-agent-assembly/agent-assembly/blob/main/docs/src/adr/0032-local-first-sensitive-data-provider-architecture.md) (`RuntimeVerdict` frozen)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

### Verification — real output

Toolchain: `RUSTUP_TOOLCHAIN=stable`, cargo 1.97.0, macOS aarch64.

`cargo nextest run -p aa-runtime -p aa-security -p conformance`:

```
     Summary [  25.404s] 738 tests run: 738 passed, 2 skipped
```

The 27 `pipeline::enforcement` tests, including the six added here:

```
PASS [ 0.035s] binary_payload_with_secret_is_dropped_whole_never_corrupted
PASS [ 0.033s] chunk_split_multibyte_clean_payload_round_trips_byte_identically
PASS [ 0.032s] chunk_split_multibyte_payload_with_secret_introduces_no_replacement_char
PASS [ 0.018s] scanned_bytes_counts_input_bytes_not_the_lossy_expansion
PASS [ 0.018s] valid_utf8_multibyte_payload_keeps_surrounding_bytes_on_redaction
PASS [ 0.239s] enforce_emits_undecodable_metric
     Summary [   0.262s] 27 tests run: 27 passed, 513 skipped
```

`cargo clippy -p aa-runtime --all-targets --all-features -- -D warnings` → exit 0.
`cargo fmt --all -- --check` → exit 0.
`cargo doc -p aa-runtime --no-deps` → exit 0 (the 4 warnings it prints are
pre-existing, in `approval_sink.rs` / `ebpf_bridge.rs` / `correlate`).

### The tests fail on the pre-fix code — verified, not assumed

Before any fix was written, the three reproducing tests were run against
`5bf15981`. Real output:

```
binary_payload_with_secret_is_never_corrupted
  panicked at enforcement.rs:882: payload corrupted: U+FFFD spliced into the output

split_cjk_with_secret_introduces_no_replacement_char
  panicked at enforcement.rs:916: surviving bytes must not carry U+FFFD

scanned_bytes_counts_input_bytes_not_lossy_expansion
  panicked at enforcement.rs:932: assertion `left == right` failed:
    scanned_bytes must count input bytes, not the lossy decoding
      left: 27
     right: 22

Summary [0.109s] 4 tests run: 1 passed, 3 failed
```

Those three names differ slightly from the shipped ones because
`UNDECODABLE_MARKER` and `undecodable_fields` do not exist at `5bf15981`; the
assertions that reference them were removed so the tests would compile against the
base, and the names were adjusted to match. The assertions that actually detect the
bug — no U+FFFD in the output, no raw secret, and the byte count — are identical to
the shipped versions and are what failed.

The one that passed pre-fix is `chunk_split_..._clean_payload_round_trips_byte_identically`,
and that is expected and called out in its commit message: the old write-back
only fired on a finding, so a clean payload was never rewritten. It guards the
property against a future change that starts normalising clean payloads; it is
not a reproducer.

### Acceptance criteria

| Criterion | Evidence |
|---|---|
| Binary payload with a secret is redacted or explicitly not transformed — never corrupted | `binary_payload_with_secret_is_dropped_whole_never_corrupted` asserts the output equals `UNDECODABLE_MARKER` exactly, contains no U+FFFD, and no raw secret |
| Split multi-byte payload round-trips byte-identically when clean | `chunk_split_multibyte_clean_payload_round_trips_byte_identically` compares `Vec<u8>` to `Vec<u8>` |
| Same split payload with a secret introduces no U+FFFD | `chunk_split_multibyte_payload_with_secret_introduces_no_replacement_char` |
| `scanned_bytes` accurate | Confirmed as a bug and fixed; `scanned_bytes_counts_input_bytes_not_the_lossy_expansion` pins it (was 27 for a 22-byte payload) |
| Fail-closed preserved (ADR 0015) | Undecodable + findings ⇒ whole-field drop, `is_clean()` stays false, findings still recorded, counter + metric emitted. The payload is never forwarded with the secret intact |
| Regression test fails pre-fix | Verified against `5bf15981` — output above |

### Performance

`scan_bytes` is on the enforcement hot path and the repo has an SLA test for it
(`scan_latency_test`), so the change was measured rather than assumed. The two
implementations were run **interleaved in a single process** — alternating which
arm goes first each iteration — so machine load and cache state hit both arms
equally:

```
=== payload 256 bytes, 1500 iters/arm ===
  OLD   p50=  28.000µs  p95=  32.250µs  p99=  35.625µs
  NEW   p50=  27.917µs  p95=  32.209µs  p99=  35.334µs
=== payload 4096 bytes, 1500 iters/arm ===
  OLD   p50= 327.333µs  p95= 356.292µs  p99= 381.458µs
  NEW   p50= 326.750µs  p95= 354.208µs  p99= 375.667µs
=== payload 61440 bytes, 1500 iters/arm ===
  OLD   p50=   6.871ms  p95=  45.240ms  p99=  97.535ms
  NEW   p50=   6.802ms  p95=  50.064ms  p99=  92.408ms
```

No regression; the new path is marginally faster, as expected — `from_utf8_lossy`
calls `str::from_utf8` internally and then wraps the result in a `Cow`, so
validating directly does strictly less work.

**That "strictly less work" claim is scoped to the valid-UTF-8 path**, which is what
the numbers above measure and what essentially all real traffic takes. The
*undecodable* branch validates twice: `from_utf8` fails, then `from_utf8_lossy`
re-validates from the start. That is a deliberate trade — matching on `from_utf8`
states the security-relevant question ("is this payload faithfully spliceable?")
explicitly, rather than inferring it from which `Cow` variant came back, and the
branch it guards ends in dropping the field anyway. Paying one extra validation on
the path that is already the abnormal, fail-closed one is the right place to spend
it. The benchmark harness was temporary and is not part of this PR.

## Review response (post-review commits)

Seven commits added after the adversarial review:

| Item | Commit | What changed |
|---|---|---|
| S1 | `a8c5e9ef` | `[REDACTED:UNDECODABLE]` documented beside all four existing `OVERSIZED` mentions — product-brief disposition table + G1 guarantee, protection-model fail-closed examples, workflows runtime invariants |
| S2 | `193fe1e2` | The audit-content loss, and the sharper `zh-TW` case pending AAASM-5344, stated in `limitations.md` and in this body |
| N1 | `67c1b4ab` | Comment recording that undecodable-path finding spans are kind-only; kept rather than zeroed because the *kind* is the audit-relevant fact |
| N3 | `a48774c4` | `assert_eq!(out, UNDECODABLE_MARKER.as_bytes())` added to the split-with-secret test so it pins behaviour instead of an absence |
| N4 | `9f78915c` | `#[non_exhaustive]` on `EnforcementOutcome` — taken, see below |
| S3 / N2 | this body | CI ticked; the perf claim scoped to the valid-UTF-8 path |
| self-caught | `adb80fa5` | The S2 commit added a third bullet under "Two knock-on limits worth stating" without updating the count — corrected to "Three" |

**N4 was taken rather than deferred.** This branch already adds a field, so
out-of-crate struct literals are already affected; doing it now costs one break
instead of two, and the crate is pre-1.0 at rc.6. In-crate construction is
unaffected, every in-tree site uses `..Default::default()`, and field reads — all
`aa-integration-tests` does — are not restricted. Verified with a full-workspace
`cargo clippy --all-targets --all-features -- -D warnings`.

**N2 was actioned as a body change only, not a code change**, per the review: the
explicit `from_utf8` match is more defensible on a security branch than inferring
validity from the `Cow` variant.

Re-verified after all seven: `cargo nextest run -p aa-runtime -p aa-security -p conformance`
→ `738 tests run: 738 passed, 2 skipped` (no flake this time). Clippy `-D warnings`,
`cargo fmt --check` → exit 0. The docs changes were additionally verified by building
the book locally (`mdbook build` → exit 0) and checking the rendered HTML: the
`[AAASM-5344]` reference-style link resolves to a real anchor rather than literal
text, and the corrected count renders.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing — re-verified on `adb80fa5`. Every check that exercises this diff is green: Rust conformance suite, Rustdoc, Format check, Clippy lint, Test, Build aa-runtime sidecar, Integration tests (macos-latest), Build mdBook, Check internal doc links, Verify documented commands, and CodeQL Analyze (rust/go/python/js-ts). Zero failures. `Build mdBook` + `Check internal doc links` passing independently confirms the doc edits render and the `[AAASM-5344]` reference link resolves.
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)

## Notes for the reviewer

- All fixtures are synthetic (`AKIAIOSFODNN7EXAMPLE`, the documented AWS example
  key already used throughout this test module). No real credential appears in
  the code, the tests, the commits, or this description, and
  `enforce_emits_undecodable_metric` asserts the value never reaches the metrics
  registry.
- `aa-security` is deliberately untouched — sibling branches are changing the
  scanner, and this fix needed nothing from it.
