### PR TITLE
[AAASM-5434] 📝 (docs): Clarify verification-ticket convention for QA Epics

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -103,7 +103,15 @@ cargo doc --workspace --no-deps        # checked on push by hooks
   (`ai-agent-assembly/agent-assembly`) — it is the native `components` field, not
   `customfield_10041` (which is null; per the `.github` registry `jira` section /
   ADR 0014); Team (`customfield_10001`) = Pioneer.
-  Epic → Story → Subtask (one Subtask ≈ one commit) + a `Verify …` subtask per Story.
+  For **feature work**: Epic → Story → Subtask (one Subtask ≈ one commit) + a `Verify …` subtask per Story.
+  For a **dedicated QA / verification Epic** (e.g. AAASM-4522 *user-smoke*, AAASM-5020
+  *design-QA*): **one verification item = one Story directly under the Epic**
+  (the `[Journey NN]` style) — no middle "checklist" Task, no Subtasks. Each such
+  Story is verified by **operating the live product as a real user** (real running
+  server, live API, real browser through the real login flow); CI / unit tests /
+  mocked e2e (`page.route`, injected tokens) **never** substitute for real-user
+  verification, even when they already cover the case. File a Bug only after
+  reproducing through the genuine end-to-end path.
 - **Self-hosted deployment is out of scope** product-wide — don't propose
   Helm/Terraform/air-gapped/migration work even if the spec mentions it.
 - **The Protocol Specification stays in this monorepo** — do not move spec work to a


### PR DESCRIPTION
## What
Clarifies the JIRA ticket-hierarchy line in `.claude/CLAUDE.md` (project policy).

## Why
The line `Epic → Story → Subtask (one Subtask ≈ one commit) + a Verify subtask per Story` describes **feature work** but was silent on **dedicated QA/verification Epics**. During the 2026-08-02 verification round this ambiguity caused two real mistakes:
1. Verification items were opened as **Subtasks under a middle checklist Task** instead of as **Stories directly under the QA Epic** (the established `[Journey NN]` style under AAASM-4522) — later rebuilt correctly.
2. The line said nothing about **how** to verify, which let CI / unit tests / mocked e2e be treated as substitutes for real-user verification — and a mocked-auth shortcut produced a **false bug (AAASM-5433, retracted)**.

## Change (docs-only, 1 file, +9/-1)
Split the guidance:
- **Feature work** — unchanged: `Epic → Story → Subtask` + a Verify subtask per Story.
- **Dedicated QA / verification Epic** (AAASM-4522 user-smoke, AAASM-5020 design-QA) — **one verification item = one Story directly under the Epic** (no middle checklist Task, no Subtasks), verified by **operating the live product as a real user**; CI / unit / mocked e2e never substitute; file a Bug only after a genuine end-to-end repro.

## How to verify
Read the diff — it's a single clarifying edit to the project-policy bullet in `.claude/CLAUDE.md`. No code paths touched.

Refs AAASM-5434. Context: AAASM-5433 (retracted false bug), AAASM-4522 / AAASM-5020 (the QA Epics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)