### PR TITLE
[AAASM-5432] 🔧 (ci): Package the publishable set in one invocation, not one per crate

### DIFF
--- a/scripts/check-packaged-artifacts.sh
+++ b/scripts/check-packaged-artifacts.sh
@@ -188,11 +188,60 @@ echo "  ✓ every internal aa-* pin matches the workspace version"
 # ---------------------------------------------------------------------------
 step "3/6 cargo package (--no-verify, see header for why verify cannot run)"
 
+# One invocation naming every publishable crate, rather than one invocation per
+# crate (AAASM-5432).
+#
+# Packaging strips the `path` from an internal dependency and leaves the version,
+# so a crate packaged ALONE has its siblings resolved through the crates.io
+# index. For a sibling already published that silently resolves to the PREVIOUS
+# release; for a sibling this branch INTRODUCES there is nothing to resolve, and
+# every dependent fails:
+#
+#     no matching package named `aa-policy` found
+#     location searched: crates.io index
+#     required by package `aa-gateway v0.0.1-rc.6`
+#
+# That made it impossible to add an internal crate in the same PR that adds it —
+# the gate reported a defect in the change rather than a gap in its own method.
+# `release.yml` never had the problem because it publishes in dependency order.
+#
+# Naming them together makes cargo resolve inter-dependencies *within the set
+# being packaged*, which is the same thing a topological publish achieves. It is
+# also strictly closer to what ships: the gate now reasons about this tree's
+# crates rather than partly about the last release's.
+#
+# `[patch.crates-io]` is NOT an alternative here — cargo ignores it when it
+# validates a packaged manifest against the index, and reports the entries as
+# `patch ... was not used in the crate graph`.
+pkg_args=()
 while IFS= read -r pkg; do
     [ -n "$pkg" ] || continue
-    ( cd "$TREE" && cargo package -p "$pkg" --no-verify --allow-dirty ) >/dev/null 2>&1 \
-        || { err "cargo package -p $pkg failed"; continue; }
-    echo "  ✓ packaged $pkg"
+    pkg_args+=(-p "$pkg")
+done <<EOF
+$PUBLISHABLE
+EOF
+
+if ! ( cd "$TREE" && cargo package "${pkg_args[@]}" --no-verify --allow-dirty ) >"$WORK/package.log" 2>&1; then
+    # The reason, not just the fact: this step used to discard both streams, so a
+    # failure said only "cargo package -p X failed" and every diagnosis began by
+    # reproducing the gate by hand.
+    # Show the `error:`/`Caused by:` block, not the tail. Cargo's tail is
+    # progress output — the packaging lines for crates that succeeded before the
+    # failure — so a naive tail buries the one thing the reader needs.
+    reason="$( awk '/^error(\[|:)/{f=1} f' "$WORK/package.log" | head -25 )"
+    [ -n "$reason" ] || reason="$( tail -25 "$WORK/package.log" )"
+    err "cargo package failed:"$'\n'"$( printf '%s' "$reason" | sed 's/^/      /' )"
+fi
+
+# Assert the artifact exists per crate rather than trusting the exit status —
+# a tarball missing from the set is exactly what steps 4-6 would then misread.
+while IFS= read -r pkg; do
+    [ -n "$pkg" ] || continue
+    if [ -f "$CARGO_TARGET_DIR/package/$pkg-$WS_VERSION.crate" ]; then
+        echo "  ✓ packaged $pkg"
+    else
+        err "no tarball produced for $pkg ($pkg-$WS_VERSION.crate)"
+    fi
 done <<EOF
 $PUBLISHABLE
 EOF


### PR DESCRIPTION
## Description

The packaged-artifact gate makes it impossible to add a new internal crate in the PR that adds it. Found while landing **AAASM-5349**; the gate failed PR #1896 and was **right to fail it** — the defect is in the gate's method, not in the change.

## What happens

Step 3 packaged each publishable crate in its own `cargo package -p <name>` invocation. Packaging strips the `path` from an internal dependency and leaves only the version, so a crate packaged **alone** has its siblings resolved through the crates.io index:

- a sibling already on crates.io resolves to the **previous release** — the wrong artifact, but a resolvable one, so nothing complained;
- a sibling this branch **introduces** has nothing to resolve, and every already-published dependent fails.

```
error: failed to prepare local package for uploading

Caused by:
  no matching package named `aa-policy` found
  location searched: crates.io index
  required by package `aa-gateway v0.0.1-rc.6`
```

`aa-policy` itself packaged fine — the log even prints `✓ packaged aa-policy`. What failed was `aa-gateway`, which now depends on it.

`release.yml` never had this problem: it publishes in dependency order, so a new leaf reaches the index before anything needing it. This gate packages everything from one tree without publishing, so it has to model that ordering itself.

## Fix

Name the whole publishable set in **one** `cargo package` invocation. Cargo then resolves inter-dependencies *within the set being packaged*, which is exactly what a topological publish achieves. It also moves the gate closer to what ships: it now reasons about this tree's crates rather than partly about the last release's.

**`[patch.crates-io]` is not an alternative, and I verified that rather than assuming it.** My first attempt was a topological sort plus a growing patch block pointing at freshly unpacked tarballs. Cargo ignores `[patch]` when validating a packaged manifest against the index and reports every entry as `patch ... was not used in the crate graph`; the packaging error was unchanged. That approach is gone.

## Two reporting defects fixed alongside

Both cost real diagnosis time on #1896:

1. **The step discarded its own error.** `>/dev/null 2>&1` meant a failure reported only `cargo package -p aa-gateway failed` — the cause had to be recovered by rebuilding the gate's tree by hand. It now prints the `error:`/`Caused by:` block. Deliberately *not* the log tail: the tail is progress output for the crates that packaged successfully first, which buries the one line that matters.
2. **Per-crate success was inferred from a single exit status** covering all of them. Now asserted from the tarball on disk, so a crate silently missing from the set is caught rather than carried into steps 4–6.

## Type of Change

- [x] 🔧 Configuration / CI

## Breaking Changes

- [ ] No. Same crates packaged, same assertions, same failure semantics — one invocation instead of N.

## Related Issues

- Jira ticket: AAASM-5432
- Unblocks: #1896 (AAASM-5349), which cannot pass CI until this merges

## Testing

Run against the branch that fails today (`v0.0.1/AAASM-5349/refactor/extract_aa_policy`), in both directions — a gate change that only makes things pass would be worse than the bug it fixes:

**Passes where it wrongly failed.** All 17 publishable crates package, including `aa-gateway` and `aa-cli`, and every step-4 content assertion holds (`aa-cli` dashboard bundle, `aa-proto` `_embedded`, `aa-ebpf` probes, `aa-gateway` `.sqlx` + migrations).

**Still fails on a real packaging defect.** With `aa-sandbox` (publishable) made to depend on `aa-sdk-client` (`publish = false`, so never in the packaged set nor on crates.io — the same shape as the `aa-policy` case), the gate fails at step 3 and prints:

```
::error::cargo package failed:
      error: failed to prepare local package for uploading

      Caused by:
        no matching package named `aa-sdk-client` found
        location searched: crates.io index
        required by package `aa-sandbox v0.0.1-rc.6`
::error::no tarball produced for aa-auth (aa-auth-0.0.1-rc.6.crate)
```

An earlier mutation attempt (a dependency on a wholly nonexistent crate) was **rejected as a test**: it breaks the workspace itself, so the gate died in step 1 and never exercised the changed code. The mutation above breaks *packaging only*, which is the property under test.

`bash -n` and `shellcheck -S error` both clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (the why is recorded in the script, where the next reader will be)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
