### PR TITLE
[AAASM-5355] ✨ (aa-core): Add SensitiveDataDecisionEvent and normalized finding records

### DIFF
--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -71,6 +71,12 @@ pub enum PolicyDecision {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+// Schema-described because `ExecutionEvidence` embeds the mode: whether
+// enforcement was applied or merely computed is condition 4 of ADR 0032 §8's
+// prevention test, so a consumer reading the schema of a sensitive-data event
+// has to see it. Additive and feature-gated — no other type in this module is
+// schema-described, and none needs to be.
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum EnforcementMode {
     /// Default: deny blocks, redact strips, pending halts execution.
     #[default]

--- a/aa-core/src/types/mod.rs
+++ b/aa-core/src/types/mod.rs
@@ -14,6 +14,11 @@
 mod agent_id;
 mod audit_event;
 mod credential;
+// Gated on `std` rather than `alloc` because the sensitive-data records are
+// built from `aa-security`'s canonical finding model, and `aa-security` is only
+// a dependency under `std` (see this crate's `Cargo.toml`).
+#[cfg(feature = "std")]
+pub mod sensitive_data;
 mod session_ctx;
 
 pub use agent_id::{AgentId, AgentIdParseError};

--- a/aa-core/src/types/sensitive_data/category_label.rs
+++ b/aa-core/src/types/sensitive_data/category_label.rs
@@ -1,0 +1,230 @@
+//! The rendered canonical category, as it appears in a record.
+
+use alloc::string::{String, ToString};
+
+use aa_security::canonical::CanonicalCategory;
+
+use super::guard::{check_shape, FieldRejection, MAX_LABEL_BYTES};
+
+/// A canonical category in its rendered `BASE` or `BASE[qualifier]` form.
+///
+/// # Why a record stores the rendering and not the category
+///
+/// Not a stylistic choice — `aa-security`'s [`CanonicalCategory`] implements
+/// `Serialize` and deliberately **not** `Deserialize`, so that a finding is
+/// never reconstructed from bytes but always derived from something the process
+/// detected. A record that has to round-trip through storage therefore cannot
+/// hold one directly, and `aa-core` cannot add the missing impl: both the type
+/// and the trait are foreign.
+///
+/// So a record stores what `Display` produced. That is not a downgrade: ADR
+/// 0032 §2 makes the rendered form *the* contract, which is why AAASM-5352
+/// hand-wrote `Serialize` to emit exactly it.
+///
+/// # Reading one back, and the reader that is deliberately absent
+///
+/// [`resolve`](Self::resolve) returns `Option<CanonicalCategory>`, `None` for a
+/// category this build does not know — a locale category from AAASM-5353 read
+/// by a build that predates it, say.
+///
+/// `aa-security`'s `ParseCategoryError::UnknownCategory` records that a weaker,
+/// display-only reader — a `parse_base` handing back `NATIONAL_ID` from
+/// `NATIONAL_ID[zh-TW/arc_new]` — would belong with this ticket's projection if
+/// one were wanted. **It is not added, and the reasoning is worth keeping.**
+///
+/// - Nothing needs it. The dashboard renders a category; it does not have to
+///   understand one. [`as_str`](Self::as_str) hands over the rendered string
+///   verbatim, which displays a category from a newer build *perfectly* — better
+///   than a partial parse, which would show `NATIONAL_ID` and silently discard
+///   the jurisdiction that says what the finding means.
+/// - Adding it here would put a second parser for `aa-security`'s vocabulary in
+///   a different crate, free to drift from the catalogue it mirrors.
+/// - `aa-core` is not only read by dashboards. A `parse_base` sitting in the
+///   shared domain crate is reachable from an enforcement path, and a partial
+///   category is exactly the confident-looking wrong answer ADR 0032 §5 exists
+///   to prevent.
+///
+/// If a concrete reader ever needs base-level routing, the honest place for it
+/// is `aa-security` beside the catalogue, named so it says it is doing
+/// something weaker — not here, and not before there is a caller.
+///
+/// # Unknown labels survive
+///
+/// Deserialization accepts any well-shaped label, including one this build
+/// cannot resolve. An audit record read by an older build must round-trip
+/// intact; dropping a field because the reader is behind the writer loses data
+/// permanently, and the record is the evidence.
+///
+/// # Wire format
+///
+/// Serializes transparently as the rendered string:
+///
+/// ```json
+/// "ACCESS_TOKEN[github:personal_access]"
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(transparent))]
+pub struct CategoryLabel(String);
+
+impl CategoryLabel {
+    /// Accept a label read from storage, or say why not.
+    ///
+    /// Prefer [`From<CanonicalCategory>`](#impl-From<CanonicalCategory>) when
+    /// the category is in hand — it cannot fail and cannot produce a label
+    /// outside this build's catalogue. This constructor exists for the read
+    /// path, where the label came from a record rather than from a detector.
+    ///
+    /// # Errors
+    ///
+    /// [`FieldRejection::Empty`], [`FieldRejection::TooLong`] past
+    /// [`MAX_LABEL_BYTES`](super::MAX_LABEL_BYTES), or
+    /// [`FieldRejection::ControlCharacter`]. Not screened with the credential
+    /// scanner: a rendered category is generated from a compiled-in catalogue,
+    /// never lifted out of scanned bytes.
+    pub fn new(label: impl Into<String>) -> Result<Self, FieldRejection> {
+        let label = label.into();
+        check_shape(&label, MAX_LABEL_BYTES)?;
+        Ok(Self(label))
+    }
+
+    /// The rendered category, exactly as written.
+    ///
+    /// Always safe to display, including for a category this build does not
+    /// know — which is the whole reason no partial parse is offered.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The category this label names, or `None` if this build has never heard
+    /// of it.
+    ///
+    /// `None` is not an error to paper over: it means a newer build produced
+    /// the record. Display the label, do not guess at the category.
+    pub fn resolve(&self) -> Option<CanonicalCategory> {
+        self.0.parse().ok()
+    }
+}
+
+impl From<CanonicalCategory> for CategoryLabel {
+    fn from(category: CanonicalCategory) -> Self {
+        Self(category.to_string())
+    }
+}
+
+impl core::fmt::Display for CategoryLabel {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every category this build can produce survives the round-trip through a
+    /// record and back.
+    ///
+    /// This is the fidelity claim the whole design rests on — if rendering and
+    /// resolving are not inverse, a stored event names a category that cannot
+    /// be read back. It also demonstrates the bounded cardinality ADR 0032 §9
+    /// requires of a metric label: the label domain *is*
+    /// `CanonicalCategory::ALL`, a compile-time list.
+    #[test]
+    fn every_known_category_round_trips_through_its_label() {
+        for category in CanonicalCategory::ALL {
+            let label = CategoryLabel::from(*category);
+            assert_eq!(
+                label.resolve(),
+                Some(*category),
+                "category {label} did not resolve back to itself"
+            );
+        }
+        assert!(
+            !CanonicalCategory::ALL.is_empty(),
+            "an empty catalogue would make this vacuous"
+        );
+    }
+
+    /// A locale-qualified category this build does not know resolves to `None`
+    /// and — the part that matters — is **not** degraded to its base.
+    ///
+    /// This is the shape AAASM-5353's locale packs have. A reader that answered
+    /// `NATIONAL_ID` here would be discarding the jurisdiction, which is what
+    /// says whether the finding is a residence certificate or something else
+    /// entirely. This test is the record of that decision: add a partial parse
+    /// and it fails.
+    ///
+    /// The locale is deliberately synthetic (`xx-ZZ`, a reserved-for-private-use
+    /// tag) rather than a real one. A real locale would stop being unknown the
+    /// moment a locale pack landed, and this test would then be asserting the
+    /// opposite of what it was written to assert.
+    #[test]
+    fn an_unknown_category_resolves_to_none_and_is_never_degraded_to_its_base() {
+        let rendered = "NATIONAL_ID[xx-ZZ/synthetic_for_test]";
+        let label = CategoryLabel::new(rendered).unwrap();
+
+        assert!(
+            label.as_str().starts_with("NATIONAL_ID"),
+            "the base is plainly legible in the rendering — that is what makes the temptation real"
+        );
+        assert_eq!(
+            label.resolve(),
+            None,
+            "a legible base must still not be handed back as a partial category"
+        );
+        assert_eq!(label.as_str(), rendered, "the full rendering survives for display");
+    }
+
+    /// The label is displayable whatever it holds — the property that makes a
+    /// weaker display-only parser unnecessary.
+    #[test]
+    fn an_unresolvable_label_still_displays_verbatim() {
+        let label = CategoryLabel::new("SOMETHING_THIS_BUILD_HAS_NEVER_SEEN[xx-YY/whatever]").unwrap();
+        assert_eq!(
+            alloc::format!("{label}"),
+            "SOMETHING_THIS_BUILD_HAS_NEVER_SEEN[xx-YY/whatever]"
+        );
+    }
+
+    #[test]
+    fn a_malformed_label_is_refused() {
+        assert_eq!(CategoryLabel::new(""), Err(FieldRejection::Empty));
+        assert_eq!(CategoryLabel::new("API\nKEY"), Err(FieldRejection::ControlCharacter));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::*;
+
+    /// The label serializes to the same string `aa-security` emits for the
+    /// category itself, so a record's category field and a canonical finding's
+    /// category field are the same bytes. If they diverged, an event and the
+    /// audit-tier finding it came from would disagree about what was found.
+    #[test]
+    fn a_label_serializes_identically_to_the_category_it_came_from() {
+        for category in CanonicalCategory::ALL {
+            let label = CategoryLabel::from(*category);
+            assert_eq!(
+                serde_json::to_string(&label).unwrap(),
+                serde_json::to_string(category).unwrap(),
+                "label and category serialized differently for {category}"
+            );
+        }
+    }
+
+    /// A record written by a newer build survives being read and written again
+    /// by an older one. Dropping the field would lose it permanently.
+    #[test]
+    fn an_unknown_label_round_trips_intact() {
+        // Synthetic locale, for the same reason as the resolve test: a real one
+        // stops being unknown as soon as a locale pack ships.
+        let json = r#""NATIONAL_ID[xx-ZZ/synthetic_for_test]""#;
+        let label: CategoryLabel = serde_json::from_str(json).unwrap();
+        assert_eq!(label.resolve(), None);
+        assert_eq!(serde_json::to_string(&label).unwrap(), json);
+    }
+}

--- a/aa-core/src/types/sensitive_data/category_label.rs
+++ b/aa-core/src/types/sensitive_data/category_label.rs
@@ -48,12 +48,24 @@ use super::guard::{check_shape, FieldRejection, MAX_LABEL_BYTES};
 /// is `aa-security` beside the catalogue, named so it says it is doing
 /// something weaker — not here, and not before there is a caller.
 ///
-/// # Unknown labels survive
+/// # Unknown labels survive, but only well-shaped ones
 ///
-/// Deserialization accepts any well-shaped label, including one this build
-/// cannot resolve. An audit record read by an older build must round-trip
-/// intact; dropping a field because the reader is behind the writer loses data
-/// permanently, and the record is the evidence.
+/// Deserialization accepts any label that passes [`CategoryLabel::new`]'s shape
+/// check, including one this build cannot resolve. An audit record read by an
+/// older build must round-trip intact; dropping a field because the reader is
+/// behind the writer loses data permanently, and the record is the evidence.
+///
+/// It is **not** closed over the catalogue, and cannot be: closing it would
+/// break exactly that round-trip. So a `CategoryLabel` is bounded in *shape*
+/// and unbounded in *value*, and any consumer that needs a bounded value —
+/// a metric label, above all — must resolve it rather than render it. That is
+/// why [`SensitiveDataMetricLabels`](super::SensitiveDataMetricLabels) holds a
+/// resolved [`CanonicalCategory`] and not one of these.
+///
+/// The shape check on the read path is deliberate rather than incidental: the
+/// derived `Deserialize` this once had ran no validation at all, so a stored
+/// record could carry any string here — including one long enough or noisy
+/// enough to be a payload fragment.
 ///
 /// # Wire format
 ///
@@ -63,11 +75,28 @@ use super::guard::{check_shape, FieldRejection, MAX_LABEL_BYTES};
 /// "ACCESS_TOKEN[github:personal_access]"
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(transparent))]
 pub struct CategoryLabel(String);
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for CategoryLabel {
+    /// Runs the same shape check as [`CategoryLabel::new`].
+    ///
+    /// Hand-written rather than derived for the reason
+    /// [`RuntimeVerdictLabel`](super::RuntimeVerdictLabel) is: a derived
+    /// `Deserialize` on a `serde(transparent)` newtype validates nothing, so
+    /// the guard on the write path would simply not exist on the read path.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error as _;
+        let label = String::deserialize(deserializer)?;
+        // The rejection is reported by Display, which never quotes the input —
+        // a label that failed the check is exactly the thing not to log.
+        Self::new(label).map_err(D::Error::custom)
+    }
+}
 
 impl CategoryLabel {
     /// Accept a label read from storage, or say why not.
@@ -176,6 +205,35 @@ mod tests {
             "a legible base must still not be handed back as a partial category"
         );
         assert_eq!(label.as_str(), rendered, "the full rendering survives for display");
+    }
+
+    /// The same rule, over a base that is in the catalogue **unqualified**.
+    ///
+    /// This case exists because the previous test is not enough on its own, and
+    /// the gap is subtle. `NationalId` appears in
+    /// [`CanonicalCategory::ALL`] only as `with_locale(…, "en-US", "ssn")`, so a
+    /// naive base-level fallback written as
+    /// `self.0.split('[').next()?.parse().ok()` finds nothing for
+    /// `NATIONAL_ID` and returns `None` anyway — passing the test it was
+    /// supposed to fail, for the wrong reason.
+    ///
+    /// `EMAIL_ADDRESS` *is* in the catalogue unqualified, so that same naive
+    /// fallback resolves `EMAIL_ADDRESS[xx-ZZ/…]` to
+    /// `unqualified(EmailAddress)` and this assertion catches it. Between the
+    /// two, both the faithful and the naive form of the fallback fail.
+    #[test]
+    fn a_qualified_form_of_a_catalogue_base_still_resolves_to_none() {
+        let label = CategoryLabel::new("EMAIL_ADDRESS[xx-ZZ/synthetic_for_test]").unwrap();
+
+        assert!(
+            CategoryLabel::new("EMAIL_ADDRESS").unwrap().resolve().is_some(),
+            "precondition: the bare base is in the catalogue, which is what makes this case bite"
+        );
+        assert_eq!(
+            label.resolve(),
+            None,
+            "a qualified category was degraded to the catalogue entry for its bare base"
+        );
     }
 
     /// The label is displayable whatever it holds — the property that makes a

--- a/aa-core/src/types/sensitive_data/counts.rs
+++ b/aa-core/src/types/sensitive_data/counts.rs
@@ -124,6 +124,23 @@ impl FindingCounts {
         let summed: u64 = self.by_category.iter().map(|entry| u64::from(entry.count)).sum();
         summed == u64::from(self.total)
     }
+
+    /// Whether `transformed + blocked` is within `total`.
+    ///
+    /// The read-path counterpart of the check
+    /// [`tally`](Self::tally) enforces at construction. It exists because
+    /// `tally` is not the only way to get a `FindingCounts`: deserializing one
+    /// runs no invariant at all, so a stored row can say `blocked: 99` against
+    /// `total: 1` — which is precisely the "prevention dashboard reporting more
+    /// blocked findings than there were findings" that
+    /// [`CountsError::DispositionCountsExceedTotal`] exists to prevent, arriving
+    /// at exactly the layer that reads.
+    ///
+    /// Always true for a tallied set; ask it of anything that came from storage,
+    /// as with [`breakdown_is_complete`](Self::breakdown_is_complete).
+    pub fn disposition_counts_are_consistent(&self) -> bool {
+        u64::from(self.transformed) + u64::from(self.blocked) <= u64::from(self.total)
+    }
 }
 
 #[cfg(test)]
@@ -134,7 +151,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::types::sensitive_data::FieldPath;
+    use crate::types::sensitive_data::{AuditLabel, FieldPath};
 
     fn record(category: CanonicalCategory, path: &str) -> SensitiveDataFindingRecord {
         let finding = CanonicalFinding::new(
@@ -147,7 +164,12 @@ mod tests {
             FindingStatus::Confirmed,
         )
         .unwrap();
-        SensitiveDataFindingRecord::from_finding(&finding, FieldPath::parse(path).unwrap()).unwrap()
+        SensitiveDataFindingRecord::from_finding(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
+            &finding,
+            FieldPath::parse(path).unwrap(),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -209,6 +231,38 @@ mod tests {
         let mut counts = FindingCounts::tally(&[], 0, 0).unwrap();
         counts.total = 5;
         assert!(!counts.breakdown_is_complete());
+    }
+
+    /// The disposition invariant is checkable on a value `tally` never saw.
+    ///
+    /// `tally` refuses to build this, but deserialization will happily produce
+    /// it, and a dashboard reads deserialized rows — so a constructor-only
+    /// check protects the one path that was never in danger.
+    #[test]
+    fn inconsistent_disposition_counts_are_detectable_after_the_fact() {
+        let mut counts = FindingCounts::tally(&[], 0, 0).unwrap();
+        assert!(
+            counts.disposition_counts_are_consistent(),
+            "an empty tally is consistent"
+        );
+
+        counts.total = 1;
+        counts.blocked = 99;
+        assert!(
+            !counts.disposition_counts_are_consistent(),
+            "99 blocked findings out of 1 read as consistent"
+        );
+
+        counts.blocked = 1;
+        assert!(counts.disposition_counts_are_consistent());
+
+        // The boundary: transformed + blocked == total is fine, one more is not.
+        counts.total = 4;
+        counts.transformed = 2;
+        counts.blocked = 2;
+        assert!(counts.disposition_counts_are_consistent());
+        counts.blocked = 3;
+        assert!(!counts.disposition_counts_are_consistent());
     }
 }
 

--- a/aa-core/src/types/sensitive_data/counts.rs
+++ b/aa-core/src/types/sensitive_data/counts.rs
@@ -1,0 +1,251 @@
+//! Finding counts, kept rigorously separate from event counts.
+
+use alloc::vec::Vec;
+
+use super::{CategoryLabel, SensitiveDataFindingRecord};
+
+/// How many findings of one category an event carried.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct CategoryCount {
+    /// The category counted.
+    pub category: CategoryLabel,
+    /// How many findings of it. Never zero in a tallied set.
+    pub count: u32,
+}
+
+/// Why a set of counts was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CountsError {
+    /// More findings were said to be transformed and blocked than exist.
+    ///
+    /// A finding is transformed or blocked, not both, so the two together
+    /// cannot exceed the total. Left unchecked, this is how a prevention
+    /// dashboard ends up reporting more blocked findings than findings.
+    DispositionCountsExceedTotal,
+}
+
+impl core::fmt::Display for CountsError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::DispositionCountsExceedTotal => {
+                f.write_str("transformed + blocked finding counts exceed the total finding count")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CountsError {}
+
+/// The finding-level tallies for one inspected action.
+///
+/// # Findings are not events
+///
+/// ADR 0032 §8 and forbidden design #11: event counts and finding counts are
+/// distinct metrics and may never be collapsed. One event carries many
+/// findings, so the two answer different questions — "how many actions did we
+/// block?" and "how much sensitive data did we stop?" — and a dashboard that
+/// conflates them is wrong by a factor that varies per action.
+///
+/// **Nothing in this struct is an event count.** Every field here counts
+/// findings; the event-level counts are
+/// [`blocked_event_count`](super::SensitiveDataDecisionEvent::blocked_event_count)
+/// and its neighbours, which live on the event and are named so the difference
+/// is visible at the call site. The §8 worked example — three findings in one
+/// blocked action gives `blocked_event_count = 1` and
+/// `blocked_finding_count = 3` — is asserted on the event.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct FindingCounts {
+    /// Total findings in the inspected action.
+    pub total: u32,
+    /// Findings per category, in first-seen order.
+    pub by_category: Vec<CategoryCount>,
+    /// Findings whose value was rewritten — redacted, masked or tokenized — and
+    /// then **forwarded**. A transformed finding is not a prevented one.
+    pub transformed: u32,
+    /// Findings whose action was refused outright.
+    pub blocked: u32,
+}
+
+impl FindingCounts {
+    /// Tally a set of finding rows.
+    ///
+    /// `total` and `by_category` are computed from `records`, so they cannot
+    /// disagree with each other or with the rows they describe. `transformed`
+    /// and `blocked` are supplied because they are properties of the
+    /// enforcement decision, not of the findings.
+    ///
+    /// # Errors
+    ///
+    /// [`CountsError::DispositionCountsExceedTotal`] if `transformed + blocked`
+    /// is greater than the number of records.
+    pub fn tally(records: &[SensitiveDataFindingRecord], transformed: u32, blocked: u32) -> Result<Self, CountsError> {
+        let total = u32::try_from(records.len()).unwrap_or(u32::MAX);
+        if u64::from(transformed) + u64::from(blocked) > u64::from(total) {
+            return Err(CountsError::DispositionCountsExceedTotal);
+        }
+
+        let mut by_category: Vec<CategoryCount> = Vec::new();
+        for record in records {
+            match by_category.iter_mut().find(|entry| entry.category == record.category) {
+                Some(entry) => entry.count += 1,
+                None => by_category.push(CategoryCount {
+                    category: record.category.clone(),
+                    count: 1,
+                }),
+            }
+        }
+
+        Ok(Self {
+            total,
+            by_category,
+            transformed,
+            blocked,
+        })
+    }
+
+    /// Findings of one category, or zero if none were seen.
+    pub fn of_category(&self, category: &CategoryLabel) -> u32 {
+        self.by_category
+            .iter()
+            .find(|entry| &entry.category == category)
+            .map_or(0, |entry| entry.count)
+    }
+
+    /// Whether the per-category breakdown accounts for exactly `total`.
+    ///
+    /// Always true for a tallied set. Worth asking of a deserialized one, which
+    /// is whatever the writer stored.
+    pub fn breakdown_is_complete(&self) -> bool {
+        let summed: u64 = self.by_category.iter().map(|entry| u64::from(entry.count)).sum();
+        summed == u64::from(self.total)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aa_security::canonical::{
+        ByteSpan, CanonicalCategory, CanonicalFinding, CategoryBase, ConfidenceBand, DetectionMethod, FindingStatus,
+        Provenance, Recognizer, Severity,
+    };
+
+    use super::*;
+    use crate::types::sensitive_data::FieldPath;
+
+    fn record(category: CanonicalCategory, path: &str) -> SensitiveDataFindingRecord {
+        let finding = CanonicalFinding::new(
+            category,
+            Severity::Critical,
+            ConfidenceBand::High,
+            ByteSpan::new(0, 8),
+            DetectionMethod::Deterministic,
+            Provenance::new(Recognizer::BuiltinScanner, "0.0.0-test"),
+            FindingStatus::Confirmed,
+        )
+        .unwrap();
+        SensitiveDataFindingRecord::from_finding(&finding, FieldPath::parse(path).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn a_tally_counts_each_category_separately() {
+        let email = CanonicalCategory::unqualified(CategoryBase::EmailAddress);
+        let token = CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access");
+        let counts = FindingCounts::tally(
+            &[
+                record(email, "body.a"),
+                record(email, "body.b"),
+                record(token, "body.c"),
+            ],
+            0,
+            3,
+        )
+        .unwrap();
+
+        assert_eq!(counts.total, 3);
+        assert_eq!(counts.of_category(&CategoryLabel::from(email)), 2);
+        assert_eq!(counts.of_category(&CategoryLabel::from(token)), 1);
+        assert!(counts.breakdown_is_complete());
+    }
+
+    /// A category nobody saw counts zero rather than being absent-and-awkward.
+    #[test]
+    fn an_unseen_category_counts_zero() {
+        let counts = FindingCounts::tally(&[], 0, 0).unwrap();
+        assert_eq!(
+            counts.of_category(&CategoryLabel::from(CanonicalCategory::unqualified(
+                CategoryBase::EmailAddress
+            ))),
+            0
+        );
+    }
+
+    /// A finding is transformed or blocked, never both, so the two cannot
+    /// exceed the total. Without this a prevention dashboard can report more
+    /// blocked findings than there were findings.
+    #[test]
+    fn disposition_counts_cannot_exceed_the_total() {
+        let email = CanonicalCategory::unqualified(CategoryBase::EmailAddress);
+        let records = [record(email, "body.a"), record(email, "body.b")];
+
+        assert_eq!(
+            FindingCounts::tally(&records, 2, 1),
+            Err(CountsError::DispositionCountsExceedTotal)
+        );
+        assert!(FindingCounts::tally(&records, 1, 1).is_ok());
+        assert!(
+            FindingCounts::tally(&records, 0, 0).is_ok(),
+            "an action can leave findings neither transformed nor blocked"
+        );
+    }
+
+    /// A breakdown that does not sum to the total is detectable. This can only
+    /// arise from a deserialized record, which is exactly when it matters.
+    #[test]
+    fn an_inconsistent_breakdown_is_detectable() {
+        let mut counts = FindingCounts::tally(&[], 0, 0).unwrap();
+        counts.total = 5;
+        assert!(!counts.breakdown_is_complete());
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::*;
+
+    #[test]
+    fn finding_counts_round_trip() {
+        let counts = FindingCounts {
+            total: 3,
+            by_category: alloc::vec![CategoryCount {
+                category: CategoryLabel::new("EMAIL_ADDRESS").unwrap(),
+                count: 3,
+            }],
+            transformed: 0,
+            blocked: 3,
+        };
+        let json = serde_json::to_string(&counts).unwrap();
+        let restored: FindingCounts = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, counts);
+    }
+
+    /// The counts are named on the wire, not positional, and `transformed` and
+    /// `blocked` are separate keys. A single `disposition_count` would be the
+    /// collapse ADR 0032 forbids.
+    #[test]
+    fn transformed_and_blocked_are_separate_wire_fields() {
+        let json = serde_json::to_value(FindingCounts {
+            total: 3,
+            by_category: Vec::new(),
+            transformed: 1,
+            blocked: 2,
+        })
+        .unwrap();
+        assert_eq!(json["total"], 3);
+        assert_eq!(json["transformed"], 1);
+        assert_eq!(json["blocked"], 2);
+    }
+}

--- a/aa-core/src/types/sensitive_data/event.rs
+++ b/aa-core/src/types/sensitive_data/event.rs
@@ -1,0 +1,926 @@
+//! The per-action sensitive-data decision event.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aa_security::canonical::{ConfidenceBand, DetectionMethod, FindingStatus, Severity};
+
+use crate::time::Timestamp;
+use crate::types::AgentId;
+
+use super::counts::FindingCounts;
+use super::evidence::{ExecutionEvidence, InspectionFailurePath};
+use super::guard::{screen, AuditLabel, FieldPath, FieldRejection, MAX_LABEL_BYTES};
+use super::schema::{SchemaVersion, SENSITIVE_DATA_SCHEMA_VERSION};
+use super::verdict::RuntimeVerdictLabel;
+use super::vocab;
+use super::DetectionProvenance;
+
+/// Which organisation, tenant and team the action belongs to.
+///
+/// Carried on every event because every aggregate over these records has to be
+/// scoped by it. An aggregation that loses the tenant is not a smaller answer,
+/// it is one tenant's data shown to another.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Tenancy {
+    /// Owning organisation.
+    pub org_id: AuditLabel,
+    /// Owning tenant within the organisation.
+    pub tenant_id: AuditLabel,
+    /// Owning team, when the action is attributable to one.
+    pub team_id: Option<AuditLabel>,
+}
+
+/// Who acted, and on whose behalf.
+///
+/// The existing audit bridge keeps `team_id` and drops all of this, which is
+/// why "which agent, acting for which root agent, sent this?" is unanswerable
+/// today.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct AgentLineage {
+    /// The agent that performed the action.
+    pub acting_agent: AgentId,
+    /// The agent at the root of the delegation chain. Equal to `acting_agent`
+    /// when nothing was delegated.
+    pub root_agent: AgentId,
+    /// The agent that delegated to the actor, if any.
+    pub parent_agent: Option<AgentId>,
+    /// How many delegation hops from the root. Zero when the actor is the root.
+    pub delegation_depth: u32,
+}
+
+/// The identifiers that stitch this event to the rest of the trace.
+///
+/// All optional: a producer that has no trace context records none rather than
+/// inventing one.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct CorrelationIds {
+    /// The agent session the action belongs to.
+    pub session_id: Option<AuditLabel>,
+    /// Distributed-trace id.
+    pub trace_id: Option<AuditLabel>,
+    /// Id of the individual request.
+    pub request_id: Option<AuditLabel>,
+    /// Caller-chosen correlation id.
+    pub correlation_id: Option<AuditLabel>,
+}
+
+/// What kind of thing an [`Endpoint`] names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub enum EndpointKind {
+    /// A tool exposed to the agent.
+    Tool,
+    /// An MCP server.
+    McpServer,
+    /// Another agent, over A2A.
+    AgentPeer,
+    /// A network host reached over HTTP(S).
+    HttpHost,
+    /// A path on the local filesystem.
+    FilePath,
+    /// A model provider endpoint.
+    Model,
+}
+
+impl EndpointKind {
+    /// The stable spelling used in events.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Tool => "tool",
+            Self::McpServer => "mcp_server",
+            Self::AgentPeer => "agent_peer",
+            Self::HttpHost => "http_host",
+            Self::FilePath => "file_path",
+            Self::Model => "model",
+        }
+    }
+}
+
+/// Where an action came from, or was going.
+///
+/// # Screened, and not a metric label
+///
+/// The `identifier` is derived from the inspected request, so it is screened
+/// with the credential scanner exactly as a [`FieldPath`] is. The concrete
+/// case this closes is a destination written as
+/// `postgresql://user:password@db.internal/app`: the scanner flags it and the
+/// caller has to record the destination without the password.
+///
+/// It is also **unbounded cardinality** and must never become a metric label —
+/// ADR 0032 §9 restricts labels to a bounded set, and validation requirement 4
+/// names `destination` explicitly. Use
+/// [`SensitiveDataMetricLabels`](super::SensitiveDataMetricLabels).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Endpoint {
+    /// What kind of endpoint this is.
+    pub kind: EndpointKind,
+    /// Its name: a tool name, an MCP server id, a host, a path.
+    identifier: String,
+}
+
+impl Endpoint {
+    /// Name an endpoint, screening the identifier.
+    ///
+    /// # Errors
+    ///
+    /// [`FieldRejection::CarriesSensitiveValue`] when the scanner recognises
+    /// something in the identifier, plus the usual shape rejections.
+    pub fn new(kind: EndpointKind, identifier: impl Into<String>) -> Result<Self, FieldRejection> {
+        let identifier = identifier.into();
+        screen(&identifier, MAX_LABEL_BYTES)?;
+        Ok(Self { kind, identifier })
+    }
+
+    /// The endpoint's name.
+    pub fn identifier(&self) -> &str {
+        &self.identifier
+    }
+}
+
+/// The kind of operation that was inspected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub enum OperationKind {
+    /// A tool invocation.
+    ToolCall,
+    /// A call to an MCP server.
+    McpCall,
+    /// An agent-to-agent message.
+    AgentToAgent,
+    /// Outbound network traffic.
+    NetworkEgress,
+    /// A write to the filesystem.
+    FileWrite,
+    /// A prompt or completion sent to a model.
+    ModelCompletion,
+}
+
+impl OperationKind {
+    /// The stable spelling used in events.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::ToolCall => "tool_call",
+            Self::McpCall => "mcp_call",
+            Self::AgentToAgent => "agent_to_agent",
+            Self::NetworkEgress => "network_egress",
+            Self::FileWrite => "file_write",
+            Self::ModelCompletion => "model_completion",
+        }
+    }
+}
+
+/// How far outside the trust boundary the destination sits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub enum TrustZone {
+    /// Inside the organisation's own boundary.
+    Internal,
+    /// A known third party under contract.
+    PartnerBoundary,
+    /// The open internet.
+    Public,
+    /// Not classified. Never treated as `Internal` by default — an unclassified
+    /// destination is the one most worth looking at.
+    Unknown,
+}
+
+impl TrustZone {
+    /// The stable spelling used in events.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Internal => "internal",
+            Self::PartnerBoundary => "partner_boundary",
+            Self::Public => "public",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Which way the inspected payload was travelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub enum RequestDirection {
+    /// Leaving the boundary. The direction sensitive-data egress policy is about.
+    Outbound,
+    /// Arriving from outside.
+    Inbound,
+    /// Between components inside the boundary.
+    Internal,
+}
+
+impl RequestDirection {
+    /// The stable spelling used in events.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Outbound => "outbound",
+            Self::Inbound => "inbound",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+/// The action that was inspected, and where it was going.
+///
+/// Destination is the dimension the existing audit event does not have at all,
+/// which is why "what did agent X try to send to tool Y" cannot be answered
+/// today.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct InspectedAction {
+    /// What kind of operation it was.
+    pub operation: OperationKind,
+    /// Where it originated, when that is meaningfully distinct from the actor.
+    pub source: Option<Endpoint>,
+    /// Where it was intended to go.
+    pub destination: Endpoint,
+    /// How far outside the boundary the destination sits.
+    pub trust_zone: TrustZone,
+    /// Which way the payload was travelling.
+    pub direction: RequestDirection,
+}
+
+/// Which policy decided, and which of its rules matched.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct PolicyAttribution {
+    /// Identifier of the policy document in force.
+    pub document_id: Option<AuditLabel>,
+    /// Version of that document.
+    pub version: Option<u64>,
+    /// Ids of the rules that matched. Empty when nothing matched.
+    pub matched_rule_ids: Vec<AuditLabel>,
+}
+
+/// A machine-aggregatable reason for the decision.
+///
+/// A closed vocabulary rather than free text, because the point of a reason
+/// code is to be counted. A prose reason cannot be grouped, and an operator
+/// asking "why are we blocking so much traffic to this tool?" gets a list of
+/// sentences instead of an answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub enum PolicyReasonCode {
+    /// Sensitive data was detected in the payload.
+    SensitiveDataDetected,
+    /// A rule in the active policy document matched.
+    PolicyRuleMatched,
+    /// The destination is not permitted to receive this class of data.
+    DestinationNotPermitted,
+    /// The action needs a human decision before it can proceed.
+    ApprovalRequired,
+    /// Detection could not be performed. Never a synonym for "nothing found"
+    /// (ADR 0032 §5).
+    DetectionUnavailable,
+    /// The decision was computed but not applied, because the agent is in
+    /// observe mode.
+    ShadowEvaluationOnly,
+}
+
+impl PolicyReasonCode {
+    /// The stable spelling used in events and metric labels.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::SensitiveDataDetected => "sensitive_data_detected",
+            Self::PolicyRuleMatched => "policy_rule_matched",
+            Self::DestinationNotPermitted => "destination_not_permitted",
+            Self::ApprovalRequired => "approval_required",
+            Self::DetectionUnavailable => "detection_unavailable",
+            Self::ShadowEvaluationOnly => "shadow_evaluation_only",
+        }
+    }
+}
+
+/// How long inspection took.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct InspectionLatency {
+    /// Time spent inside a detection provider, in microseconds.
+    ///
+    /// `None` for every v1 event: ADR 0032 D-1 puts out-of-process providers
+    /// out of scope, so there is no provider to attribute time to. The field
+    /// exists so the deferred work does not need a schema change to report it.
+    pub provider_us: Option<u64>,
+    /// Total time spent inspecting, in microseconds.
+    pub total_us: u64,
+}
+
+/// The summary classification of an action's findings.
+///
+/// # Why there is no `summarise` constructor
+///
+/// The obvious helper would fold a set of findings into "highest severity,
+/// lowest confidence". It is deliberately not provided, because
+/// [`ConfidenceBand`] does not derive `PartialOrd` and that is a decision, not
+/// an oversight: `aa-security` documents that `confidence >= threshold` must
+/// not compile, since confidence is evidence about a detection and never an
+/// authorisation input. Supplying a ranking here would hand back exactly the
+/// comparison that was withheld, one crate over.
+///
+/// So the aggregation policy belongs to the writer — AAASM-5357 — which can
+/// choose it with the reader's needs in view and without minting a general
+/// ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct FindingClassification {
+    /// Severity representing the action's findings.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::severity"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "vocab::severity::schema"))]
+    pub severity: Severity,
+    /// Confidence band representing the action's findings.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::confidence"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "vocab::confidence::schema"))]
+    pub confidence: ConfidenceBand,
+    /// The detection technique representing the action's findings.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::method"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "vocab::method::schema"))]
+    pub method: DetectionMethod,
+    /// The triage state representing the action's findings.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::status"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "vocab::status::schema"))]
+    pub status: FindingStatus,
+}
+
+/// One inspected action, and everything decided about it (ADR 0032 §8).
+///
+/// Written **alongside** the existing `audit_entry_to_storage_event` bridge,
+/// never by extending it — forbidden design #15. That bridge loses 14 fields
+/// including every credential finding, the hash chain and all lineage except
+/// `team_id`, and sets `action` and `decision` from the same source; it is
+/// superseded by attrition.
+///
+/// # Extending this without breaking it
+///
+/// `#[non_exhaustive]`, so downstream crates construct it through
+/// [`builder`](Self::builder) and a new field is additive for every caller.
+/// That is the seam AAASM-5356 uses for its optional
+/// `sensitive_data_disposition` (ADR 0032 D-2), together with the
+/// minor-version rule in [`SchemaVersion`]. For the same reason no type in this
+/// module uses `serde(deny_unknown_fields)`: a strict reader would reject a
+/// newer writer's event outright and turn an additive change into a breaking
+/// one.
+///
+/// # Counting
+///
+/// Event counts and finding counts are separate and are reached through
+/// separately named accessors —
+/// [`blocked_event_count`](Self::blocked_event_count) versus
+/// [`blocked_finding_count`](Self::blocked_finding_count) — so the two cannot
+/// be confused at a call site.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub struct SensitiveDataDecisionEvent {
+    /// Schema this event was written against.
+    pub schema_version: SchemaVersion,
+    /// Unique id for this event.
+    pub event_id: AuditLabel,
+    /// When the action was inspected.
+    pub occurred_at: Timestamp,
+    /// Owning organisation, tenant and team.
+    pub tenancy: Tenancy,
+    /// Who acted, and on whose behalf.
+    pub lineage: AgentLineage,
+    /// Trace and correlation identifiers.
+    pub correlation: CorrelationIds,
+    /// The action and its destination.
+    pub action: InspectedAction,
+    /// Names of the fields that were inspected. **Names only** — ADR 0032 §9
+    /// makes the field path the drill-down granularity in place of offsets.
+    pub inspected_fields: Vec<FieldPath>,
+    /// Which policy decided, and which rules matched.
+    pub policy: PolicyAttribution,
+    /// Finding-level tallies. Contains no event counts.
+    pub finding_counts: FindingCounts,
+    /// Summary classification of the findings, absent when there were none.
+    pub classification: Option<FindingClassification>,
+    /// Which recognizers contributed, and at which versions.
+    pub detection: Vec<DetectionProvenance>,
+    /// The enforcement outcome, as ADR 0018's frozen verdict.
+    pub verdict: RuntimeVerdictLabel,
+    /// What was observed about execution and transmission.
+    pub execution: ExecutionEvidence,
+    /// How the detection pass itself terminated.
+    pub inspection_failure_path: InspectionFailurePath,
+    /// How long inspection took.
+    pub latency: InspectionLatency,
+    /// Machine-aggregatable reasons for the decision.
+    pub reason_codes: Vec<PolicyReasonCode>,
+}
+
+impl SensitiveDataDecisionEvent {
+    /// Start building an event from the parts that are always required.
+    ///
+    /// Required arguments rather than required setters: forgetting one is then
+    /// a compile error instead of a runtime error on a record that is already
+    /// being written.
+    pub fn builder(
+        event_id: AuditLabel,
+        occurred_at: Timestamp,
+        tenancy: Tenancy,
+        lineage: AgentLineage,
+        action: InspectedAction,
+        verdict: RuntimeVerdictLabel,
+        execution: ExecutionEvidence,
+    ) -> SensitiveDataDecisionEventBuilder {
+        SensitiveDataDecisionEventBuilder {
+            event: Self {
+                schema_version: SENSITIVE_DATA_SCHEMA_VERSION,
+                event_id,
+                occurred_at,
+                tenancy,
+                lineage,
+                correlation: CorrelationIds::default(),
+                action,
+                inspected_fields: Vec::new(),
+                policy: PolicyAttribution::default(),
+                finding_counts: FindingCounts::default(),
+                classification: None,
+                detection: Vec::new(),
+                verdict,
+                execution,
+                inspection_failure_path: InspectionFailurePath::Completed,
+                latency: InspectionLatency::default(),
+                reason_codes: Vec::new(),
+            },
+        }
+    }
+
+    /// Always `1`. One event describes one inspected action.
+    ///
+    /// Trivial, and it exists anyway: it gives a call site somewhere to say
+    /// "event" out loud next to [`total_finding_count`](Self::total_finding_count),
+    /// which is the distinction ADR 0032 forbidden design #11 is about.
+    pub const fn event_count(&self) -> u32 {
+        1
+    }
+
+    /// `1` if this action was blocked outright, `0` otherwise.
+    ///
+    /// An **event** count. The action is blocked when the verdict is `deny`; a
+    /// scrubbed action was permitted, with its payload rewritten.
+    pub fn blocked_event_count(&self) -> u32 {
+        u32::from(self.verdict == RuntimeVerdictLabel::DENY)
+    }
+
+    /// How many findings this action carried in total.
+    pub const fn total_finding_count(&self) -> u32 {
+        self.finding_counts.total
+    }
+
+    /// How many **findings** were blocked.
+    ///
+    /// ADR 0032 §8's worked example: an action with three findings that is
+    /// blocked gives `blocked_event_count() == 1` and
+    /// `blocked_finding_count() == 3`.
+    pub const fn blocked_finding_count(&self) -> u32 {
+        self.finding_counts.blocked
+    }
+
+    /// How many **findings** were rewritten and then forwarded.
+    pub const fn transformed_finding_count(&self) -> u32 {
+        self.finding_counts.transformed
+    }
+
+    /// Whether this event may be counted as prevented transmission.
+    ///
+    /// The only place ADR 0032 §8's four conditions are conjoined:
+    ///
+    /// 1. the enforcement point was pre-transmission;
+    /// 2. the verdict was a deny or a transforming disposition;
+    /// 3. explicit evidence records the payload did not reach its destination;
+    /// 4. the action was not in observe mode.
+    ///
+    /// Conditions 1, 3 and 4 come from [`ExecutionEvidence`]; 2 from the
+    /// verdict. Everything else is *detected*, not prevented — and a redaction,
+    /// which forwards the scrubbed bytes, is a transformed transmission.
+    ///
+    /// Derived rather than stored, so it cannot disagree with the evidence it
+    /// is drawn from.
+    pub fn counts_as_prevented_transmission(&self) -> bool {
+        self.execution.establishes_non_transmission() && self.verdict.is_deny_or_transforming()
+    }
+}
+
+/// Builds a [`SensitiveDataDecisionEvent`].
+///
+/// Exists because the event is `#[non_exhaustive]` — downstream crates cannot
+/// write a struct literal, and that is what lets AAASM-5356 add a field without
+/// breaking them.
+#[derive(Debug, Clone)]
+pub struct SensitiveDataDecisionEventBuilder {
+    event: SensitiveDataDecisionEvent,
+}
+
+impl SensitiveDataDecisionEventBuilder {
+    /// Attach trace and correlation identifiers.
+    #[must_use]
+    pub fn correlation(mut self, correlation: CorrelationIds) -> Self {
+        self.event.correlation = correlation;
+        self
+    }
+
+    /// Record the names of the inspected fields.
+    #[must_use]
+    pub fn inspected_fields(mut self, fields: Vec<FieldPath>) -> Self {
+        self.event.inspected_fields = fields;
+        self
+    }
+
+    /// Attribute the decision to a policy document and its matched rules.
+    #[must_use]
+    pub fn policy(mut self, policy: PolicyAttribution) -> Self {
+        self.event.policy = policy;
+        self
+    }
+
+    /// Attach the finding tallies.
+    #[must_use]
+    pub fn finding_counts(mut self, counts: FindingCounts) -> Self {
+        self.event.finding_counts = counts;
+        self
+    }
+
+    /// Attach the summary classification of the findings.
+    #[must_use]
+    pub fn classification(mut self, classification: FindingClassification) -> Self {
+        self.event.classification = Some(classification);
+        self
+    }
+
+    /// Record which recognizers contributed.
+    #[must_use]
+    pub fn detection(mut self, detection: Vec<DetectionProvenance>) -> Self {
+        self.event.detection = detection;
+        self
+    }
+
+    /// Record how the detection pass terminated.
+    #[must_use]
+    pub fn inspection_failure_path(mut self, path: InspectionFailurePath) -> Self {
+        self.event.inspection_failure_path = path;
+        self
+    }
+
+    /// Record inspection latency.
+    #[must_use]
+    pub fn latency(mut self, latency: InspectionLatency) -> Self {
+        self.event.latency = latency;
+        self
+    }
+
+    /// Record the machine-aggregatable reasons for the decision.
+    #[must_use]
+    pub fn reason_codes(mut self, codes: Vec<PolicyReasonCode>) -> Self {
+        self.event.reason_codes = codes;
+        self
+    }
+
+    /// Finish the event.
+    #[must_use]
+    pub fn build(self) -> SensitiveDataDecisionEvent {
+        self.event
+    }
+}
+
+#[cfg(test)]
+pub(super) mod fixtures {
+    use aa_security::canonical::{
+        ByteSpan, CanonicalCategory, CanonicalFinding, CategoryBase, ConfidenceBand, DetectionMethod, FindingStatus,
+        Provenance, Recognizer, Severity,
+    };
+
+    use super::*;
+    use crate::policy::EnforcementMode;
+    use crate::types::sensitive_data::evidence::{EnforcementPoint, TransmissionEvidence};
+    use crate::types::sensitive_data::SensitiveDataFindingRecord;
+
+    /// A finding record built from synthetic inputs — no real credential is
+    /// ever constructed anywhere in this module's tests.
+    pub(in crate::types::sensitive_data) fn finding(
+        category: CanonicalCategory,
+        path: &str,
+    ) -> SensitiveDataFindingRecord {
+        let finding = CanonicalFinding::new(
+            category,
+            Severity::Critical,
+            ConfidenceBand::High,
+            ByteSpan::new(4, 44),
+            DetectionMethod::Deterministic,
+            Provenance::new(Recognizer::BuiltinScanner, "0.0.0-test"),
+            FindingStatus::Confirmed,
+        )
+        .expect("well-formed span");
+        SensitiveDataFindingRecord::from_finding(&finding, FieldPath::parse(path).unwrap()).unwrap()
+    }
+
+    pub(in crate::types::sensitive_data) fn tenancy() -> Tenancy {
+        Tenancy {
+            org_id: AuditLabel::new("acme").unwrap(),
+            tenant_id: AuditLabel::new("acme-prod").unwrap(),
+            team_id: Some(AuditLabel::new("billing").unwrap()),
+        }
+    }
+
+    pub(in crate::types::sensitive_data) fn lineage() -> AgentLineage {
+        AgentLineage {
+            acting_agent: AgentId::parse("acme/billing-bot").unwrap(),
+            root_agent: AgentId::parse("acme/orchestrator").unwrap(),
+            parent_agent: Some(AgentId::parse("acme/orchestrator").unwrap()),
+            delegation_depth: 1,
+        }
+    }
+
+    pub(in crate::types::sensitive_data) fn action() -> InspectedAction {
+        InspectedAction {
+            operation: OperationKind::ToolCall,
+            source: None,
+            destination: Endpoint::new(EndpointKind::HttpHost, "api.example.com").unwrap(),
+            trust_zone: TrustZone::Public,
+            direction: RequestDirection::Outbound,
+        }
+    }
+
+    /// The ADR 0032 §8 worked example: three findings in one blocked action,
+    /// refused before transmission while enforcing.
+    pub(in crate::types::sensitive_data) fn blocked_action_with_three_findings() -> SensitiveDataDecisionEvent {
+        let email = CanonicalCategory::unqualified(CategoryBase::EmailAddress);
+        let token = CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access");
+        let records = [
+            finding(email, "body.customer.email"),
+            finding(email, "body.contact.email"),
+            finding(token, "headers.authorization"),
+        ];
+        let counts = FindingCounts::tally(&records, 0, 3).unwrap();
+
+        SensitiveDataDecisionEvent::builder(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
+            Timestamp::from_nanos(1_700_000_000_000_000_000),
+            tenancy(),
+            lineage(),
+            action(),
+            RuntimeVerdictLabel::DENY,
+            ExecutionEvidence::new(
+                EnforcementPoint::PreTransmission,
+                TransmissionEvidence::NotForwarded,
+                EnforcementMode::Enforce,
+            ),
+        )
+        .finding_counts(counts)
+        .classification(FindingClassification {
+            severity: Severity::Critical,
+            confidence: ConfidenceBand::High,
+            method: DetectionMethod::Deterministic,
+            status: FindingStatus::Confirmed,
+        })
+        .detection(alloc::vec![DetectionProvenance::new(
+            Recognizer::BuiltinScanner,
+            "0.0.0-test"
+        )
+        .unwrap()])
+        .inspected_fields(alloc::vec![
+            FieldPath::parse("body.customer.email").unwrap(),
+            FieldPath::parse("body.contact.email").unwrap(),
+            FieldPath::parse("headers.authorization").unwrap(),
+        ])
+        .reason_codes(alloc::vec![PolicyReasonCode::SensitiveDataDetected])
+        .latency(InspectionLatency {
+            provider_us: None,
+            total_us: 6,
+        })
+        .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aa_security::canonical::{CanonicalCategory, CategoryBase};
+
+    use super::fixtures::*;
+    use super::*;
+    use crate::policy::EnforcementMode;
+    use crate::types::sensitive_data::evidence::{EnforcementPoint, TransmissionEvidence};
+    use crate::types::sensitive_data::CategoryLabel;
+
+    /// **ADR 0032 §8's worked example, and validation requirement 5.**
+    ///
+    /// Three findings in one blocked action gives `blocked_event_count = 1` and
+    /// `blocked_finding_count = 3`. Collapsing the two is forbidden design #11,
+    /// and this is the assertion that notices.
+    #[test]
+    fn three_findings_in_one_blocked_action_give_one_event_and_three_findings() {
+        let event = blocked_action_with_three_findings();
+
+        assert_eq!(event.event_count(), 1);
+        assert_eq!(event.blocked_event_count(), 1);
+        assert_eq!(event.total_finding_count(), 3);
+        assert_eq!(event.blocked_finding_count(), 3);
+        assert_ne!(
+            event.blocked_event_count(),
+            event.blocked_finding_count(),
+            "the two counts must not be interchangeable, which is the whole point"
+        );
+    }
+
+    /// The per-category breakdown survives onto the event, so "how many
+    /// findings of each class went to tool Y" is answerable.
+    #[test]
+    fn the_event_carries_the_per_category_breakdown() {
+        let event = blocked_action_with_three_findings();
+        let email = CategoryLabel::from(CanonicalCategory::unqualified(CategoryBase::EmailAddress));
+        let token = CategoryLabel::from(CanonicalCategory::with_scheme(
+            CategoryBase::AccessToken,
+            "github",
+            "personal_access",
+        ));
+        assert_eq!(event.finding_counts.of_category(&email), 2);
+        assert_eq!(event.finding_counts.of_category(&token), 1);
+    }
+
+    /// A blocked, pre-transmission, enforced action with refusal evidence is the
+    /// one case that counts as prevented.
+    #[test]
+    fn a_blocked_pre_transmission_action_counts_as_prevented() {
+        assert!(blocked_action_with_three_findings().counts_as_prevented_transmission());
+    }
+
+    /// **ADR 0032 validation requirement 6**: absence of execution evidence
+    /// prevents an event counting as prevented, however restrictive the verdict.
+    #[test]
+    fn without_execution_evidence_a_deny_does_not_count_as_prevented() {
+        let mut event = blocked_action_with_three_findings();
+        event.execution = ExecutionEvidence::unrecorded(EnforcementMode::Enforce);
+
+        assert_eq!(event.verdict, RuntimeVerdictLabel::DENY, "still a deny");
+        assert!(
+            !event.counts_as_prevented_transmission(),
+            "a deny with no evidence is a decision, not a demonstrated prevention"
+        );
+    }
+
+    /// A redaction forwards the scrubbed bytes. It is a transformed
+    /// transmission, and calling it prevention is the mistake the
+    /// `CredentialLeakBlocked` event name already made once.
+    #[test]
+    fn a_successful_redaction_does_not_count_as_prevented() {
+        let mut event = blocked_action_with_three_findings();
+        event.verdict = RuntimeVerdictLabel::SCRUB;
+        event.execution = ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::ForwardedClean,
+            EnforcementMode::Enforce,
+        );
+
+        assert!(
+            event.verdict.is_deny_or_transforming(),
+            "scrub does satisfy the verdict condition on its own"
+        );
+        assert!(
+            !event.counts_as_prevented_transmission(),
+            "but the bytes went, so nothing was prevented"
+        );
+    }
+
+    /// An observe-mode action computes a decision and applies nothing.
+    #[test]
+    fn an_observe_mode_action_does_not_count_as_prevented() {
+        let mut event = blocked_action_with_three_findings();
+        event.execution = ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Observe,
+        );
+        assert!(!event.counts_as_prevented_transmission());
+    }
+
+    /// A `scrub` verdict is not a blocked event, even though it is restrictive.
+    #[test]
+    fn only_a_deny_is_a_blocked_event() {
+        let mut event = blocked_action_with_three_findings();
+        for verdict in [
+            RuntimeVerdictLabel::ALLOW,
+            RuntimeVerdictLabel::NARROW,
+            RuntimeVerdictLabel::SCRUB,
+            RuntimeVerdictLabel::PENDING,
+        ] {
+            event.verdict = verdict;
+            assert_eq!(event.blocked_event_count(), 0, "{verdict} counted as a blocked event");
+        }
+        event.verdict = RuntimeVerdictLabel::DENY;
+        assert_eq!(event.blocked_event_count(), 1);
+    }
+
+    /// A destination carrying an embedded password is refused, so it cannot
+    /// become a permanent field of an audit record.
+    #[test]
+    fn a_destination_with_an_embedded_credential_is_refused() {
+        assert_eq!(
+            Endpoint::new(
+                EndpointKind::HttpHost,
+                "postgresql://user:password@db.internal:5432/app"
+            ),
+            Err(FieldRejection::CarriesSensitiveValue)
+        );
+        assert!(Endpoint::new(EndpointKind::HttpHost, "db.internal:5432").is_ok());
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::fixtures::*;
+    use super::*;
+
+    #[test]
+    fn an_event_round_trips() {
+        let event = blocked_action_with_three_findings();
+        let json = serde_json::to_string(&event).unwrap();
+        let restored: SensitiveDataDecisionEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, event);
+        assert_eq!(restored.blocked_event_count(), 1);
+        assert_eq!(restored.blocked_finding_count(), 3);
+    }
+
+    /// **No `deny_unknown_fields`.** A `1.1` writer that adds
+    /// `sensitive_data_disposition` must not break a `1.0` reader — that is
+    /// ADR 0032 D-2's "absent must mean exactly what absence means today", and
+    /// it only holds if the reader tolerates the field it has never heard of.
+    ///
+    /// Simulated with the actual field name AAASM-5356 will add, so this test
+    /// is the guarantee that ticket depends on rather than a generic one.
+    #[test]
+    fn an_event_from_a_newer_minor_still_deserializes() {
+        let mut json = serde_json::to_value(blocked_action_with_three_findings()).unwrap();
+        let object = json.as_object_mut().unwrap();
+        object.insert(
+            "sensitive_data_disposition".into(),
+            serde_json::Value::String("redact".into()),
+        );
+        object.insert("schema_version".into(), serde_json::json!({ "major": 1, "minor": 1 }));
+
+        let restored: SensitiveDataDecisionEvent =
+            serde_json::from_value(json).expect("a 1.0 reader must tolerate a 1.1 writer's added field");
+        assert!(restored.schema_version.is_readable_by(SENSITIVE_DATA_SCHEMA_VERSION));
+        assert_eq!(restored.blocked_finding_count(), 3);
+    }
+
+    /// The event carries no raw value and no offset anywhere in its tree,
+    /// including inside the nested finding-level structures.
+    #[test]
+    fn a_serialized_event_carries_no_span_offset_or_length() {
+        let json = serde_json::to_value(blocked_action_with_three_findings()).unwrap();
+
+        fn walk(value: &serde_json::Value, forbidden: &[&str]) {
+            match value {
+                serde_json::Value::Object(map) => {
+                    for (key, child) in map {
+                        assert!(
+                            !forbidden.contains(&key.as_str()),
+                            "the event leaked `{key}`, which ADR 0032 §9 confines to the audit tier"
+                        );
+                        walk(child, forbidden);
+                    }
+                }
+                serde_json::Value::Array(items) => items.iter().for_each(|item| walk(item, forbidden)),
+                _ => {}
+            }
+        }
+
+        walk(&json, &["span", "start", "end", "offset", "length", "len"]);
+    }
+
+    /// The verdict is on the wire as ADR 0018's label, not as a competing
+    /// outcome enum of this module's own.
+    #[test]
+    fn the_event_carries_the_frozen_verdict_label() {
+        let json = serde_json::to_value(blocked_action_with_three_findings()).unwrap();
+        assert_eq!(json["verdict"], "deny");
+    }
+}

--- a/aa-core/src/types/sensitive_data/event.rs
+++ b/aa-core/src/types/sensitive_data/event.rs
@@ -639,7 +639,12 @@ pub(super) mod fixtures {
             FindingStatus::Confirmed,
         )
         .expect("well-formed span");
-        SensitiveDataFindingRecord::from_finding(&finding, FieldPath::parse(path).unwrap()).unwrap()
+        SensitiveDataFindingRecord::from_finding(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
+            &finding,
+            FieldPath::parse(path).unwrap(),
+        )
+        .unwrap()
     }
 
     pub(in crate::types::sensitive_data) fn tenancy() -> Tenancy {

--- a/aa-core/src/types/sensitive_data/evidence.rs
+++ b/aa-core/src/types/sensitive_data/evidence.rs
@@ -1,0 +1,400 @@
+//! What was actually observed about an inspected action — as evidence, never as
+//! a claim.
+//!
+//! # Why there is no `prevented: bool`
+//!
+//! ADR 0032 forbidden design #11 puts it directly: calling an outcome
+//! "prevented" without execution evidence is not allowed. The reason is
+//! specific rather than pedantic. The event type the runtime emits today is
+//! named `CredentialLeakBlocked`, and it does not mean blocked — it means
+//! *redact*, and redaction **forwards** the scrubbed bytes upstream. A boolean
+//! named `prevented` set from that event would have been wrong for the single
+//! most common case, and nothing downstream could have noticed.
+//!
+//! So this module records what was seen and lets the metric be derived. The
+//! four conditions ADR 0032 §8 requires before an event counts as prevented
+//! transmission are:
+//!
+//! 1. the enforcement point was **pre-transmission** — [`EnforcementPoint`];
+//! 2. the decision was a deny or a transforming disposition —
+//!    [`RuntimeVerdictLabel::is_deny_or_transforming`](super::RuntimeVerdictLabel::is_deny_or_transforming),
+//!    which lives with the verdict because that is where the answer is;
+//! 3. explicit evidence records that the action did not reach its destination —
+//!    [`TransmissionEvidence::NotForwarded`];
+//! 4. the action was not in observe mode — [`EnforcementMode`].
+//!
+//! [`ExecutionEvidence`] holds 1, 3 and 4;
+//! [`SensitiveDataDecisionEvent::counts_as_prevented_transmission`](super::SensitiveDataDecisionEvent::counts_as_prevented_transmission)
+//! adds 2 and is the only place the conjunction is spelled.
+//!
+//! # The evidence is not yet produced everywhere
+//!
+//! ADR 0032 §8 is explicit that the observable exists —
+//! `aa_proxy::probe_adjudication::ForwardedPayload` — but is produced on only
+//! one of the two `dial_upstream_tls` call sites and is never persisted.
+//! Generalising and persisting it is AAASM-5358's work, not this ticket's.
+//! Until then most events will carry [`TransmissionEvidence::NotRecorded`],
+//! which is exactly the point: an unwired path reports *no evidence* and
+//! therefore no prevention, rather than defaulting to a flattering answer.
+
+use crate::policy::EnforcementMode;
+
+/// Where in the request's life the decision was applied.
+///
+/// Condition 1 of the prevention test. A decision taken after the bytes left
+/// cannot have stopped them, however restrictive it was — that is detection,
+/// which is a different and less valuable thing than prevention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub enum EnforcementPoint {
+    /// The decision was applied before the payload could leave the process or
+    /// host — the SDK pre-execution gate, or the proxy before it dials
+    /// upstream.
+    PreTransmission,
+    /// The decision was reached after the payload had already gone: an eBPF
+    /// uprobe observing a completed write, or a post-hoc audit scan.
+    PostTransmission,
+    /// The producing layer did not record where it sat.
+    ///
+    /// Never satisfies condition 1. An unwired producer must not be able to
+    /// claim prevention by saying nothing.
+    NotRecorded,
+}
+
+impl EnforcementPoint {
+    /// The stable spelling used in events and metric labels.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::PreTransmission => "pre_transmission",
+            Self::PostTransmission => "post_transmission",
+            Self::NotRecorded => "not_recorded",
+        }
+    }
+}
+
+/// What was observed about the bytes that would have gone to the destination.
+///
+/// Mirrors `aa_proxy::probe_adjudication::ForwardedPayload`, which is the
+/// observable ADR 0032 §8 names, plus a [`NotRecorded`](Self::NotRecorded) for
+/// the paths that do not produce it yet. The mirroring is deliberate: this is
+/// the vocabulary of the thing that actually knows, and inventing a second one
+/// would put a translation step between the evidence and the record of it.
+///
+/// Like `ForwardedPayload`, this is about **bytes, not about the decision**. A
+/// layer that decided to redact but emitted a payload still carrying the
+/// credential reports [`ForwardedCarryingSensitiveValue`](Self::ForwardedCarryingSensitiveValue)
+/// and must not read as protection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub enum TransmissionEvidence {
+    /// There were no bytes to inspect: the request was refused. The only
+    /// observation that can support a prevention claim.
+    NotForwarded,
+    /// Bytes were forwarded and re-inspection found nothing sensitive in them.
+    /// This is what a successful redaction looks like — a *transformed
+    /// transmission*, not a prevented one.
+    ForwardedClean,
+    /// Bytes were forwarded and re-inspection still found a sensitive value.
+    ForwardedCarryingSensitiveValue,
+    /// Bytes were forwarded and nothing re-inspected them, so this layer cannot
+    /// say what they carried. Never protective.
+    ForwardedNotInspected,
+    /// No execution evidence was captured at all.
+    ///
+    /// The default state of every path AAASM-5358 has not reached yet. Distinct
+    /// from [`ForwardedNotInspected`](Self::ForwardedNotInspected), which at
+    /// least establishes that bytes went.
+    NotRecorded,
+}
+
+impl TransmissionEvidence {
+    /// The stable spelling used in events and metric labels.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::NotForwarded => "not_forwarded",
+            Self::ForwardedClean => "forwarded_clean",
+            Self::ForwardedCarryingSensitiveValue => "forwarded_carrying_sensitive_value",
+            Self::ForwardedNotInspected => "forwarded_not_inspected",
+            Self::NotRecorded => "not_recorded",
+        }
+    }
+
+    /// Whether the payload is known to have reached the destination.
+    ///
+    /// `false` for [`NotRecorded`](Self::NotRecorded) — absence of evidence is
+    /// not evidence of transmission any more than it is evidence of prevention.
+    /// Use [`proves_non_transmission`](Self::proves_non_transmission) for the
+    /// other direction rather than negating this one.
+    pub const fn proves_transmission(&self) -> bool {
+        matches!(
+            self,
+            Self::ForwardedClean | Self::ForwardedCarryingSensitiveValue | Self::ForwardedNotInspected
+        )
+    }
+
+    /// Whether the payload is known **not** to have reached the destination.
+    ///
+    /// True only for [`NotForwarded`](Self::NotForwarded). Deliberately not the
+    /// negation of [`proves_transmission`](Self::proves_transmission): both are
+    /// `false` for `NotRecorded`, because a path that recorded nothing has
+    /// proved nothing in either direction.
+    pub const fn proves_non_transmission(&self) -> bool {
+        matches!(self, Self::NotForwarded)
+    }
+}
+
+/// How the detection pass itself terminated.
+///
+/// ADR 0032 §5 and validation requirement 8: a detection source that could not
+/// handle its input must produce an outcome distinguishable from "clean", never
+/// a clean result. [`Completed`](Self::Completed) is the *only* value that says
+/// detection ran to completion, and it says nothing about whether anything was
+/// found — the finding counts do that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub enum InspectionFailurePath {
+    /// Detection ran to completion. Not a synonym for "found nothing".
+    Completed,
+    /// Detection could not complete and the action was allowed to proceed.
+    FailedOpen,
+    /// Detection could not complete and the action was refused.
+    FailedClosed,
+    /// The primary path could not complete and a reduced one answered instead —
+    /// so the result is real but weaker, and a false-positive or false-negative
+    /// report has to know that.
+    Fallback,
+}
+
+impl InspectionFailurePath {
+    /// The stable spelling used in events and metric labels.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::FailedOpen => "failed_open",
+            Self::FailedClosed => "failed_closed",
+            Self::Fallback => "fallback",
+        }
+    }
+
+    /// Whether detection ran to completion.
+    ///
+    /// Exists so a reader asks this question instead of `!= FailedOpen`, which
+    /// would quietly treat a fallback result as a full one.
+    pub const fn is_complete(&self) -> bool {
+        matches!(self, Self::Completed)
+    }
+}
+
+/// The record of what happened to the action, assembled from what was observed.
+///
+/// Holds conditions 1, 3 and 4 of ADR 0032 §8's prevention test. Condition 2 is
+/// a property of the verdict and is not duplicated here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct ExecutionEvidence {
+    /// Where the decision was applied.
+    pub enforcement_point: EnforcementPoint,
+    /// What was observed about the forwarded bytes.
+    pub transmission: TransmissionEvidence,
+    /// Whether enforcement was actually applied, or merely computed.
+    ///
+    /// Reuses [`EnforcementMode`] rather than introducing a third mode
+    /// vocabulary. Only [`EnforcementMode::Enforce`] satisfies condition 4:
+    /// under `Observe` the decision was computed and audited but never applied,
+    /// and under `Disabled` policy evaluation did not run.
+    pub mode: EnforcementMode,
+}
+
+impl ExecutionEvidence {
+    /// Assemble an evidence record.
+    pub const fn new(
+        enforcement_point: EnforcementPoint,
+        transmission: TransmissionEvidence,
+        mode: EnforcementMode,
+    ) -> Self {
+        Self {
+            enforcement_point,
+            transmission,
+            mode,
+        }
+    }
+
+    /// The state of a path that has not been instrumented yet.
+    ///
+    /// Nothing observed, nothing claimed. This is the honest default for every
+    /// producer AAASM-5358 has not reached, and it can never satisfy
+    /// [`establishes_non_transmission`](Self::establishes_non_transmission).
+    pub const fn unrecorded(mode: EnforcementMode) -> Self {
+        Self::new(EnforcementPoint::NotRecorded, TransmissionEvidence::NotRecorded, mode)
+    }
+
+    /// Whether conditions 1, 3 and 4 of the prevention test all hold.
+    ///
+    /// Not the whole test — the verdict supplies condition 2. A caller wanting
+    /// the prevention metric must use
+    /// [`SensitiveDataDecisionEvent::counts_as_prevented_transmission`](super::SensitiveDataDecisionEvent::counts_as_prevented_transmission),
+    /// which is the only place all four are conjoined.
+    pub const fn establishes_non_transmission(&self) -> bool {
+        matches!(self.enforcement_point, EnforcementPoint::PreTransmission)
+            && self.transmission.proves_non_transmission()
+            && matches!(self.mode, EnforcementMode::Enforce)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The single positive case. Everything else in this module is about the
+    /// ways it must *not* hold.
+    #[test]
+    fn a_pre_transmission_enforced_refusal_establishes_non_transmission() {
+        let evidence = ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+        );
+        assert!(evidence.establishes_non_transmission());
+    }
+
+    /// Dropping any one of the three conditions must destroy the claim. Written
+    /// as a sweep rather than one happy assertion because a conjunction that
+    /// silently loses a clause still passes its positive test.
+    #[test]
+    fn every_single_condition_is_load_bearing() {
+        let base = ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+        );
+
+        for point in [EnforcementPoint::PostTransmission, EnforcementPoint::NotRecorded] {
+            let weakened = ExecutionEvidence {
+                enforcement_point: point,
+                ..base
+            };
+            assert!(
+                !weakened.establishes_non_transmission(),
+                "a {point:?} decision cannot have stopped bytes that had already gone"
+            );
+        }
+
+        for transmission in [
+            TransmissionEvidence::ForwardedClean,
+            TransmissionEvidence::ForwardedCarryingSensitiveValue,
+            TransmissionEvidence::ForwardedNotInspected,
+            TransmissionEvidence::NotRecorded,
+        ] {
+            let weakened = ExecutionEvidence { transmission, ..base };
+            assert!(
+                !weakened.establishes_non_transmission(),
+                "{transmission:?} is not proof the payload was withheld"
+            );
+        }
+
+        for mode in [EnforcementMode::Observe, EnforcementMode::Disabled] {
+            let weakened = ExecutionEvidence { mode, ..base };
+            assert!(
+                !weakened.establishes_non_transmission(),
+                "{mode:?} computes a decision without applying it"
+            );
+        }
+    }
+
+    /// A successful redaction is the case the old `CredentialLeakBlocked` name
+    /// got wrong: the scrubbed bytes *were* forwarded, so it is a transformed
+    /// transmission and must never read as prevention.
+    #[test]
+    fn a_clean_forwarded_payload_is_a_transmission_not_a_prevention() {
+        assert!(TransmissionEvidence::ForwardedClean.proves_transmission());
+        assert!(!TransmissionEvidence::ForwardedClean.proves_non_transmission());
+    }
+
+    /// Absence of evidence proves nothing in either direction. If the two
+    /// predicates were ever made complements, an uninstrumented path would
+    /// start claiming one of the two answers for free.
+    #[test]
+    fn unrecorded_evidence_proves_nothing_in_either_direction() {
+        assert!(!TransmissionEvidence::NotRecorded.proves_transmission());
+        assert!(!TransmissionEvidence::NotRecorded.proves_non_transmission());
+        assert!(!ExecutionEvidence::unrecorded(EnforcementMode::Enforce).establishes_non_transmission());
+    }
+
+    /// `Completed` is not a synonym for "clean", and a fallback result is not a
+    /// complete one — ADR 0032 §5's rule that a degraded pass never presents as
+    /// a full one.
+    #[test]
+    fn only_a_completed_inspection_reads_as_complete() {
+        assert!(InspectionFailurePath::Completed.is_complete());
+        for degraded in [
+            InspectionFailurePath::FailedOpen,
+            InspectionFailurePath::FailedClosed,
+            InspectionFailurePath::Fallback,
+        ] {
+            assert!(!degraded.is_complete(), "{degraded:?} read as a complete inspection");
+        }
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::*;
+
+    /// Each vocabulary serializes to exactly its `as_str()`, so the JSON and the
+    /// documented spelling cannot drift one variant at a time — the same
+    /// discipline `aa-security`'s canonical model applies to its own
+    /// vocabularies.
+    #[test]
+    fn every_evidence_vocabulary_serializes_as_its_as_str() {
+        macro_rules! assert_as_str {
+            ($($value:expr),* $(,)?) => {
+                $(
+                    assert_eq!(
+                        serde_json::to_string(&$value).unwrap(),
+                        alloc::format!("\"{}\"", $value.as_str()),
+                        "serialized form diverged from as_str() for {:?}",
+                        $value
+                    );
+                )*
+            };
+        }
+
+        assert_as_str!(
+            EnforcementPoint::PreTransmission,
+            EnforcementPoint::PostTransmission,
+            EnforcementPoint::NotRecorded,
+            TransmissionEvidence::NotForwarded,
+            TransmissionEvidence::ForwardedClean,
+            TransmissionEvidence::ForwardedCarryingSensitiveValue,
+            TransmissionEvidence::ForwardedNotInspected,
+            TransmissionEvidence::NotRecorded,
+            InspectionFailurePath::Completed,
+            InspectionFailurePath::FailedOpen,
+            InspectionFailurePath::FailedClosed,
+            InspectionFailurePath::Fallback,
+        );
+    }
+
+    #[test]
+    fn execution_evidence_round_trips() {
+        let evidence = ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+        );
+        let json = serde_json::to_string(&evidence).unwrap();
+        let restored: ExecutionEvidence = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, evidence);
+        assert!(restored.establishes_non_transmission());
+    }
+}

--- a/aa-core/src/types/sensitive_data/finding_record.rs
+++ b/aa-core/src/types/sensitive_data/finding_record.rs
@@ -126,15 +126,36 @@ impl core::fmt::Display for AggregateKey {
 ///
 /// # What it can carry
 ///
-/// The only caller-supplied string is the [`FieldPath`], which is screened. The
-/// redaction label is *derived* from the category rather than accepted, so a
-/// caller cannot pass arbitrary text through it. Everything else comes from
+/// Three of its fields hold caller-supplied strings, at three strengths, and
+/// it is worth being exact about which is which:
+///
+/// | Field | Guard on the way in |
+/// |---|---|
+/// | [`field_path`](Self::field_path) | credential scan **and** shape check |
+/// | [`event_id`](Self::event_id), [`provenance.version`](DetectionProvenance::version) | shape check only ([`AuditLabel`]) |
+/// | [`category`](Self::category), [`redaction_label`](Self::redaction_label) | shape check only; *derived* by [`from_finding`](Self::from_finding), but see below |
+///
+/// [`from_finding`](Self::from_finding) derives the category and the redaction
+/// label from the finding and offers no parameter for either, so **that path**
+/// cannot be handed arbitrary text. Everything else it writes comes from
 /// `aa-security`'s compiled-in vocabularies.
 ///
+/// # What that does not mean
+///
 /// The same honesty `aa-security` applies to its own model applies here: this
-/// is a property of the construction paths, not an unrepresentable state.
-/// Deserialization reconstructs a record from bytes without re-running the
-/// guard, deliberately — see [`FieldPath`].
+/// is a property of the construction paths, **not an unrepresentable state**.
+/// Two ways around it, both deliberate:
+///
+/// - the fields are `pub`, so a caller can assign one after construction; and
+/// - `Deserialize` rebuilds a record from bytes, re-checking shape but never
+///   re-screening, because a stored record has to round-trip even if a later
+///   build tightens the rules.
+///
+/// So a record in hand is **not** evidence that its category is one this build
+/// knows or that its labels are bounded. A consumer that needs either must
+/// check — which is exactly why
+/// [`SensitiveDataMetricLabels::from_finding`](super::SensitiveDataMetricLabels::from_finding)
+/// resolves the category and returns `None` rather than trusting this type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -142,6 +163,17 @@ impl core::fmt::Display for AggregateKey {
 pub struct SensitiveDataFindingRecord {
     /// Schema this row was written against.
     pub schema_version: SchemaVersion,
+    /// The [`SensitiveDataDecisionEvent`](super::SensitiveDataDecisionEvent)
+    /// this finding belongs to.
+    ///
+    /// Without it "child row" would be a name rather than a relationship: the
+    /// event holds no `Vec<SensitiveDataFindingRecord>` — [`FindingCounts::tally`](super::FindingCounts::tally)
+    /// consumes the rows and keeps only the tallies — so this is the *only*
+    /// thing tying a finding to the action it came from. Aggregating without it
+    /// leaves `finding_counts.by_category` as the sole answer to the Epic's
+    /// motivating question, which drops severity, confidence, method, status,
+    /// field path and provenance.
+    pub event_id: AuditLabel,
     /// What was found, in provider-neutral terms.
     pub category: CategoryLabel,
     /// How damaging its exposure would be.
@@ -176,6 +208,9 @@ pub struct SensitiveDataFindingRecord {
 impl SensitiveDataFindingRecord {
     /// Project a canonical finding into a storable row, dropping the span.
     ///
+    /// `event_id` is required rather than optional: a finding row that cannot
+    /// name its parent event is not a child row.
+    ///
     /// The redaction label is derived from the finding's category — there is no
     /// parameter for it, so a caller cannot substitute text of its own.
     ///
@@ -184,10 +219,15 @@ impl SensitiveDataFindingRecord {
     /// [`FieldRejection`] if the derived redaction label or the recognizer
     /// version fails the shape check. The `field_path` was screened when it was
     /// built.
-    pub fn from_finding(finding: &CanonicalFinding, field_path: FieldPath) -> Result<Self, FieldRejection> {
+    pub fn from_finding(
+        event_id: AuditLabel,
+        finding: &CanonicalFinding,
+        field_path: FieldPath,
+    ) -> Result<Self, FieldRejection> {
         let category = finding.category();
         Ok(Self {
             schema_version: SENSITIVE_DATA_SCHEMA_VERSION,
+            event_id,
             category: CategoryLabel::from(category),
             severity: finding.severity(),
             confidence: finding.confidence(),
@@ -238,6 +278,7 @@ mod tests {
 
     fn a_record() -> SensitiveDataFindingRecord {
         SensitiveDataFindingRecord::from_finding(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
             &synthetic_finding(
                 CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access"),
                 Severity::Critical,
@@ -276,6 +317,7 @@ mod tests {
     #[test]
     fn an_unmappable_category_redacts_to_the_opaque_label() {
         let record = SensitiveDataFindingRecord::from_finding(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
             &synthetic_finding(
                 CanonicalCategory::with_locale(CategoryBase::NationalId, "xx-ZZ", "synthetic_for_test"),
                 Severity::Medium,
@@ -299,9 +341,13 @@ mod tests {
 
         let key_of = |result: &aa_security::ScanResult| {
             let finding = CanonicalFinding::try_from(&result.findings[0]).unwrap();
-            SensitiveDataFindingRecord::from_finding(&finding, path.clone())
-                .unwrap()
-                .aggregate_key()
+            SensitiveDataFindingRecord::from_finding(
+                AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
+                &finding,
+                path.clone(),
+            )
+            .unwrap()
+            .aggregate_key()
         };
 
         assert_eq!(
@@ -317,6 +363,7 @@ mod tests {
     fn the_aggregate_key_separates_field_and_category() {
         let base = a_record();
         let other_field = SensitiveDataFindingRecord::from_finding(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
             &synthetic_finding(
                 CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access"),
                 Severity::Critical,
@@ -325,6 +372,7 @@ mod tests {
         )
         .unwrap();
         let other_category = SensitiveDataFindingRecord::from_finding(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
             &synthetic_finding(
                 CanonicalCategory::unqualified(CategoryBase::EmailAddress),
                 Severity::Medium,
@@ -344,10 +392,18 @@ mod tests {
     fn the_aggregate_key_ignores_severity() {
         let path = FieldPath::parse("body.token").unwrap();
         let category = CanonicalCategory::unqualified(CategoryBase::EmailAddress);
-        let critical =
-            SensitiveDataFindingRecord::from_finding(&synthetic_finding(category, Severity::Critical), path.clone())
-                .unwrap();
-        let low = SensitiveDataFindingRecord::from_finding(&synthetic_finding(category, Severity::Low), path).unwrap();
+        let critical = SensitiveDataFindingRecord::from_finding(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
+            &synthetic_finding(category, Severity::Critical),
+            path.clone(),
+        )
+        .unwrap();
+        let low = SensitiveDataFindingRecord::from_finding(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
+            &synthetic_finding(category, Severity::Low),
+            path,
+        )
+        .unwrap();
         assert_eq!(critical.aggregate_key(), low.aggregate_key());
     }
 }
@@ -369,8 +425,12 @@ mod serde_tests {
             FindingStatus::Confirmed,
         )
         .unwrap();
-        SensitiveDataFindingRecord::from_finding(&finding, FieldPath::parse("body.headers.authorization").unwrap())
-            .unwrap()
+        SensitiveDataFindingRecord::from_finding(
+            AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap(),
+            &finding,
+            FieldPath::parse("body.headers.authorization").unwrap(),
+        )
+        .unwrap()
     }
 
     /// **The span-free-subset test.** ADR 0032 §9 confines offsets and lengths
@@ -411,6 +471,7 @@ mod serde_tests {
             serde_json::to_string(&a_record()).unwrap(),
             concat!(
                 r#"{"schema_version":{"major":1,"minor":0},"#,
+                r#""event_id":"01HZX9V8ABCDEFGHJKMNPQRSTV","#,
                 r#""category":"ACCESS_TOKEN[github:personal_access]","severity":"critical","#,
                 r#""confidence":"high","method":"deterministic","status":"confirmed","#,
                 r#""provenance":{"recognizer":"aa-security::scanner","version":"0.0.0-test"},"#,

--- a/aa-core/src/types/sensitive_data/finding_record.rs
+++ b/aa-core/src/types/sensitive_data/finding_record.rs
@@ -1,0 +1,441 @@
+//! The finding-level child row of a sensitive-data decision event.
+
+use alloc::string::String;
+
+use aa_security::canonical::{
+    CanonicalFinding, ConfidenceBand, DetectionMethod, FindingStatus, Provenance, Recognizer, Severity,
+};
+
+use super::guard::{AuditLabel, FieldPath, FieldRejection};
+use super::schema::{SchemaVersion, SENSITIVE_DATA_SCHEMA_VERSION};
+use super::vocab;
+use super::CategoryLabel;
+
+/// Which recognizer produced a finding, and at which version.
+///
+/// The `aa-core` counterpart of
+/// [`Provenance`](aa_security::canonical::Provenance), which cannot be stored
+/// directly because its `version` is a `&'static str` and nothing deserializes
+/// into one.
+///
+/// Carries the same warning `aa-security` attaches to its own type, because
+/// nothing about crossing into a record improves it: **this is not an
+/// authenticity boundary.** Provenance is stamped by whoever built the finding.
+/// It records which recognizer a value *claims* to come from, and a well-formed
+/// forgery is indistinguishable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct DetectionProvenance {
+    /// The detection source the finding claims to come from.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::recognizer"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "vocab::recognizer::schema"))]
+    pub recognizer: Recognizer,
+    /// Version of that recognizer. Descriptive, not a trust signal — it says
+    /// which build's detectors ran, not that they really did.
+    pub version: AuditLabel,
+}
+
+impl DetectionProvenance {
+    /// Name a recognizer and its version.
+    ///
+    /// # Errors
+    ///
+    /// Whatever [`AuditLabel::new`] rejects the version for.
+    pub fn new(recognizer: Recognizer, version: impl Into<String>) -> Result<Self, FieldRejection> {
+        Ok(Self {
+            recognizer,
+            version: AuditLabel::new(version)?,
+        })
+    }
+}
+
+impl TryFrom<Provenance> for DetectionProvenance {
+    type Error = FieldRejection;
+
+    /// Fallible only because the version is re-checked on the way in.
+    ///
+    /// In practice `aa-security` builds it from `CARGO_PKG_VERSION`, so this
+    /// does not fail — but the check is not skipped on that basis, because
+    /// `&'static str` does not mean "compiled in" (`Box::leak` produces one
+    /// from arbitrary runtime bytes in safe Rust), and this crate would rather
+    /// not have an unchecked way in.
+    fn try_from(provenance: Provenance) -> Result<Self, Self::Error> {
+        Self::new(provenance.recognizer, provenance.version)
+    }
+}
+
+/// The stable identity a finding is grouped and deduplicated by.
+///
+/// # Not a fingerprint
+///
+/// ADR 0032 §9 permits tenant-keyed HMAC fingerprints only above roughly 80 bits
+/// of value entropy, which excludes every PII category: a Taiwan national ID has
+/// about 5.2 × 10⁸ candidates and enumerates in well under a second on one GPU
+/// given the tenant key. Forbidden design #14 names it directly.
+///
+/// So this key is built from **where and what**, never from the value: the
+/// category, the field path, the detection method and the recognizer. Two
+/// different national IDs found in the same field under the same category
+/// produce the *same* key. That is the intended behaviour for deduplication,
+/// and it is also precisely why the key is safe — it cannot distinguish one
+/// value from another, so it cannot be enumerated back to one.
+///
+/// # Not a metric label
+///
+/// The key embeds a field path, which is caller-derived and unbounded.
+/// ADR 0032 §9 restricts metric labels to a bounded set; use
+/// [`SensitiveDataMetricLabels`](super::SensitiveDataMetricLabels) for that.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(transparent))]
+pub struct AggregateKey(String);
+
+impl AggregateKey {
+    /// The key as a single string, `category|field_path|method|recognizer`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl core::fmt::Display for AggregateKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// One normalized finding, as it appears beneath a
+/// [`SensitiveDataDecisionEvent`](super::SensitiveDataDecisionEvent).
+///
+/// # Span-free by construction
+///
+/// A [`CanonicalFinding`] carries a [`ByteSpan`](aa_security::canonical::ByteSpan),
+/// and ADR 0032 §9 permits offsets and lengths **only** in the tamper-evident
+/// audit tier — a length plus a category can identify a value in a small domain,
+/// and forbidden design #12 puts them out of bounds for metric labels, traces
+/// and API responses outright.
+///
+/// This record is the other tier. [`from_finding`](Self::from_finding) reads a
+/// canonical finding and **discards** the span; there is no field to put one in
+/// and no accessor to get one out. AAASM-5352 recorded this obligation against
+/// this ticket in `aa-security`'s `serde_impls.rs`, observing that it would be
+/// incoherent to keep `end()` `pub(crate)` in Rust and then publish the offset
+/// in JSON to anything that asks. Discharged here.
+///
+/// # What it can carry
+///
+/// The only caller-supplied string is the [`FieldPath`], which is screened. The
+/// redaction label is *derived* from the category rather than accepted, so a
+/// caller cannot pass arbitrary text through it. Everything else comes from
+/// `aa-security`'s compiled-in vocabularies.
+///
+/// The same honesty `aa-security` applies to its own model applies here: this
+/// is a property of the construction paths, not an unrepresentable state.
+/// Deserialization reconstructs a record from bytes without re-running the
+/// guard, deliberately — see [`FieldPath`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub struct SensitiveDataFindingRecord {
+    /// Schema this row was written against.
+    pub schema_version: SchemaVersion,
+    /// What was found, in provider-neutral terms.
+    pub category: CategoryLabel,
+    /// How damaging its exposure would be.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::severity"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "vocab::severity::schema"))]
+    pub severity: Severity,
+    /// How much the recognizer trusts the finding. Never an authorisation input.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::confidence"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "vocab::confidence::schema"))]
+    pub confidence: ConfidenceBand,
+    /// The technique that produced it.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::method"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "vocab::method::schema"))]
+    pub method: DetectionMethod,
+    /// Its triage state. Nothing in this vocabulary means "clean".
+    #[cfg_attr(feature = "serde", serde(with = "vocab::status"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "vocab::status::schema"))]
+    pub status: FindingStatus,
+    /// Which recognizer claims to have produced it, and at which version.
+    pub provenance: DetectionProvenance,
+    /// The name of the inspected field. The drill-down granularity ADR 0032 §9
+    /// grants in place of the byte offsets this tier may not have.
+    pub field_path: FieldPath,
+    /// The `[REDACTED:…]` label this finding redacts to.
+    ///
+    /// Stored rather than recomputed on read: it is what the writing build
+    /// actually emitted, and for a category a reader does not know, the
+    /// writer's label is the more accurate of the two.
+    pub redaction_label: AuditLabel,
+}
+
+impl SensitiveDataFindingRecord {
+    /// Project a canonical finding into a storable row, dropping the span.
+    ///
+    /// The redaction label is derived from the finding's category — there is no
+    /// parameter for it, so a caller cannot substitute text of its own.
+    ///
+    /// # Errors
+    ///
+    /// [`FieldRejection`] if the derived redaction label or the recognizer
+    /// version fails the shape check. The `field_path` was screened when it was
+    /// built.
+    pub fn from_finding(finding: &CanonicalFinding, field_path: FieldPath) -> Result<Self, FieldRejection> {
+        let category = finding.category();
+        Ok(Self {
+            schema_version: SENSITIVE_DATA_SCHEMA_VERSION,
+            category: CategoryLabel::from(category),
+            severity: finding.severity(),
+            confidence: finding.confidence(),
+            method: finding.method(),
+            status: finding.status(),
+            provenance: DetectionProvenance::try_from(finding.provenance())?,
+            field_path,
+            redaction_label: AuditLabel::new(category.redaction_label())?,
+        })
+    }
+
+    /// The identity this row deduplicates and aggregates under.
+    ///
+    /// Derived on demand rather than stored. A stored copy is a second source of
+    /// truth for something already fully determined by the row, and the failure
+    /// mode of that is a key that disagrees with the record it keys.
+    pub fn aggregate_key(&self) -> AggregateKey {
+        AggregateKey(alloc::format!(
+            "{}|{}|{}|{}",
+            self.category,
+            self.field_path,
+            self.method.as_str(),
+            self.provenance.recognizer.as_str()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aa_security::canonical::{ByteSpan, CanonicalCategory, CategoryBase};
+    use aa_security::CredentialScanner;
+
+    use super::*;
+
+    /// Build a finding without going near a real secret.
+    fn synthetic_finding(category: CanonicalCategory, severity: Severity) -> CanonicalFinding {
+        CanonicalFinding::new(
+            category,
+            severity,
+            ConfidenceBand::High,
+            ByteSpan::new(12, 52),
+            DetectionMethod::Deterministic,
+            Provenance::new(Recognizer::BuiltinScanner, "0.0.0-test"),
+            FindingStatus::Confirmed,
+        )
+        .expect("well-formed span")
+    }
+
+    fn a_record() -> SensitiveDataFindingRecord {
+        SensitiveDataFindingRecord::from_finding(
+            &synthetic_finding(
+                CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access"),
+                Severity::Critical,
+            ),
+            FieldPath::parse("body.headers.authorization").unwrap(),
+        )
+        .unwrap()
+    }
+
+    /// The record faithfully carries everything the finding said.
+    #[test]
+    fn a_record_carries_the_findings_classification() {
+        let record = a_record();
+        assert_eq!(record.category.as_str(), "ACCESS_TOKEN[github:personal_access]");
+        assert_eq!(record.severity, Severity::Critical);
+        assert_eq!(record.confidence, ConfidenceBand::High);
+        assert_eq!(record.method, DetectionMethod::Deterministic);
+        assert_eq!(record.status, FindingStatus::Confirmed);
+        assert_eq!(record.provenance.recognizer, Recognizer::BuiltinScanner);
+        assert_eq!(record.provenance.version.as_str(), "0.0.0-test");
+        assert_eq!(record.schema_version, SENSITIVE_DATA_SCHEMA_VERSION);
+    }
+
+    /// The redaction label reproduces the published `CredentialKind` label for a
+    /// category that maps back to one — the frozen contract
+    /// `GET /api/v1/scrub/patterns` serves.
+    #[test]
+    fn the_redaction_label_is_derived_from_the_category() {
+        assert_eq!(a_record().redaction_label.as_str(), "[REDACTED:GitHubPat]");
+    }
+
+    /// A category with no `CredentialKind` gets the opaque sentinel, not an
+    /// invented `[REDACTED:<category>]` — which would publish a pattern name
+    /// that `/api/v1/scrub/patterns` does not list and extend the frozen
+    /// catalogue by accident.
+    #[test]
+    fn an_unmappable_category_redacts_to_the_opaque_label() {
+        let record = SensitiveDataFindingRecord::from_finding(
+            &synthetic_finding(
+                CanonicalCategory::with_locale(CategoryBase::NationalId, "xx-ZZ", "synthetic_for_test"),
+                Severity::Medium,
+            ),
+            FieldPath::parse("body.id").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(record.redaction_label.as_str(), "[REDACTED]");
+    }
+
+    /// Findings of the same category in the same field share a key, whatever
+    /// the underlying values were. That is the deduplication behaviour, and it
+    /// is the reason the key cannot be enumerated back to a value.
+    #[test]
+    fn the_aggregate_key_is_structural_and_not_value_derived() {
+        let scanner = CredentialScanner::new();
+        // Two different synthetic GitHub PATs.
+        let first = scanner.scan("token ghp_16C7e42F292c6912E7710c838347Ae178B4a");
+        let second = scanner.scan("token ghp_ZZZ7e42F292c6912E7710c838347Ae178B4a");
+        let path = FieldPath::parse("body.token").unwrap();
+
+        let key_of = |result: &aa_security::ScanResult| {
+            let finding = CanonicalFinding::try_from(&result.findings[0]).unwrap();
+            SensitiveDataFindingRecord::from_finding(&finding, path.clone())
+                .unwrap()
+                .aggregate_key()
+        };
+
+        assert_eq!(
+            key_of(&first),
+            key_of(&second),
+            "two different values in the same field must aggregate together"
+        );
+    }
+
+    /// The key still separates the dimensions it is supposed to. Without this,
+    /// the previous test would be satisfied by a constant.
+    #[test]
+    fn the_aggregate_key_separates_field_and_category() {
+        let base = a_record();
+        let other_field = SensitiveDataFindingRecord::from_finding(
+            &synthetic_finding(
+                CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access"),
+                Severity::Critical,
+            ),
+            FieldPath::parse("body.other_field").unwrap(),
+        )
+        .unwrap();
+        let other_category = SensitiveDataFindingRecord::from_finding(
+            &synthetic_finding(
+                CanonicalCategory::unqualified(CategoryBase::EmailAddress),
+                Severity::Medium,
+            ),
+            FieldPath::parse("body.headers.authorization").unwrap(),
+        )
+        .unwrap();
+
+        assert_ne!(base.aggregate_key(), other_field.aggregate_key());
+        assert_ne!(base.aggregate_key(), other_category.aggregate_key());
+    }
+
+    /// Severity is not part of the aggregate identity: it is a property of the
+    /// category, so including it would add nothing and would split a group the
+    /// moment a severity was retuned.
+    #[test]
+    fn the_aggregate_key_ignores_severity() {
+        let path = FieldPath::parse("body.token").unwrap();
+        let category = CanonicalCategory::unqualified(CategoryBase::EmailAddress);
+        let critical =
+            SensitiveDataFindingRecord::from_finding(&synthetic_finding(category, Severity::Critical), path.clone())
+                .unwrap();
+        let low = SensitiveDataFindingRecord::from_finding(&synthetic_finding(category, Severity::Low), path).unwrap();
+        assert_eq!(critical.aggregate_key(), low.aggregate_key());
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use aa_security::canonical::{ByteSpan, CanonicalCategory, CategoryBase};
+
+    use super::*;
+
+    fn a_record() -> SensitiveDataFindingRecord {
+        let finding = CanonicalFinding::new(
+            CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access"),
+            Severity::Critical,
+            ConfidenceBand::High,
+            ByteSpan::new(12, 52),
+            DetectionMethod::Deterministic,
+            Provenance::new(Recognizer::BuiltinScanner, "0.0.0-test"),
+            FindingStatus::Confirmed,
+        )
+        .unwrap();
+        SensitiveDataFindingRecord::from_finding(&finding, FieldPath::parse("body.headers.authorization").unwrap())
+            .unwrap()
+    }
+
+    /// **The span-free-subset test.** ADR 0032 §9 confines offsets and lengths
+    /// to the tamper-evident audit tier, and this record is not that tier.
+    ///
+    /// Asserted against the serialized JSON rather than the struct definition,
+    /// because the struct having no span field is only half of it — a nested
+    /// type could reintroduce one, and the JSON is what actually leaves.
+    #[test]
+    fn a_serialized_record_carries_no_span_offset_or_length() {
+        let json = serde_json::to_value(a_record()).unwrap();
+
+        fn walk(value: &serde_json::Value, forbidden: &[&str]) {
+            match value {
+                serde_json::Value::Object(map) => {
+                    for (key, child) in map {
+                        assert!(
+                            !forbidden.contains(&key.as_str()),
+                            "the projection leaked `{key}`, which ADR 0032 §9 confines to the audit tier"
+                        );
+                        walk(child, forbidden);
+                    }
+                }
+                serde_json::Value::Array(items) => items.iter().for_each(|item| walk(item, forbidden)),
+                _ => {}
+            }
+        }
+
+        walk(&json, &["span", "start", "end", "offset", "length", "len"]);
+    }
+
+    /// The wire shape, pinned. Everything a consumer keys off is here, spelled
+    /// the way `aa-security` spells it — `"critical"`, not `"Critical"`, and the
+    /// rendered category rather than a nested object.
+    #[test]
+    fn a_finding_record_serializes_to_its_documented_shape() {
+        assert_eq!(
+            serde_json::to_string(&a_record()).unwrap(),
+            concat!(
+                r#"{"schema_version":{"major":1,"minor":0},"#,
+                r#""category":"ACCESS_TOKEN[github:personal_access]","severity":"critical","#,
+                r#""confidence":"high","method":"deterministic","status":"confirmed","#,
+                r#""provenance":{"recognizer":"aa-security::scanner","version":"0.0.0-test"},"#,
+                r#""field_path":"body.headers.authorization","redaction_label":"[REDACTED:GitHubPat]"}"#
+            )
+        );
+    }
+
+    #[test]
+    fn a_finding_record_round_trips() {
+        let record = a_record();
+        let json = serde_json::to_string(&record).unwrap();
+        let restored: SensitiveDataFindingRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, record);
+        assert_eq!(restored.aggregate_key(), record.aggregate_key());
+    }
+
+    /// An unknown severity is refused rather than coerced. Reading
+    /// `"catastrophic"` as `low` because it is first in some list would
+    /// understate a finding forever.
+    #[test]
+    fn an_unknown_vocabulary_label_fails_to_deserialize() {
+        let json = serde_json::to_string(&a_record())
+            .unwrap()
+            .replace(r#""severity":"critical""#, r#""severity":"catastrophic""#);
+        assert!(serde_json::from_str::<SensitiveDataFindingRecord>(&json).is_err());
+    }
+}

--- a/aa-core/src/types/sensitive_data/guard.rs
+++ b/aa-core/src/types/sensitive_data/guard.rs
@@ -114,7 +114,7 @@ impl core::fmt::Display for FieldRejection {
 impl std::error::Error for FieldRejection {}
 
 /// Shape check shared by every guarded string: non-empty, bounded, printable.
-fn check_shape(candidate: &str, limit: usize) -> Result<(), FieldRejection> {
+pub(super) fn check_shape(candidate: &str, limit: usize) -> Result<(), FieldRejection> {
     if candidate.is_empty() {
         return Err(FieldRejection::Empty);
     }

--- a/aa-core/src/types/sensitive_data/guard.rs
+++ b/aa-core/src/types/sensitive_data/guard.rs
@@ -1,0 +1,403 @@
+//! The screened string types, and the guard that stands between a caller and a
+//! sensitive-data record.
+//!
+//! # Why a guard exists at all
+//!
+//! Everything else in a [`SensitiveDataDecisionEvent`](super::SensitiveDataDecisionEvent)
+//! or a [`SensitiveDataFindingRecord`](super::SensitiveDataFindingRecord) is an
+//! enum, an integer, or a `&'static str` from `aa-security`'s compiled-in
+//! catalogue — none of which can hold bytes the scanner read. The strings a
+//! caller supplies are the entire remaining surface through which a raw
+//! sensitive value could reach a record, so they are the only thing worth
+//! guarding, and guarding them is tractable.
+//!
+//! ADR 0032's security section asks for these prohibitions to be enforced in
+//! the type system "where possible rather than by convention". This is the
+//! where-possible part: the records have no constructor that takes a bare
+//! `String`, so there is no path to a record field that does not pass through
+//! one of the types below.
+//!
+//! # Two strengths of guarantee, and why they differ
+//!
+//! | Type | Check |
+//! |---|---|
+//! | [`AuditLabel`] | shape only — bounded length, no ASCII control characters |
+//! | [`FieldPath`], and [`Endpoint`](super::Endpoint) identifiers | shape **and** a credential scan |
+//!
+//! The split is not laziness, it is a measurement. `AuditLabel` holds
+//! system-generated identifiers — a ULID session id, a trace id, a tenant slug —
+//! and the scanner flags a ULID: `01HZX9V8ABCDEFGHJKMNPQRSTV` scans as
+//! `GenericHighEntropy`, because a detector whose job is to notice high-entropy
+//! blobs cannot tell one from a correlation id. Screening those would reject
+//! well-formed events for a risk that is not there: an id is minted by the
+//! system, never lifted out of the payload being inspected.
+//!
+//! A field path and an endpoint identifier *are* derived from the inspected
+//! request, so they get the scan. The concrete leak this closes is a database
+//! URI as a destination — `postgresql://user:password@db.internal/app` is
+//! flagged and refused, and the caller has to record the destination without
+//! the password in it.
+//!
+//! # The guard is not a proof
+//!
+//! Stated plainly, because the neighbouring `aa-security` module was careful to
+//! state its own limits and it would be dishonest to overclaim here.
+//!
+//! The scan can only refuse what the scanner recognises. A sensitive value of a
+//! category no detector covers passes, and so does a partial one. What the
+//! guard buys is that the *known* categories — every one the product claims to
+//! detect — cannot be written into an audit record through the one channel that
+//! could carry them, and that the failure is a refusal rather than a silent
+//! acceptance.
+
+use alloc::string::String;
+use std::sync::OnceLock;
+
+use aa_security::CredentialScanner;
+
+/// Longest accepted [`AuditLabel`], in bytes.
+///
+/// Generous next to a ULID or a UUID, and small enough that a payload fragment
+/// does not fit. A bound also matters because these values reach metric and log
+/// contexts where an unbounded string is its own problem.
+pub const MAX_LABEL_BYTES: usize = 256;
+
+/// Longest accepted [`FieldPath`], in bytes, across all segments and separators.
+pub const MAX_FIELD_PATH_BYTES: usize = 512;
+
+/// The process-wide scanner used for screening.
+///
+/// Built once: pattern compilation is the expensive part of
+/// [`CredentialScanner::new`], and screening happens once per string per event.
+fn screening_scanner() -> &'static CredentialScanner {
+    static SCANNER: OnceLock<CredentialScanner> = OnceLock::new();
+    SCANNER.get_or_init(CredentialScanner::new)
+}
+
+/// Why a caller-supplied string was refused as a record field.
+///
+/// # No offending text
+///
+/// No variant carries the rejected input, and none ever should. The whole point
+/// of [`FieldRejection::CarriesSensitiveValue`] is that the string held
+/// something that must not be written down; embedding it in an error would put
+/// it straight into the log line that reports the refusal, which is precisely
+/// the tier ADR 0032 §9 keeps it out of.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FieldRejection {
+    /// The input, or one of a path's segments, was empty.
+    Empty,
+    /// The input exceeded the type's byte limit.
+    TooLong,
+    /// The input contained an ASCII control character. Beyond being meaningless
+    /// in a path or an identifier, a newline forges record boundaries in any
+    /// line-oriented sink downstream.
+    ControlCharacter,
+    /// The credential scanner recognised something in the input. See the module
+    /// documentation for what this does and does not prove.
+    CarriesSensitiveValue,
+}
+
+impl core::fmt::Display for FieldRejection {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let message = match self {
+            Self::Empty => "must not be empty",
+            Self::TooLong => "exceeds the maximum length for this field",
+            Self::ControlCharacter => "must not contain ASCII control characters",
+            Self::CarriesSensitiveValue => "was refused: it matches a sensitive-data detector",
+        };
+        f.write_str(message)
+    }
+}
+
+impl std::error::Error for FieldRejection {}
+
+/// Shape check shared by every guarded string: non-empty, bounded, printable.
+fn check_shape(candidate: &str, limit: usize) -> Result<(), FieldRejection> {
+    if candidate.is_empty() {
+        return Err(FieldRejection::Empty);
+    }
+    if candidate.len() > limit {
+        return Err(FieldRejection::TooLong);
+    }
+    if candidate.chars().any(char::is_control) {
+        return Err(FieldRejection::ControlCharacter);
+    }
+    Ok(())
+}
+
+/// Shape check plus a credential scan.
+///
+/// Used for the strings derived from the inspected request — a field path, an
+/// endpoint identifier — as opposed to the system-minted ids
+/// [`AuditLabel`] holds. `pub(super)` so [`Endpoint`](super::Endpoint) applies
+/// the same rule without a second implementation of it.
+pub(super) fn screen(candidate: &str, limit: usize) -> Result<(), FieldRejection> {
+    check_shape(candidate, limit)?;
+    if !screening_scanner().scan(candidate).is_clean() {
+        return Err(FieldRejection::CarriesSensitiveValue);
+    }
+    Ok(())
+}
+
+/// A bounded, printable, system-generated identifier: an event id, a tenant, a
+/// team, a trace or correlation id, a policy document id, a rule id.
+///
+/// Shape-checked, not scanned — see the module documentation for the ULID
+/// measurement that decides this.
+///
+/// # Wire format
+///
+/// Serializes transparently as a JSON string, so a consumer sees an identifier
+/// and not a wrapper object:
+///
+/// ```json
+/// "01HZX9V8ABCDEFGHJKMNPQRSTV"
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(transparent))]
+pub struct AuditLabel(String);
+
+impl AuditLabel {
+    /// Accept an identifier, or say why not.
+    ///
+    /// # Errors
+    ///
+    /// [`FieldRejection::Empty`], [`FieldRejection::TooLong`] past
+    /// [`MAX_LABEL_BYTES`], or [`FieldRejection::ControlCharacter`].
+    pub fn new(value: impl Into<String>) -> Result<Self, FieldRejection> {
+        let value = value.into();
+        check_shape(&value, MAX_LABEL_BYTES)?;
+        Ok(Self(value))
+    }
+
+    /// The identifier.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl core::fmt::Display for AuditLabel {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The dotted name of an inspected field — `body.customer.national_id` — and
+/// never its value.
+///
+/// ADR 0032 §9 makes the field path the drill-down granularity that everything
+/// outside the tamper-evident tier gets, in place of the byte offsets it is not
+/// allowed. That makes the path the one string in a record that is both
+/// caller-supplied and derived from the inspected request, so it is screened
+/// with the credential scanner as well as shape-checked.
+///
+/// # Wire format
+///
+/// Serializes transparently as the joined path:
+///
+/// ```json
+/// "body.customer.national_id"
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(transparent))]
+pub struct FieldPath(String);
+
+impl FieldPath {
+    /// Accept a dotted path, or say why not.
+    ///
+    /// Every `.`-separated segment must be non-empty, so `body..ssn` and a
+    /// leading or trailing `.` are refused: an empty segment would make two
+    /// different paths render identically and quietly merge two fields in any
+    /// aggregate keyed on the path.
+    ///
+    /// # Errors
+    ///
+    /// [`FieldRejection::Empty`] for an empty path or segment,
+    /// [`FieldRejection::TooLong`] past [`MAX_FIELD_PATH_BYTES`],
+    /// [`FieldRejection::ControlCharacter`], or
+    /// [`FieldRejection::CarriesSensitiveValue`] when the scanner recognises
+    /// something in the path — which is what a value passed where a name
+    /// belongs looks like.
+    pub fn parse(path: impl Into<String>) -> Result<Self, FieldRejection> {
+        let path = path.into();
+        screen(&path, MAX_FIELD_PATH_BYTES)?;
+        if path.split('.').any(str::is_empty) {
+            return Err(FieldRejection::Empty);
+        }
+        Ok(Self(path))
+    }
+
+    /// The whole path as written.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The path's segments, outermost first.
+    pub fn segments(&self) -> impl Iterator<Item = &str> {
+        self.0.split('.')
+    }
+
+    /// How deeply nested the named field is. Always at least 1.
+    pub fn depth(&self) -> usize {
+        self.segments().count()
+    }
+}
+
+impl core::fmt::Display for FieldPath {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The measurement the two-strength split rests on. If the scanner ever
+    /// stops flagging a ULID, the reason `AuditLabel` is not screened
+    /// evaporates and this module's design should be revisited — so it is
+    /// asserted rather than left as a claim in a comment.
+    #[test]
+    fn a_ulid_is_flagged_by_the_scanner_which_is_why_labels_are_not_screened() {
+        assert!(
+            !screening_scanner().scan("01HZX9V8ABCDEFGHJKMNPQRSTV").is_clean(),
+            "a ULID no longer scans as high-entropy; revisit whether AuditLabel should be screened"
+        );
+        assert!(AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").is_ok());
+    }
+
+    /// The leak this guard exists for: a value passed where a name belongs.
+    ///
+    /// The literal is a documentation-only example from `aa-security`'s own
+    /// test corpus, not a live credential.
+    #[test]
+    fn a_field_path_carrying_a_token_is_refused() {
+        assert_eq!(
+            FieldPath::parse("body.ghp_16C7e42F292c6912E7710c838347Ae178B4a"),
+            Err(FieldRejection::CarriesSensitiveValue)
+        );
+    }
+
+    /// The other concrete case: a destination-shaped string with a password in
+    /// it. Screening is what forces the caller to record the destination
+    /// without the credential.
+    #[test]
+    fn a_path_holding_a_database_uri_is_refused() {
+        assert_eq!(
+            FieldPath::parse("config.postgresql://user:password@db.internal:5432/app"),
+            Err(FieldRejection::CarriesSensitiveValue)
+        );
+    }
+
+    #[test]
+    fn ordinary_paths_are_accepted() {
+        for path in [
+            "body",
+            "body.customer.national_id",
+            "headers.authorization",
+            "args[0].url",
+        ] {
+            assert!(FieldPath::parse(path).is_ok(), "rejected a legitimate path: {path}");
+        }
+    }
+
+    /// An empty segment would render two distinct paths identically and merge
+    /// them in any aggregate keyed on the path.
+    #[test]
+    fn empty_segments_are_refused() {
+        assert_eq!(FieldPath::parse("body..ssn"), Err(FieldRejection::Empty));
+        assert_eq!(FieldPath::parse(".body"), Err(FieldRejection::Empty));
+        assert_eq!(FieldPath::parse("body."), Err(FieldRejection::Empty));
+        assert_eq!(FieldPath::parse(""), Err(FieldRejection::Empty));
+    }
+
+    /// A newline forges a record boundary in any line-oriented sink.
+    #[test]
+    fn control_characters_are_refused_in_both_guarded_types() {
+        assert_eq!(
+            FieldPath::parse("body\nfake_record"),
+            Err(FieldRejection::ControlCharacter)
+        );
+        assert_eq!(
+            AuditLabel::new("tenant\nfake_record"),
+            Err(FieldRejection::ControlCharacter)
+        );
+    }
+
+    #[test]
+    fn over_long_input_is_refused() {
+        assert_eq!(
+            AuditLabel::new("x".repeat(MAX_LABEL_BYTES + 1)),
+            Err(FieldRejection::TooLong)
+        );
+        assert!(AuditLabel::new("x".repeat(MAX_LABEL_BYTES)).is_ok());
+        assert_eq!(
+            FieldPath::parse("x".repeat(MAX_FIELD_PATH_BYTES + 1)),
+            Err(FieldRejection::TooLong)
+        );
+    }
+
+    /// A rejection must not quote what it rejected: the report of a refusal is
+    /// itself a log line, and `CarriesSensitiveValue` means the input is the
+    /// thing that must not be logged.
+    #[test]
+    fn a_rejection_never_echoes_the_offending_input() {
+        let secret = "ghp_16C7e42F292c6912E7710c838347Ae178B4a";
+        let rejection = FieldPath::parse(format!("body.{secret}")).unwrap_err();
+        let rendered = alloc::format!("{rejection}");
+        assert!(
+            !rendered.contains(secret),
+            "the rejection message quoted the value it exists to keep out of logs"
+        );
+        let debugged = alloc::format!("{rejection:?}");
+        assert!(!debugged.contains(secret), "the Debug rendering quoted the value");
+    }
+
+    #[test]
+    fn depth_counts_segments() {
+        assert_eq!(FieldPath::parse("body").unwrap().depth(), 1);
+        assert_eq!(FieldPath::parse("body.customer.national_id").unwrap().depth(), 3);
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::*;
+
+    /// Both guarded types are transparent on the wire: a consumer reads a
+    /// string, not `{"0":"…"}`.
+    #[test]
+    fn guarded_strings_serialize_transparently() {
+        let path = FieldPath::parse("body.customer.national_id").unwrap();
+        assert_eq!(serde_json::to_string(&path).unwrap(), r#""body.customer.national_id""#);
+
+        let label = AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").unwrap();
+        assert_eq!(
+            serde_json::to_string(&label).unwrap(),
+            r#""01HZX9V8ABCDEFGHJKMNPQRSTV""#
+        );
+    }
+
+    /// Deserialization is the guard's back door, and it is open by design: a
+    /// stored record must round-trip even if a future build tightens the rules,
+    /// or replaying an audit log would fail on its own history.
+    ///
+    /// Pinned so the trade-off is a decision on the record rather than a
+    /// surprise. It is sound because the guard's job is to stop a value being
+    /// *written* into a record; a record being read back was already screened
+    /// when it was written.
+    #[test]
+    fn deserialization_does_not_re_run_the_guard() {
+        let path: FieldPath = serde_json::from_str(r#""body..not_constructible_via_parse""#).unwrap();
+        assert_eq!(path.as_str(), "body..not_constructible_via_parse");
+        assert!(FieldPath::parse(path.as_str()).is_err());
+    }
+}

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -41,10 +41,22 @@
 //! `aa-security`'s compiled-in catalogue — none of which can hold bytes the
 //! scanner read. The strings a caller supplies are the whole remaining surface
 //! through which a raw sensitive value could reach a record, so they are
-//! screened rather than trusted: see [`FieldPath`], [`Endpoint`] and
-//! [`FieldRejection`]. There is no constructor that takes an unscreened string.
-//! [`FieldRejection`]'s documentation states plainly what that does and does
-//! not prove.
+//! guarded rather than trusted: see [`FieldPath`], [`Endpoint`] and
+//! [`FieldRejection`].
+//!
+//! No constructor takes an **unguarded** string, but there are **two strengths
+//! of guard** and the difference matters. [`FieldPath`] and [`Endpoint`]
+//! identifiers are derived from the inspected request and get a credential
+//! scan; [`AuditLabel`] and [`CategoryLabel`] hold system-minted values and get
+//! a shape check only, because the scanner flags a ULID and screening ids would
+//! reject well-formed events. [`FieldRejection`]'s documentation states which
+//! is which, and what neither proves.
+//!
+//! Deserialization is the deliberate gap in both: a stored record must
+//! round-trip, so the read path re-checks shape but never re-screens. Any
+//! consumer needing a *bounded* value — a metric label above all — must
+//! therefore resolve rather than trust, which is what
+//! [`SensitiveDataMetricLabels`] does.
 //!
 //! # Counting rules that are not negotiable
 //!

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -3,6 +3,8 @@
 //!
 //! Types only — nothing here writes, stores or serves anything.
 
+mod guard;
 mod schema;
 
+pub use guard::{AuditLabel, FieldPath, FieldRejection, MAX_FIELD_PATH_BYTES, MAX_LABEL_BYTES};
 pub use schema::{SchemaVersion, SENSITIVE_DATA_SCHEMA_VERSION};

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -4,6 +4,7 @@
 //! Types only — nothing here writes, stores or serves anything.
 
 mod category_label;
+mod counts;
 mod evidence;
 mod finding_record;
 mod guard;
@@ -12,6 +13,7 @@ mod verdict;
 mod vocab;
 
 pub use category_label::CategoryLabel;
+pub use counts::{CategoryCount, CountsError, FindingCounts};
 pub use evidence::{EnforcementPoint, ExecutionEvidence, InspectionFailurePath, TransmissionEvidence};
 pub use finding_record::{AggregateKey, DetectionProvenance, SensitiveDataFindingRecord};
 pub use guard::{AuditLabel, FieldPath, FieldRejection, MAX_FIELD_PATH_BYTES, MAX_LABEL_BYTES};

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -9,6 +9,7 @@ mod event;
 mod evidence;
 mod finding_record;
 mod guard;
+mod projection;
 mod schema;
 mod verdict;
 mod vocab;
@@ -23,5 +24,6 @@ pub use event::{
 pub use evidence::{EnforcementPoint, ExecutionEvidence, InspectionFailurePath, TransmissionEvidence};
 pub use finding_record::{AggregateKey, DetectionProvenance, SensitiveDataFindingRecord};
 pub use guard::{AuditLabel, FieldPath, FieldRejection, MAX_FIELD_PATH_BYTES, MAX_LABEL_BYTES};
+pub use projection::SensitiveDataMetricLabels;
 pub use schema::{SchemaVersion, SENSITIVE_DATA_SCHEMA_VERSION};
 pub use verdict::RuntimeVerdictLabel;

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -3,11 +3,13 @@
 //!
 //! Types only — nothing here writes, stores or serves anything.
 
+mod category_label;
 mod evidence;
 mod guard;
 mod schema;
 mod verdict;
 
+pub use category_label::CategoryLabel;
 pub use evidence::{EnforcementPoint, ExecutionEvidence, InspectionFailurePath, TransmissionEvidence};
 pub use guard::{AuditLabel, FieldPath, FieldRejection, MAX_FIELD_PATH_BYTES, MAX_LABEL_BYTES};
 pub use schema::{SchemaVersion, SENSITIVE_DATA_SCHEMA_VERSION};

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -1,0 +1,8 @@
+//! The sensitive-data decision event and its normalized finding rows
+//! (ADR 0032 §8, AAASM-5355).
+//!
+//! Types only — nothing here writes, stores or serves anything.
+
+mod schema;
+
+pub use schema::{SchemaVersion, SENSITIVE_DATA_SCHEMA_VERSION};

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -5,6 +5,7 @@
 
 mod category_label;
 mod counts;
+mod event;
 mod evidence;
 mod finding_record;
 mod guard;
@@ -14,6 +15,11 @@ mod vocab;
 
 pub use category_label::CategoryLabel;
 pub use counts::{CategoryCount, CountsError, FindingCounts};
+pub use event::{
+    AgentLineage, CorrelationIds, Endpoint, EndpointKind, FindingClassification, InspectedAction, InspectionLatency,
+    OperationKind, PolicyAttribution, PolicyReasonCode, RequestDirection, SensitiveDataDecisionEvent,
+    SensitiveDataDecisionEventBuilder, Tenancy, TrustZone,
+};
 pub use evidence::{EnforcementPoint, ExecutionEvidence, InspectionFailurePath, TransmissionEvidence};
 pub use finding_record::{AggregateKey, DetectionProvenance, SensitiveDataFindingRecord};
 pub use guard::{AuditLabel, FieldPath, FieldRejection, MAX_FIELD_PATH_BYTES, MAX_LABEL_BYTES};

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -5,12 +5,15 @@
 
 mod category_label;
 mod evidence;
+mod finding_record;
 mod guard;
 mod schema;
 mod verdict;
+mod vocab;
 
 pub use category_label::CategoryLabel;
 pub use evidence::{EnforcementPoint, ExecutionEvidence, InspectionFailurePath, TransmissionEvidence};
+pub use finding_record::{AggregateKey, DetectionProvenance, SensitiveDataFindingRecord};
 pub use guard::{AuditLabel, FieldPath, FieldRejection, MAX_FIELD_PATH_BYTES, MAX_LABEL_BYTES};
 pub use schema::{SchemaVersion, SENSITIVE_DATA_SCHEMA_VERSION};
 pub use verdict::RuntimeVerdictLabel;

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -3,10 +3,12 @@
 //!
 //! Types only — nothing here writes, stores or serves anything.
 
+mod evidence;
 mod guard;
 mod schema;
 mod verdict;
 
+pub use evidence::{EnforcementPoint, ExecutionEvidence, InspectionFailurePath, TransmissionEvidence};
 pub use guard::{AuditLabel, FieldPath, FieldRejection, MAX_FIELD_PATH_BYTES, MAX_LABEL_BYTES};
 pub use schema::{SchemaVersion, SENSITIVE_DATA_SCHEMA_VERSION};
 pub use verdict::RuntimeVerdictLabel;

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -5,6 +5,8 @@
 
 mod guard;
 mod schema;
+mod verdict;
 
 pub use guard::{AuditLabel, FieldPath, FieldRejection, MAX_FIELD_PATH_BYTES, MAX_LABEL_BYTES};
 pub use schema::{SchemaVersion, SENSITIVE_DATA_SCHEMA_VERSION};
+pub use verdict::RuntimeVerdictLabel;

--- a/aa-core/src/types/sensitive_data/mod.rs
+++ b/aa-core/src/types/sensitive_data/mod.rs
@@ -1,7 +1,73 @@
 //! The sensitive-data decision event and its normalized finding rows
 //! (ADR 0032 §8, AAASM-5355).
 //!
-//! Types only — nothing here writes, stores or serves anything.
+//! # What these records exist to answer
+//!
+//! *"How many findings of each class did agent X attempt to send to tool Y, how
+//! many were blocked versus redacted, how many were uncertain?"* — a question
+//! the system cannot answer today, for four separate reasons:
+//! `audit_entry_to_storage_event` drops every credential finding, the hash chain
+//! and all lineage except `team_id`; destination is not a dimension of the audit
+//! event at all; "blocked" and "redacted" are indistinguishable from the event
+//! type; and findings are binary, with no notion of uncertainty.
+//!
+//! These types are the lossless shape that bridge should have had. They are
+//! **types only** — nothing here writes, stores or serves anything. ADR 0032 §8
+//! requires the new projection to be written *beside* the existing bridge
+//! rather than the bridge extended field by field (forbidden design #15), and
+//! that writer is AAASM-5357's work.
+//!
+//! # Tiering — what may appear where
+//!
+//! ADR 0032 §9 splits the world in two, and that split is the main thing this
+//! module encodes:
+//!
+//! | Tier | May carry |
+//! |---|---|
+//! | tamper-evident audit | byte offsets and lengths (`aa_security::canonical::ByteSpan`) |
+//! | everything else — metrics, traces, API responses, dashboards | category, severity, confidence, outcome, method, recognizer, **field paths** |
+//!
+//! [`SensitiveDataFindingRecord`] is in the second tier and is **span-free by
+//! construction**: it is built *from* a `CanonicalFinding` and discards the
+//! span. [`SensitiveDataMetricLabels`] narrows further, to the six
+//! bounded-cardinality labels §9 permits. AAASM-5352 recorded that obligation
+//! against this ticket, noting that it would be incoherent to keep `end()`
+//! `pub(crate)` in Rust and then publish the offset in JSON to anything that
+//! asks.
+//!
+//! # Why the caller-supplied strings are screened
+//!
+//! Every other field is an enum, an integer, or a `&'static str` from
+//! `aa-security`'s compiled-in catalogue — none of which can hold bytes the
+//! scanner read. The strings a caller supplies are the whole remaining surface
+//! through which a raw sensitive value could reach a record, so they are
+//! screened rather than trusted: see [`FieldPath`], [`Endpoint`] and
+//! [`FieldRejection`]. There is no constructor that takes an unscreened string.
+//! [`FieldRejection`]'s documentation states plainly what that does and does
+//! not prove.
+//!
+//! # Counting rules that are not negotiable
+//!
+//! **Event counts and finding counts are different measures** (ADR 0032 §8,
+//! forbidden design #11). One event carries many findings; an action with three
+//! findings that is blocked contributes `1` to a blocked *event* count and `3`
+//! to a blocked *finding* count. [`FindingCounts`] holds only finding tallies,
+//! and the event exposes the two through separately named accessors so they
+//! cannot be confused at a call site.
+//!
+//! **"Prevented" requires evidence.** There is deliberately no `prevented:
+//! bool`. [`ExecutionEvidence`] records what was observed about the bytes, and
+//! [`SensitiveDataDecisionEvent::counts_as_prevented_transmission`] derives the
+//! metric under §8's four conditions. Redaction *forwards* the scrubbed bytes,
+//! so a redacted action is a transformed transmission and never a prevented
+//! one — the mistake the `CredentialLeakBlocked` event name already made once.
+//!
+//! # Where the verdict lives
+//!
+//! ADR 0018's `RuntimeVerdict` is frozen by ADR 0032 D-2 and is **not** mirrored
+//! as an enum here. See [`RuntimeVerdictLabel`] for why the event carries a
+//! closed label newtype instead, and for the seam AAASM-5356 fills with the
+//! additive `sensitive_data_disposition` field.
 
 mod category_label;
 mod counts;

--- a/aa-core/src/types/sensitive_data/projection.rs
+++ b/aa-core/src/types/sensitive_data/projection.rs
@@ -1,11 +1,12 @@
 //! The bounded label set a sensitive-data metric may carry.
 
-use aa_security::canonical::{ConfidenceBand, DetectionMethod, Recognizer, Severity};
+use alloc::string::{String, ToString};
+
+use aa_security::canonical::{CanonicalCategory, ConfidenceBand, DetectionMethod, Recognizer, Severity};
 
 use super::finding_record::SensitiveDataFindingRecord;
 use super::verdict::RuntimeVerdictLabel;
 use super::vocab;
-use super::CategoryLabel;
 
 /// The six labels ADR 0032 §9 permits on a sensitive-data metric.
 ///
@@ -28,12 +29,47 @@ use super::CategoryLabel;
 ///
 /// # Bounded cardinality, by construction
 ///
-/// Every field is drawn from a compile-time catalogue: five closed
-/// `aa-security` vocabularies plus [`CanonicalCategory::ALL`](aa_security::canonical::CanonicalCategory::ALL).
-/// There is no constructor that takes a string. That is what keeps a metric
-/// series count finite, and it is why validation requirement 4's forbidden
-/// labels — `agent_id`, `destination`, `session_id`, and any fingerprint — are
-/// not merely absent but unrepresentable here.
+/// ADR 0032 §9 bounds metric **series**, and a series is a name *and* a value.
+/// Fixing the six names is only half of it; each value has to come from a
+/// finite domain too.
+///
+/// So every field is drawn from a compile-time catalogue: five closed
+/// `aa-security` vocabularies plus
+/// [`CanonicalCategory::ALL`](aa_security::canonical::CanonicalCategory::ALL).
+/// The category is held as a **resolved [`CanonicalCategory`]**, not as a
+/// [`CategoryLabel`](super::CategoryLabel), and
+/// [`from_finding`](Self::from_finding) returns `None` when the record's label
+/// does not resolve. An unresolvable category is by definition not a member of
+/// a bounded set, so it must not become a bounded label.
+///
+/// That refusal is the load-bearing part. A `CategoryLabel` is bounded in shape
+/// and unbounded in value — it deliberately round-trips categories a newer
+/// build produced — so rendering one straight into a metric would put an
+/// arbitrary string in a series name. Worse, a `SensitiveDataFindingRecord`
+/// deserialized from storage can carry any well-shaped label at all, which is
+/// how a raw credential reached a metric label value in an earlier revision of
+/// this type.
+///
+/// # What this does and does not guarantee
+///
+/// Stated as a property of the construction paths, not as a claim about the
+/// type system, because the distinction has been got wrong here before.
+///
+/// **Guaranteed by construction:** the only way to build one of these is
+/// [`from_finding`](Self::from_finding); the fields are private and the struct
+/// is `#[non_exhaustive]`, so there is no struct literal and no post-hoc field
+/// assignment; and every value it can hold is a member of a compile-time
+/// catalogue. Validation requirement 4's forbidden labels — `agent_id`,
+/// `destination`, `session_id`, and any fingerprint — have no way in.
+///
+/// **Not guaranteed:** this is `Serialize`-only and has no `Deserialize`, so
+/// nothing reconstructs one from bytes; but a `ByteSpan` field added here would
+/// still compile, because the absence of `Deserialize` is what makes a span a
+/// type error over in [`SensitiveDataFindingRecord`](super::SensitiveDataFindingRecord).
+/// Here only
+/// [`the_metric_projection_serializes_only_the_six_permitted_labels`](#) stands
+/// between an offset and a metric, and an assertion is something a future
+/// change can delete.
 ///
 /// # No tenant label, deliberately
 ///
@@ -53,23 +89,28 @@ use super::CategoryLabel;
 /// nothing here needs to round-trip.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
 pub struct SensitiveDataMetricLabels {
-    /// The finding's canonical category, rendered. Bounded by the catalogue.
-    pub category: CategoryLabel,
-    /// How damaging exposure would be.
+    /// The resolved category. Serialized through `rendered_category`.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    category: CanonicalCategory,
+    /// `category`'s rendering, derived from it at construction.
+    ///
+    /// Held rather than recomputed so [`as_pairs`](Self::as_pairs) can hand out
+    /// a borrow without allocating on a metrics hot path. It cannot diverge
+    /// from `category`: both are private, set together in the one constructor,
+    /// and there is no `Deserialize` to reach around them.
+    #[cfg_attr(feature = "serde", serde(rename = "category"))]
+    rendered_category: String,
     #[cfg_attr(feature = "serde", serde(with = "vocab::severity"))]
-    pub severity: Severity,
-    /// How much the recognizer trusted the finding.
+    severity: Severity,
     #[cfg_attr(feature = "serde", serde(with = "vocab::confidence"))]
-    pub confidence_band: ConfidenceBand,
-    /// The enforcement outcome, as ADR 0018's frozen verdict label.
-    pub outcome: RuntimeVerdictLabel,
-    /// The technique that produced the finding.
+    confidence_band: ConfidenceBand,
+    outcome: RuntimeVerdictLabel,
     #[cfg_attr(feature = "serde", serde(with = "vocab::method"))]
-    pub detection_method: DetectionMethod,
-    /// Which recognizer produced it. `provider_id` in §9's spelling.
+    detection_method: DetectionMethod,
     #[cfg_attr(feature = "serde", serde(with = "vocab::recognizer"))]
-    pub provider_id: Recognizer,
+    provider_id: Recognizer,
 }
 
 impl SensitiveDataMetricLabels {
@@ -87,23 +128,64 @@ impl SensitiveDataMetricLabels {
     /// Project a finding row and the action's verdict into metric labels.
     ///
     /// The only constructor. It takes a record and a verdict — never a string —
-    /// so a caller cannot introduce a label of its own, which is what makes the
-    /// cardinality argument hold rather than merely be intended.
-    pub fn from_finding(record: &SensitiveDataFindingRecord, outcome: RuntimeVerdictLabel) -> Self {
-        Self {
-            category: record.category.clone(),
+    /// so a caller cannot introduce a label value of its own.
+    ///
+    /// Returns `None` when the record's category does not resolve against this
+    /// build's catalogue. That is not a failure to handle away: a category this
+    /// build cannot name is not a bounded label, and emitting it would put an
+    /// arbitrary string into a metric series. A caller should count the event
+    /// under a separate "unresolvable category" series — a constant, and
+    /// therefore bounded — rather than reach for the rendered form.
+    pub fn from_finding(record: &SensitiveDataFindingRecord, outcome: RuntimeVerdictLabel) -> Option<Self> {
+        let category = record.category.resolve()?;
+        Some(Self {
+            // Rendered from the *resolved* category, never from the record's
+            // stored label, so the value is provably a member of the catalogue's
+            // rendering set even when the record came from storage.
+            rendered_category: category.to_string(),
+            category,
             severity: record.severity,
             confidence_band: record.confidence,
             outcome,
             detection_method: record.method,
             provider_id: record.provenance.recognizer,
-        }
+        })
+    }
+
+    /// The resolved category these labels describe.
+    pub const fn category(&self) -> CanonicalCategory {
+        self.category
+    }
+
+    /// How damaging exposure would be.
+    pub const fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    /// How much the recognizer trusted the finding.
+    pub const fn confidence_band(&self) -> ConfidenceBand {
+        self.confidence_band
+    }
+
+    /// The enforcement outcome, as ADR 0018's frozen verdict label.
+    pub const fn outcome(&self) -> RuntimeVerdictLabel {
+        self.outcome
+    }
+
+    /// The technique that produced the finding.
+    pub const fn detection_method(&self) -> DetectionMethod {
+        self.detection_method
+    }
+
+    /// Which recognizer produced it. `provider_id` in §9's spelling.
+    pub const fn provider_id(&self) -> Recognizer {
+        self.provider_id
     }
 
     /// The labels as name/value pairs, ready for a metrics exporter.
     pub fn as_pairs(&self) -> [(&'static str, &str); 6] {
         [
-            ("category", self.category.as_str()),
+            ("category", self.rendered_category.as_str()),
             ("severity", self.severity.as_str()),
             ("confidence_band", self.confidence_band.as_str()),
             ("outcome", self.outcome.as_str()),
@@ -126,6 +208,7 @@ mod tests {
             "headers.authorization",
         );
         SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::DENY)
+            .expect("a catalogue category resolves")
     }
 
     /// **ADR 0032 validation requirement 4.** The label names are exactly §9's
@@ -175,10 +258,11 @@ mod tests {
     fn every_category_in_the_catalogue_produces_a_bounded_label() {
         for category in CanonicalCategory::ALL {
             let record = finding(*category, "body.field");
-            let labels = SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::SCRUB);
+            let labels = SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::SCRUB)
+                .expect("a catalogue category resolves");
             assert_eq!(
-                labels.category.resolve(),
-                Some(*category),
+                labels.category(),
+                *category,
                 "a metric label escaped the catalogue it is supposed to be bounded by"
             );
         }
@@ -217,11 +301,9 @@ mod serde_tests {
             CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access"),
             "headers.authorization",
         );
-        let json = serde_json::to_value(SensitiveDataMetricLabels::from_finding(
-            &record,
-            RuntimeVerdictLabel::DENY,
-        ))
-        .unwrap();
+        let labels = SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::DENY)
+            .expect("a catalogue category resolves");
+        let json = serde_json::to_value(labels).unwrap();
 
         let object = json.as_object().expect("labels serialize as an object");
         let mut keys: alloc::vec::Vec<&str> = object.keys().map(alloc::string::String::as_str).collect();

--- a/aa-core/src/types/sensitive_data/projection.rs
+++ b/aa-core/src/types/sensitive_data/projection.rs
@@ -1,0 +1,240 @@
+//! The bounded label set a sensitive-data metric may carry.
+
+use aa_security::canonical::{ConfidenceBand, DetectionMethod, Recognizer, Severity};
+
+use super::finding_record::SensitiveDataFindingRecord;
+use super::verdict::RuntimeVerdictLabel;
+use super::vocab;
+use super::CategoryLabel;
+
+/// The six labels ADR 0032 §9 permits on a sensitive-data metric.
+///
+/// # Why this type exists rather than "just use the record"
+///
+/// AAASM-5352 left this ticket an explicit obligation. `CanonicalFinding`
+/// derives `Serialize` and emits its [`ByteSpan`](aa_security::canonical::ByteSpan)
+/// unconditionally, and `aa-security`'s `serde_impls.rs` records that the
+/// resulting JSON is **audit-tier only**: ADR 0032 §9 permits offsets and
+/// lengths solely in the tamper-evident tier, because a length plus a category
+/// can identify a value in a small domain. A consumer that is not the audit
+/// sink has to project a span-free subset rather than forward that output —
+/// guarding the offset behind `pub(crate)` in Rust and then publishing it in
+/// JSON to anything that asks would undo the guard one layer later.
+///
+/// [`SensitiveDataFindingRecord`] is already span-free. This narrows further,
+/// to the exact set §9 allows on a metric:
+///
+/// > `{category, severity, confidence_band, outcome, detection_method, provider_id}`
+///
+/// # Bounded cardinality, by construction
+///
+/// Every field is drawn from a compile-time catalogue: five closed
+/// `aa-security` vocabularies plus [`CanonicalCategory::ALL`](aa_security::canonical::CanonicalCategory::ALL).
+/// There is no constructor that takes a string. That is what keeps a metric
+/// series count finite, and it is why validation requirement 4's forbidden
+/// labels — `agent_id`, `destination`, `session_id`, and any fingerprint — are
+/// not merely absent but unrepresentable here.
+///
+/// # No tenant label, deliberately
+///
+/// ADR 0032 §9's permitted set does not include a tenant, and this type does not
+/// add one. A tenant id is unbounded, and a metric series broken down by tenant
+/// puts one tenant's activity in a series a shared dashboard can read.
+///
+/// The consequence is worth being clear about: **these metrics do not answer
+/// per-tenant questions.** A tenant-scoped answer comes from querying the
+/// events, which carry [`Tenancy`](super::Tenancy), and where the isolation can
+/// actually be enforced by the query.
+///
+/// # Emitted, not stored
+///
+/// `Serialize` only. These labels go to a metrics exporter and are never read
+/// back — the event is the record. Nothing here is a durable representation, so
+/// nothing here needs to round-trip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct SensitiveDataMetricLabels {
+    /// The finding's canonical category, rendered. Bounded by the catalogue.
+    pub category: CategoryLabel,
+    /// How damaging exposure would be.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::severity"))]
+    pub severity: Severity,
+    /// How much the recognizer trusted the finding.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::confidence"))]
+    pub confidence_band: ConfidenceBand,
+    /// The enforcement outcome, as ADR 0018's frozen verdict label.
+    pub outcome: RuntimeVerdictLabel,
+    /// The technique that produced the finding.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::method"))]
+    pub detection_method: DetectionMethod,
+    /// Which recognizer produced it. `provider_id` in §9's spelling.
+    #[cfg_attr(feature = "serde", serde(with = "vocab::recognizer"))]
+    pub provider_id: Recognizer,
+}
+
+impl SensitiveDataMetricLabels {
+    /// The names of the six labels, in the order [`as_pairs`](Self::as_pairs)
+    /// returns them.
+    pub const LABEL_NAMES: [&'static str; 6] = [
+        "category",
+        "severity",
+        "confidence_band",
+        "outcome",
+        "detection_method",
+        "provider_id",
+    ];
+
+    /// Project a finding row and the action's verdict into metric labels.
+    ///
+    /// The only constructor. It takes a record and a verdict — never a string —
+    /// so a caller cannot introduce a label of its own, which is what makes the
+    /// cardinality argument hold rather than merely be intended.
+    pub fn from_finding(record: &SensitiveDataFindingRecord, outcome: RuntimeVerdictLabel) -> Self {
+        Self {
+            category: record.category.clone(),
+            severity: record.severity,
+            confidence_band: record.confidence,
+            outcome,
+            detection_method: record.method,
+            provider_id: record.provenance.recognizer,
+        }
+    }
+
+    /// The labels as name/value pairs, ready for a metrics exporter.
+    pub fn as_pairs(&self) -> [(&'static str, &str); 6] {
+        [
+            ("category", self.category.as_str()),
+            ("severity", self.severity.as_str()),
+            ("confidence_band", self.confidence_band.as_str()),
+            ("outcome", self.outcome.as_str()),
+            ("detection_method", self.detection_method.as_str()),
+            ("provider_id", self.provider_id.as_str()),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aa_security::canonical::{CanonicalCategory, CategoryBase};
+
+    use super::*;
+    use crate::types::sensitive_data::event::fixtures::finding;
+
+    fn labels() -> SensitiveDataMetricLabels {
+        let record = finding(
+            CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access"),
+            "headers.authorization",
+        );
+        SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::DENY)
+    }
+
+    /// **ADR 0032 validation requirement 4.** The label names are exactly §9's
+    /// six, and none of the forbidden dimensions is among them.
+    ///
+    /// Asserted as an equality against the full expected set rather than as a
+    /// series of `assert!(!contains(...))` checks: a "does not contain
+    /// agent_id" test keeps passing when someone adds `tool_name`, and the
+    /// cardinality problem is the same one.
+    #[test]
+    fn the_label_names_are_exactly_the_six_the_adr_permits() {
+        assert_eq!(
+            SensitiveDataMetricLabels::LABEL_NAMES,
+            [
+                "category",
+                "severity",
+                "confidence_band",
+                "outcome",
+                "detection_method",
+                "provider_id"
+            ]
+        );
+
+        let emitted: alloc::vec::Vec<&str> = labels().as_pairs().iter().map(|(name, _)| *name).collect();
+        assert_eq!(emitted, SensitiveDataMetricLabels::LABEL_NAMES.to_vec());
+
+        for forbidden in [
+            "agent_id",
+            "destination",
+            "session_id",
+            "tenant_id",
+            "field_path",
+            "span",
+            "fingerprint",
+        ] {
+            assert!(
+                !emitted.contains(&forbidden),
+                "`{forbidden}` reached a metric label; ADR 0032 §9 restricts labels to a bounded set"
+            );
+        }
+    }
+
+    /// Every label value comes from a compile-time catalogue, so the series
+    /// count is finite. Demonstrated over the whole category catalogue, which is
+    /// the only field with more than a handful of values.
+    #[test]
+    fn every_category_in_the_catalogue_produces_a_bounded_label() {
+        for category in CanonicalCategory::ALL {
+            let record = finding(*category, "body.field");
+            let labels = SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::SCRUB);
+            assert_eq!(
+                labels.category.resolve(),
+                Some(*category),
+                "a metric label escaped the catalogue it is supposed to be bounded by"
+            );
+        }
+    }
+
+    /// The values carry the documented spellings, not Rust identifiers.
+    #[test]
+    fn the_label_values_use_the_published_spellings() {
+        let labels = labels();
+        let pairs = labels.as_pairs();
+        assert_eq!(pairs[0].1, "ACCESS_TOKEN[github:personal_access]");
+        assert_eq!(pairs[1].1, "critical");
+        assert_eq!(pairs[2].1, "high");
+        assert_eq!(pairs[3].1, "deny");
+        assert_eq!(pairs[4].1, "deterministic");
+        assert_eq!(pairs[5].1, "aa-security::scanner");
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use aa_security::canonical::{CanonicalCategory, CategoryBase};
+
+    use super::*;
+    use crate::types::sensitive_data::event::fixtures::finding;
+
+    /// **The span-free-subset test AAASM-5352 asked this ticket for.**
+    ///
+    /// The record it is projected from was built from a finding whose span is
+    /// `4..44`, and neither the offsets nor the length may appear here.
+    /// Asserted on the serialized JSON keys *and* values: a length can leak as
+    /// a number under an innocent name just as easily as under `length`.
+    #[test]
+    fn the_metric_projection_serializes_only_the_six_permitted_labels() {
+        let record = finding(
+            CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access"),
+            "headers.authorization",
+        );
+        let json = serde_json::to_value(SensitiveDataMetricLabels::from_finding(
+            &record,
+            RuntimeVerdictLabel::DENY,
+        ))
+        .unwrap();
+
+        let object = json.as_object().expect("labels serialize as an object");
+        let mut keys: alloc::vec::Vec<&str> = object.keys().map(alloc::string::String::as_str).collect();
+        keys.sort_unstable();
+        let mut expected = SensitiveDataMetricLabels::LABEL_NAMES.to_vec();
+        expected.sort_unstable();
+        assert_eq!(keys, expected, "the metric projection changed shape");
+
+        for (key, value) in object {
+            assert!(
+                value.is_string(),
+                "label `{key}` serialized as {value}, and a non-string label is how an offset or a length gets out"
+            );
+        }
+    }
+}

--- a/aa-core/src/types/sensitive_data/schema.rs
+++ b/aa-core/src/types/sensitive_data/schema.rs
@@ -1,0 +1,126 @@
+//! The version stamped on every sensitive-data record, and the rule for reading
+//! a record written by a different build.
+
+/// The schema version a sensitive-data record was written against.
+///
+/// Every record in this module carries one, because these records outlive the
+/// process that wrote them: an audit row read a year later has to be
+/// interpretable by whatever build is reading it, and "whatever build" is not
+/// necessarily the one that wrote it.
+///
+/// # Compatibility rule
+///
+/// A **major** bump means a reader of the old major cannot interpret the record
+/// — a field changed meaning, or a required field was removed. A **minor** bump
+/// means fields were only added.
+///
+/// [`is_readable_by`](Self::is_readable_by) therefore compares majors and
+/// ignores minors in *both* directions. A newer writer's record is readable by
+/// an older reader, which is the property AAASM-5356 depends on: it adds an
+/// optional `sensitive_data_disposition` field to
+/// [`SensitiveDataDecisionEvent`](super::SensitiveDataDecisionEvent) as a
+/// `1.1` minor bump, and every `1.0` reader must keep working. That is also why
+/// none of the types in this module use `serde(deny_unknown_fields)`, unlike
+/// [`AuditEvent`](crate::types::AuditEvent) — a strict reader would reject the
+/// newer writer's event outright and turn an additive change into a breaking
+/// one.
+///
+/// # Wire format
+///
+/// A two-field object rather than a `"1.0"` string, so a reader compares
+/// integers instead of parsing:
+///
+/// ```json
+/// { "major": 1, "minor": 0 }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct SchemaVersion {
+    /// Incompatible revision. A reader of a different major must refuse the record.
+    pub major: u16,
+    /// Additive revision. Ignored when deciding readability.
+    pub minor: u16,
+}
+
+impl SchemaVersion {
+    /// Name a version.
+    pub const fn new(major: u16, minor: u16) -> Self {
+        Self { major, minor }
+    }
+
+    /// Whether a record stamped `self` can be interpreted by a `reader` build.
+    ///
+    /// True exactly when the majors agree. The minor is deliberately not
+    /// compared: a newer minor only adds fields, and refusing it would make an
+    /// additive change breaking — see the type documentation.
+    pub const fn is_readable_by(self, reader: Self) -> bool {
+        self.major == reader.major
+    }
+}
+
+/// The version this build writes and the one it reads natively.
+///
+/// `1.0` is the initial shape. AAASM-5356's disposition field is the first
+/// planned change and is a minor bump.
+pub const SENSITIVE_DATA_SCHEMA_VERSION: SchemaVersion = SchemaVersion::new(1, 0);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A newer writer's record stays readable by an older reader.
+    ///
+    /// This is the whole reason the minor is ignored. If this regresses,
+    /// AAASM-5356 adding `sensitive_data_disposition` as a `1.1` field silently
+    /// becomes a breaking change for every `1.0` consumer.
+    #[test]
+    fn a_newer_minor_is_readable_by_an_older_reader() {
+        assert!(SchemaVersion::new(1, 7).is_readable_by(SchemaVersion::new(1, 0)));
+    }
+
+    /// The converse: a build that knows `1.1` reads a record written at `1.0`,
+    /// treating the absent field as absent rather than as malformed.
+    #[test]
+    fn an_older_minor_is_readable_by_a_newer_reader() {
+        assert!(SchemaVersion::new(1, 0).is_readable_by(SchemaVersion::new(1, 1)));
+    }
+
+    /// A major bump is refused in both directions — that is what distinguishes
+    /// it from a minor and the only thing that makes the rule load-bearing.
+    #[test]
+    fn a_differing_major_is_refused_in_both_directions() {
+        assert!(!SchemaVersion::new(2, 0).is_readable_by(SchemaVersion::new(1, 9)));
+        assert!(!SchemaVersion::new(1, 9).is_readable_by(SchemaVersion::new(2, 0)));
+    }
+
+    /// The constant this build stamps. Pinned so a bump is a deliberate edit
+    /// with a reviewer looking at it, not a side effect of an unrelated change.
+    #[test]
+    fn this_build_writes_one_dot_zero() {
+        assert_eq!(SENSITIVE_DATA_SCHEMA_VERSION, SchemaVersion::new(1, 0));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::*;
+
+    /// The wire shape, pinned. A schema version that serialized as `"1.0"` in
+    /// one build and `{"major":1,…}` in another would make version negotiation
+    /// itself the thing that fails to negotiate.
+    #[test]
+    fn schema_version_serializes_as_a_major_minor_object() {
+        assert_eq!(
+            serde_json::to_string(&SENSITIVE_DATA_SCHEMA_VERSION).unwrap(),
+            r#"{"major":1,"minor":0}"#
+        );
+    }
+
+    #[test]
+    fn schema_version_round_trips() {
+        let json = serde_json::to_string(&SchemaVersion::new(3, 12)).unwrap();
+        let restored: SchemaVersion = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, SchemaVersion::new(3, 12));
+    }
+}

--- a/aa-core/src/types/sensitive_data/verdict.rs
+++ b/aa-core/src/types/sensitive_data/verdict.rs
@@ -62,6 +62,20 @@ impl RuntimeVerdictLabel {
     ///
     /// Five, permanently. A sixth entry here would be a breaking wire change
     /// under ADR 0024 and a violation of ADR 0032 D-2.
+    ///
+    /// # This list is a mirror, and nothing yet enforces the reflection
+    ///
+    /// `aa_api::models::verdict::RuntimeVerdict` is the authority; these are its
+    /// wire labels, maintained by hand. **No test currently ties the two**, so a
+    /// rename or reorder in `aa-api` would break every stored
+    /// [`SensitiveDataDecisionEvent`](super::SensitiveDataDecisionEvent) and go
+    /// unnoticed — not even a whole-workspace build would object, since this
+    /// type is referenced by no crate but its own.
+    ///
+    /// The contract test belongs in `aa-api`, the only crate that can see both
+    /// types, and is tracked as **AAASM-5384**. It is not here because
+    /// `aa-core` cannot import `aa-api` — that dependency runs the other way,
+    /// deliberately (ADR 0018).
     pub const ALL: &'static [Self] = &[Self::ALLOW, Self::NARROW, Self::SCRUB, Self::PENDING, Self::DENY];
 
     /// Read a verdict back from its wire label.

--- a/aa-core/src/types/sensitive_data/verdict.rs
+++ b/aa-core/src/types/sensitive_data/verdict.rs
@@ -1,0 +1,230 @@
+//! The frozen runtime verdict, as an event field.
+
+use alloc::string::String;
+
+/// The enforcement outcome an action received, spelled exactly as ADR 0018's
+/// `RuntimeVerdict` spells it.
+///
+/// # Why this is not an enum
+///
+/// ADR 0032 D-2 freezes `aa_api::models::verdict::RuntimeVerdict` — its five
+/// variants are not added to, renamed or reordered, because ADR 0024 establishes
+/// that adding an enum variant is not additive on the wire. AAASM-5355 is
+/// forbidden from defining a competing outcome enum, and it does not.
+///
+/// It also cannot simply *use* `RuntimeVerdict`: that type lives in `aa-api`,
+/// which depends on `aa-core`, and ADR 0018 put it there deliberately so it
+/// could carry a `utoipa::ToSchema` derive. The dependency will not be inverted
+/// for an event field.
+///
+/// So the event carries the verdict's **wire label** rather than a second copy
+/// of the vocabulary. A newtype over `&'static str` with five associated
+/// constants is not a competing enum in the way a parallel `enum` would be: it
+/// cannot be `match`ed exhaustively, it has no variants to reorder, and it
+/// cannot acquire a sixth meaning without someone editing a list that says in
+/// its own documentation that the list is frozen. `aa-gateway` already writes
+/// this verdict as a lowercase string for exactly the same reason
+/// (`service/convert.rs`), so the label — not the Rust type — is what actually
+/// crosses layers today.
+///
+/// # The seam AAASM-5356 fills
+///
+/// D-2's finer vocabulary — `redact` · `mask` · `tokenize` · `require_approval`
+/// · `approval_granted` · `approval_denied` · `shadow_only` · `none` — is a
+/// **separate optional** `sensitive_data_disposition` field on
+/// [`SensitiveDataDecisionEvent`](super::SensitiveDataDecisionEvent), and it is
+/// AAASM-5356's deliverable, not this one's. Three things here exist to keep
+/// that addition easy and honest:
+///
+/// - The event is `#[non_exhaustive]` and built through a builder, so a new
+///   optional field is additive for every constructor.
+/// - The schema rule ignores minor versions, so a `1.1` writer's event is
+///   readable by a `1.0` reader ([`SchemaVersion`](super::SchemaVersion)).
+/// - Nothing in this module consults the verdict to decide whether an action is
+///   permitted, and nothing may consult the disposition either. Both are
+///   *records of* an authorisation decision `aa-gateway` already made.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RuntimeVerdictLabel(&'static str);
+
+impl RuntimeVerdictLabel {
+    /// Action permitted unchanged.
+    pub const ALLOW: Self = Self("allow");
+    /// Action permitted but scoped down.
+    pub const NARROW: Self = Self("narrow");
+    /// Action permitted, payload stripped of secrets or PII en route.
+    pub const SCRUB: Self = Self("scrub");
+    /// Action held awaiting human approval.
+    pub const PENDING: Self = Self("pending");
+    /// Action blocked outright.
+    pub const DENY: Self = Self("deny");
+
+    /// Every verdict ADR 0018 defines, in the order it defines them.
+    ///
+    /// Five, permanently. A sixth entry here would be a breaking wire change
+    /// under ADR 0024 and a violation of ADR 0032 D-2.
+    pub const ALL: &'static [Self] = &[Self::ALLOW, Self::NARROW, Self::SCRUB, Self::PENDING, Self::DENY];
+
+    /// Read a verdict back from its wire label.
+    ///
+    /// Returns `None` for anything else rather than inventing a verdict. An
+    /// unrecognised outcome is a recorded failure, never a permissive default —
+    /// the same rule ADR 0032 §5 applies to detection, for the same reason.
+    pub fn from_wire(label: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|verdict| verdict.0 == label)
+    }
+
+    /// The wire label, which is the whole contract.
+    pub const fn as_str(&self) -> &'static str {
+        self.0
+    }
+
+    /// Whether this verdict satisfies ADR 0032 §8's *second* condition for
+    /// counting an event as prevented transmission: the decision was a deny or
+    /// a transforming disposition.
+    ///
+    /// True for [`DENY`](Self::DENY) and [`SCRUB`](Self::SCRUB) only. `NARROW`
+    /// scopes the action rather than transforming the payload, `PENDING` has
+    /// not decided anything yet, and `ALLOW` is the absence of a restriction.
+    ///
+    /// This is **reporting, not authorisation.** Nothing may call it to decide
+    /// whether an action is permitted; it answers one clause of a metric
+    /// predicate, and on its own it is not enough to claim prevention — see
+    /// [`SensitiveDataDecisionEvent::counts_as_prevented_transmission`](super::SensitiveDataDecisionEvent::counts_as_prevented_transmission)
+    /// for the other three conditions.
+    pub fn is_deny_or_transforming(&self) -> bool {
+        *self == Self::DENY || *self == Self::SCRUB
+    }
+}
+
+impl core::fmt::Display for RuntimeVerdictLabel {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for RuntimeVerdictLabel {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for RuntimeVerdictLabel {
+    /// Resolves against [`ALL`](RuntimeVerdictLabel::ALL) rather than leaking a
+    /// runtime string into a `&'static str`.
+    ///
+    /// `Box::leak` would make an arbitrary wire value into a verdict in safe
+    /// stable Rust, which is the hole `aa-security`'s `CategoryQualifier`
+    /// documents and closes the same way.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error as _;
+        let label = String::deserialize(deserializer)?;
+        Self::from_wire(&label).ok_or_else(|| {
+            // The label is echoed because a verdict is a closed five-value
+            // vocabulary, not caller data — there is nothing sensitive it can
+            // hold, and a reader needs to know what it choked on.
+            D::Error::custom(alloc::format!(
+                "not one of the five ADR 0018 runtime verdicts: {label:?}"
+            ))
+        })
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl schemars::JsonSchema for RuntimeVerdictLabel {
+    fn schema_name() -> alloc::borrow::Cow<'static, str> {
+        "RuntimeVerdictLabel".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "enum": ["allow", "narrow", "scrub", "pending", "deny"],
+            "description": "ADR 0018 runtime verdict, as its wire label.",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The vocabulary, pinned to exactly five labels with exactly these
+    /// spellings.
+    ///
+    /// This is the ADR 0032 D-2 acceptance criterion in test form. A sixth
+    /// entry or a respelling is a breaking wire change under ADR 0024, and the
+    /// dashboard keys its verdict styling off these strings — so a "tidy-up"
+    /// rename would silently unstyle the UI as well as break every stored
+    /// event.
+    #[test]
+    fn the_verdict_vocabulary_is_exactly_adr_0018s_five_labels() {
+        let labels: alloc::vec::Vec<&str> = RuntimeVerdictLabel::ALL.iter().map(|v| v.as_str()).collect();
+        assert_eq!(labels, ["allow", "narrow", "scrub", "pending", "deny"]);
+    }
+
+    /// An unknown outcome is refused, not defaulted. A verdict that fell back
+    /// to `allow` on an unparseable label would turn a read error into a
+    /// permissive-looking record.
+    #[test]
+    fn an_unknown_label_is_refused_rather_than_defaulted() {
+        assert_eq!(RuntimeVerdictLabel::from_wire("redact"), None);
+        assert_eq!(RuntimeVerdictLabel::from_wire("Allow"), None);
+        assert_eq!(RuntimeVerdictLabel::from_wire(""), None);
+        assert_eq!(
+            RuntimeVerdictLabel::from_wire("allow"),
+            Some(RuntimeVerdictLabel::ALLOW)
+        );
+    }
+
+    /// Only a deny or a payload transformation can support a prevention claim.
+    ///
+    /// `NARROW` is the trap: it *sounds* restrictive, but it scopes the action
+    /// rather than stopping the payload, so counting it would inflate the
+    /// prevention metric with actions that were carried out.
+    #[test]
+    fn only_deny_and_scrub_satisfy_the_transforming_condition() {
+        assert!(RuntimeVerdictLabel::DENY.is_deny_or_transforming());
+        assert!(RuntimeVerdictLabel::SCRUB.is_deny_or_transforming());
+        assert!(!RuntimeVerdictLabel::NARROW.is_deny_or_transforming());
+        assert!(!RuntimeVerdictLabel::PENDING.is_deny_or_transforming());
+        assert!(!RuntimeVerdictLabel::ALLOW.is_deny_or_transforming());
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::*;
+
+    /// The serialized form is the label itself, matching what `aa-api`'s
+    /// `RuntimeVerdict` emits with `serde(rename_all = "lowercase")` and what
+    /// `aa-gateway` already writes. If these two ever disagree, a stored event
+    /// stops deserializing on the read side.
+    #[test]
+    fn a_verdict_serializes_as_its_lowercase_label() {
+        for verdict in RuntimeVerdictLabel::ALL {
+            assert_eq!(
+                serde_json::to_string(verdict).unwrap(),
+                alloc::format!("\"{}\"", verdict.as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn a_verdict_round_trips() {
+        for verdict in RuntimeVerdictLabel::ALL {
+            let json = serde_json::to_string(verdict).unwrap();
+            let restored: RuntimeVerdictLabel = serde_json::from_str(&json).unwrap();
+            assert_eq!(&restored, verdict);
+        }
+    }
+
+    /// Deserialization refuses an unknown label instead of leaking it into a
+    /// `&'static str`, which is what a grammar-driven parse would need to do.
+    #[test]
+    fn deserializing_an_unknown_label_fails() {
+        assert!(serde_json::from_str::<RuntimeVerdictLabel>(r#""redact""#).is_err());
+        assert!(serde_json::from_str::<RuntimeVerdictLabel>(r#""blocked""#).is_err());
+    }
+}

--- a/aa-core/src/types/sensitive_data/vocab.rs
+++ b/aa-core/src/types/sensitive_data/vocab.rs
@@ -1,0 +1,198 @@
+//! Reading `aa-security`'s canonical vocabularies back out of a stored record.
+//!
+//! # Why this module has to exist
+//!
+//! `aa-security`'s canonical model implements `Serialize` and, deliberately, no
+//! `Deserialize` at all: a finding is never reconstructed from bytes, only
+//! derived from something the process detected. That is the right rule for a
+//! *finding*, and it is the reason `aa-core` cannot simply derive
+//! `Deserialize` on a record that embeds
+//! [`Severity`](aa_security::canonical::Severity) and its siblings — and cannot
+//! supply the missing impl either, because both the type and the trait are
+//! foreign to this crate.
+//!
+//! `serde(with = …)` needs no trait impl, so each vocabulary gets a pair of free
+//! functions here. Serialization delegates to `aa-security`'s own hand-written
+//! impl, so the spelling cannot drift from the one AAASM-5352 pinned;
+//! deserialization resolves against a list of variants and compares
+//! `as_str()`, so it cannot drift either.
+//!
+//! # Fail-closed here, survives-unknown elsewhere
+//!
+//! An unrecognised label is a **hard deserialization error** for every
+//! vocabulary in this module. That is the opposite of what
+//! [`CategoryLabel`](super::CategoryLabel) does with an unknown category, and
+//! the difference is deliberate:
+//!
+//! - The **category taxonomy is designed to grow** — ADR 0032 §2 exists so that
+//!   a new locale pack is a new qualifier under an existing base, and
+//!   `aa-security` documents the locale packs as the next addition. Categories
+//!   will routinely be read by builds that predate them, so a record naming one
+//!   must survive intact.
+//! - These vocabularies are not. Severity is the same four-level scale already
+//!   published over `GET /api/v1/scrub/patterns`; confidence is a three-value
+//!   band that is deliberately not even ordered; a new [`Recognizer`] means a
+//!   genuinely new detection source, not a new pattern — the locale packs
+//!   extend the *built-in scanner*, which is already one of the two. A new value
+//!   in any of them is a rare, deliberate contract change, and reading it as
+//!   something else would be a guess about how severe a finding was or about
+//!   which detector claimed it.
+//!
+//! The cost is real and worth stating: if `aa-security` does add a variant to
+//! one of these `#[non_exhaustive]` enums, the list below stops being complete
+//! and an older reader refuses a newer record outright. Refusing is the safe
+//! direction — the alternative is inventing a severity — but the list is the
+//! thing to update, which is what the size test exists to say.
+
+use aa_security::canonical::{ConfidenceBand, DetectionMethod, FindingStatus, Recognizer, Severity};
+
+/// Define the serde/schemars bridge for one `aa-security` vocabulary.
+///
+/// The variant list is the single source for deserialization *and* for the JSON
+/// schema, and both read spellings through `as_str()`, so neither can disagree
+/// with `aa-security`'s serialization.
+macro_rules! vocabulary_bridge {
+    ($module:ident, $ty:ty, [$($variant:expr),* $(,)?]) => {
+        pub(super) mod $module {
+            #[allow(unused_imports)]
+            use super::*;
+
+            /// Every variant of this vocabulary known to this build.
+            pub(in crate::types::sensitive_data) const ALL: &[$ty] = &[$($variant),*];
+
+            /// Resolve a wire label, or `None` if this build does not know it.
+            pub(in crate::types::sensitive_data) fn from_label(label: &str) -> Option<$ty> {
+                ALL.iter().copied().find(|value| value.as_str() == label)
+            }
+
+            #[cfg(feature = "serde")]
+            pub fn serialize<S: serde::Serializer>(value: &$ty, serializer: S) -> Result<S::Ok, S::Error> {
+                // Delegates to aa-security's hand-written impl rather than
+                // re-emitting as_str(), so there is exactly one spelling.
+                serde::Serialize::serialize(value, serializer)
+            }
+
+            #[cfg(feature = "serde")]
+            pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<$ty, D::Error> {
+                use serde::de::Error as _;
+                use serde::Deserialize as _;
+                let label = alloc::string::String::deserialize(deserializer)?;
+                from_label(&label).ok_or_else(|| {
+                    // The label is echoed because these vocabularies are closed
+                    // and contain no caller data — there is nothing sensitive a
+                    // severity label can hold.
+                    D::Error::custom(alloc::format!(
+                        "not a {} this build knows: {label:?}",
+                        stringify!($ty)
+                    ))
+                })
+            }
+
+            #[cfg(feature = "schemars")]
+            pub fn schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                let variants: alloc::vec::Vec<&'static str> = ALL.iter().map(|value| value.as_str()).collect();
+                schemars::json_schema!({
+                    "type": "string",
+                    "enum": variants,
+                })
+            }
+        }
+    };
+}
+
+vocabulary_bridge!(
+    severity,
+    Severity,
+    [Severity::Critical, Severity::High, Severity::Medium, Severity::Low]
+);
+
+vocabulary_bridge!(
+    confidence,
+    ConfidenceBand,
+    [ConfidenceBand::High, ConfidenceBand::Medium, ConfidenceBand::Low]
+);
+
+vocabulary_bridge!(
+    method,
+    DetectionMethod,
+    [
+        DetectionMethod::Deterministic,
+        DetectionMethod::Heuristic,
+        DetectionMethod::Nlp,
+        DetectionMethod::PolicyDefined,
+    ]
+);
+
+vocabulary_bridge!(
+    status,
+    FindingStatus,
+    [
+        FindingStatus::Confirmed,
+        FindingStatus::Suspected,
+        FindingStatus::ProviderDisagreement,
+        FindingStatus::NeedsReview,
+        FindingStatus::Dismissed,
+    ]
+);
+
+vocabulary_bridge!(
+    recognizer,
+    Recognizer,
+    [Recognizer::BuiltinScanner, Recognizer::PolicyRegex]
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every listed variant resolves from its own `as_str()`.
+    ///
+    /// Cheap, but it is what stops a hand-written list from containing a value
+    /// whose spelling was typed rather than read — the failure mode a plain
+    /// string match would have.
+    #[test]
+    fn every_listed_variant_resolves_from_its_own_spelling() {
+        macro_rules! assert_resolves {
+            ($($module:ident),* $(,)?) => {
+                $(
+                    assert!(!$module::ALL.is_empty(), "an empty list would make this vacuous");
+                    for value in $module::ALL {
+                        assert_eq!(
+                            $module::from_label(value.as_str()),
+                            Some(*value),
+                            "{value:?} did not resolve from its own as_str()"
+                        );
+                    }
+                )*
+            };
+        }
+        assert_resolves!(severity, confidence, method, status, recognizer);
+    }
+
+    /// The counts these lists are believed complete at.
+    ///
+    /// Every one of these enums is `#[non_exhaustive]`, so the compiler will not
+    /// notice a new variant — nothing here can be exhaustiveness-checked. A
+    /// count is the crudest possible guard and it is the only one available:
+    /// when `aa-security` adds a variant, this fails and points at the list that
+    /// needs extending, instead of an older reader silently refusing newer
+    /// records in production.
+    #[test]
+    fn the_vocabulary_lists_are_the_expected_size() {
+        assert_eq!(severity::ALL.len(), 4, "aa-security's Severity scale changed size");
+        assert_eq!(confidence::ALL.len(), 3, "aa-security's ConfidenceBand changed size");
+        assert_eq!(method::ALL.len(), 4, "aa-security's DetectionMethod changed size");
+        assert_eq!(status::ALL.len(), 5, "aa-security's FindingStatus changed size");
+        assert_eq!(recognizer::ALL.len(), 2, "aa-security's Recognizer set changed size");
+    }
+
+    /// An unknown label resolves to `None` rather than to the first variant,
+    /// which is what a `find` written as an `unwrap_or_default` would do.
+    #[test]
+    fn an_unknown_label_resolves_to_none() {
+        assert_eq!(severity::from_label("catastrophic"), None);
+        assert_eq!(severity::from_label("Critical"), None);
+        assert_eq!(confidence::from_label(""), None);
+        assert_eq!(recognizer::from_label("aa-gateway::something_new"), None);
+    }
+}

--- a/aa-core/tests/sensitive_data_projection_boundary.rs
+++ b/aa-core/tests/sensitive_data_projection_boundary.rs
@@ -1,0 +1,154 @@
+//! The metric-label boundary, attacked from a genuinely downstream crate.
+//!
+//! # Why this is an integration test and not a unit test
+//!
+//! Everything in `aa-core`'s own `mod tests` can see private fields and
+//! `pub(super)` constructors, so a unit test cannot tell the difference between
+//! "the boundary holds" and "the boundary holds for anyone who is not already
+//! inside". This file is compiled as a separate crate and sees exactly the
+//! public API a consumer sees.
+//!
+//! It exists because an earlier revision of
+//! [`SensitiveDataMetricLabels`](aa_core::types::sensitive_data::SensitiveDataMetricLabels)
+//! documented its labels as "unrepresentable" and was wrong: a
+//! `SensitiveDataFindingRecord` deserialized from storage could carry an
+//! arbitrary category string, and projecting it put **a raw credential into a
+//! metric label value** — ADR 0032 forbidden design #12. The fix was to hold a
+//! resolved `CanonicalCategory` and refuse to project what does not resolve.
+//!
+//! Every literal here is synthetic.
+
+use aa_core::types::sensitive_data::{
+    CategoryLabel, RuntimeVerdictLabel, SensitiveDataFindingRecord, SensitiveDataMetricLabels,
+};
+
+/// A synthetic token in `aa-security`'s documented example format. Not a live
+/// credential; it exists so the test asserts about the shape of a secret
+/// without containing one.
+const SYNTHETIC_TOKEN: &str = "ghp_16C7e42F292c6912E7710c838347Ae178B4a";
+
+/// Build a stored record whose category field is whatever the caller says.
+///
+/// This is the hostile input: a row read back from storage, which no
+/// construction-time guard ever saw.
+fn stored_record_with_category(category: &str) -> Result<SensitiveDataFindingRecord, serde_json::Error> {
+    let json = format!(
+        r#"{{"schema_version":{{"major":1,"minor":0}},
+            "event_id":"01HZX9V8ABCDEFGHJKMNPQRSTV",
+            "category":"{category}",
+            "severity":"critical","confidence":"high","method":"deterministic","status":"confirmed",
+            "provenance":{{"recognizer":"aa-security::scanner","version":"0.0.0-test"}},
+            "field_path":"body.token","redaction_label":"[REDACTED]"}}"#
+    );
+    serde_json::from_str(&json)
+}
+
+/// **The blocker, as a regression test.**
+///
+/// A stored record carrying a raw credential where its category should be must
+/// not yield metric labels. Before the fix this produced
+/// `("category", "ghp_16C7e42F292c…")` and serialized it.
+#[test]
+fn a_credential_smuggled_into_a_stored_category_cannot_become_a_metric_label() {
+    let record = stored_record_with_category(SYNTHETIC_TOKEN).expect("a well-shaped string still deserializes");
+
+    // The record itself carries it — deserialization is deliberately not
+    // catalogue-closed, so that a newer build's category survives a round-trip.
+    assert_eq!(record.category.as_str(), SYNTHETIC_TOKEN);
+
+    // But it does not resolve, so it cannot be projected.
+    assert_eq!(record.category.resolve(), None);
+    assert!(
+        SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::DENY).is_none(),
+        "an unresolvable category was projected into a bounded metric label"
+    );
+}
+
+/// The same guarantee stated over the serialized output, since that is what
+/// actually reaches an exporter.
+#[test]
+fn no_projection_exists_to_serialize_for_an_unresolvable_category() {
+    for hostile in [
+        SYNTHETIC_TOKEN,
+        "postgresql://user:password@db.internal:5432/app",
+        "NATIONAL_ID[xx-ZZ/synthetic_for_test]",
+        "arbitrary text a writer chose",
+    ] {
+        let record = stored_record_with_category(hostile).expect("well-shaped");
+        assert!(
+            SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::SCRUB).is_none(),
+            "`{hostile}` reached the projection"
+        );
+    }
+}
+
+/// A category the build *does* know still projects, so the refusal above is not
+/// simply "nothing ever projects".
+///
+/// Without this, deleting the body of `from_finding` and returning `None`
+/// unconditionally would satisfy every other test in this file.
+#[test]
+fn a_catalogue_category_still_projects() {
+    let record = stored_record_with_category("ACCESS_TOKEN[github:personal_access]").expect("well-shaped");
+    let labels =
+        SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::DENY).expect("a catalogue category");
+
+    let pairs = labels.as_pairs();
+    assert_eq!(pairs[0], ("category", "ACCESS_TOKEN[github:personal_access]"));
+    assert_eq!(pairs.len(), 6);
+}
+
+/// Every label value that can leave this type is a member of a compile-time
+/// catalogue — asserted from outside, over the serialized form.
+#[test]
+fn every_serialized_label_value_is_a_catalogue_member() {
+    let record = stored_record_with_category("EMAIL_ADDRESS").expect("well-shaped");
+    let labels = SensitiveDataMetricLabels::from_finding(&record, RuntimeVerdictLabel::ALLOW).expect("catalogue");
+
+    let json: serde_json::Value = serde_json::to_value(&labels).unwrap();
+    let object = json.as_object().expect("an object");
+
+    // The resolved category must render as itself, and nothing may appear that
+    // is not one of the six.
+    assert_eq!(object.len(), 6, "the projection changed shape: {object:?}");
+    assert_eq!(object["category"], "EMAIL_ADDRESS");
+    for name in SensitiveDataMetricLabels::LABEL_NAMES {
+        assert!(object.contains_key(name), "missing label `{name}`");
+        assert!(object[name].is_string(), "label `{name}` is not a string");
+    }
+}
+
+/// The honest limit of the guard, pinned so it is not mistaken for something
+/// stronger.
+///
+/// `CategoryLabel::new` is public and shape-only — it is the read path's
+/// constructor and cannot be catalogue-closed without breaking the deliberate
+/// round-trip of a newer build's category. So a caller *can* mint a label
+/// holding arbitrary text. What it cannot do is get that text into a metric,
+/// which is where ADR 0032 §9 requires boundedness.
+#[test]
+fn a_hostile_label_can_be_built_but_goes_nowhere() {
+    let label = CategoryLabel::new(SYNTHETIC_TOKEN).expect("shape-only check accepts it");
+    assert_eq!(label.resolve(), None, "it is not a category, and never claims to be");
+
+    // Shape is still enforced on that path.
+    assert!(CategoryLabel::new("has\na newline").is_err());
+    assert!(CategoryLabel::new("x".repeat(4096)).is_err());
+}
+
+/// A stored record whose category is malformed is refused outright, rather than
+/// carried. The derived `Deserialize` this type once had validated nothing.
+#[test]
+fn a_malformed_stored_category_fails_to_deserialize() {
+    // A control character in the category is refused on the read path.
+    let json = r#"{"schema_version":{"major":1,"minor":0},
+        "event_id":"01HZX9V8ABCDEFGHJKMNPQRSTV",
+        "category":"API_KEY\nforged",
+        "severity":"critical","confidence":"high","method":"deterministic","status":"confirmed",
+        "provenance":{"recognizer":"aa-security::scanner","version":"0.0.0-test"},
+        "field_path":"body.token","redaction_label":"[REDACTED]"}"#;
+    assert!(
+        serde_json::from_str::<SensitiveDataFindingRecord>(json).is_err(),
+        "a category with an embedded newline was accepted from storage"
+    );
+}


### PR DESCRIPTION
## Description

Adds `aa_core::types::sensitive_data` — `SensitiveDataDecisionEvent`, `SensitiveDataFindingRecord`, and the supporting vocabularies (ADR 0032 §8, backlog item B-9). **Types only**: nothing here writes, stores or serves anything, and nothing is wired up. `aa-security` is consumed, never modified.

Today the system cannot answer the Epic's motivating question — *"how many findings of each class did agent X attempt to send to tool Y, how many were blocked versus redacted, how many were uncertain?"* — for four separate reasons. `audit_entry_to_storage_event` drops every credential finding, the hash chain, and all lineage except `team_id`; destination is not a dimension of the audit event at all; `action` and `decision` are set from the same source, so "blocked" and "redacted" are indistinguishable; and findings are binary. These types are the lossless shape that bridge should have had. Per forbidden design #15 they are written to sit **beside** that bridge, not to extend it — the writer is AAASM-5357.

### The two decisions that carry the most weight

> **Review round 2 (7 further commits).** An adversarial review found a **blocker**: this PR's metric projection claimed its labels were "unrepresentable" and was wrong — a raw credential could reach a metric label value. That is fixed, plus five should-fix items and two nits. The section below is rewritten to describe what the code now does; see **"What the review found"** for the before/after.
>
> One word is now banned in this programme unless the compiler enforces it: **unrepresentable**. It has been falsified on this Epic three times, once by me here.

**1. `SensitiveDataFindingRecord` is span-free by construction.** AAASM-5352 left this ticket an explicit obligation: `CanonicalFinding: Serialize` emits its `ByteSpan` unconditionally, and `aa-security`'s `serde_impls.rs` documents that output as audit-tier only, because ADR 0032 §9 permits offsets and lengths solely in the tamper-evident tier — a length plus a category can identify a value in a small domain. Guarding the offset behind `pub(crate)` in Rust means nothing if JSON publishes it to anything that asks.

`from_finding()` reads a `CanonicalFinding` and **discards** the span; there is no field to hold one and no accessor to retrieve one. `SensitiveDataMetricLabels` narrows further to exactly the six labels §9 permits. It holds a **resolved `CanonicalCategory`** and `from_finding` returns `Option<Self>`, refusing to project a category this build cannot name — because ADR 0032 §9 bounds metric *series*, which are name **and** value, and a category value that does not resolve is by definition not from a bounded set.

A notable result while mutation-testing this: **reintroducing the span does not compile.** `ByteSpan` implements neither `Deserialize` nor `JsonSchema`, so adding it back to a round-trippable record is a type error, not a test failure:

```
error[E0277]: the trait bound `ByteSpan: serde::Deserialize<'de>` is not satisfied
error[E0277]: the trait bound `ByteSpan: JsonSchema` is not satisfied
```

That is a stronger guarantee than an assertion — it is enforced by the type system rather than by a check someone can delete. It does *not* prove the JSON test works, so that was mutated separately with a plain `usize` length, which compiles and is caught at runtime (see Testing).

**2. Execution is modelled as evidence, not as a `prevented` flag.** The runtime's `CredentialLeakBlocked` event does not mean blocked — it means *redact*, and redaction **forwards** the scrubbed bytes. A boolean set from that event would have been wrong for the most common case with nothing able to notice. `TransmissionEvidence` therefore mirrors `aa_proxy::probe_adjudication::ForwardedPayload`, the observable ADR 0032 §8 names, plus a `NotRecorded` for the paths AAASM-5358 has not yet instrumented.

No field name or doc in this module implies a block that did not happen. `ForwardedClean` — a successful redaction — is documented and tested as a *transformed transmission*. `counts_as_prevented_transmission()` is the only place §8's four conditions are conjoined, and it is derived rather than stored so it cannot disagree with the evidence behind it. `proves_transmission()` and `proves_non_transmission()` are deliberately **not** complements: both are false for `NotRecorded`, because a path that recorded nothing has proved nothing in either direction.

### Other decisions worth a reviewer's attention

- **`RuntimeVerdict` is untouched.** ADR 0032 D-2 freezes it and this ticket may not define a competing outcome enum — but `aa-core` cannot *use* it either, since `aa-api` depends on `aa-core` and ADR 0018 placed it there deliberately for its `ToSchema` derive. The event carries `RuntimeVerdictLabel`, a newtype over `&'static str` with five associated constants: nothing to `match` exhaustively, no variants to reorder, no sixth meaning without editing a list that documents itself as frozen. `aa-gateway` already writes this verdict as a lowercase string for the same reason.
- **The AAASM-5356 seam is left open, not filled.** The event is `#[non_exhaustive]` and built through a builder; `SchemaVersion::is_readable_by` compares majors only; and **no type in this module uses `deny_unknown_fields`**. Those three together are what let `sensitive_data_disposition` arrive as a `1.1` minor bump with every `1.0` reader still working — which is what D-2's "absent must mean exactly what absence means today" requires. A test simulates that exact field name.
- **Caller-supplied strings are screened, and the limits are stated.** Every other field is an enum, an integer, or a `&'static str` from a compiled-in catalogue, so the caller-supplied strings are the entire remaining surface a raw value could reach a record through. `FieldPath` and `Endpoint` identifiers get a credential scan; the concrete leak closed is a destination written as `postgresql://user:password@db.internal/app`. `AuditLabel` (system-minted ids) gets a shape check only — because a ULID scans as `GenericHighEntropy`, so screening ids would reject well-formed events. That is measured and asserted, not assumed. The docs state plainly that the scan can only refuse what the scanner recognises, and is not a proof.
- **No HMAC fingerprint anywhere.** `AggregateKey` is built from where-and-what (category, field path, method, recognizer), never from the value. Two different national IDs in the same field produce the *same* key — that is the deduplication behaviour, and it is also precisely why the key cannot be enumerated back to a value the way an HMAC of a 9-digit ID can (forbidden design #14).
- **No `parse_base`.** See "Decision requested" below.
- **No tenant label on metrics.** ADR 0032 §9's permitted label set has no tenant, and adding one would be unbounded *and* would put one tenant's activity in a series a shared dashboard can read. The consequence is stated in the type's docs: these metrics do not answer per-tenant questions; a tenant-scoped answer comes from querying the events, which carry `Tenancy` and where isolation can be enforced by the query.

No raw sensitive value appears anywhere in this diff. All fixtures are synthetic.

## What the review found, and what changed

### Blocker — a raw credential could reach a metric label value

The first revision held the category as a `CategoryLabel` (a `String` newtype) and documented the label set as "unrepresentable". Reproduced from a downstream crate: a `SensitiveDataFindingRecord` deserialized from storage carried an arbitrary category, and projecting it produced

```
("category", "ghp_16C7e42F292c6912E7710c838347Ae178B4a")
{"category":"ghp_16C7e42F292c…","severity":"critical",…}
```

ADR 0032 forbidden design #12, and a failure of this ticket's own AC.

**The generalisable lesson, which is worth more to the next reader than any individual fix here: mutation 17 was genuine but only ever exercised the half I had already got right.** ADR 0032 §9 bounds metric *series* — name **and** value. I fixed the six label *names*, tested them thoroughly, and then read that green result as covering the values too, when the value side had no coverage at all. A passing mutation test says the property it pins is real; it says nothing whatever about the properties adjacent to it. When a rule has two halves, testing one half hard makes the other half *less* likely to be examined, not more.

Five distinct routes existed: unvalidated `Deserialize` on `CategoryLabel`; the public shape-only `CategoryLabel::new`; a struct literal (the projection was not `#[non_exhaustive]` and its fields were `pub`); and post-hoc field assignment on the record. The name set really was fixed at six — that part of mutation 17 was genuine — but a fixed name with an unbounded value is still an unbounded series.

Fixed at the projection boundary, which is where boundedness is actually required:

- `SensitiveDataMetricLabels` holds a resolved `CanonicalCategory`; `from_finding` returns `None` for anything unresolvable, and renders from the **resolved** category, never from the record's stored label.
- The struct is `#[non_exhaustive]` with private fields and typed accessors, closing the literal and assignment routes.
- `CategoryLabel` gains a hand-written `Deserialize` running `check_shape`, modelled on `RuntimeVerdictLabel`. Deliberately still **not** catalogue-closed — closing it would break the round-trip that lets a newer build's category survive an older reader, which is why the real fix belongs at the projection rather than at the label.

The regression test is an **integration test on purpose** (`aa-core/tests/sensitive_data_projection_boundary.rs`, 6 tests). A unit test sees private fields and cannot distinguish "the boundary holds" from "the boundary holds for anyone not already inside it".

New mutation: making `from_finding` render the stored label again fails 2 downstream tests — *"an unresolvable category was projected into a bounded metric label"*.

### S1 — "child row" with no parent key

Correct, and it would have cost AAASM-5357 a wire-shape change against a golden this PR pins. `SensitiveDataFindingRecord` now carries `event_id: AuditLabel`, required by `from_finding`.

### S2, S3 — two more overclaims, both mine

- *"There is no constructor that takes an unscreened string"* was contradicted by `guard.rs`'s own two-strength table nine lines later. Restated: no constructor takes an **unguarded** string, and there are two strengths — credential scan for request-derived strings, shape check for system-minted ones — plus a deliberate deserialization gap in both.
- *"The only caller-supplied string is the `FieldPath`"* was false: `DetectionProvenance::version` is shape-checked only, and `redaction_label` is a `pub` field assignable after construction. Replaced with a per-field table and an explicit statement that a record in hand is **not** evidence its category is known or its labels bounded.

### S4 — invariant unenforceable where dashboards read

Correct. `tally()` rejected `transformed + blocked > total`, but deserialization ran no invariant, so a stored row could claim `blocked: 99` against `total: 1` — arriving at the one layer the constructor check never protected. Added `disposition_counts_are_consistent()`, symmetric with the existing `breakdown_is_complete()`.

### S5 — the verdict freeze rests on two unlinked lists

Confirmed: `RuntimeVerdictLabel` is referenced by no crate but its own, so nothing would notice a rename in `aa-api`. **Filed as [AAASM-5384](https://lightning-dust-mite.atlassian.net/browse/AAASM-5384) rather than fixed here** — the contract test belongs in `aa-api`, which is outside this ticket's lane and held by a concurrent agent. The gap is now recorded in `RuntimeVerdictLabel::ALL`'s own docs so a reader hits it where it matters.

### Nits — both valid

- **Mutation 8 was weaker than I claimed.** The faithful `parse_base` does fail the named tests, but the naive form a contributor would actually write (`self.0.split('[').next()?.parse().ok()`) passed 71/71, because `NationalId` is in the catalogue only as `with_locale(en-US/ssn)` so the base never resolves. Added `a_qualified_form_of_a_catalogue_base_still_resolves_to_none` over `EMAIL_ADDRESS`, which **is** in the catalogue unqualified — the naive fallback resolves it and is now caught. Verified: that mutation now fails exactly this test.
- **The type-level span guarantee does not extend to the projection**, which is `Serialize`-only, so a `ByteSpan` field there would compile. Now stated in the type's docs alongside what *is* guaranteed by construction.


## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Purely additive. Nothing is wired up, so there is no wire, OpenAPI, proto or SDK change and no migration. `AuditEntry`, `CredentialFinding`, `AuditEvent` and `RuntimeVerdict` are all untouched — `RuntimeVerdict` verifiably so, since this branch changes no file outside `aa-core/`. Rollback is deleting an unused module.

`aa-core` gains **no new dependency**; `Cargo.toml` is unchanged. The one edit outside the new module is a feature-gated `JsonSchema` derive on the existing `EnforcementMode`, needed because `ExecutionEvidence` embeds the mode (condition 4 of the prevention test). It adds no derive under default features and changes no runtime behaviour.

## Related Issues

- Related Jira ticket: [AAASM-5355](https://lightning-dust-mite.atlassian.net/browse/AAASM-5355)
- Parent Epic: [AAASM-5270](https://lightning-dust-mite.atlassian.net/browse/AAASM-5270) · Depends on ADR 0032 and [AAASM-5352](https://lightning-dust-mite.atlassian.net/browse/AAASM-5352) (merged, `7ce62fd1`)
- Related GitHub issues: N/A

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

`cargo nextest run -p aa-core` → **485 passed, 0 skipped** (79 unit + 6 downstream integration in the new module).

### These tests run in the default profile — verified, not assumed

`cargo nextest run --workspace` does not pass `--all-features`, so a test behind `#[cfg(feature = "serde")]` can be a vacuous assertion at the build level. `aa-core` already carries a self dev-dependency (`aa-core = { path = ".", features = ["serde", "schemars"] }`) for exactly this reason, and this module follows it. Confirmed by negative control — removing that dev-dependency and re-running the *same* default-profile command:

| | `test(sensitive_data)` | of those, `serde_tests` |
|---|---|---|
| with the self dev-dependency | **71 run, 71 passed** | **22 run, 22 passed** |
| without it (control) | 49 run | **0 run** — `error: no tests to run` |

All 22 serde-gated tests execute under plain `cargo nextest run -p aa-core`.

### Mutation evidence

Every property below was verified by breaking it and observing the specific test fail, then reverting. Nothing here passed by default.

| # | Mutation | Result |
|---|---|---|
| 1 | `is_readable_by` also compares the minor | 2 fail — `a_newer_minor_is_readable_by_an_older_reader`, `an_older_minor_is_readable_by_a_newer_reader` (would silently make AAASM-5356's field breaking) |
| 2 | Credential screen removed from `screen()` | 3 fail — `a_field_path_carrying_a_token_is_refused`, `a_path_holding_a_database_uri_is_refused`, `a_rejection_never_echoes_the_offending_input` |
| 3 | `NARROW` counted as transforming | 1 fail — `only_deny_and_scrub_satisfy_the_transforming_condition` |
| 4 | Sixth label added to `RuntimeVerdictLabel::ALL` | 3 fail, incl. `the_verdict_vocabulary_is_exactly_adr_0018s_five_labels` |
| 5 | `proves_non_transmission` true for `NotRecorded` | 2 fail — `unrecorded_evidence_proves_nothing_in_either_direction`, `every_single_condition_is_load_bearing` |
| 6 | Observe-mode clause dropped from the conjunction | 1 fail — `every_single_condition_is_load_bearing` |
| 7 | `ForwardedClean` counted as non-transmission | 2 fail, incl. `a_clean_forwarded_payload_is_a_transmission_not_a_prevention` |
| 8 | `resolve()` falls back to the base category | 2 fail — `an_unknown_category_resolves_to_none_and_is_never_degraded_to_its_base`, `an_unknown_label_round_trips_intact` |
| 9 | **Span reintroduced into the record** | **does not compile** — `ByteSpan: Deserialize` / `JsonSchema` unsatisfied (type-level, see above) |
| 9b | Match **length** leaked as a plain `usize` (compiles) | 2 fail — `a_serialized_record_carries_no_span_offset_or_length`: *"the projection leaked `length`, which ADR 0032 §9 confines to the audit tier"* |
| 10 | `AggregateKey` gains a severity dimension | 1 fail — `the_aggregate_key_ignores_severity` |
| 11 | Redaction label hardcoded instead of derived | 1 fail — `a_finding_record_serializes_to_its_documented_shape` |
| 12 | `transformed + blocked ≤ total` invariant removed | 1 fail — `disposition_counts_cannot_exceed_the_total` |
| 13 | Per-category breakdown collapsed into one bucket | 1 fail — `a_tally_counts_each_category_separately` |
| 14 | Prevention derived from the verdict alone | 3 fail — `without_execution_evidence_a_deny_does_not_count_as_prevented`, `an_observe_mode_action_does_not_count_as_prevented`, `a_successful_redaction_does_not_count_as_prevented` |
| 15 | **`blocked_event_count` collapsed onto the finding count** | 3 fail, incl. the ADR §8 worked example: `assertion left == right failed; left: 3, right: 1` |
| 16 | `deny_unknown_fields` added to the event | 1 fail — `an_event_from_a_newer_minor_still_deserializes` (this is AAASM-5356's guarantee) |
| 17 | **Seventh metric label added** | **does not compile** — `can't compare [&str; 7] with [&str; 6]` (arity is fixed) |
| 17b | `provider_id` swapped for `destination` (same arity) | 3 fail — `the_label_names_are_exactly_the_six_the_adr_permits` and 2 others |
| 18 | **Projection renders the stored label instead of resolving** (the blocker, restored) | 2 fail — `a_credential_smuggled_into_a_stored_category_cannot_become_a_metric_label`, `no_projection_exists_to_serialize_for_an_unresolvable_category` |
| 19 | **The naive `parse_base`** the review showed passing 71/71 | 1 fail — `a_qualified_form_of_a_catalogue_base_still_resolves_to_none` |

Mutation 15 initially appeared to fail only one unrelated test, because nextest's fail-fast cancelled the run before the §8 example executed. Re-run with `--no-fail-fast` to confirm the real assertion fires — worth noting, since a truncated run reads as a weaker result than it is.

### ADR 0032 validation requirements discharged

- **#4** (metric-label cardinality rejects `agent_id`/`destination`/`session_id`/fingerprints) — `the_label_names_are_exactly_the_six_the_adr_permits`, asserted as set *equality* rather than as "does not contain `agent_id`", which keeps passing when someone adds `tool_name`.
- **#5** (three findings in one blocked action ⇒ `blocked_event_count = 1`, `blocked_finding_count = 3`) — `three_findings_in_one_blocked_action_give_one_event_and_three_findings`.
- **#6** (absence of execution evidence prevents an event counting as prevented) — `without_execution_evidence_a_deny_does_not_count_as_prevented`.

## Decision requested — the display-only category reader

`aa-security`'s `ParseCategoryError::UnknownCategory` docs name *this ticket's projection* as where a weaker, explicitly-named reader (`parse_base`) would belong if one were wanted. **I did not add it.** Reasoning, so the call can be overridden knowingly:

- **Nothing needs it.** `CategoryLabel::as_str()` hands back the rendered string verbatim, which displays a newer build's category *perfectly*. A partial parse would show `NATIONAL_ID` and silently drop the jurisdiction — and a locale is not decoration, it changes what the finding means.
- **It would be a second parser for a vocabulary `aa-security` owns**, in a different crate, free to drift from the catalogue it mirrors.
- **`aa-core` is not only read by dashboards.** A `parse_base` in the shared domain crate is reachable from an enforcement path, and a partial category is exactly the confident-looking wrong answer ADR 0032 §5 exists to prevent.
- There is no caller today, and adding an unused weaker parser now is a shim for code that does not exist.

If a concrete reader ever needs base-level routing, the honest home is `aa-security` beside the catalogue, named so it says it is doing something weaker. The decision and its reasoning are recorded in `CategoryLabel`'s docs, and mutation 8 fails if a base-level fallback is added later.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending; verified locally: `cargo fmt --all --check` clean, `cargo clippy -p aa-core --all-targets --all-features` clean, `cargo deny check` → *advisories ok, bans ok, licenses ok, sources ok*, `cargo doc` clean for this module (2 pre-existing `evaluators` link warnings elsewhere in `aa-core` are untouched)
- [x] Commits are small and follow the Gitmoji convention — 18 commits, one logical unit each
  - One caveat, disclosed rather than rewritten: `72b67f44f` (adds `event_id`) does not build standalone — see **"A bisectability defect, and a corrected diagnosis"** below.
- [x] Commits are signed off (`git commit -s`)

## A bisectability defect, and a corrected diagnosis

`72b67f44f` changed `SensitiveDataFindingRecord::from_finding`'s signature but committed only the definition. Checked out standalone, its test target does not compile — in **two** call sites, not one:

```
$ git worktree add --detach /tmp/bisect 72b67f44f
$ cargo test -p aa-core --no-run
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> aa-core/src/types/sensitive_data/counts.rs:150:9
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> aa-core/src/types/sensitive_data/event.rs:642:9
```

Both are fixed by later commits, so the branch tip is sound and CI is green — but that one commit is not bisectable.

**My first explanation was wrong and I am retracting it.** I claimed the pre-commit clippy runs without `--all-targets`. It does not: `lefthook.toml:11` is `cargo clippy --all-targets --all-features -- -D warnings`. **`lefthook.toml` is correct and should not be changed.** Had that gone into a ticket unchecked, it would have sent someone to "fix" a config that was already right.

A second hypothesis — that the history had been re-split with `git reset --soft`, so only the final tree was ever hook-checked — is also **not** what happened. The branch's `git reflog` shows plain `commit:` entries throughout, no resets.

**The actual mechanism is ordinary partial staging.** `cargo` reads the *working tree*; `git commit` records the *index*. I ran `git add <one file>` while other files were still modified on disk — which is simply how you produce a single-concern commit — so the hook validated a consistent working tree that was never committed as such, while the commit captured a subset. `lefthook.toml` configures no `stash` directive, so unstaged changes are not hidden from the build.

Demonstrated rather than argued: running the exact hook command against a working tree whose `HEAD` is the broken commit passes cleanly.

So the real, ticket-worthy finding is not a missing flag — it is that **nothing in this repo verifies that each commit builds, and `lefthook` structurally cannot**, because a pre-commit hook can only ever see the working tree. CI compounds it by building only the tip. Filed as **[AAASM-5385](https://lightning-dust-mite.atlassian.net/browse/AAASM-5385)**, with the reproduction and an explicit note that the hook config needs no change.

Not rewritten here: the branch is pushed and reviewed, and folding the fixture commit back would mean a force-push.


## Note for concurrent reviewers

Runs alongside AAASM-5353, which owns `aa-security/**` and `conformance/vectors/**`. This branch touches **`aa-core/` only** — `git diff --name-only remote/main..HEAD` returns nothing under `aa-security/`, `aa-gateway/`, `aa-api/`, `conformance/` or `dashboard/`, so there is no file-level overlap.

One semantic interaction was found and handled: two tests originally pinned `NATIONAL_ID[zh-TW/arc_new]` as an *unknown* category — which is exactly the locale AAASM-5353 adds to `CanonicalCategory::ALL`, so they would have gone red on that merge while asserting the opposite of their intent. Both now use a synthetic `xx-ZZ` private-use tag. The catalogue-wide round-trip test iterates `CanonicalCategory::ALL` and stays correct as that list grows.


[AAASM-5384]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ