### PR TITLE
[AAASM-5384] ✅ (aa-api): Pin RuntimeVerdict against aa-core's RuntimeVerdictLabel

### DIFF
--- a/aa-api/src/models/verdict.rs
+++ b/aa-api/src/models/verdict.rs
@@ -50,6 +50,120 @@ pub enum RuntimeVerdict {
     Deny,
 }
 
+/// Ties [`RuntimeVerdict`] to `aa-core`'s mirror of it (AAASM-5384).
+///
+/// ADR 0032 D-2 freezes ADR 0018's five-way verdict, and that freeze is asserted
+/// in two files that nothing else connects: the enum above, and
+/// `aa_core::types::sensitive_data::RuntimeVerdictLabel::ALL`, a hand-maintained
+/// list of the same five wire labels. `aa-core` cannot import the enum — the
+/// dependency runs the other way, deliberately, so `RuntimeVerdict` can carry a
+/// `utoipa::ToSchema` derive (ADR 0018) — so the sensitive-data event stream
+/// carries the *label*, and the label is a mirror. `aa-api` is the only crate
+/// that can see both types, which is why the contract test lives here.
+#[cfg(test)]
+mod aa_core_label_contract {
+    use super::*;
+    use aa_core::types::sensitive_data::RuntimeVerdictLabel;
+
+    /// Every [`RuntimeVerdict`], in ADR 0018's order.
+    ///
+    /// Spelled out because Rust has no variant reflection. [`variant_index`] is
+    /// what keeps this list from silently going stale.
+    const VERDICTS_IN_ADR_0018_ORDER: [RuntimeVerdict; 5] = [
+        RuntimeVerdict::Allow,
+        RuntimeVerdict::Narrow,
+        RuntimeVerdict::Scrub,
+        RuntimeVerdict::Pending,
+        RuntimeVerdict::Deny,
+    ];
+
+    /// The position ADR 0018 assigns each variant.
+    ///
+    /// This exists for its `match`, not its return value. The arms are
+    /// exhaustive with no `_` fallback, so **adding** a `RuntimeVerdict` variant
+    /// stops `aa-api` compiling, and **removing** one leaves both this match and
+    /// [`VERDICTS_IN_ADR_0018_ORDER`] naming a variant that no longer exists.
+    ///
+    /// Without it the test below would be vacuous against a sixth variant: a
+    /// hand-written five-element array simply would not mention it, both lists
+    /// would still be five long, and every assertion would still pass.
+    fn variant_index(verdict: RuntimeVerdict) -> usize {
+        match verdict {
+            RuntimeVerdict::Allow => 0,
+            RuntimeVerdict::Narrow => 1,
+            RuntimeVerdict::Scrub => 2,
+            RuntimeVerdict::Pending => 3,
+            RuntimeVerdict::Deny => 4,
+        }
+    }
+
+    /// [`RuntimeVerdict`] serializes to exactly `RuntimeVerdictLabel::ALL` —
+    /// same length, same spellings, same order.
+    ///
+    /// # Why order matters
+    ///
+    /// The comparison is positional rather than set-based, because a set
+    /// comparison would still pass with `ALL` permuted and `ALL`'s order is
+    /// load-bearing in `aa-core`: it is documented as "the order [ADR 0018]
+    /// defines them", it is the order `from_wire` searches, and
+    /// `RuntimeVerdictLabel`'s hand-written `schemars` schema repeats the same
+    /// five strings in the same order. Anyone reconciling those by eye is
+    /// checking order, so this test checks order too.
+    ///
+    /// # Why the label is not serialized
+    ///
+    /// Expectations come from `RuntimeVerdictLabel::as_str`, not from
+    /// `serde_json::to_string` of the label. `aa-core`'s `Serialize` impl sits
+    /// behind that crate's `serde` feature, which `aa-api` does not enable; a
+    /// test written against it would need a `#[cfg(feature = ...)]` and would
+    /// then not run under a plain `cargo nextest run --workspace`, which passes
+    /// no `--all-features`. `ALL` and `as_str` carry no feature gate, so this
+    /// runs in the default profile.
+    #[test]
+    fn runtime_verdict_serializes_to_exactly_aa_cores_label_vocabulary() {
+        // Checked before zipping, because `zip` silently truncates to the
+        // shorter of the two and would turn a dropped label into a pass.
+        assert_eq!(
+            VERDICTS_IN_ADR_0018_ORDER.len(),
+            RuntimeVerdictLabel::ALL.len(),
+            "aa-api defines {} runtime verdicts but aa-core mirrors {} labels",
+            VERDICTS_IN_ADR_0018_ORDER.len(),
+            RuntimeVerdictLabel::ALL.len(),
+        );
+
+        for (position, (verdict, label)) in VERDICTS_IN_ADR_0018_ORDER
+            .iter()
+            .zip(RuntimeVerdictLabel::ALL)
+            .enumerate()
+        {
+            assert_eq!(
+                variant_index(*verdict),
+                position,
+                "VERDICTS_IN_ADR_0018_ORDER is itself out of ADR 0018 order at index {position}",
+            );
+
+            let json = serde_json::to_string(verdict).unwrap();
+            let wire: String = serde_json::from_str(&json).expect("a RuntimeVerdict serializes as a JSON string");
+
+            assert_eq!(
+                wire,
+                label.as_str(),
+                "aa-api serializes {verdict:?} as {wire:?} but aa-core's \
+                 RuntimeVerdictLabel::ALL[{position}] is {:?}",
+                label.as_str(),
+            );
+
+            // The failure this whole contract guards: a stored
+            // SensitiveDataDecisionEvent that aa-core can no longer read back.
+            assert_eq!(
+                RuntimeVerdictLabel::from_wire(&wire),
+                Some(*label),
+                "aa-core cannot resolve the label aa-api writes for {verdict:?}",
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-core/src/types/sensitive_data/verdict.rs
+++ b/aa-core/src/types/sensitive_data/verdict.rs
@@ -63,19 +63,21 @@ impl RuntimeVerdictLabel {
     /// Five, permanently. A sixth entry here would be a breaking wire change
     /// under ADR 0024 and a violation of ADR 0032 D-2.
     ///
-    /// # This list is a mirror, and nothing yet enforces the reflection
+    /// # This list is a mirror, and `aa-api` enforces the reflection
     ///
     /// `aa_api::models::verdict::RuntimeVerdict` is the authority; these are its
-    /// wire labels, maintained by hand. **No test currently ties the two**, so a
-    /// rename or reorder in `aa-api` would break every stored
-    /// [`SensitiveDataDecisionEvent`](super::SensitiveDataDecisionEvent) and go
-    /// unnoticed — not even a whole-workspace build would object, since this
-    /// type is referenced by no crate but its own.
+    /// wire labels, maintained by hand. The two are tied together by
+    /// `aa_api::models::verdict::aa_core_label_contract`, which asserts that
+    /// each variant serializes to exactly the entry of this list at the same
+    /// index (AAASM-5384). A rename, reorder, addition or removal on either
+    /// side now fails that test instead of silently breaking every stored
+    /// [`SensitiveDataDecisionEvent`](super::SensitiveDataDecisionEvent).
     ///
-    /// The contract test belongs in `aa-api`, the only crate that can see both
-    /// types, and is tracked as **AAASM-5384**. It is not here because
-    /// `aa-core` cannot import `aa-api` — that dependency runs the other way,
-    /// deliberately (ADR 0018).
+    /// The test lives in `aa-api` — the only crate that can see both types —
+    /// rather than here, because `aa-core` cannot import `aa-api`: that
+    /// dependency runs the other way, deliberately (ADR 0018). So editing this
+    /// list alone still builds and tests clean *within this crate*; it is
+    /// `cargo nextest run -p aa-api` that objects.
     pub const ALL: &'static [Self] = &[Self::ALLOW, Self::NARROW, Self::SCRUB, Self::PENDING, Self::DENY];
 
     /// Read a verdict back from its wire label.


### PR DESCRIPTION
## Description

ADR 0032 D-2 freezes ADR 0018's five-way runtime verdict. That freeze was asserted in two files that nothing connected:

- `aa-api/src/models/verdict.rs` — the `RuntimeVerdict` enum, five variants, `#[serde(rename_all = "lowercase")]`.
- `aa-core/src/types/sensitive_data/verdict.rs` — `RuntimeVerdictLabel::ALL`, five hand-maintained `&'static str` labels.

`aa-core` cannot import the enum — `aa-api` depends on `aa-core`, and ADR 0018 put `RuntimeVerdict` there deliberately so it could carry a `utoipa::ToSchema` derive. So the sensitive-data event stream carries the *label*, and the label is a mirror. A rename or reorder on either side would have broken every stored `SensitiveDataDecisionEvent` and failed no test; `RuntimeVerdictLabel` is referenced by no crate but its own, so not even a whole-workspace build objected.

`aa-api` is the only crate that can see both types, so the contract test lives there. Two commits:

1. **`✅ (aa-api)`** — `models::verdict::aa_core_label_contract`, asserting each `RuntimeVerdict` serializes to exactly the `RuntimeVerdictLabel::ALL` entry at the same index, plus that `RuntimeVerdictLabel::from_wire` can read back what `aa-api` writes.
2. **`📝 (aa-core)`** — the doc on `ALL` said *"No test currently ties the two"*. That is no longer true, so it is corrected. Doc comment only; no code, no vocabulary change.

Neither `RuntimeVerdict` nor `RuntimeVerdictLabel` is changed. They already agreed — `allow` / `narrow` / `scrub` / `pending` / `deny`, same spellings, same order — so nothing had to be reconciled.

### Three design points worth reviewing

**Order is pinned, not just the set.** A set comparison would still pass with `ALL` permuted, and `ALL`'s order is load-bearing in `aa-core`: it is documented as ADR 0018's order, it is the order `from_wire` searches, and `RuntimeVerdictLabel`'s hand-written `schemars` schema repeats the same five strings in the same order. Anyone reconciling those by eye is checking order.

**The test does not serialize the label.** Expectations come from `RuntimeVerdictLabel::as_str`, not `serde_json::to_string` of the label. `aa-core`'s `Serialize` impl is behind that crate's `serde` feature, which `aa-api` does not enable — a test written against it would need a `#[cfg(feature = ...)]` and would then not run under `cargo nextest run --workspace`, which passes no `--all-features`. `ALL` and `as_str` carry no feature gate. (`sensitive_data` is gated on `std`, which *is* an `aa-core` default and which `aa-api` takes.) Verified by observing the test actually execute in a default-profile run — see Testing.

**An exhaustive `match` is what stops the test being vacuous.** Rust has no variant reflection, so the variant list is spelled out; a hand-written five-element array would simply not mention a sixth variant, and every assertion would still pass. `variant_index` exists for its `match` — exhaustive, no `_` arm — so an added or removed variant is a compile error. This is demonstrated below, in both directions.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update _(the `aa-core` doc correction)_
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

_Primarily a test-only change (`✅`), which the list above has no checkbox for._

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Adds a test and corrects a doc comment. No type, variant, wire label or public signature changes.

## Related Issues

- Related Jira ticket: [AAASM-5384](https://lightning-dust-mite.atlassian.net/browse/AAASM-5384)
- Related GitHub issues: follows #1894 (AAASM-5355), the PR whose adversarial review filed this.

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed _(mutation testing, below)_
- [ ] No tests required (explain why)

### The test runs in the default profile

`cargo nextest run --workspace` passes no `--all-features`, so a feature-gated test would silently not run. Confirmed by name in a default-profile run:

```
PASS [0.021s] aa-api models::verdict::aa_core_label_contract::runtime_verdict_serializes_to_exactly_aa_cores_label_vocabulary
```

### Mutation proof

Each mutation was applied, run, and reverted. All four fail; the table records how, because two of them fail at compile time by design.

| # | Mutation | Side changed | Result |
|---|---|---|---|
| 1 | `#[serde(rename = "scrubbed")]` on `Scrub` | `aa-api` alone | **FAIL** — `aa-api serializes Scrub as "scrubbed" but aa-core's RuntimeVerdictLabel::ALL[2] is "scrub"` |
| 2 | `ALL` reordered (`SCRUB` before `NARROW`) | `aa-core` alone | **FAIL** — `aa-api serializes Narrow as "narrow" but aa-core's RuntimeVerdictLabel::ALL[1] is "scrub"` |
| 3 | Sixth variant `Quarantine` added | `aa-api` alone | **FAIL** — `error[E0004]: non-exhaustive patterns: RuntimeVerdict::Quarantine not covered` |
| 4 | `SCRUB` removed from `ALL` | `aa-core` alone | **FAIL** — `aa-api defines 5 runtime verdicts but aa-core mirrors 4 labels` |

Both directions are covered: 1 and 3 change `aa-api` alone, 2 and 4 change `aa-core` alone.

Mutation 1 is a wire-level rename that still compiles, which is the dangerous silent case. A variant *identifier* rename is caught by the same mechanism as 3 and 4 — `variant_index` and the array both stop naming a variant that exists.

Mutation 4 removes the label. Removing the enum variant instead is the mirror of mutation 3 and fails the same way, at compile time.

#### Vacuity check

The concern with a test like this is that it passes for the wrong reason. Re-running mutation 3 with `variant_index`'s guard weakened by a `_ => 5` arm — a sixth variant present, everything else identical:

```
PASS [0.019s] (1/1) aa-api models::verdict::aa_core_label_contract::runtime_verdict_serializes_to_exactly_aa_cores_label_vocabulary
Summary [0.020s] 1 test run: 1 passed, 1158 skipped
```

It passes. Both lists are still five long and every string still matches, so nothing notices the sixth verdict. The exhaustive `match` is doing real work, not decoration.

### Suite

Scoped to the two crates in play:

```
$ cargo nextest run -p aa-api -p aa-core
Summary [179.210s] 1644 tests run: 1644 passed (2 leaky), 0 skipped
NEXTEST_EXIT=0
```

`cargo clippy -p aa-api --all-targets -- -D warnings` exits 0. The 6 warnings it prints are pre-existing `default-features` manifest warnings in other crates. `cargo doc -p aa-core --no-deps` builds; its 2 broken-intra-doc-link warnings (`DenyAllEvaluator`, `PermitAllEvaluator`) are pre-existing and untouched by this branch. `fmt`, `clippy` and `doc` hooks ran on every commit and push.

No raw sensitive values anywhere — the test's only data is the five frozen verdict labels.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing _(org Actions is intermittently billing-blocked; validated locally as above)_
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`) — DCO sign-off is optional/advisory here, not enforced


[AAASM-5384]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ