### PR TITLE
[AAASM-5349] ♻️ (aa-policy): Move the launch resolver in beside the semantics it uses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "aa-core",
  "aa-devtool",
  "aa-gateway",
+ "aa-policy",
  "aa-proto",
  "aa-proxy",
  "aa-runtime",
@@ -451,6 +452,7 @@ version = "0.0.1-rc.6"
 dependencies = [
  "aa-core",
  "aa-security",
+ "anyhow",
  "async-trait",
  "chrono",
  "chrono-tz",
@@ -523,6 +525,7 @@ dependencies = [
  "aa-devtool-claude-code",
  "aa-ebpf",
  "aa-ebpf-common",
+ "aa-policy",
  "aa-proto",
  "aa-security",
  "aa-storage-sqlite-buffer",

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -46,6 +46,7 @@ aa-security          = { path = "../aa-security", version = "0.0.1-rc.6", featur
 aa-devtool           = { path = "../aa-devtool", version = "0.0.1-rc.6" }
 # strip-for-publish:end devtool
 aa-gateway           = { path = "../aa-gateway", version = "0.0.1-rc.6" }
+aa-policy            = { path = "../aa-policy", version = "0.0.1-rc.6" }
 # AAASM-5280: `aasm integrations` is a Developer Integration API client. The
 # reference client, the socket convention and the local enrolment file all live
 # in aa-runtime, and reimplementing any of them here would be the second

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -30,7 +30,6 @@ pub mod policy;
 pub mod proxy;
 // strip-for-publish:begin devtool
 pub mod run;
-pub mod run_policy;
 pub mod run_registration;
 // strip-for-publish:end devtool
 pub mod sandbox;

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -12,11 +12,13 @@ use tokio::signal::unix::SignalKind;
 
 use aa_core::{DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel};
 
-use crate::commands::run_policy;
+// AAASM-5349: resolution is shared with the devint service, so it lives in
+// `aa-policy` rather than here. Aliased so the call sites read unchanged.
 use crate::commands::run_registration::{self, GovernedRegistration};
 use crate::commands::status::models::redact_database_url;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
+use aa_policy::resolve as run_policy;
 
 /// Arguments for the `aasm run <tool> [args...]` subcommand.
 #[derive(Debug, Args)]

--- a/aa-cli/tests/run_policy_fail_closed.rs
+++ b/aa-cli/tests/run_policy_fail_closed.rs
@@ -197,7 +197,7 @@ async fn the_refusal_names_the_remedy() {
 async fn an_explicit_allow_all_artifact_launches() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("allow-all.yaml");
-    std::fs::write(&path, aa_cli::commands::run_policy::ALLOW_ALL_TEMPLATE).unwrap();
+    std::fs::write(&path, aa_policy::resolve::ALLOW_ALL_TEMPLATE).unwrap();
 
     let (result, launched, rules_seen) = run_with(path).await;
 

--- a/aa-policy/Cargo.toml
+++ b/aa-policy/Cargo.toml
@@ -13,6 +13,10 @@ serde        = { workspace = true }
 serde_json   = { workspace = true }
 serde_yaml   = { workspace = true }
 rust_decimal = { workspace = true, features = ["serde-str"] }
+# The resolver's refusal text is composed for an operator to read and is
+# returned as one error; a typed enum per refusal would be the better library
+# shape and is a follow-up, not part of relocating the code unchanged.
+anyhow       = { workspace = true }
 thiserror    = { workspace = true }
 async-trait  = { workspace = true }
 sha2         = { workspace = true }

--- a/aa-policy/src/lib.rs
+++ b/aa-policy/src/lib.rs
@@ -39,7 +39,11 @@ pub mod history;
 pub mod network;
 pub mod raw;
 pub mod rbac;
+pub mod resolve;
 pub mod scope;
+
+#[cfg(test)]
+mod test_support;
 pub mod validator;
 
 pub use context::{ContextError, PolicyContext};

--- a/aa-policy/src/resolve.rs
+++ b/aa-policy/src/resolve.rs
@@ -36,7 +36,7 @@ use aa_core::{PolicyDecision, PolicyDocument, PolicyRule};
 /// other dimension. There is no dedicated `permissive: true` switch, because a
 /// switch is easy to set without reading what it turns off — writing the
 /// wildcard out is the smallest thing that is unambiguously deliberate, and it
-/// validates through the same [`aa_gateway::policy::PolicyValidator`] as every
+/// validates through the same [`crate::PolicyValidator`] as every
 /// other policy rather than through a bypass.
 pub const ALLOW_ALL_TEMPLATE: &str = r#"apiVersion: agent-assembly/v1
 kind: Policy
@@ -342,7 +342,7 @@ pub fn load(source: &Path) -> PolicyResolution {
 ///
 /// Split out from [`load`] so classification is testable without a filesystem.
 pub fn classify(source: &Path, yaml: &str) -> PolicyResolution {
-    let validated = match aa_gateway::policy::PolicyValidator::from_yaml(yaml) {
+    let validated = match crate::PolicyValidator::from_yaml(yaml) {
         Ok(output) => output.document,
         Err(errors) => {
             return PolicyResolution::LoadFailed {
@@ -377,7 +377,7 @@ pub fn classify(source: &Path, yaml: &str) -> PolicyResolution {
 /// enforced — and labelling it permissive would understate the governance in
 /// place. The check is therefore conservative in the safe direction: it says
 /// "permissive" only when there is genuinely nothing left to enforce.
-fn is_explicit_allow_all(doc: &aa_gateway::policy::PolicyDocument) -> bool {
+fn is_explicit_allow_all(doc: &crate::PolicyDocument) -> bool {
     let tools_are_wildcard_allow = doc.tools.len() == 1
         && doc
             .tools
@@ -400,7 +400,7 @@ fn is_explicit_allow_all(doc: &aa_gateway::policy::PolicyDocument) -> bool {
 /// cap or an egress allowlist — those are enforced by the gateway and the proxy.
 /// Rules are sorted so the rendered settings are byte-stable across runs; the
 /// source is a `HashMap` and would otherwise reorder on every launch.
-fn project_rules(doc: &aa_gateway::policy::PolicyDocument) -> PolicyDocument {
+fn project_rules(doc: &crate::PolicyDocument) -> PolicyDocument {
     let mut rules: Vec<PolicyRule> = doc
         .tools
         .iter()

--- a/aa-policy/src/test_support.rs
+++ b/aa-policy/src/test_support.rs
@@ -1,0 +1,25 @@
+//! Shared synchronization for this crate's unit tests.
+//!
+//! The process environment is one global table, so two tests that
+//! `set_var`/`remove_var` concurrently race. `cargo nextest` hides this by
+//! giving each test its own process, but plain `cargo test` — which the
+//! SonarCloud coverage job runs — executes a crate's tests in one process under
+//! libtest's multi-threaded harness, where the race is real.
+//!
+//! A lock is per test binary, so this is deliberately `aa-policy`'s own rather
+//! than something shared with `aa-cli`: that crate's tests run in a different
+//! process and cannot contend with these.
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Serializes every test in this crate that mutates a process environment
+/// variable.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the shared environment lock for the duration of the returned guard.
+///
+/// Recovers from a poisoned mutex so one panicking test does not cascade into
+/// every later test that needs the environment.
+pub(crate) fn env_guard() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -20,6 +20,7 @@ integration-test = []
 
 [dependencies]
 aa-core                     = { path = "../aa-core", version = "0.0.1-rc.6", features = ["serde"] }
+aa-policy                   = { path = "../aa-policy", version = "0.0.1-rc.6" }
 # strip-for-publish:begin devtool
 # AAASM-5280: the DI-API lifecycle service registers the built-in dev-tool
 # adapters (ADR 0030 §6.1 — explicit construction into an in-memory registry at


### PR DESCRIPTION
## Description

Second of the **AAASM-5349** PRs. #1896 moved the policy *semantics* into the `aa-policy` leaf crate; this moves the **launch resolver** in beside them, so one implementation can serve every surface that has to answer "which of the four policy states did this launch resolve?".

It changes no behaviour.

## Why it has to move

`run_policy` lived in `aa-cli`. AAASM-5349 needs the same answer from the developer-integration service in `aa-runtime`, because ADR 0030 **forbidden design 10** makes `status` and `verify` render what the *service* computed rather than deriving a state client-side — `aa-cli/src/commands/integrations/status.rs` states the rule outright.

A resolver reachable only from the CLI cannot serve that. A second copy inside the service would be a second definition of what "governed" means, which is the defect this ticket exists to remove rather than one to introduce.

So it moves to `aa-policy`, beside the validator it already calls, where `aa-cli`, `aa-runtime` and `aa-gateway` can all reach one implementation. `aa-cli` imports it as `run_policy`, so its call sites read unchanged.

## Type of Change

- [x] ♻️ Refactor (no functional change)

## Breaking Changes

- [ ] No. Same four states, same refusal text, same search order, same tests. `aa_cli::commands::run_policy` is gone as a path; it was crate-internal apart from one integration test, updated here.

## Related Issues

- Jira ticket: AAASM-5349 (PR 2 of 4)
- Follows: #1896 (`ffeb2955` gate fix, `2d5dff58` extraction)
- Precedes: DI-API v3 carrying policy posture on `StatusView`/`VerificationView`; then the audit variant

## Testing

**Test-count parity, the check a move has to pass:** `main` has **16** `#[test]` in `aa-cli/src/commands/run_policy.rs`; this branch has **16** in `aa-policy/src/resolve.rs`. A move that silently dropped a `mod tests` would still compile and still pass everything remaining.

- **`aa-policy` alone: 315/315** — 299 from #1896 plus the 16 relocated
- **`aa-cli`: 946/946**
- `cargo clippy -p aa-policy -p aa-cli --all-targets -- -D warnings` passes

### Two things that only surfaced building the crate by itself

Both would have passed unnoticed in a workspace-wide run, which is exactly the trap that produced the `tokio/time` defect on #1896:

1. **`resolve.rs`'s tests called `crate::test_support::env_guard()`** — a lock that lives in `aa-cli`. `aa-policy` now has its own. A lock is per test binary, so the two crates' tests can never contend and sharing one would be meaningless.
2. **`aa-cli/tests/run_policy_fail_closed.rs` read `ALLOW_ALL_TEMPLATE` from the old path.** It now reads it from `aa_policy::resolve`, which is where the authority moved to — the test pointing at the shared crate is the point of the change, not an incidental fix.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module docs state why the resolver sits where it does)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## One thing deliberately not done

`into_enforceable()` returns `anyhow::Result`, so `aa-policy` gains an `anyhow` dependency. A typed error per refusal is the better shape for a library crate whose consumers now include a service, but changing it would alter the API and every caller — that belongs in its own change, not in relocating code unchanged.
