### PR TITLE
[AAASM-5348] 📝 (docs): Document the proxy bind refusal and --allow-remote-clients

### DIFF
--- a/docs/src/cli/proxy.md
+++ b/docs/src/cli/proxy.md
@@ -32,7 +32,8 @@ attacker-planted `aa-proxy`.
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--listen <LISTEN>` | string | `127.0.0.1:8899` (env `AA_PROXY_ADDR`) | Address the proxy listens on. |
+| `--listen <LISTEN>` | string | `127.0.0.1:8899` (env `AA_PROXY_ADDR`) | Address the proxy listens on. **Must be loopback with a named port** — see below. |
+| `--allow-remote-clients` | flag | off | State that a non-loopback `--listen` is intended. Does not currently permit one — see below. |
 | `--gateway <GATEWAY>` | string | env `AA_GATEWAY_URL` | Gateway URL to forward policy decisions to. |
 | `--ca-dir <CA_DIR>` | path | env `AA_CA_DIR` | Directory for CA certificate and key storage. |
 | `--no-detach` | flag | off | Run in the foreground instead of daemonizing. |
@@ -41,6 +42,52 @@ attacker-planted `aa-proxy`.
 ```bash
 aasm proxy start --listen 127.0.0.1:8899 --gateway http://localhost:50051
 ```
+
+### The listen address must be loopback, and must name its port
+
+`--listen` is checked before anything is spawned and before a state file is
+written, so a refused start leaves nothing behind (AAASM-5348). Two addresses
+that used to start a proxy no longer do:
+
+* **A non-loopback address** — `0.0.0.0`, a LAN address, `[::]`. The proxy reads
+  intercepted traffic under a CA this machine trusts and injects your provider
+  credentials into forwarded requests, so anything that can reach the listener
+  can do both.
+* **Port `0`** — it asks the OS for any free port, but the recorded endpoint
+  would still say `0`. The proxy would bind a real port that nothing can name:
+  `aasm run` refuses a port-0 endpoint, `aasm proxy stop` could not reach the
+  process, and the start would report failure while the proxy kept running.
+
+Both previously succeeded and produced an endpoint `aasm run` would then refuse
+to route a governed tool at — a proxy that worked for everything except the one
+job it exists to do. `aasm proxy start` and `aasm run` now apply the same test,
+so an address one accepts is an address the other trusts.
+
+### `--allow-remote-clients` states intent, and still refuses
+
+Intent is not authorization. A proxy reachable from other hosts also needs TLS
+on its listener and client authentication — **`aa-proxy` implements neither**,
+so the flag currently changes only which refusal you get:
+
+```console
+$ aasm proxy start --listen 0.0.0.0:8899 --allow-remote-clients
+error: refusing to listen on 0.0.0.0:8899: --allow-remote-clients was given, but
+a proxy reachable from other hosts also requires protection aa-proxy does not
+implement: TLS on the proxy listener, client authentication and authorization.
+Being reachable is not being trusted — without those, every host that can route
+to 0.0.0.0:8899 is an authorized client of an interception endpoint that holds
+CA material and provider credentials. Listen on a loopback address instead.
+```
+
+The flag exists rather than being omitted because a refusal that names the two
+missing protections is more useful than one that says only "not supported", and
+because the guard relaxes on its own once either protection is implemented. To
+reach another machine's proxy today, forward the loopback port over SSH.
+
+> **`AA_PROXY_ADDR` is not covered by this check.** The guard lives in
+> `aasm proxy start`; running the `aa-proxy` binary directly with a non-loopback
+> `AA_PROXY_ADDR` — which is what the container image and the self-hosting
+> example do — still binds it. Tracked as AAASM-5370.
 
 ---
 


### PR DESCRIPTION
## Description

`aasm proxy start` changed a shipped CLI contract in #1886 (AAASM-5348) and added a flag, and the reference page was not touched. This documents both.

Three gaps, all in `docs/src/cli/proxy.md`:

- **`--allow-remote-clients` appeared nowhere in `docs/`.** A new flag, undocumented.
- **`--listen` was documented with no mention that a non-loopback value is now refused** — a breaking change an operator would meet as an unexplained error.
- **Port 0 is refused too**, and for a reason worth stating: the child binds a real port that nothing records, the five-second wait on port 0 fails, the pid file is removed, and the proxy keeps running with nothing able to name or stop it.

## The refusal text is verbatim, not paraphrased

The point of naming the two missing protections in the refusal is that the operator reads them, so the console block reproduces the `Display` impl exactly. Machine-diffed against `aa-proxy/src/config.rs:283-289` after normalising whitespace and substituting `{addr}` / `{}` — **exact match**. If that string is ever reworded, this page should be reworded with it.

## What this page now says that it did not

The guard lives in `aasm proxy start`. Running the `aa-proxy` binary directly with a non-loopback `AA_PROXY_ADDR` — which is exactly what `aa-proxy/Dockerfile:41` and `examples/docker-compose/docker-compose.yml` do — **still binds it**. Leaving that out would let the reference page imply a protection that is not there for the deployment shape most likely to be exposed. Called out with a pointer to **AAASM-5370**, which owns that exposure.

It also directs operators who genuinely need to reach another machine's proxy at SSH port-forwarding, rather than leaving "not supported" as the whole answer.

## Type of Change

- [x] 📝 Documentation

## Breaking Changes

- [ ] No — documents a breaking change made in #1886; changes no behaviour itself.

## Related Issues

- Jira ticket: AAASM-5348 (documentation follow-up to #1886, `80f8ef01`)
- References AAASM-5370

## Testing

`mdbook build` succeeds. `scripts/check-doc-orphans.sh` clean. `scripts/check-doc-links.sh docs/src/cli/proxy.md` — all internal links resolve. The refusal-string diff described above is the substantive check; `mdbook` would happily build a page that misquotes the binary.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Note on how this was found

Not by review of #1886 — I merged that PR without noticing its docs were missing. It surfaced afterwards, checking whether the two merges that landed minutes apart (`5906f3b4` docs, `80f8ef01` code) were mutually consistent. A three-code-file diff with no docs change is exactly the shape that passes a checks list and leaves a contract undocumented.
