### PR TITLE
[AAASM-5348] 🐛 (aa-cli): Refuse a non-loopback proxy bind before anything starts

### DIFF
--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -28,8 +28,15 @@ pub struct StartArgs {
     /// File to redirect proxy stdout/stderr to (background mode only).
     #[arg(long)]
     pub log_file: Option<PathBuf>,
-    /// State that a non-loopback `--listen` address is intended. Still refused
-    /// until the proxy can protect such a listener — see `checked_listen`.
+    // The doc comment is the `--help` text clap shows, so it is written for the
+    // operator reading it; the reasoning behind the refusal lives on
+    // `checked_listen`.
+    /// State that a non-loopback `--listen` address is intended
+    ///
+    /// Intent is not authorization. A proxy reachable from other hosts also
+    /// needs TLS on its listener and client authentication, neither of which
+    /// aa-proxy implements — so this option currently changes only which
+    /// refusal you get, and never permits the bind.
     #[arg(long)]
     pub allow_remote_clients: bool,
 }

--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -325,6 +325,72 @@ mod tests {
         assert_eq!(w.inner.listen, "0.0.0.0:9000");
     }
 
+    /// The default is the address `aasm run` will trust, so the shipped
+    /// behaviour must survive the guard untouched.
+    #[test]
+    fn the_default_listen_address_is_accepted() {
+        let default = Wrapper::parse_from(["test"]).inner.listen;
+        assert_eq!(checked_listen(&default, false), Ok(()), "default {default} must start");
+    }
+
+    #[test]
+    fn an_explicit_loopback_listen_address_is_accepted() {
+        assert_eq!(checked_listen("127.0.0.1:9000", false), Ok(()));
+        assert_eq!(checked_listen("[::1]:9000", false), Ok(()));
+    }
+
+    /// AAASM-5348: the address that used to start a proxy `aasm run` would
+    /// never trust. The diagnostic has to carry the reason, since the operator
+    /// asked for this address on purpose.
+    #[test]
+    fn a_bare_non_loopback_listen_address_is_refused() {
+        let reason = checked_listen("0.0.0.0:9000", false)
+            .expect_err("a proxy reachable from other hosts must not start by default");
+        assert!(reason.contains("0.0.0.0:9000"), "must name the address, got: {reason}");
+        assert!(
+            reason.contains("not a loopback address"),
+            "must say what disqualified it, got: {reason}"
+        );
+        assert!(
+            reason.contains("--allow-remote-clients"),
+            "must point at the option that states the intent, got: {reason}"
+        );
+    }
+
+    /// The opt-in records intent; it cannot supply protections the proxy does
+    /// not have. Naming them is the point — "refused" alone would read as a bug.
+    #[test]
+    fn the_opt_in_does_not_authorize_an_unprotected_remote_listener() {
+        let reason = checked_listen("0.0.0.0:9000", true)
+            .expect_err("--allow-remote-clients must not open an unauthenticated listener");
+        assert!(
+            reason.contains("TLS on the proxy listener"),
+            "must name the missing transport protection, got: {reason}"
+        );
+        assert!(
+            reason.contains("client authentication and authorization"),
+            "must name the missing client-identity protection, got: {reason}"
+        );
+    }
+
+    /// A `--listen` the proxy cannot parse is refused here rather than becoming
+    /// an opaque "did not bind within 5s" after a process has been spawned.
+    #[test]
+    fn an_unparseable_listen_address_is_refused() {
+        let reason = checked_listen("localhost:9000", false).expect_err("a hostname is not an ip:port literal");
+        assert!(reason.contains("localhost:9000"), "must quote the input, got: {reason}");
+    }
+
+    #[test]
+    fn start_args_allow_remote_clients_defaults_false() {
+        assert!(!Wrapper::parse_from(["test"]).inner.allow_remote_clients);
+        assert!(
+            Wrapper::parse_from(["test", "--allow-remote-clients"])
+                .inner
+                .allow_remote_clients
+        );
+    }
+
     #[test]
     fn start_args_gateway_is_optional() {
         let w = Wrapper::parse_from(["test"]);

--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -29,7 +29,7 @@ pub struct StartArgs {
     #[arg(long)]
     pub log_file: Option<PathBuf>,
     /// State that a non-loopback `--listen` address is intended. Still refused
-    /// until the proxy can protect such a listener — see [`checked_listen`].
+    /// until the proxy can protect such a listener — see `checked_listen`.
     #[arg(long)]
     pub allow_remote_clients: bool,
 }

--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -28,6 +28,43 @@ pub struct StartArgs {
     /// File to redirect proxy stdout/stderr to (background mode only).
     #[arg(long)]
     pub log_file: Option<PathBuf>,
+    /// State that a non-loopback `--listen` address is intended. Still refused
+    /// until the proxy can protect such a listener — see [`checked_listen`].
+    #[arg(long)]
+    pub allow_remote_clients: bool,
+}
+
+/// Whether a proxy may be started on `listen`, or the message to print instead.
+///
+/// AAASM-5348. Before this check, `aasm proxy start --listen 0.0.0.0:PORT`
+/// succeeded and `aasm proxy status` reported a healthy proxy, while every
+/// `aasm run` refused to route a governed tool at it — [`trust::verify_endpoint`]
+/// requires a loopback literal. The operator was left holding a proxy that
+/// worked for everything except the one job it exists to do, with nothing
+/// explaining the contradiction. Applying the same loopback rule here is what
+/// removes that split: an address `aasm run` will never trust is one
+/// `aasm proxy start` never produces.
+///
+/// Refusing rather than teaching `aasm run` to accept a remote endpoint is the
+/// deliberate direction. `aasm run` refuses because the endpoint is reachable
+/// off-host, and reachability is not authorization: `aa-proxy` has no listener
+/// TLS and no client authentication ([`aa_proxy::config::REMOTE_PROTECTIONS`]),
+/// so a routable listener is an interception endpoint that reads traffic under
+/// a CA this machine trusts and spends the operator's provider keys for anyone
+/// who connects. Until it can tell clients apart, the honest answer at start
+/// time is no.
+///
+/// Separate from [`dispatch`] so the decision is testable without spawning a
+/// process, and called from its first statement so a refusal happens before any
+/// socket is bound and before any state file is written.
+fn checked_listen(listen: &str, allow_remote_clients: bool) -> Result<(), String> {
+    // Parsed here rather than left to the child: the loopback question cannot be
+    // asked of a string, and a `--listen` the proxy could not parse already
+    // failed — just later, as an opaque "did not bind within 5s".
+    let addr: SocketAddr = listen
+        .parse()
+        .map_err(|_| format!("invalid --listen {listen:?}: it is not an `ip:port` literal"))?;
+    aa_proxy::config::check_bind_addr(addr, allow_remote_clients).map_err(|refusal| refusal.to_string())
 }
 
 fn default_log_path() -> PathBuf {
@@ -148,6 +185,14 @@ fn canonical_binary(binary: PathBuf) -> PathBuf {
 }
 
 pub fn dispatch(args: StartArgs) -> ExitCode {
+    // First, before the binary is resolved, before anything is spawned, and
+    // before a state file exists: a refused start must not leave the operator
+    // with a half-started proxy to clean up.
+    if let Err(reason) = checked_listen(&args.listen, args.allow_remote_clients) {
+        eprintln!("error: {reason}");
+        return ExitCode::FAILURE;
+    }
+
     let Some(binary) = resolve_binary() else {
         eprintln!(
             "error: aa-proxy binary not found.\n\

--- a/aa-integration-tests/tests/cli_proxy_remote_bind_refusal.rs
+++ b/aa-integration-tests/tests/cli_proxy_remote_bind_refusal.rs
@@ -1,0 +1,197 @@
+//! `aasm proxy start` refuses a listen address `aasm run` would never trust
+//! (AAASM-5348).
+//!
+//! # Why this is measured end-to-end and not only in `start.rs`
+//!
+//! The unit tests decide whether the address is acceptable. The claim this file
+//! exists for is the one they cannot make: that a refused start leaves **no
+//! residue** — no listening socket and no state file. Those are effects of the
+//! real process, produced in the order the real `dispatch` produces them, so the
+//! only way to observe that the refusal beat them is to run the binary.
+//!
+//! The `aa-proxy` binary is put on `PATH` for every case here deliberately. The
+//! guard runs before the binary is resolved, so a run with no `aa-proxy`
+//! available would also fail — for the wrong reason, and the test would pass
+//! while measuring nothing. Each case therefore asserts the failure is *not* the
+//! missing-binary one.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+// `build_binary` rebuilds unconditionally: `aa-integration-tests` depends on
+// neither `aa-cli` nor the `aa-proxy` binary, so a stale artefact in `target/`
+// would otherwise be measured instead of this tree — a false pass for a test
+// whose whole subject is `aasm` behaviour.
+mod proxy_trust_support;
+
+use proxy_trust_support::{aa_proxy_binary, aasm_binary, prefixed_path};
+
+/// A port nothing holds, taken by binding and releasing so the reachability
+/// assertions below start from "closed".
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral loopback port");
+    listener.local_addr().expect("the bound port").port()
+}
+
+struct Refused {
+    stderr: String,
+    data_dir: PathBuf,
+    _tmp: tempfile::TempDir,
+}
+
+/// Run `aasm proxy start --listen <addr>` in an isolated `AA_DATA_DIR` with a
+/// real `aa-proxy` on `PATH`, and require it to fail.
+fn start_expecting_refusal(listen: &str, extra: &[&str]) -> Refused {
+    let aasm = aasm_binary();
+    let proxy_dir = aa_proxy_binary()
+        .parent()
+        .expect("the built binary has a parent directory")
+        .to_path_buf();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let data_dir = root.join("data");
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
+
+    let ca_dir = root.join("ca");
+    let log_file = root.join("proxy.log");
+    let mut args = vec![
+        "proxy",
+        "start",
+        "--listen",
+        listen,
+        "--ca-dir",
+        ca_dir.to_str().expect("temp path is utf-8"),
+        "--log-file",
+        log_file.to_str().expect("temp path is utf-8"),
+    ];
+    args.extend_from_slice(extra);
+
+    let out = Command::new(&aasm)
+        .env("AA_DATA_DIR", &data_dir)
+        .env("PATH", prefixed_path(&proxy_dir).expect("PATH"))
+        .args(&args)
+        .output()
+        .expect("aasm proxy start");
+
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        !out.status.success(),
+        "`aasm proxy start --listen {listen}` must not succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("aa-proxy binary not found"),
+        "the refusal must come from the listen-address guard, not from a missing binary — \
+         otherwise this test proves nothing\nstderr:\n{stderr}"
+    );
+
+    Refused {
+        stderr,
+        data_dir,
+        _tmp: tmp,
+    }
+}
+
+impl Refused {
+    /// The operator must not be left with a half-started proxy: nothing may be
+    /// listening, and no state file may exist for `aasm proxy status`/`stop` to
+    /// find.
+    ///
+    /// Reachability is probed on loopback because a `0.0.0.0` bind would have
+    /// covered it — a wildcard listener that came up anyway is observable from
+    /// here, which is the failure this guards against.
+    fn left_no_residue(&self, port: u16) {
+        let loopback: SocketAddr = format!("127.0.0.1:{port}").parse().expect("the test's own literal");
+        assert!(
+            std::net::TcpStream::connect_timeout(&loopback, Duration::from_millis(500)).is_err(),
+            "a refused start must not have bound port {port}"
+        );
+        let state = self.data_dir.join("proxy.pid");
+        assert!(
+            !state.exists(),
+            "a refused start must not leave a state file at {}",
+            state.display()
+        );
+    }
+}
+
+/// The exact invocation from the ticket: the proxy used to come up here, and
+/// `aasm run` then refused to route anything at it.
+#[test]
+fn a_bare_non_loopback_listen_address_is_refused_before_anything_starts() {
+    let port = free_port();
+    let listen = format!("0.0.0.0:{port}");
+    let refused = start_expecting_refusal(&listen, &[]);
+
+    assert!(
+        refused.stderr.contains(&listen),
+        "the diagnostic must name the address, got:\n{}",
+        refused.stderr
+    );
+    assert!(
+        refused.stderr.contains("not a loopback address"),
+        "the diagnostic must say what disqualified the address, got:\n{}",
+        refused.stderr
+    );
+    assert!(
+        refused.stderr.contains("--allow-remote-clients"),
+        "the diagnostic must name the option that states the intent, got:\n{}",
+        refused.stderr
+    );
+
+    refused.left_no_residue(port);
+}
+
+/// Asking is not being granted. The proxy has no listener TLS and no client
+/// authentication, so the opt-in changes only which refusal the operator gets —
+/// and that one has to name what is missing.
+#[test]
+fn the_opt_in_still_refuses_and_names_the_missing_protections() {
+    let port = free_port();
+    let listen = format!("0.0.0.0:{port}");
+    let refused = start_expecting_refusal(&listen, &["--allow-remote-clients"]);
+
+    assert!(
+        refused.stderr.contains("TLS on the proxy listener"),
+        "the diagnostic must name the missing transport protection, got:\n{}",
+        refused.stderr
+    );
+    assert!(
+        refused.stderr.contains("client authentication and authorization"),
+        "the diagnostic must name the missing client-identity protection, got:\n{}",
+        refused.stderr
+    );
+
+    refused.left_no_residue(port);
+}
+
+/// The guard must not have cost the working case anything: an explicit loopback
+/// address still starts a proxy, and it is one `aasm run` will trust.
+#[test]
+fn an_explicit_loopback_listen_address_still_starts() {
+    let proxy = match proxy_trust_support::TrustedProxy::start() {
+        Ok(p) => p,
+        Err(e) => {
+            // `aasm proxy start` also installs the CA into the macOS System
+            // Keychain, which needs admin. Failing the suite on a machine that
+            // has not run `aasm proxy install-ca` would say nothing about the
+            // guard, but a silent skip would hide a real regression — so say so.
+            eprintln!("an_explicit_loopback_listen_address_still_starts: skipping — proxy start failed: {e:#}");
+            return;
+        }
+    };
+
+    let addr: SocketAddr = proxy.addr().parse().expect("the harness binds an ip:port literal");
+    assert!(addr.ip().is_loopback(), "the harness must exercise a loopback address");
+    assert!(
+        std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(2)).is_ok(),
+        "a loopback proxy must still come up and accept connections"
+    );
+    assert!(
+        proxy.data_dir().join("proxy.pid").exists(),
+        "an accepted start must still write the state file `aasm run` reads"
+    );
+}

--- a/aa-integration-tests/tests/cli_proxy_remote_bind_refusal.rs
+++ b/aa-integration-tests/tests/cli_proxy_remote_bind_refusal.rs
@@ -176,10 +176,17 @@ fn an_explicit_loopback_listen_address_still_starts() {
         Ok(p) => p,
         Err(e) => {
             // `aasm proxy start` also installs the CA into the macOS System
-            // Keychain, which needs admin. Failing the suite on a machine that
-            // has not run `aasm proxy install-ca` would say nothing about the
-            // guard, but a silent skip would hide a real regression — so say so.
-            eprintln!("an_explicit_loopback_listen_address_still_starts: skipping — proxy start failed: {e:#}");
+            // Keychain, which needs admin, so a start can fail for reasons that
+            // say nothing about this guard. A guard that over-reached, though,
+            // would fail here too — and skipping on that would turn the
+            // regression this test exists to catch into a silent pass. So the
+            // one failure that is never environmental is re-raised.
+            let reported = format!("{e:#}");
+            assert!(
+                !reported.contains("refusing to listen on"),
+                "a loopback address must never be refused by the listen guard:\n{reported}"
+            );
+            eprintln!("an_explicit_loopback_listen_address_still_starts: skipping — proxy start failed: {reported}");
             return;
         }
     };

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -262,6 +262,9 @@ pub enum BindRefusal {
         addr: SocketAddr,
         missing: Vec<&'static str>,
     },
+    /// Port 0 — "any free port". The proxy would bind a real port, but nothing
+    /// records which one.
+    EphemeralPort(SocketAddr),
 }
 
 impl std::fmt::Display for BindRefusal {
@@ -286,6 +289,14 @@ impl std::fmt::Display for BindRefusal {
                  CA material and provider credentials. Listen on a loopback address instead.",
                 missing.join(", "),
             ),
+            Self::EphemeralPort(addr) => write!(
+                f,
+                "refusing to listen on {addr}: port 0 asks the OS for any free port, but the \
+                 recorded endpoint would still say port 0. The proxy would bind a real port that \
+                 nothing can name: `aasm run` refuses a port-0 endpoint, `aasm proxy stop` could \
+                 not reach the process, and the start itself would be reported as failed while \
+                 the proxy kept running. Name the port you want (for example 127.0.0.1:8899).",
+            ),
         }
     }
 }
@@ -302,6 +313,14 @@ impl std::fmt::Display for BindRefusal {
 /// governed tool at a recorded proxy endpoint, so the two commands cannot
 /// disagree about which endpoints are usable (AAASM-5348).
 pub fn check_bind_addr(addr: SocketAddr, allow_remote_clients: bool) -> Result<(), BindRefusal> {
+    // Checked before the loopback branch because it disqualifies every address:
+    // the recorded endpoint keeps the literal `:0` the operator typed, so the
+    // real port the OS assigns is written down nowhere. `verify_endpoint`
+    // already rejects a port-0 endpoint, and refusing here is what keeps the
+    // two from disagreeing — the same reason the loopback test is shared.
+    if addr.port() == 0 {
+        return Err(BindRefusal::EphemeralPort(addr));
+    }
     if addr.ip().is_loopback() {
         return Ok(());
     }
@@ -527,13 +546,43 @@ mod tests {
     /// exposure, not to stop the proxy.
     #[test]
     fn a_loopback_listen_address_is_accepted() {
-        for literal in ["127.0.0.1:8899", "127.0.0.1:0", "[::1]:8899", "127.9.9.9:8899"] {
+        for literal in ["127.0.0.1:8899", "[::1]:8899", "127.9.9.9:8899"] {
             assert_eq!(
                 check_bind_addr(addr(literal), false),
                 Ok(()),
                 "{literal} is loopback and must be accepted without any opt-in"
             );
         }
+    }
+
+    /// Port 0 is the same split this ticket closes, reached by a different
+    /// property of the address: `verify_endpoint` rejects a port-0 endpoint, so
+    /// a proxy started on one could never be routed at. Left unrefused it is
+    /// also the worse outcome of the two — the child binds a real port, the
+    /// five-second wait on port 0 fails, the pid file is removed, and an
+    /// interception process holding CA material and provider credentials keeps
+    /// running with nothing able to name or stop it.
+    #[test]
+    fn port_zero_is_refused_on_every_address() {
+        for literal in ["127.0.0.1:0", "[::1]:0", "0.0.0.0:0"] {
+            let refusal = check_bind_addr(addr(literal), false)
+                .expect_err("{literal}: a port the endpoint cannot record must not be bound");
+            assert_eq!(refusal, BindRefusal::EphemeralPort(addr(literal)));
+            assert!(
+                refusal.to_string().contains("port 0"),
+                "must say which part of the address disqualified it, got: {refusal}"
+            );
+        }
+    }
+
+    /// The opt-in states an intent about *reachability*; it says nothing about
+    /// the port being recordable, so it must not carry port 0 past the check.
+    #[test]
+    fn the_remote_opt_in_does_not_permit_port_zero() {
+        assert_eq!(
+            check_bind_addr(addr("0.0.0.0:0"), true),
+            Err(BindRefusal::EphemeralPort(addr("0.0.0.0:0")))
+        );
     }
 
     /// AAASM-5348. Anything reachable off-host is refused by default, and the

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -186,6 +186,135 @@ impl ProxyConfig {
     }
 }
 
+/// A protection a proxy listener must have before it may face anything other
+/// than loopback, and whether `aa-proxy` can supply it today.
+///
+/// `available` is a compile-time constant rather than a config knob because it
+/// describes what this crate *implements*, not what an operator asked for — an
+/// operator cannot switch on a handshake that does not exist. Whoever
+/// implements one flips its constant and [`check_bind_addr`] relaxes on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemoteProtection {
+    /// Named verbatim in the refusal, so the operator is told which specific
+    /// protection is absent rather than that "something" is.
+    pub name: &'static str,
+    /// Whether `aa-proxy` implements it. See [`REMOTE_PROTECTIONS`].
+    pub available: bool,
+}
+
+/// What a network-reachable `aa-proxy` would need, and what it has.
+///
+/// Both are `false`, and that is a statement about the current code rather than
+/// a placeholder:
+///
+/// * **Listener TLS** — [`crate::proxy::ProxyServer::run`] binds a bare
+///   [`tokio::net::TcpListener`] and speaks plain HTTP `CONNECT` on it. The
+///   `rustls` server configs in that module are the per-host MitM certificates
+///   presented *inside* an established tunnel; none of them protects the
+///   listener itself. Off-host traffic to it, including the `CONNECT` line and
+///   any plain-HTTP body, crosses the network in the clear.
+/// * **Client authentication** — nothing in the crate reads
+///   `Proxy-Authorization` or answers `407`. Every connection that completes a
+///   TCP handshake is served, so with a non-loopback bind the set of authorised
+///   clients is exactly the set of hosts that can route to the port.
+///
+/// That second point is why reachability must never be read as trust here.
+/// `aa-proxy` is a credential-disclosure surface on both sides of the tunnel:
+/// it terminates client TLS with leaves issued from a CA whose root is
+/// installed in this machine's trust store (`crate::tls::CaStore`), so it can
+/// read every intercepted request; and it injects the operator's provider keys
+/// into forwarded requests (`crate::credentials::CredentialStore`), so it will
+/// spend those keys on behalf of whoever connects. An unauthenticated listener
+/// on a routable address hands both of those to the network.
+pub const REMOTE_PROTECTIONS: [RemoteProtection; 2] = [
+    RemoteProtection {
+        name: "TLS on the proxy listener",
+        available: false,
+    },
+    RemoteProtection {
+        name: "client authentication and authorization",
+        available: false,
+    },
+];
+
+/// The protections from [`REMOTE_PROTECTIONS`] that `aa-proxy` cannot supply.
+///
+/// Empty means a non-loopback listener could be protected; today it never is.
+pub fn missing_remote_protections() -> Vec<&'static str> {
+    REMOTE_PROTECTIONS
+        .iter()
+        .filter(|p| !p.available)
+        .map(|p| p.name)
+        .collect()
+}
+
+/// Why a requested proxy listen address was refused.
+///
+/// Both variants are refusals — they differ only in what the operator has to be
+/// told, because "you did not ask for this" and "you asked, and it cannot be
+/// done safely" are different problems with different next steps.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindRefusal {
+    /// A non-loopback address, with no explicit opt-in.
+    RemoteNotRequested(SocketAddr),
+    /// The opt-in was given, but [`REMOTE_PROTECTIONS`] are missing.
+    Unprotected {
+        addr: SocketAddr,
+        missing: Vec<&'static str>,
+    },
+}
+
+impl std::fmt::Display for BindRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RemoteNotRequested(addr) => write!(
+                f,
+                "refusing to listen on {addr}: it is not a loopback address, so the proxy would \
+                 accept connections from other hosts. aa-proxy reads intercepted traffic under a \
+                 CA this machine trusts and injects the operator's provider credentials into \
+                 forwarded requests, so anything that can reach the listener can do both. Listen \
+                 on a loopback address (for example 127.0.0.1:{}), or pass --allow-remote-clients \
+                 to state the intent explicitly.",
+                addr.port(),
+            ),
+            Self::Unprotected { addr, missing } => write!(
+                f,
+                "refusing to listen on {addr}: --allow-remote-clients was given, but a proxy \
+                 reachable from other hosts also requires protection aa-proxy does not implement: \
+                 {}. Being reachable is not being trusted — without those, every host that can \
+                 route to {addr} is an authorized client of an interception endpoint that holds \
+                 CA material and provider credentials. Listen on a loopback address instead.",
+                missing.join(", "),
+            ),
+        }
+    }
+}
+
+/// Whether the proxy may listen on `addr`.
+///
+/// Loopback is always allowed and is the default. Anything else is refused
+/// unless the operator opted in **and** every [`REMOTE_PROTECTIONS`] entry is
+/// available — which is why the opt-in currently refuses too. A flag whose
+/// preconditions cannot be met is honest; a flag that exposes an
+/// unauthenticated interception endpoint is not.
+///
+/// The loopback test is the same one `aasm run` applies before it will route a
+/// governed tool at a recorded proxy endpoint, so the two commands cannot
+/// disagree about which endpoints are usable (AAASM-5348).
+pub fn check_bind_addr(addr: SocketAddr, allow_remote_clients: bool) -> Result<(), BindRefusal> {
+    if addr.ip().is_loopback() {
+        return Ok(());
+    }
+    if !allow_remote_clients {
+        return Err(BindRefusal::RemoteNotRequested(addr));
+    }
+    let missing = missing_remote_protections();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(BindRefusal::Unprotected { addr, missing })
+}
+
 /// Directory, under the Agent Assembly state root, holding one MitM host list
 /// per installed developer integration.
 const MITM_HOSTS_DIR: &str = "mitm-hosts.d";

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -518,6 +518,96 @@ mod tests {
         std::env::remove_var("AASM_STATE_DIR");
     }
 
+    fn addr(s: &str) -> SocketAddr {
+        s.parse().expect("test address literal")
+    }
+
+    /// The default, and the address an operator types when they mean "this
+    /// machine only". Both must keep working — the guard exists to stop an
+    /// exposure, not to stop the proxy.
+    #[test]
+    fn a_loopback_listen_address_is_accepted() {
+        for literal in ["127.0.0.1:8899", "127.0.0.1:0", "[::1]:8899", "127.9.9.9:8899"] {
+            assert_eq!(
+                check_bind_addr(addr(literal), false),
+                Ok(()),
+                "{literal} is loopback and must be accepted without any opt-in"
+            );
+        }
+    }
+
+    /// AAASM-5348. Anything reachable off-host is refused by default, and the
+    /// operator is told which fact about the address disqualified it and what
+    /// the alternatives are — a bare "invalid address" would leave them
+    /// guessing.
+    #[test]
+    fn a_non_loopback_listen_address_is_refused_without_the_opt_in() {
+        for literal in ["0.0.0.0:8899", "192.168.1.7:8899", "[::]:8899"] {
+            let refusal = check_bind_addr(addr(literal), false).expect_err(&format!(
+                "{literal} is reachable from other hosts and must not be accepted by default"
+            ));
+            assert_eq!(refusal, BindRefusal::RemoteNotRequested(addr(literal)));
+
+            let msg = refusal.to_string();
+            assert!(msg.contains(literal), "the refusal must name the address, got: {msg}");
+            assert!(
+                msg.contains("not a loopback address"),
+                "the refusal must say what disqualified the address, got: {msg}"
+            );
+            assert!(
+                msg.contains("--allow-remote-clients"),
+                "the refusal must name the option that states the intent, got: {msg}"
+            );
+        }
+    }
+
+    /// The heart of AAASM-5348: asking is not enough. `aa-proxy` can neither
+    /// encrypt its listener nor tell one client from another, so with the
+    /// opt-in given the answer is still no — and the diagnostic names both
+    /// absent protections rather than reporting a generic failure.
+    #[test]
+    fn the_opt_in_alone_does_not_make_a_remote_listen_address_acceptable() {
+        let requested = addr("0.0.0.0:8899");
+        let refusal = check_bind_addr(requested, true)
+            .expect_err("--allow-remote-clients must not by itself authorize an unprotected listener");
+
+        let BindRefusal::Unprotected { addr: refused, missing } = &refusal else {
+            panic!("expected an Unprotected refusal naming what is absent, got: {refusal:?}");
+        };
+        assert_eq!(*refused, requested);
+        assert_eq!(
+            missing,
+            &["TLS on the proxy listener", "client authentication and authorization"]
+        );
+
+        let msg = refusal.to_string();
+        assert!(
+            msg.contains("TLS on the proxy listener"),
+            "the refusal must name the missing transport protection, got: {msg}"
+        );
+        assert!(
+            msg.contains("client authentication and authorization"),
+            "the refusal must name the missing client-identity protection, got: {msg}"
+        );
+        assert!(
+            msg.contains("Being reachable is not being trusted"),
+            "the refusal must say why reaching the port is not authorization, got: {msg}"
+        );
+    }
+
+    /// The refusal above is derived from the crate's real capabilities, not
+    /// hardcoded — so this records that today it supplies neither, and turns
+    /// into a failure the moment someone implements one without revisiting
+    /// [`check_bind_addr`].
+    #[test]
+    fn neither_remote_protection_is_implemented_today() {
+        assert_eq!(
+            missing_remote_protections(),
+            vec!["TLS on the proxy listener", "client authentication and authorization"],
+            "both protections are absent; a change here must be matched by one in the listener"
+        );
+    }
+
     /// AAASM-5276 condition C5. An installed integration extends the DLP
     /// surface to the hosts it named, and `llm_only` stays on — the alternative
     /// (turning it off) would MitM every host on the machine.


### PR DESCRIPTION
## Description

Implements **AAASM-5348** (owner Decision 3, Option A): `aasm proxy start` refuses a non-loopback bind, removing the split brain where the proxy started successfully on an address `aasm run` would never trust.

## The split brain, reproduced

```
$ aasm proxy start --listen 0.0.0.0:18991
Proxy started on http://0.0.0.0:18991
$ aasm proxy status
running (PID 19426, listening on 0.0.0.0:18991)

$ aasm run claude
error: refusing to launch ungoverned: the recorded proxy endpoint `0.0.0.0:18991`
is unusable: it is not a loopback address, so intercepted traffic would leave this machine
```

The refusing side was `proxy/trust.rs:359`; the permissive side was `proxy/start.rs::dispatch`, which had **no address check at all**.

## Both required protections are absent — so the opt-in always refuses

The contract requires a non-loopback bind to have TLS and client authentication. Neither exists:

- **Listener TLS: absent.** `aa-proxy/src/proxy/mod.rs:255` binds a bare `TcpListener` and speaks plain HTTP `CONNECT`. The three `rustls` configs there are not listener protection — `:1068` is the per-host MitM *server* cert presented **inside** an established tunnel (`.with_no_client_auth()`); `:385`/`:394` are the **upstream client** config.
- **Client authentication: absent.** No `Proxy-Authorization`, no `407`, no peer check anywhere in the crate.

So `--allow-remote-clients` is **implemented as a flag whose preconditions can never currently be met**, and it says so in the code, in `--help`, and in the refusal. It is driven by a `REMOTE_PROTECTIONS` table (`aa-proxy/src/config.rs:229`) with both marked `available: false` — flipping either constant relaxes the guard automatically when the protection lands.

A flag that always refuses is honest. A flag that appeared to gate on protections which do not exist would be **worse than the split brain it replaces**, because it would read as "remote clients are supported, with safeguards" when neither half is true.

## What an operator sees

```
### bare non-loopback
error: refusing to listen on 0.0.0.0:18992: it is not a loopback address, so the proxy
would accept connections from other hosts. aa-proxy reads intercepted traffic under a CA
this machine trusts and injects the operator's provider credentials into forwarded
requests, so anything that can reach the listener can do both. Listen on a loopback
address (for example 127.0.0.1:18992), or pass --allow-remote-clients to state the intent
explicitly.
exit=1 ; state files: 0

### with --allow-remote-clients
error: refusing to listen on 0.0.0.0:18992: --allow-remote-clients was given, but a proxy
reachable from other hosts also requires protection aa-proxy does not implement: TLS on
the proxy listener, client authentication and authorization. Being reachable is not being
trusted — without those, every host that can route to 0.0.0.0:18992 is an authorized
client of an interception endpoint that holds CA material and provider credentials.
exit=1 ; state files: 0

### loopback
Proxy started on http://127.0.0.1:18992 ; exit=0
```

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature (`--allow-remote-clients`)

## Breaking Changes

- [x] Yes — `aasm proxy start --listen <non-loopback>` now refuses. It previously succeeded and produced an endpoint `aasm run` would not trust, so no working configuration is lost.

## Related Issues

- Related Jira ticket: AAASM-5348 (owner decision recorded at creation)
- Surfaced **AAASM-5370** — see below

## Testing

**12 mutations, all killed.** The load-bearing pair is **M6/M7**: the same refusal moved to *after* spawn and *after* the port binds. They keep the exit code non-zero and change **only** ordering, isolating "refused before anything binds or writes state" from "refused at all":

```
a refused start must not leave a state file at /var/folders/.../data/proxy.pid
a refused start must not have bound port 54661
```

Others: M1 drops the opt-in gate; M2 makes the opt-in sufficient (`--allow-remote-clients must not by itself authorize an unprotected listener`); M3/M10 claim each protection is implemented (`both protections are absent; a change here must be matched by one in the listener`); M4 breaks loopback acceptance; M5 lets an unparseable `--listen` silently become the default; M8 removes the guard entirely, reproducing pre-fix behaviour; M11 stops naming the address; M12 defaults the opt-in on.

`aa-proxy` + `aa-cli` **1207/1207**; `cli_proxy_remote_bind_refusal` + `cli_run_trusted_proxy` + `cli_run` **22/22**; `cli_proxy` + `cli_run_claude_launch_env` **21/21**. `cargo doc --workspace --no-deps` adds no new warnings. The integration test uses `proxy_trust_support::{aasm_binary, aa_proxy_binary}` — the unconditional-rebuild path, so no stale-binary risk.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Found, not fixed — one is a live exposure

**The `aa-proxy` process itself is still exposable, and closing it needs files outside this ticket.** The guard lives in `aasm proxy start`; `ProxyConfig::from_env()` still honours `AA_PROXY_ADDR`, which is exactly how the container runs. Wiring `check_bind_addr` into `from_env()` was deliberately **not** done here because it would break three shipped things at once:

1. `aa-proxy/Dockerfile:41` — `ENV AA_PROXY_ADDR="0.0.0.0:8080"`; the published image would refuse to start.
2. `ci/integration/bypass-permissions/docker-compose.yml`, driven by a workflow outside this lane's ownership; CI would go red.
3. `examples/docker-compose/docker-compose.yml` and `docs/src/usage-guide/self-hosting.md:148` document the exposure as supported.

That third item is a live security issue on its own merits and is now **AAASM-5370**: the shipped self-host example sets `AA_PROXY_ADDR: "0.0.0.0:8899"` **and** publishes `"8899:8899"` to all host interfaces, with `AA_PROXY_MCP_FAIL_OPEN: "1"`. `check_bind_addr` is public and ready for that caller.

**Port 0 was the same split reached by a different property of the address, and is now also refused** (second commit). `trust.rs:365` rejects a port-0 endpoint, so a proxy started on one could never be routed at — but it was the worse of the two outcomes, not a smaller one. `aa-proxy` parses `:0` fine and binds an OS-assigned port; `wait_for_port("127.0.0.1:0")` then fails, `start.rs:254` removes the pid file, and **the child keeps running** — an interception process holding CA material and provider credentials that `aasm proxy stop` can no longer name or reach. The check runs *before* the loopback branch, because it disqualifies every address and `--allow-remote-clients` states an intent about reachability that says nothing about a recordable port. Two tests added; the ordering was mutation-checked by moving the condition below the loopback `return Ok(())`, which lets `127.0.0.1:0` through and fails the test. `aa-proxy` + `aa-cli` now **1209/1209**.

**Orphaned proxy on any failed start — pre-existing, not fixed here, ticket filed.** Refusing port 0 removes one way to reach it, but the underlying defect is general: *any* `wait_for_port` timeout (port already in use, missing CA dir, a crash during startup) takes the same path — the spawned `aa-proxy` is never killed and the pid file is removed, so the CLI loses its handle on a running interception process. Fixing it means killing the child on the failure path and is a change to the spawn lifecycle, outside this ticket's contract.

**Pre-existing, unrelated:** `cli_proxy proxy_logs_follow_streams_new_entries` fails deterministically under `cargo nextest` without `AASM_BIN_PATH` — its fixture shells out to `cargo run`, which blocks on the build lock nextest already holds. Passes with `AASM_BIN_PATH` set, which is the CI path.