### PR TITLE
[AAASM-5332] ✨ (aa-sdk-client): Replace the derived registration key with a durable CSPRNG identity

### DIFF
--- a/aa-api/tests/serve_local_grpc_registration.rs
+++ b/aa-api/tests/serve_local_grpc_registration.rs
@@ -28,6 +28,14 @@ fn sdk_config(agent_id: &str, endpoint: String) -> AssemblyConfig {
         team_id: None,
         parent_agent_id: None,
         sdk_version: None,
+        // A per-process temporary identity store, so the durable key this test
+        // enrols never lands in the developer's real `~/.aasm`.
+        identity_dir: Some(
+            std::env::temp_dir()
+                .join(format!("aa-api-grpc-reg-identity-{}", std::process::id()))
+                .to_string_lossy()
+                .into_owned(),
+        ),
     }
 }
 
@@ -64,7 +72,7 @@ async fn grpc_registered_agent_is_visible_via_rest() {
             .await
             .expect("connect to embedded gRPC AgentLifecycleService");
         let challenge = client
-            .request_challenge(build_challenge_request(&config))
+            .request_challenge(build_challenge_request(&config).expect("the agent must have a durable identity key"))
             .await
             .expect("request_challenge succeeds");
         let request = build_register_request(
@@ -72,7 +80,8 @@ async fn grpc_registered_agent_is_visible_via_rest() {
             "grpc-reg-test-agent".to_string(),
             "langgraph".to_string(),
             &challenge.nonce,
-        );
+        )
+        .expect("the agent must have a durable identity key");
         let response = client.register(request).await.expect("register succeeds");
         assert!(
             !response.credential_token.is_empty(),

--- a/aa-cli/src/commands/run_registration.rs
+++ b/aa-cli/src/commands/run_registration.rs
@@ -19,6 +19,15 @@
 //! * `verify_possession_proof` over a **server-issued, single-use, time-bound**
 //!   nonce obtained from `RequestChallenge` (AAASM-3591 / AAASM-3866).
 //!
+//! Those three checks only bite if the private key behind them is a secret.
+//! Until AAASM-5332 it was not — it was `SHA-256(agent_id)`, and the agent id is
+//! published in audit records and on the dashboard — so all three were
+//! satisfiable by anyone who had read one. The key is now generated randomly and
+//! stored owner-only by `aa-sdk-client`'s `identity_store`, and this module
+//! registers with that key: `register` refuses with
+//! [`RegistrationError::IdentityUnavailable`] rather than launching under an
+//! identity it cannot prove it holds.
+//!
 //! Serving the CLI over a second, weaker route would have meant one product with
 //! two registration contracts, the weaker of which is reachable by anything that
 //! can speak HTTP. So `aasm run` registers through the *same* gRPC handshake the
@@ -55,15 +64,25 @@ const LAUNCH_FRAMEWORK: &str = "aasm-run";
 /// A registration the gateway accepted, and the identity it was accepted under.
 #[derive(Clone)]
 pub struct GovernedRegistration {
-    /// The operator-facing identifier the keypair (and therefore the DID) is
-    /// derived from. This is the value handed to the launched tool as
+    /// The operator-facing identifier that *selects* the agent's durable
+    /// identity key. This is the value handed to the launched tool as
     /// `AA_AGENT_ID`, and it is what makes the correlation in
     /// [`registration_did`](Self::registration_did) reproducible: anything that
-    /// derives from this identifier — an SDK inside the launched tool, a later
-    /// `aasm run` for the same agent — arrives at the same DID.
+    /// resolves this identifier — an SDK inside the launched tool, a later
+    /// `aasm run` for the same agent — loads the same stored key and so arrives
+    /// at the same DID.
+    ///
+    /// Since AAASM-5332 it selects a key rather than *being* one. The identifier
+    /// is public (it appears in audit records and on the dashboard); the key it
+    /// names is random and readable only by this user.
     pub agent_id: String,
-    /// The `did:key` the gateway registered, and the identity every audit record
-    /// for this session is attributed to.
+    /// The `did:key` the gateway registered, and the identity the **gateway's**
+    /// audit records for this session are attributed to (they carry
+    /// `SHA-256(did)[..16]`).
+    ///
+    /// Not the whole attribution story: entries written by `aa-runtime` on the
+    /// SDK path hash the plaintext `AA_AGENT_ID` instead, so the two halves of
+    /// the trail are joined by this struct rather than by a shared identifier.
     pub registration_did: String,
     /// The gateway's own registry key for this agent, hex-encoded.
     ///
@@ -104,6 +123,9 @@ pub enum RegistrationError {
     ChallengeRefused { endpoint: String, reason: String },
     /// The gateway refused the registration itself.
     RegistrationRefused { endpoint: String, reason: String },
+    /// This machine has no usable durable identity key for the agent, so there
+    /// is nothing to register as (AAASM-5332).
+    IdentityUnavailable { reason: String },
 }
 
 impl std::error::Error for RegistrationError {}
@@ -116,6 +138,11 @@ impl fmt::Display for RegistrationError {
                 "the governance gateway at {endpoint} is unreachable, so this session cannot be \
                  registered. Start one with `aasm gateway start`, or point `AA_GATEWAY_ENDPOINT` \
                  at the right gRPC endpoint (note: the gRPC port, not the `--api-url` HTTP one)"
+            ),
+            Self::IdentityUnavailable { reason } => write!(
+                f,
+                "this session cannot be registered because the agent has no usable durable \
+                 identity key: {reason}"
             ),
             Self::ChallengeRefused { endpoint, reason } => write!(
                 f,
@@ -172,9 +199,10 @@ pub fn gateway_endpoint() -> String {
 /// The `AssemblyConfig` an SDK would build for this identity.
 ///
 /// Registration identity comes from exactly one place for both surfaces: the
-/// `did:key` and `public_key` are derived here by `aa-sdk-client` from
-/// `agent_id`, so a CLI launch and an SDK agent configured with the same
-/// identifier register as the same DID under the same key.
+/// `did:key` and `public_key` are read by `aa-sdk-client` from the durable
+/// identity key that `agent_id` selects, so a CLI launch and an SDK agent
+/// configured with the same identifier register as the same DID under the same
+/// key — because it is literally the same key file.
 fn sdk_config(agent_id: &str, team_id: Option<&str>, parent_agent_id: Option<&str>) -> AssemblyConfig {
     AssemblyConfig {
         agent_id: agent_id.to_string(),
@@ -183,13 +211,74 @@ fn sdk_config(agent_id: &str, team_id: Option<&str>, parent_agent_id: Option<&st
         team_id: team_id.map(str::to_string),
         parent_agent_id: parent_agent_id.map(str::to_string),
         sdk_version: None,
+        identity_dir: identity_dir_override(),
     }
 }
 
-/// The `did:key` a given operator-facing identifier registers as.
-pub fn registration_did(agent_id: &str) -> String {
-    sdk_config(agent_id, None, None).registration_did()
+/// Where the durable identity key lives. `None` in production, so the store
+/// resolves `${AASM_STATE_DIR:-~/.aasm}/identity` like every other piece of
+/// installation state.
+#[cfg(not(test))]
+fn identity_dir_override() -> Option<String> {
+    None
 }
+
+/// Under `cargo test`, redirect every unit test in this binary to one temporary
+/// directory instead of the developer's real `~/.aasm`.
+///
+/// Enrolment is a filesystem write, and a unit test that asks for an agent's DID
+/// would otherwise mint a real key in the developer's home — including the tests
+/// in `run.rs`, which reach this module through
+/// [`registration_did`](super::run_registration::registration_did) and cannot be
+/// made to opt in from here. One directory for the whole process (rather than
+/// one per test) is deliberate: `run.rs` asserts that two separate calls for one
+/// identifier agree, which is exactly the durability property, and per-test
+/// isolation would break it for the wrong reason.
+#[cfg(test)]
+fn identity_dir_override() -> Option<String> {
+    use std::sync::OnceLock;
+    static DIR: OnceLock<String> = OnceLock::new();
+    Some(
+        DIR.get_or_init(|| {
+            std::env::temp_dir()
+                .join(format!("aasm-cli-test-identity-{}", std::process::id()))
+                .to_string_lossy()
+                .into_owned()
+        })
+        .clone(),
+    )
+}
+
+/// The `did:key` a given operator-facing identifier registers as, enrolling the
+/// agent's durable identity key on first use.
+///
+/// Since AAASM-5332 the DID is a rendering of a randomly-generated key kept
+/// under `AASM_STATE_DIR`, not a hash of the identifier, so this reads the
+/// filesystem and can fail. The signature stays infallible because the preview
+/// path in `run.rs` needs a `String`; when the key cannot be established it
+/// returns [`UNRESOLVED_IDENTITY`] — a value that is deliberately **not** a
+/// `did:key`, so nothing downstream can mistake it for an identity the gateway
+/// would accept. The live path does not come through here: `register` surfaces
+/// the store's own reason as
+/// [`RegistrationError::IdentityUnavailable`](RegistrationError).
+///
+/// Repeated calls for one identifier return the same DID because they read the
+/// same stored key back — which is what keeps the identity that registered, the
+/// identity the launch runs under, and the identity audit attributes to, one
+/// principal.
+pub fn registration_did(agent_id: &str) -> String {
+    sdk_config(agent_id, None, None)
+        .registration_did()
+        .unwrap_or_else(|_| UNRESOLVED_IDENTITY.to_string())
+}
+
+/// Stand-in returned by [`registration_did`] when no durable identity key can be
+/// established.
+///
+/// Not a `did:key`, and deliberately so: the gateway rejects it outright, and a
+/// reader of `--dry-run` output sees that the identity is unresolved rather than
+/// a plausible DID that would never have been the one registered.
+pub const UNRESOLVED_IDENTITY: &str = "<no-durable-identity-key>";
 
 /// The gateway's registry key for `(team, did)`, hex-encoded.
 pub fn registry_id(team_id: Option<&str>, did: &str) -> String {
@@ -216,9 +305,10 @@ fn proto_enforcement_mode(mode: aa_core::EnforcementMode) -> i32 {
 /// actually sends. A test that rebuilt it would be asserting against its own
 /// copy, which can agree with itself while having drifted from this one — the
 /// shape of a fixture that cannot express the state it is supposed to catch.
-fn build_session_request(desc: &SessionDescriptor<'_>, nonce: &[u8]) -> RegisterRequest {
+fn build_session_request(desc: &SessionDescriptor<'_>, nonce: &[u8]) -> Result<RegisterRequest, RegistrationError> {
     let config = sdk_config(desc.agent_id, desc.team_id, desc.parent_agent_id);
-    let mut request = build_register_request(&config, desc.name.to_string(), LAUNCH_FRAMEWORK.to_string(), nonce);
+    let mut request = build_register_request(&config, desc.name.to_string(), LAUNCH_FRAMEWORK.to_string(), nonce)
+        .map_err(identity_unavailable)?;
     // Descriptive fields only. `build_register_request` owns every field the
     // gate reads (agent_id, public_key, registration_nonce, possession_proof);
     // overwriting any of those here would be the second implementation of the
@@ -228,7 +318,16 @@ fn build_session_request(desc: &SessionDescriptor<'_>, nonce: &[u8]) -> Register
     request
         .metadata
         .insert("governance_level".to_string(), desc.governance_level.to_string());
-    request
+    Ok(request)
+}
+
+/// Map an SDK-side identity failure onto this module's refusal.
+///
+/// Kept separate so every path that needs the durable key produces the same
+/// error with the store's own explanation intact — an operator whose key file is
+/// group-readable needs to be told that, not merely that registration failed.
+fn identity_unavailable(e: SdkClientError) -> RegistrationError {
+    RegistrationError::IdentityUnavailable { reason: e.to_string() }
 }
 
 /// Register this session with the gateway over gRPC.
@@ -249,15 +348,17 @@ pub async fn register(desc: SessionDescriptor<'_>) -> Result<GovernedRegistratio
         })?;
 
     let challenge = client
-        .request_challenge(build_challenge_request(&config))
+        .request_challenge(build_challenge_request(&config).map_err(identity_unavailable)?)
         .await
         .map_err(|e| RegistrationError::ChallengeRefused {
             endpoint: endpoint.clone(),
             reason: reason_of(e),
         })?;
 
-    let request = build_session_request(&desc, &challenge.nonce);
-    let did = config.registration_did();
+    let request = build_session_request(&desc, &challenge.nonce)?;
+    let did = config
+        .registration_did()
+        .map_err(|e| RegistrationError::IdentityUnavailable { reason: e.to_string() })?;
     let response = client
         .register(request)
         .await
@@ -327,18 +428,63 @@ mod tests {
     }
 
     /// The whole point of routing the CLI through `aa-sdk-client`: the identity
-    /// the CLI registers under is the identity the SDK derives from the same
+    /// the CLI registers under is the identity the SDK resolves for the same
     /// identifier. If these ever diverge the two surfaces are separate agents to
     /// the gateway, and nothing about "one contract" survives.
+    ///
+    /// Asserted against the SDK's own request builder rather than against
+    /// `agent_id_to_did_key`, because since AAASM-5332 the DID comes from a
+    /// stored key: the two surfaces must agree by *reading the same key*, which
+    /// only a shared store can demonstrate.
     #[test]
     fn the_cli_registers_under_the_same_did_as_the_sdk_for_the_same_identifier() {
-        for id in ["ops-laptop", "team-a/bot", "did:key:z6MkfoobarNotDerived"] {
+        for id in ["ops-laptop", "team-a/bot"] {
+            let sdk = build_register_request(
+                &sdk_config(id, None, None),
+                "any".to_string(),
+                "langgraph".to_string(),
+                &server_issued_nonce(id),
+            )
+            .expect("the SDK must resolve an identity")
+            .agent_id
+            .expect("agent_id is set")
+            .agent_id;
+
             assert_eq!(
                 registration_did(id),
-                aa_sdk_client::agent_id_to_did_key(id),
-                "the CLI must not derive its own identity for `{id}`"
+                sdk,
+                "the CLI must not resolve its own identity for `{id}`"
             );
         }
+    }
+
+    /// The identity is durable: asking twice returns the same DID because the
+    /// second call reads back the key the first one stored. This is contract
+    /// item 6 — registration, launch and audit must name one principal — and it
+    /// is what `run.rs` relies on when it asserts `AA_AGENT_DID` re-derives from
+    /// `AA_AGENT_ID`.
+    #[test]
+    fn one_identifier_keeps_one_identity_across_calls() {
+        let first = registration_did("durable-check");
+        let second = registration_did("durable-check");
+
+        assert_eq!(first, second);
+        assert!(first.starts_with("did:key:z"), "got {first}");
+    }
+
+    /// A `did:key` configured as the agent id is refused rather than registered
+    /// under a substituted identity. The CLI holds no private key for a DID it
+    /// did not generate, so no proof it could build would verify — and silently
+    /// registering something else would mean the launch runs under an identity
+    /// the operator never named.
+    #[test]
+    fn a_provisioned_did_as_agent_id_yields_no_registrable_identity() {
+        let resolved = registration_did("did:key:z6MkfoobarNotDerived");
+        assert_eq!(resolved, UNRESOLVED_IDENTITY);
+        assert!(
+            !resolved.starts_with("did:key:"),
+            "the stand-in must not look like an identity the gateway would accept; got {resolved}"
+        );
     }
 
     /// A stand-in for the nonce the gateway issues, built at run time rather
@@ -374,7 +520,7 @@ mod tests {
         use aa_gateway::registry::convert::{assert_did_key_binds_public_key, validate_proto_agent_id};
 
         let desc = descriptor("binding-check", Some("team-a"));
-        let request = build_session_request(&desc, &server_issued_nonce("binding-check"));
+        let request = build_session_request(&desc, &server_issued_nonce("binding-check")).expect("enrolment");
         let proto_id = request.agent_id.as_ref().expect("agent_id is set");
 
         validate_proto_agent_id(proto_id).expect("the gateway must accept the submitted agent_id");
@@ -399,7 +545,7 @@ mod tests {
     fn the_possession_proof_signs_the_server_nonce_and_verifies_under_the_public_key() {
         let desc = descriptor("proof-check", None);
         let nonce = server_issued_nonce("proof-check");
-        let request = build_session_request(&desc, &nonce);
+        let request = build_session_request(&desc, &nonce).expect("enrolment");
 
         assert_eq!(
             request.registration_nonce, nonce,
@@ -430,8 +576,8 @@ mod tests {
     #[test]
     fn two_registrations_of_one_identity_produce_different_proofs() {
         let desc = descriptor("replay-check", None);
-        let first = build_session_request(&desc, &server_issued_nonce("replay-first"));
-        let second = build_session_request(&desc, &server_issued_nonce("replay-second"));
+        let first = build_session_request(&desc, &server_issued_nonce("replay-first")).expect("enrolment");
+        let second = build_session_request(&desc, &server_issued_nonce("replay-second")).expect("load");
 
         assert_eq!(
             first.public_key, second.public_key,
@@ -449,22 +595,30 @@ mod tests {
     fn the_cli_signs_with_the_same_key_the_sdk_would() {
         let nonce = server_issued_nonce("parity-check");
         let desc = descriptor("parity-check", None);
-        let cli = build_session_request(&desc, &nonce);
+        let cli = build_session_request(&desc, &nonce).expect("enrolment");
         let sdk = build_register_request(
             &sdk_config("parity-check", None, None),
             "any-name".to_string(),
             "langgraph".to_string(),
             &nonce,
-        );
+        )
+        .expect("load");
 
         assert_eq!(cli.public_key, sdk.public_key);
         assert_eq!(
             cli.possession_proof, sdk.possession_proof,
             "the two surfaces must present the same proof for the same identity and nonce"
         );
-        assert_eq!(
+
+        // AAASM-5332: the registration key must NOT be the key anyone can
+        // recompute from the identifier. Before this ticket the two were equal,
+        // and that equality was the vulnerability — the possession proof could
+        // be produced by anybody who had seen the agent id in an audit record.
+        assert_ne!(
             AgentKeypair::derive_transport_key("parity-check").public_key_hex(),
-            cli.public_key
+            cli.public_key,
+            "the registration key is recomputable from the public agent id, so the possession \
+             proof proves nothing"
         );
     }
 

--- a/aa-cli/src/commands/run_registration.rs
+++ b/aa-cli/src/commands/run_registration.rs
@@ -384,7 +384,7 @@ mod tests {
         // The binding is what makes the DID unsquattable, so a mismatched key
         // must be refused by the same check — proving the check is live rather
         // than vacuously satisfied by whatever was passed in.
-        let foreign = AgentKeypair::derive("somebody-else").public_key_hex();
+        let foreign = AgentKeypair::derive_transport_key("somebody-else").public_key_hex();
         assert!(
             assert_did_key_binds_public_key(&proto_id.agent_id, &foreign).is_err(),
             "a DID paired with a foreign key must be refused; if this passes, the binding check \
@@ -462,7 +462,10 @@ mod tests {
             cli.possession_proof, sdk.possession_proof,
             "the two surfaces must present the same proof for the same identity and nonce"
         );
-        assert_eq!(AgentKeypair::derive("parity-check").public_key_hex(), cli.public_key);
+        assert_eq!(
+            AgentKeypair::derive_transport_key("parity-check").public_key_hex(),
+            cli.public_key
+        );
     }
 
     /// The registry id must be the gateway's own key for the registered

--- a/aa-cli/tests/gateway_support/mod.rs
+++ b/aa-cli/tests/gateway_support/mod.rs
@@ -114,15 +114,39 @@ impl Drop for TestGateway {
 pub struct GatewayEnv {
     _lock: std::sync::MutexGuard<'static, ()>,
     prior: Option<String>,
+    prior_state_dir: Option<String>,
 }
 
 impl GatewayEnv {
+    /// Point the code under test at `endpoint`, and at a throwaway state
+    /// directory.
+    ///
+    /// `AASM_STATE_DIR` is set as well because since AAASM-5332 registration
+    /// reads a durable identity key from `${AASM_STATE_DIR}/identity`. Left
+    /// unset, the CLI would enrol into the developer's real `~/.aasm` — and,
+    /// worse for these tests, into a *different* store than the one the
+    /// test-local `AssemblyConfig`s name, so the two surfaces would present
+    /// different identities and the parity assertions would be comparing
+    /// strangers.
     pub fn point_at(endpoint: &str) -> Self {
         let lock = env_lock().lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let prior = std::env::var("AA_GATEWAY_ENDPOINT").ok();
+        let prior_state_dir = std::env::var("AASM_STATE_DIR").ok();
         std::env::set_var("AA_GATEWAY_ENDPOINT", endpoint);
-        Self { _lock: lock, prior }
+        std::env::set_var("AASM_STATE_DIR", state_dir());
+        Self {
+            _lock: lock,
+            prior,
+            prior_state_dir,
+        }
     }
+}
+
+/// One throwaway state directory per test process.
+pub fn state_dir() -> std::path::PathBuf {
+    static DIR: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+    DIR.get_or_init(|| std::env::temp_dir().join(format!("aasm-gwtest-state-{}", std::process::id())))
+        .clone()
 }
 
 impl Drop for GatewayEnv {
@@ -130,6 +154,10 @@ impl Drop for GatewayEnv {
         match self.prior.take() {
             Some(v) => std::env::set_var("AA_GATEWAY_ENDPOINT", v),
             None => std::env::remove_var("AA_GATEWAY_ENDPOINT"),
+        }
+        match self.prior_state_dir.take() {
+            Some(v) => std::env::set_var("AASM_STATE_DIR", v),
+            None => std::env::remove_var("AASM_STATE_DIR"),
         }
     }
 }

--- a/aa-cli/tests/run_registration_gateway.rs
+++ b/aa-cli/tests/run_registration_gateway.rs
@@ -58,7 +58,27 @@ fn sdk_config(agent_id: &str) -> AssemblyConfig {
         team_id: Some(TEAM.to_string()),
         parent_agent_id: None,
         sdk_version: None,
+        // Each test binary keeps its enrolments in its own directory rather than
+        // the developer's real `~/.aasm`, and the CLI under test is pointed at
+        // the same one by `AASM_STATE_DIR` so both surfaces read one key.
+        identity_dir: Some(identity_dir()),
     }
+}
+
+/// One temporary identity store per test process, shared by every case in it.
+///
+/// Shared rather than per-test on purpose: several cases below assert that the
+/// CLI and an SDK configured with the same identifier arrive at the *same*
+/// identity, which is a statement about one stored key and is unprovable if each
+/// call enrols its own.
+fn identity_dir() -> String {
+    // Exactly where the store resolves `${AASM_STATE_DIR}/identity` to, so the
+    // CLI (which reads the environment) and these configs (which are explicit)
+    // name one directory and therefore one key.
+    gateway_support::state_dir()
+        .join("identity")
+        .to_string_lossy()
+        .into_owned()
 }
 
 /// Submit `request` to `endpoint` exactly as a client would.
@@ -74,7 +94,7 @@ async fn fresh_nonce(endpoint: &str, config: &AssemblyConfig) -> Vec<u8> {
     let mut client = AgentLifecycleServiceClient::connect(endpoint.to_string())
         .await
         .expect("the test gateway must be reachable");
-    let challenge: ChallengeRequest = build_challenge_request(config);
+    let challenge: ChallengeRequest = build_challenge_request(config).expect("the agent must have a durable identity");
     client
         .request_challenge(challenge)
         .await
@@ -300,7 +320,8 @@ async fn the_cli_and_the_sdk_get_the_same_verdicts() -> anyhow::Result<()> {
     // identity is taken rather than filing a second record beside it.
     let config = sdk_config("shared-identity");
     let nonce = fresh_nonce(gateway.endpoint(), &config).await;
-    let sdk = build_register_request(&config, "sdk-agent".into(), "langgraph".into(), &nonce);
+    let sdk = build_register_request(&config, "sdk-agent".into(), "langgraph".into(), &nonce)
+        .expect("the SDK agent must have a durable identity");
     assert_eq!(
         sdk.agent_id.as_ref().expect("agent_id is set").agent_id,
         cli.registration_did,
@@ -334,7 +355,8 @@ async fn the_cli_and_the_sdk_get_the_same_verdicts() -> anyhow::Result<()> {
         "sdk-agent".into(),
         "langgraph".into(),
         &fresh_nonce(gateway.endpoint(), &other).await,
-    );
+    )
+    .expect("the SDK agent must have a durable identity");
     proofless.possession_proof = Vec::new();
     let status = submit(gateway.endpoint(), proofless)
         .await

--- a/aa-cli/tests/run_registration_gateway.rs
+++ b/aa-cli/tests/run_registration_gateway.rs
@@ -232,7 +232,7 @@ async fn registering_the_clis_did_under_a_foreign_key_is_refused() -> anyhow::Re
     let _env = GatewayEnv::point_at(gateway.endpoint());
 
     let victim_did = run_registration::registration_did("ops-laptop");
-    let attacker = AgentKeypair::derive("attacker");
+    let attacker = AgentKeypair::derive_transport_key("attacker");
 
     // A challenge for the attacker's *own* identity, which the gateway will
     // issue: the attacker holds that key. The nonce is then redirected at the

--- a/aa-cli/tests/run_registration_gateway.rs
+++ b/aa-cli/tests/run_registration_gateway.rs
@@ -240,12 +240,79 @@ async fn replaying_the_clis_own_registration_is_refused() -> anyhow::Result<()> 
     Ok(())
 }
 
+/// **Bypass attempt: knowing the victim's identifier is not enough (AAASM-5332).**
+///
+/// This is the ticket's core acceptance criterion, attempted for real against
+/// the real gateway. The attacker is given every public fact about the victim —
+/// the operator-facing agent id, which appears in audit records, topology views
+/// and on the dashboard, plus the `did:key` it registered under — and tries the
+/// break that worked before AAASM-5332: reconstruct the private key by hashing
+/// the identifier, then present a genuine signature made with it.
+///
+/// It fails at the DID↔key binding, because the victim's DID now names a
+/// randomly generated key rather than `SHA-256(agent_id)`. The registry is
+/// checked afterwards so a refusal cannot be confused with a refusal that still
+/// left a record behind.
+#[tokio::test(flavor = "multi_thread")]
+async fn knowing_the_victims_identifier_does_not_let_an_attacker_register_as_it() -> anyhow::Result<()> {
+    let gateway = TestGateway::start().await?;
+    let _env = GatewayEnv::point_at(gateway.endpoint());
+
+    // The victim registers normally; the attacker observes what is public.
+    let victim = run_registration::register(descriptor("finance-bot", "L2Enforce")).await?;
+    let public_identifier = victim.agent_id.clone();
+    let public_did = victim.registration_did.clone();
+
+    // The pre-AAASM-5332 derivation, applied to the public identifier. This is
+    // precisely the computation that used to yield the victim's private key.
+    let reconstructed = AgentKeypair::derive_transport_key(&public_identifier);
+    assert_ne!(
+        reconstructed.did_key(),
+        public_did,
+        "the identifier still derives the victim's DID, so the key behind it is still public"
+    );
+
+    // A challenge for the attacker's own derived identity — the gateway issues
+    // it, because the attacker does hold that key. The nonce is then aimed at
+    // the victim's DID, which is the attack.
+    let attacker_config = sdk_config("attacker-5332");
+    let nonce = fresh_nonce(gateway.endpoint(), &attacker_config).await;
+
+    let forged = RegisterRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: String::new(),
+            team_id: TEAM.to_string(),
+            agent_id: public_did.clone(),
+        }),
+        name: "claude_code".to_string(),
+        framework: "aasm-run".to_string(),
+        version: "2.1.999".to_string(),
+        public_key: reconstructed.public_key_hex(),
+        possession_proof: reconstructed.sign(&nonce).to_vec(),
+        registration_nonce: nonce,
+        ..Default::default()
+    };
+
+    let status = submit(gateway.endpoint(), forged)
+        .await
+        .expect_err("an identity reconstructed from the public agent id must be refused");
+    assert_eq!(status.code(), tonic::Code::Unauthenticated, "{status:?}");
+
+    // Exactly one record — the victim's own. The attacker created nothing.
+    let records = gateway.registry().list();
+    assert_eq!(
+        records.len(),
+        1,
+        "the forged registration must not have produced a record"
+    );
+    Ok(())
+}
+
 /// **Bypass attempt: use the CLI's identity with an attacker's key.**
 ///
-/// Presents the victim's `did:key` — the one the CLI registers under, and which
-/// anyone can derive from a public identifier — paired with the attacker's own
-/// public key and a *valid* proof under that key. Only the DID↔key binding
-/// stands between this and a squatted identity (AAASM-4787).
+/// Presents the victim's `did:key` paired with the attacker's own public key and
+/// a *valid* proof under that key. Only the DID↔key binding stands between this
+/// and a squatted identity (AAASM-4787).
 #[tokio::test(flavor = "multi_thread")]
 async fn registering_the_clis_did_under_a_foreign_key_is_refused() -> anyhow::Result<()> {
     let gateway = TestGateway::start().await?;

--- a/aa-gateway/tests/enforcement_mode_self_registration_test.rs
+++ b/aa-gateway/tests/enforcement_mode_self_registration_test.rs
@@ -34,7 +34,7 @@ use tonic::transport::{Channel, Server};
 /// `agent_id` did:key to `public_key` (AAASM-4787), so the did:key, the
 /// `public_key`, and the possession proof are all derived from one keypair.
 fn test_keypair() -> aa_sdk_client::AgentKeypair {
-    aa_sdk_client::AgentKeypair::derive("aaasm-enforce-selfreg-agent")
+    aa_sdk_client::AgentKeypair::derive_transport_key("aaasm-enforce-selfreg-agent")
 }
 
 fn test_public_key_hex() -> String {

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -26,7 +26,7 @@ use tonic::transport::{Channel, Server};
 /// identity matches [`register_with_sdk_derived_did_key_is_accepted`] so both
 /// resolve to the same did:key.
 fn test_keypair() -> aa_sdk_client::AgentKeypair {
-    aa_sdk_client::AgentKeypair::derive("my-agent-001")
+    aa_sdk_client::AgentKeypair::derive_transport_key("my-agent-001")
 }
 
 /// The fixture's hex-encoded Ed25519 public key — the same key its `agent_id`
@@ -652,7 +652,7 @@ async fn register_echoes_parent_agent_id_and_team_id() {
 
     // Register the parent first so the sub-agent can be accepted. Each agent
     // carries its own keypair so its did:key binds to its own public_key.
-    let parent_kp = aa_sdk_client::AgentKeypair::derive("echo-parent");
+    let parent_kp = aa_sdk_client::AgentKeypair::derive_transport_key("echo-parent");
     let parent_id = ProtoAgentId {
         org_id: "org-echo".into(),
         team_id: "team-echo".into(),
@@ -676,7 +676,7 @@ async fn register_echoes_parent_agent_id_and_team_id() {
     .await
     .unwrap();
 
-    let child_kp = aa_sdk_client::AgentKeypair::derive("echo-child");
+    let child_kp = aa_sdk_client::AgentKeypair::derive_transport_key("echo-child");
     let agent_id = ProtoAgentId {
         org_id: "org-echo".into(),
         team_id: "team-echo".into(),
@@ -798,7 +798,7 @@ async fn root_agent_id_chains_3_levels() {
     let team = "chain-team";
 
     // Register A (root). Each agent carries its own keypair (AAASM-4787).
-    let kp_a = aa_sdk_client::AgentKeypair::derive("chain-A");
+    let kp_a = aa_sdk_client::AgentKeypair::derive_transport_key("chain-A");
     let proto_a = ProtoAgentId {
         org_id: org.into(),
         team_id: team.into(),
@@ -824,7 +824,7 @@ async fn root_agent_id_chains_3_levels() {
     .unwrap();
 
     // Register B (parent = A).
-    let kp_b = aa_sdk_client::AgentKeypair::derive("chain-B");
+    let kp_b = aa_sdk_client::AgentKeypair::derive_transport_key("chain-B");
     let proto_b = ProtoAgentId {
         org_id: org.into(),
         team_id: team.into(),
@@ -850,7 +850,7 @@ async fn root_agent_id_chains_3_levels() {
     .unwrap();
 
     // Register C (parent = B). C's root_agent_id must equal A's key.
-    let kp_c = aa_sdk_client::AgentKeypair::derive("chain-C");
+    let kp_c = aa_sdk_client::AgentKeypair::derive_transport_key("chain-C");
     let proto_c = ProtoAgentId {
         org_id: org.into(),
         team_id: team.into(),

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -312,11 +312,14 @@ async fn register_with_sdk_derived_did_key_is_accepted() {
         .await
         .unwrap();
 
-    // A human-readable agent_id of the kind SDKs configure today — which the
-    // gateway rejects verbatim — converted via the shared SDK derivation.
-    let plain_agent_id = "my-agent-001";
-    let did = aa_sdk_client::agent_id_to_did_key(plain_agent_id);
-    assert!(did.starts_with("did:key:z"), "derived DID must be a did:key, got {did}");
+    // The gateway rejects a human-readable agent_id verbatim, so the fixture
+    // registers the `did:key` of the keypair it also proves possession of.
+    // Taken from the keypair rather than from an identifier, because since
+    // AAASM-5332 a DID names a specific key rather than being a function of a
+    // name — and what this test exercises is the gateway's binding check, not
+    // where the SDK gets its key from.
+    let did = test_keypair().did_key();
+    assert!(did.starts_with("did:key:z"), "the DID must be a did:key, got {did}");
 
     let resp = register_with_challenge(
         &mut client,

--- a/aa-integration-tests/tests/cli_run_claude_governed_launch.rs
+++ b/aa-integration-tests/tests/cli_run_claude_governed_launch.rs
@@ -214,7 +214,7 @@ exit 0
             )
         });
         let seen = parse_dump(&raw);
-        let did = expected_did(AGENT_ID);
+        let did = expected_did(&root.join("state"), AGENT_ID);
         for (key, expected) in [
             ("AA_AGENT_ID", AGENT_ID.to_string()),
             ("AA_AGENT_DID", did.clone()),

--- a/aa-integration-tests/tests/cli_run_claude_launch_env.rs
+++ b/aa-integration-tests/tests/cli_run_claude_launch_env.rs
@@ -301,7 +301,7 @@ exit 0
         // ── and the session identity is still there ────────────────────────
         //
         // The merge adds a source; it must not cost the one that already worked.
-        let did = expected_did(AGENT_ID);
+        let did = expected_did(&host.state_dir, AGENT_ID);
         for (key, expected) in [
             ("AA_AGENT_ID", AGENT_ID.to_string()),
             ("AA_AGENT_DID", did.clone()),

--- a/aa-integration-tests/tests/e2e_runtime_gateway_deny.rs
+++ b/aa-integration-tests/tests/e2e_runtime_gateway_deny.rs
@@ -204,7 +204,7 @@ async fn perform_handshake(stream: &mut UnixStream, agent_id: &str) {
     // (AAASM-3666). This client sends no version (empty), so the signed payload
     // reduces to the bare nonce — the backward-compat path — and the runtime
     // verifies it exactly as before.
-    let keypair = AgentKeypair::derive(agent_id);
+    let keypair = AgentKeypair::derive_transport_key(agent_id);
     let sdk_version = String::new();
     let mut signed_payload = challenge.nonce.clone();
     signed_payload.extend_from_slice(sdk_version.as_bytes());

--- a/aa-integration-tests/tests/grpc_gateway_support/mod.rs
+++ b/aa-integration-tests/tests/grpc_gateway_support/mod.rs
@@ -136,13 +136,23 @@ impl Drop for GrpcGateway {
     }
 }
 
-/// The `did:key` `aasm run --agent-id <identity>` registers under.
+/// The `did:key` `aasm run --agent-id <identity>` registered under, read back
+/// from the durable identity key the launch enrolled in `state_dir`.
 ///
-/// Derived with `aa-sdk-client`'s own function — the one the CLI calls — so a
-/// change to the derivation moves the expectation with it instead of leaving
-/// these tests asserting a value nothing produces.
-pub fn expected_did(identity: &str) -> String {
-    aa_sdk_client::agent_id_to_did_key(identity)
+/// Read with `aa-sdk-client`'s own store — the one the CLI writes through — so a
+/// change to how identity is resolved moves the expectation with it instead of
+/// leaving these tests asserting a value nothing produces.
+///
+/// Deliberately a *load*, not a load-or-enrol: since AAASM-5332 the DID is a
+/// rendering of a randomly generated key, so the only way this can name the DID
+/// the child registered is by reading the key the child actually created. If the
+/// launch enrolled nothing, this panics rather than quietly minting a second
+/// identity and comparing it against itself.
+pub fn expected_did(state_dir: &std::path::Path, identity: &str) -> String {
+    aa_sdk_client::IdentityStore::at(state_dir.join("identity"))
+        .load(identity)
+        .unwrap_or_else(|e| panic!("the launch should have enrolled a durable identity key for `{identity}`: {e}"))
+        .did_key()
 }
 
 /// The registry key the gateway files that identity under, hex-encoded — the

--- a/aa-runtime/src/ipc/handshake.rs
+++ b/aa-runtime/src/ipc/handshake.rs
@@ -26,9 +26,15 @@
 //! audit events. The handshake adds defence-in-depth (a consistent identity and
 //! an authenticated version) *within* that boundary.
 //!
-//! The SDK (`aa-sdk-client`'s `AgentKeypair::derive`) and the runtime are both
-//! configured with the same `AA_AGENT_ID`, so both sides arrive at the same
-//! keypair without exchanging key material.
+//! The SDK (`aa-sdk-client`'s `AgentKeypair::derive_transport_key`) and the
+//! runtime are both configured with the same `AA_AGENT_ID`, so both sides arrive
+//! at the same keypair without exchanging key material.
+//!
+//! Note the name: since AAASM-5332 the SDK also holds a *durable identity key*,
+//! randomly generated and stored owner-only, which is what it registers with and
+//! proves possession of to the gateway. This transport key is deliberately not
+//! that key — the runtime could not verify a randomly generated key, having no
+//! way to learn it — and the two must not be conflated.
 
 use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
 use sha2::{Digest, Sha256};
@@ -42,7 +48,7 @@ pub const NONCE_LEN: usize = 32;
 /// Derive the Ed25519 verifying key the runtime expects an SDK handshake to be
 /// signed with, from the configured agent id.
 ///
-/// Mirrors `aa-sdk-client::keypair::AgentKeypair::derive`: the seed is
+/// Mirrors `aa-sdk-client::keypair::AgentKeypair::derive_transport_key`: the seed is
 /// `SHA-256(agent_id)`, which is always a valid 32-byte Ed25519 secret scalar
 /// seed, so derivation never fails.
 ///

--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -103,9 +103,12 @@ impl AssemblyClient {
     /// the gateway's `validate_credential_token` does not deny a registered
     /// agent.
     ///
-    /// `config` supplies the agent identity (its `agent_id` is derived into a
-    /// `did:key` + a consistent Ed25519 `public_key`) and the gateway gRPC
-    /// endpoint. Returns the assigned policy id from the gateway on success.
+    /// `config` supplies the agent identity (its `agent_id` selects the durable
+    /// identity key, whose public half becomes the `did:key` and the
+    /// `public_key`) and the gateway gRPC endpoint. Returns the assigned policy
+    /// id from the gateway on success, and
+    /// [`SdkClientError::IdentityUnavailable`] if the durable key cannot be
+    /// established — an agent with no identity does not register.
     pub async fn register(
         &self,
         config: &AssemblyConfig,
@@ -119,8 +122,8 @@ impl AssemblyClient {
         // register request. This round-trip is what makes the possession proof
         // non-replayable — the gateway rejects any proof over a stale, reused, or
         // attacker-derivable challenge.
-        let challenge = client.request_challenge(build_challenge_request(config)).await?;
-        let request = build_register_request(config, name, framework, &challenge.nonce);
+        let challenge = client.request_challenge(build_challenge_request(config)?).await?;
+        let request = build_register_request(config, name, framework, &challenge.nonce)?;
         let response = client.register(request).await?;
 
         {

--- a/aa-sdk-client/src/config.rs
+++ b/aa-sdk-client/src/config.rs
@@ -37,6 +37,15 @@ pub struct AssemblyConfig {
     /// shared `aa-sdk-client` crate version. `None` falls back to the crate's
     /// `CARGO_PKG_VERSION` (AAASM-3683), preserving the pre-passthrough behaviour.
     pub sdk_version: Option<String>,
+    /// Explicit directory for this agent's durable identity key (AAASM-5332).
+    /// When `None`, resolved from `AASM_STATE_DIR`, else `~/.aasm/identity`.
+    ///
+    /// Follows the same explicit-overrides-ambient shape as `socket_path` and
+    /// `gateway_endpoint` above. An embedder that keeps agent state somewhere of
+    /// its own choosing needs the key to follow it, and a test needs each case's
+    /// enrolments to be its own — a process-wide environment variable cannot
+    /// give parallel tests separate identities.
+    pub identity_dir: Option<String>,
 }
 
 impl AssemblyConfig {
@@ -112,12 +121,47 @@ impl AssemblyConfig {
     /// Return the agent identity to send on gateway registration.
     ///
     /// The gateway's `AgentLifecycleService.Register` rejects a plain
-    /// `agent_id`; it must be a `did:key` DID. This derives a conformant
-    /// `did:key` from the configured `agent_id` (passing through an
-    /// already-`did:key` identifier unchanged). The socket-path / event-tag
-    /// `agent_id` is intentionally left as-is.
-    pub fn registration_did(&self) -> String {
-        crate::identity::agent_id_to_did_key(&self.agent_id)
+    /// `agent_id`; it must be a `did:key` DID naming the key the registration's
+    /// possession proof is made with. This resolves the configured `agent_id` to
+    /// the DID of that agent's **durable identity key**, enrolling one on first
+    /// use (AAASM-5332). An `agent_id` that is already a `did:key` is refused:
+    /// this crate holds no private key for a DID it did not generate, so it
+    /// could not prove possession of one. The socket-path / event-tag `agent_id`
+    /// is intentionally left as-is.
+    ///
+    /// Fallible because the identity now lives on disk: there is no DID to
+    /// report for an agent whose key cannot be established, and returning a
+    /// plausible-looking one would recreate the defect this replaced.
+    pub fn registration_did(&self) -> Result<String, crate::identity_store::IdentityStoreError> {
+        if self.agent_id.starts_with("did:key:") {
+            return Err(crate::identity_store::IdentityStoreError::ProvisionedDidUnsupported {
+                did: self.agent_id.clone(),
+            });
+        }
+        Ok(self.identity_keypair()?.did_key())
+    }
+
+    /// The agent's durable identity keypair, enrolling one on first use.
+    ///
+    /// The single place the registration path obtains key material, so the
+    /// `did:key`, the `public_key` and the possession-proof signature in one
+    /// `RegisterRequest` cannot come from different keys.
+    pub fn identity_keypair(&self) -> Result<crate::keypair::AgentKeypair, crate::identity_store::IdentityStoreError> {
+        self.identity_store()?.load_or_enroll(&self.agent_id)
+    }
+
+    /// The identity store this config's agent keeps its durable key in.
+    ///
+    /// Resolution order:
+    /// 1. Explicit `identity_dir` if provided
+    /// 2. `${AASM_STATE_DIR:-$HOME/.aasm}/identity`
+    pub fn identity_store(
+        &self,
+    ) -> Result<crate::identity_store::IdentityStore, crate::identity_store::IdentityStoreError> {
+        match self.identity_dir {
+            Some(ref dir) if !dir.is_empty() => Ok(crate::identity_store::IdentityStore::at(dir)),
+            _ => crate::identity_store::IdentityStore::default_location(),
+        }
     }
 }
 
@@ -133,6 +177,7 @@ mod tests {
             team_id: None,
             parent_agent_id: None,
             sdk_version: None,
+            identity_dir: None,
         }
     }
 
@@ -162,6 +207,7 @@ mod tests {
             team_id: None,
             parent_agent_id: None,
             sdk_version: None,
+            identity_dir: None,
         };
         assert_eq!(config.resolve_gateway_endpoint(), "http://gw.example:50051");
     }

--- a/aa-sdk-client/src/error.rs
+++ b/aa-sdk-client/src/error.rs
@@ -27,6 +27,15 @@ pub enum SdkClientError {
     /// The gateway rejected the `Register` call. Carries the gRPC status message
     /// (e.g. an invalid did:key or public_key).
     RegisterFailed(String),
+    /// The agent's durable identity key could not be established, so there is
+    /// nothing to register as (AAASM-5332). Carries the store's reason —
+    /// unresolvable state directory, a key file owned by another user or
+    /// readable beyond its owner, a revoked identity, or an unreadable CSPRNG.
+    ///
+    /// Always a refusal. There is deliberately no weaker identity to fall back
+    /// to: the whole point of the durable key is that an agent which cannot
+    /// prove possession of a secret does not get to register.
+    IdentityUnavailable(String),
 }
 
 impl std::fmt::Display for SdkClientError {
@@ -47,6 +56,9 @@ impl std::fmt::Display for SdkClientError {
             }
             SdkClientError::RegisterFailed(msg) => {
                 write!(f, "gateway rejected registration: {msg}")
+            }
+            SdkClientError::IdentityUnavailable(reason) => {
+                write!(f, "this agent has no usable durable identity key: {reason}")
             }
         }
     }

--- a/aa-sdk-client/src/gateway.rs
+++ b/aa-sdk-client/src/gateway.rs
@@ -97,50 +97,59 @@ impl GatewayRegistrationClient {
 /// Build the `ChallengeRequest` for the registration possession-proof handshake
 /// (AAASM-3866).
 ///
-/// Derives the same deterministic [`AgentKeypair`] as [`build_register_request`]
-/// so the `agent_id` + `public_key` the challenge is bound to match the ones the
-/// agent later registers with.
-pub fn build_challenge_request(config: &AssemblyConfig) -> ChallengeRequest {
-    let keypair = AgentKeypair::derive_transport_key(&config.agent_id);
-    ChallengeRequest {
+/// Loads the same durable [`AgentKeypair`] as [`build_register_request`] so the
+/// `agent_id` + `public_key` the challenge is bound to match the ones the agent
+/// later registers with — the gateway binds the nonce to that exact pair and
+/// `Register` will refuse a proof presented for a different one.
+pub fn build_challenge_request(config: &AssemblyConfig) -> Result<ChallengeRequest, SdkClientError> {
+    let keypair = identity_keypair(config)?;
+    Ok(ChallengeRequest {
         agent_id: Some(ProtoAgentId {
             org_id: String::new(),
             team_id: config.team_id.clone().unwrap_or_default(),
-            agent_id: config.registration_did(),
+            agent_id: keypair.did_key(),
         }),
         public_key: keypair.public_key_hex(),
-    }
+    })
 }
 
 /// Build the `RegisterRequest` the gateway requires from the SDK config.
 ///
-/// Derives a deterministic [`AgentKeypair`] from `config.agent_id` so the
-/// `agent_id` did:key and the `public_key` hex encode the *same* valid Ed25519
-/// key — both of which the gateway validates at registration.
+/// The `did:key`, the `public_key` and the possession proof all come from one
+/// load of the agent's **durable identity key** (AAASM-5332), so the DID and the
+/// `public_key` encode the same valid Ed25519 key — which is what the gateway's
+/// `enforce_did_key_binding` requires — and the signature is made with the
+/// private half of that same key.
+///
+/// The DID is taken from the keypair rather than resolved separately, so the
+/// binding the gateway checks holds *by construction*: there is no arrangement
+/// of configuration under which this function can emit a DID and a `public_key`
+/// that name different keys.
 ///
 /// `nonce` is the server-issued challenge from [`build_challenge_request`] +
-/// `request_challenge` (AAASM-3866); the possession proof signs it (not the
-/// public, deterministic did:key) so the proof cannot be precomputed or
-/// replayed.
+/// `request_challenge` (AAASM-3866); the possession proof signs it so the proof
+/// cannot be precomputed or replayed. Since AAASM-5332 the signing key is
+/// randomly generated and stored owner-only rather than derived from the public
+/// agent id, so the proof now demonstrates possession of a secret rather than
+/// the ability to hash a published string.
 pub fn build_register_request(
     config: &AssemblyConfig,
     name: String,
     framework: String,
     nonce: &[u8],
-) -> RegisterRequest {
-    let keypair = AgentKeypair::derive_transport_key(&config.agent_id);
-    let registration_did = config.registration_did();
+) -> Result<RegisterRequest, SdkClientError> {
+    let keypair = identity_keypair(config)?;
 
     // AAASM-3591 / AAASM-3866: prove possession of the private key by signing the
     // server-issued nonce. The gateway verifies this over the same nonce before
     // minting a credential_token.
     let possession_proof = keypair.sign(nonce).to_vec();
 
-    RegisterRequest {
+    Ok(RegisterRequest {
         agent_id: Some(ProtoAgentId {
             org_id: String::new(),
             team_id: config.team_id.clone().unwrap_or_default(),
-            agent_id: registration_did,
+            agent_id: keypair.did_key(),
         }),
         name,
         framework,
@@ -150,13 +159,40 @@ pub fn build_register_request(
         possession_proof,
         registration_nonce: nonce.to_vec(),
         ..Default::default()
+    })
+}
+
+/// Load the agent's durable identity key, mapping the store's refusal onto the
+/// SDK's error type.
+///
+/// A failure here is a refusal to register, never a fallback: an agent whose
+/// durable key cannot be established has no identity to present, and presenting
+/// a computable stand-in is precisely the defect AAASM-5332 removed.
+fn identity_keypair(config: &AssemblyConfig) -> Result<AgentKeypair, SdkClientError> {
+    // A `did:key` configured as the agent id names a key this crate does not
+    // hold, so no proof it could build would verify. Refuse locally with a
+    // message that says so, rather than sending a request the gateway can only
+    // reject as `Unauthenticated` for reasons the operator cannot see.
+    if config.agent_id.starts_with("did:key:") {
+        return Err(SdkClientError::IdentityUnavailable(
+            crate::identity_store::IdentityStoreError::ProvisionedDidUnsupported {
+                did: config.agent_id.clone(),
+            }
+            .to_string(),
+        ));
     }
+    config
+        .identity_keypair()
+        .map_err(|e| SdkClientError::IdentityUnavailable(e.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// A config whose identity key lives in a directory unique to this test, so
+    /// no case can pass by reading a key another case enrolled and none of them
+    /// touch the developer's real `~/.aasm`.
     fn cfg(agent_id: &str) -> AssemblyConfig {
         AssemblyConfig {
             agent_id: agent_id.to_string(),
@@ -165,6 +201,17 @@ mod tests {
             team_id: None,
             parent_agent_id: None,
             sdk_version: None,
+            identity_dir: Some(
+                std::env::temp_dir()
+                    .join(format!(
+                        "aa-gateway-req-test-{}-{}-{:?}",
+                        agent_id,
+                        std::process::id(),
+                        std::thread::current().id()
+                    ))
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
         }
     }
 
@@ -173,7 +220,7 @@ mod tests {
     #[test]
     fn register_request_carries_did_and_consistent_public_key() {
         let config = cfg("my-agent");
-        let req = build_register_request(&config, "My Agent".into(), "custom".into(), TEST_NONCE);
+        let req = build_register_request(&config, "My Agent".into(), "custom".into(), TEST_NONCE).expect("enrolment");
 
         let agent_id = req.agent_id.expect("agent_id must be set");
         assert!(agent_id.agent_id.starts_with("did:key:z"), "got {}", agent_id.agent_id);
@@ -200,7 +247,7 @@ mod tests {
         use ed25519_dalek::{Signature, VerifyingKey};
 
         let config = cfg("my-agent");
-        let req = build_register_request(&config, "My Agent".into(), "custom".into(), TEST_NONCE);
+        let req = build_register_request(&config, "My Agent".into(), "custom".into(), TEST_NONCE).expect("enrolment");
 
         assert_eq!(req.registration_nonce, TEST_NONCE);
 
@@ -217,8 +264,8 @@ mod tests {
     #[test]
     fn challenge_request_binds_same_did_and_public_key_as_register() {
         let config = cfg("my-agent");
-        let challenge = build_challenge_request(&config);
-        let req = build_register_request(&config, "My Agent".into(), "custom".into(), TEST_NONCE);
+        let challenge = build_challenge_request(&config).expect("enrolment");
+        let req = build_register_request(&config, "My Agent".into(), "custom".into(), TEST_NONCE).expect("load");
 
         assert_eq!(challenge.agent_id, req.agent_id);
         assert_eq!(challenge.public_key, req.public_key);
@@ -230,7 +277,7 @@ mod tests {
         config.team_id = Some("team-payments".into());
         config.parent_agent_id = Some("11111111-2222-3333-4444-555555555555".into());
 
-        let req = build_register_request(&config, "Child".into(), "custom".into(), TEST_NONCE);
+        let req = build_register_request(&config, "Child".into(), "custom".into(), TEST_NONCE).expect("enrolment");
 
         assert_eq!(req.agent_id.expect("agent_id must be set").team_id, "team-payments");
         assert_eq!(
@@ -242,7 +289,7 @@ mod tests {
     #[test]
     fn register_request_omits_lineage_when_unset() {
         let config = cfg("root-agent");
-        let req = build_register_request(&config, "Root".into(), "custom".into(), TEST_NONCE);
+        let req = build_register_request(&config, "Root".into(), "custom".into(), TEST_NONCE).expect("enrolment");
 
         assert_eq!(req.agent_id.expect("agent_id must be set").team_id, "");
         assert_eq!(req.parent_agent_id, None);

--- a/aa-sdk-client/src/gateway.rs
+++ b/aa-sdk-client/src/gateway.rs
@@ -101,7 +101,7 @@ impl GatewayRegistrationClient {
 /// so the `agent_id` + `public_key` the challenge is bound to match the ones the
 /// agent later registers with.
 pub fn build_challenge_request(config: &AssemblyConfig) -> ChallengeRequest {
-    let keypair = AgentKeypair::derive(&config.agent_id);
+    let keypair = AgentKeypair::derive_transport_key(&config.agent_id);
     ChallengeRequest {
         agent_id: Some(ProtoAgentId {
             org_id: String::new(),
@@ -128,7 +128,7 @@ pub fn build_register_request(
     framework: String,
     nonce: &[u8],
 ) -> RegisterRequest {
-    let keypair = AgentKeypair::derive(&config.agent_id);
+    let keypair = AgentKeypair::derive_transport_key(&config.agent_id);
     let registration_did = config.registration_did();
 
     // AAASM-3591 / AAASM-3866: prove possession of the private key by signing the

--- a/aa-sdk-client/src/identity.rs
+++ b/aa-sdk-client/src/identity.rs
@@ -4,18 +4,28 @@
 //! `agent_id` to be a syntactically-valid `did:key` DID — a plain string is
 //! rejected with `InvalidArgument: agent_id is not a did:key DID (missing
 //! "did:key:" prefix)`. SDKs configure agents with human-readable identifiers
-//! (used for socket naming and event tagging), so this module derives a
-//! conformant `did:key` from such an identifier.
+//! (used for socket naming and event tagging), so this module resolves such an
+//! identifier to a conformant `did:key`.
 //!
-//! The derivation is **deterministic**: the same input always yields the same
-//! DID, so an agent keeps a stable identity across process restarts without
-//! having to persist a keypair. The DID encodes a real Ed25519 verifying key
-//! deterministically derived from the input (see [`crate::keypair`]), wrapped
-//! as an Ed25519 `did:key` (multicodec `0xed 0x01`, base58btc multibase). The
-//! resulting DID has the canonical `did:key:z6Mk…` shape, passes the gateway's
-//! syntactic `did:key` validation, and is bound to the same key the gateway
-//! receives in the `public_key` field at registration (AAASM-3396).
+//! # The DID names a key, so it comes from the key (AAASM-5332)
+//!
+//! An Ed25519 `did:key` *is* an encoding of a public key, and the gateway
+//! enforces that (`enforce_did_key_binding` refuses a registration whose DID
+//! embeds a different key than the presented `public_key`). The DID therefore
+//! cannot be chosen independently of the keypair — it is a rendering of it.
+//!
+//! Until AAASM-5332 that keypair was derived from the identifier, which made the
+//! DID a pure function of a public string and the private key computable by
+//! anyone who could read an agent id. Now the keypair is randomly generated and
+//! persisted by [`crate::identity_store`], so resolving an identifier to its DID
+//! means *loading that agent's durable key* — a fallible, filesystem-touching
+//! operation rather than a hash. That is the cost of the DID meaning something.
+//!
+//! The identifier→DID mapping stays stable for the life of the key, so the
+//! identity that registered, the identity a launch runs under, and the identity
+//! the gateway attributes audit records to remain one principal across restarts.
 
+use crate::identity_store::{IdentityStore, IdentityStoreError};
 use crate::keypair::AgentKeypair;
 
 /// Length, in bytes, of an Ed25519 public key.
@@ -26,31 +36,75 @@ const ED25519_PUBLIC_KEY_LEN: usize = 32;
 #[cfg(test)]
 const ED25519_MULTICODEC_PREFIX: [u8; 2] = [0xed, 0x01];
 
-/// Derive a deterministic, conformant Ed25519 `did:key` DID from a plain agent
-/// identifier.
+/// Resolve a plain agent identifier to the `did:key` DID it registers under,
+/// enrolling a durable identity key on first use.
 ///
 /// The returned string has the shape `did:key:z<base58btc>` where the decoded
 /// multibase value is `[0xed, 0x01]` followed by the 32-byte Ed25519 verifying
-/// key deterministically derived from `identity`. This is accepted by the
-/// gateway's `did:key` validation and binds the DID to the same key that
-/// [`AgentKeypair::public_key_hex`] supplies as the registration `public_key`.
+/// key of the agent's durable identity keypair — the same key
+/// [`AgentKeypair::public_key_hex`] supplies as the registration `public_key`,
+/// which is what `enforce_did_key_binding` requires.
 ///
-/// If `identity` is already a `did:key` DID (it starts with `did:key:`), it is
-/// returned unchanged so callers can pass through an explicitly-provisioned DID.
-pub fn agent_id_to_did_key(identity: &str) -> String {
+/// An `identity` that is *already* a `did:key` is refused with
+/// [`IdentityStoreError::ProvisionedDidUnsupported`] rather than passed through.
+/// This looks like a removed feature and is not: the pass-through could never
+/// have produced a successful registration. `build_register_request` sends a
+/// `public_key` belonging to a key this crate holds, and the gateway's
+/// `enforce_did_key_binding` requires the DID to embed *that* key — so a
+/// caller-supplied DID was guaranteed to mismatch and be rejected as
+/// `Unauthenticated`. Refusing here turns a confusing gateway-side rejection
+/// into a local error that says what is actually wrong, and it forecloses the
+/// worse alternative of silently registering the agent under a DID other than
+/// the one the operator named.
+pub fn agent_id_to_did_key(identity: &str) -> Result<String, IdentityStoreError> {
+    if identity.starts_with("did:key:") {
+        return Err(IdentityStoreError::ProvisionedDidUnsupported {
+            did: identity.to_string(),
+        });
+    }
+
+    Ok(IdentityStore::default_location()?.load_or_enroll(identity)?.did_key())
+}
+
+/// The `did:key` an identifier mapped to under the pre-AAASM-5332 derived
+/// scheme.
+///
+/// Exists for **migration and revocation only**. Every DID this function returns
+/// is compromised by construction: its private key is `SHA-256(identity)`, so
+/// anyone who has ever seen the identifier — in an audit record, a topology
+/// view, or the dashboard — can sign for it. An operator upgrading an existing
+/// deployment needs to be able to *name* those identities in order to deregister
+/// them, which is what this is for.
+///
+/// It must never be used to build a registration. Nothing in the crate calls it
+/// outside migration reporting and tests.
+pub fn legacy_derived_did(identity: &str) -> String {
     if identity.starts_with("did:key:") {
         return identity.to_string();
     }
-
     AgentKeypair::derive_transport_key(identity).did_key()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::identity_store::IdentityStore;
+
+    /// A store rooted in a fresh temporary directory, so each test's enrolments
+    /// are its own and no test can pass by reading a key another test wrote.
+    fn temp_store(label: &str) -> (IdentityStore, std::path::PathBuf) {
+        let root = std::env::temp_dir().join(format!(
+            "aa-identity-test-{}-{}-{:?}",
+            label,
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        (IdentityStore::at(root.join("identity")), root)
+    }
 
     /// Replicate the gateway's `did:key` validation so the test proves the
-    /// derived DID would be accepted by `AgentLifecycleService.Register`
+    /// resolved DID would be accepted by `AgentLifecycleService.Register`
     /// without depending on the `aa-gateway` crate.
     fn validate_did_key(value: &str) -> Result<(), &'static str> {
         let multibase = value.strip_prefix("did:key:").ok_or("missing did:key: prefix")?;
@@ -66,41 +120,101 @@ mod tests {
     }
 
     #[test]
-    fn derives_conformant_did_key() {
-        let did = agent_id_to_did_key("my-agent-001");
+    fn resolves_a_conformant_did_key() {
+        let (store, _root) = temp_store("conformant");
+        let did = store.load_or_enroll("my-agent-001").expect("enrolment").did_key();
         assert!(did.starts_with("did:key:z"), "got {did}");
-        validate_did_key(&did).expect("derived DID must pass gateway validation");
+        validate_did_key(&did).expect("resolved DID must pass gateway validation");
     }
 
+    /// Stability is what keeps registration, launch and audit attribution on one
+    /// principal — but it must come from *reading the same stored key*, not from
+    /// recomputing a hash.
     #[test]
-    fn derivation_is_deterministic() {
-        assert_eq!(agent_id_to_did_key("agent-a"), agent_id_to_did_key("agent-a"));
+    fn resolution_is_stable_across_calls_for_one_stored_key() {
+        let (store, _root) = temp_store("stable");
+        let first = store.load_or_enroll("agent-a").expect("enrolment").did_key();
+        let second = store.load_or_enroll("agent-a").expect("load").did_key();
+        assert_eq!(first, second);
     }
 
     #[test]
     fn distinct_identities_yield_distinct_dids() {
-        assert_ne!(agent_id_to_did_key("agent-a"), agent_id_to_did_key("agent-b"));
+        let (store, _root) = temp_store("distinct");
+        assert_ne!(
+            store.load_or_enroll("agent-a").expect("enrolment").did_key(),
+            store.load_or_enroll("agent-b").expect("enrolment").did_key()
+        );
+    }
+
+    /// The core AAASM-5332 property expressed at the DID level: the identifier
+    /// no longer determines the DID, so two installations that agree on the name
+    /// still hold different keys.
+    #[test]
+    fn the_same_identifier_in_two_stores_yields_two_different_dids() {
+        let (first_store, _a) = temp_store("two-stores-a");
+        let (second_store, _b) = temp_store("two-stores-b");
+
+        assert_ne!(
+            first_store.load_or_enroll("ops-laptop").expect("enrolment").did_key(),
+            second_store.load_or_enroll("ops-laptop").expect("enrolment").did_key(),
+            "if one identifier still determines one DID, the private key is still a function of \
+             public data and the possession proof still proves nothing"
+        );
     }
 
     #[test]
     fn ed25519_did_keys_use_the_canonical_prefix() {
+        let (store, _root) = temp_store("prefix");
         // The multicodec 0xed01 prefix renders as the well-known "z6Mk" head.
-        let did = agent_id_to_did_key("anything");
+        let did = store.load_or_enroll("anything").expect("enrolment").did_key();
         assert!(did.starts_with("did:key:z6Mk"), "got {did}");
     }
 
+    /// A caller-supplied DID is refused locally, because this crate cannot hold
+    /// its private key and so could never prove possession of it.
     #[test]
-    fn passes_through_existing_did_key() {
+    fn a_provisioned_did_is_refused_rather_than_registered_under_a_substitute() {
         let existing = "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T";
-        assert_eq!(agent_id_to_did_key(existing), existing);
+        let err = agent_id_to_did_key(existing).expect_err("a DID we hold no key for must be refused");
+        assert!(
+            matches!(err, IdentityStoreError::ProvisionedDidUnsupported { .. }),
+            "got {err:?}"
+        );
+        assert!(
+            err.to_string().contains(existing),
+            "the refusal must name the DID the operator supplied; got {err}"
+        );
     }
 
     #[test]
-    fn derived_did_decodes_to_ed25519_multicodec_payload() {
-        let did = agent_id_to_did_key("payload-check");
+    fn resolved_did_decodes_to_ed25519_multicodec_payload() {
+        let (store, _root) = temp_store("payload");
+        let did = store.load_or_enroll("payload-check").expect("enrolment").did_key();
         let encoded = did.strip_prefix("did:key:z").unwrap();
         let decoded = bs58::decode(encoded).into_vec().unwrap();
         assert_eq!(&decoded[..2], &ED25519_MULTICODEC_PREFIX);
         assert_eq!(decoded.len(), 2 + ED25519_PUBLIC_KEY_LEN);
+    }
+
+    /// Migration: the legacy DID must still be nameable (an operator has to
+    /// deregister it) and must be *different* from the durable one, or the
+    /// upgrade did nothing.
+    #[test]
+    fn the_legacy_derived_did_is_reproducible_and_is_not_the_durable_did() {
+        let (store, _root) = temp_store("legacy");
+        let legacy = legacy_derived_did("ops-laptop");
+
+        assert_eq!(
+            legacy,
+            legacy_derived_did("ops-laptop"),
+            "operators must be able to name it"
+        );
+        assert!(legacy.starts_with("did:key:z6Mk"), "got {legacy}");
+        assert_ne!(
+            legacy,
+            store.load_or_enroll("ops-laptop").expect("enrolment").did_key(),
+            "the durable identity must not land back on the compromised legacy DID"
+        );
     }
 }

--- a/aa-sdk-client/src/identity.rs
+++ b/aa-sdk-client/src/identity.rs
@@ -42,7 +42,7 @@ pub fn agent_id_to_did_key(identity: &str) -> String {
         return identity.to_string();
     }
 
-    AgentKeypair::derive(identity).did_key()
+    AgentKeypair::derive_transport_key(identity).did_key()
 }
 
 #[cfg(test)]

--- a/aa-sdk-client/src/identity_store.rs
+++ b/aa-sdk-client/src/identity_store.rs
@@ -429,6 +429,13 @@ impl IdentityStore {
     /// responsible for deregistering [`Rotation::previous_did`]. See the crate
     /// docs on migration for why that is a deliberate consequence rather than a
     /// gap.
+    ///
+    /// If enrolment fails *after* the rename — a full disk, a CSPRNG that will
+    /// not read — the agent is left with no current key and a retired one, and
+    /// the error names the retired path. That is recoverable by renaming it back
+    /// and is preferred to an automatic rollback, which would be a second write
+    /// on an already-failing filesystem and could destroy the retired key while
+    /// trying to restore it. Nothing here deletes a key under any outcome.
     pub fn rotate(&self, agent_id: &str) -> Result<Rotation, IdentityStoreError> {
         let previous = self.load(agent_id)?;
         let previous_did = previous.did_key();
@@ -440,7 +447,13 @@ impl IdentityStore {
             reason: format!("the superseded key could not be retired ({e})"),
         })?;
 
-        let current = self.enroll(agent_id)?;
+        let current = self.enroll(agent_id).map_err(|e| IdentityStoreError::Io {
+            path: retired_path.clone(),
+            reason: format!(
+                "the superseded key was retired but no replacement could be enrolled ({e});                  this agent currently has no identity key — rename the retired file back to {}                  to restore the previous identity",
+                path.display()
+            ),
+        })?;
         Ok(Rotation {
             previous_did,
             retired_path,

--- a/aa-sdk-client/src/identity_store.rs
+++ b/aa-sdk-client/src/identity_store.rs
@@ -654,3 +654,374 @@ fn parse_key_record(path: &Path, contents: &str) -> Result<KeyRecord, IdentitySt
         seed: Zeroizing::new(seed),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signature, VerifyingKey};
+
+    /// Assert that a store operation refused, and hand back its reason.
+    ///
+    /// `AgentKeypair` has no `Debug` — deliberately, since it holds a signing
+    /// key and a derived `Debug` is how key material ends up in a test log — so
+    /// `expect_err` cannot be used on these results. This says the same thing
+    /// without asking the success type to be printable.
+    fn expect_refusal(result: Result<AgentKeypair, IdentityStoreError>, what: &str) -> IdentityStoreError {
+        match result {
+            Ok(_) => panic!("{what} must be refused, but a usable key was returned"),
+            Err(e) => e,
+        }
+    }
+
+    /// A store in a directory unique to this test, so no case can pass by
+    /// reading a key another case wrote.
+    fn store(label: &str) -> IdentityStore {
+        let root = std::env::temp_dir().join(format!(
+            "aa-identity-store-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        IdentityStore::at(root)
+    }
+
+    // ── the key is random, not derived ────────────────────────────────────
+
+    /// The defect, stated as a test. Two independent enrolments of the *same*
+    /// agent id must produce different keys — if the identifier still determined
+    /// the key, an attacker who read the identifier would hold the key.
+    #[test]
+    fn enrolling_one_identifier_twice_in_two_stores_yields_two_different_keys() {
+        let first = store("random-a").enroll("ops-laptop").expect("enrolment");
+        let second = store("random-b").enroll("ops-laptop").expect("enrolment");
+
+        assert_ne!(
+            first.public_key_hex(),
+            second.public_key_hex(),
+            "the same identifier produced the same key, so the private half is a function of \
+             public data and the possession proof proves nothing"
+        );
+    }
+
+    /// The specific value the old implementation produced must not come back.
+    /// A regression that reintroduced `SHA-256(agent_id)` seeding would still
+    /// pass the test above if it were the only guard, because both stores would
+    /// merely agree — this names the forbidden value directly.
+    #[test]
+    fn an_enrolled_key_is_never_the_sha256_of_the_identifier() {
+        let agent_id = "ops-laptop";
+        let enrolled = store("not-sha").enroll(agent_id).expect("enrolment");
+
+        assert_ne!(
+            enrolled.public_key_hex(),
+            AgentKeypair::derive_transport_key(agent_id).public_key_hex(),
+            "the identity key is the pre-AAASM-5332 derived key; anyone who knows `{agent_id}` \
+             holds it"
+        );
+    }
+
+    // ── the key is durable ────────────────────────────────────────────────
+
+    /// Durability is the other half of the contract: the identity that
+    /// registered must be the identity a later launch runs under.
+    #[test]
+    fn a_stored_key_is_read_back_rather_than_regenerated() {
+        let store = store("durable");
+        let enrolled = store.enroll("agent-a").expect("enrolment");
+        let reloaded = store.load("agent-a").expect("load");
+
+        assert_eq!(enrolled.public_key_hex(), reloaded.public_key_hex());
+        assert_eq!(
+            store.load_or_enroll("agent-a").expect("load").public_key_hex(),
+            enrolled.public_key_hex(),
+            "load_or_enroll must load when a key exists, not mint a second identity"
+        );
+    }
+
+    #[test]
+    fn distinct_identifiers_get_distinct_keys_and_distinct_files() {
+        let store = store("distinct");
+        let a = store.enroll("agent-a").expect("enrolment");
+        let b = store.enroll("agent-b").expect("enrolment");
+
+        assert_ne!(a.public_key_hex(), b.public_key_hex());
+        assert_ne!(store.key_path("agent-a"), store.key_path("agent-b"));
+    }
+
+    #[test]
+    fn loading_an_unenrolled_identity_reports_not_enrolled_rather_than_inventing_one() {
+        let err = expect_refusal(store("absent").load("never-seen"), "loading an unenrolled identity");
+        assert!(matches!(err, IdentityStoreError::NotEnrolled { .. }), "got {err:?}");
+    }
+
+    // ── the key is never silently overwritten ─────────────────────────────
+
+    /// Contract item 4. The key file *is* the agent's identity, so a second
+    /// enrolment must fail rather than retire an identity the gateway has
+    /// records for.
+    #[test]
+    fn enrolling_twice_refuses_and_leaves_the_first_key_intact() {
+        let store = store("no-overwrite");
+        let original = store.enroll("agent-a").expect("first enrolment");
+
+        let err = expect_refusal(store.enroll("agent-a"), "a second enrolment");
+        assert!(matches!(err, IdentityStoreError::AlreadyEnrolled { .. }), "got {err:?}");
+
+        assert_eq!(
+            store.load("agent-a").expect("load").public_key_hex(),
+            original.public_key_hex(),
+            "the refused enrolment must not have disturbed the stored key"
+        );
+    }
+
+    // ── the key file is protected ─────────────────────────────────────────
+
+    #[cfg(unix)]
+    #[test]
+    fn an_enrolled_key_file_is_owner_only_and_so_is_its_directory() {
+        use std::os::unix::fs::PermissionsExt;
+        let store = store("perms");
+        store.enroll("agent-a").expect("enrolment");
+
+        let file_mode = fs::metadata(store.key_path("agent-a")).unwrap().permissions().mode() & 0o777;
+        assert_eq!(file_mode, 0o600, "key file mode is {file_mode:04o}, not 0600");
+
+        let dir_mode = fs::metadata(store.root()).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o700, "key directory mode is {dir_mode:04o}, not 0700");
+    }
+
+    /// A key another principal can read is that principal's key too, so it is
+    /// refused rather than used.
+    #[cfg(unix)]
+    #[test]
+    fn a_group_or_world_accessible_key_file_is_refused_not_used() {
+        use std::os::unix::fs::PermissionsExt;
+
+        for loosened in [0o640, 0o604, 0o660, 0o666, 0o644] {
+            let store = store(&format!("loose-{loosened:o}"));
+            store.enroll("agent-a").expect("enrolment");
+            let path = store.key_path("agent-a");
+            fs::set_permissions(&path, fs::Permissions::from_mode(loosened)).unwrap();
+
+            let err = expect_refusal(store.load("agent-a"), &format!("a key file with mode {loosened:04o}"));
+            assert!(matches!(err, IdentityStoreError::Untrusted { .. }), "got {err:?}");
+            assert!(
+                err.to_string().contains("group or other"),
+                "the refusal must say the mode is the problem: {err}"
+            );
+        }
+    }
+
+    /// A key file owned by somebody else must be refused. Ownership cannot be
+    /// changed without privilege, so the check is exercised through the
+    /// `expected_uid` parameter — which is why it is a parameter.
+    #[cfg(unix)]
+    #[test]
+    fn a_key_file_owned_by_another_user_is_refused() {
+        use std::os::unix::fs::MetadataExt;
+
+        let store = store("foreign-owner");
+        store.enroll("agent-a").expect("enrolment");
+        let path = store.key_path("agent-a");
+        let meta = fs::symlink_metadata(&path).unwrap();
+        let real_uid = meta.uid();
+
+        verify_key_file(&path, &meta, real_uid).expect("our own key file must be accepted");
+
+        let err = verify_key_file(&path, &meta, real_uid.wrapping_add(1))
+            .expect_err("a key file owned by another uid must be refused");
+        assert!(matches!(err, IdentityStoreError::Untrusted { .. }), "got {err:?}");
+        assert!(
+            err.to_string().contains("owned by uid"),
+            "the refusal must say it is an ownership problem: {err}"
+        );
+    }
+
+    /// A symlink is refused rather than followed: the metadata that was vetted
+    /// must be the metadata of the bytes that get read.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_key_file_is_refused_rather_than_followed() {
+        let real = store("symlink-target");
+        let real_key = real.enroll("agent-a").expect("enrolment");
+
+        let attacker = store("symlink-store");
+        let _ = attacker.enroll("bootstrap").expect("create the directory");
+        let link = attacker.key_path("agent-a");
+        std::os::unix::fs::symlink(real.key_path("agent-a"), &link).unwrap();
+
+        let err = expect_refusal(attacker.load("agent-a"), "a symlinked key file");
+        assert!(matches!(err, IdentityStoreError::Untrusted { .. }), "got {err:?}");
+        assert!(err.to_string().contains("symlink"), "{err}");
+
+        // And the guard is not vacuous: the target really was a loadable key.
+        assert!(real.load("agent-a").is_ok());
+        let _ = real_key;
+    }
+
+    // ── malformed records ─────────────────────────────────────────────────
+
+    #[test]
+    fn a_truncated_or_unrecognised_key_file_is_refused_rather_than_guessed_at() {
+        for (label, body) in [
+            ("no-magic", "agent_id_hex=6162\nsecret_seed_hex=00\n"),
+            ("no-seed", "aa-identity-key/1\nagent_id_hex=6162\n"),
+            (
+                "short-seed",
+                "aa-identity-key/1\nagent_id_hex=6162\nsecret_seed_hex=abcd\n",
+            ),
+            (
+                "non-hex-seed",
+                "aa-identity-key/1\nagent_id_hex=6162\nsecret_seed_hex=zz\n",
+            ),
+        ] {
+            let store = store(label);
+            let _ = store.enroll("bootstrap").expect("create the directory");
+            create_exclusive(&store.key_path("ab"), KEY_FILE_MODE, body.as_bytes()).unwrap();
+
+            let err = expect_refusal(store.load("ab"), &format!("a `{label}` key file"));
+            assert!(
+                matches!(err, IdentityStoreError::Malformed { .. }),
+                "`{label}` gave {err:?}"
+            );
+        }
+    }
+
+    /// The filename is a hash, so the file names its own agent. A record for a
+    /// different identity is refused rather than used under the wrong name.
+    #[test]
+    fn a_key_file_recording_a_different_agent_is_refused() {
+        let store = store("mismatch");
+        store.enroll("agent-a").expect("enrolment");
+
+        // Same bytes, filed under another identity's path.
+        let contents = fs::read_to_string(store.key_path("agent-a")).unwrap();
+        create_exclusive(&store.key_path("agent-b"), KEY_FILE_MODE, contents.as_bytes()).unwrap();
+
+        let err = expect_refusal(store.load("agent-b"), "a mis-filed key");
+        assert!(
+            matches!(err, IdentityStoreError::IdentityMismatch { .. }),
+            "got {err:?}"
+        );
+    }
+
+    // ── rotation and revocation ───────────────────────────────────────────
+
+    #[test]
+    fn rotation_replaces_the_identity_and_retains_the_superseded_key() {
+        let store = store("rotate");
+        let before = store.enroll("agent-a").expect("enrolment").did_key();
+
+        let rotation = store.rotate("agent-a").expect("rotation");
+
+        assert_eq!(rotation.previous_did, before);
+        assert_ne!(rotation.current_did, before, "rotation must produce a new identity");
+        assert_eq!(
+            store.load("agent-a").expect("load").did_key(),
+            rotation.current_did,
+            "the store must now serve the rotated key"
+        );
+        assert!(
+            rotation.retired_path.exists(),
+            "the superseded key must be retained, not destroyed"
+        );
+    }
+
+    #[test]
+    fn a_revoked_identity_cannot_be_loaded_or_quietly_re_enrolled() {
+        let store = store("revoke");
+        let did = store.enroll("agent-a").expect("enrolment").did_key();
+
+        let revocation = store.revoke("agent-a", "laptop stolen").expect("revocation");
+        assert_eq!(
+            revocation.revoked_did, did,
+            "the caller must learn which DID to distrust"
+        );
+
+        let load_err = expect_refusal(store.load("agent-a"), "loading a revoked key");
+        assert!(
+            matches!(load_err, IdentityStoreError::Revoked { .. }),
+            "got {load_err:?}"
+        );
+
+        // The important one: revocation must not be undone by simply running the
+        // agent again, which `load_or_enroll` would otherwise do.
+        let reenrol_err = expect_refusal(store.load_or_enroll("agent-a"), "re-enrolling a revoked identity");
+        assert!(
+            matches!(reenrol_err, IdentityStoreError::Revoked { .. }),
+            "got {reenrol_err:?}"
+        );
+    }
+
+    // ── the core acceptance criterion ─────────────────────────────────────
+
+    /// **Knowing the identifier is not enough to forge a possession proof.**
+    ///
+    /// The attacker is given everything public about the victim: the agent id,
+    /// the victim's DID, the victim's `public_key`, and the server nonce. They
+    /// then attempt the forgery for real — reproducing the pre-AAASM-5332
+    /// derivation, which is exactly how the old scheme was broken — and the
+    /// resulting signature is checked against the victim's key the same way
+    /// `verify_possession_proof` checks it.
+    #[test]
+    fn knowing_the_identifier_is_not_enough_to_forge_a_possession_proof() {
+        let agent_id = "ops-laptop";
+        let victim_store = store("forgery-victim");
+        let victim = victim_store.enroll(agent_id).expect("enrolment");
+
+        // Everything the attacker can see: the id is in audit records and on the
+        // dashboard, the DID and public key are in the registry.
+        let victim_did = victim.did_key();
+        let victim_public_key: [u8; 32] = victim.public_key_bytes();
+        let nonce = *b"a-server-issued-challenge-nonce!!";
+
+        // Attempt 1 — the actual old break: derive the key from the identifier.
+        let forged = AgentKeypair::derive_transport_key(agent_id).sign(&nonce);
+
+        // Attempt 2 — derive from the DID instead, since that is public too.
+        let forged_from_did = AgentKeypair::derive_transport_key(&victim_did).sign(&nonce);
+
+        // Attempt 3 — derive from the victim's public key, the most direct guess.
+        let forged_from_pubkey = AgentKeypair::derive_transport_key(&victim.public_key_hex()).sign(&nonce);
+
+        let verifying = VerifyingKey::from_bytes(&victim_public_key).expect("a valid Ed25519 key");
+        for (label, proof) in [
+            ("the agent id", forged),
+            ("the DID", forged_from_did),
+            ("the public key", forged_from_pubkey),
+        ] {
+            assert!(
+                verifying.verify_strict(&nonce, &Signature::from_bytes(&proof)).is_err(),
+                "a proof forged from {label} verified against the victim's key — knowing public \
+                 data is still sufficient to register as this agent"
+            );
+        }
+
+        // The guard is not vacuous: the real holder's proof does verify, so the
+        // failures above are the forgeries failing and not the check being
+        // broken for everyone.
+        assert!(
+            verifying
+                .verify_strict(&nonce, &Signature::from_bytes(&victim.sign(&nonce)))
+                .is_ok(),
+            "the genuine key holder must still be able to prove possession"
+        );
+    }
+
+    /// The attacker cannot get at the key by *reading* it either: an agent's
+    /// key file is not readable through a second store rooted elsewhere, and the
+    /// only thing a foreign store can do with the identifier is enrol a
+    /// different identity — which the gateway sees as a different DID.
+    #[test]
+    fn a_second_installation_cannot_reach_the_first_installations_identity() {
+        let agent_id = "ops-laptop";
+        let genuine = store("two-installs-genuine").enroll(agent_id).expect("enrolment");
+        let attacker = store("two-installs-attacker").enroll(agent_id).expect("enrolment");
+
+        assert_ne!(
+            genuine.did_key(),
+            attacker.did_key(),
+            "a second installation reached the first one's identity from the identifier alone"
+        );
+    }
+}

--- a/aa-sdk-client/src/identity_store.rs
+++ b/aa-sdk-client/src/identity_store.rs
@@ -733,6 +733,37 @@ mod tests {
         );
     }
 
+    // ── where the store resolves to ───────────────────────────────────────
+
+    /// The production resolution path. `nextest` runs each test in its own
+    /// process, so mutating the environment here cannot disturb a sibling —
+    /// which is also why `config.rs`'s existing env tests do it unguarded.
+    #[test]
+    fn default_location_prefers_the_state_dir_then_home_then_refuses() {
+        std::env::set_var("AASM_STATE_DIR", "/tmp/explicit-state");
+        assert_eq!(
+            IdentityStore::default_location().expect("resolves").root(),
+            Path::new("/tmp/explicit-state/identity"),
+            "AASM_STATE_DIR must win, so one variable relocates all installation state"
+        );
+
+        // Empty is treated as absent rather than resolving to `/identity`.
+        std::env::set_var("AASM_STATE_DIR", "");
+        std::env::set_var("HOME", "/tmp/fake-home");
+        assert_eq!(
+            IdentityStore::default_location().expect("resolves").root(),
+            Path::new("/tmp/fake-home/.aasm/identity")
+        );
+
+        // Nowhere durable to put a key is a refusal, not a guess.
+        std::env::remove_var("AASM_STATE_DIR");
+        std::env::remove_var("HOME");
+        let err = IdentityStore::default_location()
+            .err()
+            .expect("with no state dir and no home there is nowhere to keep a key");
+        assert!(matches!(err, IdentityStoreError::NoStateDirectory), "got {err:?}");
+    }
+
     // ── the key is durable ────────────────────────────────────────────────
 
     /// Durability is the other half of the contract: the identity that

--- a/aa-sdk-client/src/identity_store.rs
+++ b/aa-sdk-client/src/identity_store.rs
@@ -842,17 +842,24 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn a_symlinked_key_file_is_refused_rather_than_followed() {
-        let real = store("symlink-target");
+        let real = store("linktarget");
         let real_key = real.enroll("agent-a").expect("enrolment");
 
-        let attacker = store("symlink-store");
+        // Store labels deliberately avoid the word this test greps for: the
+        // refusal message embeds the path, so a label containing "symlink"
+        // would satisfy the assertion below no matter which check fired.
+        let attacker = store("linkstore");
         let _ = attacker.enroll("bootstrap").expect("create the directory");
         let link = attacker.key_path("agent-a");
         std::os::unix::fs::symlink(real.key_path("agent-a"), &link).unwrap();
 
         let err = expect_refusal(attacker.load("agent-a"), "a symlinked key file");
         assert!(matches!(err, IdentityStoreError::Untrusted { .. }), "got {err:?}");
-        assert!(err.to_string().contains("symlink"), "{err}");
+        assert!(
+            err.to_string().contains("it is a symlink"),
+            "the link must be refused *as a link* — a refusal for some other reason would mean \
+             the metadata that gets vetted is not the metadata of the bytes that get read: {err}"
+        );
 
         // And the guard is not vacuous: the target really was a loadable key.
         assert!(real.load("agent-a").is_ok());

--- a/aa-sdk-client/src/identity_store.rs
+++ b/aa-sdk-client/src/identity_store.rs
@@ -925,6 +925,34 @@ mod tests {
         );
     }
 
+    /// Contract item 5: enrolment credentials stay separate from the durable
+    /// identity key.
+    ///
+    /// The gateway's `credential_token` is a short-lived bootstrap credential
+    /// held in memory (`AssemblyClient` keeps it in a `Zeroizing<String>`), and
+    /// the registration nonce is per-handshake. Neither may be parked in the key
+    /// file: a durable file holding a bearer token is a token with the lifetime
+    /// of an identity, and one holding the nonce would make the possession proof
+    /// precomputable again. Pinning the record's field set is what stops that
+    /// happening by accident later.
+    #[test]
+    fn a_key_file_holds_only_the_identity_key_and_never_a_bootstrap_credential() {
+        let store = store("fields");
+        store.enroll("agent-a").expect("enrolment");
+        let contents = fs::read_to_string(store.key_path("agent-a")).expect("read");
+
+        let mut lines = contents.lines();
+        assert_eq!(lines.next(), Some(KEY_FILE_MAGIC));
+
+        let fields: Vec<&str> = lines.filter_map(|l| l.split_once('=').map(|(k, _)| k)).collect();
+        assert_eq!(
+            fields,
+            vec!["agent_id_hex", "created_at_unix", "secret_seed_hex"],
+            "the key file's field set changed; a durable file must not gain a credential token, \
+             a registration nonce, or anything else with a shorter life than the identity"
+        );
+    }
+
     // ── rotation and revocation ───────────────────────────────────────────
 
     #[test]

--- a/aa-sdk-client/src/identity_store.rs
+++ b/aa-sdk-client/src/identity_store.rs
@@ -1,0 +1,656 @@
+//! Durable, owner-only storage for an agent's identity private key (AAASM-5332).
+//!
+//! # What this is for
+//!
+//! An agent's registration possession proof is the only control deciding who may
+//! register as a given agent: `AgentLifecycleService.Register` is an
+//! unauthenticated bootstrap endpoint by design (mounted behind
+//! `enrich_interceptor`, which authenticates nothing and returns `Ok` for every
+//! request). For that proof to mean anything, its private key has to be
+//! something the caller *has* rather than something the caller can *compute*.
+//!
+//! Before AAASM-5332 it was computable: the signing key was seeded with
+//! `SHA-256(agent_id)`, and the agent id is public — it shows up in audit
+//! records, in topology views and on the dashboard. Anyone who could read an
+//! agent id could rebuild that agent's private key and register as it.
+//!
+//! So the private key is now generated from the OS CSPRNG and kept here. That
+//! trades "nothing to persist" for "a file that must be protected", and this
+//! module's whole job is that protection.
+//!
+//! # The guarantees
+//!
+//! * **Random, never derived.** [`random_seed`] reads the kernel CSPRNG; no
+//!   part of the private half is a function of the agent id, the DID, or any
+//!   other public value.
+//! * **One durable key per agent identity.** The key is written once and read
+//!   back on every subsequent use, so the identity that registered, the identity
+//!   a launch runs under, and the identity audit attributes actions to stay the
+//!   same principal across restarts.
+//! * **Owner-only, created atomically.** The file is created with `O_EXCL` and
+//!   mode `0600` in a single `open(2)`, so it is never briefly world-readable
+//!   and two racing enrolments cannot both win.
+//! * **Never silently overwritten.** `O_EXCL` makes re-enrolment an error rather
+//!   than a clobber; replacing a key is only ever [`IdentityStore::rotate`], and
+//!   it retains the old key rather than destroying it.
+//! * **Validated on read.** A key file that is a symlink, is not a regular file,
+//!   is owned by another user, or is readable/writable by group or other is
+//!   *refused*, not used. See [`verify_key_file`].
+//!
+//! # What is deliberately not here
+//!
+//! No key expiry and no automatic renewal (AAASM-5332 excludes them on purpose).
+//! Renewal introduces a clock, a grace window and a set of failure modes that
+//! belong in their own change, not in the repair of a key-generation defect.
+//!
+//! # Relationship to the proxy state file
+//!
+//! The read-side validation mirrors `aa-cli`'s
+//! `commands::proxy::trust::verify_state_file`, deliberately: two files that a
+//! governed launch trusts should be trusted for the same stated reasons. It is
+//! stricter in one respect — the proxy record rejects group/other *write*
+//! (`0o022`), this rejects group/other *access at all* (`0o077`) — because a
+//! record another principal can only read is merely leaky, whereas a private key
+//! another principal can read is that principal's key too.
+
+use std::fmt;
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+use crate::keypair::AgentKeypair;
+
+/// First line of a key file, identifying format and version.
+///
+/// Present so a future format change is a refusal rather than a misparse: a file
+/// whose first line is not this exact string is [`IdentityStoreError::Malformed`]
+/// and the caller fails closed instead of guessing at the bytes.
+const KEY_FILE_MAGIC: &str = "aa-identity-key/1";
+
+/// Length of an Ed25519 secret seed, in bytes.
+const SEED_LEN: usize = 32;
+
+/// Permission bits any file holding a private key must have.
+const KEY_FILE_MODE: u32 = 0o600;
+
+/// Permission bits the directory holding key files must have.
+const KEY_DIR_MODE: u32 = 0o700;
+
+/// Access bits that disqualify a private key file: any group or other
+/// permission at all, not merely write.
+const FORBIDDEN_KEY_ACCESS_BITS: u32 = 0o077;
+
+/// Why an identity key could not be resolved.
+///
+/// Every variant is a refusal. There is no variant meaning "carried on with a
+/// weaker identity" — an agent whose durable key cannot be established has no
+/// identity to register under, and inventing one is exactly the failure
+/// AAASM-5332 removes.
+#[derive(Debug)]
+pub enum IdentityStoreError {
+    /// Neither `AASM_STATE_DIR` nor a home directory could be resolved, so there
+    /// is nowhere durable to keep a key.
+    NoStateDirectory,
+    /// The key file exists but this process must not act on it — wrong owner,
+    /// too-permissive mode, a symlink, or not a regular file.
+    Untrusted { path: PathBuf, reason: String },
+    /// The key file exists and is trusted, but its contents are not a complete
+    /// record. A half-written key supports no conclusion.
+    Malformed { path: PathBuf, reason: String },
+    /// The key file names a different agent than the one being loaded, which
+    /// means two identities collided onto one path.
+    IdentityMismatch { path: PathBuf },
+    /// Enrolment was asked to create a key that already exists. Never resolved
+    /// by overwriting: the existing key *is* the agent's identity.
+    AlreadyEnrolled { path: PathBuf },
+    /// An operation that needs an existing key found none.
+    NotEnrolled { path: PathBuf },
+    /// The key has been revoked and must not be used again.
+    Revoked { path: PathBuf },
+    /// The configured agent identifier is already a `did:key`. This crate holds
+    /// no private key for a DID it did not generate, so it cannot prove
+    /// possession of one — see [`crate::identity::agent_id_to_did_key`].
+    ProvisionedDidUnsupported { did: String },
+    /// The filesystem or the CSPRNG refused.
+    Io { path: PathBuf, reason: String },
+}
+
+impl fmt::Display for IdentityStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoStateDirectory => write!(
+                f,
+                "no Agent Assembly state directory could be resolved, so this agent's identity key \
+                 has nowhere to live; set AASM_STATE_DIR"
+            ),
+            Self::Untrusted { path, reason } => write!(
+                f,
+                "the agent identity key at {} cannot be trusted: {reason}. It is refused rather \
+                 than used; move it aside and re-enrol if it is genuinely yours",
+                path.display()
+            ),
+            Self::Malformed { path, reason } => write!(
+                f,
+                "the agent identity key at {} is not a complete record: {reason}",
+                path.display()
+            ),
+            Self::IdentityMismatch { path } => write!(
+                f,
+                "the key file at {} belongs to a different agent identity",
+                path.display()
+            ),
+            Self::AlreadyEnrolled { path } => write!(
+                f,
+                "this agent already has a durable identity key at {}; enrolling again would \
+                 replace the identity it registers under. Use rotation if that is the intent",
+                path.display()
+            ),
+            Self::NotEnrolled { path } => write!(f, "this agent has no durable identity key at {} yet", path.display()),
+            Self::Revoked { path } => write!(
+                f,
+                "this agent's identity key has been revoked ({} exists) and must not be used \
+                 again; enrol a new identity",
+                path.display()
+            ),
+            Self::ProvisionedDidUnsupported { did } => write!(
+                f,
+                "the configured agent id is the DID `{did}`, but this agent holds no private key \
+                 for it and so cannot prove possession of it at registration. Configure a plain \
+                 agent identifier and let the durable identity key supply the DID"
+            ),
+            Self::Io { path, reason } => {
+                write!(f, "the agent identity key at {} is unusable: {reason}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for IdentityStoreError {}
+
+/// Read a fresh 32-byte secret seed from the operating system's CSPRNG.
+///
+/// Reads `/dev/urandom`, which is the same source `getrandom(2)` serves on the
+/// Unix targets this crate's identity storage supports. It is read directly
+/// rather than through the `rand`/`getrandom` crates because AAASM-5332 must not
+/// alter the dependency graph: `rand` is currently a dev-dependency only, and
+/// promoting it would rewrite `Cargo.lock` while three other lanes are in
+/// flight. Adding the crate later is a mechanical swap — the seed's *source*
+/// does not change, only which code reads it.
+///
+/// The bytes are collected from the reader rather than filled into a
+/// zero-initialised array so that no constant ever appears in the seed's
+/// data-flow, keeping the static analysers pointed at real hard-coded-key
+/// findings instead of this one.
+pub(crate) fn random_seed() -> io::Result<Zeroizing<[u8; SEED_LEN]>> {
+    let file = fs::File::open("/dev/urandom")?;
+    let mut bytes: Zeroizing<Vec<u8>> = Zeroizing::new(Vec::with_capacity(SEED_LEN));
+    file.take(SEED_LEN as u64).read_to_end(&mut bytes)?;
+
+    // A short read means the CSPRNG did not supply a full seed. Failing here is
+    // the only safe response: padding it would hand out a key with less entropy
+    // than its length advertises.
+    let seed: [u8; SEED_LEN] = bytes.as_slice().try_into().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            format!("the CSPRNG supplied {} bytes, not {SEED_LEN}", bytes.len()),
+        )
+    })?;
+    Ok(Zeroizing::new(seed))
+}
+
+/// Constraint: the key file must be one only this user could have written or read.
+///
+/// A symlink is rejected rather than followed — the metadata that was vetted has
+/// to be the metadata of the bytes that get read, and following a link opens a
+/// window where the two differ. Group- and other-accessible modes are rejected
+/// outright: a private key another principal can read is not private, and a
+/// private key another principal can write lets them choose which key this agent
+/// registers with, which is the whole attack this ticket closes.
+///
+/// `expected_uid` is a parameter rather than read inside so the rejection path
+/// is reachable in a test — a check that can only ever be exercised with the
+/// running user's own UID cannot be shown to fail. This mirrors
+/// `aa-cli::commands::proxy::trust::verify_state_file` for the same reason.
+pub fn verify_key_file(path: &Path, meta: &fs::Metadata, expected_uid: u32) -> Result<(), IdentityStoreError> {
+    if meta.file_type().is_symlink() {
+        return Err(IdentityStoreError::Untrusted {
+            path: path.to_path_buf(),
+            reason: "it is a symlink, so the bytes vetted need not be the bytes read".into(),
+        });
+    }
+    if !meta.is_file() {
+        return Err(IdentityStoreError::Untrusted {
+            path: path.to_path_buf(),
+            reason: "it is not a regular file".into(),
+        });
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let owner = meta.uid();
+        if owner != expected_uid {
+            return Err(IdentityStoreError::Untrusted {
+                path: path.to_path_buf(),
+                reason: format!("it is owned by uid {owner}, not by this user (uid {expected_uid})"),
+            });
+        }
+        let mode = meta.permissions().mode() & 0o777;
+        if mode & FORBIDDEN_KEY_ACCESS_BITS != 0 {
+            return Err(IdentityStoreError::Untrusted {
+                path: path.to_path_buf(),
+                reason: format!("its mode {mode:04o} grants access to group or other"),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// The parsed contents of a key file.
+struct KeyRecord {
+    agent_id: String,
+    seed: Zeroizing<[u8; SEED_LEN]>,
+}
+
+/// A completed key rotation.
+pub struct Rotation {
+    /// The `did:key` the agent registered under before rotating. It is no longer
+    /// this agent's identity and should be deregistered at the gateway.
+    pub previous_did: String,
+    /// Where the superseded key was moved to. It is retained rather than
+    /// deleted, so an operator can still prove what the old identity was.
+    pub retired_path: PathBuf,
+    /// The `did:key` the agent will register under from now on.
+    pub current_did: String,
+}
+
+/// A completed revocation.
+pub struct Revocation {
+    /// The `did:key` that must no longer be accepted for this agent.
+    pub revoked_did: String,
+    /// The marker whose existence makes the key unloadable.
+    pub marker_path: PathBuf,
+}
+
+/// A directory of durable agent identity keys.
+pub struct IdentityStore {
+    root: PathBuf,
+}
+
+impl IdentityStore {
+    /// A store rooted at `root`, whose directory is created on first enrolment.
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// The default store: `${AASM_STATE_DIR:-$HOME/.aasm}/identity`.
+    ///
+    /// Same base directory as the integration receipt store in `aa-core`
+    /// (`ReceiptStore::default_location`), so one environment variable relocates
+    /// all of an installation's durable state — which is what the test harnesses
+    /// already rely on to keep parallel runs off each other's files. `HOME` is
+    /// read directly rather than through the `dirs` crate to keep this change
+    /// out of `Cargo.lock`; on Unix `dirs::home_dir` consults `HOME` first
+    /// anyway.
+    pub fn default_location() -> Result<Self, IdentityStoreError> {
+        let base = match std::env::var_os("AASM_STATE_DIR") {
+            Some(dir) if !dir.is_empty() => PathBuf::from(dir),
+            _ => match std::env::var_os("HOME") {
+                Some(home) if !home.is_empty() => PathBuf::from(home).join(".aasm"),
+                _ => return Err(IdentityStoreError::NoStateDirectory),
+            },
+        };
+        Ok(Self::at(base.join("identity")))
+    }
+
+    /// The directory key files live in.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Where `agent_id`'s key file lives.
+    ///
+    /// The filename is `SHA-256(agent_id)` hex rather than the agent id itself:
+    /// an agent id is free-form text that may contain path separators, `..`, or
+    /// characters the filesystem will not take, and none of that should be able
+    /// to steer where a key is written. Hashing is used here purely to get a
+    /// fixed-length, filesystem-safe name — it is *not* protecting anything, and
+    /// the agent id is stored inside the file so a hash collision is caught on
+    /// read rather than silently sharing one key between two identities.
+    pub fn key_path(&self, agent_id: &str) -> PathBuf {
+        self.root.join(format!("{}.key", slug(agent_id)))
+    }
+
+    /// Where `agent_id`'s revocation marker lives, if it has been revoked.
+    pub fn revocation_path(&self, agent_id: &str) -> PathBuf {
+        self.root.join(format!("{}.revoked", slug(agent_id)))
+    }
+
+    /// Load `agent_id`'s durable identity key, enrolling one on first use.
+    ///
+    /// This is the normal path. First use is enrolment: an agent that has never
+    /// registered has no key, and generating one at that moment is what makes
+    /// the identity durable from then on. Every later call reads the same key
+    /// back, which is what keeps registration, launch and audit attribution
+    /// pointing at one principal.
+    ///
+    /// A *revoked* identity is not silently re-enrolled — that would let the
+    /// revocation be undone by simply running the agent again.
+    pub fn load_or_enroll(&self, agent_id: &str) -> Result<AgentKeypair, IdentityStoreError> {
+        match self.load(agent_id) {
+            Err(IdentityStoreError::NotEnrolled { .. }) => self.enroll(agent_id),
+            other => other,
+        }
+    }
+
+    /// Load `agent_id`'s durable identity key, refusing to create one.
+    ///
+    /// Returns [`IdentityStoreError::NotEnrolled`] when no key exists, and
+    /// refuses outright when one exists but cannot be trusted.
+    pub fn load(&self, agent_id: &str) -> Result<AgentKeypair, IdentityStoreError> {
+        let revocation = self.revocation_path(agent_id);
+        if revocation.exists() {
+            return Err(IdentityStoreError::Revoked { path: revocation });
+        }
+
+        // Establishes both that the identity directory is ours and which UID
+        // "ours" is, so the file check below has something to compare against.
+        let expected_uid = self.ensure_root()?;
+
+        let path = self.key_path(agent_id);
+        let meta = match fs::symlink_metadata(&path) {
+            Ok(meta) => meta,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Err(IdentityStoreError::NotEnrolled { path }),
+            Err(e) => {
+                return Err(IdentityStoreError::Untrusted {
+                    path,
+                    reason: format!("it could not be inspected ({e})"),
+                })
+            }
+        };
+        verify_key_file(&path, &meta, expected_uid)?;
+
+        let contents = Zeroizing::new(fs::read_to_string(&path).map_err(|e| IdentityStoreError::Io {
+            path: path.clone(),
+            reason: e.to_string(),
+        })?);
+        let record = parse_key_record(&path, &contents)?;
+
+        // The filename is a hash, so two agent ids could in principle land on
+        // one path. Compare the authoritative copy inside the file rather than
+        // trusting the name.
+        if record.agent_id != agent_id {
+            return Err(IdentityStoreError::IdentityMismatch { path });
+        }
+
+        Ok(AgentKeypair::from_seed(&record.seed))
+    }
+
+    /// Generate and persist a fresh durable identity key for `agent_id`.
+    ///
+    /// Fails with [`IdentityStoreError::AlreadyEnrolled`] if a key is already
+    /// there. That refusal is the point: the key file *is* the agent's identity,
+    /// so overwriting it would silently retire an identity the gateway has
+    /// records for and start registering as a stranger. It is enforced by
+    /// `O_EXCL` in the same `open(2)` that creates the file, so it also holds
+    /// against a second process enrolling concurrently.
+    pub fn enroll(&self, agent_id: &str) -> Result<AgentKeypair, IdentityStoreError> {
+        let revocation = self.revocation_path(agent_id);
+        if revocation.exists() {
+            return Err(IdentityStoreError::Revoked { path: revocation });
+        }
+
+        let _ = self.ensure_root()?;
+        let path = self.key_path(agent_id);
+
+        let (keypair, seed) = AgentKeypair::generate().map_err(|e| IdentityStoreError::Io {
+            path: path.clone(),
+            reason: format!("the OS CSPRNG could not be read ({e})"),
+        })?;
+
+        write_key_file(&path, agent_id, &seed)?;
+        Ok(keypair)
+    }
+
+    /// Retire `agent_id`'s current key and enrol a fresh one.
+    ///
+    /// The superseded key is renamed aside, not deleted — an operator
+    /// reconstructing an incident needs to be able to say which key signed what,
+    /// and this module deletes nothing. The rename happens before the new key is
+    /// created so the `O_EXCL` guarantee in [`enroll`](Self::enroll) still holds.
+    ///
+    /// Rotation produces a **new `did:key`**, because the DID encodes the public
+    /// key. The gateway therefore sees a new agent identity; the caller is
+    /// responsible for deregistering [`Rotation::previous_did`]. See the crate
+    /// docs on migration for why that is a deliberate consequence rather than a
+    /// gap.
+    pub fn rotate(&self, agent_id: &str) -> Result<Rotation, IdentityStoreError> {
+        let previous = self.load(agent_id)?;
+        let previous_did = previous.did_key();
+
+        let path = self.key_path(agent_id);
+        let retired_path = self.root.join(format!("{}.retired-{}.key", slug(agent_id), unix_now()));
+        fs::rename(&path, &retired_path).map_err(|e| IdentityStoreError::Io {
+            path: path.clone(),
+            reason: format!("the superseded key could not be retired ({e})"),
+        })?;
+
+        let current = self.enroll(agent_id)?;
+        Ok(Rotation {
+            previous_did,
+            retired_path,
+            current_did: current.did_key(),
+        })
+    }
+
+    /// Revoke `agent_id`'s identity so this store will never sign with it again.
+    ///
+    /// Writes a marker beside the key rather than editing or removing the key
+    /// itself: the key bytes stay available for forensic comparison, and
+    /// [`load`](Self::load) refuses as long as the marker exists. Local
+    /// revocation is immediate and unconditional.
+    ///
+    /// **Propagation is the caller's job and is only partial.** Revoking here
+    /// stops *this* installation from using the key; it does not tell the
+    /// gateway to stop honouring the DID. The gateway's `AgentLifecycleService`
+    /// exposes no revoke RPC (`proto/agent.proto` has `RequestChallenge`,
+    /// `Register`, `Heartbeat`, `Deregister`, `ControlStream` and nothing else),
+    /// so the strongest propagation available today is `Deregister` on the
+    /// revoked DID. A real revocation list is deferred — see the report on this
+    /// ticket.
+    pub fn revoke(&self, agent_id: &str, reason: &str) -> Result<Revocation, IdentityStoreError> {
+        let revoked_did = self.load(agent_id)?.did_key();
+        let marker_path = self.revocation_path(agent_id);
+
+        let record = format!(
+            "revoked_at_unix={}\nrevoked_did={}\nreason={}\n",
+            unix_now(),
+            revoked_did,
+            reason.replace('\n', " ")
+        );
+        create_exclusive(&marker_path, KEY_FILE_MODE, record.as_bytes())?;
+
+        Ok(Revocation {
+            revoked_did,
+            marker_path,
+        })
+    }
+
+    /// Create the key directory owner-only, and report the UID that owns it.
+    ///
+    /// The directory's mode matters as much as the files': a directory group or
+    /// other can write to lets another principal unlink a key file and drop in
+    /// their own, which [`verify_key_file`] cannot detect because the
+    /// replacement would be a perfectly well-formed file owned by whoever
+    /// created it.
+    ///
+    /// The returned UID is *how this module learns which principal it is*, and
+    /// the reason is worth stating: `chmod(2)` succeeds only for the file's
+    /// owner (or root), so a `set_permissions` that succeeds on this directory
+    /// proves this process owns it, and the directory's owner UID is therefore
+    /// this process's own. Learning it this way keeps the crate free of a `libc`
+    /// dependency — `aa-sdk-client` is pinned by git SHA into three external SDK
+    /// repos, so its dependency graph is deliberately minimal — and it fails
+    /// closed in the case that actually matters: if the identity directory
+    /// belongs to somebody else, the `chmod` returns `EPERM` and every load and
+    /// enrolment refuses rather than trusting a stranger's directory.
+    fn ensure_root(&self) -> Result<u32, IdentityStoreError> {
+        fs::create_dir_all(&self.root).map_err(|e| IdentityStoreError::Io {
+            path: self.root.clone(),
+            reason: format!("the identity directory could not be created ({e})"),
+        })?;
+        restrict_dir(&self.root)?;
+        owner_uid(&self.root)
+    }
+}
+
+#[cfg(unix)]
+fn owner_uid(path: &Path) -> Result<u32, IdentityStoreError> {
+    use std::os::unix::fs::MetadataExt;
+    fs::metadata(path)
+        .map(|meta| meta.uid())
+        .map_err(|e| IdentityStoreError::Io {
+            path: path.to_path_buf(),
+            reason: format!("the identity directory's owner could not be read ({e})"),
+        })
+}
+
+#[cfg(not(unix))]
+fn owner_uid(_path: &Path) -> Result<u32, IdentityStoreError> {
+    Ok(0)
+}
+
+#[cfg(unix)]
+fn restrict_dir(path: &Path) -> Result<(), IdentityStoreError> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(KEY_DIR_MODE)).map_err(|e| IdentityStoreError::Io {
+        path: path.to_path_buf(),
+        reason: format!("the identity directory could not be restricted to this user ({e})"),
+    })
+}
+
+#[cfg(not(unix))]
+fn restrict_dir(_path: &Path) -> Result<(), IdentityStoreError> {
+    Ok(())
+}
+
+/// Filesystem-safe, fixed-length name for an agent id. See
+/// [`IdentityStore::key_path`] for why this is a hash and what it is not.
+fn slug(agent_id: &str) -> String {
+    hex::encode(Sha256::digest(agent_id.as_bytes()))
+}
+
+/// Seconds since the Unix epoch, or 0 if the clock is before it.
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default()
+}
+
+/// Serialise and write a key file, refusing to replace an existing one.
+fn write_key_file(path: &Path, agent_id: &str, seed: &Zeroizing<[u8; SEED_LEN]>) -> Result<(), IdentityStoreError> {
+    let body = Zeroizing::new(format!(
+        "{KEY_FILE_MAGIC}\nagent_id_hex={}\ncreated_at_unix={}\nsecret_seed_hex={}\n",
+        hex::encode(agent_id.as_bytes()),
+        unix_now(),
+        hex::encode(seed.as_ref()),
+    ));
+    create_exclusive(path, KEY_FILE_MODE, body.as_bytes())
+}
+
+/// Create `path` with exactly `mode` and write `body`, failing if it exists.
+///
+/// `create_new` maps to `O_EXCL`, and `mode` is applied by the same `open(2)`
+/// that creates the file. Both matter: the first makes "do not silently
+/// overwrite" a kernel guarantee rather than a check with a race in it, and the
+/// second means the file is never momentarily readable by anyone else, as it
+/// would be if permissions were tightened after writing. The mode is reasserted
+/// straight after creation so an unusually restrictive umask cannot leave the
+/// owner unable to read back their own key.
+fn create_exclusive(path: &Path, mode: u32, body: &[u8]) -> Result<(), IdentityStoreError> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(mode);
+    }
+
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            return Err(IdentityStoreError::AlreadyEnrolled {
+                path: path.to_path_buf(),
+            })
+        }
+        Err(e) => {
+            return Err(IdentityStoreError::Io {
+                path: path.to_path_buf(),
+                reason: e.to_string(),
+            })
+        }
+    };
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|e| IdentityStoreError::Io {
+            path: path.to_path_buf(),
+            reason: format!("permissions could not be set ({e})"),
+        })?;
+    }
+
+    file.write_all(body)
+        .and_then(|()| file.sync_all())
+        .map_err(|e| IdentityStoreError::Io {
+            path: path.to_path_buf(),
+            reason: e.to_string(),
+        })
+}
+
+/// Parse a key file, rejecting anything that is not a complete record.
+fn parse_key_record(path: &Path, contents: &str) -> Result<KeyRecord, IdentityStoreError> {
+    let malformed = |reason: &str| IdentityStoreError::Malformed {
+        path: path.to_path_buf(),
+        reason: reason.to_string(),
+    };
+
+    let mut lines = contents.lines();
+    if lines.next() != Some(KEY_FILE_MAGIC) {
+        return Err(malformed("it does not start with a recognised key-file header"));
+    }
+
+    let mut agent_id_hex = None;
+    let mut secret_seed_hex = None;
+    for line in lines {
+        match line.split_once('=') {
+            Some(("agent_id_hex", value)) => agent_id_hex = Some(value),
+            Some(("secret_seed_hex", value)) => secret_seed_hex = Some(value),
+            _ => {}
+        }
+    }
+
+    let agent_id_bytes = hex::decode(agent_id_hex.ok_or_else(|| malformed("it records no agent id"))?)
+        .map_err(|_| malformed("its agent id is not valid hex"))?;
+    let agent_id = String::from_utf8(agent_id_bytes).map_err(|_| malformed("its agent id is not valid UTF-8"))?;
+
+    let seed_bytes = Zeroizing::new(
+        hex::decode(secret_seed_hex.ok_or_else(|| malformed("it records no key material"))?)
+            .map_err(|_| malformed("its key material is not valid hex"))?,
+    );
+    let seed: [u8; SEED_LEN] = seed_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| malformed("its key material is not a 32-byte Ed25519 seed"))?;
+
+    Ok(KeyRecord {
+        agent_id,
+        seed: Zeroizing::new(seed),
+    })
+}

--- a/aa-sdk-client/src/identity_store.rs
+++ b/aa-sdk-client/src/identity_store.rs
@@ -20,7 +20,7 @@
 //!
 //! # The guarantees
 //!
-//! * **Random, never derived.** [`random_seed`] reads the kernel CSPRNG; no
+//! * **Random, never derived.** `random_seed` reads the kernel CSPRNG; no
 //!   part of the private half is a function of the agent id, the DID, or any
 //!   other public value.
 //! * **One durable key per agent identity.** The key is written once and read

--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -234,17 +234,26 @@ async fn perform_handshake(
 }
 
 /// Build a `HandshakeProof` for `agent_id` over the runtime-issued `nonce`,
-/// using the agent's deterministic Ed25519 keypair (AAASM-3587).
+/// using the agent's deterministic **transport** keypair (AAASM-3587).
 ///
 /// The signature covers `nonce || sdk_version` (AAASM-3666), so the version is
 /// authenticated rather than merely carried: a local tamperer cannot substitute
 /// a current version for a downgraded build's without invalidating the proof.
+///
+/// Deliberately *not* the durable identity key AAASM-5332 introduced. The
+/// runtime verifies this proof by recomputing `SHA-256(agent_id)` itself
+/// (`aa-runtime::ipc::handshake::expected_verifying_key`), so the two ends must
+/// keep agreeing on a value neither of them stores — and that channel's trust
+/// boundary is the socket's `0600` mode plus the peercred UID check, which is
+/// where it has always been (AAASM-3922). Signing this handshake with the
+/// identity key would neither strengthen it nor be verifiable, since the runtime
+/// has no way to learn a randomly-generated public key.
 fn build_handshake_proof(
     agent_id: &str,
     nonce: &[u8],
     sdk_version: &str,
 ) -> aa_proto::assembly::ipc::v1::HandshakeProof {
-    let keypair = crate::keypair::AgentKeypair::derive(agent_id);
+    let keypair = crate::keypair::AgentKeypair::derive_transport_key(agent_id);
     let signed_payload = handshake_signed_payload(nonce, sdk_version);
     aa_proto::assembly::ipc::v1::HandshakeProof {
         agent_did: keypair.did_key(),
@@ -329,7 +338,7 @@ mod tests {
 
         assert_eq!(proof.sdk_version, "1.2.3", "proof must carry the SDK version");
 
-        let vk = crate::keypair::AgentKeypair::derive(TEST_AGENT_ID);
+        let vk = crate::keypair::AgentKeypair::derive_transport_key(TEST_AGENT_ID);
         let pk = ed25519_dalek::VerifyingKey::from_bytes(&vk.public_key_bytes()).unwrap();
         let sig_bytes: [u8; 64] = proof.signature.as_slice().try_into().unwrap();
         let sig = Signature::from_bytes(&sig_bytes);

--- a/aa-sdk-client/src/keypair.rs
+++ b/aa-sdk-client/src/keypair.rs
@@ -13,7 +13,7 @@
 //! This module deliberately exposes two *different* kinds of keypair, because
 //! the crate needs two things that look alike and are not:
 //!
-//! * [`AgentKeypair::generate`] / [`AgentKeypair::from_seed`] — the **durable
+//! * `AgentKeypair::generate` / `AgentKeypair::from_seed` — the **durable
 //!   agent identity key**. Its private half is real key material: randomly
 //!   generated from the OS CSPRNG, persisted once by
 //!   [`crate::identity_store`], and never reconstructible from anything public.
@@ -65,8 +65,7 @@ const ED25519_MULTICODEC_PREFIX: [u8; 2] = [0xed, 0x01];
 /// genuine, valid Ed25519 keypair that the gateway will accept.
 ///
 /// How the instance was built decides whether its private half is a secret at
-/// all — see the module docs. [`generate`](Self::generate) and
-/// [`from_seed`](Self::from_seed) produce identity keys;
+/// all — see the module docs. `generate` and `from_seed` produce identity keys;
 /// [`derive_transport_key`](Self::derive_transport_key) produces the
 /// deliberately non-secret IPC transport key.
 pub struct AgentKeypair {

--- a/aa-sdk-client/src/keypair.rs
+++ b/aa-sdk-client/src/keypair.rs
@@ -1,4 +1,4 @@
-//! Deterministic Ed25519 keypair derivation for gateway registration.
+//! Ed25519 keypairs for agent identity and for the local IPC transport.
 //!
 //! The gateway's `AgentLifecycleService.Register` requires *both* a
 //! syntactically-valid `did:key` agent identity *and* a real Ed25519
@@ -8,39 +8,121 @@
 //! valid Ed25519 verifying key, so the registration identity and the
 //! `public_key` field must both come from one real keypair to stay consistent.
 //!
-//! SDKs configure agents with a human-readable identifier rather than a
-//! provisioned keypair, so this module derives a **deterministic** keypair from
-//! that identifier: the same agent id always yields the same keypair, giving a
-//! stable identity across process restarts without persisting key material. The
-//! seed is `SHA-256(identifier)`, fed to [`SigningKey::from_bytes`]; the
-//! resulting [`VerifyingKey`] backs both the `did:key` and the `public_key`.
+//! # Two keys, one of which is a secret (AAASM-5332)
+//!
+//! This module deliberately exposes two *different* kinds of keypair, because
+//! the crate needs two things that look alike and are not:
+//!
+//! * [`AgentKeypair::generate`] / [`AgentKeypair::from_seed`] — the **durable
+//!   agent identity key**. Its private half is real key material: randomly
+//!   generated from the OS CSPRNG, persisted once by
+//!   [`crate::identity_store`], and never reconstructible from anything public.
+//!   This is the key the registration possession proof is made with.
+//! * [`AgentKeypair::derive_transport_key`] — the **local IPC transport key**,
+//!   deterministically derived from the agent id. It is *not* a secret and is
+//!   documented as such at both ends (see `aa-runtime::ipc::handshake`, whose
+//!   `expected_verifying_key` recomputes the identical value, and AAASM-3922).
+//!
+//! # Why the identity key is generated, not derived
+//!
+//! Until AAASM-5332 the identity key was *also* derived, seeded with
+//! `SHA-256(agent_id)`. That looked deliberate — it bought a stable identity
+//! across restarts with nothing to persist — but the seed is a hash of a public
+//! value. The agent id appears in audit records, topology views and the
+//! dashboard, and `Register` is reachable unauthenticated by design (it is a
+//! bootstrap endpoint mounted behind `enrich_interceptor`, which authenticates
+//! nothing). So the possession proof, the single control deciding *who may
+//! register as a given agent*, proved only that the caller could compute
+//! SHA-256 of a value everyone can read.
+//!
+//! Every surrounding control was correctly built and none of them helped,
+//! because each rests on that same non-secret: `enforce_did_key_binding` binds
+//! the DID to the presented public key, but an attacker who derives the keypair
+//! derives a self-consistent pair; `verify_possession_proof` checks a real
+//! signature, made with a key the attacker holds just as legitimately; the nonce
+//! is genuinely single-use, which stops replay and not impersonation.
+//!
+//! A derived key cannot be repaired by strengthening what surrounds it. The
+//! private half has to be something the attacker cannot compute, which means it
+//! has to be random and it has to be stored.
 
 use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
 use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
 
 /// Multicodec prefix for an Ed25519 public key (`0xed`), varint-encoded as the
 /// two bytes `0xed 0x01`. An Ed25519 `did:key` is the base58btc multibase
 /// encoding of these two bytes followed by the 32-byte verifying key.
 const ED25519_MULTICODEC_PREFIX: [u8; 2] = [0xed, 0x01];
 
-/// A deterministic Ed25519 keypair derived from an agent identifier.
+/// An Ed25519 keypair backing an agent's `did:key`, `public_key` and
+/// signatures.
 ///
 /// Holds the signing key so it can both expose the verifying key (and the
 /// identity values derived from it) and **sign** challenges — the latter proves
-/// key possession in the local IPC session handshake (AAASM-3587) and could
-/// back per-RPC request signing. The verifying key is guaranteed to come from a
+/// key possession to the gateway at registration and in the local IPC session
+/// handshake (AAASM-3587). The verifying key is guaranteed to come from a
 /// genuine, valid Ed25519 keypair that the gateway will accept.
+///
+/// How the instance was built decides whether its private half is a secret at
+/// all — see the module docs. [`generate`](Self::generate) and
+/// [`from_seed`](Self::from_seed) produce identity keys;
+/// [`derive_transport_key`](Self::derive_transport_key) produces the
+/// deliberately non-secret IPC transport key.
 pub struct AgentKeypair {
     signing_key: SigningKey,
     verifying_key: VerifyingKey,
 }
 
 impl AgentKeypair {
-    /// Derive the deterministic keypair for `identifier`.
+    /// Build an identity keypair from a 32-byte secret seed (AAASM-5332).
     ///
-    /// The seed is `SHA-256(identifier)` (always 32 bytes), which is a valid
-    /// Ed25519 secret scalar seed, so derivation never fails.
-    pub fn derive(identifier: &str) -> Self {
+    /// Every 32-byte value is a valid Ed25519 secret scalar seed, so this cannot
+    /// fail. `seed` is the private half of the agent's identity and must have
+    /// come from [`crate::identity_store`] — either freshly generated from the
+    /// OS CSPRNG or read back from the owner-only key file. Seeding this from
+    /// anything an attacker could compute reintroduces the AAASM-5332 defect
+    /// wholesale, which is why the only in-crate caller is the identity store.
+    pub(crate) fn from_seed(seed: &Zeroizing<[u8; 32]>) -> Self {
+        let signing_key = SigningKey::from_bytes(seed);
+        let verifying_key = signing_key.verifying_key();
+        Self {
+            signing_key,
+            verifying_key,
+        }
+    }
+
+    /// Generate a fresh identity keypair from the operating system's CSPRNG.
+    ///
+    /// Delegates the seed to [`crate::identity_store::random_seed`], so there is
+    /// exactly one randomness source in the crate to audit. Returns the seed
+    /// alongside the keypair because the caller — the identity store — must
+    /// persist it: a generated key that is not written down is a new identity on
+    /// every process start, which is the opposite of what registration needs.
+    pub(crate) fn generate() -> std::io::Result<(Self, Zeroizing<[u8; 32]>)> {
+        let seed = crate::identity_store::random_seed()?;
+        let keypair = Self::from_seed(&seed);
+        Ok((keypair, seed))
+    }
+
+    /// Derive the **non-secret** local IPC transport keypair for `identifier`.
+    ///
+    /// The seed is `SHA-256(identifier)` (always 32 bytes), so derivation never
+    /// fails — and so any local process that knows the agent id can recompute
+    /// this keypair. That is understood and accepted at both ends: the runtime's
+    /// `aa-runtime::ipc::handshake::expected_verifying_key` computes the very
+    /// same value in order to check the handshake, and the trust boundary for
+    /// that channel is the socket's `0600` mode plus the peercred UID check, not
+    /// this signature (AAASM-3922). What the signature buys there is integrity
+    /// and SDK-version binding (AAASM-3666) *within* that boundary.
+    ///
+    /// It follows that this key must never be used where a secret is required.
+    /// It is not the agent's identity and it must not sign a registration
+    /// possession proof — for that, and for the `did:key` the gateway registers,
+    /// use the durable key from [`crate::identity_store`]. The name says
+    /// "transport" so that a future caller reaching for a keypair cannot pick
+    /// this one up believing it authenticates anybody.
+    pub fn derive_transport_key(identifier: &str) -> Self {
         let seed: [u8; 32] = Sha256::digest(identifier.as_bytes()).into();
         let signing_key = SigningKey::from_bytes(&seed);
         let verifying_key = signing_key.verifying_key();
@@ -85,25 +167,84 @@ impl AgentKeypair {
 mod tests {
     use super::*;
 
+    /// The transport key must stay reproducible from the agent id alone: the
+    /// runtime recomputes it independently to check the IPC handshake, so a
+    /// change here silently breaks every SDK connection.
     #[test]
-    fn derivation_is_deterministic() {
+    fn transport_key_derivation_is_deterministic() {
         assert_eq!(
-            AgentKeypair::derive("agent-a").public_key_hex(),
-            AgentKeypair::derive("agent-a").public_key_hex()
+            AgentKeypair::derive_transport_key("agent-a").public_key_hex(),
+            AgentKeypair::derive_transport_key("agent-a").public_key_hex()
+        );
+    }
+
+    /// The exact value the runtime expects. `aa-runtime`'s `expected_verifying_key`
+    /// computes `SHA-256(agent_id)` → `SigningKey` → `VerifyingKey`; pinning it
+    /// here means a well-meaning change to the transport key fails in this crate
+    /// rather than as a mysterious handshake rejection at run time.
+    #[test]
+    fn transport_key_is_the_value_the_runtime_recomputes() {
+        let seed: [u8; 32] = Sha256::digest(b"agent-a").into();
+        let expected = SigningKey::from_bytes(&seed).verifying_key();
+        assert_eq!(
+            AgentKeypair::derive_transport_key("agent-a").public_key_bytes(),
+            expected.to_bytes()
         );
     }
 
     #[test]
-    fn distinct_identifiers_yield_distinct_keys() {
+    fn distinct_identifiers_yield_distinct_transport_keys() {
         assert_ne!(
-            AgentKeypair::derive("agent-a").public_key_hex(),
-            AgentKeypair::derive("agent-b").public_key_hex()
+            AgentKeypair::derive_transport_key("agent-a").public_key_hex(),
+            AgentKeypair::derive_transport_key("agent-b").public_key_hex()
+        );
+    }
+
+    /// The heart of AAASM-5332: an identity key is *random*, so asking for one
+    /// twice for the same agent must not produce the same key. If this ever
+    /// passes trivially the generator has gone back to deriving from something.
+    #[test]
+    fn generated_identity_keys_are_random_not_derived() {
+        let (first, first_seed) = AgentKeypair::generate().expect("the OS CSPRNG must be readable");
+        let (second, second_seed) = AgentKeypair::generate().expect("the OS CSPRNG must be readable");
+
+        assert_ne!(
+            first.public_key_hex(),
+            second.public_key_hex(),
+            "two generated identity keys must differ; identical keys mean the private half is a \
+             function of something predictable, which is the defect this ticket exists to remove"
+        );
+        assert_ne!(*first_seed, *second_seed, "the seeds themselves must differ");
+    }
+
+    /// A generated identity key must never coincide with the transport key for
+    /// any identifier — that is what makes knowing the agent id insufficient.
+    #[test]
+    fn a_generated_identity_key_is_not_the_transport_key_for_any_identifier() {
+        let (identity, _) = AgentKeypair::generate().expect("the OS CSPRNG must be readable");
+        for id in ["agent-a", "ops-laptop", "", "did:key:z6Mkwhatever"] {
+            assert_ne!(
+                identity.public_key_hex(),
+                AgentKeypair::derive_transport_key(id).public_key_hex(),
+                "a generated identity key must not be recomputable from `{id}`"
+            );
+        }
+    }
+
+    /// Round-trip: the seed the store persists must rebuild the same key, or a
+    /// restart silently becomes a different agent.
+    #[test]
+    fn from_seed_reproduces_the_generated_key() {
+        let (generated, seed) = AgentKeypair::generate().expect("the OS CSPRNG must be readable");
+        assert_eq!(
+            AgentKeypair::from_seed(&seed).public_key_hex(),
+            generated.public_key_hex()
         );
     }
 
     #[test]
     fn public_key_hex_is_64_chars() {
-        let hex = AgentKeypair::derive("any").public_key_hex();
+        let hex = AgentKeypair::derive_transport_key("any").public_key_hex();
         assert_eq!(hex.len(), 64);
         assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
     }
@@ -111,7 +252,7 @@ mod tests {
     #[test]
     fn public_key_is_a_valid_ed25519_verifying_key() {
         // Mirror the gateway's acceptance check: decode hex and parse as a key.
-        let kp = AgentKeypair::derive("gateway-accepts-me");
+        let (kp, _) = AgentKeypair::generate().expect("the OS CSPRNG must be readable");
         let bytes = hex::decode(kp.public_key_hex()).unwrap();
         let arr: [u8; 32] = bytes.try_into().unwrap();
         VerifyingKey::from_bytes(&arr).expect("public_key must be a valid Ed25519 key");
@@ -120,7 +261,7 @@ mod tests {
     #[test]
     fn sign_produces_a_signature_that_verifies_under_the_public_key() {
         use ed25519_dalek::{Signature, Verifier};
-        let kp = AgentKeypair::derive("signer");
+        let (kp, _) = AgentKeypair::generate().expect("the OS CSPRNG must be readable");
         let msg = b"challenge-nonce";
         let sig_bytes = kp.sign(msg);
         let vk = VerifyingKey::from_bytes(&kp.public_key_bytes()).unwrap();
@@ -130,19 +271,19 @@ mod tests {
 
     #[test]
     fn sign_is_deterministic_for_same_input() {
-        let kp = AgentKeypair::derive("signer");
+        let kp = AgentKeypair::derive_transport_key("signer");
         assert_eq!(kp.sign(b"abc"), kp.sign(b"abc"));
     }
 
     #[test]
     fn did_key_uses_canonical_ed25519_prefix() {
-        let did = AgentKeypair::derive("anything").did_key();
+        let did = AgentKeypair::derive_transport_key("anything").did_key();
         assert!(did.starts_with("did:key:z6Mk"), "got {did}");
     }
 
     #[test]
     fn did_key_and_public_key_encode_the_same_key() {
-        let kp = AgentKeypair::derive("consistency");
+        let (kp, _) = AgentKeypair::generate().expect("the OS CSPRNG must be readable");
         let encoded = kp.did_key().strip_prefix("did:key:z").unwrap().to_string();
         let decoded = bs58::decode(encoded).into_vec().unwrap();
         // Strip the 0xed 0x01 multicodec prefix; the rest must equal the pubkey.

--- a/aa-sdk-client/src/lib.rs
+++ b/aa-sdk-client/src/lib.rs
@@ -42,7 +42,7 @@ pub use client::AssemblyClient;
 pub use config::AssemblyConfig;
 pub use decision::resolve_decision;
 pub use error::SdkClientError;
-pub use identity::agent_id_to_did_key;
+pub use identity::{agent_id_to_did_key, legacy_derived_did};
 pub use identity_store::{IdentityStore, IdentityStoreError};
 pub use keypair::AgentKeypair;
 #[cfg(feature = "preflight")]

--- a/aa-sdk-client/src/lib.rs
+++ b/aa-sdk-client/src/lib.rs
@@ -32,6 +32,7 @@ pub mod decision;
 pub mod error;
 pub mod gateway;
 pub mod identity;
+pub mod identity_store;
 pub mod ipc;
 pub mod keypair;
 #[cfg(feature = "preflight")]
@@ -42,6 +43,7 @@ pub use config::AssemblyConfig;
 pub use decision::resolve_decision;
 pub use error::SdkClientError;
 pub use identity::agent_id_to_did_key;
+pub use identity_store::{IdentityStore, IdentityStoreError};
 pub use keypair::AgentKeypair;
 #[cfg(feature = "preflight")]
 pub use preflight::Preflight;

--- a/aa-sdk-client/tests/gateway_register_with_core.rs
+++ b/aa-sdk-client/tests/gateway_register_with_core.rs
@@ -164,6 +164,7 @@ async fn register_then_check_carries_token_and_surfaces_deny() {
         team_id: None,
         parent_agent_id: None,
         sdk_version: None,
+        identity_dir: None,
     };
 
     // 1) Register directly against the mock gateway — issues + stores the token.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -119,6 +119,7 @@
 # Migration
 
 - [Migration Template](migration/template.md)
+- [Agent identity keys (AAASM-5332)](migration/agent-identity-keys.md)
 
 # Events
 

--- a/docs/src/migration/agent-identity-keys.md
+++ b/docs/src/migration/agent-identity-keys.md
@@ -1,0 +1,161 @@
+# Migration Guide — agent identity keys are generated, not derived
+
+**Security fix introduced in:** AAASM-5332
+**Affected components:** every agent registered by `aa-sdk-client` or `aasm run` before this change
+**Estimated migration effort:** Low mechanically, but it requires a deliberate decision per agent
+
+---
+
+## What changed
+
+An agent's Ed25519 identity keypair used to be **derived** from its
+operator-facing identifier: the signing key was seeded with
+`SHA-256(agent_id)`. The keypair is now **generated from the operating system's
+CSPRNG** and stored, owner-only, at
+`${AASM_STATE_DIR:-~/.aasm}/identity/<hash>.key`.
+
+The derivation looked deliberate — it bought a stable identity across restarts
+with nothing to persist — but the seed was a hash of a **public** value. Agent
+identifiers appear in audit records, in topology views, and on the dashboard.
+`AgentLifecycleService.Register` is reachable unauthenticated by design (it is a
+bootstrap endpoint, mounted behind `enrich_interceptor`, which authenticates
+nothing), so the possession proof is the only control deciding who may register
+as a given agent. With a derived key, that proof established only that the caller
+could compute SHA-256 of a string anyone could read.
+
+The controls around it were all correctly implemented and none of them helped,
+because each rested on the same non-secret:
+
+| Control | Why it did not close the gap |
+|---|---|
+| `enforce_did_key_binding` | Binds the DID to the presented public key — but an attacker who derives the keypair derives a *self-consistent* pair. |
+| `verify_possession_proof` | Verifies a real Ed25519 signature — made with a key the attacker holds just as legitimately. |
+| Single-use registration nonce | Correct, and orthogonal: it prevents replay, not impersonation. |
+
+---
+
+## What this means for identities you already have
+
+> **Treat every `did:key` registered before this change as compromised.**
+
+Its private key is `SHA-256(<agent_id>)`, and the `agent_id` is published. Anyone
+who has read one of your audit records, topology views, or dashboard pages can
+reconstruct the corresponding private key and register as that agent, sign its
+possession proof, and obtain a `credential_token` for it. This is true
+retroactively and cannot be fixed by upgrading alone — an attacker who recorded
+the identifiers already has the keys.
+
+Two things make the cleanup tractable:
+
+- **No key material has to be migrated.** The gateway never stored a private
+  key. `AgentRecord` holds the public key hex and a composite hash of the
+  identity; nothing on the server side needs rewriting.
+- **Upgrading does not silently reuse the compromised key.** An upgraded agent
+  finds no key file, enrols a fresh random one, and registers under a **new**
+  `did:key`. The old identity simply stops being presented.
+
+---
+
+## What upgrading does on its own
+
+1. The first registration after upgrading enrols a new key at
+   `${AASM_STATE_DIR:-~/.aasm}/identity/<hash>.key`, mode `0600`, in a directory
+   at mode `0700`.
+2. The agent registers under a new `did:key` derived from that key.
+3. Every later run reads the same key back, so the identity is stable — the
+   identity that registered is the one the launch runs under and the one the
+   gateway attributes audit records to.
+
+Nothing about the old registration is cleaned up automatically. That is
+deliberate: deregistering an agent is an operational act with a blast radius, and
+this change does not perform one on your behalf.
+
+---
+
+## Migration steps
+
+1. **Enumerate the compromised identities.** For each identifier still in use,
+   `aa_sdk_client::legacy_derived_did(agent_id)` returns the `did:key` that
+   identifier mapped to under the old scheme. It exists only for this purpose.
+
+2. **Upgrade and let each agent re-enrol.** Run each agent (or `aasm run`) once.
+   It will enrol a durable key and register under its new DID. Verify the new
+   identity is the one you expect:
+
+   ```bash
+   aasm run <tool> --agent-id <identifier> --dry-run
+   ```
+
+   The printed `registration_did` is read from the stored key. If it shows
+   `<no-durable-identity-key>`, the key could not be established — check that
+   `AASM_STATE_DIR` (or `$HOME`) is writable and that no existing key file is
+   group- or world-accessible.
+
+3. **Deregister the old identities.** Once the new registration is confirmed,
+   remove the pre-migration record so the compromised DID cannot be used to
+   impersonate a live agent. Deregistration is authenticated by the
+   `credential_token` the original registration minted; where that token is no
+   longer held, remove the record through the operator-authenticated
+   `DELETE /api/v1/agents/{id}`.
+
+4. **Protect the new key files.** They are the agent's identity. They are created
+   `0600` and are *refused* on read — not used — if they become group- or
+   world-accessible, are owned by another user, or are replaced by a symlink. A
+   backup or configuration-management system that copies them to a shared
+   location, or that widens their permissions, will make the agent fail to
+   register rather than register insecurely.
+
+5. **Do not carry an agent id that is already a `did:key`.** That configuration
+   is now refused locally. It could never have registered successfully anyway —
+   the `public_key` came from a key the SDK holds, so a caller-supplied DID was
+   guaranteed to fail the binding check — and it now fails with a message saying
+   so instead of an opaque `Unauthenticated` from the gateway.
+
+---
+
+## Audit continuity
+
+Gateway-written audit entries attribute actions to `SHA-256(did)[..16]`, so
+**pre- and post-migration entries for the same operator-facing agent will not
+join**. Entries written by `aa-runtime` on the SDK path hash the plaintext
+`AA_AGENT_ID` instead and are unaffected, so that half of the trail stays
+continuous across the migration.
+
+If you need the two eras joined, record the mapping from
+`legacy_derived_did(agent_id)` to the new DID at migration time — after
+re-enrolment the old DID is no longer derivable from anything the system stores.
+
+---
+
+## Rotation and revocation
+
+Once an identity is a stored key rather than a function of a name, replacing it
+becomes a real operation:
+
+- **Rotation** retires the current key (retained on disk, never deleted) and
+  enrols a fresh one. It produces a **new `did:key`**, because a `did:key` *is*
+  an encoding of a public key; the previous DID should be deregistered.
+- **Revocation** writes a marker beside the key. The key file itself is left
+  intact for forensic comparison, and the store refuses to load — or to quietly
+  re-enrol — a revoked identity, so revocation cannot be undone by running the
+  agent again.
+
+Both are **local** operations. Propagating a revocation to the gateway is
+currently limited to deregistering the revoked DID: `AgentLifecycleService`
+exposes no revoke RPC, so there is no revocation list a gateway consults before
+honouring a credential. That gap is tracked separately.
+
+---
+
+## What this change deliberately does not add
+
+**No key expiry and no automatic renewal.** Renewal introduces a clock, a grace
+window, and a set of failure modes that belong in their own change rather than in
+the repair of a key-generation defect. Keys created by this change do not expire.
+
+---
+
+## See also
+
+- [Trust boundaries](../security/trust-boundaries.md)
+- [Threat model](../security/threat-model.md)


### PR DESCRIPTION
## Description

Implements **AAASM-5332** (owner Decision 1, Option B): the agent registration identity becomes a **real Ed25519 keypair from a CSPRNG**, durable until explicit rotation or revocation — replacing a private key that was a pure function of a public value.

## The defect

`aa-sdk-client/src/keypair.rs:43-51` seeded the signing key with `SHA-256(identifier)`, where the identifier is the **public** agent id. The possession proof therefore established that the caller could compute SHA-256, not that it held a secret.

Every surrounding control was correctly implemented and none helped:

- `enforce_did_key_binding` (`lifecycle_service.rs:232-239`, called at `:384` and `:437`) binds DID↔public key — and a derived pair is self-consistent.
- `verify_possession_proof` (`:241-259`) is a real `verify_strict` — over a key the attacker can also derive.
- The nonce is genuinely single-use (`:453-455`) — correct, and orthogonal.

And registration is reachable **unauthenticated by design**: `AgentLifecycleServiceServer` is mounted with `enrich`, not `auth` (`server.rs:728`, `:873`), and `enrich_interceptor` returns `Ok(req)` **unconditionally** (`grpc_auth.rs:150-161`). Right for a bootstrap endpoint — and it made the possession proof the only thing deciding who may register as a given agent.

## The proof this is fixed

**M1 — revert to the derived key — kills 8 assertions across 3 crates**, including an end-to-end forgery against a real gateway:

```
a proof forged from the agent id verified against the victim's key — knowing public
data is still sufficient to register as this agent

if one identifier still determines one DID, the private key is still a function of
public data and the possession proof still proves nothing

a second installation reached the first one's identity from the identifier alone
```

Eleven further mutations, each verbatim-confirmed: `create_new`→`create` (`a second enrolment must be refused, but a usable key was returned`), permission-bit check, uid check, file mode, revocation, identity mismatch, rotation ×2, CSPRNG→constant (`two generated identity keys must differ`), token-in-keyfile, empty `AASM_STATE_DIR`.

**M5 caught a bug in the test itself.** Deleting the symlink guard left it green — the refusal message embeds the path, and the temp dir was named `symlink-store`, so the assertion was matching its own fixture name. Fixed in `05733597`; it now asserts `"it is a symlink"` and dies with `it is not a regular file` under mutation.

## Where the key lives

`${AASM_STATE_DIR:-~/.aasm}/identity/<sha256(agent_id)>.key` — mode `0600` in a `0700` directory, created with `O_EXCL` and the mode in a single `open(2)`. Refuses a symlink, a non-regular file, a foreign uid, or **any** group-or-other access (`0o077` — stricter than the proxy state file's `0o022`).

The filename is hashed only for filesystem safety; the agent id is stored **inside** and checked on read, so a hash collision is refused rather than silently sharing a key.

**An attacker previously needed only to read an agent id.** Now they need read access to that file as its owning uid — and if they obtain it by loosening permissions or symlinking, the agent refuses to start rather than registering insecurely.

## One derived key was kept, deliberately

`aa-runtime/src/ipc/handshake.rs:54-57` also recomputes `SHA-256(agent_id)`. That key is documented at both ends as **non-secret** (AAASM-3922); its real boundary is socket `0600` plus peercred. Renamed to `derive_transport_key` and left in place, so `aa-runtime` needed no change. Registration no longer touches it.

Not every derived key was the bug — only the one claiming to prove possession.

## Migration — honest about what cannot be saved

**Every pre-existing `did:key` is compromised retroactively**: anyone who recorded an identifier already holds the key. No key material needs migrating, because the gateway never stored a private key.

Upgrading enrols a fresh random key and registers under a **new** DID. Old records are **not** cleaned up automatically and must be deregistered deliberately, using `legacy_derived_did(agent_id)` to name them. **Gateway audit entries will not join across the migration** — they key on `SHA-256(did)[..16]`. Runtime-written entries hash the plaintext agent id and are unaffected.

Documented at `docs/src/migration/agent-identity-keys.md`.

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] Yes — agents re-enrol under a new DID; audit history does not join across the migration. `AssemblyConfig` gains a public `identity_dir` field, so the three external SDK shims that build it with a struct literal will need it at their next git-SHA bump.

## Related Issues

- Related Jira ticket: AAASM-5332 (owner decision recorded in comment 19980)

## Testing

`aa-sdk-client` 99 pass; `aa-sdk-client` + `aa-cli` 1030 pass; workspace `clippy --all-targets --all-features -D warnings` clean; `cargo doc` adds no warnings. Tree clean, 22 files, **zero** forbidden files — `run.rs`, `proxy/**`, `Cargo.lock`, `deny.toml`, workflows and every `Cargo.toml` untouched.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Reviewer notes — two constraint-driven choices

1. **`/dev/urandom` is read directly rather than using `getrandom` or `rand`**, because `Cargo.lock` was off-limits to this lane and adding a dependency would have touched another session's file. Same kernel source; swapping in the crate later is mechanical. Flagging it as a constraint artefact rather than the idiomatic choice.
2. **The process uid is learned by chmod-ing our own key directory** rather than `libc::geteuid`, for the same reason.

Neither is wrong; both are worth a second look if the dependency constraint is lifted.

## Deferred, named — not silently dropped

**Gateway-side revocation propagation.** `proto/agent.proto` has only `RequestChallenge` / `Register` / `Heartbeat` / `Deregister` / `ControlStream` — no revoke RPC and no revocation list. Adding one touches `proto/` and `aa-gateway/`, outside this lane. The strongest propagation available today is `Deregister` on the revoked DID. Local rotate and revoke operations **are** implemented.

## Found, not fixed

- **`run.rs` needs two follow-ups from its owner** (untouchable from this lane): its `--dry-run` path enrols a throwaway key when `--agent-id` is absent (`dry-run-<uuid>`); and its doc at `:162-163` claims the DID is what *all* audit records attribute to — true only for gateway-written entries. `registration_did(&str) -> String` was kept so `run.rs` compiles unchanged, returning `<no-durable-identity-key>` (deliberately not a DID) when no key can be established.
- **Pre-existing defect worth its own ticket, unrelated to this change:** `AgentViolationCounts` keys on `SHA-256(did)[..16]` but is looked up with the registry key `SHA-256("org/team/did")[..16]` (`agent_violations.rs:64` vs `agents.rs:204`), so `policy_violations_count` and `is_flagged` appear to be **0 for every agent whenever a team or org is set**. The same mismatch would hit `GET /agents/{id}/decisions`. Reported from the implementer's analysis; not independently re-verified here.
- 3 flaky `aa-gateway` hot-reload/watcher tests under heavy load (passed on retry). Nothing in `aa-gateway/src` was changed.
