### PR TITLE
[AAASM-5371] 🐛 (conformance): Slice vector offsets as bytes, not code points

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -20,7 +20,7 @@ conformance/
 │   ├── message_serialization/  # 10 vectors: one per proto message golden
 │   ├── proto/                  # *.bin golden files (prost encode_to_vec output)
 │   ├── policy_query/           # 10 vectors: ALLOW, DENY, PENDING, REDACT decisions
-│   ├── credential_detection/   # 23 vectors: API keys, auth tokens, DB URLs, PII, entropy
+│   ├── credential_detection/   # 34 vectors: API keys, auth tokens, DB URLs, PII, entropy
 │   └── session_lifecycle/      # 10 vectors: Register, Heartbeat, Deregister, ControlCommand
 └── runner/
     ├── requirements.txt        # Python runner dependencies (colorama)

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -25,7 +25,8 @@ conformance/
 └── runner/
     ├── requirements.txt        # Python runner dependencies (colorama)
     ├── runner.py               # Python SDK conformance runner
-    └── test_runner_redact.py   # Regression tests for the runner's own redaction logic
+    ├── test_runner_redact.py   # Regression tests for the runner's own redaction logic
+    └── check_redact_equivalence.py  # Differential sweep vs. the pre-AAASM-5371 redaction
 ```
 
 ## Test categories
@@ -162,6 +163,21 @@ without an SDK and without any vector file:
 ```bash
 python conformance/runner/test_runner_redact.py
 ```
+
+Changing how spans are spliced is the change most likely to break the 26 ASCII
+vectors without any of them failing, since a wrong unit still lands in the right
+place on ASCII. The differential sweep drives the current implementation and the
+pre-AAASM-5371 one over every span position in every ASCII vector and requires
+byte-identical output:
+
+```bash
+python conformance/runner/check_redact_equivalence.py
+python conformance/runner/check_redact_equivalence.py --self-check
+```
+
+`--self-check` sabotages the implementation by one character and asserts the
+sweep notices — a differential harness that silently compares one thing to itself
+reports zero mismatches forever and looks exactly like proof.
 
 ## Adding new vectors
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -24,7 +24,8 @@ conformance/
 │   └── session_lifecycle/      # 10 vectors: Register, Heartbeat, Deregister, ControlCommand
 └── runner/
     ├── requirements.txt        # Python runner dependencies (colorama)
-    └── runner.py               # Python SDK conformance runner
+    ├── runner.py               # Python SDK conformance runner
+    └── test_runner_redact.py   # Regression tests for the runner's own redaction logic
 ```
 
 ## Test categories
@@ -81,6 +82,27 @@ Vector schema:
 }
 ```
 
+#### Offset unit — normative
+
+`expected_findings[].offset` is a **byte offset into the UTF-8 encoding of
+`input_text`**, counting from zero. So is the `end` an SDK reports alongside it.
+This is not negotiable per language: it is the unit `CredentialScanner` emits,
+and the vectors are the same bytes for every SDK.
+
+It matters because each language's native string index means something different,
+and for ASCII input all three units coincide — so a harness that picks the wrong
+one still passes every ASCII vector and only breaks on the first multi-byte one:
+
+| Language | Native string index | Correct against this schema? |
+|---|---|---|
+| Rust | bytes (`&str[a..b]`) | yes, directly |
+| Go | bytes (`s[a:b]`) | yes, directly |
+| Python | code points (`s[a:b]`) | **no** — encode to `bytes`, splice, decode back |
+| Node/TS | UTF-16 code units (`s.slice(a, b)`) | **no** — splice a `Buffer`/`Uint8Array` instead |
+
+An offset that does not fall on a character boundary is not redactable; reject it
+rather than splicing, so no harness can emit invalid UTF-8 or a partial value.
+
 Categories: API keys (Anthropic, OpenAI, AWS, GCP, Azure), auth tokens (GitHub,
 Slack), database URLs (Postgres, MySQL, MongoDB), private keys (RSA, EC, OpenSSH,
 PKCS8, PGP), PII (credit card, SSN, email), high-entropy tokens.
@@ -126,6 +148,20 @@ The `scan()` function must return a list of dicts, each with:
 - `"kind"` (str) — credential kind string matching `CredentialKind.as_str()`
 - `"offset"` (int) — byte offset of the finding in the input text
 - `"end"` (int) — byte end of the matched region (used for redaction)
+
+Both positions are byte offsets into the UTF-8 encoding of the input, per
+[Offset unit — normative](#offset-unit--normative). A Python SDK that reports
+`str` indices will pass every ASCII vector and fail every non-ASCII one.
+
+### Testing the runner itself
+
+The runner reconstructs the redacted string from the spans an SDK reports, so it
+can be wrong in exactly the same way an SDK can. Its own regression tests run
+without an SDK and without any vector file:
+
+```bash
+python conformance/runner/test_runner_redact.py
+```
 
 ## Adding new vectors
 

--- a/conformance/runner/.gitignore
+++ b/conformance/runner/.gitignore
@@ -1,0 +1,2 @@
+# Byte-code caches from running the conformance runner and its tests locally.
+__pycache__/

--- a/conformance/runner/check_redact_equivalence.py
+++ b/conformance/runner/check_redact_equivalence.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Differential check: the byte-slicing `_redact` vs. the code-point-slicing one it replaced.
+
+Why this exists
+---------------
+AAASM-5371 changed how `runner._redact` interprets a finding's span. The claim
+that came with it — "ASCII behaviour is unchanged" — is the kind of claim that is
+easy to assert and easy to get wrong, because every committed ASCII vector passes
+either way. This script is the evidence for it, kept runnable so the number in the
+PR is reproducible rather than something you have to take on trust.
+
+It drives both implementations over every span position in every ASCII vector and
+compares their output byte for byte.
+
+    well-formed spans (0 <= offset <= end)   must be identical      → else exit 1
+    malformed spans   (offset < 0)           are expected to differ → reported only
+
+The second bucket is the one honest exception. The old code let a negative offset
+fall through to Python's negative indexing and spliced garbage into the middle of
+the text; the new code rejects it. That is a fix, not a regression, so it is
+counted and printed rather than asserted away.
+
+Self-check
+----------
+A differential harness that compares two things which are quietly the same object
+reports zero mismatches forever and looks like proof. `--self-check` sabotages the
+new implementation by one character and asserts this sweep *notices*, so a clean
+run means the sweep can discriminate rather than that it is inert.
+
+Run
+---
+    python conformance/runner/check_redact_equivalence.py
+    python conformance/runner/check_redact_equivalence.py --self-check
+
+Needs no SDK, sets no environment, and reads the vectors without writing to them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from runner import _redact  # noqa: E402
+
+Redactor = Callable[[str, list[dict]], str]
+
+
+def _legacy_redact(text: str, findings: list[dict]) -> str:
+    """`_redact` exactly as it stood before AAASM-5371 — slices the `str`.
+
+    Kept verbatim, and deliberately not refactored: its value is being the thing
+    that actually shipped, so any tidying would weaken the comparison.
+    """
+    sorted_findings = sorted(findings, key=lambda f: f.get("offset", 0), reverse=True)
+    result = text
+    for finding in sorted_findings:
+        offset = finding.get("offset")
+        end = finding.get("end")
+        kind = finding.get("kind", "UNKNOWN")
+        if offset is None or end is None:
+            continue
+        if end > len(result) or offset > end:
+            continue
+        placeholder = f"[REDACTED:{kind}]"
+        result = result[:offset] + placeholder + result[end:]
+    return result
+
+
+def _mutated_redact(text: str, findings: list[dict]) -> str:
+    """The current `_redact` with a one-character sabotage: `offset` → `offset + 1`.
+
+    Used only by --self-check, to prove the sweep below can tell two nearly
+    identical implementations apart.
+    """
+    sorted_findings = sorted(findings, key=lambda f: f.get("offset", 0), reverse=True)
+    result = text.encode("utf-8")
+    for finding in sorted_findings:
+        offset = finding.get("offset")
+        end = finding.get("end")
+        kind = finding.get("kind", "UNKNOWN")
+        if offset is None or end is None:
+            continue
+        if offset < 0 or end > len(result) or offset > end:
+            continue
+        placeholder = f"[REDACTED:{kind}]".encode("utf-8")
+        result = result[: offset + 1] + placeholder + result[end:]  # ← the sabotage
+    return result.decode("utf-8", errors="replace")
+
+
+def _positions(n: int) -> list[int]:
+    """Every index 0..n for short inputs; ~160 evenly spaced ones for long inputs.
+
+    Private keys run to a few thousand bytes and an exhaustive O(n^2) pair sweep
+    over those adds hours without adding span *shapes*. The endpoint is always
+    included because off-by-one at the tail is the interesting case.
+    """
+    step = 1 if n <= 160 else max(1, n // 160)
+    positions = list(range(0, n + 1, step))
+    if positions[-1] != n:
+        positions.append(n)
+    return positions
+
+
+def _wellformed_cases(n: int, positions: list[int]) -> list[list[dict]]:
+    """Span sets with non-negative offsets: single, paired, and degenerate."""
+    cases: list[list[dict]] = []
+    # Single span at every (offset, end) pair with offset <= end.
+    for o, e in itertools.combinations_with_replacement(positions, 2):
+        cases.append([{"kind": "K", "offset": o, "end": e}])
+    # Two spans, sampled every 7th triple, so overlapping and adjacent pairs are
+    # covered without squaring the single-span cost. The second span is short and
+    # anchored at o2 to exercise the reverse-order splice after a length change.
+    for o1, e1, o2 in itertools.islice(
+        itertools.product(positions, positions, positions), 0, None, 7
+    ):
+        if not (o1 <= e1 <= n and o2 <= n):
+            continue
+        cases.append(
+            [
+                {"kind": "A", "offset": o1, "end": e1},
+                {"kind": "B", "offset": o2, "end": min(o2 + 5, n)},
+            ]
+        )
+    # Degenerate shapes: no findings, missing "end", past the end, inverted.
+    cases.append([])
+    cases.append([{"kind": "K", "offset": 0}])
+    cases.append([{"kind": "K", "offset": 3, "end": n + 50}])
+    cases.append([{"kind": "K", "offset": n, "end": 0}])
+    return cases
+
+
+def _malformed_cases(n: int, positions: list[int]) -> list[list[dict]]:
+    """Negative offsets — impossible from a `usize`-based scanner, possible from a bug."""
+    negatives = sorted({-1, -2, -(n // 2 or 1), -n or -1})
+    return [
+        [{"kind": "K", "offset": o, "end": e}]
+        for o in negatives
+        for e in positions
+    ]
+
+
+def _load_ascii_vectors(vectors_dir: Path) -> tuple[list[str], int]:
+    """Return the ASCII vector inputs, plus how many files were skipped as non-ASCII."""
+    inputs, skipped = [], 0
+    for f in sorted(vectors_dir.glob("*.json")):
+        with f.open(encoding="utf-8") as fh:
+            v: dict[str, Any] = json.load(fh)
+        text = v["input_text"]
+        if all(ord(c) < 128 for c in text):
+            inputs.append(text)
+        else:
+            skipped += 1
+    return inputs, skipped
+
+
+def sweep(inputs: list[str], new: Redactor) -> tuple[int, int, int, list[str]]:
+    """Compare *new* against the legacy implementation. Returns counts + samples."""
+    wellformed = mismatched = malformed_differs = 0
+    samples: list[str] = []
+    for text in inputs:
+        positions = _positions(len(text))
+        for findings in _wellformed_cases(len(text), positions):
+            wellformed += 1
+            if _legacy_redact(text, findings) != new(text, findings):
+                mismatched += 1
+                if len(samples) < 5:
+                    samples.append(f"well-formed span differs: {findings}")
+        for findings in _malformed_cases(len(text), positions):
+            if _legacy_redact(text, findings) != new(text, findings):
+                malformed_differs += 1
+    return wellformed, mismatched, malformed_differs, samples
+
+
+def main() -> int:
+    here = Path(__file__).resolve().parent
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    p.add_argument(
+        "--vectors",
+        type=Path,
+        default=here.parent / "vectors" / "credential_detection",
+        help="credential_detection vector directory (read-only)",
+    )
+    p.add_argument(
+        "--self-check",
+        action="store_true",
+        help="prove the sweep detects a one-character sabotage of _redact",
+    )
+    args = p.parse_args()
+
+    inputs, skipped = _load_ascii_vectors(args.vectors)
+    if not inputs:
+        print(f"ERROR: no ASCII vectors found in {args.vectors}")
+        return 2
+
+    if args.self_check:
+        _, mismatched, _, _ = sweep(inputs, _mutated_redact)
+        print(f"self-check: sabotaged implementation produced {mismatched} mismatches")
+        if mismatched == 0:
+            print("ERROR: the sweep did not notice a broken implementation.")
+            return 1
+        print("OK: the sweep discriminates.")
+        return 0
+
+    wellformed, mismatched, malformed_differs, samples = sweep(inputs, _redact)
+    print(f"ASCII vectors swept        : {len(inputs)}")
+    print(f"non-ASCII vectors skipped  : {skipped}")
+    print(f"well-formed span cases     : {wellformed}")
+    print(f"  mismatches               : {mismatched}")
+    print(f"malformed (offset < 0) now rejected instead of mangled: {malformed_differs}")
+    for s in samples:
+        print(f"  {s}")
+    if mismatched:
+        print("FAIL: byte-slicing changed behaviour for a well-formed span.")
+        return 1
+    print("OK: identical for every well-formed span.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/runner/runner.py
+++ b/conformance/runner/runner.py
@@ -157,7 +157,8 @@ def run(vectors_dir: Path, verbose: bool) -> bool:
             continue
 
         # Redact check: reconstruct the redacted string from findings.
-        # This mirrors the Rust ScanResult::redact() logic.
+        # Approximates Rust's ScanResult::redact() — see _redact for the two
+        # ways it still diverges (no coalescing, fails open).
         redacted = _redact(input_text, actual_findings)
         if redacted != expected_redacted:
             failed += 1
@@ -197,7 +198,7 @@ def _is_utf8_boundary(buf: bytes, index: int) -> bool:
 
 
 def _redact(text: str, findings: list[dict]) -> str:
-    """Apply findings to text in reverse offset order (mirrors Rust ScanResult::redact).
+    """Apply findings to text in reverse offset order.
 
     `offset` and `end` are **byte** positions in the UTF-8 encoding of *text* —
     that is the unit the reference scanner emits and the unit the vector schema
@@ -207,6 +208,12 @@ def _redact(text: str, findings: list[dict]) -> str:
 
     A span that is out of range, inverted, or not aligned to a character
     boundary is skipped rather than spliced, so this never emits invalid UTF-8.
+
+    That skip is where this **diverges from** Rust's `ScanResult::redact`, which
+    fails closed on exactly those spans and returns `"[REDACTED]"` for the whole
+    text (aa-security/src/scanner.rs:447-458). Rust also coalesces overlapping
+    findings before splicing; this does not. Both gaps are AAASM-5373 — until
+    they close, do not describe this function as mirroring the Rust one.
     """
     # Each finding must have "kind", "offset", and "end" (byte end of match).
     # If "end" is absent, the runner cannot redact — skip silently.

--- a/conformance/runner/runner.py
+++ b/conformance/runner/runner.py
@@ -188,23 +188,43 @@ def run(vectors_dir: Path, verbose: bool) -> bool:
     return failed == 0
 
 
+def _is_utf8_boundary(buf: bytes, index: int) -> bool:
+    """True if *index* is the start of a character in *buf* (Rust `is_char_boundary`)."""
+    if index in (0, len(buf)):
+        return True
+    # UTF-8 continuation bytes are 0b10xxxxxx; any other byte starts a character.
+    return buf[index] & 0xC0 != 0x80
+
+
 def _redact(text: str, findings: list[dict]) -> str:
-    """Apply findings to text in reverse offset order (mirrors Rust ScanResult::redact)."""
+    """Apply findings to text in reverse offset order (mirrors Rust ScanResult::redact).
+
+    `offset` and `end` are **byte** positions in the UTF-8 encoding of *text* —
+    that is the unit the reference scanner emits and the unit the vector schema
+    documents. Splicing therefore happens on the encoded `bytes`, which is
+    decoded back once at the end; slicing the `str` would index code points and
+    land the redaction in the wrong place for any non-ASCII input.
+
+    A span that is out of range, inverted, or not aligned to a character
+    boundary is skipped rather than spliced, so this never emits invalid UTF-8.
+    """
     # Each finding must have "kind", "offset", and "end" (byte end of match).
     # If "end" is absent, the runner cannot redact — skip silently.
     sorted_findings = sorted(findings, key=lambda f: f.get("offset", 0), reverse=True)
-    result = text
+    result = text.encode("utf-8")
     for finding in sorted_findings:
         offset = finding.get("offset")
         end = finding.get("end")
         kind = finding.get("kind", "UNKNOWN")
         if offset is None or end is None:
             continue
-        if end > len(result) or offset > end:
+        if offset < 0 or end > len(result) or offset > end:
             continue
-        placeholder = f"[REDACTED:{kind}]"
+        if not _is_utf8_boundary(result, offset) or not _is_utf8_boundary(result, end):
+            continue
+        placeholder = f"[REDACTED:{kind}]".encode("utf-8")
         result = result[:offset] + placeholder + result[end:]
-    return result
+    return result.decode("utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/conformance/runner/runner.py
+++ b/conformance/runner/runner.py
@@ -25,7 +25,10 @@ a scan() function with this signature:
         ...
         # Returns a list of findings, each a dict with keys:
         #   "kind"   (str)  — matches CredentialKind.as_str() in aa-core
-        #   "offset" (int)  — byte offset of the finding in `text`
+        #   "offset" (int)  — start of the finding, as a byte offset into the
+        #                     UTF-8 encoding of `text` (not a str index)
+        #   "end"    (int)  — end of the match, same unit. Required: a finding
+        #                     without it cannot be redacted and is skipped.
 
 If AA_SDK_MODULE is unset the runner uses a no-op stub that always returns []
 and prints a warning — all vectors with expected_findings will fail.

--- a/conformance/runner/test_runner_redact.py
+++ b/conformance/runner/test_runner_redact.py
@@ -83,16 +83,28 @@ class RedactByteOffsetTests(unittest.TestCase):
             "一=[REDACTED:SyntheticKey]、二=[REDACTED:SyntheticToken]",
         )
 
-    def test_span_inside_a_character_is_skipped_not_mangled(self) -> None:
+    def test_span_inside_a_character_is_skipped_pending_fail_closed(self) -> None:
         # A span that starts mid-character cannot be spliced without producing
-        # invalid UTF-8. It must be dropped, never emitted as mojibake and never
-        # raise — the Rust reference rejects the same spans via is_char_boundary.
+        # invalid UTF-8, so the runner drops it — never mojibake, never a raise.
+        #
+        # This pins CURRENT HARNESS BEHAVIOUR, NOT DESIRED BEHAVIOUR. The Rust
+        # reference rejects the same span and then fails *closed*: it returns
+        # "[REDACTED]" for the entire text rather than hand back text it cannot
+        # prove is clean (aa-security/src/scanner.rs:454-458 — "never return the
+        # raw text with a secret intact"). The runner fails open here.
+        #
+        # Closing that gap is AAASM-5373. Whoever does it must change this
+        # assertion — it is a marker for the divergence, not an endorsement of it.
         text = "番号=1234"
         findings = [{"kind": "SyntheticNumber", "offset": 1, "end": 6}]
 
         self.assertEqual(_redact(text, findings), text)
 
-    def test_out_of_range_span_is_skipped(self) -> None:
+    def test_out_of_range_span_is_skipped_pending_fail_closed(self) -> None:
+        # Same divergence as above for an out-of-range span: the runner skips it,
+        # Rust returns "[REDACTED]" for the whole text
+        # (aa-security/src/scanner.rs:447-458). Pins current behaviour; see
+        # AAASM-5373.
         text = "番号=1234"
         findings = [{"kind": "SyntheticNumber", "offset": 3, "end": 999}]
 

--- a/conformance/runner/test_runner_redact.py
+++ b/conformance/runner/test_runner_redact.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the conformance runner's redaction reconstruction.
+
+Why this file exists
+--------------------
+`runner._redact` reassembles the redacted string from the spans an SDK reports,
+and the vector schema defines those spans in **bytes** (that is what the Rust
+reference scanner emits). Python `str` indices are code points, so on any input
+containing a multi-byte character the two units diverge and the splice lands in
+the wrong place — silently, because `_redact` has no way to tell a wrong-but-
+in-range index from a right one.
+
+Every vector in the suite was ASCII when the runner was written, where the two
+units coincide, so nothing caught it. These fixtures are deliberately multi-byte
+so the units cannot coincide: they fail against a code-point-slicing `_redact`
+and pass against a byte-slicing one.
+
+The fixtures are synthetic and defined here rather than loaded from
+`conformance/vectors/` on purpose — the runner must be provable independently of
+which vectors happen to be committed, and no fixture here contains real
+credential material or real personal data.
+
+Run
+---
+    python conformance/runner/test_runner_redact.py     # stdlib unittest
+    pytest conformance/runner/test_runner_redact.py     # or under pytest
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from runner import _redact  # noqa: E402
+
+
+def _span(kind: str, text: str, secret: str) -> dict:
+    """Build the finding an SDK reporting byte offsets would return for *secret*."""
+    offset = text.encode("utf-8").index(secret.encode("utf-8"))
+    return {"kind": kind, "offset": offset, "end": offset + len(secret.encode("utf-8"))}
+
+
+class RedactByteOffsetTests(unittest.TestCase):
+    """`_redact` must interpret `offset`/`end` as byte positions, not code points."""
+
+    def test_multibyte_prefix_shifts_the_span(self) -> None:
+        # The label before the value is CJK, so the value's byte offset (13) and
+        # its code-point offset (9) differ. A code-point splice cuts four bytes
+        # early and leaves a fragment of the flagged value in the output.
+        secret = "sk-DUMMY-NOT-A-REAL-KEY"
+        text = f"メモ token={secret}"
+        findings = [_span("SyntheticKey", text, secret)]
+
+        self.assertEqual(_redact(text, findings), "メモ token=[REDACTED:SyntheticKey]")
+
+    def test_multibyte_value_body(self) -> None:
+        # The flagged value is itself multi-byte (full-width digits, 3 bytes
+        # each), so `end` overshoots the code-point length by a factor of three.
+        secret = "１２３４５６７８"
+        text = f"番号={secret}"
+        findings = [_span("SyntheticNumber", text, secret)]
+
+        self.assertEqual(_redact(text, findings), "番号=[REDACTED:SyntheticNumber]")
+
+    def test_multiple_spans_with_multibyte_separator(self) -> None:
+        # Two spans separated by multi-byte text. `_redact` splices in reverse
+        # offset order, so this also proves the earlier span's byte offsets stay
+        # valid after the later splice changed the buffer's length.
+        first = "DUMMY-VALUE-ONE"
+        second = "DUMMY-VALUE-TWO"
+        text = f"一={first}、二={second}"
+        findings = [
+            _span("SyntheticKey", text, first),
+            _span("SyntheticToken", text, second),
+        ]
+
+        self.assertEqual(
+            _redact(text, findings),
+            "一=[REDACTED:SyntheticKey]、二=[REDACTED:SyntheticToken]",
+        )
+
+    def test_span_inside_a_character_is_skipped_not_mangled(self) -> None:
+        # A span that starts mid-character cannot be spliced without producing
+        # invalid UTF-8. It must be dropped, never emitted as mojibake and never
+        # raise — the Rust reference rejects the same spans via is_char_boundary.
+        text = "番号=1234"
+        findings = [{"kind": "SyntheticNumber", "offset": 1, "end": 6}]
+
+        self.assertEqual(_redact(text, findings), text)
+
+    def test_out_of_range_span_is_skipped(self) -> None:
+        text = "番号=1234"
+        findings = [{"kind": "SyntheticNumber", "offset": 3, "end": 999}]
+
+        self.assertEqual(_redact(text, findings), text)
+
+
+class RedactAsciiUnchangedTests(unittest.TestCase):
+    """ASCII behaviour is the contract the 26 committed vectors rely on.
+
+    These pass both before and after the byte-offset fix by design — they are a
+    guard against regressing ASCII, not evidence that the fix works.
+    """
+
+    def test_single_ascii_span(self) -> None:
+        secret = "DUMMY-NOT-A-REAL-KEY"
+        text = f"key={secret}"
+        findings = [_span("SyntheticKey", text, secret)]
+
+        self.assertEqual(_redact(text, findings), "key=[REDACTED:SyntheticKey]")
+
+    def test_no_findings_returns_input_unchanged(self) -> None:
+        text = "nothing sensitive here"
+
+        self.assertEqual(_redact(text, []), text)
+
+    def test_finding_without_end_is_skipped(self) -> None:
+        # The schema's `expected_findings` entries carry no `end`; only the SDK's
+        # reply does. A finding without one is not redactable and must be left be.
+        text = "key=DUMMY-NOT-A-REAL-KEY"
+        findings = [{"kind": "SyntheticKey", "offset": 4}]
+
+        self.assertEqual(_redact(text, findings), text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

`conformance/runner/runner.py::_redact` sliced a Python `str` with what the vector
schema defines as **byte** offsets. Python `str` indices are code points, so the
two units only coincide on ASCII — which every vector in the suite was until
AAASM-5351 landed the first non-ASCII ones. On any multi-byte input the redaction
lands in the wrong place or silently does not happen, and the harness reports a
spurious FAIL against a *correct* SDK.

`_redact` now splices the UTF-8 encoding and decodes once at the end. That form
was chosen over converting byte offsets to code-point offsets because it is the
same operation `ScanResult::redact` performs on the Rust side, so the harness
stays byte-for-byte comparable with the implementation it grades instead of
approximating it through a second unit. Spans that miss a character boundary are
now rejected rather than spliced, so a bad span cannot produce invalid UTF-8 or
leave a fragment of the flagged value in the output.

Also in this PR: the offset unit is now stated normatively in
`conformance/README.md` with the per-language consequence spelled out (Go indexes
bytes and is correct as-written; Node/TS indexes UTF-16 code units and is not),
and the stale `credential_detection/` vector count is corrected.

Scope is `conformance/runner/` plus those `conformance/README.md` edits. **No
vector file is touched** — ADR 0015 forbids editing a committed vector to make
anything pass, and that rule is exactly what this defect would have eroded.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

Test harness only — no production code path, no schema change to the vector files,
no SDK contract change. ASCII behaviour is provably unchanged (see below), so any
SDK currently pinning this `conformance/` revision is unaffected.

## Related Issues

- Related Jira ticket: [AAASM-5371](https://lightning-dust-mite.atlassian.net/browse/AAASM-5371)
- Parent Epic: [AAASM-5270](https://lightning-dust-mite.atlassian.net/browse/AAASM-5270) — Local-first sensitive-data intelligence and enforcement architecture
- Vectors that exposed this: [AAASM-5351](https://lightning-dust-mite.atlassian.net/browse/AAASM-5351) (#1887, merged — this branch is rebased on it)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

### 1. Mutation proof — the new regression tests fail without the fix

A test that passes both before and after proves nothing, so here is the same test
file run against both runners.

**Before** (`conformance/runner/runner.py` at `remote/main`):

```
test_finding_without_end_is_skipped ... ok
test_no_findings_returns_input_unchanged ... ok
test_single_ascii_span ... ok
test_multibyte_prefix_shifts_the_span ... FAIL
test_multibyte_value_body ... FAIL
test_multiple_spans_with_multibyte_separator ... FAIL
test_out_of_range_span_is_skipped ... ok
test_span_inside_a_character_is_skipped_not_mangled ... FAIL

FAIL: test_multibyte_prefix_shifts_the_span
AssertionError: 'メモ token=sk-DUMMY-NOT-A-REAL-KEY' != 'メモ token=[REDACTED:SyntheticKey]'

FAIL: test_multibyte_value_body
AssertionError: '番号=１２３４５６７８' != '番号=[REDACTED:SyntheticNumber]'

FAIL: test_multiple_spans_with_multibyte_separator
AssertionError: '一=DU[REDACTED:SyntheticKey]=DUMMY-VALUE-TWO' != '一=[REDACTED:SyntheticKey]、二=[REDACTED:SyntheticToken]'

FAIL: test_span_inside_a_character_is_skipped_not_mangled
AssertionError: '番[REDACTED:SyntheticNumber]4' != '番号=1234'

Ran 8 tests in 0.002s

FAILED (failures=4)
EXIT=1
```

**After** (this branch):

```
test_finding_without_end_is_skipped ... ok
test_no_findings_returns_input_unchanged ... ok
test_single_ascii_span ... ok
test_multibyte_prefix_shifts_the_span ... ok
test_multibyte_value_body ... ok
test_multiple_spans_with_multibyte_separator ... ok
test_out_of_range_span_is_skipped ... ok
test_span_inside_a_character_is_skipped_not_mangled ... ok

Ran 8 tests in 0.000s

OK
EXIT=0
```

The fixtures are synthetic and declared inline in the test file rather than loaded
from `vectors/` — the harness has to be provable independently of which vectors
happen to be committed, and no assertion diff can then print real credential
material. The three `ok`-before/`ok`-after cases are ASCII guards, not evidence;
they are labelled as such in the file.

### 2. The 8 AAASM-5351 vectors, end to end through the runner

Per the ticket's verification plan, driven with `AA_SDK_MODULE` set to an oracle
stub that reports correct byte offsets.

**Before** (`remote/main` runner) — 5/8, and the 3 failures are precisely the
vectors with a multi-byte span:

```
Results: 5/8 passed, 3 failed
  FAIL [AAASM-5344 bypass guard: ... ASCII high-entropy secret flush against Chinese text ...]: redact mismatch
  FAIL [AAASM-5345: ... Visa test number ... in full-width digits ...]: redact mismatch
  FAIL [AAASM-5345: ... documentation SSN ... in full-width digits with ASCII separators ...]: redact mismatch
EXIT=1
```

(The `got:`/`expected:` lines are omitted here deliberately; the failure identity
is the vector, not its payload.)

**After** (this branch):

```
Results: 8/8 passed  all passed
EXIT=0
```

### 3. The 26 pre-existing ASCII vectors: unchanged for every well-formed span

Not just "still pass" — the old code-point-slicing `_redact` and the new
byte-slicing one were run head-to-head over **every** span position in each of the
26 ASCII vector inputs (single spans at every `(offset, end)` pair, two-span
combinations, plus out-of-range / inverted / missing-`end` cases).

The sweep is committed as `conformance/runner/check_redact_equivalence.py` so the
numbers below are reproducible rather than something to take on trust:

```
$ python conformance/runner/check_redact_equivalence.py
ASCII vectors swept        : 26
non-ASCII vectors skipped  : 8
well-formed span cases     : 994838
  mismatches               : 0
malformed (offset < 0) now rejected instead of mangled: 6528
OK: identical for every well-formed span.
```

**Precise claim: unchanged for all well-formed spans; malformed negative offsets
are now rejected instead of silently mangled.** That second bucket is a real
behaviour change and it is a fix, not a regression — the old code let `offset: -1`
fall through to Python's negative indexing and spliced a placeholder into the
middle of the text, returning duplicated garbage; the guard added here rejects it.
An earlier draft of this PR said "byte-identical before and after" on the strength
of a sweep whose generator never emitted a negative offset. It is corrected above,
and the committed sweep now enumerates that bucket explicitly instead of leaving
it outside the search space.

A differential harness is the specific kind of test that passes for the wrong
reason — compare two things that are quietly the same object and you get zero
mismatches forever. So the sweep has to show it can still fail:

```
$ python conformance/runner/check_redact_equivalence.py --self-check
self-check: sabotaged implementation produced 994708 mismatches
OK: the sweep discriminates.
```

Driving the runner over those 26 vectors with the oracle stub gives `22/22 passed`
on both old and new runners — 22, not 26, because 4 vectors are excluded for an
unrelated pre-existing defect described below.

### 4. Suites

```
cargo nextest run -p conformance    → 49 tests run: 49 passed, 0 skipped   (exit 0)
python conformance/runner/test_runner_redact.py                            (exit 0)
python conformance/runner/runner.py    (CI's default invocation)           (exit 0)
```

Exit codes were captured from the command itself, not from a pipe.

### Node / Go harness audit (acceptance criterion)

**Neither harness exists.** `conformance/runner/` contains only `runner.py`; the
`conformance-node` and `conformance-go` CI jobs are `echo`-and-`exit 0`
placeholders that literally say "Add a `conformance/runner/runner.js` and wire it
up here." The `*conformance*` files in the `node-sdk` / `go-sdk` repos are
fail-open governance-gate tests, unrelated to credential-detection vectors.

So the defect cannot be present today, but it is pre-loaded for whoever writes
those harnesses, and the two languages are not equally exposed:

| Language | Native string index | Correct against this schema? |
|---|---|---|
| Go | bytes (`s[a:b]`) | yes, directly |
| Node/TS | UTF-16 code units (`s.slice(a, b)`) | **no** — must splice a `Buffer`/`Uint8Array` |

Node is the live hazard: `slice()` is wrong for *any* multi-byte character, and
like Python it will pass 100% of the ASCII vectors while doing so. That table is
now in `conformance/README.md` so the next harness author meets it before writing
the splice.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced

No Rust source changed, so lefthook's `fmt`/`clippy`/`deny` hooks reported
"no matching staged files" on every commit rather than running.

## Out of scope — filed for follow-up, deliberately not fixed here

**`_redact` does not coalesce overlapping spans, so 4 committed vectors cannot
pass.** Rust's `ScanResult::redact` runs `coalesce_findings` first, merging
overlapping findings into a single label; the Python runner splices each finding
separately. For `db_urls_postgres`, `db_urls_mongodb`, `db_urls_mysql` and
`private_keys_ec_short_trailing_line`, `expected_findings` lists 2–3 findings
while `expected_redacted` contains exactly one label — so **the spans a correct
scanner reports cannot reproduce it**, whatever unit those spans are in.

(Stated precisely, because the stronger phrasing is falsifiable: for
`private_keys_ec_short_trailing_line` there do exist contrived `end` pairs that
happen to reconstruct the expected string, artefacts of the bound being checked
against the mutated buffer. They are not the spans the scanner emits. Three of
the four admit no solution at all.)

This is pre-existing, independent of the byte/code-point bug, and equally latent
(it also only bites once `AA_SDK_MODULE` is set and the jobs gate merges). It is
excluded from the 22/22 run above rather than papered over. Same blast radius as
this ticket: a correct SDK failing on a harness defect. Tracked as **AAASM-5373**.

Two smaller ones, same file:

- **`_redact` skips an unspliceable span; Rust fails closed** and returns
  `"[REDACTED]"` for the whole text rather than risk emitting the flagged region
  (`aa-security/src/scanner.rs:447-458`). This diff *adds* three such fail-open
  paths — the `offset < 0` guard and both `_is_utf8_boundary` checks — so the
  divergence widens here even though the offset unit is fixed. Deferred to
  AAASM-5373 rather than implemented, but deliberately not written down as
  correct: the two tests that pin it are named
  `..._pending_fail_closed`, carry the Rust line and the ticket in a comment, and
  the docstring no longer claims this function mirrors `ScanResult::redact`.
- **Nothing runs `test_runner_redact.py` or the sweep in CI**, and the
  `conformance-python` job that does run is a no-op twice over: beyond
  `continue-on-error: true`, `run()` short-circuits to `return True` at
  `runner.py:127-133` because `AA_SDK_MODULE` is unset, so it never loads a
  vector. The workflow comment at `ci.yml:1173-1174` saying the runner "exits 1
  until a real SDK implementation is wired up" is wrong — it exits 0. Wiring any
  of this up needs a `ci.yml` edit, outside this PR's scope. Tracked as
  **AAASM-5374**.

Separately: the repo configures **no Python linting at all** — no `ruff`/`mypy`
config, no `pyproject.toml`, no `.pre-commit-config.yaml`, and no Python linter in
any workflow. `conformance/runner/*.py` is unlinted by construction. All three
files were checked with `python -m py_compile`.


[AAASM-5371]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ