### PR TITLE
[AAASM-5344] 🐛 (aa-security): Stop classifying non-ASCII text as high-entropy secrets

### DIFF
--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -953,8 +953,31 @@ const BASE64_RUN_MIN_LEN: usize = 20;
 /// security-critical part. A secret worth hiding is ASCII by construction
 /// (base64, hex, base62 key material), so a whole-token test would let an
 /// attacker prepend one glyph from any non-Latin script and carry the secret
-/// straight through the gate. Segmenting keeps every ASCII candidate visible no
-/// matter what surrounds it.
+/// straight through the gate. Segmenting keeps a *contiguous* ASCII candidate
+/// visible no matter what surrounds it.
+///
+/// # Known residual — a non-ASCII byte splits, as whitespace already does
+///
+/// Because non-ASCII is now purely a run boundary, a glyph inserted into the
+/// *middle* of a secret splits it into two runs, and if both fall under the
+/// 20-character floor neither is scored. Detection of such a secret is lost
+/// relative to the old byte-entropy behaviour.
+///
+/// This is a deliberate, bounded trade, not an oversight:
+///
+/// * It grants an attacker nothing new. Splitting with a plain **space**, tab or
+///   newline defeats the same floor and always has — separator-splitting was
+///   already fully open, and remains equally open. This change only makes a
+///   non-ASCII separator behave like the whitespace separators beside it.
+/// * The old behaviour was not detection. It was the byte-entropy defect firing
+///   on a clause that happened to contain a secret, and it "worked" only by
+///   redacting the entire surrounding clause — which is precisely the
+///   false-positive defect this function exists to fix. The catch cannot be kept
+///   while fixing the bug.
+///
+/// The general separator-split gap is tracked as AAASM-5368, which owns closing
+/// it for every separator class at once; `separator_split_secret_is_a_known_residual`
+/// pins the current behaviour so that ticket's change is visible when it lands.
 fn ascii_runs(s: &str) -> impl Iterator<Item = (usize, &str)> {
     let bytes = s.as_bytes();
     let mut i = 0usize;

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2551,6 +2551,18 @@ mod tests {
         assert_eq!(result.redact(text), text);
     }
 
+    /// Reported reproducer 4, and the end-to-end one: on the enforcement path
+    /// this whole sentence became `[REDACTED:GenericHighEntropy]`, so a support
+    /// request written in Chinese reached the model as nothing at all.
+    #[test]
+    fn zh_tw_support_request_survives_redact() {
+        let scanner = CredentialScanner::new();
+        let text = "客戶反映系統登入失敗請協助處理謝謝";
+        let result = scanner.scan(text);
+        assert!(result.is_clean(), "unexpected findings: {:?}", result.findings);
+        assert_eq!(result.redact(text), text);
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2442,6 +2442,16 @@ mod tests {
         assert_eq!(runs, vec![(6, "abc"), (12, "xy")]);
     }
 
+    /// The behaviour-preservation claim of the whole change: for ASCII input the
+    /// run *is* the token, so the entropy pass sees the same slice at the same
+    /// offset it always did and every pre-existing finding is reproduced.
+    #[test]
+    fn ascii_runs_yields_the_whole_slice_for_ascii_only_input() {
+        let token = "xK9mP2nQvR7sT4wY1aB6dF3hJ8lN0eC5";
+        let runs: Vec<(usize, &str)> = ascii_runs(token).collect();
+        assert_eq!(runs, vec![(0, token)]);
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2583,6 +2583,26 @@ mod tests {
         assert!(!result.redact(&text).contains(secret));
     }
 
+    /// Detection-strength guard for the base64-run pass. Deliberately shaped as
+    /// compact JSON with no whitespace and a run past 64 chars, so the
+    /// whitespace-token pass cannot reach it — this asserts pass 3 specifically.
+    #[test]
+    fn ascii_base64_secret_is_still_detected() {
+        let scanner = CredentialScanner::new();
+        let secret = "aGVsbG9Xb3JsZFRoaXNJc0FWZXJ5TG9uZ0Jhc2U2NFNlY3JldFRva2VuQmV5b25kU2l4dHlGb3VyQ2hhcnM5OQ";
+        let text = format!("{{\"api_token\":\"{secret}\"}}");
+        let result = scanner.scan(&text);
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|f| f.kind == CredentialKind::GenericHighEntropy),
+            "ASCII base64 secret must still be flagged: {:?}",
+            result.findings
+        );
+        assert!(!result.redact(&text).contains(secret));
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -542,7 +542,7 @@ impl CredentialScanner {
     /// Scan `text` for credential patterns and return a [`ScanResult`].
     ///
     /// Four passes are performed:
-    /// 1. Aho-Corasick literal prefix scan — O(n), 18 patterns covering API keys,
+    /// 1. Aho-Corasick literal prefix scan — O(n), 28 patterns covering API keys,
     ///    auth tokens, cloud credentials, database URLs, and PEM private key headers.
     /// 2. Credit card and SSN digit-sequence scan.
     /// 3. Email address scan.
@@ -557,7 +557,7 @@ impl CredentialScanner {
         let mut findings = Vec::new();
 
         // Phase 1: AC literal prefix scan (API keys, auth tokens, cloud creds,
-        //          database URLs, PEM private key headers — 18 patterns + custom)
+        //          database URLs, PEM private key headers — 28 patterns + custom)
         for mat in self.patterns.find_iter(text) {
             let kind = self.kinds[mat.pattern()].clone();
             let offset = mat.start();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1004,6 +1004,12 @@ fn is_base64_char(b: u8) -> bool {
 ///    into 2-char groups that clear neither the pass-2 length bar nor (with `-`
 ///    kept inside the base64 alphabet) the pass-3 entropy gate, so it evades
 ///    passes 1-3 entirely; this pass closes that gap.
+///
+/// Passes 2-4 need no ASCII narrowing of their own: every byte they accept is
+/// selected by an ASCII predicate (`is_ascii_hexdigit`, [`is_base64_char`],
+/// [`is_hex_group_separator`]), and every byte of a multi-byte UTF-8 sequence
+/// is ≥ `0x80`, so non-ASCII terminates their runs exactly as whitespace does.
+/// Their runs are therefore ASCII by construction and score correctly already.
 fn scan_high_entropy(text: &str, findings: &mut Vec<CredentialFinding>) {
     // Pass 1: whitespace-delimited high-entropy tokens, length 20–64.
     let mut offset = 0usize;

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2484,6 +2484,36 @@ mod tests {
         assert_eq!(result.redact(&corpus), corpus, "clean traffic must survive redact()");
     }
 
+    /// The evasion this fix must not create. Skipping any whitespace token that
+    /// holds a non-ASCII byte would have fixed the false positives and handed an
+    /// attacker a one-glyph bypass: prepend a Han character and the secret rides
+    /// through untouched. The fixture's punctuation keeps it out of the base64
+    /// alphabet, so passes 2-4 cannot cover for pass 1 here — the whitespace-token
+    /// pass is the only thing that can catch it, which is the point.
+    ///
+    /// Asserting the exact span also pins the offset arithmetic: the finding must
+    /// start after the leading Han characters (3 bytes each) and stop before the
+    /// trailing ones rather than swallowing the surrounding prose.
+    #[test]
+    fn a_cjk_prefix_cannot_hide_an_ascii_secret() {
+        let scanner = CredentialScanner::new();
+        let secret = "Xk9!mQ2*vB7#nR4$wT6%zP1&";
+        let text = format!("日誌：{secret}，狀態正常");
+
+        let result = scanner.scan(&text);
+        let hit = result
+            .findings
+            .iter()
+            .find(|f| f.kind == CredentialKind::GenericHighEntropy)
+            .expect("an ASCII secret must stay visible behind a CJK prefix");
+
+        assert_eq!(&text[hit.offset..hit.end], secret, "span must cover exactly the secret");
+        assert!(
+            !result.redact(&text).contains(secret),
+            "secret must not survive redact()"
+        );
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2693,6 +2693,41 @@ mod tests {
         );
     }
 
+    /// Pins the known residual documented on [`ascii_runs`]: a separator dropped
+    /// into the *middle* of a secret splits it into two sub-20-char runs and
+    /// neither is scored. Asserted as **not detected**, deliberately — a test
+    /// that documents a gap is how the gap stays visible instead of being
+    /// rediscovered by an attacker.
+    ///
+    /// The whitespace rows are the reason this is an accepted trade rather than
+    /// a regression: they are undetected on `main` too, so separator-splitting
+    /// was already fully open and a non-ASCII glyph merely joins the class. The
+    /// undivided row is the control — remove the splitter and detection returns.
+    ///
+    /// AAASM-5368 closes this for every separator class; when it lands, the
+    /// first five rows flip and this test is expected to be rewritten, not
+    /// deleted.
+    #[test]
+    fn separator_split_secret_is_a_known_residual() {
+        let scanner = CredentialScanner::new();
+        // One synthetic 24-char high-entropy secret, split after 15 chars.
+        let (head, tail) = ("Xk9!mQ2*vB7#nR4", "$wT6%zP1&");
+
+        for splitter in ["中", "😀", "д", " ", "\t", "\n"] {
+            let text = format!("log {head}{splitter}{tail} end");
+            assert!(
+                scanner.scan(&text).is_clean(),
+                "residual changed for splitter {splitter:?} — if AAASM-5368 landed, update this test"
+            );
+        }
+
+        let undivided = format!("log {head}{tail} end");
+        assert!(
+            !scanner.scan(&undivided).is_clean(),
+            "control: the same secret undivided must still be detected"
+        );
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2514,6 +2514,18 @@ mod tests {
         );
     }
 
+    /// Reported reproducer 1. This redacted to `[REDACTED:GenericHighEntropy]
+    /// 的狀態`, destroying the sentence around a synthetic order reference that
+    /// is not a secret at all.
+    #[test]
+    fn zh_tw_order_reference_survives_redact() {
+        let scanner = CredentialScanner::new();
+        let text = "請查詢訂單編號：ORD20260427001 的狀態";
+        let result = scanner.scan(text);
+        assert!(result.is_clean(), "unexpected findings: {:?}", result.findings);
+        assert_eq!(result.redact(text), text);
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2526,6 +2526,18 @@ mod tests {
         assert_eq!(result.redact(text), text);
     }
 
+    /// Reported reproducer 2, redacted in its entirety. The digits are a
+    /// synthetic Taiwanese mobile number: 10 digits, so neither the SSN shape
+    /// nor the Luhn range applies and the PII passes are not what fired here.
+    #[test]
+    fn zh_tw_contact_line_survives_redact() {
+        let scanner = CredentialScanner::new();
+        let text = "聯絡電話：0912-345-678，請於上班時間撥打";
+        let result = scanner.scan(text);
+        assert!(result.is_clean(), "unexpected findings: {:?}", result.findings);
+        assert_eq!(result.redact(text), text);
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2603,6 +2603,27 @@ mod tests {
         assert!(!result.redact(&text).contains(secret));
     }
 
+    /// Detection-strength guard for the hex-run pass. Hex tops out at 4.0
+    /// bits/char, below the gate, so this can only ever be caught by the
+    /// dedicated length rule — an entropy-side regression would be invisible
+    /// here, which is exactly why it needs its own assertion.
+    #[test]
+    fn ascii_hex_secret_is_still_detected() {
+        let scanner = CredentialScanner::new();
+        let secret = "deadbeefcafebabe0123456789abcdef0123456789abcdeffedcba9876543210";
+        let text = format!("key={secret}");
+        let result = scanner.scan(&text);
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|f| f.kind == CredentialKind::GenericHighEntropy),
+            "64-char ASCII hex secret must still be flagged: {:?}",
+            result.findings
+        );
+        assert!(!result.redact(&text).contains(secret));
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2624,6 +2624,31 @@ mod tests {
         assert!(!result.redact(&text).contains(secret));
     }
 
+    /// Detection-strength guard for the literal prefix pass, across the vendor
+    /// families whose prefixes dilute run entropy below the gate — for these the
+    /// AC scan is the only reliable path, so a regression here is a silent leak.
+    #[test]
+    fn ascii_api_key_prefixes_are_still_detected() {
+        let scanner = CredentialScanner::new();
+        for (text, expected) in [
+            ("k=AKIAIOSFODNN7EXAMPLE", CredentialKind::AwsAccessKey),
+            ("k=ghp_0000000000000000000000000000000000ab", CredentialKind::GitHubPat),
+            ("k=sk-ant-api03-000000000000000000000000", CredentialKind::AnthropicKey),
+            ("k=xoxb-000000000000-000000000000-abcdef", CredentialKind::SlackBotToken),
+            (
+                "url=postgres://user:notarealpassword@host:5432/db",
+                CredentialKind::PostgresUrl,
+            ),
+        ] {
+            let result = scanner.scan(text);
+            assert!(
+                result.findings.iter().any(|f| f.kind == expected),
+                "{expected:?} must still be flagged: {:?}",
+                result.findings
+            );
+        }
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2563,6 +2563,26 @@ mod tests {
         assert_eq!(result.redact(text), text);
     }
 
+    /// Detection-strength guard: the plain ASCII high-entropy token is the case
+    /// the whitespace-token pass exists for, and the case this change edits. It
+    /// must be unaffected.
+    #[test]
+    fn ascii_high_entropy_token_is_still_detected() {
+        let scanner = CredentialScanner::new();
+        let secret = "xK9mP2nQvR7sT4wY1aB6dF3hJ8lN0eC5";
+        let text = format!("token={secret}");
+        let result = scanner.scan(&text);
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|f| f.kind == CredentialKind::GenericHighEntropy),
+            "ASCII high-entropy token must still be flagged: {:?}",
+            result.findings
+        );
+        assert!(!result.redact(&text).contains(secret));
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -874,7 +874,15 @@ fn scan_digit_sequences(text: &str, findings: &mut Vec<CredentialFinding>) {
     }
 }
 
-/// Computes the Shannon entropy of `s` in bits per character.
+/// Computes the Shannon entropy of `s` in bits per **byte**.
+///
+/// Callers must pass an ASCII-only slice. Bytes and characters coincide only
+/// for ASCII, and every threshold this result is compared against
+/// ([`ENTROPY_BITS_GATE`]) is specified per character. Feeding it multi-byte
+/// UTF-8 measures the encoding rather than the text: Han characters spread
+/// their bytes widely and land at 4.6-4.9 bits, above a gate calibrated on
+/// English prose, which is how ordinary Chinese was reported as leaked secrets
+/// (AAASM-5344). Every call site therefore narrows to an ASCII run first.
 fn shannon_entropy(s: &str) -> f64 {
     if s.is_empty() {
         return 0.0;
@@ -893,10 +901,13 @@ fn shannon_entropy(s: &str) -> f64 {
         .sum()
 }
 
-/// Shannon-entropy gate, in bits per character.
+/// Shannon-entropy gate, in bits per character, over **ASCII** text.
 ///
 /// Base64/base85 encodings of random bytes sit around 5-6 bits/char, while
 /// English prose and `snake_case` / `kebab-case` identifiers stay below this.
+/// The corpus behind that calibration is ASCII, and the gate is only meaningful
+/// against ASCII — see [`shannon_entropy`] for why non-ASCII input measures the
+/// UTF-8 encoding instead of the text (AAASM-5344).
 /// Note hex tops out at `log2(16) = 4.0` bits/char, so hex-encoded secrets never
 /// trip this gate — they are caught by the dedicated hex rule (see
 /// [`HEX_RUN_MIN_LEN`]).

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2538,6 +2538,19 @@ mod tests {
         assert_eq!(result.redact(text), text);
     }
 
+    /// Reported reproducer 3. The URL is the interesting part: it is a 30-char
+    /// ASCII run, squarely inside the 20-64 window, and it stays clean because
+    /// its entropy is genuinely below the gate — the same verdict the identical
+    /// URL gets in English text. That is the equivalence the fix restores.
+    #[test]
+    fn zh_tw_document_link_survives_redact() {
+        let scanner = CredentialScanner::new();
+        let text = "文件連結：https://example.com/docs/guide 請參考";
+        let result = scanner.scan(text);
+        assert!(result.is_clean(), "unexpected findings: {:?}", result.findings);
+        assert_eq!(result.redact(text), text);
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2649,6 +2649,27 @@ mod tests {
         }
     }
 
+    /// Detection-strength guard for PEM private keys, whose span is assembled
+    /// from a literal header plus an entropy-caught body (ADR 0015 §2/§5.1) —
+    /// the one detector that depends on the edited pass for part of its answer,
+    /// so it needs asserting on both halves rather than on the header alone.
+    #[test]
+    fn ascii_private_key_block_is_still_detected() {
+        let scanner = CredentialScanner::new();
+        let body = "MIIEpAIBAAKCAQEAx7Vq2mNfP9sKdL3wQzR8tYuI0oP1aScDeFgHjKlMnBvCxZ";
+        let text = format!("-----BEGIN RSA PRIVATE KEY-----\n{body}\n-----END RSA PRIVATE KEY-----");
+        let result = scanner.scan(&text);
+        assert!(
+            result.findings.iter().any(|f| f.kind == CredentialKind::RsaPrivateKey),
+            "PEM private key header must still be flagged: {:?}",
+            result.findings
+        );
+        assert!(
+            !result.redact(&text).contains(body),
+            "key material must not survive redact()"
+        );
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2428,6 +2428,20 @@ mod tests {
         assert!(kinds.contains(&&CredentialKind::Custom));
     }
 
+    // --- AAASM-5344: the entropy gate measures ASCII runs, not raw bytes ---
+    //
+    // Every fixture below is synthetic: no real credential, order reference,
+    // phone number or person appears in this section.
+
+    /// Offsets are byte offsets into the slice handed in, since that is what the
+    /// caller adds to the token's own offset to place a finding. Each Han
+    /// character is 3 UTF-8 bytes, so character indices would be silently wrong.
+    #[test]
+    fn ascii_runs_segments_a_token_around_its_non_ascii_bytes() {
+        let runs: Vec<(usize, &str)> = ascii_runs("日誌abc：xy").collect();
+        assert_eq!(runs, vec![(6, "abc"), (12, "xy")]);
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -940,6 +940,39 @@ const HEX_RUN_MIN_LEN: usize = 64;
 /// and clean regardless of length.
 const BASE64_RUN_MIN_LEN: usize = 20;
 
+/// Yields each maximal run of ASCII bytes in `s` as `(byte offset in s, run)`.
+///
+/// The whitespace-token entropy pass needs this because both halves of its gate
+/// are byte-denominated while their thresholds are character-denominated: a
+/// 7-character Han phrase is 21 bytes, already inside the 20-64 "looks like a
+/// secret" window, and [`shannon_entropy`] then scores its UTF-8 bytes above a
+/// gate calibrated on English. Narrowing to ASCII runs restores bytes ==
+/// characters, which is what both thresholds were written for (AAASM-5344).
+///
+/// Runs — rather than dropping any token that holds a non-ASCII byte — is the
+/// security-critical part. A secret worth hiding is ASCII by construction
+/// (base64, hex, base62 key material), so a whole-token test would let an
+/// attacker prepend one glyph from any non-Latin script and carry the secret
+/// straight through the gate. Segmenting keeps every ASCII candidate visible no
+/// matter what surrounds it.
+fn ascii_runs(s: &str) -> impl Iterator<Item = (usize, &str)> {
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    std::iter::from_fn(move || {
+        while i < bytes.len() && !bytes[i].is_ascii() {
+            i += 1;
+        }
+        let start = i;
+        while i < bytes.len() && bytes[i].is_ascii() {
+            i += 1;
+        }
+        // Both bounds are ASCII-adjacent, hence UTF-8 char boundaries: `start`
+        // is an ASCII byte and `i` is either the end of `s` or the lead byte of
+        // a multi-byte sequence, since a continuation byte never follows ASCII.
+        (start < i).then(|| (start, &s[start..i]))
+    })
+}
+
 /// Returns `true` if `b` is in the base64 / base64url alphabet
 /// (alphanumerics plus `+ / - _`). `=` padding and all delimiters are excluded.
 fn is_base64_char(b: u8) -> bool {
@@ -953,8 +986,11 @@ fn is_base64_char(b: u8) -> bool {
 /// A secret caught by more than one pass yields overlapping same-kind findings
 /// that [`scan`]'s final [`dedupe_same_kind_overlaps`] collapses back to one:
 ///
-/// 1. **Whitespace-token entropy** (unchanged spec behaviour) — a whitespace
-///    token of length 20–64 with Shannon entropy > [`ENTROPY_BITS_GATE`].
+/// 1. **Whitespace-token entropy** (unchanged spec behaviour for ASCII input) —
+///    an ASCII run *within* a whitespace token, of length 20–64 with Shannon
+///    entropy > [`ENTROPY_BITS_GATE`]. For ASCII-only text the run and the
+///    token are the same slice, so this is the original rule; for mixed text it
+///    is what stops the gate scoring UTF-8 bytes (see [`ascii_runs`]).
 /// 2. **Long hex run** (AAASM-3870) — a contiguous hex run ≥ [`HEX_RUN_MIN_LEN`],
 ///    closing the hex-encoding evasion (hex entropy is capped at 4.0 bits/char,
 ///    below the gate, so pass 1 never catches it at any length).
@@ -974,19 +1010,30 @@ fn scan_high_entropy(text: &str, findings: &mut Vec<CredentialFinding>) {
     for token in text.split_whitespace() {
         let token_offset = text[offset..].find(token).map(|i| offset + i).unwrap_or(offset);
         let whitespace_end = token_offset + token.len();
-        let len = token.len();
-        if (20..=64).contains(&len) && shannon_entropy(token) > ENTROPY_BITS_GATE {
-            // The whitespace token can still carry trailing delimiters when a
-            // secret is embedded in structured text (e.g. `...key"}]}` in compact
-            // JSON). Clamp the finding's `end` at the first token-terminating
-            // character so the span covers only the credential — matching how the
-            // AC literal scan derives its `end`.
-            let end = token_end(text, token_offset);
-            findings.push(CredentialFinding::new(
-                CredentialKind::GenericHighEntropy,
-                token_offset,
-                end,
-            ));
+        // Gate each of the token's ASCII runs, not the token itself. A script
+        // that does not delimit words with spaces (Chinese, Japanese, Thai)
+        // makes one "token" an entire clause, and both the length window and
+        // the entropy gate then measure UTF-8 bytes against character-scale
+        // thresholds — which classified ordinary Chinese prose as leaked
+        // secrets. See [`ascii_runs`] for why this segments rather than skips
+        // (AAASM-5344). For ASCII-only text the run is the whole token, so
+        // every pre-existing finding is reproduced byte-identically.
+        for (run_offset, run) in ascii_runs(token) {
+            let run_start = token_offset + run_offset;
+            if (20..=64).contains(&run.len()) && shannon_entropy(run) > ENTROPY_BITS_GATE {
+                // The whitespace token can still carry trailing delimiters when a
+                // secret is embedded in structured text (e.g. `...key"}]}` in compact
+                // JSON). Clamp the finding's `end` at the first token-terminating
+                // character so the span covers only the credential — matching how the
+                // AC literal scan derives its `end`. The run's own end bounds it too,
+                // so a trailing non-ASCII neighbour is never swallowed into the span.
+                let end = token_end(text, run_start).min(run_start + run.len());
+                findings.push(CredentialFinding::new(
+                    CredentialKind::GenericHighEntropy,
+                    run_start,
+                    end,
+                ));
+            }
         }
         offset = whitespace_end;
     }

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2452,6 +2452,38 @@ mod tests {
         assert_eq!(runs, vec![(0, token)]);
     }
 
+    /// Synthetic mixed `zh-TW`/English agent traffic carrying no credential.
+    const BENIGN_ZH_TW_BLOCK: &str = "使用者請求：請協助查詢訂單狀態，並將結果整理成報表。\
+         系統回應：查詢完成，共 12 筆資料，處理時間 340 毫秒。\
+         備註 (note): the retrieval step returned 12 rows from the orders table. \
+         設定檔版本 version = \"1.0.0\"，環境 environment = production。\
+         日誌：2026-04-27T12:00:00Z 資訊 處理中 request_id=abc123 狀態正常。\
+         客戶反映系統登入失敗請協助處理謝謝，我們已於今日上午完成修復並通知使用者。\
+         測試涵蓋率報告顯示核心模組的分支覆蓋率為百分之九十二，尚有兩個邊界案例待補。";
+
+    /// The headline defect: 32 KB of this traffic produced 87 `GenericHighEntropy`
+    /// findings while the byte-equivalent English produced none, so a `zh-TW`
+    /// tenant on `credential_action: Block` was denied for speaking Chinese.
+    #[test]
+    fn benign_mixed_zh_tw_traffic_yields_no_findings() {
+        let mut corpus = String::new();
+        while corpus.len() < 32 * 1024 {
+            corpus.push_str(BENIGN_ZH_TW_BLOCK);
+        }
+
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan(&corpus);
+
+        assert!(
+            result.findings.is_empty(),
+            "{} bytes of benign zh-TW traffic must be clean, got {} findings: {:?}",
+            corpus.len(),
+            result.findings.len(),
+            result.findings,
+        );
+        assert_eq!(result.redact(&corpus), corpus, "clean traffic must survive redact()");
+    }
+
     #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();


### PR DESCRIPTION
## Description

`aa-security`'s whitespace-token entropy pass classified ordinary
Traditional-Chinese text as leaked secrets. 32 KB of benign mixed `zh-TW`/English
agent traffic containing **zero** credentials produced **87** `GenericHighEntropy`
findings; the byte-equivalent English produced **0**. Under
`credential_action: Block` an agent communicating in Chinese was denied outright,
and every false positive reached redaction, the audit entry and the alert store —
so any "leaks detected" figure for a `zh-TW` tenant was dominated by noise. The
failure generalises to every space-less script (Chinese, Japanese, Thai).

**Root cause** — three byte/character confusions in `aa-security/src/scanner.rs`,
each individually reasonable:

1. `:963` `text.split_whitespace()` — Chinese does not delimit words with spaces,
   so one "token" is an entire clause.
2. `:966-967` `let len = token.len();` gated at `(20..=64)`. `str::len()` is
   **bytes** and a Han character is 3 UTF-8 bytes, so a 7-character phrase already
   sits inside the "looks like a secret" window.
3. `:878-894` `shannon_entropy` counts over `s.as_bytes()` while its doc at `:877`
   called the result "bits per **character**" — an equivalence that holds only for
   ASCII. Han characters spread bytes widely and land at 4.6-4.9 bits against
   `ENTROPY_BITS_GATE = 4.5` (`:903`), whose calibration note names its corpus
   explicitly: *"…while **English prose** … stay below this."*

**Fix** — the entropy pass now evaluates the maximal **ASCII runs** within each
whitespace token instead of the raw token. Both of the pass's thresholds are
character-denominated; narrowing to an ASCII run restores bytes == characters,
which is what they were written for.

## Type of Change

- [x] 🐛 Bug fix
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

No schema, API or wire change. Behaviour moves only in the direction of *fewer*
false positives on non-ASCII text; ASCII behaviour is byte-identical.
`CredentialKind` variants and redaction labels are untouched. No migration.

## Related Issues

- Related Jira ticket: [AAASM-5344](https://lightning-dust-mite.atlassian.net/browse/AAASM-5344)
  — backlog item **B-2**, under Epic
  [AAASM-5270](https://lightning-dust-mite.atlassian.net/browse/AAASM-5270).
- **ADR 0032** — *Local-first sensitive-data provider architecture*
  (`docs/src/adr/0032-local-first-sensitive-data-provider-architecture.md`).
  Decision **D-3** ships this in `v0.0.1-rc.7`, ahead of the architecture
  migration, and requires the fix **must not weaken detection of ASCII base64,
  hex or high-entropy secrets**.
- **ADR 0015** — *DLP trust boundary and redaction semantics*
  (`docs/src/adr/0015-dlp-trust-boundary-and-redaction-semantics.md`). Its rule
  that a committed golden vector is never edited to make a change pass is why the
  26 existing conformance vectors are untouched here.

## Why the bypass is prevented

The obvious fix — *skip any whitespace token containing a non-ASCII byte*, which
is what the ticket's proposed-fix section suggests — is **not safe**. It removes
the false positives and simultaneously opens a one-glyph evasion: prepend a
single Han character to a base64 secret and the entire token is skipped, so the
secret is never scored. That trades a false-positive bug for a detection hole.

This PR **segments rather than discards**. Within each whitespace token, every
maximal ASCII run is gated independently:

- A secret worth hiding is ASCII by construction (base64, hex, base62 key
  material), so it always *is* one of those runs — no amount of surrounding
  non-Latin script can remove it from consideration.
- Non-ASCII bytes act only as run boundaries, so they can never contribute to a
  run's entropy score. That is precisely what removes the false positives.
- Spans stay byte-exact in the **original** text: a run's offset within the token
  is added to the token's own offset, and the finding's `end` is clamped to
  `token_end(text, run_start).min(run_start + run.len())`, so a trailing
  non-ASCII neighbour is never swallowed into the redacted span.

This was verified by mutation, not by argument. Substituting the naive
`if token.is_ascii() { … } else { skip }` for the run loop:

```
PASS  benign_mixed_zh_tw_traffic_yields_no_findings     <- the naive fix passes this
FAIL  a_cjk_prefix_cannot_hide_an_ascii_secret          <- and fails this
      an ASCII secret must stay visible behind a CJK prefix
```

Only the bypass test tells the two implementations apart — without it the ticket
could have been closed green having introduced an evasion. Its fixture is
deliberately shaped so passes 2-4 cannot cover for pass 1: the punctuation keeps
it out of the base64 alphabet, so the whitespace-token pass is the only detector
that can catch it.

Reverting the fix entirely reproduces the defect against the new corpus test:

```
FAIL  benign_mixed_zh_tw_traffic_yields_no_findings
      33110 bytes of benign zh-TW traffic must be clean, got 55 findings
```

**Passes 2-4 are unaffected, and this is shown rather than assumed.**
`scan_long_hex_runs`, `scan_long_base64_runs` and `scan_separated_hex_runs`
select bytes with ASCII predicates (`is_ascii_hexdigit`, `is_base64_char`,
`is_hex_group_separator`). Every byte of a multi-byte UTF-8 sequence is `>= 0x80`,
so non-ASCII already terminates their runs exactly as whitespace does — their
runs are ASCII by construction and were always scored correctly. The reasoning is
recorded in `scan_high_entropy`'s doc comment so it is not re-derived, or
"fixed", later.

## Security impact

This is a detection-strength change and was treated as one.

- **Detection strength on ASCII: unchanged.** For ASCII-only input the ASCII run
  *is* the whole token, at the same offset, so every pre-existing finding is
  reproduced byte-identically.
  `ascii_runs_yields_the_whole_slice_for_ascii_only_input` pins that claim at the
  helper, so a future refactor that starts segmenting on punctuation fails there
  rather than in a golden vector someone might be tempted to rewrite.
- **No evasion is newly reachable** — see the section above for the prepend case,
  and the residual below for the mid-insertion case.

### Known residual, accepted deliberately

Detection of a secret **split by a non-ASCII character into sub-20-char ASCII
runs is lost.** Because non-ASCII is now purely a run boundary, one glyph dropped
into the middle of a secret produces two runs that each fall under the
20-character floor, and neither is scored.

This makes non-ASCII separators equivalent to whitespace separators, which are
already an open evasion on `main` — space-splitting is undetected both before and
after. **No evasion is newly reachable.** Measured both sides, same fixture:

| splitter inserted mid-secret | `main` | this branch |
|---|---|---|
| `中` (CJK) | 1 finding | 0 findings |
| `😀` (emoji) | 1 finding | 0 findings |
| `д` (Cyrillic) | 1 finding | 0 findings |
| **plain space** | **0 findings** | **0 findings** |
| **tab** | **0 findings** | **0 findings** |
| *(control)* no splitter | 1 finding | 1 finding |

`main`'s apparent catch on the first three rows was not the length gate working.
It was the byte-entropy defect this PR fixes, accidentally firing on a clause
that happened to contain a secret — and it "succeeded" only by redacting the
entire surrounding clause, which *is* the false-positive defect. That catch
cannot be kept while fixing the bug.

The general separator-split gap is tracked as
[AAASM-5368](https://lightning-dust-mite.atlassian.net/browse/AAASM-5368), which
owns closing it for every separator class at once. The residual is documented
beside the evasion rationale on `ascii_runs` and pinned by
`separator_split_secret_is_a_known_residual`, which asserts the gap so that
ticket's change is visible when it lands.

> An earlier revision of this description claimed detection on mixed text was
> "strictly increased" and that "nothing detected before is undetected now".
> Both were false; adversarial review caught them and they are corrected above.
> The implementation is unchanged — only the claim was wrong.
- All fixtures are synthetic. No live credential, real person, real phone number
  or real order reference appears in the diff, and no raw secret value is written
  to logs or test output (`CredentialFinding`'s `matched` field is the redacted
  label, not the secret).

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed (benchmark harness, mutation testing)

### `cargo nextest run -p aa-security -p conformance`

```
    Summary [   0.197s] 195 tests run: 195 passed, 0 skipped
```

181 before, 195 after — 14 new unit tests, all in `aa-security`. The
`credential_detection` conformance tests pass unchanged:

```
PASS conformance::credential_detection all_vectors_have_correct_finding_offsets
PASS conformance::credential_detection all_vectors_have_correct_finding_kinds
PASS conformance::credential_detection all_vectors_have_correct_finding_count
PASS conformance::credential_detection all_vectors_redact_correctly
PASS conformance::credential_detection unknown_key_secret_is_redacted
PASS conformance::credential_detection multiple_nested_secrets_all_redacted
PASS conformance::credential_detection embedded_in_surrounding_text_is_redacted
PASS conformance::credential_detection nested_json_secret_is_redacted
```

**No golden vector was edited.** The diff touches exactly one file:

```
$ git diff --stat remote/main...HEAD
 aa-security/src/scanner.rs | 344 ++++++++++++++++++++++++++++++++++++++++++---
 1 file changed, 325 insertions(+), 19 deletions(-)
```

All 26 `conformance/vectors/credential_detection/*.json` **inputs** are pure
ASCII — the only non-ASCII bytes anywhere in them are em-dashes inside
`description` fields — which is why the fix is provably a no-op against the
committed suite rather than merely observed to be one.

### `cargo bench -p aa-security --bench spike_5269_percentiles`

`AA_SPIKE_SAMPLES=200`, same machine, same invocation before and after. Only the
**findings** column is meaningful for this PR; the harness asserts nothing and
the latency columns are noise-dominated on a loaded laptop.

| case | findings before | findings after |
|---|---:|---:|
| `small_tool_call_1_finding` | 1 | 1 |
| `small_tool_call_clean` | 0 | 0 |
| `medium_prompt_history_32kb` | 4 | 4 |
| `medium_prompt_history_32kb_clean` | 0 | 0 |
| `large_document_1mb` | 6 | 6 |
| `large_document_1mb_clean` | 0 | 0 |
| **`mixed_zh_tw_32kb`** | **91** | **4** |
| **`mixed_zh_tw_32kb_clean`** | **87** | **0** |
| `high_density_500_findings` | 600 | 600 |

`mixed_zh_tw_32kb_clean` is the acceptance criterion: **87 → 0**. Every
English-only and secret-bearing row is unchanged. `mixed_zh_tw_32kb` also drops,
91 → 4 — the same defect being removed, not a detection loss: 4 is exactly the
count `medium_prompt_history_32kb` reports for the same 3 planted synthetic
secrets, so what disappeared is the 87 findings of zh-TW noise and nothing else.

No latency regression: `medium_prompt_history_32kb_clean` p50 397 µs → 443 µs and
`large_document_1mb_clean` p50 12.60 ms → 14.00 ms sit inside this harness's
run-to-run spread on an unpinned laptop, and the `mixed_zh_tw_*` rows get *faster*
(408 µs → 412 µs p50 while emitting 87 fewer findings).

### Wider suite

- `cargo nextest run -p aa-security -p conformance -p aa-runtime -p aa-proxy
  -p aa-sdk-client -p aa-core -p aa-cli` — **2398/2398 passed**. This is the full
  reverse-dependency set of `aa-security` minus `aa-gateway`/`aa-api`.
- `cargo nextest run -p aa-gateway -p aa-api` — 2336 passed, **1 failed**.

**Two load-induced flakes were observed across these runs. Neither is caused by
this change; both are recorded here rather than only the more obvious one.**

1. `aa-gateway engine::watcher::tests::hot_reload_reflects_new_policy_within_one_second`
   — asserts a debounced filesystem policy-watcher swaps a `PolicyDocument`
   within one second (`aa-gateway/src/engine/watcher.rs:191`). Touches no
   credential-scanning code path, and **passes in isolation**:
   ```
   PASS [1.438s] aa-gateway engine::watcher::tests::hot_reload_reflects_new_policy_within_one_second
        Summary [1.439s] 2 tests run: 2 passed, 1479 skipped
   ```
2. `aa-runtime scan_latency_test::enforce_scan_p99_within_budget` — flaked in the
   reverse-dependency run. Measured like-for-like, the ASCII path costs
   p50 717-734 µs → 741-748 µs (+2-4%, one extra iterator hop per token) while the
   zh-TW path gets *faster*, so this is not a regression; it is exactly the
   load-induced variance that test's own doc comment
   (`aa-runtime/tests/scan_latency_test.rs:99-114`) anticipates.

Both should be triaged as flakes in their own tickets rather than folded in here.

### Acceptance criteria

| Criterion | Evidence |
|---|---|
| 32 KB benign mixed `zh-TW`/English → 0 findings | `benign_mixed_zh_tw_traffic_yields_no_findings`; bench row `mixed_zh_tw_32kb_clean` 87 → 0 |
| All four reproducers untouched by `redact()` | `zh_tw_order_reference_survives_redact`, `zh_tw_contact_line_survives_redact`, `zh_tw_document_link_survives_redact`, `zh_tw_support_request_survives_redact` |
| All 26 conformance vectors pass unchanged | 194/194 green; diff touches only `scanner.rs` |
| ASCII base64 / hex / API-key / private-key / high-entropy still fire | `ascii_base64_secret_is_still_detected`, `ascii_hex_secret_is_still_detected`, `ascii_api_key_prefixes_are_still_detected`, `ascii_private_key_block_is_still_detected`, `ascii_high_entropy_token_is_still_detected` |
| CJK-adjacent ASCII secret still detected (no bypass) | `a_cjk_prefix_cannot_hide_an_ascii_secret`, including an exact-span assertion; mutation-verified to fail under the naive fix |
| Stale "18 patterns" comment corrected to 28 | **Partly met.** `aa-security/src/scanner.rs` done (both the `scan()` doc and the inline phase-1 comment). `aa-gateway/src/engine/mod.rs:1437` **deferred** — see below |

### Lint

```
$ cargo fmt --all -- --check          # exit 0, no output

$ cargo clippy --all-targets --all-features -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.66s   # exit 0
```

## Follow-up (deliberately not in this PR)

- **`aa-gateway/src/engine/mod.rs:1437` — deliberately deferred, and owned.** It
  still reads `(18+ patterns via aa-core::CredentialScanner)`, which is doubly
  stale: there are 28 patterns, and the scanner lives in `aa-security`, not
  `aa-core`. It is a **different crate**, so fixing it here widens this PR's blast
  radius beyond `aa-security` for a comment. It is already an explicit acceptance
  criterion of
  [AAASM-5354](https://lightning-dust-mite.atlassian.net/browse/AAASM-5354) (B-8),
  which formalises the detection seam in that exact function and calls out this
  comment by line number — so it lands there with a reviewer already in the file,
  not as an orphaned drive-by. This is the one AC of AAASM-5344 not fully met by
  this PR, and it is called out rather than quietly dropped.
- **The separator-split gap** is
  [AAASM-5368](https://lightning-dust-mite.atlassian.net/browse/AAASM-5368) — see
  the residual section above.
- New CJK conformance vectors are **AAASM-5345 / B-5**'s scope, not this
  ticket's — which is what lets this diff be reviewed against an unchanged
  existing suite.

## Reviewer notes

- **Commit ordering nit, not rewritten.** `6ee70ba4` lands the doc describing the
  ASCII precondition one commit *before* the code that establishes it. Harmless
  and bisectable (it is a doc-only commit), and rewriting pushed history to
  reorder a comment is not worth it.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)


[AAASM-5344]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ