### PR TITLE
[AAASM-5349] ✨ (aa-cli): Record a governed launch in the audit trail, and state what is missing

### DIFF
--- a/.ci/strip-for-publish.sh
+++ b/.ci/strip-for-publish.sh
@@ -89,6 +89,11 @@ DELETED_FILES=(
     # (publish = false), stripped from aa-cli/Cargo.toml by the `sdkclient`
     # region, so the module that imports it has to go with the dep.
     "${REPO_ROOT}/aa-cli/src/commands/run_registration.rs"
+    # AAASM-5349: the audit record a governed launch emits. Consumes `tonic`
+    # (stripped by the `sdkclient` region) and only ever runs on the `aasm run`
+    # path, so it goes with the two files above rather than being left behind
+    # importing a dependency the published manifest no longer declares.
+    "${REPO_ROOT}/aa-cli/src/commands/run_audit.rs"
     "${REPO_ROOT}/aa-cli/src/commands/tools.rs"
     "${REPO_ROOT}/aa-cli/tests/run_command.rs"
     "${REPO_ROOT}/aa-integration-tests/tests/cli_run.rs"

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -68,6 +68,12 @@ aa-proxy             = { path = "../aa-proxy", version = "0.0.1-rc.6" }
 # `.ci/strip-for-publish.sh` along with `run.rs` and `run_registration.rs`, its
 # only consumers.
 aa-sdk-client        = { path = "../aa-sdk-client", version = "0.0.1-rc.6" }
+# AAASM-5349: `aasm run` reports its governed launch to the gateway's
+# `AuditService` over the same gRPC transport, authenticated with the credential
+# token registration returned. In this region because `run_audit.rs` is stripped
+# with the rest of the `aasm run` surface — a dependency left behind with no
+# consumer would enlarge the published crate for nothing.
+tonic                = { workspace = true }
 # strip-for-publish:end sdkclient
 aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-rc.6" }
 aa-storage           = { path = "../aa-storage", version = "0.0.1-rc.6" }

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub mod policy;
 pub mod proxy;
 // strip-for-publish:begin devtool
 pub mod run;
+pub mod run_audit;
 pub mod run_registration;
 // strip-for-publish:end devtool
 pub mod sandbox;

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -678,6 +678,21 @@ pub async fn execute_with_adapters(args: &RunArgs, adapters: &HashMap<&str, Box<
     // no identity is an ungoverned process wearing a governed launch's name.
     let registration = register_with_gateway(&info, args).await?;
     let handle = RegistrationHandle::of(&registration);
+
+    // Recorded now, not at exit: an audit trail that only learns about a session
+    // when it ends loses every session still running and every one that does not
+    // end cleanly. Reachable only for a policy that permitted the launch — the
+    // two refusing states are refused above, before any registration exists, so
+    // they cannot reach the trail at all (see `run_audit`'s module docs).
+    run_registration::report_launch(
+        &registration,
+        &handle.trace_id,
+        &handle.session_id,
+        &args.tool,
+        &args.tool_args,
+        &resolution.posture(),
+    )
+    .await;
     let mut child_env = build_child_env(&handle, proxy.as_deref(), args.no_proxy, mode);
     resolution.annotate_env(&mut child_env);
 

--- a/aa-cli/src/commands/run_audit.rs
+++ b/aa-cli/src/commands/run_audit.rs
@@ -1,0 +1,244 @@
+//! The audit record a governed launch leaves behind.
+//!
+//! # What is recorded, and what provably is not (AAASM-5349)
+//!
+//! A launch that reaches this module has **registered**, which means it
+//! resolved a policy that permits launching — `enforced` or `permissive`. Those
+//! two states are recorded here.
+//!
+//! The other two are not, and cannot currently be:
+//! [`PolicyState::Unconfigured`] and [`PolicyState::LoadFailed`] both **refuse**
+//! the launch, and `aasm run` refuses *before* it registers — deliberately, so
+//! that a refused session never becomes "a governed identity with no process
+//! behind it". The gateway's `AuditService` is mounted behind the fail-closed
+//! auth interceptor, which resolves a caller strictly by looking up a
+//! registered agent's credential token
+//! (`aa_gateway::iam::grpc_auth::resolve_caller`). A refusal therefore has no
+//! principal to authenticate as, and no authenticated path to the trail.
+//!
+//! **So the audit surface is partial, and says so rather than implying
+//! otherwise.** Recording only the permitting states while describing the
+//! surface as "distinguishes the four states" would be the over-claim this
+//! whole ticket exists to remove. AAASM-5435 owns designing a secure
+//! pre-registration refusal audit; until it lands, refusals are visible on the
+//! operator's terminal and in the `--dry-run` receipt, and nowhere server-side.
+//!
+//! Three things were deliberately **not** done to close the gap, because each
+//! trades a real guarantee for coverage:
+//!
+//! * registering a session purely to emit an audit record and then
+//!   deregistering — it manufactures the exact identity-without-a-process the
+//!   ordering exists to prevent;
+//! * a local file or socket side channel — a second, unauthenticated write path
+//!   to the governance record;
+//! * relaxing the audit API to accept a pre-registration principal — an
+//!   authentication weakening on a governance surface, which needs the threat
+//!   analysis AAASM-5435 carries, not an expedient patch.
+
+use std::collections::HashMap;
+
+use aa_core::integration::policy_posture::{PolicyPosture, PolicyState};
+use aa_proto::assembly::audit::v1::audit_service_client::AuditServiceClient;
+use aa_proto::assembly::audit::v1::{audit_event, AuditEvent, ProcessExecDetail, ReportEventsRequest};
+use aa_proto::assembly::common::v1::{ActionType, Decision};
+use tonic::Request;
+
+/// Label carrying the resolved policy state, using the same token
+/// `AA_POLICY_STATE`, the `policy=` banner and `aasm integrations status` use.
+pub const LABEL_POLICY_STATE: &str = "aasm.policy_state";
+/// Label carrying the artifact the state came from, when there is one.
+pub const LABEL_POLICY_SOURCE: &str = "aasm.policy_source";
+/// Label marking this exec as a governed launch rather than an arbitrary
+/// subprocess, so a query can separate the two.
+pub const LABEL_LAUNCH: &str = "aasm.launch";
+
+/// Build the labels describing the policy a launch ran under.
+///
+/// A posture that is not `Resolved` contributes no state label at all rather
+/// than an "unknown" one: this code path only runs after a successful
+/// registration, so an unresolved posture here is a defect, and inventing a
+/// token for it would hide that behind a plausible value.
+pub fn policy_labels(posture: &PolicyPosture) -> HashMap<String, String> {
+    let mut labels = HashMap::new();
+    labels.insert(LABEL_LAUNCH.to_string(), "governed".to_string());
+    if let PolicyPosture::Resolved { state, source, .. } = posture {
+        labels.insert(LABEL_POLICY_STATE.to_string(), state.token().to_string());
+        if let Some(source) = source {
+            labels.insert(LABEL_POLICY_SOURCE.to_string(), source.clone());
+        }
+    }
+    labels
+}
+
+/// Whether a posture is one this module is able to record.
+///
+/// Exactly the two permitting states. Used to keep the module's own claim
+/// honest: anything else reaching here means the ordering invariant changed and
+/// the documentation above has gone stale.
+pub fn is_recordable(posture: &PolicyPosture) -> bool {
+    matches!(
+        posture,
+        PolicyPosture::Resolved {
+            state: PolicyState::Enforced | PolicyState::Permissive,
+            ..
+        }
+    )
+}
+
+/// Everything one governed-launch audit record needs.
+///
+/// Grouped rather than passed as ten arguments: the set is cohesive — it is one
+/// record — and a long positional list is where a `trace_id` quietly swaps with
+/// a `session_id`.
+pub struct GovernedLaunchRecord<'a> {
+    /// The gateway endpoint the audit service is reached on.
+    pub endpoint: &'a str,
+    /// The credential token registration returned. The only principal this
+    /// module can authenticate as, and the reason refusals cannot be recorded.
+    pub credential_token: &'a str,
+    /// The identity the gateway attributes the record to.
+    pub agent_id: aa_proto::assembly::common::v1::AgentId,
+    /// Unique id for this record.
+    pub event_id: String,
+    /// Correlates this launch's records with each other.
+    pub trace_id: String,
+    /// Identifies this single `aasm run` invocation.
+    pub session_id: String,
+    /// The tool being launched.
+    pub command: &'a str,
+    /// Its arguments.
+    pub args: &'a [String],
+    /// The policy the launch resolved, from the one shared mapping.
+    pub posture: &'a PolicyPosture,
+    /// When the launch happened.
+    pub occurred_at_unix_secs: u64,
+}
+
+/// Report a governed launch to the gateway's audit trail.
+///
+/// Best-effort by design: a launch that governed correctly must not be aborted
+/// because the audit upload failed. The failure is surfaced by the caller rather
+/// than swallowed — an audit record that silently did not happen is worse than
+/// one that visibly did not.
+pub async fn report_governed_launch(record: GovernedLaunchRecord<'_>) -> Result<(), String> {
+    let GovernedLaunchRecord {
+        endpoint,
+        credential_token,
+        agent_id,
+        event_id,
+        trace_id,
+        session_id,
+        command,
+        args,
+        posture,
+        occurred_at_unix_secs,
+    } = record;
+    let event = AuditEvent {
+        event_id,
+        agent_id: Some(agent_id),
+        occurred_at: Some(aa_proto::assembly::common::v1::Timestamp {
+            unix_ms: (occurred_at_unix_secs as i64).saturating_mul(1_000),
+        }),
+        action_type: ActionType::ProcessExec as i32,
+        // The launch proceeded: the policy permitted it. A refusal never
+        // reaches this call, which is the whole subject of this module's docs.
+        decision: Decision::Allow as i32,
+        trace_id,
+        session_id,
+        labels: policy_labels(posture),
+        detail: Some(audit_event::Detail::Process(ProcessExecDetail {
+            command: command.to_string(),
+            args: args.to_vec(),
+            // The record is written at launch, not at exit: an audit trail that
+            // only learns about a session when it ends loses every session that
+            // is still running, and every one that never ends cleanly.
+            exit_code: 0,
+            duration_ms: 0,
+            succeeded: true,
+        })),
+        ..Default::default()
+    };
+
+    let mut client = AuditServiceClient::connect(endpoint.to_string())
+        .await
+        .map_err(|e| format!("could not reach the gateway audit service: {e}"))?;
+
+    let mut request = Request::new(ReportEventsRequest { events: vec![event] });
+    let bearer = format!("Bearer {credential_token}")
+        .parse()
+        .map_err(|e| format!("the credential token is not a valid header value: {e}"))?;
+    request.metadata_mut().insert("authorization", bearer);
+
+    client
+        .report_events(request)
+        .await
+        .map_err(|e| format!("the gateway rejected the audit record: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolved(state: PolicyState, source: Option<&str>) -> PolicyPosture {
+        PolicyPosture::Resolved {
+            state,
+            source: source.map(str::to_string),
+            detail: "d".to_string(),
+        }
+    }
+
+    /// The state label must be the shared token, so an audit query and
+    /// `AA_POLICY_STATE` select the same sessions without translation.
+    #[test]
+    fn the_state_label_is_the_shared_token() {
+        for state in [PolicyState::Enforced, PolicyState::Permissive] {
+            let labels = policy_labels(&resolved(state, Some("/p.yaml")));
+            assert_eq!(labels.get(LABEL_POLICY_STATE).map(String::as_str), Some(state.token()));
+        }
+    }
+
+    /// A governed launch is distinguishable from any other subprocess exec.
+    /// Without this the audit trail cannot separate the two, and PROCESS_EXEC
+    /// was chosen precisely because the launch genuinely is one.
+    #[test]
+    fn a_governed_launch_is_marked_as_one() {
+        let labels = policy_labels(&resolved(PolicyState::Enforced, None));
+        assert_eq!(labels.get(LABEL_LAUNCH).map(String::as_str), Some("governed"));
+    }
+
+    /// No source label rather than an empty one: an empty string would read as
+    /// an artifact whose path is blank instead of the absence of an artifact.
+    #[test]
+    fn an_absent_source_contributes_no_label() {
+        let labels = policy_labels(&resolved(PolicyState::Permissive, None));
+        assert!(!labels.contains_key(LABEL_POLICY_SOURCE));
+    }
+
+    /// The two refusing states are not recordable here, and this asserts the
+    /// documented limit rather than the implementation: if the ordering
+    /// invariant ever changes so a refusal can register, this test fails and
+    /// the module documentation must be revisited with it.
+    #[test]
+    fn only_the_two_permitting_states_are_recordable() {
+        assert!(is_recordable(&resolved(PolicyState::Enforced, None)));
+        assert!(is_recordable(&resolved(PolicyState::Permissive, None)));
+        assert!(!is_recordable(&resolved(PolicyState::Unconfigured, None)));
+        assert!(!is_recordable(&resolved(PolicyState::LoadFailed, None)));
+        assert!(!is_recordable(&PolicyPosture::Unknown {
+            reason: "r".to_string()
+        }));
+    }
+
+    /// An unresolved posture must not acquire a state label. This path runs
+    /// only after registration, so `Unknown` here is a defect — and a label
+    /// invented for it would hide the defect behind a plausible value.
+    #[test]
+    fn an_unknown_posture_contributes_no_state_label() {
+        let labels = policy_labels(&PolicyPosture::Unknown {
+            reason: "no resolution".to_string(),
+        });
+        assert!(!labels.contains_key(LABEL_POLICY_STATE));
+        assert_eq!(labels.get(LABEL_LAUNCH).map(String::as_str), Some("governed"));
+    }
+}

--- a/aa-cli/src/commands/run_registration.rs
+++ b/aa-cli/src/commands/run_registration.rs
@@ -383,6 +383,54 @@ pub async fn register(desc: SessionDescriptor<'_>) -> Result<GovernedRegistratio
 ///
 /// Best-effort by design: the session is already over, and a gateway that has
 /// gone away or has already swept the agent leaves nothing for the caller to do.
+/// Report this governed launch to the gateway's audit trail.
+///
+/// Lives here rather than in [`crate::commands::run_audit`] because the
+/// credential token is private to this module by design — the module docs
+/// explain why — and an accessor would widen it for one caller.
+///
+/// Best-effort: a launch that governed correctly is not aborted because the
+/// audit upload failed. The failure is printed rather than swallowed, because an
+/// audit record that silently did not happen is worse than one that visibly did
+/// not (AAASM-5349).
+///
+/// Only reachable for a launch that registered, which means the policy permitted
+/// it — `enforced` or `permissive`. The two refusing states never get here; see
+/// [`crate::commands::run_audit`] for why that gap exists and what owns closing
+/// it.
+pub async fn report_launch(
+    registration: &GovernedRegistration,
+    trace_id: &str,
+    session_id: &str,
+    command: &str,
+    args: &[String],
+    posture: &aa_core::integration::policy_posture::PolicyPosture,
+) {
+    let agent_id = ProtoAgentId {
+        org_id: String::new(),
+        team_id: registration.team_id.clone().unwrap_or_default(),
+        agent_id: registration.registration_did.clone(),
+    };
+    let record = crate::commands::run_audit::GovernedLaunchRecord {
+        endpoint: &registration.endpoint,
+        credential_token: &registration.credential_token,
+        agent_id,
+        event_id: uuid::Uuid::now_v7().to_string(),
+        trace_id: trace_id.to_string(),
+        session_id: session_id.to_string(),
+        command,
+        args,
+        posture,
+        occurred_at_unix_secs: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    };
+    if let Err(e) = crate::commands::run_audit::report_governed_launch(record).await {
+        eprintln!("warning: this launch was not recorded in the audit trail: {e}");
+    }
+}
+
 pub async fn deregister(registration: &GovernedRegistration, reason: &str) {
     let Ok(mut client) = GatewayRegistrationClient::connect(registration.endpoint.clone()).await else {
         return;

--- a/aa-policy/src/resolve.rs
+++ b/aa-policy/src/resolve.rs
@@ -27,6 +27,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
+use aa_core::integration::policy_posture::{PolicyPosture, PolicyState};
 use aa_core::{PolicyDecision, PolicyDocument, PolicyRule};
 
 /// A minimal policy artifact that permits everything.
@@ -129,6 +130,49 @@ pub enum Unconfigured {
         /// The artifact that turned out to be empty.
         source: PathBuf,
     },
+}
+
+impl PolicyResolution {
+    /// The reportable posture for this resolution.
+    ///
+    /// One mapping, used by every surface that reports policy state: the
+    /// developer-integration service for `status` and `verify`, and `aasm run`
+    /// for the audit record it emits after registration. A second mapping would
+    /// be a second definition of what each state means, which is the defect
+    /// AAASM-5349 exists to remove rather than one to introduce.
+    ///
+    /// Always `Resolved` — a resolution, by construction, resolved something.
+    /// [`PolicyPosture::Unknown`] is for callers that could not resolve at all,
+    /// which is a fact about the caller and not about any policy.
+    pub fn posture(&self) -> PolicyPosture {
+        match self {
+            Self::Enforced { source, document } => PolicyPosture::Resolved {
+                state: PolicyState::Enforced,
+                source: Some(source.display().to_string()),
+                detail: format!("{} rule(s)", document.rules.len()),
+            },
+            Self::Permissive { source, .. } => PolicyPosture::Resolved {
+                state: PolicyState::Permissive,
+                source: Some(source.display().to_string()),
+                detail: "explicit allow-all artifact; nothing is restricted".to_string(),
+            },
+            Self::Unconfigured(Unconfigured::NoSource { searched }) => PolicyPosture::Resolved {
+                state: PolicyState::Unconfigured,
+                source: None,
+                detail: format!("no policy artifact found; searched {}", searched.join(", ")),
+            },
+            Self::Unconfigured(Unconfigured::EmptyDocument { source }) => PolicyPosture::Resolved {
+                state: PolicyState::Unconfigured,
+                source: Some(source.display().to_string()),
+                detail: "parsed cleanly but declares no tool rule".to_string(),
+            },
+            Self::LoadFailed { source, detail } => PolicyPosture::Resolved {
+                state: PolicyState::LoadFailed,
+                source: Some(source.display().to_string()),
+                detail: detail.clone(),
+            },
+        }
+    }
 }
 
 impl PolicyResolution {

--- a/aa-runtime/src/devint/service.rs
+++ b/aa-runtime/src/devint/service.rs
@@ -52,7 +52,7 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use aa_core::dev_tool::{DevToolKind, GovernanceLevel};
-use aa_core::integration::policy_posture::{PolicyPosture, PolicyState};
+use aa_core::integration::policy_posture::PolicyPosture;
 use aa_core::integration::{
     now_unix_secs, ApplyContext, DevToolIntegration, DriftKind, DriftReport, EngineError, FilesystemExecutor,
     IntegrationCapability, IntegrationEngine, IntegrationPlan, IntegrationReceipt, IntegrationRequest,
@@ -409,35 +409,10 @@ fn engine_error(e: EngineError) -> LifecycleError {
 /// `Unconfigured`: the latter is a governance finding about the operator's
 /// setup, and an error reading the disk is not.
 pub(crate) fn resolve_host_policy() -> PolicyPosture {
-    use aa_policy::resolve::{PolicyResolution, Unconfigured};
-
-    match aa_policy::resolve::resolve(None) {
-        PolicyResolution::Enforced { source, document } => PolicyPosture::Resolved {
-            state: PolicyState::Enforced,
-            source: Some(source.display().to_string()),
-            detail: format!("{} rule(s)", document.rules.len()),
-        },
-        PolicyResolution::Permissive { source, .. } => PolicyPosture::Resolved {
-            state: PolicyState::Permissive,
-            source: Some(source.display().to_string()),
-            detail: "explicit allow-all artifact; nothing is restricted".to_string(),
-        },
-        PolicyResolution::Unconfigured(Unconfigured::NoSource { searched }) => PolicyPosture::Resolved {
-            state: PolicyState::Unconfigured,
-            source: None,
-            detail: format!("no policy artifact found; searched {}", searched.join(", ")),
-        },
-        PolicyResolution::Unconfigured(Unconfigured::EmptyDocument { source }) => PolicyPosture::Resolved {
-            state: PolicyState::Unconfigured,
-            source: Some(source.display().to_string()),
-            detail: "parsed cleanly but declares no tool rule".to_string(),
-        },
-        PolicyResolution::LoadFailed { source, detail } => PolicyPosture::Resolved {
-            state: PolicyState::LoadFailed,
-            source: Some(source.display().to_string()),
-            detail,
-        },
-    }
+    // The mapping lives in `aa-policy` beside the resolution it describes, so
+    // `status`, `verify` and the audit record `aasm run` emits cannot drift
+    // into three descriptions of the same four states (AAASM-5349).
+    aa_policy::resolve::resolve(None).posture()
 }
 
 #[async_trait]


### PR DESCRIPTION
## Description

Last of the **AAASM-5349** PRs: `aasm run` records its governed launch in the gateway audit trail. It implements the authenticated half **and states plainly what it cannot record**, rather than describing a two-state surface as a four-state one.

## What is recorded

A `PROCESS_EXEC` event — the launch genuinely is a subprocess exec — carrying the resolved policy on labels:

```
AuditEvent {
  action_type: PROCESS_EXEC
  decision:    ALLOW
  detail: ProcessExecDetail { command: "claude", args: [...] }
  labels: {
    "aasm.launch":        "governed"     ← separates this from any other exec
    "aasm.policy_state":  "enforced"     ← same token as AA_POLICY_STATE
    "aasm.policy_source": "/…/policy.yaml"
  }
}
```

**No proto change.** `PROCESS_EXEC` and the `labels` map already exist, so the SDK-facing audit contract does not move, nothing is version-bumped, and the three SDKs are untouched.

The tokens come from `PolicyResolution::posture()`, which this PR also makes the single shared mapping — receipt, `status`, `verify` and audit now read **one** definition of the four states instead of four descriptions of them. `resolve_host_policy` in the devint service becomes a one-liner over it.

## What is not recorded, and why

| Policy state | Launch | In the trail |
|---|---|---|
| `enforced` | proceeds | ✅ |
| `permissive` | proceeds | ✅ |
| `unconfigured` | **refused** | ❌ |
| `load_failed` | **refused** | ❌ |

Two deliberate decisions meet, and each is right on its own terms:

1. **`aasm run` refuses before it registers** — `run.rs` calls `into_enforceable()` before `register_with_gateway`, because *"a registered session that never launched is a governed identity with no process behind it"*.
2. **The audit service is fail-closed on a registered principal** — `AuditServiceServer` is mounted with the `auth` interceptor, and `resolve_caller` resolves callers **only** via `registry.find_by_credential_token`. An API key does not authenticate there.

So a refusal has no principal and no authenticated path to the trail. The two states that cannot be recorded are the two that **refuse** — the security-relevant ones.

Recording only the permitting states while calling the surface complete would be the exact over-claim this ticket exists to remove. Instead: the module documents it at the point of use, `is_recordable()` asserts the limit **as a test**, and **AAASM-5435** owns designing a secure pre-registration refusal audit. If the ordering invariant ever changes so a refusal can register, that test fails and the documentation is revisited with it rather than quietly going stale.

### Three shortcuts rejected, not overlooked

- **Register purely to emit a record, then deregister** — manufactures the identity-without-a-process that decision 1 exists to prevent, and pollutes the registry with sessions that never ran.
- **A local file or socket side channel** — a second, unauthenticated write path into the governance record. ADR 0030 separately forbids audit traffic on the DI-API socket.
- **Relax the audit API to accept a pre-registration principal** — an authentication weakening on a governance surface, which needs AAASM-5435's threat analysis, not an expedient patch.

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation (the partial-surface statement is part of the deliverable)

## Breaking Changes

- [ ] No. No proto change, no version bump, no SDK impact. The emission is best-effort: a launch that governed correctly is never aborted because the audit upload failed — the failure is printed, because a record that silently did not happen is worse than one that visibly did not.

## Related Issues

- Jira: AAASM-5349 (PR 4 of 4) — **does not close it**; AC 6 needs the revision proposed on the ticket
- Follow-up: **AAASM-5435** — secure pre-registration refusal audit
- Follows #1896, #1900, #1902

## Testing

`aa-policy` + `aa-cli` **1271/1271**. `clippy --all-targets -- -D warnings` clean. `aa-policy`, `aa-runtime` and `aa-cli` each compile **alone**.

Five tests on the new module, aimed at the claims rather than the mechanics:

| Test | Property |
|---|---|
| `the_state_label_is_the_shared_token` | an audit query and `AA_POLICY_STATE` select the same sessions without translation |
| `a_governed_launch_is_marked_as_one` | a governed launch is separable from any other `PROCESS_EXEC` |
| `an_absent_source_contributes_no_label` | absence of an artifact ≠ an artifact with a blank path |
| `only_the_two_permitting_states_are_recordable` | asserts the **documented limit**, so the docs cannot outlive the invariant |
| `an_unknown_posture_contributes_no_state_label` | an unresolved posture never acquires an invented token |

## Publish-strip correctness

`run_audit.rs` consumes `tonic`, which the publish strip removes, so it joins `run.rs` and `run_registration.rs` in the strip's `DELETED_FILES`, its module declaration sits in the existing `devtool` region, and its dependency sits inside the `sdkclient` region. A module left behind importing a dependency the published manifest no longer declares is the AAASM-5309 failure shape exactly.

Because this touches `aa-cli/src/commands/mod.rs` and `aa-cli/Cargo.toml`, the packaged-artifact gate **runs** on this PR rather than being path-filtered out.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated (module docs carry the limitation where it is used)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
