### PR TITLE
[AAASM-5333] 🐛 (aa-cli): Pair the Linux start tick with the pidfs inode

### DIFF
--- a/aa-cli/src/commands/proxy/identity.rs
+++ b/aa-cli/src/commands/proxy/identity.rs
@@ -22,6 +22,41 @@
 //!   process-identity pair for exactly this reason (it is what `pidfd`, systemd
 //!   and every correct pidfile implementation reduce to).
 //!
+//! # Why the start time alone is not enough on Linux (AAASM-5333)
+//!
+//! `/proc/<pid>/stat` publishes the start time in **clock ticks** — `USER_HZ`,
+//! which is 100 on every mainstream configuration, so a 10 ms grid. Two
+//! processes that started inside the same 10 ms carry byte-identical values, and
+//! a token built from that field alone cannot tell them apart. The hole is
+//! narrow but real: the executable check already rejects a recycled PID running
+//! *something else*, so the start time is the only thing left to reject a
+//! *second `aa-proxy`* that took the same number, and two incarnations landing
+//! in one tick would pass both checks.
+//!
+//! Linux exposes no finer start time, so the token pairs the tick with an
+//! independent kernel fact rather than a more precise clock: the **pidfs inode**
+//! behind `pidfd_open(2)`. From Linux 6.9 each process owns an inode on the
+//! `pidfs` filesystem, allocated at process creation from a counter that owes
+//! nothing to the clock — so a pair that collides on the tick still differs
+//! here, and forging a token now requires forging both. It survives the
+//! constraint that shapes the rest of this module, too: `pidfd_open` is not
+//! behind the ptrace gate, so it answers for the non-dumpable process every real
+//! `aa-proxy` is.
+//!
+//! Two candidates were measured and rejected. The `/proc/<pid>` directory's own
+//! inode is *not* stable — it is allocated at dentry lookup and observably
+//! changes when the dentry is evicted, which would turn a running proxy into a
+//! refused one. A nonce the proxy generates for itself would move the fact from
+//! the kernel to the process: a process can lie about a value it invents, where
+//! it cannot lie about its own creation, and identity evidence should not be
+//! sourced from the thing being identified.
+//!
+//! Kernels before 6.9 answer `pidfd_open` with one anonymous inode shared by
+//! every pidfd, which discriminates nothing. That case is detected by the
+//! filesystem magic rather than guessed at from a version number, and the token
+//! then carries a different scheme tag — the resolution it actually has is
+//! stated, never assumed.
+//!
 //! # Why per-platform, and why absent evidence is fatal rather than skippable
 //!
 //! Neither fact is portable. Each platform reads it natively; a platform with no
@@ -186,14 +221,44 @@ pub fn image(_pid: u32) -> ImageEvidence {
     ImageEvidence::Unsupported
 }
 
-/// An opaque token identifying *this* incarnation of `pid`.
-///
-/// The value is only ever compared for equality against a token captured
-/// earlier for the same PID, so its encoding is private to this module. It is
-/// prefixed with the platform that produced it so a state file carried between
-/// hosts of different kinds can never compare equal by coincidence.
+/// Scheme tag for a Linux token that carries both the start tick and the
+/// kernel's per-process pidfs inode. See the module docs for why the tick alone
+/// is not enough.
 #[cfg(target_os = "linux")]
-pub fn start_token(pid: u32) -> Option<String> {
+const LINUX_SCHEME_PIDFS: &str = "linux-pidfs";
+
+/// Scheme tag for a Linux token carrying the start tick and nothing else,
+/// emitted only where the kernel publishes no per-process inode. The tag is
+/// distinct so a token never claims a resolution it does not have.
+#[cfg(target_os = "linux")]
+const LINUX_SCHEME_TICKS: &str = "linux-ticks";
+
+/// Scheme tag for the macOS token. Unchanged: `PROC_PIDTBSDINFO` already
+/// answers in microseconds, so there is no tick-collision problem to fix here
+/// and no reason to invalidate records written by an earlier build.
+#[cfg(target_os = "macos")]
+const MACOS_SCHEME: &str = "macos-starttime";
+
+/// `f_type` of the `pidfs` filesystem (`"PIDF"`), which is what a `pidfd`
+/// reports from Linux 6.9 onwards.
+///
+/// Before that release `pidfd_open` returned an *anonymous* inode shared by
+/// every pidfd on the system, so its inode number is the same for all processes
+/// and discriminates nothing. Checking the magic distinguishes "the kernel gave
+/// me this process's own identifier" from "the kernel gave me the one global
+/// placeholder" — a distinction a bare `fstat` cannot make, and getting it wrong
+/// would append a constant to every token while appearing to strengthen it.
+#[cfg(target_os = "linux")]
+const PID_FS_MAGIC: i64 = 0x5049_4446;
+
+/// Field 22 of `/proc/<pid>/stat` — the process's start time in clock ticks
+/// since boot.
+///
+/// `USER_HZ` is 100 on every mainstream configuration, so this is a 10 ms grid
+/// and is *not* on its own a unique per-process value; see the module docs and
+/// [`start_token`], which is what callers should use.
+#[cfg(target_os = "linux")]
+fn start_ticks(pid: u32) -> Option<u64> {
     let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
     // Field 2 (`comm`) is parenthesised and may itself contain spaces and even
     // ')', so the only safe split point in `/proc/<pid>/stat` is the *last*
@@ -202,8 +267,100 @@ pub fn start_token(pid: u32) -> Option<String> {
     let rest = stat.get(stat.rfind(')')? + 1..)?;
     // Tokens after that point start at field 3 (`state`), so field 22
     // (`starttime`, in clock ticks since boot) is at index 19.
-    let ticks: u64 = rest.split_whitespace().nth(19)?.parse().ok()?;
-    Some(format!("linux-starttime:{ticks}"))
+    rest.split_whitespace().nth(19)?.parse().ok()
+}
+
+/// The kernel's own globally-unique identifier for the process currently behind
+/// `pid`, or `None` if this kernel publishes none.
+///
+/// This is the pidfs inode reached through `pidfd_open(2)`. Three properties
+/// make it the right partner for the start tick:
+///
+/// * it is allocated when the process is created, from a counter unrelated to
+///   the clock, so it cannot collide for the same reason the tick does;
+/// * it is stable for the lifetime of the process, so the value recorded at
+///   `aasm proxy start` still reads back identically at `aasm run`; and
+/// * `pidfd_open` is not behind the ptrace gate, so it answers for a process
+///   that has marked itself non-dumpable — which every real `aa-proxy` has
+///   (AAASM-3584), and which is precisely why `/proc/<pid>/exe` cannot be the
+///   fallback here.
+///
+/// A reaped PID yields `ESRCH` and therefore `None`; a zombie still answers,
+/// which is correct — rejecting a zombie is the image evidence's job, not this
+/// one's.
+#[cfg(target_os = "linux")]
+fn incarnation_inode(pid: u32) -> Option<u64> {
+    // Safety: `pidfd_open` takes a PID and a flag word by value and returns a
+    // file descriptor or -1. Nothing is dereferenced.
+    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0 as libc::c_uint) };
+    if fd < 0 {
+        // ENOSYS on kernels before 5.3, ESRCH once the PID has been reaped.
+        return None;
+    }
+    let fd = fd as libc::c_int;
+    let inode = pidfs_inode_of(fd);
+    // Safety: `fd` was just returned by the kernel and is not used again.
+    unsafe { libc::close(fd) };
+    inode
+}
+
+/// The inode number behind an open pidfd, but only when it is a genuine `pidfs`
+/// inode. See [`PID_FS_MAGIC`] for why the filesystem is checked first.
+#[cfg(target_os = "linux")]
+fn pidfs_inode_of(fd: libc::c_int) -> Option<u64> {
+    // Safety: both calls fill a caller-owned struct of exactly the size the
+    // kernel is told, and are checked for failure before the struct is read.
+    let mut fs: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::fstatfs(fd, &mut fs) } != 0 || fs.f_type as i64 != PID_FS_MAGIC {
+        return None;
+    }
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { libc::fstat(fd, &mut st) } != 0 {
+        return None;
+    }
+    Some(st.st_ino as u64)
+}
+
+/// Whether this host can tell apart two processes that started inside the same
+/// kernel clock tick.
+///
+/// False only on Linux before 6.9, where the tick is genuinely all the kernel
+/// offers. Exposed so the property can be asserted rather than assumed.
+#[cfg(target_os = "linux")]
+pub fn distinguishes_within_a_tick() -> bool {
+    incarnation_inode(std::process::id()).is_some()
+}
+
+/// See the Linux variant. macOS start times are microsecond-resolution, so the
+/// tick-collision case does not arise.
+#[cfg(target_os = "macos")]
+pub fn distinguishes_within_a_tick() -> bool {
+    true
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn distinguishes_within_a_tick() -> bool {
+    false
+}
+
+/// An opaque token identifying *this* incarnation of `pid`.
+///
+/// The value is only ever compared for equality against a token captured
+/// earlier for the same PID, so its encoding is private to this module. It is
+/// prefixed with a scheme tag naming the evidence inside it, so that a record
+/// carried between hosts of different kinds — or written by a build that
+/// gathered different evidence — can be recognised as such rather than
+/// silently comparing unequal.
+#[cfg(target_os = "linux")]
+pub fn start_token(pid: u32) -> Option<String> {
+    // Read the tick first: it is the fact whose absence means "there is no such
+    // process", and it must keep deciding that. `pidfd_open` still answers for a
+    // zombie, so consulting it first would turn a reaped PID into a token.
+    let ticks = start_ticks(pid)?;
+    Some(match incarnation_inode(pid) {
+        Some(inode) => format!("{LINUX_SCHEME_PIDFS}:{ticks}.{inode}"),
+        None => format!("{LINUX_SCHEME_TICKS}:{ticks}"),
+    })
 }
 
 /// An opaque token identifying *this* incarnation of `pid`. See the Linux
@@ -229,7 +386,7 @@ pub fn start_token(pid: u32) -> Option<String> {
         return None;
     }
     Some(format!(
-        "macos-starttime:{}.{:06}",
+        "{MACOS_SCHEME}:{}.{:06}",
         info.pbi_start_tvsec, info.pbi_start_tvusec
     ))
 }
@@ -302,21 +459,102 @@ mod tests {
         assert_eq!(first, second, "a process's start time must not change under it");
     }
 
-    /// The evidence is worthless if two processes share a token, so pin that a
-    /// separately-started process reports a different one.
+    /// A `sleep` child killed and reaped when it goes out of scope, so the retry
+    /// loop below cannot leave strays behind on a busy CI host.
+    struct SleepingChild(std::process::Child);
+
+    impl SleepingChild {
+        fn spawn() -> Self {
+            Self(
+                std::process::Command::new("sleep")
+                    .arg("30")
+                    .spawn()
+                    .expect("spawn sleep"),
+            )
+        }
+        fn pid(&self) -> u32 {
+            self.0.id()
+        }
+    }
+
+    impl Drop for SleepingChild {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    /// Two live processes the kernel recorded as having started inside the same
+    /// clock tick.
+    ///
+    /// The collision is *verified* rather than hoped for. That is the whole
+    /// defect in the test this replaces: it assumed two separately-spawned
+    /// processes would land in different ticks, so on the runs where they did
+    /// the assertion held for a reason that had nothing to do with the token.
+    #[cfg(target_os = "linux")]
+    fn pair_started_in_one_tick() -> (SleepingChild, SleepingChild) {
+        for _ in 0..64 {
+            let first = SleepingChild::spawn();
+            let second = SleepingChild::spawn();
+            let (a, b) = (start_ticks(first.pid()), start_ticks(second.pid()));
+            assert!(
+                a.is_some() && b.is_some(),
+                "both children must publish a start tick, or the pair proves nothing"
+            );
+            if a == b {
+                return (first, second);
+            }
+        }
+        panic!(
+            "could not start two processes inside one 10 ms tick in 64 attempts — the collision \
+             this test exists to close could not be constructed, so it would have measured nothing"
+        );
+    }
+
+    /// macOS records start times in microseconds, so two processes spawned
+    /// back-to-back are already the closest-together case the platform has;
+    /// there is no coarse grid to deliberately land them both in.
+    #[cfg(not(target_os = "linux"))]
+    fn pair_started_in_one_tick() -> (SleepingChild, SleepingChild) {
+        (SleepingChild::spawn(), SleepingChild::spawn())
+    }
+
+    /// AAASM-5333 regression, and the reason the token is more than a start tick.
+    ///
+    /// `/proc/<pid>/stat` measures start time on a 10 ms grid, and under
+    /// `cargo nextest` each test runs in a process that is itself only
+    /// milliseconds old — so a test binary and the child it spawns land in one
+    /// tick as the *normal* case, not the rare one. The predecessor of this test
+    /// therefore failed on Linux CI on every attempt, including retries.
+    ///
+    /// The fix is not to give the two processes more distance. It is to make the
+    /// token survive having none, so this test removes the distance on purpose
+    /// and requires the token to hold.
     #[test]
-    fn start_token_differs_between_two_processes() {
-        let mine = start_token(std::process::id()).expect("own start token");
-        let mut child = std::process::Command::new("sleep")
-            .arg("5")
-            .spawn()
-            .expect("spawn sleep");
-        let theirs = start_token(child.id()).expect("child start token");
-        let _ = child.kill();
-        let _ = child.wait();
+    fn processes_started_in_the_same_clock_tick_do_not_share_a_start_token() {
+        let (first, second) = pair_started_in_one_tick();
+        let a = start_token(first.pid()).expect("first child's start token");
+        let b = start_token(second.pid()).expect("second child's start token");
+
+        if !distinguishes_within_a_tick() {
+            // Linux before 6.9 publishes nothing finer than the tick, so on such
+            // a host the collision is real and cannot be closed. Pin that the
+            // token *admits* it — a coarse token wearing the fine scheme's tag
+            // would be the genuine defect, and is what this branch exists to
+            // catch. Never reached on CI, which runs a kernel that can.
+            #[cfg(target_os = "linux")]
+            assert!(
+                a.starts_with(&format!("{LINUX_SCHEME_TICKS}:")),
+                "a host that cannot separate two same-tick processes must not emit a token \
+                 claiming that it can; got {a}"
+            );
+            return;
+        }
+
         assert_ne!(
-            mine, theirs,
-            "two processes started at different times must not share a start token"
+            a, b,
+            "two processes are two incarnations even when the kernel clock cannot separate them — \
+             a shared token is a PID-reuse guard that waves the second incarnation through"
         );
     }
 

--- a/aa-cli/src/commands/proxy/identity.rs
+++ b/aa-cli/src/commands/proxy/identity.rs
@@ -239,6 +239,20 @@ const LINUX_SCHEME_TICKS: &str = "linux-ticks";
 #[cfg(target_os = "macos")]
 const MACOS_SCHEME: &str = "macos-starttime";
 
+/// Every scheme tag [`start_token`] can emit on this host. A recorded token
+/// tagged with anything else was not written here, or not written by this build
+/// — see [`scheme_is_current`].
+#[cfg(target_os = "linux")]
+const CURRENT_SCHEMES: &[&str] = &[LINUX_SCHEME_PIDFS, LINUX_SCHEME_TICKS];
+
+#[cfg(target_os = "macos")]
+const CURRENT_SCHEMES: &[&str] = &[MACOS_SCHEME];
+
+/// A platform with no [`start_token`] implementation produces no tokens, so no
+/// recorded token can have come from it.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+const CURRENT_SCHEMES: &[&str] = &[];
+
 /// `f_type` of the `pidfs` filesystem (`"PIDF"`), which is what a `pidfd`
 /// reports from Linux 6.9 onwards.
 ///
@@ -349,8 +363,8 @@ pub fn distinguishes_within_a_tick() -> bool {
 /// earlier for the same PID, so its encoding is private to this module. It is
 /// prefixed with a scheme tag naming the evidence inside it, so that a record
 /// carried between hosts of different kinds — or written by a build that
-/// gathered different evidence — can be recognised as such rather than
-/// silently comparing unequal.
+/// gathered different evidence — is recognised as such by
+/// [`scheme_is_current`] instead of silently comparing unequal.
 #[cfg(target_os = "linux")]
 pub fn start_token(pid: u32) -> Option<String> {
     // Read the tick first: it is the fact whose absence means "there is no such
@@ -394,6 +408,31 @@ pub fn start_token(pid: u32) -> Option<String> {
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn start_token(_pid: u32) -> Option<String> {
     None
+}
+
+/// Whether `token` was produced by a scheme [`start_token`] still emits on this
+/// host.
+///
+/// A recorded token that fails this test cannot support a trust decision, and —
+/// this is the point — cannot be *compared* into one either: it would simply
+/// differ from every fresh reading, which reads as "the PID was recycled" and
+/// sends an operator hunting a process-identity problem that does not exist.
+/// Callers must refuse such a record with a diagnostic of its own (see
+/// [`super::trust::ProxyTrustError::IdentityEvidenceUnrecognised`]) rather than
+/// let it fall through to the equality comparison.
+///
+/// It fires for a record written by an `aasm` that gathered different evidence
+/// (before AAASM-5333, Linux tokens carried the start tick alone), and for one
+/// carried over from a host of another kind. Migration is deliberately not
+/// attempted: the older evidence is a strict subset, so honouring it would mean
+/// re-admitting exactly the weakness the new scheme exists to close.
+pub fn scheme_is_current(token: &str) -> bool {
+    match token.split_once(':') {
+        // An empty value is not a token: it names a scheme and then says
+        // nothing, which would compare equal to another empty one.
+        Some((scheme, value)) => !value.is_empty() && CURRENT_SCHEMES.contains(&scheme),
+        None => false,
+    }
 }
 
 #[cfg(test)]
@@ -556,6 +595,32 @@ mod tests {
             "two processes are two incarnations even when the kernel clock cannot separate them — \
              a shared token is a PID-reuse guard that waves the second incarnation through"
         );
+    }
+
+    /// The compatibility gate. Evidence gathered under any scheme this host does
+    /// not currently emit — a record from before AAASM-5333, or one carried over
+    /// from another kind of host — must be recognised as foreign, because the
+    /// alternative is comparing it and reporting a PID reuse that never happened.
+    #[test]
+    fn only_the_scheme_this_host_emits_is_current() {
+        assert!(
+            scheme_is_current(&start_token(std::process::id()).expect("own start token")),
+            "whatever this platform emits must be recognised as its own"
+        );
+        // The superseded Linux scheme: the same start tick, without the
+        // per-process inode that makes it discriminating.
+        assert!(!scheme_is_current("linux-starttime:112163742"));
+        #[cfg(target_os = "linux")]
+        assert!(
+            !scheme_is_current("macos-starttime:1750000000.000001"),
+            "a record carried from another kind of host must not be honoured"
+        );
+        for malformed in ["", "not-a-token", "linux-pidfs:", ":112163742"] {
+            assert!(
+                !scheme_is_current(malformed),
+                "a token with no readable scheme and value must not pass: {malformed:?}"
+            );
+        }
     }
 
     #[test]

--- a/aa-cli/src/commands/proxy/pid.rs
+++ b/aa-cli/src/commands/proxy/pid.rs
@@ -181,7 +181,7 @@ mod tests {
         ProxyState {
             pid: std::process::id(),
             listen_addr: "127.0.0.1:8899".into(),
-            start_token: "linux-starttime:123456".into(),
+            start_token: "linux-pidfs:123456.789".into(),
             exe_path: PathBuf::from("/usr/local/bin/aa-proxy"),
         }
     }
@@ -261,9 +261,9 @@ mod tests {
     #[test]
     fn parse_state_rejects_empty_fields() {
         for content in [
-            "4242\n\nlinux-starttime:1\n/usr/local/bin/aa-proxy\n",
+            "4242\n\nlinux-pidfs:1.2\n/usr/local/bin/aa-proxy\n",
             "4242\n127.0.0.1:8899\n\n/usr/local/bin/aa-proxy\n",
-            "4242\n127.0.0.1:8899\nlinux-starttime:1\n\n",
+            "4242\n127.0.0.1:8899\nlinux-pidfs:1.2\n\n",
         ] {
             assert!(
                 parse_state(content).is_none(),

--- a/aa-cli/src/commands/proxy/trust.rs
+++ b/aa-cli/src/commands/proxy/trust.rs
@@ -86,6 +86,11 @@ pub enum ProxyTrustError {
     },
     /// The PID is live but is not the process that was recorded.
     IdentityMismatch { pid: u32, field: &'static str },
+    /// The record's identity evidence was gathered by something other than this
+    /// build on this host, so it cannot be compared against a fresh reading.
+    /// Distinct from [`Self::IdentityMismatch`] because it is not a statement
+    /// about the process at all — see [`identity::scheme_is_current`].
+    IdentityEvidenceUnrecognised { pid: u32 },
     /// The record names something other than the proxy binary.
     NotTheProxyBinary { exe: PathBuf },
     /// The recorded address is not a usable loopback proxy endpoint.
@@ -133,6 +138,13 @@ impl fmt::Display for ProxyTrustError {
                 f,
                 "PID {pid} is live but its {field} does not match the recorded proxy — the proxy \
                  exited and an unrelated process took its PID. Re-run `aasm proxy start`"
+            ),
+            Self::IdentityEvidenceUnrecognised { pid } => write!(
+                f,
+                "the recorded proxy (PID {pid}) carries process-identity evidence this `aasm` does \
+                 not produce — the record was written by an older version, or on a different kind \
+                 of host. It is not evidence that the PID was recycled, and it is not evidence \
+                 that the proxy is sound either. Re-run `aasm proxy start`"
             ),
             Self::NotTheProxyBinary { exe } => write!(
                 f,
@@ -307,6 +319,16 @@ pub fn verify_identity(state: &ProxyState) -> Result<(), ProxyTrustError> {
             reason: "its /proc entry could not be read",
         });
     };
+    // Checked before the comparison, not after it. An old-scheme record differs
+    // from every fresh reading, so comparing it first would report a PID-reuse
+    // mismatch — a confident, specific, wrong diagnosis that sends an operator
+    // looking for a recycled PID. Accepting it on a prefix or a shared substring
+    // would be worse still: the pre-AAASM-5333 evidence is exactly the weaker
+    // subset this scheme replaced, so honouring it re-opens the hole. Neither
+    // silently mistrusted nor silently accepted — named, and refused.
+    if !identity::scheme_is_current(&state.start_token) {
+        return Err(ProxyTrustError::IdentityEvidenceUnrecognised { pid: state.pid });
+    }
     if token != state.start_token {
         return Err(ProxyTrustError::IdentityMismatch {
             pid: state.pid,
@@ -712,6 +734,37 @@ mod tests {
                 }
             ),
             "expected a start-time mismatch, got {err:?}"
+        );
+    }
+
+    /// Compatibility, stated deliberately (AAASM-5333): a record written by an
+    /// `aasm` from before the token scheme changed. Every other field is
+    /// truthful and the PID really is the recorded process, so the *only* thing
+    /// wrong is that its identity evidence predates this build.
+    ///
+    /// It must be refused — the old evidence is the weaker subset the new scheme
+    /// replaced, so honouring it would re-open the hole — and refused as what it
+    /// is. Reporting it as a start-time mismatch would tell an operator, with
+    /// full confidence, that their proxy had been replaced by an impostor.
+    #[test]
+    fn a_record_written_under_a_superseded_token_scheme_is_refused() {
+        let mut state = truthful_state_for_self();
+        state.start_token = "linux-starttime:112163742".into();
+
+        let err = verify_identity(&state).expect_err("evidence this build cannot read must be refused");
+
+        assert!(
+            matches!(err, ProxyTrustError::IdentityEvidenceUnrecognised { .. }),
+            "expected IdentityEvidenceUnrecognised, got {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("older version"),
+            "the refusal must name the actual cause: {message}"
+        );
+        assert!(
+            message.contains("Re-run `aasm proxy start`"),
+            "the refusal must tell the operator how to fix it: {message}"
         );
     }
 

--- a/aa-cli/src/commands/proxy/trust.rs
+++ b/aa-cli/src/commands/proxy/trust.rs
@@ -797,7 +797,7 @@ mod tests {
         std::fs::write(
             &path,
             format!(
-                "{}\n127.0.0.1:8899\nlinux-starttime:1\n/usr/local/bin/{PROXY_BINARY_NAME}\n",
+                "{}\n127.0.0.1:8899\nlinux-pidfs:1.2\n/usr/local/bin/{PROXY_BINARY_NAME}\n",
                 std::process::id()
             ),
         )

--- a/aa-integration-tests/tests/cli_run_trusted_proxy.rs
+++ b/aa-integration-tests/tests/cli_run_trusted_proxy.rs
@@ -33,7 +33,7 @@ mod proxy_trust_support;
 
 #[cfg(unix)]
 mod refusals {
-    use super::proxy_trust_support::{aasm_binary, prefixed_path, TrustedProxy};
+    use super::proxy_trust_support::{aasm_binary, foreign_incarnation_token, prefixed_path, TrustedProxy};
     use std::path::{Path, PathBuf};
 
     /// A host whose `claude`, home and state roots are all inside a temp dir, so
@@ -261,11 +261,18 @@ exit 0
     /// running proxy, its PID, its executable and its bound socket untouched:
     /// every other check still passes, so a failure here is attributable to the
     /// start-time comparison and to nothing else.
+    ///
+    /// The substitute keeps the writer's own scheme tag ([`foreign_incarnation_token`])
+    /// so that it is the comparison being measured and not the AAASM-5333
+    /// compatibility check, which refuses a foreign scheme before ever getting
+    /// there.
     #[test]
     fn launch_refuses_when_the_recorded_pid_is_a_different_incarnation() -> anyhow::Result<()> {
         let host = Host::create()?;
         let proxy = TrustedProxy::start()?;
-        tamper_line(&proxy.data_dir().join("proxy.pid"), 2, "not-the-recorded-incarnation");
+        let state = proxy.data_dir().join("proxy.pid");
+        let other_incarnation = foreign_incarnation_token(&state)?;
+        tamper_line(&state, 2, &other_incarnation);
 
         let out = host.run(proxy.data_dir())?;
 

--- a/aa-integration-tests/tests/proxy_trust_support/mod.rs
+++ b/aa-integration-tests/tests/proxy_trust_support/mod.rs
@@ -322,6 +322,35 @@ impl Drop for TrustedProxy {
     }
 }
 
+/// A start token that is well-formed for whatever scheme the running `aasm`
+/// wrote into `state_file`, but names a different incarnation of the PID.
+///
+/// The scheme tag has to be preserved. Since AAASM-5333 the trust check refuses
+/// an *unrecognised* scheme with a diagnostic of its own — that is how a record
+/// left by an older `aasm` is told apart from a PID that really was recycled —
+/// so substituting an arbitrary string would exercise that path instead of the
+/// start-time comparison, and the test would still see a refusal while measuring
+/// the wrong one.
+pub fn foreign_incarnation_token(state_file: &Path) -> anyhow::Result<String> {
+    let content = std::fs::read_to_string(state_file)?;
+    let recorded = content
+        .lines()
+        .nth(2)
+        .ok_or_else(|| anyhow::anyhow!("state record at {} has no start-token line", state_file.display()))?;
+    let (scheme, _) = recorded
+        .split_once(':')
+        .ok_or_else(|| anyhow::anyhow!("recorded start token {recorded:?} carries no scheme tag"))?;
+    // `0` is a value no scheme can genuinely produce: the Linux schemes lead
+    // with a start tick, which is zero only for a process that began at boot,
+    // and the macOS scheme leads with an epoch second.
+    let substitute = format!("{scheme}:0");
+    anyhow::ensure!(
+        substitute != recorded,
+        "the substitute token must differ from the recorded one, or the refusal proves nothing"
+    );
+    Ok(substitute)
+}
+
 /// `PATH` with `first` prepended, so a `which` probe in a child finds our binary
 /// while the child keeps whatever else it needs from the host.
 pub fn prefixed_path(first: &Path) -> anyhow::Result<std::ffi::OsString> {


### PR DESCRIPTION
## Description

**Fixes red `main`.** `commands::proxy::identity::tests::start_token_differs_between_two_processes` has been failing on `ubuntu-latest` since `be192256` (run `30689213155`, job `91340914613`), failing all three nextest retries.

## It was never a flake

I filed AAASM-5333 as "a test flake *and* a narrow gap in the incarnation guarantee." That was wrong.

`/proc/<pid>/stat` field 22 is in `USER_HZ` ticks — measured `USER_HZ=100`, a 10 ms grid. Under `cargo nextest` every test runs in a **freshly spawned process**, so the test binary is itself only milliseconds old when it forks. Reproduced on Linux: **196 collisions in 200 runs.**

A 98% collision rate means the start-token half of the PID-reuse guard was **effectively absent on Linux**. It failed all retries because it was deterministic, not intermittent.

## The discriminator was chosen by measurement

Token becomes `linux-pidfs:<ticks>.<inode>` — the start tick paired with the **pidfs inode** from `pidfd_open(2)` (Linux ≥ 6.9).

The obvious candidate was tried and **rejected empirically**: the `/proc/<pid>` directory inode changed under dcache pressure (`22199307 → 22199310`), which would turn a running proxy into a refused one.

A self-generated nonce was rejected because it moves the fact from the kernel to the process being identified — a process can lie about a value it generates; it cannot lie about its own `/proc` start time.

The pidfs inode was verified on four properties: unique per process, **stable across reads**, `ESRCH` on a reaped PID (so `identity_of_a_dead_pid_is_unavailable` still holds), and — decisively — **readable for a non-dumpable process**, which `/proc/<pid>/exe` is not. That is the shape every real `aa-proxy` has, because of `prctl(PR_SET_DUMPABLE, 0)` (AAASM-3584) — the same constraint that broke Linux in #1861. It is the one discriminator that survives the problem shaping this module.

**To forge a token an attacker must now land on the recycled PID *and* match the victim's pidfs inode** — a counter allocated at process creation that owes nothing to the clock. Colliding on the tick no longer suffices.

**Honest limit:** the state file is `0600` and the trust boundary is "this user", so a same-uid attacker can rewrite the record outright. This guard is against *coincidence* — a second `aa-proxy` on a recycled number — and that hole is what closes here.

**Pre-6.9 kernels** (Ubuntu 22.04, Debian 12, RHEL 9) return one shared anonymous inode. Detected from the **filesystem magic** (`PID_FS_MAGIC`, verified unprivileged) rather than guessed from a version number, and such a token carries the distinct tag `linux-ticks:` — a coarse token never wears the fine scheme's badge. A test pins that branch, so the weakness cannot be silent.

## Old records are refused, not migrated

An old `linux-starttime:` record now yields `IdentityEvidenceUnrecognised`, telling the operator to re-run `aasm proxy start`. Migration was declined deliberately: the old evidence is a strict subset, so honouring it re-opens the hole.

**The check ordering is load-bearing.** The scheme check runs *before* the equality comparison — otherwise an old record reads as a start-time mismatch, i.e. *"your proxy was replaced by an impostor"*: confident, specific, and wrong.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] Yes — a proxy state record written by an older `aasm proxy start` is refused with an instruction to restart the proxy. Deliberate; the alternative re-opens the defect.

## Related Issues

- Related Jira ticket: AAASM-5333
- Fixes red `main` at `be192256`; regression introduced by #1861

## Testing

| Run | Result |
|---|---|
| **Old scheme**, 200 fresh-process runs | **196 / 200 collided** |
| **Fixed**, 200 fresh-process runs (Linux) | **0 failures / 200** |
| 30 × `cargo nextest run -p aa-cli commands::proxy::` | 0 failures / 30 |
| `cargo nextest run -p aa-cli` | **934 / 934** |
| `cli_run_trusted_proxy` 10-case matrix | **10 / 10**, Linux *and* macOS |

The test now **constructs** the collision — it retries spawns until the kernel reports equal ticks, and panics if it cannot — so all 200 runs provably exercised the collision rather than dodging it.

**Mutation A** (drop the inode, keep the tag):
```
assertion `left != right` failed: two processes are two incarnations even when the
kernel clock cannot separate them
  left: "linux-pidfs:112291171"
 right: "linux-pidfs:112291171"
```

**Mutation B** (`if false && token != state.start_token`) — read how it fails:
```
panicked at cli_run_trusted_proxy.rs:128: the operator must be told the launch was refused
error: refusing to launch unregistered: the governance gateway ... is unreachable
```
The tampered record **sails through the trust gate** and only trips a later, unrelated gateway check. That is the silent-bypass signature: the guard fails and the error points somewhere else entirely.

Both reverted; 75/75 green after. `cargo fmt` / `clippy -D warnings` clean on **both** macOS and Linux (the new code is Linux-only, so clippy was run inside a container too); `cargo doc` clean; lefthook on every commit, never bypassed.

Each of the four commits is bisectable — the 10-case matrix was verified passing at the intermediate commit, before the scheme check lands.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Found, not fixed

- **Pre-existing latent flake:** `commands::run::tests::no_gateway_credential_reaches_the_launched_tool` fails under plain `cargo test -p aa-cli --lib` on Linux but passes in isolation, on macOS, and under nextest (934/934). A parallel env-var race that nextest's process-per-test isolation hides. Anyone running `cargo test` rather than `nextest` will hit it.
- **Pre-6.9 kernels** cannot separate two same-tick processes. Unclosable — Linux publishes nothing finer — so the token declares it via the tag and a test pins that branch. Worth a ticket if those kernels are supported targets.
- **Integration-harness flake:** `TrustedProxy::start()` gives `aa-proxy` a 5 s bind timeout; on a loaded machine with cold binaries it times out and every test in the file fails with a misleading message. Hit once, passed on retry.
- **The Docker VM disk hit 100% during this work** (17 GB of reclaimable build cache remains). It is already causing unrelated failures elsewhere — `initdb: … pg_wal: No space left on device` in `aa-gateway` migration tests.
