### PR TITLE
[AAASM-5367] ✅ (aa-gateway): Make the hot-reload watcher test deterministic under load

### DIFF
--- a/aa-gateway/src/engine/watcher.rs
+++ b/aa-gateway/src/engine/watcher.rs
@@ -164,25 +164,30 @@ mod tests {
     /// (AAASM-5367).
     ///
     /// Filesystem notification delivery is a property of the platform backend,
-    /// not of this watcher. Measured on macOS/FSEvents, the same unchanged
-    /// watcher swapped anywhere between ~50 ms and ~6 s on an idle machine, and
-    /// a small fraction of writes produced no notification at all within 20 s.
-    /// Any fixed deadline short enough to be interesting is therefore a coin
-    /// flip — the old one-second sleep lost that flip on ~2 runs in 3 here.
-    /// This bound exists only so a watcher that has genuinely stopped working
-    /// fails instead of hanging; it is far above every observed success.
+    /// not of this watcher, and the two platforms are nothing alike. On Linux
+    /// (inotify — what CI runs) this test completes in **0.014 s**. On macOS
+    /// (FSEvents) the same unchanged watcher takes a median of **0.7 s**, a p90
+    /// of **5.7 s** and a worst case of **8.7 s** over 80 measured trials, and
+    /// up to **17 s** when a second workspace build shares the machine. Any
+    /// fixed deadline short enough to be interesting is therefore a coin flip on
+    /// macOS — the old one-second sleep lost that flip on ~2 runs in 3 here.
     ///
-    /// Sized against the worst case actually seen rather than a guess: during a
-    /// full `cargo nextest run --workspace` sharing the machine with a second
-    /// concurrent workspace build, this swap took **17 s**. Widening the bound
-    /// costs nothing on a healthy watcher — [`wait_for_swap`] returns the moment
-    /// the swap lands, so the bound is only ever reached when hot-reload is
-    /// genuinely broken.
+    /// So this is a backstop, not a deadline: it is only reached when the
+    /// watcher has stopped storing anything at all. The trade-off it carries,
+    /// which is real and worth stating: a *broken* watcher now costs 60 s per
+    /// attempt — with `retries = 2` in `.config/nextest.toml`, ~180 s and a
+    /// `SLOW` marker before the suite reports it. That is the deliberate price
+    /// of never failing a healthy watcher, and a healthy run pays none of it
+    /// because [`wait_for_swap`] returns the moment a store lands.
     const WATCH_LIVENESS_BOUND: Duration = Duration::from_secs(60);
 
     /// How long to wait for one application of the stimulus before re-applying
-    /// it. Chosen to comfortably exceed the common-case delivery latency so
-    /// re-writing is the exception, not the norm.
+    /// it.
+    ///
+    /// Re-writing is the *normal* path, not an exception: 55% of 80 measured
+    /// macOS runs needed more than one round (median 2, max 18). That is the
+    /// mechanism working as intended, not a symptom — see [`wait_for_swap`] for
+    /// why one write is not enough.
     const STIMULUS_ROUND: Duration = Duration::from_millis(500);
 
     fn parse_doc(yaml: &str) -> PolicyDocument {
@@ -194,11 +199,24 @@ mod tests {
     ///
     /// Two things make this deterministic where a fixed sleep was not. It polls
     /// instead of sleeping a fixed interval, so it returns as soon as the
-    /// watcher has acted — typically a few hundred milliseconds, i.e. *faster*
-    /// than the one-second sleep it replaces. And it re-applies the stimulus
-    /// each round, because a single write is not guaranteed to yield a
-    /// notification: with one write, 5 of 80 runs here saw nothing within 20 s;
-    /// re-writing rescued 80 of 80 (worst case 19 rounds).
+    /// watcher has acted rather than always paying a fixed wait. And it
+    /// re-applies the stimulus each round, because on macOS a single write is
+    /// not guaranteed to yield a notification at all.
+    ///
+    /// That second point was challenged in review and re-measured properly, as
+    /// 80 interleaved trials of one-write-only against this re-applying loop on
+    /// the same machine:
+    ///
+    /// | | one write | re-applied |
+    /// |---|---|---|
+    /// | never observed | **5 / 80 (6.25%)** | **0 / 80** |
+    /// | median latency | 0.85 s | 0.69 s |
+    /// | mean latency | 1.88 s | 1.84 s |
+    ///
+    /// Re-applying is what removes the misses, and it is not slower doing it —
+    /// the two latency distributions are indistinguishable. (A short run can
+    /// easily see 8/8 clean with one write; at a 6.25% miss rate that happens
+    /// 60% of the time, which is why the sample size matters here.)
     ///
     /// This does not weaken the property under test. The caller still asserts
     /// what landed in the slot; only "how promptly the OS reported the write"

--- a/aa-gateway/src/engine/watcher.rs
+++ b/aa-gateway/src/engine/watcher.rs
@@ -300,6 +300,43 @@ mod tests {
         f.flush().unwrap();
     }
 
+    /// A truncated policy file must not clobber the live policy (AAASM-3561).
+    ///
+    /// `handle_fs_event` skips zero-byte reads because a truncate-then-write
+    /// edit fires a Modify event for the empty file first. Without that guard an
+    /// empty document parses as a Global allow-all and would replace a deny
+    /// policy for the width of the write — a fail-*open* window. The guard had
+    /// no test of its own: deleting it left every other test in this module
+    /// green. The cascade watcher's equivalent is covered by
+    /// `cascade_hot_reload_invalid_yaml_preserves_cascade`; this is the
+    /// single-file twin.
+    #[test]
+    fn truncated_file_keeps_previous_policy() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path();
+
+        let initial_doc = parse_doc(DENY_YAML);
+        let slot = Arc::new(ArcSwap::new(Arc::new(initial_doc.clone())));
+
+        // Whitespace-only stands in for the mid-truncation read: it is what the
+        // watcher sees between the truncate and the new bytes landing.
+        write_file(path, "   \n");
+        handle_fs_event(modify_event(path), path, &slot);
+        assert_eq!(
+            *slot.load_full(),
+            initial_doc,
+            "a truncated file must not clobber the live policy with an allow-all"
+        );
+
+        write_file(path, ALLOW_YAML);
+        handle_fs_event(modify_event(path), path, &slot);
+        assert!(
+            slot.load_full().tools["search"].allow,
+            "control: the same event over valid YAML must reach the parse step \
+             and swap, otherwise the assertion above proves nothing"
+        );
+    }
+
     /// Drives [`handle_fs_event`] directly rather than through a real watcher
     /// (AAASM-5367).
     ///

--- a/aa-gateway/src/engine/watcher.rs
+++ b/aa-gateway/src/engine/watcher.rs
@@ -205,7 +205,7 @@ mod tests {
     /// stops being part of the assertion.
     fn wait_for_swap(
         slot: &ArcSwap<PolicyDocument>,
-        previous: &PolicyDocument,
+        previous: &Arc<PolicyDocument>,
         mut stimulus: impl FnMut(),
     ) -> Arc<PolicyDocument> {
         let start = std::time::Instant::now();
@@ -214,16 +214,24 @@ mod tests {
             let round = std::time::Instant::now();
             while round.elapsed() < STIMULUS_ROUND {
                 let current = slot.load_full();
-                if *current != *previous {
+                // Compare *identity*, not value. The handler allocates a fresh
+                // Arc for every store, so this observes the store itself rather
+                // than the store's effect. A value comparison would be blind to
+                // a watcher that swaps in a document equal to the live one —
+                // the natural shape of a "reload read stale content" bug — and
+                // would then time out and blame a watcher that is in fact
+                // firing constantly. The caller checks the content.
+                if !Arc::ptr_eq(&current, previous) {
                     return current;
                 }
                 std::thread::sleep(Duration::from_millis(5));
             }
         }
         panic!(
-            "watcher never swapped the policy slot within {WATCH_LIVENESS_BOUND:?} \
-             despite the policy file being rewritten every {STIMULUS_ROUND:?} — \
-             hot-reload is broken"
+            "watcher stored nothing into the policy slot within \
+             {WATCH_LIVENESS_BOUND:?}, despite the policy file being rewritten \
+             every {STIMULUS_ROUND:?} — the watcher is not firing at all, or is \
+             firing but rejecting the content it reads"
         );
     }
 
@@ -233,14 +241,14 @@ mod tests {
         write!(tmp, "{}", ALLOW_YAML).unwrap();
         tmp.flush().unwrap();
 
-        let initial_doc = parse_doc(ALLOW_YAML);
-        let slot = Arc::new(ArcSwap::new(Arc::new(initial_doc.clone())));
+        let initial = Arc::new(parse_doc(ALLOW_YAML));
+        let slot = Arc::new(ArcSwap::new(initial.clone()));
 
         let _watcher = start_watcher(tmp.path(), slot.clone()).unwrap();
 
         // Overwrite the file with the DENY policy until the watcher reports it.
         let path = tmp.path().to_path_buf();
-        let current_doc = wait_for_swap(&slot, &initial_doc, || {
+        let current_doc = wait_for_swap(&slot, &initial, || {
             let mut f = std::fs::OpenOptions::new()
                 .write(true)
                 .truncate(true)

--- a/aa-gateway/src/engine/watcher.rs
+++ b/aa-gateway/src/engine/watcher.rs
@@ -159,12 +159,68 @@ mod tests {
     const ALLOW_YAML: &str = "version: \"1\"\ntools:\n  search:\n    allow: true\n";
     const DENY_YAML: &str = "version: \"1\"\ntools:\n  search:\n    allow: false\n";
 
+    /// Overall bound on observing a hot-reload, and *not* a latency assertion
+    /// (AAASM-5367).
+    ///
+    /// Filesystem notification delivery is a property of the platform backend,
+    /// not of this watcher. Measured on macOS/FSEvents, the same unchanged
+    /// watcher swapped anywhere between ~50 ms and ~6 s on an idle machine, and
+    /// a small fraction of writes produced no notification at all within 20 s.
+    /// Any fixed deadline short enough to be interesting is therefore a coin
+    /// flip — the old one-second sleep lost that flip on ~2 runs in 3 here.
+    /// This bound exists only so a watcher that has genuinely stopped working
+    /// fails instead of hanging; it is far above every observed success.
+    const WATCH_LIVENESS_BOUND: Duration = Duration::from_secs(30);
+
+    /// How long to wait for one application of the stimulus before re-applying
+    /// it. Chosen to comfortably exceed the common-case delivery latency so
+    /// re-writing is the exception, not the norm.
+    const STIMULUS_ROUND: Duration = Duration::from_millis(500);
+
     fn parse_doc(yaml: &str) -> PolicyDocument {
         PolicyValidator::from_yaml(yaml).unwrap().document
     }
 
+    /// Drive `stimulus` until `slot` holds something other than `previous`,
+    /// returning whatever was swapped in.
+    ///
+    /// Two things make this deterministic where a fixed sleep was not. It polls
+    /// instead of sleeping a fixed interval, so it returns as soon as the
+    /// watcher has acted — typically a few hundred milliseconds, i.e. *faster*
+    /// than the one-second sleep it replaces. And it re-applies the stimulus
+    /// each round, because a single write is not guaranteed to yield a
+    /// notification: with one write, 5 of 80 runs here saw nothing within 20 s;
+    /// re-writing rescued 80 of 80 (worst case 19 rounds).
+    ///
+    /// This does not weaken the property under test. The caller still asserts
+    /// what landed in the slot; only "how promptly the OS reported the write"
+    /// stops being part of the assertion.
+    fn wait_for_swap(
+        slot: &ArcSwap<PolicyDocument>,
+        previous: &PolicyDocument,
+        mut stimulus: impl FnMut(),
+    ) -> Arc<PolicyDocument> {
+        let start = std::time::Instant::now();
+        while start.elapsed() < WATCH_LIVENESS_BOUND {
+            stimulus();
+            let round = std::time::Instant::now();
+            while round.elapsed() < STIMULUS_ROUND {
+                let current = slot.load_full();
+                if *current != *previous {
+                    return current;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        }
+        panic!(
+            "watcher never swapped the policy slot within {WATCH_LIVENESS_BOUND:?} \
+             despite the policy file being rewritten every {STIMULUS_ROUND:?} — \
+             hot-reload is broken"
+        );
+    }
+
     #[test]
-    fn hot_reload_reflects_new_policy_within_one_second() {
+    fn hot_reload_swaps_in_the_new_policy() {
         let mut tmp = NamedTempFile::new().unwrap();
         write!(tmp, "{}", ALLOW_YAML).unwrap();
         tmp.flush().unwrap();
@@ -174,24 +230,20 @@ mod tests {
 
         let _watcher = start_watcher(tmp.path(), slot.clone()).unwrap();
 
-        // Overwrite file with DENY policy.
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(tmp.path())
-            .unwrap();
-        write!(f, "{}", DENY_YAML).unwrap();
-        f.flush().unwrap();
-        drop(f);
+        // Overwrite the file with the DENY policy until the watcher reports it.
+        let path = tmp.path().to_path_buf();
+        let current_doc = wait_for_swap(&slot, &initial_doc, || {
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(&path)
+                .unwrap();
+            write!(f, "{}", DENY_YAML).unwrap();
+            f.flush().unwrap();
+        });
 
-        std::thread::sleep(Duration::from_secs(1));
-
-        let loaded = slot.load();
-        let current_doc: &PolicyDocument = &loaded;
-        assert_ne!(
-            current_doc, &initial_doc,
-            "slot should have been swapped to the new policy"
-        );
+        // Assert on *what* was swapped in: a swap to the wrong document fails
+        // here immediately rather than being waited out.
         assert!(
             !current_doc.tools["search"].allow,
             "search.allow should be false after hot-reload"

--- a/aa-gateway/src/engine/watcher.rs
+++ b/aa-gateway/src/engine/watcher.rs
@@ -171,7 +171,14 @@ mod tests {
     /// flip — the old one-second sleep lost that flip on ~2 runs in 3 here.
     /// This bound exists only so a watcher that has genuinely stopped working
     /// fails instead of hanging; it is far above every observed success.
-    const WATCH_LIVENESS_BOUND: Duration = Duration::from_secs(30);
+    ///
+    /// Sized against the worst case actually seen rather than a guess: during a
+    /// full `cargo nextest run --workspace` sharing the machine with a second
+    /// concurrent workspace build, this swap took **17 s**. Widening the bound
+    /// costs nothing on a healthy watcher — [`wait_for_swap`] returns the moment
+    /// the swap lands, so the bound is only ever reached when hot-reload is
+    /// genuinely broken.
+    const WATCH_LIVENESS_BOUND: Duration = Duration::from_secs(60);
 
     /// How long to wait for one application of the stimulus before re-applying
     /// it. Chosen to comfortably exceed the common-case delivery latency so

--- a/aa-gateway/src/engine/watcher.rs
+++ b/aa-gateway/src/engine/watcher.rs
@@ -153,6 +153,7 @@ fn is_yaml_path(path: &Path) -> bool {
 mod tests {
     use super::*;
     use arc_swap::ArcSwap;
+    use notify::event::{DataChange, ModifyKind};
     use std::{io::Write, sync::Arc, time::Duration};
     use tempfile::NamedTempFile;
 
@@ -250,34 +251,57 @@ mod tests {
         );
     }
 
+    /// A content-change `Modify` event for `path`, shaped as the notify
+    /// backends report one.
+    fn modify_event(path: &Path) -> notify::Result<notify::Event> {
+        Ok(notify::Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content))).add_path(path.to_path_buf()))
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .unwrap();
+        write!(f, "{}", contents).unwrap();
+        f.flush().unwrap();
+    }
+
+    /// Drives [`handle_fs_event`] directly rather than through a real watcher
+    /// (AAASM-5367).
+    ///
+    /// This asserts a *negative* — that nothing is swapped in — so waiting a
+    /// fixed second for a notification made it pass for the wrong reason
+    /// whenever the notification simply hadn't arrived yet, which measurement
+    /// showed is the common case. Feeding the handler the event removes the
+    /// notification path from the test entirely: the ignore-invalid-content
+    /// decision is exercised on every run, deterministically and instantly.
+    ///
+    /// The valid-content half is the control that keeps the negative honest —
+    /// it proves this event actually reaches the parse step, so the first
+    /// assertion cannot pass merely because the handler discarded the event.
     #[test]
     fn invalid_yaml_keeps_previous_policy() {
-        let mut tmp = NamedTempFile::new().unwrap();
-        write!(tmp, "{}", ALLOW_YAML).unwrap();
-        tmp.flush().unwrap();
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path();
 
         let initial_doc = parse_doc(ALLOW_YAML);
         let slot = Arc::new(ArcSwap::new(Arc::new(initial_doc.clone())));
 
-        let _watcher = start_watcher(tmp.path(), slot.clone()).unwrap();
-
-        // Overwrite file with invalid YAML.
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(tmp.path())
-            .unwrap();
-        write!(f, "invalid: yaml: [[[").unwrap();
-        f.flush().unwrap();
-        drop(f);
-
-        std::thread::sleep(Duration::from_secs(1));
-
-        let loaded = slot.load();
-        let current_doc: &PolicyDocument = &loaded;
+        write_file(path, "invalid: yaml: [[[");
+        handle_fs_event(modify_event(path), path, &slot);
         assert_eq!(
-            current_doc, &initial_doc,
+            *slot.load_full(),
+            initial_doc,
             "slot should still hold the original policy after an invalid parse"
+        );
+
+        write_file(path, DENY_YAML);
+        handle_fs_event(modify_event(path), path, &slot);
+        assert!(
+            !slot.load_full().tools["search"].allow,
+            "control: the same event over valid YAML must reach the parse step \
+             and swap, otherwise the assertion above proves nothing"
         );
     }
 }

--- a/aa-gateway/src/engine/watcher.rs
+++ b/aa-gateway/src/engine/watcher.rs
@@ -218,6 +218,14 @@ mod tests {
     /// easily see 8/8 clean with one write; at a 6.25% miss rate that happens
     /// 60% of the time, which is why the sample size matters here.)
     ///
+    /// The limit of what this proves, stated so nobody over-reads it: because
+    /// the stimulus repeats, a *lossy* watcher still passes. A mutant dropping
+    /// 49 of every 50 notifications is not caught — it merely takes ~24 s. The
+    /// test therefore proves hot-reload works, not that it works promptly, and
+    /// it cannot distinguish a healthy watcher from a badly degraded one. That
+    /// is the deliberate cost of tolerating a platform which loses ~6% of
+    /// notifications on its own; a test that failed on loss would flake.
+    ///
     /// This does not weaken the property under test. The caller still asserts
     /// what landed in the slot; only "how promptly the OS reported the write"
     /// stops being part of the assertion.


### PR DESCRIPTION
## Description

`engine::watcher::tests::hot_reload_reflects_new_policy_within_one_second` asserted that a
filesystem-notification round-trip completes inside a fixed one-second wall-clock budget. That
budget is a property of the platform's notification backend, not of the watcher — so the test was
a coin flip, and it made `cargo nextest run --workspace` an unreliable gate.

This PR makes both tests in `aa-gateway/src/engine/watcher.rs` deterministic. **Test-only change —
no production code is touched, and no production seam was introduced.**

### Root cause — confirmed by measurement, not assumed

The ticket's hypothesis was that the timing assumption, not the watcher, was at fault. I confirmed
that before changing anything, by instrumenting the swap and polling for up to 30 s:

* Over 50 instrumented runs (idle and under CPU load) the watcher **always** swapped. Latency
  ranged from **52 ms to 6.05 s** — a >100x spread on the same unchanged code.
* Reproduced the original failure at **20 failures in 30 isolated runs** on this machine.

So the watcher's parse/swap logic is sound; the one-second deadline is the defect. There is no
documented one-second hot-reload SLO anywhere in the repo — `grep` finds the phrase only in the
test's own name, so the deadline was an invented assertion rather than a product property.

### A second cause the sleep had been hiding

Making the test wait properly surfaced something the fixed sleep could never distinguish: a single
write does **not** reliably produce a notification at all.

* With one write and a 20 s wait, **5 of 80 runs saw nothing** — not late, absent.
* Adding a 500 ms settle *before* the write did not help, so this is not a watcher-arming window.
* **Re-applying the write rescued 80 of 80 runs** (worst case 19 rounds).

This is macOS/FSEvents delivery behaviour, not a race in `handle_fs_event` — the swap logic is
never wrong, it just sometimes never gets told. Flagged separately below; it is not fixed here.

### Re-derivation after review: is the re-application causing the latency it cures?

Review measured a single write as ~5x faster and 8/8 reliable, and asked whether re-applying the
stimulus was self-inflicted slowness. Re-derived as **80 interleaved trials** of one-write-only
against the shipped loop on the same machine, alternating so both see identical conditions:

| | one write only | re-applied (shipped) |
|---|---|---|
| **never observed** | **5 / 80 (6.25%)** | **0 / 80** |
| median latency | 0.85 s | 0.69 s |
| mean latency | 1.88 s | 1.84 s |
| p90 latency | 4.96 s | 5.71 s |

The re-application is what removes the misses, and it is **not** slower doing it — the two latency
distributions are indistinguishable. The original 5/80 replicated exactly. Review's 8/8 is not in
conflict: at a 6.25% miss rate, 8 consecutive clean trials happen 60% of the time, which is why
the sample size is the whole argument here. **Mechanism kept, now with the numbers beside it.**

Review was right about the *description* though: re-writing is the normal path, not the exception
(55% of runs need more than one round, median 2, max 18), and "typically a few hundred
milliseconds" was quoted without naming a platform when the two differ by two orders of magnitude.
Both comments are corrected in `ac034e60`.

### Approach and why

**`hot_reload_swaps_in_the_new_policy`** (renamed; `git grep` over `remote/main` finds the old
name only inside `watcher.rs` itself, and no product doc claims a one-second reload SLO):
poll for the swap and **re-apply the stimulus each round**, bounded by a generous liveness limit.

* Rejected *widen the timeout* — explicitly ruled out by the ticket, and the measurements show why:
  a longer sleep still loses to the ~6% of writes that produce no notification at all.
* Rejected *inject the clock/debounce* — there is no debounce to inject; the latency is the OS's,
  so a production seam would buy nothing.
* Rejected `#[ignore]` — the property is worth testing on every run, and it can be.
* The 60 s bound is **not** the assertion. It exists only so a genuinely broken watcher fails
  instead of hanging, and it is far above every observed success. The assertion is still
  *what* landed in the slot, so a swap to the wrong document fails immediately rather than being
  waited out. In the common case the test now returns in a few hundred milliseconds — **faster**
  than the one-second sleep it replaces. It was sized against the measured 17 s worst case from
  the workspace run below (third commit), not guessed. Note this is categorically different from
  the "just widen the timeout" the ticket rules out: a widened *sleep* is paid on every healthy
  run, whereas this bound is paid only when hot-reload is actually broken.

**`invalid_yaml_keeps_previous_policy`**: this asserts a *negative* — a bad edit must not clobber
the live policy — and an untouched slot is also exactly what you see when the notification never
arrived. Given the measurements above, it was largely passing **without ever reaching the parse it
claims to cover**, while spending a wall-clock second doing so. It now feeds the handler the event
directly, which removes the notification path from a test that was never about notifications. A
valid-content control follows the negative so the event shape is proven to reach the parse step —
otherwise the negative could pass merely because the handler discarded the event. End-to-end
coverage from a real filesystem write through to a swap stays with the other test.

### Mutation proof — the tests still catch a broken watcher

Each mutation was applied to production code, built, run, and reverted:

| Mutation | hot_reload | invalid_yaml | truncated_file |
|---|---|---|---|
| M1 — `start_watcher` never calls `watch()` | **caught** | pass¹ | pass¹ |
| M2 — bad edit fails **open** (invalid YAML clobbers with an allow-all) | pass | **caught** | pass |
| M3 — handler never swaps | **caught** | **caught** | **caught** |
| M6 — reload reads **stale** content (stores a doc *equal* to the live one) | **caught** | pass | pass |
| M7 — delete the empty-file fail-closed guard | pass | pass | **caught** |
| M8 — watcher drops 49 of every 50 notifications | **pass — not caught** | pass | pass |

¹ by design: those two bypass the watcher entirely.

Every mutation except M8 is caught by exactly the test that owns the property.

**M8 is reported as a negative result, against the review's expectation.** A watcher dropping 49 of
every 50 notifications is *not* caught — it merely takes ~24 s, because the stimulus repeats for a
minute and one delivery in fifty is still a delivery. So the test proves hot-reload works, not that
it works promptly, and cannot separate a healthy watcher from a badly degraded one. Tolerating loss
is deliberate (macOS drops ~6% unprompted; failing on loss would *be* the flake), but the limit is
now written into the code rather than assumed.

**M6 is what commit `17ff5275` fixes.** Before it, a stale-content watcher made the test wait out
the full bound and report "never swapped — hot-reload is broken", which is the wrong diagnosis and
makes the bound the assertion for that whole class. `wait_for_swap` now compares `Arc` identity, so
the store itself is observed and the content check decides: M6 now fails in 18 s on
`search.allow should be false after hot-reload`.

### Repetition evidence

| Scenario | Result |
|---|---|
| **Before** — old test, isolated | **10 pass / 20 fail** in 30 runs |
| After — `hot_reload_swaps_in_the_new_policy`, isolated | **100 / 100** |
| After — `hot_reload_swaps_in_the_new_policy`, under 12-way CPU load | **60 / 60** |
| After — `invalid_yaml_keeps_previous_policy`, isolated | **50 / 50** |
| After — `invalid_yaml_keeps_previous_policy`, under 12-way CPU load | **60 / 60** |
| After — both tests at the 60 s bound, sharing the machine with another agent's workspace build | **40 / 40** each |
| **Final head**, all three tests, 40 reps each | **40 / 40 / 40** |

200 post-fix repetitions of the previously-flaky test plus the two full-workspace runs, 0 failures.

### Real test output

`cargo nextest run -p aa-gateway engine::watcher` — 3 consecutive repetitions:

```
    Starting 2 tests across 68 binaries (1479 tests skipped)
        PASS [   0.018s] (1/2) aa-gateway engine::watcher::tests::invalid_yaml_keeps_previous_policy
        PASS [   1.202s] (2/2) aa-gateway engine::watcher::tests::hot_reload_swaps_in_the_new_policy
     Summary [   1.202s] 2 tests run: 2 passed, 1479 skipped

        PASS [   0.023s] (1/2) aa-gateway engine::watcher::tests::invalid_yaml_keeps_previous_policy
        PASS [   0.550s] (2/2) aa-gateway engine::watcher::tests::hot_reload_swaps_in_the_new_policy
     Summary [   0.552s] 2 tests run: 2 passed, 1479 skipped

        PASS [   0.014s] (1/2) aa-gateway engine::watcher::tests::invalid_yaml_keeps_previous_policy
        PASS [   1.161s] (2/2) aa-gateway engine::watcher::tests::hot_reload_swaps_in_the_new_policy
     Summary [   1.162s] 2 tests run: 2 passed, 1479 skipped
```

`cargo nextest run -p aa-gateway` (in-crate parallelism):

```
     Summary [ 286.368s] 1481 tests run: 1481 passed (1 slow, 1 leaky), 0 skipped
```

**`cargo nextest run --workspace` — settled by CI, which is the gate that counts.**
Run [30717327263](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/30717327263) on
this head — **6367/6367 passed in 205.8 s**, 30/30 checks green, all four workflows success:

```
        PASS [   0.007s] (3305/6367) aa-gateway engine::watcher::tests::invalid_yaml_keeps_previous_policy
        PASS [   0.007s] (3306/6367) aa-gateway engine::watcher::tests::truncated_file_keeps_previous_policy
        PASS [   0.013s] (3307/6367) aa-gateway engine::watcher::tests::hot_reload_swaps_in_the_new_policy
     Summary [ 205.774s] 6367 tests run: 6367 passed, 11 skipped
```

**0.013 s on Linux.** On inotify the notification is effectively instantaneous, the re-application
loop never reaches a second round in CI, and the AC "workspace suite completes without hitting
nextest's global timeout" is satisfied outright. An earlier revision of this description argued
that point at length from a *truncated local* run instead of citing this green CI run — that was
the wrong evidence to lead with. (Related: nextest has no 600 s global timeout; the number in the
ticket was a tool timeout misread as a runner limit.)

For completeness, the local macOS picture that motivated the sizing: a workspace run there reached
4763 tests / 0 failures with both watcher tests green, the hot-reload one taking **17.0 s** under a
concurrent second workspace build. That 17 s is why the backstop is 60 s. The bound gates only the
outer retry loop — success returns from the inner one — so raising it can only turn a fail into a
pass. Its real cost lands on a *broken* watcher: ~180 s with `retries = 2`, now stated in the code.

`cargo clippy -p aa-gateway --all-targets --all-features -- -D warnings` — exit 0. The 6 warnings
emitted are pre-existing `Cargo.toml` `default-features` manifest notices in `aa-core`,
`aa-integration-tests` and `aa-storage-postgres`, not clippy lints and not from this change.

`cargo fmt --all -- --check` — clean.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Test-only. No production code, schema, contract or behaviour change. In particular the debounce
interval did **not** need to become injectable, so the production-visible seam the ticket
pre-authorised was not required.

## Related Issues

- Related Jira ticket: [AAASM-5367](https://lightning-dust-mite.atlassian.net/browse/AAASM-5367)
- Related GitHub issues: N/A

## Follow-up worth its own ticket

Not fixed here, and not a regression from this PR: on macOS a single write to the watched policy
file intermittently produces **no** notification at all (5 of 80 measured runs saw nothing within
20 s). In production this would mean an operator's policy edit is silently missed, leaving the
gateway on stale policy until the next write. The exposure is low — the gateway runs on Linux
(inotify) in production, and macOS is a dev-machine platform — and the cause is FSEvents/`notify`
delivery rather than anything in `handle_fs_event`. Worth tracking separately; raising it now so
it is not lost.

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)


[AAASM-5367]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ