### PR TITLE
[AAASM-5385] 🔧 (ci): Verify the merge result, not only the PR head

### DIFF
--- a/.ci/bisect-run.sh
+++ b/.ci/bisect-run.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# bisect-run.sh — a `git bisect run` predicate that skips unbuildable history.
+#
+# AAASM-5385.
+#
+# THE PROBLEM
+# -----------
+# `git bisect run <script>` scores each commit by the script's exit status:
+# 0 = good, 1..124 = bad, 125 = skip, 128+ = abort. A commit that does not
+# COMPILE cannot honestly answer good or bad — the test never ran. A naive
+# "build && test" one-liner exits non-zero there, bisect scores it "bad", and
+# the search moves its bound past the real first-bad commit. The result is a
+# confident wrong answer, which is worse than no answer, because nothing in the
+# output distinguishes it from a correct one.
+#
+# 125 is the only sound answer for such a commit, and this script exists to
+# return it.
+#
+# USAGE
+# -----
+#     # Copy the script OUT of the repository first — see the warning below.
+#     cp .ci/bisect-run.sh /tmp/aa-bisect-run.sh
+#
+#     git bisect start <bad> <good>
+#     AA_BISECT_TEST='cargo test -p aa-gateway locale' \
+#         git bisect run /tmp/aa-bisect-run.sh
+#
+# With no AA_BISECT_TEST, the predicate is "does this commit build", which is
+# what you want when bisecting for the commit that broke the build itself.
+#
+# WHY THE SCRIPT MUST BE COPIED OUT OF THE WORKING TREE
+# -----------------------------------------------------
+# `git bisect` rewrites the working tree at every step. A script living at
+# `.ci/bisect-run.sh` is therefore REPLACED by whatever that path held at each
+# commit under test — and for every commit older than AAASM-5385 that is
+# nothing at all, at which point `git bisect run` aborts with "cannot run". The
+# same hazard applies to the skip list, which is why it is NOT read from the
+# working tree either (see below). Copying the script to a path outside the
+# repository is what makes it stable across the walk.
+#
+# WHY THE SKIP LIST IS READ FROM A REF, NOT FROM DISK
+# ---------------------------------------------------
+# `.ci/bisect-skip.txt` is read with `git show <ref>:.ci/bisect-skip.txt`, not
+# `cat`. Reading it from the checked-out tree would consult the version of the
+# list as it existed at the commit under test — which for the commits that most
+# need skipping is an absent or shorter list, so the entries that matter would
+# be invisible exactly when they are needed. Reading it from a ref yields the
+# current, complete list at every step.
+
+set -uo pipefail
+
+SKIP_LIST_PATH=".ci/bisect-skip.txt"
+
+BUILD_CMD=${AA_BISECT_BUILD:-"cargo check --workspace --all-targets --exclude aa-ebpf"}
+TEST_CMD=${AA_BISECT_TEST:-}
+
+EXIT_GOOD=0
+EXIT_BAD=1
+EXIT_SKIP=125
+EXIT_ABORT=128
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "bisect-run: not inside a git repository" >&2
+    exit $EXIT_ABORT
+fi
+
+# Resolve the ref the skip list is read from. `main` may not exist locally under
+# that name — this repository's push remote is `remote`, not `origin`, and a
+# fresh clone may have neither — so try the usual candidates and abort loudly
+# rather than silently proceeding with an empty list. An empty list would make
+# every unbuildable commit score "bad", which is the exact failure this script
+# exists to prevent, so it must never be reached by accident.
+resolve_list_ref() {
+    local candidate
+    if [[ -n "${AA_BISECT_LIST_REF:-}" ]]; then
+        if git rev-parse --verify --quiet "${AA_BISECT_LIST_REF}:${SKIP_LIST_PATH}" >/dev/null; then
+            printf '%s' "$AA_BISECT_LIST_REF"
+            return 0
+        fi
+        return 1
+    fi
+    for candidate in remote/main origin/main main HEAD; do
+        if git rev-parse --verify --quiet "${candidate}:${SKIP_LIST_PATH}" >/dev/null; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+if ! list_ref=$(resolve_list_ref); then
+    echo "bisect-run: cannot read ${SKIP_LIST_PATH} from any of" >&2
+    echo "  \${AA_BISECT_LIST_REF}, remote/main, origin/main, main, HEAD" >&2
+    echo "Refusing to run: without the skip list every unbuildable commit would" >&2
+    echo "be scored 'bad' and the bisect would return a wrong answer." >&2
+    echo "Fetch the default branch, or set AA_BISECT_LIST_REF to a ref that has it." >&2
+    exit $EXIT_ABORT
+fi
+
+commit=$(git rev-parse HEAD)
+short=${commit:0:9}
+
+# Match on full SHAs only. An abbreviated SHA in the list would risk a prefix
+# collision and silently skip an unrelated commit.
+skip_reason=""
+while IFS= read -r line; do
+    case "$line" in
+        '#'* | '') continue ;;
+    esac
+    entry_sha=${line%%[[:space:]]*}
+    if [[ ${#entry_sha} -ne 40 ]]; then
+        echo "bisect-run: malformed entry in ${SKIP_LIST_PATH} (not a 40-char SHA): ${entry_sha}" >&2
+        exit $EXIT_ABORT
+    fi
+    if [[ "$entry_sha" == "$commit" ]]; then
+        skip_reason=${line#"$entry_sha"}
+        break
+    fi
+done < <(git show "${list_ref}:${SKIP_LIST_PATH}")
+
+if [[ -n "$skip_reason" ]]; then
+    echo "bisect-run: SKIP ${short} — known-unbuildable (${SKIP_LIST_PATH}@${list_ref})"
+    echo "bisect-run: reason:${skip_reason}"
+    exit $EXIT_SKIP
+fi
+
+echo "bisect-run: building ${short} — ${BUILD_CMD}"
+if ! eval "$BUILD_CMD"; then
+    # An unbuildable commit that is NOT on the list is still not a "bad" answer:
+    # the test never ran, so the only honest verdict is skip. It is reported
+    # loudly because it means the list needs an entry (or, if the commit is
+    # recent, that `.ci/verify-range-builds.sh` was bypassed).
+    echo "bisect-run: SKIP ${short} — does not build and is NOT in ${SKIP_LIST_PATH}." >&2
+    echo "bisect-run: add it to the list (with a reason) so the next bisect is cheaper." >&2
+    exit $EXIT_SKIP
+fi
+
+if [[ -z "$TEST_CMD" ]]; then
+    echo "bisect-run: GOOD ${short} — builds (no AA_BISECT_TEST set)"
+    exit $EXIT_GOOD
+fi
+
+echo "bisect-run: testing ${short} — ${TEST_CMD}"
+if eval "$TEST_CMD"; then
+    echo "bisect-run: GOOD ${short}"
+    exit $EXIT_GOOD
+fi
+
+echo "bisect-run: BAD ${short}"
+exit $EXIT_BAD

--- a/.ci/bisect-run.sh
+++ b/.ci/bisect-run.sh
@@ -103,6 +103,14 @@ short=${commit:0:9}
 
 # Match on full SHAs only. An abbreviated SHA in the list would risk a prefix
 # collision and silently skip an unrelated commit.
+# `matched` is tracked separately from `skip_reason` on purpose. Keying the
+# decision off the reason text would make an entry that is a bare SHA with no
+# reason — which passes the 40-char check above — yield an empty reason and so
+# be silently ignored, building the commit instead of skipping it. That is a
+# missing-data bug reported as a clean "good", the failure mode this whole
+# script exists to avoid; the reason is for the human reading the output, and
+# must not be load-bearing for the verdict.
+matched=0
 skip_reason=""
 while IFS= read -r line; do
     case "$line" in
@@ -114,12 +122,14 @@ while IFS= read -r line; do
         exit $EXIT_ABORT
     fi
     if [[ "$entry_sha" == "$commit" ]]; then
+        matched=1
         skip_reason=${line#"$entry_sha"}
         break
     fi
 done < <(git show "${list_ref}:${SKIP_LIST_PATH}")
 
-if [[ -n "$skip_reason" ]]; then
+if [[ $matched -eq 1 ]]; then
+    [[ -n "$skip_reason" ]] || skip_reason=" (no reason recorded — please add one)"
     echo "bisect-run: SKIP ${short} — known-unbuildable (${SKIP_LIST_PATH}@${list_ref})"
     echo "bisect-run: reason:${skip_reason}"
     exit $EXIT_SKIP

--- a/.ci/bisect-run.sh
+++ b/.ci/bisect-run.sh
@@ -52,7 +52,12 @@ set -uo pipefail
 
 SKIP_LIST_PATH=".ci/bisect-skip.txt"
 
-BUILD_CMD=${AA_BISECT_BUILD:-"cargo check --workspace --all-targets --exclude aa-ebpf"}
+# Deliberately identical to `.ci/verify-range-builds.sh`'s command, so that
+# "does not build" means one thing across the gate, this predicate, and the
+# reasons recorded in `.ci/bisect-skip.txt`. If they diverged, a commit could be
+# unbuildable by the gate's definition and buildable by this one, and the skip
+# list would document a failure the harness could not reproduce.
+BUILD_CMD=${AA_BISECT_BUILD:-"cargo check --workspace --all-targets --all-features --exclude aa-ebpf"}
 TEST_CMD=${AA_BISECT_TEST:-}
 
 EXIT_GOOD=0

--- a/.ci/bisect-run.sh
+++ b/.ci/bisect-run.sh
@@ -80,7 +80,12 @@ resolve_list_ref() {
         fi
         return 1
     fi
-    for candidate in remote/main origin/main main HEAD; do
+    # NOT `HEAD`. During `git bisect run`, HEAD *is* the commit under test, so
+    # falling back to it would read the list as it existed at that commit —
+    # a different, older list at every step, which is exactly the hazard the
+    # `git show <ref>:` approach exists to avoid (see the header). Aborting
+    # loudly is the correct outcome when no stable ref can be found.
+    for candidate in remote/main origin/main main; do
         if git rev-parse --verify --quiet "${candidate}:${SKIP_LIST_PATH}" >/dev/null; then
             printf '%s' "$candidate"
             return 0
@@ -91,7 +96,7 @@ resolve_list_ref() {
 
 if ! list_ref=$(resolve_list_ref); then
     echo "bisect-run: cannot read ${SKIP_LIST_PATH} from any of" >&2
-    echo "  \${AA_BISECT_LIST_REF}, remote/main, origin/main, main, HEAD" >&2
+    echo "  \${AA_BISECT_LIST_REF}, remote/main, origin/main, main" >&2
     echo "Refusing to run: without the skip list every unbuildable commit would" >&2
     echo "be scored 'bad' and the bisect would return a wrong answer." >&2
     echo "Fetch the default branch, or set AA_BISECT_LIST_REF to a ref that has it." >&2

--- a/.ci/bisect-skip.txt
+++ b/.ci/bisect-skip.txt
@@ -14,8 +14,12 @@
 # Returning 125 is the only answer that preserves correctness: it tells bisect
 # to pick a neighbouring commit instead of drawing a conclusion.
 #
-# `.ci/verify-range-builds.sh` prevents new entries from being needed. This file
-# records the ones that predate that gate. It should stop growing.
+# `.ci/verify-range-builds.sh` is what stops new entries being needed, on every
+# PR that triggers CI. It is not airtight: `ci.yml`'s `on.pull_request.paths` is
+# evaluated against a PR's NET diff, so a PR whose net diff touches no listed
+# path never starts CI, and its intermediate commits go unchecked. This file
+# should therefore grow rarely — not never — and every entry that does appear
+# is worth asking how it got past the gate.
 #
 # FORMAT
 # ------

--- a/.ci/bisect-skip.txt
+++ b/.ci/bisect-skip.txt
@@ -1,0 +1,30 @@
+# Commits on `main` that are known not to build.
+#
+# AAASM-5385. Consumed by `.ci/bisect-run.sh`, which returns 125 ("skip") to
+# `git bisect run` for any commit listed here.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# `git bisect run` has three useful answers per commit: good (0), bad (1) and
+# skip (125). A commit that does not COMPILE can answer none of them honestly —
+# the test it was asked to run never executed. Left to a naive build-and-test
+# script, such a commit reports non-zero and is scored "bad", which moves the
+# bisect's lower bound past the real first-bad commit and returns a confident,
+# wrong answer. Scoring it "good" is equally wrong in the other direction.
+# Returning 125 is the only answer that preserves correctness: it tells bisect
+# to pick a neighbouring commit instead of drawing a conclusion.
+#
+# `.ci/verify-range-builds.sh` prevents new entries from being needed. This file
+# records the ones that predate that gate. It should stop growing.
+#
+# FORMAT
+# ------
+# One entry per line: a full 40-character SHA, whitespace, then a reason.
+# Blank lines and `#` comments are ignored. Full SHAs only — an abbreviated one
+# is ambiguous against a repository that keeps growing, and this list is
+# consulted long after the commit was written.
+#
+# Adding an entry is one line; the reason field is what makes the list
+# auditable, so state what fails to build and what repaired it.
+
+c596246a2100e706d20fcaf6e61d88f3cb77e840  Clean-but-semantic merge on the AAASM-5354 branch: rename detection carried a validator into aa-policy referencing crate::engine::detection::LocalePack, which exists only in aa-gateway. `cargo check --workspace --all-targets` exits 101 with E0433. Both parents build. Repaired by the next commit, 8cbe2c1d7. Disclosed rather than rebased away (AAASM-5385, out of scope: rewriting history).

--- a/.ci/bisect-skip.txt
+++ b/.ci/bisect-skip.txt
@@ -28,3 +28,5 @@
 # auditable, so state what fails to build and what repaired it.
 
 c596246a2100e706d20fcaf6e61d88f3cb77e840  Clean-but-semantic merge on the AAASM-5354 branch: rename detection carried a validator into aa-policy referencing crate::engine::detection::LocalePack, which exists only in aa-gateway. `cargo check --workspace --all-targets` exits 101 with E0433. Both parents build. Repaired by the next commit, 8cbe2c1d7. Disclosed rather than rebased away (AAASM-5385, out of scope: rewriting history).
+
+72b67f44f0a84e56effd82fa962db80f146a29a1  Partial staging on the AAASM-5355 branch (PR #1894): aa-core/src/types/sensitive_data/finding_record.rs changed `SensitiveDataFindingRecord::from_finding` to take 3 arguments, but the two call sites in counts.rs:150 and event.rs:642 were left at 2 and committed separately. `cargo check --workspace --all-targets` exits 101 with two E0061. Visible only under --all-targets — the failing unit is `aa-core (lib test)`, so a lib-only build passes. This is the reproduction AAASM-5385 was raised from; disclosed rather than rebased away.

--- a/.ci/verify-range-builds.sh
+++ b/.ci/verify-range-builds.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# verify-range-builds.sh — build every commit a merge will introduce.
+#
+# AAASM-5385.
+#
+# WHAT THIS CLOSES
+# ----------------
+# CONTRIBUTING requires commits to be bisectable ("keep commits small and
+# bisectable"). Nothing enforced it. Two distinct holes existed, and they need
+# different arguments — conflating them produces a gate that closes neither:
+#
+#   1. An intermediate commit that does not build. Partial staging (`git add`
+#      of one file while others stay modified) is the normal way to produce an
+#      atomic commit, and it routinely records an index that was never built:
+#      lefthook runs `cargo clippy` against the WORKING TREE, but `git commit`
+#      records the INDEX. When they differ, the hook validates a tree that is
+#      never committed. No pre-commit hook can close this without stashing, and
+#      `lefthook.toml` is deliberately left alone (AAASM-5385 acceptance).
+#
+#   2. A merge commit that does not build even though both of its parents do.
+#      `git merge` exiting 0 means "no textual conflict", which is not the same
+#      claim as "the result compiles". Rename detection and independent edits to
+#      disjoint regions of the same file both produce clean-but-broken merges.
+#      This is a semantic conflict, and only a build can see it.
+#
+# The recorded instance of (2) on this repository is c596246a2100e706d20fca...,
+# a local `git merge remote/main` on the AAASM-5354 branch. Both parents build;
+# the merge does not (`cannot find engine in crate`, aa-policy). It reached
+# `main` because the next commit repaired it, so every commit CI ever built was
+# green. See `.ci/bisect-skip.txt`.
+#
+# WHY THE RANGE IS `HEAD^1..HEAD` ON THE MERGE REF
+# ------------------------------------------------
+# On a `pull_request` event, `actions/checkout` checks out `refs/pull/N/merge`
+# by default — GitHub's own synthetic merge of the PR into its base. This
+# repository's `ci.yml` never overrides `ref:` on any job (verified: the only
+# `ref:` in `.github/workflows/` is in `docs.yml`, for a `workflow_run`), so
+# existing CI already builds the merge RESULT, not the PR head. That part was
+# never broken and this script does not change it.
+#
+# We reuse `refs/pull/N/merge` rather than constructing a merge ourselves,
+# because a merge we construct is a merge nobody will ever push: GitHub decides
+# the parent order and strategy that actually lands, and re-deriving it risks
+# validating a different tree than the one that merges. Taking GitHub's ref as
+# given, the commits the merge introduces are exactly
+#
+#     git rev-list --reverse HEAD^1..HEAD      # HEAD^1 = base tip
+#
+# which yields every commit on the PR branch not already in the base, PLUS the
+# synthetic merge commit itself as the final element. One range therefore covers
+# both holes above: intermediate commits and the merge result.
+#
+# WHY `cargo check`, NOT `clippy` OR `build`
+# ------------------------------------------
+# Cost is the reason this gate survives rather than gets disabled. `cargo check`
+# stops after type-checking and skips codegen/linking, and is what actually
+# distinguishes "this commit compiles" from "this commit does not". Lint
+# cleanliness and test outcomes at intermediate commits are not what bisect
+# needs — `git bisect` needs each commit to BUILD so a test can be run against
+# it. The tip is separately covered by the full `build`/`clippy`/`test` jobs, so
+# nothing is lost by checking intermediate commits more cheaply than the tip.
+#
+# `--exclude aa-ebpf` matches the `build` and `clippy` jobs: aya-build shells
+# out to a nightly toolchain, and `ebpf-build` covers that crate separately.
+#
+# USAGE
+# -----
+#   .ci/verify-range-builds.sh                 # infer range from HEAD (a merge)
+#   .ci/verify-range-builds.sh <base> <head>   # explicit range
+#
+# Exits 0 if every commit in the range builds; 1 naming the first that does not.
+
+set -euo pipefail
+
+CARGO_CHECK_ARGS=(check --workspace --all-targets --exclude aa-ebpf)
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+if [[ $# -eq 2 ]]; then
+    base=$(git rev-parse --verify "$1^{commit}")
+    head=$(git rev-parse --verify "$2^{commit}")
+elif [[ $# -eq 0 ]]; then
+    head=$(git rev-parse --verify HEAD)
+    if [[ -z "$(git rev-parse --verify --quiet "${head}^2" || true)" ]]; then
+        echo "error: HEAD ($head) is not a merge commit, so the base cannot be" >&2
+        echo "       inferred. Pass the range explicitly: $0 <base> <head>" >&2
+        echo "       In CI this means the checkout was not refs/pull/N/merge." >&2
+        exit 2
+    fi
+    base=$(git rev-parse --verify "${head}^1")
+else
+    echo "usage: $0 [<base> <head>]" >&2
+    exit 2
+fi
+
+# Portable to bash 3.2 (the /bin/bash macOS still ships), so the same script a
+# contributor runs locally is the one CI runs. `mapfile` would restrict this to
+# bash 4+ and silently diverge the two.
+commits=()
+commit_count=0
+while IFS= read -r line; do
+    commits[commit_count]=$line
+    commit_count=$((commit_count + 1))
+done < <(git rev-list --reverse "${base}..${head}")
+
+if [[ $commit_count -eq 0 ]]; then
+    echo "No commits in ${base:0:9}..${head:0:9} — nothing to verify."
+    exit 0
+fi
+
+echo "Range ${base:0:9}..${head:0:9} introduces ${commit_count} commit(s)."
+echo
+
+# A commit is skipped only when EVERY path it touches is provably incapable of
+# affecting `cargo check` — documentation, images, CI config, dashboard sources
+# (the dashboard's build output is not committed; aa-cli's build.rs tolerates
+# its absence). The polarity matters: default to building, and skip only on
+# proof of irrelevance. A filter that instead allow-lists "Rust-looking" paths
+# silently stops covering every future file type that feeds the build.
+is_skippable() {
+    local commit=$1 path saw_path=0
+
+    # A merge is never skipped: a semantic conflict can appear in a merge whose
+    # own diff-tree output is empty or trivial, which is hole (2) exactly.
+    if [[ -n "$(git rev-parse --verify --quiet "${commit}^2" || true)" ]]; then
+        return 1
+    fi
+
+    while IFS= read -r path; do
+        saw_path=1
+        case "$path" in
+            *.md | docs/* | .github/* | dashboard/* | \
+            *.png | *.jpg | *.jpeg | *.svg | *.gif | *.ico | \
+            LICENSE* | CODEOWNERS | .gitignore) ;;
+            *) return 1 ;;
+        esac
+    done < <(git diff-tree --no-commit-id --name-only -r "$commit")
+
+    # An empty diff (an empty commit, or a merge already handled above) is not
+    # proof of irrelevance, so it is built rather than skipped.
+    [[ $saw_path -eq 1 ]]
+}
+
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/aa-range-build.XXXXXX")
+worktree="$scratch/wt"
+cleanup() {
+    git worktree remove --force "$worktree" >/dev/null 2>&1 || true
+    rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+# One worktree reused across every commit, with one shared CARGO_TARGET_DIR, so
+# cargo reuses compiled dependencies across the loop. Without this the gate
+# costs a cold build per commit and would not be affordable.
+git worktree add --detach --quiet "$worktree" "${commits[0]}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$scratch/target}"
+
+failed=""
+checked=0
+skipped=0
+
+for commit in "${commits[@]}"; do
+    subject=$(git log -1 --format='%s' "$commit")
+    short=${commit:0:9}
+
+    if is_skippable "$commit"; then
+        echo "skip  $short  $subject"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    echo "build $short  $subject"
+    git -C "$worktree" checkout --detach --quiet "$commit"
+
+    if ! cargo "${CARGO_CHECK_ARGS[@]}" --manifest-path "$worktree/Cargo.toml" 2>&1 | sed 's/^/      | /'; then
+        failed=$commit
+        break
+    fi
+    checked=$((checked + 1))
+done
+
+echo
+if [[ -n "$failed" ]]; then
+    echo "::error::Commit ${failed:0:9} does not build: $(git log -1 --format='%s' "$failed")"
+    cat >&2 <<EOF
+
+Commit ${failed} does not build on its own.
+
+Every commit that lands on main must build, so that 'git bisect' can run a
+test at any point in history without first having to guess which commits are
+merely broken scaffolding.
+
+To reproduce it exactly:
+
+    git worktree add --detach /tmp/broken ${failed}
+    cd /tmp/broken && cargo ${CARGO_CHECK_ARGS[*]}
+
+If it is an ordinary commit, the usual cause is partial staging — the fix
+belongs squashed into that commit (interactive rebase), not appended as a
+follow-up, since a later repair leaves the broken commit in history.
+
+If it is a MERGE commit, both parents almost certainly build and the merge is
+a semantic conflict that 'git merge' could not see. Redo the merge and fix the
+result in the merge commit itself.
+EOF
+    exit 1
+fi
+
+echo "All ${checked} build-relevant commit(s) in the range build (${skipped} skipped as non-build paths)."

--- a/.ci/verify-range-builds.sh
+++ b/.ci/verify-range-builds.sh
@@ -117,9 +117,23 @@ commit_count=0
 while IFS= read -r line; do
     commits[commit_count]=$line
     commit_count=$((commit_count + 1))
-done < <(git rev-list --reverse "${base}..${head}")
+# `--topo-order` so "the first commit that fails" is the first in ANCESTRY, not
+# the earliest by commit date. Without it rev-list orders by date, and a branch
+# rebased or cherry-picked out of chronological order — or a merge bringing in
+# older commits — would be walked in an order that does not match how the
+# history reads, making the reported "first failure" arbitrary among several.
+done < <(git rev-list --reverse --topo-order "${base}..${head}")
 
 if [[ $commit_count -eq 0 ]]; then
+    # An empty range is a legitimate no-op in CI (a PR with nothing new), but
+    # for an explicitly-passed range it is much more often the arguments the
+    # wrong way round — which would otherwise exit 0 and read as "verified".
+    if [[ $# -eq 2 ]] && [[ -n "$(git rev-list -1 "${head}..${base}")" ]]; then
+        echo "error: no commits in ${base:0:9}..${head:0:9}, but ${head:0:9}..${base:0:9}" >&2
+        echo "       is non-empty — the arguments look reversed. Expected" >&2
+        echo "       <base> <head>, e.g. '$0 remote/main HEAD'." >&2
+        exit 2
+    fi
     echo "No commits in ${base:0:9}..${head:0:9} — nothing to verify."
     exit 0
 fi

--- a/.ci/verify-range-builds.sh
+++ b/.ci/verify-range-builds.sh
@@ -64,6 +64,14 @@
 # `--exclude aa-ebpf` matches the `build` and `clippy` jobs: aya-build shells
 # out to a nightly toolchain, and `ebpf-build` covers that crate separately.
 #
+# WHAT THIS DOES NOT CHECK
+# ------------------------
+# Only that each commit COMPILES. It does not run tests, lint, or rustfmt at
+# intermediate commits — `git bisect` needs a commit to build so that a test can
+# be run against it, and the tip is separately held to all three by the
+# `build`/`clippy`/`test`/`fmt` jobs. `aa-ebpf` is excluded, so a commit that
+# breaks only that crate passes here and is caught by `ebpf-build`.
+#
 # USAGE
 # -----
 #   .ci/verify-range-builds.sh                 # infer range from HEAD (a merge)
@@ -73,7 +81,13 @@
 
 set -euo pipefail
 
-CARGO_CHECK_ARGS=(check --workspace --all-targets --exclude aa-ebpf)
+# `--all-features` matches the `clippy` job (ci.yml). Without it the gate would
+# enforce "compiles on its own" for DEFAULT features only, so a commit could
+# break a feature-gated path, pass here, and still fail the tip's clippy job —
+# two different meanings of "builds" for the same history. Measured at parity
+# with default features once the target dir is warm (~33s either way), so there
+# is no cost argument for the weaker guarantee.
+CARGO_CHECK_ARGS=(check --workspace --all-targets --all-features --exclude aa-ebpf)
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,13 @@ jobs:
     env:
       # AAASM-2581: select mold for host-target links only.
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      # Must sit inside the workspace: `Swatinem/rust-cache` caches
+      # `$GITHUB_WORKSPACE/target` and nothing else. The script otherwise
+      # defaults this to a temp dir it deletes on exit, which leaves the cache
+      # unpopulated and re-pays the cold dependency build on EVERY run, forever.
+      # Measured on the first run of this job: 5m03s for the first commit vs
+      # ~33s for each subsequent one — that 5m03s is the part being cached.
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "deny.toml"
+      # AAASM-5385: the Rust jobs' own shell implementations (the commit-range
+      # gate, the compat-matrix check). Without this, editing a gate's script
+      # does not re-run the gate that the script IS.
+      - ".ci/*.sh"
       - "openapi/v1.yaml"
       - "schemas/**/*.json"
       - "schemas/**/*.yaml"
@@ -84,6 +88,10 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "deny.toml"
+      # AAASM-5385: the Rust jobs' own shell implementations (the commit-range
+      # gate, the compat-matrix check). Without this, editing a gate's script
+      # does not re-run the gate that the script IS.
+      - ".ci/*.sh"
       - "openapi/v1.yaml"
       - "schemas/**/*.json"
       - "schemas/**/*.yaml"
@@ -174,6 +182,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'deny.toml'
+              - '.ci/*.sh'
               - 'openapi/v1.yaml'
               - '.spectral.yaml'
               - '.github/workflows/ci.yml'
@@ -317,6 +326,43 @@ jobs:
         # aa-ebpf requires nightly (aya-build invokes rustup run nightly).
         # It is validated by the dedicated ebpf-build job.
         run: cargo build --workspace --exclude aa-ebpf
+
+  # AAASM-5385. Every other Rust job builds exactly one tree: the merge result.
+  # That is the right tree to build (this repository never overrides `ref:`, so
+  # `actions/checkout` gives `refs/pull/N/merge` on a pull_request, not the PR
+  # head), but building only it leaves every INTERMEDIATE commit unbuilt, and an
+  # intermediate commit that a later commit repairs reaches `main` with every
+  # check green. c596246a2 did exactly that. `git bisect` then cannot run a test
+  # at that point in history, which is the cost CONTRIBUTING's "keep commits
+  # small and bisectable" was meant to buy.
+  #
+  # This job asserts behaviour — does each commit compile — so per CONTRIBUTING
+  # ("Which CI jobs block a merge") it is a member of `ci-success` and blocks.
+  # It is pull_request-only: a `push` to main has no merge ref, so there is no
+  # range to walk, and `ci-success` treats a skipped need as passing.
+  commit-range-build:
+    needs: [changes]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    name: Every commit in the range builds
+    runs-on: ubuntu-latest
+    env:
+      # AAASM-2581: select mold for host-target links only.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The whole job is a walk over history, so the default shallow clone
+          # cannot serve it: `git rev-list HEAD^1..HEAD` needs the base's
+          # ancestry present. No `ref:` — the default merge ref is the point.
+          fetch-depth: 0
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Build every commit the merge introduces
+        run: .ci/verify-range-builds.sh
 
   fmt:
     needs: [changes]
@@ -1662,6 +1708,11 @@ jobs:
       - changes
       - dashboard-assets
       - build
+      # AAASM-5385: asserts behaviour (does every commit in the range compile),
+      # not a metric, so it blocks — see CONTRIBUTING, "Which CI jobs block a
+      # merge". A gate that catches an unbuildable commit but does not block is
+      # a report nobody reads, which is the condition it exists to end.
+      - commit-range-build
       - fmt
       - clippy
       - docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,13 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "deny.toml"
-      # AAASM-5385: the Rust jobs' own shell implementations (the commit-range
-      # gate, the compat-matrix check). Without this, editing a gate's script
-      # does not re-run the gate that the script IS.
-      - ".ci/*.sh"
+      # AAASM-5385: the Rust jobs' own shell implementations, by exact filename.
+      # Without these, editing a gate's script does not re-run the gate that the
+      # script IS. Named individually rather than `.ci/*.sh` because the other
+      # four scripts in `.ci/` belong to docs.yml, release.yml and
+      # sdk-sha-drift.yml, and have no business triggering the Rust matrix.
+      - ".ci/verify-range-builds.sh"
+      - ".ci/check-compatibility-matrix.sh"
       - "openapi/v1.yaml"
       - "schemas/**/*.json"
       - "schemas/**/*.yaml"
@@ -88,10 +91,13 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "deny.toml"
-      # AAASM-5385: the Rust jobs' own shell implementations (the commit-range
-      # gate, the compat-matrix check). Without this, editing a gate's script
-      # does not re-run the gate that the script IS.
-      - ".ci/*.sh"
+      # AAASM-5385: the Rust jobs' own shell implementations, by exact filename.
+      # Without these, editing a gate's script does not re-run the gate that the
+      # script IS. Named individually rather than `.ci/*.sh` because the other
+      # four scripts in `.ci/` belong to docs.yml, release.yml and
+      # sdk-sha-drift.yml, and have no business triggering the Rust matrix.
+      - ".ci/verify-range-builds.sh"
+      - ".ci/check-compatibility-matrix.sh"
       - "openapi/v1.yaml"
       - "schemas/**/*.json"
       - "schemas/**/*.yaml"
@@ -182,7 +188,8 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'deny.toml'
-              - '.ci/*.sh'
+              - '.ci/verify-range-builds.sh'
+              - '.ci/check-compatibility-matrix.sh'
               - 'openapi/v1.yaml'
               - '.spectral.yaml'
               - '.github/workflows/ci.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,11 +338,23 @@ jobs:
   #
   # This job asserts behaviour — does each commit compile — so per CONTRIBUTING
   # ("Which CI jobs block a merge") it is a member of `ci-success` and blocks.
-  # It is pull_request-only: a `push` to main has no merge ref, so there is no
-  # range to walk, and `ci-success` treats a skipped need as passing.
+  #
+  # It deliberately does NOT gate on `needs.changes.outputs.rust`. That router is
+  # `dorny/paths-filter` over the PR's NET three-dot diff, which is blind to
+  # intermediate commits by construction — and this job exists precisely because
+  # intermediate commits differ from the net diff. Gating on it would reopen the
+  # hole: a PR whose net diff touches only `dashboard/**` sets `rust=false`, so
+  # the job would skip, `ci-success` treats a skipped need as passing, and a
+  # sequence of `break aa-gateway` -> `revert it` -> `dashboard work` would land
+  # an unbuildable commit on `main` with every check green. `is_skippable` in the
+  # script already skips non-build commits, per commit, where the decision is
+  # actually sound; a job-level allow-list only subtracts coverage.
+  #
+  # pull_request-only is a COST choice, not a capability one: `main`'s commits
+  # are merges (`HEAD^1..HEAD` would walk fine on push), but every commit in that
+  # range was already walked by this job on the PR that introduced it.
   commit-range-build:
-    needs: [changes]
-    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    if: github.event_name == 'pull_request'
     name: Every commit in the range builds
     runs-on: ubuntu-latest
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,70 @@ Examples:
 - `🐛 (aa-gateway): Fix policy evaluation order for overlapping rules`
 - `🔧 (ci): Add matrix build for MSRV check`
 
+### Every commit must build (enforced)
+
+"Bisectable" above is a hard requirement, not an aspiration: **every commit that
+lands on `main` must compile on its own**. The `Every commit in the range builds`
+CI job enforces it on each PR by walking `git rev-list HEAD^1..HEAD` over the
+merge result and running `cargo check --workspace --all-targets --exclude
+aa-ebpf` at each commit. It names the first commit that fails.
+
+Run it yourself before pushing — it is the same script CI runs:
+
+```bash
+.ci/verify-range-builds.sh <base> <head>     # e.g. remote/main HEAD
+```
+
+Two things break this in practice, and neither is exotic:
+
+- **Partial staging.** `git add` of one file while others stay modified records
+  an index nobody built. The pre-commit hook cannot catch this: `cargo` reads
+  the *working tree*, `git commit` records the *index*, and when they differ the
+  hook validates a tree that is never committed. This is why `lefthook.toml`
+  is not the place to fix it, and is deliberately left alone.
+- **A clean-but-broken merge.** `git merge` exiting 0 means "no textual
+  conflict" — not "the result compiles". Rename detection and independent edits
+  to the same file both produce merges that build on neither side's terms while
+  reporting success. `c596246a2` on `main` is a recorded instance: both parents
+  build, the merge does not, and it entered `main` because the very next commit
+  repaired it, so every tree CI ever built was green.
+
+If the job names one of your commits, fix it **in that commit** — an interactive
+rebase, or redoing the merge — rather than appending a repair. A follow-up fix
+leaves the broken commit in history, which is the whole problem.
+
+### Bisecting across known-broken history
+
+`git bisect run` scores a commit by exit status: 0 good, 1 bad, 125 skip. A
+commit that does not *compile* can answer neither good nor bad — the test never
+ran — and a naive `build && test` script exits non-zero there, which bisect
+scores "bad" and returns a confident wrong answer.
+
+Use the supplied predicate, which returns 125 for such commits:
+
+```bash
+cp .ci/bisect-run.sh /tmp/aa-bisect-run.sh        # see below — must be copied out
+git bisect start <bad> <good>
+AA_BISECT_TEST='cargo test -p aa-gateway locale' git bisect run /tmp/aa-bisect-run.sh
+```
+
+With no `AA_BISECT_TEST`, the predicate is simply "does this commit build".
+
+**Copy the script out of the working tree first.** `git bisect` rewrites the
+tree at every step, so a script at `.ci/bisect-run.sh` is replaced by whatever
+that path held at the commit under test — and for commits older than this gate,
+by nothing at all, at which point bisect aborts. For the same reason the script
+reads `.ci/bisect-skip.txt` via `git show <ref>:...` rather than from disk:
+reading the list from the checked-out tree would consult the version that
+existed at the commit under test, so the entries that matter would be invisible
+exactly when they are needed.
+
+`.ci/bisect-skip.txt` is the auditable list of commits already on `main` that do
+not build. Adding an entry is one line — a full 40-character SHA and a reason.
+An unbuildable commit that is *not* on the list is still skipped rather than
+scored "bad", and reported loudly so the list can be extended. The list should
+stop growing now that the CI gate prevents new entries.
+
 ## Adding a new crate
 
 To add a new crate to the workspace:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,14 +103,26 @@ Examples:
 "Bisectable" above is a hard requirement, not an aspiration: **every commit that
 lands on `main` must compile on its own**. The `Every commit in the range builds`
 CI job enforces it on each PR by walking `git rev-list HEAD^1..HEAD` over the
-merge result and running `cargo check --workspace --all-targets --exclude
-aa-ebpf` at each commit. It names the first commit that fails.
+merge result and running `cargo check --workspace --all-targets --all-features
+--exclude aa-ebpf` at each commit. It names the first commit that fails.
 
-Run it yourself before pushing — it is the same script CI runs:
+Precisely what that does and does not assert: it checks that each commit
+**compiles**, not that its tests pass, that it is lint-clean, or that it is
+formatted — the tip is separately held to all of those. `aa-ebpf` is excluded
+and covered by `ebpf-build`.
+
+Run it yourself before pushing:
 
 ```bash
 .ci/verify-range-builds.sh <base> <head>     # e.g. remote/main HEAD
 ```
+
+Same script, but **a weaker guarantee than CI's**, and the difference is the
+one this gate was built for. `remote/main..HEAD` contains no merge commit, so
+locally you are checking only your own commits. CI runs it over
+`refs/pull/N/merge`, whose range ends in the synthetic merge commit — so the
+**merge result** is checked only by CI. A clean-but-broken merge (below) is
+invisible locally by construction.
 
 Two things break this in practice, and neither is exotic:
 
@@ -160,7 +172,12 @@ exactly when they are needed.
 not build. Adding an entry is one line — a full 40-character SHA and a reason.
 An unbuildable commit that is *not* on the list is still skipped rather than
 scored "bad", and reported loudly so the list can be extended. The list should
-stop growing now that the CI gate prevents new entries.
+rarely need new entries now that the CI gate runs on every PR that triggers CI.
+One residual gap: `ci.yml`'s `on.pull_request.paths` is evaluated against a PR's
+*net* diff, so a PR whose net diff touches no listed path never starts CI at
+all — and its intermediate commits go unchecked even if they break the build.
+Closing that would mean dropping path-based CI gating repo-wide, which is a
+separate cost decision; until then, a new entry here is possible.
 
 ## Adding a new crate
 


### PR DESCRIPTION
## Description

`main` contains a merge commit that does not build. `c596246a2` fails
`cargo check --workspace --all-targets` with exit 101 (`cannot find engine in
crate`, `aa-policy`); `8cbe2c1d7`, the very next commit, repairs it. Both of
its parents build. `git merge` reported success — cleanly auto-merging
`aa-policy/src/validator.rs` — because "no textual conflict" is not the same
claim as "the result compiles". It reached `main` with every check green.

This PR adds the gate that would have stopped it, and makes `git bisect` safe
across the history that already contains it.

**A correction to the premise this was raised under.** The suspicion was that
CI tested the PR *branch head* rather than the merge result. It does not:
`.github/workflows/ci.yml` never overrides `ref:` on any job — the only `ref:`
anywhere in `.github/workflows/` is in `docs.yml`, for a `workflow_run` — so
`actions/checkout` already gives every job `refs/pull/N/merge`. The merge
result was always built. The real gap is narrower and was correctly stated in
AAASM-5385: only **one** tree is ever built, the final merge result, so any
**intermediate** commit that a later commit repairs passes unexamined. That is
exactly how `c596246a2` entered.

Three pieces:

- **`.ci/verify-range-builds.sh`** — walks `git rev-list --reverse HEAD^1..HEAD`
  over the merge ref (in `--topo-order`) and runs `cargo check --workspace
  --all-targets --all-features --exclude aa-ebpf` at each commit, naming the
  first that fails. On `refs/pull/N/merge`
  that range is every commit the PR introduces **plus the synthetic merge
  commit itself**, so one walk covers both the intermediate-commit hole and the
  merge-result hole. We reuse GitHub's merge ref rather than constructing a
  merge because a merge we construct is one nobody will ever push.
- **`.ci/bisect-run.sh` + `.ci/bisect-skip.txt`** — a `git bisect run` predicate
  that returns **125 (skip)** for commits that cannot compile. A naive
  `build && test` script exits non-zero on such a commit, bisect scores it
  "bad", and the search returns a confident wrong answer.
- **`ci.yml`** — a new blocking `commit-range-build` job.

`lefthook.toml` is deliberately **unchanged**. The hook is correct and
structurally cannot do this: `cargo` reads the working tree, `git commit`
records the index, and partial staging (the normal way to make an atomic
commit) makes them differ.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

No product code is touched. The new job blocks merges that introduce an
unbuildable commit — intended, and the point of the ticket.

## Related Issues

- Related Jira ticket: [AAASM-5385](https://lightning-dust-mite.atlassian.net/browse/AAASM-5385)
- Related GitHub issues: N/A

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Every claim below was run, and each was checked for being *vacuously* true —
that the assertion can actually fail, and did.

### 1. A green PR head whose merge result does not build is rejected

Reconstructed from real history: PR head `ead9d2acc`, base `2d5dff58c`.
`git merge` exits **0** ("Auto-merging aa-policy/src/validator.rs") and the
resulting tree is byte-identical to `c596246a2`'s
(`41f806350561736ad383adf045a073c66f827f0d` both). Each parent builds on its own
(`cargo check --workspace --all-targets` → exit 0 for both). The gate:

```
Range 2d5dff58c..655ac21c5 introduces 7 commit(s).

build e66d694a9  ♻️ (aa-gateway): Add the sealed canonical detection port for stage 6
build b67500507  ✨ (aa-gateway): Add canonical_findings to EvaluationResult
build ad1a6b29e  🔧 (aa-gateway): Add the data.locale_packs gate, empty by default
build 73554504f  ♻️ (aa-gateway): Route both stage-6 scans through the detection port
build 4c15e3b58  ✅ (aa-gateway): Prove the production path runs the port and fails closed
build ead9d2acc  ✅ (aa-gateway): Cover the cascade path's stage-6 seam independently
build 655ac21c5  Merge commit 'ead9d2acc' into HEAD

::error::Commit 655ac21c5 does not build: Merge commit 'ead9d2acc' into HEAD
```

Exit 1. Not vacuous: all six branch commits — including the PR head — pass, and
only the merge result fails.

### 2. A merge depending on a later repair cannot enter `main` unnoticed

Distinct from (1): here the branch tip is fine and only an intermediate commit
is broken. Run against the **real merge that actually entered `main`**,
`2239336f3` (PR #1901):

```
Range 244c963ef..2239336f3 introduces 13 commit(s).
...
build ead9d2acc  ✅ (aa-gateway): Cover the cascade path's stage-6 seam independently
build c596246a2  Merge remote-tracking branch 'remote/main' into v0.0.1/AAASM-5354/...

::error::Commit c596246a2 does not build: Merge remote-tracking branch 'remote/main' ...
```

Exit 1. The tip `2239336f3` builds green on its own (verified separately) — so
this is caught purely by walking the range, and the gate would have blocked
PR #1901.

### 3. The bisect harness returns 125, and correct good/bad

Against real `c596246a2`, via the skip list (not the build fallback — note it
resolves in 5 s without attempting a build):

```
bisect-run: SKIP c596246a2 — known-unbuildable (.ci/bisect-skip.txt@...)
PREDICATE_EXIT=125
```

Verdicts on a buildable commit (`2239336f3`), exit codes captured from the
command itself, not through a pipe:

| predicate | exit | meaning |
|---|---|---|
| no `AA_BISECT_TEST` | 0 | good |
| test that passes | 0 | good |
| test that fails | 1 | bad |

**End-to-end `git bisect run`, skip path.** Over a range whose only untested
candidate is `c596246a2`, bisect receives 125 and reports honest ambiguity
rather than blaming it:

```
There are only 'skip'ped commits left to test.
The first bad commit could be any of:
c596246a2100e706d20fcaf6e61d88f3cb77e840
8cbe2c1d7beea4b8c920c3934f9f3e197005260b
```

**End-to-end `git bisect run`, convergent.** Over `2d5dff58c..64027ece1` with a
real content predicate, producing both GOOD and BAD verdicts:

```
bisect-run: GOOD ead9d2acc
bisect-run: BAD  e17299801
bisect-run: GOOD 8cbe2c1d7
e172998015f4c74afa76418aae1da95e525201e6 is the first bad commit
```

The answer was predicted independently before the run by checking the marker's
distribution across all eight commits (absent through `8cbe2c1d7`, present from
`e17299801`) — the first attempt at this run *did* pass vacuously, with a
regex that matched nowhere so that bisect "converged" on the asserted `bad`
endpoint without the predicate ever firing. It is included only after that was
found and fixed.

### Skip path is live, not dead code

Against real docs-only commit `394b9b733`: `skip`, 2 s, no build attempted.

### Cost (AAASM-5385 acceptance: "state the measured cost")

**Measured in CI, not locally** — an earlier revision of this description quoted
≈16 s/commit from a warm local target dir, which is a number CI never achieves.
Per-commit wall times read from the job logs:

| run | features | first commit | each subsequent |
|---|---|---|---|
| first (target dir in `$TMPDIR`) | default | 5 m 03 s | ~33 s |
| second (target dir in workspace, `--all-features`) | all | 6 m 46 s | ~48 s |
| current (cache evicted before restore) | all | 6 m 35 s | ~44 s |

So the honest marginal is **~48 s per build-relevant commit**. This PR's own
latest run took **15 m 25 s** wall for a 17-commit range (11 built, 6 skipped),
of which 6 m 35 s is the dependency build that the cache *would* remove if the
repo's cache store were not over quota (see below).
A 40-commit Rust PR projects to ~32 min, uncapped.

**This is the number to argue with, and `--all-features` is the lever.** It buys
one consistent definition of "builds" across the gate, the bisect predicate and
the skip list, at ~15 s/commit (~45%). If the projection is judged too expensive,
dropping back to default features is a one-word change to `CARGO_CHECK_ARGS` and
the matching default in `bisect-run.sh` — the ticket's own guidance is that a
cheap check that runs beats a thorough one that gets disabled. I have gone with
consistency; say the word and it goes the other way.

Two structural notes:

- The first-commit cost is the workspace's dependency build. It was being paid
  on every run because the script's default target dir lives in `$TMPDIR` and is
  deleted on exit, while `Swatinem/rust-cache` caches only
  `$GITHUB_WORKSPACE/target` — so the cache was saved empty. The job now sets
  `CARGO_TARGET_DIR` into the workspace, and the save works: the run before last
  uploaded a populated 530 MB tree.

  **It still did not help, and I checked rather than assuming it would.** The
  next run logged `No cache found.` under a byte-identical cache key
  (`v0-rust-commit-range-build-Linux-x64-4cdea902-1478d4f4`), and the first
  commit cost 6 m 35 s again. The cause is not this job: the repository's Actions
  cache is **over quota and thrashing** — 12.86 GB against GitHub's 10 GB
  per-repo limit, with every surviving entry's `last_accessed_at` inside a single
  ~22-minute window and several duplicate 1.14 GB `v0-rust-test` entries. Our
  530 MB entry was evicted within about half an hour, before it could ever be
  restored.

  So the `CARGO_TARGET_DIR` fix is necessary but not sufficient: it is what makes
  a restore *possible*, and it will pay off the moment the cache store has room.
  Until then the ~6.5 min dependency build recurs, and it recurs for every other
  `rust-cache` job in this repo too — this is a repo-wide problem this PR merely
  surfaced, not one it introduced. Worth its own ticket; deliberately not fixed
  here, since pruning other jobs' caches is destructive and out of scope.
- `--all-features` costs ~15 s/commit more than default features and is worth it
  (see the review-fix notes below).

What keeps it bounded: `cargo check` rather than `clippy` or `build`; one reused
worktree with one shared target dir so dependencies are not recompiled per
commit; and skipping commits whose every path provably cannot affect the build.
The skip filter's polarity is deliberate — it skips only on *proof* of
irrelevance and otherwise builds, so it cannot silently stop covering a new file
type.

### The job actually runs — and builds the merge ref

A workflow with a syntax error is *absent* from `gh pr checks`, not failing, so
"added the YAML" is not evidence. This is the job's real output on this PR
(latest run, conclusion `success`):

```
Range 11b98020c..80b9fd9a7 introduces 17 commit(s).
...
build 56bee2971  📝 (ci): Name the net-diff gap that can still add a skip-list entry
build 02eaa7d0e  🔧 (ci): Make bisect's build match the gate's, so "builds" means one thing
build 80b9fd9a7  Merge 02eaa7d0e15813aba8b07fe333307b2e8eb8c569 into 11b98020ccf1075e58044add2918eebda89b552e

All 11 build-relevant commit(s) in the range build (6 skipped as non-build paths).
```

Not vacuous on two counts. It did real work — eleven commits built, six skipped.
And the last entry is the load-bearing one: that final commit is
`refs/pull/1906/merge`, GitHub's synthetic merge (confirmed by fetching the ref
directly and matching parents). The job therefore built **the merge result that
will land**, not the branch head, on a base that had already moved well past
where this branch was cut. That is Deliverable 1 demonstrated by observation
rather than by reading `actions/checkout`'s documented default.

The first run of this job showed the same shape with 4 built / 2 skipped, which
is what makes the blocker fix visible: that run gated on
`needs.changes.outputs.rust`, and it only ran at all because this PR edits
`ci.yml`, which is itself in the `rust` filter — the filter was never actually
exercised as a gate. It is now removed.

### Base merged in (not rebased)

The branch was 9 commits behind `main`, which is why the Release-artifact gate
could not pass on it: `46a4617f5`, the commit that classifies
`aa-api-server-pg-qa` as intentionally unreleased, was on `main` and not here.
`remote/main` is now merged in via an ordinary merge commit — no rebase, no
force-push, no `update-branch` (whose only undo is a force-push).

That merge is itself the gate's first real test, and it was treated that way:
`git merge` exited 0, which after `c596246a2` is worth nothing on its own, so
the merge commit was built before pushing. `.ci/verify-range-builds.sh
remote/main HEAD` over the resulting 17-commit range exits **0**, with the merge
commit `d7a4b630d` built rather than skipped (merges are never skipped). The
merge brought in `aa-api/src/bin/aa-api-server-pg-qa.rs` and
`aa-security/tests/dlp_realuser_verify.rs` from other branches — exactly the
shape of change that produced the AAASM-5354 semantic conflict — and the result
compiles.

### The red checks before that merge, and why they were not this PR's

`Release-artifact completeness gate` fails with *"workspace binary
`aa-api-server-pg-qa` is neither in RELEASE_BINARIES nor the intentionally-
unreleased allowlist"*. That binary is not touched by this PR and does not exist
on this branch. It was introduced on `main` by `ec832c1e3` and classified by
`46a4617f5` (PR #1913, `AAASM-5444`) — and the timing is decisive: **this run
started 02:42:55Z; #1913 merged 02:53:05Z**, ten minutes later. The PR's merge
ref was computed against `main` during that window. Base movement alone does not
re-trigger PR workflows, so it will clear on the next push or branch update. I
have not force-pushed or rebased to paper over it.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing — except `Release-artifact completeness gate`,
      which fails for a reason introduced and already fixed on `main` outside
      this PR (see "One red check" above)
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)

## Changes from review

One blocker, five should-fixes and the nits, each re-verified rather than
assumed. All three falsification runs were re-run against the **final** scripts
afterwards and still hold (exit 1 at `655ac21c5`, exit 1 at `c596246a2` with the
same `E0433`, 125 for both listed commits, and the convergent bisect still lands
on `e17299801`).

**Blocker — the job's own `if:` was the allow-list this PR condemns.** It gated
on `needs.changes.outputs.rust`, which is `dorny/paths-filter` over the PR's
*net* three-dot diff and is therefore blind to intermediate commits by
construction — the exact thing the job exists to see. A PR whose net diff is
only `dashboard/**` would set `rust=false`, skip the job, and `ci-success`
treats a skipped need as passing. Now `if: github.event_name == 'pull_request'`,
with `needs: [changes]` dropped as unused; `is_skippable` makes the per-commit
decision where it is actually sound. Also fixed the comment claiming a `push` to
`main` "has no merge ref" — `main`'s commits *are* merges, so `HEAD^1..HEAD`
would walk fine on push; PR-only is a cost choice and now says so.

**SF1 — `72b67f44f` added to the skip list.** Independently verified: it is an
ancestor of `main` and exits 101 with two `E0061` (`from_finding` takes 3 args,
`counts.rs:150` and `event.rs:642` pass 2). The failing unit is `aa-core (lib
test)`, so it is visible only under `--all-targets`. It is this ticket's own
reproduction, so a list omitting it was not auditable. *While adding it I first
wrote a fabricated full SHA from the abbreviation; caught by resolving it with
`git rev-parse` before commit. Both entries are now verified to exist and to be
ancestors of `main`.*

**SF2 — dropped the `HEAD` fallback when resolving the skip-list ref.** During
`git bisect`, `HEAD` *is* the commit under test, so that fallback read a
different, older list at every step — falsifying the invariant stated three
lines above it. Now aborts loudly instead (verified: exit 128 in a repo with no
`main`/`origin/main`).

**SF3 — a skip-list entry with no reason was silently ignored.** The verdict
keyed off `skip_reason` being non-empty, so a bare 40-char SHA passed the length
check, produced an empty reason, and the commit was **built instead of skipped**
(reproduced: exit 0). Now tracked by a separate `matched` flag; reason is for
the human only. Verified 125 for a bare-SHA entry, 125 with a reason, 0 for an
unlisted commit.

**SF4 — `CARGO_TARGET_DIR` now points into the workspace.** See the cost section.

**SF5 — the documented local command is now labelled as the weaker check it is.**
`remote/main..HEAD` contains no merge commit, so locally you check only your own
commits; the merge result is checked only by CI. Same script, different
guarantee — and the difference is this PR's headline.

**Nits.** `--all-features` added, matching the `clippy` job, so "builds" means
the same thing at every commit as at the tip (measured at parity locally,
~15 s/commit in CI — worth it to avoid two definitions of "builds").
`--topo-order` added so "the first commit that fails" is first in ancestry, not
by date. A reversed explicit range now exits 2 instead of silently exiting 0.
`bisect-run.sh`'s default build command aligned to the gate's for the same
one-definition reason. The `.ci/*.sh` path filter is narrowed to the two exact
filenames ci.yml actually uses — the other four belong to `docs.yml`,
`release.yml` and `sdk-sha-drift.yml` and have no business triggering the Rust
matrix.

**Where I did not simply agree.** Two claims in the docs were flagged as
overreaching once the blocker is fixed ("prevents new entries", "should stop
growing"). Fixing the blocker does not fully redeem them: `ci.yml`'s
`on.pull_request.paths` is *also* evaluated against the net diff, so a PR whose
net diff touches no listed path never starts CI at all and its intermediate
commits go unchecked. Rather than restore the strong claim, both statements now
name that residual gap. Closing it would mean dropping path-based CI gating
repo-wide — a separate cost decision, not this ticket's.

## Notes for the reviewer

- **Documentation went to `CONTRIBUTING.md`, not an ADR** — git/CI/bisect
  workflow mechanics, per the owner's explicit instruction on this ticket.
- **`.ci/*.sh` was added to the `rust` path filter and both `on.*.paths`
  blocks.** Without it, editing the gate's own script would not re-run the gate
  that the script *is* — the dead-trigger failure CONTRIBUTING warns about.
- **`bisect-run.sh` must be copied out of the working tree before use**, and
  reads its skip list via `git show <ref>:...` rather than from disk. Both
  follow from the same fact: `git bisect` rewrites the tree at every step, so
  anything read from the tree is read *at the commit under test*, where the
  script and the list are older or absent. This is documented at the point of
  use in `CONTRIBUTING.md` and in the script header.
- An unbuildable commit **not** on the skip list is still skipped rather than
  scored "bad" — the list buys speed and auditability, but correctness does not
  depend on the list being complete.
- `c596246a2` is left exactly as it is. This PR prevents recurrence and makes
  bisect safe; it does not rewrite history.


[AAASM-5385]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ