### PR TITLE
[AAASM-5358] ✨ (aa-proxy): Persist non-transmission as execution evidence

### DIFF
--- a/aa-proxy/src/audit_jsonl.rs
+++ b/aa-proxy/src/audit_jsonl.rs
@@ -21,7 +21,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 
 use aa_core::types::sensitive_data::ExecutionEvidence;
-use aa_security::CredentialFinding;
+use aa_security::{CredentialFinding, CredentialKind};
 
 /// Decision recorded for a single intercepted request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -86,8 +86,19 @@ pub struct ProxyAuditEntry {
     /// lowercase hex characters, which is deliberately too short to be a
     /// content digest.
     pub probe_correlation: Option<String>,
-    /// Per-match scanner output. Empty when no secrets were detected.
-    pub credential_findings: Vec<CredentialFinding>,
+    /// Per-match scanner output, projected for this tier. Empty when no secrets
+    /// were detected.
+    ///
+    /// Capped at [`MAX_PERSISTED_FINDINGS`]; the overflow is counted in
+    /// [`Self::findings_omitted`] rather than dropped silently.
+    pub credential_findings: Vec<PersistedFinding>,
+    /// How many findings the cap dropped from
+    /// [`Self::credential_findings`].
+    ///
+    /// A truncated list that said nothing about being truncated would make the
+    /// finding count on this record quietly wrong, and finding counts are a
+    /// measure ADR 0032 §8 keeps deliberately separate from event counts.
+    pub findings_omitted: u32,
     /// Post-scan body content.
     ///
     /// `None` when the proxy bypassed the scanner, when the caller had no body
@@ -98,6 +109,66 @@ pub struct ProxyAuditEntry {
     /// on disk" guarantee exactly as strong as the scrubber, in the one case
     /// where the proxy knows the scrubber did not hold.
     pub redacted_body: Option<String>,
+}
+
+/// A scanner finding as it may be persisted **outside** the tamper-evident
+/// audit tier.
+///
+/// `aa_security::CredentialFinding` carries a `pub offset` — the byte position
+/// of the match in the original body — and ADR 0032 §9 permits offsets and
+/// lengths **only** in the tamper-evident tier. This module's own header states
+/// it is not that tier, and AAASM-5358 is what first constructs the writer in
+/// production, so this PR is what would first put those offsets on disk.
+///
+/// `aa-security` already drew this line and drew it half-way: `end` is private
+/// and `#[serde(skip)]` citing §9, while `offset` stays public and serializes.
+/// Projecting here rather than widening that skip keeps the decision local to
+/// the tier that has the constraint — the tamper-evident writer still needs the
+/// offset.
+///
+/// File permissions are not a substitute. `0600` is access control; §9 is about
+/// what may exist in the record at all, and an offset paired with a category
+/// can identify a value in a small domain regardless of who can read the file.
+///
+/// `matched` is the redaction **label** (`[REDACTED:AwsAccessKey]`), derived
+/// from `kind` and never the secret. It is kept because it is what a consumer
+/// already reads.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedFinding {
+    /// Category of the detected credential.
+    pub kind: CredentialKind,
+    /// Redaction label, e.g. `[REDACTED:AwsAccessKey]`.
+    pub matched: String,
+}
+
+impl PersistedFinding {
+    /// Project a scanner finding, discarding the byte offset.
+    pub fn project(finding: &CredentialFinding) -> Self {
+        Self {
+            kind: finding.kind.clone(),
+            matched: finding.matched.clone(),
+        }
+    }
+}
+
+/// Most findings persisted on a single record.
+///
+/// `redacted_body` alone does not bound a line: a 64 MiB body densely packed
+/// with detectable patterns yields on the order of a million findings at ~50-80
+/// serialized bytes each, so an uncapped vector turns one request into a line of
+/// hundreds of megabytes on a sink with no rotation.
+pub const MAX_PERSISTED_FINDINGS: usize = 256;
+
+/// Project and cap a finding list, returning the retained rows and how many
+/// were dropped.
+pub fn bound_persisted_findings(findings: &[CredentialFinding]) -> (Vec<PersistedFinding>, u32) {
+    let kept: Vec<PersistedFinding> = findings
+        .iter()
+        .take(MAX_PERSISTED_FINDINGS)
+        .map(PersistedFinding::project)
+        .collect();
+    let omitted = findings.len().saturating_sub(kept.len()) as u32;
+    (kept, omitted)
 }
 
 /// Longest post-scan body persisted on a single record.
@@ -133,9 +204,15 @@ pub fn bound_persisted_body(body: String) -> String {
 ///
 /// A prevention metric derived from a silently lossy record is not
 /// authoritative. `try_send` is the right call on the data path — a slow writer
-/// must not stall an intercepted request — so the loss is exported instead of
-/// prevented, and a consumer can refuse to publish a rate over a window in
-/// which this moved.
+/// must not stall an intercepted request — so the loss is *counted* rather than
+/// prevented.
+///
+/// Scope, stated because the obvious reading overstates it: today the only
+/// surfacing is the running total on the `warn!` each drop emits. Nothing in
+/// this repo reads [`dropped_entries`] outside its own tests, so a consumer
+/// cannot yet gate a published rate on it. Putting it on the proxy's metrics
+/// output is follow-up work; the counter exists so that work has something to
+/// read, not because the plumbing is finished.
 static DROPPED_ENTRIES: AtomicU64 = AtomicU64::new(0);
 
 /// Record one dropped entry, returning the new running total.
@@ -290,7 +367,8 @@ mod tests {
                 EnforcementMode::Enforce,
             ),
             probe_correlation: None,
-            credential_findings: scan.findings,
+            credential_findings: scan.findings.iter().map(PersistedFinding::project).collect(),
+            findings_omitted: 0,
             redacted_body: Some(redacted),
         };
 
@@ -333,6 +411,7 @@ mod tests {
             execution: ExecutionEvidence::unrecorded(EnforcementMode::Enforce),
             probe_correlation: None,
             credential_findings: vec![],
+            findings_omitted: 0,
             redacted_body: None,
         }
     }
@@ -466,6 +545,7 @@ mod tests {
             ),
             probe_correlation: None,
             credential_findings: vec![],
+            findings_omitted: 0,
             redacted_body: Some("clean body".into()),
         };
         let json = serde_json::to_string(&entry).unwrap();
@@ -476,6 +556,66 @@ mod tests {
         assert_eq!(back.decision, ProxyAuditDecision::ForwardedRedacted);
         assert_eq!(back.redacted_body.as_deref(), Some("clean body"));
         assert_eq!(back.execution, entry.execution);
+    }
+
+    /// ADR 0032 §9 permits byte offsets only in the tamper-evident tier, and
+    /// this sink is not it. AAASM-5358 is what first constructs the writer in
+    /// production, so without the projection this would be the change that put
+    /// them on disk.
+    #[tokio::test]
+    async fn a_persisted_finding_carries_no_byte_offset() {
+        use aa_security::CredentialScanner;
+
+        let body = format!(r#"{{"k":"{FAKE_AWS_ACCESS_KEY}"}}"#);
+        let scan = CredentialScanner::new().scan(&body);
+        assert!(!scan.findings.is_empty(), "scanner fixture invariant");
+        // Non-vacuity: the source finding really does carry an offset, and the
+        // body is long enough that the offset is not coincidentally 0.
+        let source_offset = scan.findings[0].offset;
+        assert!(source_offset > 0, "fixture must produce a non-zero offset");
+
+        let (projected, omitted) = bound_persisted_findings(&scan.findings);
+        assert_eq!(omitted, 0);
+        assert!(!projected.is_empty(), "otherwise the assertions below are vacuous");
+        assert_eq!(projected[0].kind, scan.findings[0].kind);
+        assert_eq!(projected[0].matched, scan.findings[0].matched);
+
+        let entry = ProxyAuditEntry {
+            credential_findings: projected,
+            ..clean_entry("api.example", ProxyAuditDecision::ForwardedRedacted)
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !json.contains("\"offset\""),
+            "ADR 0032 §9: a byte offset must not reach this tier: {json}"
+        );
+        // The category — which §9 does permit — survives, so the record is
+        // still useful.
+        assert!(json.contains("AwsAccessKey"), "the category must survive: {json}");
+    }
+
+    /// `redacted_body` alone does not bound a line: the findings vector does
+    /// too, and a densely-matching 64 MiB body produces on the order of a
+    /// million of them.
+    #[test]
+    fn an_oversized_finding_list_is_capped_and_the_remainder_counted() {
+        use aa_security::CredentialScanner;
+
+        let one = CredentialScanner::new().scan(&format!(r#"{{"k":"{FAKE_AWS_ACCESS_KEY}"}}"#));
+        assert!(!one.findings.is_empty(), "scanner fixture invariant");
+        let many: Vec<_> = std::iter::repeat_with(|| one.findings[0].clone())
+            .take(MAX_PERSISTED_FINDINGS + 37)
+            .collect();
+
+        let (kept, omitted) = bound_persisted_findings(&many);
+        assert_eq!(kept.len(), MAX_PERSISTED_FINDINGS);
+        assert_eq!(omitted, 37, "the remainder must be counted, not silently dropped");
+
+        // Under the cap nothing is omitted, so the counter is not simply
+        // always-positive.
+        let (kept, omitted) = bound_persisted_findings(&many[..3]);
+        assert_eq!(kept.len(), 3);
+        assert_eq!(omitted, 0);
     }
 
     /// The sink is a new durable file holding `CredentialFinding.offset` —

--- a/aa-proxy/src/audit_jsonl.rs
+++ b/aa-proxy/src/audit_jsonl.rs
@@ -241,11 +241,18 @@ impl JsonlWriter {
     ///
     /// The file is `0600`, and an existing file's mode is re-asserted on every
     /// open — the same discipline `CaStore` applies to the CA private key. The
-    /// default `0644` would have been world-readable, and these records carry
-    /// `CredentialFinding.offset`, which ADR 0032 §9 permits only in the
-    /// tamper-evident audit tier; this module is explicitly not that tier (see
-    /// the module docs). A byte offset into a body is a pointer at where the
-    /// secret was, and it does not belong to every local account.
+    /// default `0644` would have been world-readable.
+    ///
+    /// What justifies that is what the record *does* carry: the destination
+    /// host, the redacted request path, the redacted body, and which credential
+    /// categories an agent was caught sending. That is a per-agent behavioural
+    /// trail, and it does not belong to every local account on the machine.
+    ///
+    /// It is **not** justified by byte offsets: [`PersistedFinding`] discards
+    /// `CredentialFinding.offset`, because ADR 0032 §9 permits offsets only in
+    /// the tamper-evident tier and this module is explicitly not that tier.
+    /// Permissions are access control; §9 is about what may exist in the record
+    /// at all, and the two are not substitutes for one another.
     pub async fn new(path: &Path, receiver: mpsc::Receiver<ProxyAuditEntry>) -> io::Result<Self> {
         let file = tokio::fs::OpenOptions::new()
             .create(true)
@@ -618,10 +625,13 @@ mod tests {
         assert_eq!(omitted, 0);
     }
 
-    /// The sink is a new durable file holding `CredentialFinding.offset` —
-    /// pointers at where a secret sat in a body — which ADR 0032 §9 permits
-    /// only in the tamper-evident tier this module explicitly is not. The
-    /// default `0644` would have published them to every local account.
+    /// The sink is a new durable file holding a per-agent behavioural trail —
+    /// destination hosts, redacted paths and bodies, and which credential
+    /// categories an agent was caught sending. The default `0644` would have
+    /// published all of it to every local account.
+    ///
+    /// Byte offsets are handled separately and are not on disk at all; see
+    /// [`PersistedFinding`] and `a_persisted_finding_carries_no_byte_offset`.
     #[tokio::test]
     async fn the_audit_file_is_not_world_readable() {
         let tmp = tempfile::tempdir().unwrap();

--- a/aa-proxy/src/audit_jsonl.rs
+++ b/aa-proxy/src/audit_jsonl.rs
@@ -12,7 +12,9 @@
 //! commit for how this struct reaches disk.
 
 use std::io;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
@@ -68,10 +70,82 @@ pub struct ProxyAuditEntry {
     /// and the whole point is that such an event exists and says so out loud
     /// rather than being absent.
     pub execution: ExecutionEvidence,
+    /// Correlation id when this record describes a protection probe's own
+    /// request, `None` for ordinary traffic.
+    ///
+    /// Probe traffic is synthetic. Under `credential_action=block` a probe's
+    /// request is genuinely refused before any dial, so its record satisfies
+    /// every condition of ADR 0032 §8 and would be counted as a prevented
+    /// transmission — one per probe run, indistinguishable from a real leak
+    /// that was stopped. A consumer computing a prevention rate has to be able
+    /// to exclude synthetic traffic, and can only do that if the record says
+    /// which it is (AAASM-5359/5360).
+    ///
+    /// The value is an opaque caller-minted id whose grammar is enforced by
+    /// [`ProbeCorrelation`](crate::probe_adjudication::ProbeCorrelation) — 32
+    /// lowercase hex characters, which is deliberately too short to be a
+    /// content digest.
+    pub probe_correlation: Option<String>,
     /// Per-match scanner output. Empty when no secrets were detected.
     pub credential_findings: Vec<CredentialFinding>,
-    /// Post-scan body content. `None` when the proxy bypassed the scanner.
+    /// Post-scan body content.
+    ///
+    /// `None` when the proxy bypassed the scanner, when the caller had no body
+    /// to persist, **and** when re-inspection reported the post-scan bytes as
+    /// still carrying a sensitive value — see
+    /// [`crate::proxy::ProxyServer::observe_forwarding`]. Persisting bytes the
+    /// proxy has itself just declared unscrubbed would make the "no raw value
+    /// on disk" guarantee exactly as strong as the scrubber, in the one case
+    /// where the proxy knows the scrubber did not hold.
     pub redacted_body: Option<String>,
+}
+
+/// Longest post-scan body persisted on a single record.
+///
+/// The MitM path accepts bodies up to `MAX_BODY_LEN` (64 MiB), and the JSONL
+/// sink has no rotation or retention, so an unbounded body turns one oversized
+/// request into an unbounded line and an unbounded file. Truncation is on a
+/// character boundary and marked, so a reader can tell a short body from a cut
+/// one.
+pub const MAX_PERSISTED_BODY_BYTES: usize = 8 * 1024;
+
+/// Marker appended to a body that was cut at [`MAX_PERSISTED_BODY_BYTES`].
+pub const BODY_TRUNCATION_MARKER: &str = "…[truncated]";
+
+/// Bound a post-scan body to [`MAX_PERSISTED_BODY_BYTES`], on a character
+/// boundary.
+pub fn bound_persisted_body(body: String) -> String {
+    if body.len() <= MAX_PERSISTED_BODY_BYTES {
+        return body;
+    }
+    let cut = body
+        .char_indices()
+        .map(|(i, _)| i)
+        .take_while(|i| *i <= MAX_PERSISTED_BODY_BYTES)
+        .last()
+        .unwrap_or(0);
+    let mut out = body[..cut].to_owned();
+    out.push_str(BODY_TRUNCATION_MARKER);
+    out
+}
+
+/// Count of audit entries dropped because the channel was full or closed.
+///
+/// A prevention metric derived from a silently lossy record is not
+/// authoritative. `try_send` is the right call on the data path — a slow writer
+/// must not stall an intercepted request — so the loss is exported instead of
+/// prevented, and a consumer can refuse to publish a rate over a window in
+/// which this moved.
+static DROPPED_ENTRIES: AtomicU64 = AtomicU64::new(0);
+
+/// Record one dropped entry, returning the new running total.
+pub fn record_dropped_entry() -> u64 {
+    DROPPED_ENTRIES.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+/// Entries dropped since process start.
+pub fn dropped_entries() -> u64 {
+    DROPPED_ENTRIES.load(Ordering::Relaxed)
 }
 
 /// Append-only JSONL writer.
@@ -87,12 +161,28 @@ pub struct JsonlWriter {
 impl JsonlWriter {
     /// Open `path` in append mode (creating it if missing) and bind the
     /// supplied receiver. Parent directories must already exist.
+    ///
+    /// The file is `0600`, and an existing file's mode is re-asserted on every
+    /// open — the same discipline `CaStore` applies to the CA private key. The
+    /// default `0644` would have been world-readable, and these records carry
+    /// `CredentialFinding.offset`, which ADR 0032 §9 permits only in the
+    /// tamper-evident audit tier; this module is explicitly not that tier (see
+    /// the module docs). A byte offset into a body is a pointer at where the
+    /// secret was, and it does not belong to every local account.
     pub async fn new(path: &Path, receiver: mpsc::Receiver<ProxyAuditEntry>) -> io::Result<Self> {
         let file = tokio::fs::OpenOptions::new()
             .create(true)
             .append(true)
+            .mode(0o600)
             .open(path)
             .await?;
+        // `mode()` applies only at creation, so an already-existing file keeps
+        // whatever it had. Re-assert rather than trust.
+        let mut perms = file.metadata().await?.permissions();
+        if perms.mode() & 0o777 != 0o600 {
+            perms.set_mode(0o600);
+            file.set_permissions(perms).await?;
+        }
         Ok(Self {
             receiver,
             file: tokio::io::BufWriter::new(file),
@@ -199,6 +289,7 @@ mod tests {
                 TransmissionEvidence::ForwardedClean,
                 EnforcementMode::Enforce,
             ),
+            probe_correlation: None,
             credential_findings: scan.findings,
             redacted_body: Some(redacted),
         };
@@ -240,6 +331,7 @@ mod tests {
             path: "/".into(),
             decision,
             execution: ExecutionEvidence::unrecorded(EnforcementMode::Enforce),
+            probe_correlation: None,
             credential_findings: vec![],
             redacted_body: None,
         }
@@ -372,6 +464,7 @@ mod tests {
                 TransmissionEvidence::ForwardedClean,
                 EnforcementMode::Enforce,
             ),
+            probe_correlation: None,
             credential_findings: vec![],
             redacted_body: Some("clean body".into()),
         };
@@ -383,6 +476,91 @@ mod tests {
         assert_eq!(back.decision, ProxyAuditDecision::ForwardedRedacted);
         assert_eq!(back.redacted_body.as_deref(), Some("clean body"));
         assert_eq!(back.execution, entry.execution);
+    }
+
+    /// The sink is a new durable file holding `CredentialFinding.offset` —
+    /// pointers at where a secret sat in a body — which ADR 0032 §9 permits
+    /// only in the tamper-evident tier this module explicitly is not. The
+    /// default `0644` would have published them to every local account.
+    #[tokio::test]
+    async fn the_audit_file_is_not_world_readable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audit.jsonl");
+        let (_tx, rx) = mpsc::channel(1);
+        let _writer = JsonlWriter::new(&path, rx).await.unwrap();
+        let mode = tokio::fs::metadata(&path).await.unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "audit file mode was {mode:o}");
+    }
+
+    /// A file left over from an earlier, looser build must be tightened rather
+    /// than inherited — `mode()` applies only at creation.
+    #[tokio::test]
+    async fn an_existing_loose_audit_file_is_tightened_on_open() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audit.jsonl");
+        tokio::fs::write(&path, b"").await.unwrap();
+        tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .await
+            .unwrap();
+        // Non-vacuity: the file really is loose before the writer opens it.
+        let before = tokio::fs::metadata(&path).await.unwrap().permissions().mode() & 0o777;
+        assert_eq!(before, 0o644);
+
+        let (_tx, rx) = mpsc::channel(1);
+        let _writer = JsonlWriter::new(&path, rx).await.unwrap();
+        let after = tokio::fs::metadata(&path).await.unwrap().permissions().mode() & 0o777;
+        assert_eq!(after, 0o600, "an existing audit file kept mode {after:o}");
+    }
+
+    /// The MitM path accepts bodies up to 64 MiB and this sink has no rotation,
+    /// so one oversized request must not become an unbounded line.
+    #[test]
+    fn an_oversized_body_is_truncated_on_a_character_boundary_and_marked() {
+        let short = "already small".to_owned();
+        assert_eq!(bound_persisted_body(short.clone()), short);
+
+        // Multi-byte characters, so a naive byte slice would panic.
+        let big = "é".repeat(MAX_PERSISTED_BODY_BYTES);
+        assert!(big.len() > MAX_PERSISTED_BODY_BYTES);
+        let bounded = bound_persisted_body(big);
+        assert!(bounded.ends_with(BODY_TRUNCATION_MARKER), "truncation must be visible");
+        assert!(
+            bounded.len() <= MAX_PERSISTED_BODY_BYTES + BODY_TRUNCATION_MARKER.len(),
+            "bounded body was {} bytes",
+            bounded.len()
+        );
+    }
+
+    /// A prevention metric computed over a silently lossy record is not
+    /// authoritative. The data path is right to drop rather than block, so the
+    /// loss has to be countable.
+    #[test]
+    fn dropped_entries_are_counted() {
+        let before = dropped_entries();
+        let first = record_dropped_entry();
+        let second = record_dropped_entry();
+        assert_eq!(first, before + 1);
+        assert_eq!(second, before + 2);
+        assert_eq!(dropped_entries(), before + 2);
+    }
+
+    /// A probe's own traffic must be identifiable in the record, so a consumer
+    /// can exclude synthetic preventions from a rate.
+    #[test]
+    fn a_probe_record_round_trips_its_correlation_id() {
+        let entry = ProxyAuditEntry {
+            probe_correlation: Some("0123456789abcdef0123456789abcdef".into()),
+            ..clean_entry("api.example", ProxyAuditDecision::Blocked)
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let back: ProxyAuditEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.probe_correlation.as_deref(),
+            Some("0123456789abcdef0123456789abcdef")
+        );
+        // Ordinary traffic stays distinguishable from synthetic traffic.
+        let ordinary = clean_entry("api.example", ProxyAuditDecision::Blocked);
+        assert!(ordinary.probe_correlation.is_none());
     }
 
     /// `build_audit_sink(None)` is the historical default: no path, no writer,

--- a/aa-proxy/src/audit_jsonl.rs
+++ b/aa-proxy/src/audit_jsonl.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 
+use aa_core::types::sensitive_data::ExecutionEvidence;
 use aa_security::CredentialFinding;
 
 /// Decision recorded for a single intercepted request.
@@ -53,6 +54,20 @@ pub struct ProxyAuditEntry {
     pub path: String,
     /// What the proxy did with the request.
     pub decision: ProxyAuditDecision,
+    /// What was **observed** about whether the payload left this process.
+    ///
+    /// [`Self::decision`] is what the proxy resolved to do; this is what
+    /// happened to the bytes, and the two are not the same claim. A
+    /// [`ProxyAuditDecision::ForwardedRedacted`] is a *transformed
+    /// transmission* — the scrubbed bytes went — and only evidence recorded
+    /// here can distinguish that from a payload that never left, which is the
+    /// distinction ADR 0032 §8's prevention rule turns on (AAASM-5358).
+    ///
+    /// Built by [`crate::transmission_evidence`]; there is no default, because
+    /// a record that omitted it would be an event with no execution evidence,
+    /// and the whole point is that such an event exists and says so out loud
+    /// rather than being absent.
+    pub execution: ExecutionEvidence,
     /// Per-match scanner output. Empty when no secrets were detected.
     pub credential_findings: Vec<CredentialFinding>,
     /// Post-scan body content. `None` when the proxy bypassed the scanner.
@@ -122,6 +137,9 @@ impl JsonlWriter {
 mod tests {
     use super::*;
 
+    use aa_core::policy::EnforcementMode;
+    use aa_core::types::sensitive_data::{EnforcementPoint, TransmissionEvidence};
+
     /// Synthetic AWS access key from AWS public documentation. Not a real credential.
     const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
 
@@ -149,6 +167,11 @@ mod tests {
             method: "POST".into(),
             path: "/v1/chat/completions".into(),
             decision: ProxyAuditDecision::ForwardedRedacted,
+            execution: ExecutionEvidence::new(
+                EnforcementPoint::PreTransmission,
+                TransmissionEvidence::ForwardedClean,
+                EnforcementMode::Enforce,
+            ),
             credential_findings: scan.findings,
             redacted_body: Some(redacted),
         };
@@ -189,6 +212,7 @@ mod tests {
             method: "GET".into(),
             path: "/".into(),
             decision,
+            execution: ExecutionEvidence::unrecorded(EnforcementMode::Enforce),
             credential_findings: vec![],
             redacted_body: None,
         }
@@ -316,6 +340,11 @@ mod tests {
             method: "POST".into(),
             path: "/v1/do".into(),
             decision: ProxyAuditDecision::ForwardedRedacted,
+            execution: ExecutionEvidence::new(
+                EnforcementPoint::PreTransmission,
+                TransmissionEvidence::ForwardedClean,
+                EnforcementMode::Enforce,
+            ),
             credential_findings: vec![],
             redacted_body: Some("clean body".into()),
         };
@@ -326,5 +355,42 @@ mod tests {
         assert_eq!(back.host, "api.example");
         assert_eq!(back.decision, ProxyAuditDecision::ForwardedRedacted);
         assert_eq!(back.redacted_body.as_deref(), Some("clean body"));
+        assert_eq!(back.execution, entry.execution);
+    }
+
+    /// The evidence has to survive serialisation to reach a reader at all, and
+    /// it has to survive it *as the thing that was recorded* — a round trip that
+    /// silently normalised `not_forwarded` into anything else would leave the
+    /// prevention rule reading a value the proxy never observed.
+    #[tokio::test]
+    async fn non_transmission_evidence_survives_the_trip_to_disk() {
+        let entry = ProxyAuditEntry {
+            execution: ExecutionEvidence::new(
+                EnforcementPoint::PreTransmission,
+                TransmissionEvidence::NotForwarded,
+                EnforcementMode::Enforce,
+            ),
+            ..clean_entry("api.example", ProxyAuditDecision::Blocked)
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audit.jsonl");
+        let (tx, rx) = mpsc::channel(4);
+        let writer = JsonlWriter::new(&path, rx).await.unwrap();
+        let handle = tokio::spawn(writer.run());
+        tx.send(entry).await.unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let on_disk = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(
+            on_disk.contains("\"not_forwarded\""),
+            "the on-disk line must spell the evidence: {on_disk}"
+        );
+        let back: ProxyAuditEntry = serde_json::from_str(on_disk.trim()).expect("the line parses");
+        assert!(
+            back.execution.establishes_non_transmission(),
+            "the persisted record lost the only observation that can support a prevention claim"
+        );
     }
 }

--- a/aa-proxy/src/audit_jsonl.rs
+++ b/aa-proxy/src/audit_jsonl.rs
@@ -133,6 +133,33 @@ impl JsonlWriter {
     }
 }
 
+/// Bounded capacity of the audit channel.
+///
+/// The data path uses `try_send` and drops on overflow rather than
+/// back-pressuring an intercepted request, so this bound is the amount of
+/// writer lag the proxy will absorb before audit lines start being lost.
+const AUDIT_CHANNEL_CAPACITY: usize = 1024;
+
+/// Open the audit sink an operator asked for, and spawn the writer that drains
+/// it.
+///
+/// `None` in, `None` out: no path configured means no persistence, which is
+/// the historical default and leaves the data path byte-identical.
+///
+/// # Errors
+///
+/// Propagates the open failure rather than degrading to `None`. An operator who
+/// configured an audit trail and silently got none would be in exactly the state
+/// this whole work stream exists to prevent — believing a record exists when it
+/// does not — so the proxy refuses to start instead.
+pub async fn build_audit_sink(path: Option<&Path>) -> io::Result<Option<mpsc::Sender<ProxyAuditEntry>>> {
+    let Some(path) = path else { return Ok(None) };
+    let (tx, rx) = mpsc::channel(AUDIT_CHANNEL_CAPACITY);
+    let writer = JsonlWriter::new(path, rx).await?;
+    tokio::spawn(writer.run());
+    Ok(Some(tx))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -356,6 +383,60 @@ mod tests {
         assert_eq!(back.decision, ProxyAuditDecision::ForwardedRedacted);
         assert_eq!(back.redacted_body.as_deref(), Some("clean body"));
         assert_eq!(back.execution, entry.execution);
+    }
+
+    /// `build_audit_sink(None)` is the historical default: no path, no writer,
+    /// nothing on disk.
+    #[tokio::test]
+    async fn no_configured_path_builds_no_sink() {
+        let sink = build_audit_sink(None).await.expect("no path is not an error");
+        assert!(sink.is_none(), "an unconfigured proxy must not construct a writer");
+    }
+
+    /// The wiring `run()` depends on: a configured path really does produce a
+    /// live sender whose entries reach the file. Without this the sink would be
+    /// constructed-in-name-only, which is the exact defect this ticket found in
+    /// production.
+    #[tokio::test]
+    async fn a_configured_path_builds_a_sink_that_reaches_the_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audit.jsonl");
+        let sink = build_audit_sink(Some(&path))
+            .await
+            .expect("open succeeds")
+            .expect("a configured path yields a sender");
+
+        sink.send(clean_entry("wired.example", ProxyAuditDecision::Blocked))
+            .await
+            .expect("the writer task is alive and draining");
+        drop(sink);
+
+        // The writer task owns the file; poll briefly for the flushed line
+        // rather than assuming the spawn has been scheduled.
+        let mut on_disk = String::new();
+        for _ in 0..200 {
+            on_disk = tokio::fs::read_to_string(&path).await.unwrap_or_default();
+            if !on_disk.is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            on_disk.contains("wired.example"),
+            "the sink returned by build_audit_sink never reached disk: {on_disk:?}"
+        );
+    }
+
+    /// An operator who asked for an audit trail and cannot have one must be
+    /// told, not silently given a proxy that records nothing.
+    #[tokio::test]
+    async fn an_unopenable_path_is_an_error_not_a_silent_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("does/not/exist/audit.jsonl");
+        match build_audit_sink(Some(&path)).await {
+            Ok(_) => panic!("a configured-but-unopenable audit path must not degrade to no sink"),
+            Err(e) => assert_eq!(e.kind(), io::ErrorKind::NotFound),
+        }
     }
 
     /// The evidence has to survive serialisation to reach a reader at all, and

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -468,6 +468,21 @@ fn parse_credential_action_env() -> Result<CredentialAction, ProxyError> {
     }
 }
 
+/// Path the proxy should append its audit JSONL to, if the operator configured
+/// one.
+///
+/// Deliberately **not** a [`ProxyConfig`] field: the sink is a process-lifetime
+/// resource (a file handle and a writer task built once in [`crate::run`]),
+/// whereas `ProxyConfig` carries the per-request knobs `ProxyServer` consults on
+/// the data path — which is handed a channel `Sender`, never a path.
+///
+/// Env: `AA_PROXY_AUDIT_JSONL_PATH`. Unset (or empty) means no persistence,
+/// which is the historical behaviour: before AAASM-5358 nothing constructed the
+/// writer at all, so every proxy finding was discarded on process exit.
+pub fn audit_jsonl_path_from_env() -> Option<PathBuf> {
+    env_optional("AA_PROXY_AUDIT_JSONL_PATH").map(PathBuf::from)
+}
+
 /// Read an env var as `Some(value)` when set and non-empty, otherwise `None`.
 fn env_optional(name: &str) -> Option<String> {
     match std::env::var(name) {
@@ -534,7 +549,35 @@ mod tests {
         std::env::remove_var("AA_PROXY_CREDENTIAL_ACTION");
         std::env::remove_var("AA_PROXY_GATEWAY_ENDPOINT");
         std::env::remove_var("AA_PROXY_MCP_FAIL_OPEN");
+        std::env::remove_var("AA_PROXY_AUDIT_JSONL_PATH");
         std::env::remove_var("AASM_STATE_DIR");
+    }
+
+    /// Audit persistence is opt-in. An unset variable must reproduce the
+    /// pre-AAASM-5358 behaviour exactly — no writer, nothing on disk — so
+    /// wiring the sink cannot change an existing deployment by itself.
+    #[test]
+    fn an_unset_audit_path_means_no_persistence() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env_vars();
+        assert_eq!(audit_jsonl_path_from_env(), None);
+        // An empty value is an operator who set nothing, not a request to
+        // append to a file named "".
+        std::env::set_var("AA_PROXY_AUDIT_JSONL_PATH", "");
+        assert_eq!(audit_jsonl_path_from_env(), None);
+        clear_env_vars();
+    }
+
+    #[test]
+    fn a_configured_audit_path_is_read_from_the_environment() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env_vars();
+        std::env::set_var("AA_PROXY_AUDIT_JSONL_PATH", "/tmp/aa-proxy-audit.jsonl");
+        assert_eq!(
+            audit_jsonl_path_from_env(),
+            Some(PathBuf::from("/tmp/aa-proxy-audit.jsonl"))
+        );
+        clear_env_vars();
     }
 
     fn addr(s: &str) -> SocketAddr {

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -242,6 +242,17 @@ impl Interceptor {
     /// decided to redact but produced bytes still carrying a credential must not
     /// read as protection. The ordinary data path has no need to re-scan what it
     /// just produced.
+    /// Whether this interceptor has a scanner at all.
+    ///
+    /// Exists so a caller can tell "scanned and found nothing" from "nothing
+    /// scanned it" — [`VerdictDecision::Forward`] with no findings is emitted
+    /// for both, and only the first may be reported as a clean payload
+    /// (AAASM-5358). The cheap answer to a question a second full scan would
+    /// otherwise have to be run on the hot path to answer.
+    pub fn inspects(&self) -> bool {
+        self.scanner.is_some()
+    }
+
     pub fn forwarded_payload_is_clean(&self, bytes: &[u8]) -> Option<bool> {
         let scanner = self.scanner.as_ref()?;
         Some(scanner.scan(&String::from_utf8_lossy(bytes)).is_clean())
@@ -976,6 +987,18 @@ mod tests {
     }
 
     // ── forwarded_payload_is_clean (AAASM-5300 probe reply) ─────────────────
+
+    /// A clean verdict and a disabled scanner both surface as
+    /// [`VerdictDecision::Forward`] with no findings, so the *only* thing that
+    /// separates "scanned and clean" from "nothing scanned it" is this
+    /// predicate. If it ever answered `true` unconditionally, an uninspected
+    /// payload would start being recorded as clean (AAASM-5358).
+    #[test]
+    fn inspects_distinguishes_a_configured_scanner_from_a_disabled_one() {
+        let (tx, _rx) = broadcast::channel(4);
+        assert!(Interceptor::new(tx.clone()).inspects());
+        assert!(!Interceptor::with_scanner(tx, None).inspects());
+    }
 
     #[test]
     fn forwarded_payload_is_clean_reports_a_credential_bearing_payload() {

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -32,7 +32,7 @@ use crate::proxy::http::decompress_content_encoding;
 ///
 /// Returned by [`Interceptor::intercept_request`]; the data path branches on
 /// `decision` and uses `redacted_body` when applicable.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VerdictDecision {
     /// No findings — forward the original body unmodified.
     Forward,

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -68,7 +68,21 @@ pub async fn run(
         tracing::info!("CA installed successfully");
     }
 
-    let server = proxy::ProxyServer::new(config, ca, event_tx);
+    // AAASM-5358: until now nothing in production ever constructed the JSONL
+    // writer — this call site passed `None` unconditionally, so every finding,
+    // every block and every redaction the proxy recorded was discarded when the
+    // process exited. Persistence stays **opt-in** (an unset
+    // `AA_PROXY_AUDIT_JSONL_PATH` reproduces exactly that behaviour), but it is
+    // now reachable at all, which is what makes the execution evidence recorded
+    // on each entry worth recording. A configured-but-unopenable path is an
+    // error rather than a silent `None`: an operator who believes an audit trail
+    // exists and has none is the failure mode this work stream is about.
+    let audit_jsonl_tx = audit_jsonl::build_audit_sink(config::audit_jsonl_path_from_env().as_deref()).await?;
+    if audit_jsonl_tx.is_some() {
+        tracing::info!("proxy audit JSONL persistence enabled via AA_PROXY_AUDIT_JSONL_PATH");
+    }
+
+    let server = proxy::ProxyServer::new_with_audit_sink(config, ca, event_tx, audit_jsonl_tx);
     server.run().await?;
     Ok(())
 }

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -28,6 +28,7 @@ pub mod probe_adjudication;
 pub mod proxy;
 pub mod ssrf;
 pub mod tls;
+pub mod transmission_evidence;
 
 pub use config::ProxyConfig;
 pub use error::ProxyError;

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -6,7 +6,7 @@
 pub mod http;
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime};
@@ -19,7 +19,7 @@ use tokio_rustls::{TlsAcceptor, TlsConnector};
 use aa_runtime::gateway_client::GatewayClient;
 use aa_runtime::pipeline::PipelineEvent;
 
-use crate::audit_jsonl::{ProxyAuditDecision, ProxyAuditEntry};
+use crate::audit_jsonl::{bound_persisted_body, ProxyAuditDecision, ProxyAuditEntry};
 use crate::config::ProxyConfig;
 use crate::credentials::CredentialStore;
 use crate::error::ProxyError;
@@ -34,9 +34,9 @@ use crate::proxy::http::{
     serialize_http_response, HttpRequest, MAX_BODY_LEN, MAX_HEADER_BYTES, MAX_HEADER_COUNT, MAX_HEADER_LINE_LEN,
 };
 use crate::tls::{CaStore, CertCache};
-use crate::transmission_evidence::{self, ForwardAuthorized};
+use crate::transmission_evidence::{self, DecisionRecord, ForwardAuthorized, ForwardObservation};
 
-use aa_core::types::sensitive_data::ExecutionEvidence;
+use aa_core::types::sensitive_data::{ExecutionEvidence, TransmissionEvidence};
 
 /// A TLS `ServerCertVerifier` that accepts any certificate.
 ///
@@ -82,6 +82,23 @@ impl ServerCertVerifier for NoCertVerifier {
             .supported_schemes()
     }
 }
+
+/// The observation shared by every rule that refuses a request before a
+/// credential verdict exists (AAASM-5358).
+///
+/// These are the *most* provable preventions the proxy makes — the denylist,
+/// the network allowlist, in-tunnel host forgery, a plaintext downgrade to an
+/// LLM host, a gateway `tools/call` deny — because the 403 or JSON-RPC error is
+/// written in place of a dial that has no code path after it.
+///
+/// It is **logged and not persisted**. These branches refuse before
+/// `intercept_request` runs, so there is no sensitive-data decision event to
+/// attach evidence to, and synthesising one would invent events the audit trail
+/// has never counted. The consequence is real and should be stated rather than
+/// glossed: until a producer exists for them, the §8 prevention metric cannot
+/// see the proxy's strongest refusals. Persisting them is follow-up work, not
+/// something this constant achieves.
+const NOT_FORWARDED_BY_RULE: ExecutionEvidence = transmission_evidence::not_forwarded_by_rule();
 
 /// Build a JSON-RPC 2.0 error response body carrying the policy reason.
 ///
@@ -295,11 +312,11 @@ impl ProxyServer {
     /// a slow JSONL writer must not stall the data path; a dropped entry
     /// is preferable to back-pressuring the proxy.
     ///
-    /// `execution` is required rather than derived from `decision`: the
-    /// decision says what the proxy resolved to do, and only the caller knows
-    /// what was observed about the bytes (AAASM-5358). Every call site that
-    /// reaches here has already had to name its observation in order to
-    /// continue — see [`crate::transmission_evidence`].
+    /// This is the **refusal** path's recorder: it takes evidence as a
+    /// parameter and produces no dial key, because a branch that returns to the
+    /// client has no wire to reach. Forwarding branches must go through
+    /// [`ForwardObservation::persist`], which supplies its own evidence and is
+    /// the only source of a [`ForwardAuthorized`] (AAASM-5358).
     async fn emit_audit_entry(
         self: &Arc<Self>,
         host: &str,
@@ -309,18 +326,37 @@ impl ProxyServer {
         decision: ProxyAuditDecision,
         execution: ExecutionEvidence,
     ) {
-        let Some(tx) = self.audit_jsonl_tx.as_ref() else { return };
-        let ts_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
-        let redacted_body = verdict
-            .redacted_body
-            .as_ref()
-            .and_then(|b| std::str::from_utf8(b).ok().map(|s| s.to_owned()));
-        let entry = ProxyAuditEntry {
-            ts_ms,
-            agent_id: None,
+        self.decision_record(host, method, target, verdict, decision, execution, None)
+            .send(self.audit_jsonl_tx.as_ref(), execution);
+    }
+
+    /// Assemble the identifying half of a decision record.
+    ///
+    /// `execution` is consulted, not stored: a body the proxy has just reported
+    /// as *still carrying a sensitive value* is not persisted. The "no raw
+    /// value on disk" guarantee would otherwise be exactly as strong as the
+    /// scrubber, in the one branch where the proxy itself says the scrubber did
+    /// not hold.
+    #[allow(clippy::too_many_arguments)]
+    fn decision_record(
+        &self,
+        host: &str,
+        method: &str,
+        target: &str,
+        verdict: &InterceptVerdict,
+        decision: ProxyAuditDecision,
+        execution: ExecutionEvidence,
+        probe_correlation: Option<String>,
+    ) -> DecisionRecord {
+        let redacted_body = if execution.transmission == TransmissionEvidence::ForwardedCarryingSensitiveValue {
+            None
+        } else {
+            verdict
+                .redacted_body
+                .as_ref()
+                .and_then(|b| std::str::from_utf8(b).ok().map(|s| bound_persisted_body(s.to_owned())))
+        };
+        DecisionRecord {
             host: host.to_owned(),
             method: method.to_owned(),
             // The target can carry a secret in its query string (`?key=…`,
@@ -329,17 +365,54 @@ impl ProxyServer {
             // body-only redaction left target secrets in cleartext (AAASM-4738).
             path: self.interceptor.redact_target(target),
             decision,
-            execution,
-            credential_findings: verdict.findings.clone(),
+            findings: verdict.findings.clone(),
             redacted_body,
-        };
-        if let Err(e) = tx.try_send(entry) {
-            tracing::warn!(error = %e, "proxy audit jsonl channel full or closed, dropping entry");
+            probe_correlation,
         }
     }
 
-    /// State what will be on the wire for a verdict that resolved to forward,
-    /// and take the authorization that permits the dial (AAASM-5358).
+    /// Persist a forwarding decision and take the key to the wire.
+    ///
+    /// The single choke point between "we resolved to forward" and any dial.
+    /// The evidence written is the observation's own — this function never sees
+    /// an `ExecutionEvidence` parameter, so it cannot record one observation
+    /// and authorize another.
+    ///
+    /// `decision` is `None` for a branch with no decision event to write: a
+    /// clean body decided nothing, and minting an event for it would change
+    /// what the audit trail counts.
+    async fn record_forwarding(
+        self: &Arc<Self>,
+        observation: ForwardObservation,
+        host: &str,
+        method: &str,
+        target: &str,
+        verdict: &InterceptVerdict,
+        decision: Option<ProxyAuditDecision>,
+    ) -> ForwardAuthorized {
+        let record = decision.map(|decision| {
+            self.decision_record(host, method, target, verdict, decision, observation.evidence(), None)
+        });
+        observation.persist(self.audit_jsonl_tx.as_ref(), record)
+    }
+
+    /// Which decision event, if any, a forwarding verdict writes.
+    ///
+    /// `ForwardRedacted` and `AlertAndForward` both found something and both
+    /// forwarded; a clean `Forward` decided nothing. Shared by all three
+    /// forwarding paths so plain-HTTP cannot drift from the MitM handlers
+    /// again — it previously omitted `alert_only` entirely, silently emptying
+    /// the detected-but-forwarded numerator for cleartext traffic.
+    fn forwarding_audit_decision(decision: VerdictDecision) -> Option<ProxyAuditDecision> {
+        match decision {
+            VerdictDecision::ForwardRedacted => Some(ProxyAuditDecision::ForwardedRedacted),
+            VerdictDecision::AlertAndForward => Some(ProxyAuditDecision::Forwarded),
+            VerdictDecision::Forward | VerdictDecision::Block => None,
+        }
+    }
+
+    /// State what will be on the wire for a verdict that resolved to forward
+    /// (AAASM-5358).
     ///
     /// The re-inspection question is "what do the bytes that are about to go
     /// carry", which is not answerable from the verdict alone:
@@ -354,7 +427,7 @@ impl ProxyServer {
     ///   first may be reported as clean — hence
     ///   [`Interceptor::inspects`](crate::intercept::Interceptor::inspects)
     ///   rather than a second full scan on the hot path.
-    fn observe_forwarding(&self, verdict: &InterceptVerdict) -> (ExecutionEvidence, ForwardAuthorized) {
+    fn observe_forwarding(&self, verdict: &InterceptVerdict) -> ForwardObservation {
         let reinspection = match verdict.decision {
             VerdictDecision::ForwardRedacted => verdict
                 .redacted_body
@@ -399,7 +472,13 @@ impl ProxyServer {
     /// time the proxy actually dials. We refuse any such address here. Resolved
     /// addresses are filtered, not just the first, so a poisoned A-record set
     /// cannot slip an internal IP through behind a public one.
-    async fn connect_revalidated(&self, target: &str) -> Result<TcpStream, ProxyError> {
+    ///
+    /// Takes a [`ForwardAuthorized`] because this is the *shared* bottom of
+    /// every route to the wire — the TLS dial, the plain-HTTP dial, and the
+    /// transparent tunnel all end here. Gating only the first two left the
+    /// tunnel (which under the default `llm_only: true` carries all non-LLM
+    /// traffic) reachable without an observation (AAASM-5358).
+    async fn connect_revalidated(&self, target: &str, _authorized: ForwardAuthorized) -> Result<TcpStream, ProxyError> {
         let addrs: Vec<_> = tokio::net::lookup_host(target)
             .await
             .map_err(|e| ProxyError::Config(format!("dns resolution failed for {target}: {e}")))?
@@ -447,7 +526,7 @@ impl ProxyServer {
             // mock, so the SSRF re-validation below would (correctly) reject it.
             // Skip it here; the override is never set in production.
             Some(addr) => TcpStream::connect(addr).await?,
-            None => self.connect_revalidated(target).await?,
+            None => self.connect_revalidated(target, _authorized).await?,
         };
         let client_config = if self.config.skip_upstream_tls_verify {
             // Integration-test-only path: skip certificate verification so tests
@@ -491,7 +570,7 @@ impl ProxyServer {
     ) -> Result<TcpStream, ProxyError> {
         match self.config.upstream_override {
             Some(addr) => Ok(TcpStream::connect(addr).await?),
-            None => self.connect_revalidated(upstream_addr).await,
+            None => self.connect_revalidated(upstream_addr, _authorized).await,
         }
     }
 
@@ -704,7 +783,7 @@ impl ProxyServer {
             tracing::info!(
                 connect_host = %host,
                 in_tunnel_host = %in_host,
-                transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
+                transmission = NOT_FORWARDED_BY_RULE.transmission.as_str(),
                 "in-tunnel egress denied: {reason}",
             );
             self.interceptor.emit_policy_decision(in_host, true).await;
@@ -723,7 +802,7 @@ impl ProxyServer {
                 McpEvalOutcome::Deny(resp) => {
                     tracing::info!(
                         %host,
-                        transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
+                        transmission = NOT_FORWARDED_BY_RULE.transmission.as_str(),
                         "MCP call refused; answering the client instead of dialling upstream",
                     );
                     let mut client_tls = client_reader.into_inner();
@@ -766,37 +845,24 @@ impl ProxyServer {
             return Ok(());
         }
 
-        // AAASM-5358: name the observation before anything can reach the wire.
-        // `authorized` is the only key to `dial_upstream_tls`.
-        let (execution, authorized) = self.observe_forwarding(&verdict);
+        // AAASM-5358: record the observation, and take the key the dial needs.
+        // The evidence persisted here is the observation's own — there is no
+        // route from this branch to the wire that does not go through it.
+        let authorized = self
+            .record_forwarding(
+                self.observe_forwarding(&verdict),
+                host,
+                &req.method,
+                &req.target,
+                &verdict,
+                Self::forwarding_audit_decision(verdict.decision),
+            )
+            .await;
         let forward_body: &[u8] = match verdict.decision {
-            VerdictDecision::ForwardRedacted => {
-                self.emit_audit_entry(
-                    host,
-                    &req.method,
-                    &req.target,
-                    &verdict,
-                    ProxyAuditDecision::ForwardedRedacted,
-                    execution,
-                )
-                .await;
-                verdict
-                    .redacted_body
-                    .as_deref()
-                    .expect("ForwardRedacted always carries redacted_body")
-            }
-            VerdictDecision::AlertAndForward => {
-                self.emit_audit_entry(
-                    host,
-                    &req.method,
-                    &req.target,
-                    &verdict,
-                    ProxyAuditDecision::Forwarded,
-                    execution,
-                )
-                .await;
-                &req.body
-            }
+            VerdictDecision::ForwardRedacted => verdict
+                .redacted_body
+                .as_deref()
+                .expect("ForwardRedacted always carries redacted_body"),
             _ => &req.body,
         };
 
@@ -951,7 +1017,7 @@ impl ProxyServer {
             tracing::info!(
                 connect_host = %host,
                 in_tunnel_host = %in_host,
-                transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
+                transmission = NOT_FORWARDED_BY_RULE.transmission.as_str(),
                 "in-tunnel egress denied: {reason}",
             );
             self.interceptor.emit_policy_decision(in_host, true).await;
@@ -1018,8 +1084,20 @@ impl ProxyServer {
                 transmission = execution.transmission.as_str(),
                 "adjudicated a protection probe request; answering it instead of forwarding upstream",
             );
-            self.emit_audit_entry(host, &req.method, &req.target, &verdict, audit_decision, execution)
-                .await;
+            // AAASM-5358: mark the record as synthetic. Under `block` this
+            // refusal is real and satisfies every §8 condition, so without the
+            // marker each probe run would contribute a prevented transmission
+            // indistinguishable from a real leak that was stopped.
+            self.decision_record(
+                host,
+                &req.method,
+                &req.target,
+                &verdict,
+                audit_decision,
+                execution,
+                Some(correlation.as_str().to_owned()),
+            )
+            .send(self.audit_jsonl_tx.as_ref(), execution);
             let mut client_tls = client_reader.into_inner();
             client_tls.write_all(&adjudication.http_response()).await?;
             let _ = client_tls.shutdown().await;
@@ -1051,36 +1129,18 @@ impl ProxyServer {
 
         // AAASM-5358: the audit entry for a forwarding branch used to be emitted
         // *after* the dial, so a request whose dial failed left no record at
-        // all. It is now emitted here, before the dial, and `authorized` is the
-        // only key to `dial_upstream_tls`.
-        let (execution, authorized) = self.observe_forwarding(&verdict);
-        match verdict.decision {
-            VerdictDecision::ForwardRedacted => {
-                self.emit_audit_entry(
-                    host,
-                    &req.method,
-                    &req.target,
-                    &verdict,
-                    ProxyAuditDecision::ForwardedRedacted,
-                    execution,
-                )
-                .await;
-            }
-            // Emit an audit entry so operators can see the alert-mode decision
-            // (findings are still recorded, body is not).
-            VerdictDecision::AlertAndForward => {
-                self.emit_audit_entry(
-                    host,
-                    &req.method,
-                    &req.target,
-                    &verdict,
-                    ProxyAuditDecision::Forwarded,
-                    execution,
-                )
-                .await;
-            }
-            _ => {}
-        }
+        // all. It is now written here, before the dial, and writing it is what
+        // produces the key `dial_upstream_tls` demands.
+        let authorized = self
+            .record_forwarding(
+                self.observe_forwarding(&verdict),
+                host,
+                &req.method,
+                &req.target,
+                &verdict,
+                Self::forwarding_audit_decision(verdict.decision),
+            )
+            .await;
 
         // Dial upstream only after we have decided not to block.
         let upstream_tls = self.dial_upstream_tls(host, target, authorized).await?;
@@ -1283,9 +1343,20 @@ impl ProxyServer {
     /// this path too — it is the most likely SSRF vector when the host resolves
     /// to an internal address.
     async fn transparent_tunnel(self: &Arc<Self>, stream: TcpStream, target: &str) -> Result<(), ProxyError> {
+        // AAASM-5358: this path relays bytes it never inspected, so the honest
+        // observation is "forwarded, and nothing looked at it" — never clean.
+        // There is no decision event to write (no verdict was taken), but the
+        // observation still has to exist, because it is what unlocks the dial.
+        let authorized = transmission_evidence::forwarded(
+            VerdictDecision::Forward,
+            self.config.credential_action,
+            // Not "the scanner is disabled" but "this route does not scan".
+            None,
+        )
+        .persist(self.audit_jsonl_tx.as_ref(), None);
         let upstream = match self.config.upstream_override {
             Some(addr) => TcpStream::connect(addr).await?,
-            None => self.connect_revalidated(target).await?,
+            None => self.connect_revalidated(target, authorized).await?,
         };
         let (mut cr, mut cw) = tokio::io::split(stream);
         let (mut ur, mut uw) = tokio::io::split(upstream);
@@ -1352,7 +1423,7 @@ impl ProxyServer {
         if let Some(reason) = self.connect_deny_reason(deny_host) {
             tracing::info!(
                 host = %deny_host,
-                transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
+                transmission = NOT_FORWARDED_BY_RULE.transmission.as_str(),
                 "plain-HTTP egress denied: {reason}",
             );
             self.interceptor.emit_policy_decision(deny_host, true).await;
@@ -1378,7 +1449,7 @@ impl ProxyServer {
         if detect_api(deny_host) != LlmApiPattern::Unknown {
             tracing::info!(
                 host = %deny_host,
-                transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
+                transmission = NOT_FORWARDED_BY_RULE.transmission.as_str(),
                 "plain-HTTP egress to LLM host refused: cleartext downgrade bypasses DLP",
             );
             self.interceptor.emit_policy_decision(deny_host, true).await;
@@ -1472,26 +1543,29 @@ impl ProxyServer {
             None
         };
 
-        // AAASM-5358: state what is about to go before the dial can happen.
-        // A bodyless request had nothing to inspect, which is reported as
-        // "forwarded, not inspected" — never as clean.
-        let (execution, authorized) = match verdict.as_ref() {
-            Some(verdict) => self.observe_forwarding(verdict),
-            None => transmission_evidence::forwarded(VerdictDecision::Forward, self.config.credential_action, None),
-        };
-        if let Some(verdict) = verdict.as_ref() {
-            if verdict.decision == VerdictDecision::ForwardRedacted {
-                self.emit_audit_entry(
+        // AAASM-5358: state what is about to go, and let writing that record be
+        // what unlocks the dial. A bodyless request had nothing to inspect,
+        // which is reported as "forwarded, not inspected" — never as clean.
+        //
+        // The audit decision comes from the same helper the MitM handlers use.
+        // This path previously wrote a record only for `ForwardRedacted`, so an
+        // `alert_only` deployment detected a credential in cleartext traffic,
+        // forwarded it, and persisted nothing at all.
+        let authorized = match verdict.as_ref() {
+            Some(verdict) => {
+                self.record_forwarding(
+                    self.observe_forwarding(verdict),
                     deny_host,
                     method,
                     target,
                     verdict,
-                    ProxyAuditDecision::ForwardedRedacted,
-                    execution,
+                    Self::forwarding_audit_decision(verdict.decision),
                 )
-                .await;
+                .await
             }
-        }
+            None => transmission_evidence::forwarded(VerdictDecision::Forward, self.config.credential_action, None)
+                .persist(self.audit_jsonl_tx.as_ref(), None),
+        };
 
         // Connect to upstream via plain TCP.
         let upstream_addr = if host.contains(':') {
@@ -2248,7 +2322,7 @@ mod tests {
             findings: Vec::new(),
             redacted_body: None,
         };
-        let (execution, _authorized) = server.observe_forwarding(&verdict);
+        let execution = server.observe_forwarding(&verdict).evidence();
         server
             .emit_audit_entry(
                 "api.example.com",
@@ -2496,10 +2570,11 @@ mod tests {
     /// A bodyless request has nothing to inspect. "Not inspected" is the honest
     /// answer; "clean" would be a claim no scan supports.
     #[tokio::test]
-    async fn a_bodyless_forward_is_recorded_as_uninspected_not_clean() {
+    async fn a_bodyless_forward_observes_an_uninspected_payload_not_a_clean_one() {
         let (server, _audit_rx) = server_with_audit(crate::config::CredentialAction::RedactOnly, None).await;
-        let (evidence, _authorized) =
-            transmission_evidence::forwarded(VerdictDecision::Forward, server.config.credential_action, None);
+        let evidence =
+            transmission_evidence::forwarded(VerdictDecision::Forward, server.config.credential_action, None)
+                .evidence();
         assert_eq!(evidence.transmission.as_str(), "forwarded_not_inspected");
         assert!(!evidence.transmission.proves_non_transmission());
     }
@@ -2568,7 +2643,7 @@ mod tests {
             },
         ];
         for verdict in verdicts {
-            let (evidence, _authorized) = server.observe_forwarding(&verdict);
+            let evidence = server.observe_forwarding(&verdict).evidence();
             assert!(
                 evidence.transmission.proves_transmission(),
                 "{:?} authorized a dial without recording that bytes went",
@@ -2582,19 +2657,120 @@ mod tests {
         }
     }
 
-    /// `alert_only` computes a decision and applies nothing, so its forwards are
-    /// dry-run and can never be counted as prevention.
+    /// `alert_only` detects a credential, forwards it unchanged, and must still
+    /// leave a record — the detected-but-forwarded numerator is exactly what a
+    /// dry-run deployment exists to produce.
+    ///
+    /// The plain-HTTP path wrote a record only for `ForwardRedacted`, so every
+    /// cleartext alert-mode detection was silently invisible. Driven end to end
+    /// through `handle_connection` rather than asserted on `observe_forwarding`,
+    /// which cannot see the sink and so could never have caught the omission.
     #[tokio::test]
-    async fn an_alert_only_forward_is_recorded_as_observed_not_enforced() {
-        let (server, mut audit_rx) = server_with_audit(crate::config::CredentialAction::AlertOnly, None).await;
-        let verdict = InterceptVerdict {
-            decision: VerdictDecision::AlertAndForward,
-            findings: Vec::new(),
-            redacted_body: None,
-        };
-        let (evidence, _authorized) = server.observe_forwarding(&verdict);
-        assert_eq!(evidence.mode, aa_core::policy::EnforcementMode::Observe);
-        assert!(!evidence.establishes_non_transmission());
-        assert!(audit_rx.try_recv().is_err(), "observing a verdict must not persist one");
+    async fn an_alert_only_plain_http_detection_is_recorded_as_an_observed_transmission() {
+        use tokio::io::AsyncReadExt as _;
+        let upstream = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let upstream_task = tokio::spawn(async move {
+            let (mut sock, _) = upstream.accept().await.unwrap();
+            let mut chunk = [0u8; 4096];
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(500), sock.read(&mut chunk)).await;
+            let _ = sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+            let _ = sock.shutdown().await;
+        });
+
+        let (server, mut audit_rx) =
+            server_with_audit(crate::config::CredentialAction::AlertOnly, Some(upstream_addr)).await;
+        drive_plain_http(
+            &server,
+            &credential_post_with("http://example.com/v1/ingest", "example.com", &scrubbable_body()),
+        )
+        .await;
+        let _ = upstream_task.await;
+
+        let entry = audit_rx
+            .try_recv()
+            .expect("an alert-mode detection that was forwarded must still be recorded");
+        assert_eq!(entry.decision, ProxyAuditDecision::Forwarded);
+        assert!(
+            !entry.credential_findings.is_empty(),
+            "the record must carry the findings that were detected, else it counts nothing"
+        );
+        assert_eq!(entry.execution.mode, aa_core::policy::EnforcementMode::Observe);
+        assert!(entry.execution.transmission.proves_transmission());
+        assert!(
+            !entry.execution.establishes_non_transmission(),
+            "a dry-run forward is never a prevention"
+        );
+    }
+
+    /// The record must not carry bytes the proxy has just reported as still
+    /// carrying a sensitive value. In that branch the proxy's own re-inspection
+    /// says the scrubber did not hold, so persisting its output would rest the
+    /// "no raw value on disk" guarantee on the thing it just distrusted.
+    #[tokio::test]
+    async fn a_body_that_reinspects_dirty_is_not_persisted() {
+        use tokio::io::AsyncReadExt as _;
+        let upstream = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let upstream_task = tokio::spawn(async move {
+            let (mut sock, _) = upstream.accept().await.unwrap();
+            let mut chunk = [0u8; 4096];
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(500), sock.read(&mut chunk)).await;
+            let _ = sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+            let _ = sock.shutdown().await;
+        });
+
+        let (server, mut audit_rx) =
+            server_with_audit(crate::config::CredentialAction::RedactOnly, Some(upstream_addr)).await;
+        drive_plain_http(
+            &server,
+            &credential_post_with("http://example.com/v1/ingest", "example.com", &unscrubbable_body()),
+        )
+        .await;
+        let _ = upstream_task.await;
+
+        let entry = audit_rx.try_recv().expect("the redaction persisted a decision record");
+        // Non-vacuity: this is the dirty branch, and the record has content.
+        assert_eq!(
+            entry.execution.transmission.as_str(),
+            "forwarded_carrying_sensitive_value"
+        );
+        assert!(!entry.credential_findings.is_empty());
+        assert!(
+            entry.redacted_body.is_none(),
+            "bytes the proxy reported as still carrying a value must not be persisted, got {:?}",
+            entry.redacted_body
+        );
+    }
+
+    /// The control for the previous test: it must be possible for a body to be
+    /// persisted at all, otherwise "not persisted" asserts nothing.
+    #[tokio::test]
+    async fn a_body_that_reinspects_clean_is_persisted() {
+        use tokio::io::AsyncReadExt as _;
+        let upstream = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let upstream_task = tokio::spawn(async move {
+            let (mut sock, _) = upstream.accept().await.unwrap();
+            let mut chunk = [0u8; 4096];
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(500), sock.read(&mut chunk)).await;
+            let _ = sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+            let _ = sock.shutdown().await;
+        });
+
+        let (server, mut audit_rx) =
+            server_with_audit(crate::config::CredentialAction::RedactOnly, Some(upstream_addr)).await;
+        drive_plain_http(
+            &server,
+            &credential_post_with("http://example.com/v1/ingest", "example.com", &scrubbable_body()),
+        )
+        .await;
+        let _ = upstream_task.await;
+
+        let entry = audit_rx.try_recv().expect("the redaction persisted a decision record");
+        assert_eq!(entry.execution.transmission.as_str(), "forwarded_clean");
+        let body = entry.redacted_body.expect("a clean scrub is persisted");
+        assert!(body.contains("[REDACTED:"), "got {body}");
+        assert!(!body.contains(EVIDENCE_TEST_SECRET));
     }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -34,6 +34,9 @@ use crate::proxy::http::{
     serialize_http_response, HttpRequest, MAX_BODY_LEN, MAX_HEADER_BYTES, MAX_HEADER_COUNT, MAX_HEADER_LINE_LEN,
 };
 use crate::tls::{CaStore, CertCache};
+use crate::transmission_evidence::{self, ForwardAuthorized};
+
+use aa_core::types::sensitive_data::ExecutionEvidence;
 
 /// A TLS `ServerCertVerifier` that accepts any certificate.
 ///
@@ -291,12 +294,20 @@ impl ProxyServer {
     /// No-op when `audit_jsonl_tx` is `None`. `try_send` is intentional —
     /// a slow JSONL writer must not stall the data path; a dropped entry
     /// is preferable to back-pressuring the proxy.
+    ///
+    /// `execution` is required rather than derived from `decision`: the
+    /// decision says what the proxy resolved to do, and only the caller knows
+    /// what was observed about the bytes (AAASM-5358). Every call site that
+    /// reaches here has already had to name its observation in order to
+    /// continue — see [`crate::transmission_evidence`].
     async fn emit_audit_entry(
         self: &Arc<Self>,
         host: &str,
-        req: &HttpRequest,
+        method: &str,
+        target: &str,
         verdict: &InterceptVerdict,
         decision: ProxyAuditDecision,
+        execution: ExecutionEvidence,
     ) {
         let Some(tx) = self.audit_jsonl_tx.as_ref() else { return };
         let ts_ms = SystemTime::now()
@@ -311,18 +322,71 @@ impl ProxyServer {
             ts_ms,
             agent_id: None,
             host: host.to_owned(),
-            method: req.method.clone(),
+            method: method.to_owned(),
             // The target can carry a secret in its query string (`?key=…`,
             // `?token=…`, a presigned `?X-Amz-Signature=…`), so it is redacted
             // through the same scanner as the body before being persisted — the
             // body-only redaction left target secrets in cleartext (AAASM-4738).
-            path: self.interceptor.redact_target(&req.target),
+            path: self.interceptor.redact_target(target),
             decision,
+            execution,
             credential_findings: verdict.findings.clone(),
             redacted_body,
         };
         if let Err(e) = tx.try_send(entry) {
             tracing::warn!(error = %e, "proxy audit jsonl channel full or closed, dropping entry");
+        }
+    }
+
+    /// State what will be on the wire for a verdict that resolved to forward,
+    /// and take the authorization that permits the dial (AAASM-5358).
+    ///
+    /// The re-inspection question is "what do the bytes that are about to go
+    /// carry", which is not answerable from the verdict alone:
+    ///
+    /// * a redaction produces a **different** payload from the one the scan
+    ///   ran on, so it is re-scanned — a redaction that failed to scrub must
+    ///   read as still carrying a value, never as protection;
+    /// * `alert_only` forwards the original body, which the scan already found
+    ///   a value in, so no second pass is needed to know what it carries;
+    /// * a clean verdict and a disabled scanner are indistinguishable from the
+    ///   verdict alone (both are `Forward` with no findings), and only the
+    ///   first may be reported as clean — hence
+    ///   [`Interceptor::inspects`](crate::intercept::Interceptor::inspects)
+    ///   rather than a second full scan on the hot path.
+    fn observe_forwarding(&self, verdict: &InterceptVerdict) -> (ExecutionEvidence, ForwardAuthorized) {
+        let reinspection = match verdict.decision {
+            VerdictDecision::ForwardRedacted => verdict
+                .redacted_body
+                .as_deref()
+                .and_then(|bytes| self.interceptor.forwarded_payload_is_clean(bytes)),
+            VerdictDecision::AlertAndForward => Some(false),
+            VerdictDecision::Forward => self.interceptor.inspects().then_some(true),
+            // Unreachable from a forwarding branch. If a future refactor routes
+            // a refusal through here, "cannot say" is the answer that cannot
+            // become a false protection claim.
+            VerdictDecision::Block => None,
+        };
+        transmission_evidence::forwarded(verdict.decision, self.config.credential_action, reinspection)
+    }
+
+    /// Evidence for a request the protection-probe protocol answered here
+    /// instead of relaying (AAASM-5358).
+    ///
+    /// A probe request is withheld by *that protocol*, not by the policy, so
+    /// only a genuine `Block` may be recorded as non-transmission. Recording
+    /// the other branches that way would be true about the bytes and a lie
+    /// about the cause: under `redact_only` the verdict is transforming, so all
+    /// four conditions of ADR 0032 §8 would hold and every probe run would
+    /// manufacture a "prevented transmission" for traffic the policy would in
+    /// fact have forwarded in redacted form — inflating the exact metric the
+    /// probe exists to measure.
+    fn probe_execution_evidence(&self, verdict: &InterceptVerdict) -> ExecutionEvidence {
+        match verdict.decision {
+            VerdictDecision::Block => {
+                transmission_evidence::not_forwarded(verdict.decision, self.config.credential_action)
+            }
+            _ => transmission_evidence::terminated_by_probe_protocol(verdict.decision, self.config.credential_action),
         }
     }
 
@@ -364,10 +428,19 @@ impl ProxyServer {
     /// Honours [`ProxyConfig::upstream_override`] when set — used by
     /// integration tests to redirect the dial to a local mock without
     /// hijacking DNS or modifying the client's CONNECT line.
+    ///
+    /// `_authorized` is the AAASM-5358 invariant, not a parameter this function
+    /// reads: a [`ForwardAuthorized`] can only be obtained from
+    /// [`transmission_evidence::forwarded`], which issues it together with
+    /// evidence that the bytes went. A branch that recorded non-transmission
+    /// has no way to produce one, so the ordering "evidence first, wire second"
+    /// is a property of the call graph rather than of where a line happens to
+    /// sit.
     async fn dial_upstream_tls(
         self: &Arc<Self>,
         host: &str,
         target: &str,
+        _authorized: ForwardAuthorized,
     ) -> Result<tokio_rustls::client::TlsStream<TcpStream>, ProxyError> {
         let upstream_tcp = match self.config.upstream_override {
             // Integration-test path: the dial is redirected to a trusted local
@@ -401,6 +474,25 @@ impl ProxyServer {
             .map_err(|e| ProxyError::Tls(e.to_string()))?;
         tracing::debug!(%host, "upstream TLS handshake complete");
         Ok(upstream_tls)
+    }
+
+    /// Dial the plain-HTTP upstream, honouring
+    /// [`ProxyConfig::upstream_override`] and otherwise re-validating the
+    /// resolved addresses against the SSRF denylist.
+    ///
+    /// Takes a [`ForwardAuthorized`] for the same reason
+    /// [`Self::dial_upstream_tls`] does: this is the plain-HTTP path's route to
+    /// the wire, and it must be unreachable from a branch that recorded the
+    /// payload as withheld.
+    async fn dial_upstream_plain(
+        &self,
+        upstream_addr: &str,
+        _authorized: ForwardAuthorized,
+    ) -> Result<TcpStream, ProxyError> {
+        match self.config.upstream_override {
+            Some(addr) => Ok(TcpStream::connect(addr).await?),
+            None => self.connect_revalidated(upstream_addr).await,
+        }
     }
 
     /// Evaluate an MCP call against the gateway and return the routing outcome.
@@ -609,7 +701,12 @@ impl ProxyServer {
         // host before any gateway dispatch or upstream dial.
         if let Some(reason) = self.in_tunnel_deny_reason(&req) {
             let in_host = Self::effective_request_host(&req).unwrap_or(host);
-            tracing::info!(connect_host = %host, in_tunnel_host = %in_host, "in-tunnel egress denied: {reason}");
+            tracing::info!(
+                connect_host = %host,
+                in_tunnel_host = %in_host,
+                transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
+                "in-tunnel egress denied: {reason}",
+            );
             self.interceptor.emit_policy_decision(in_host, true).await;
             let mut client_tls = client_reader.into_inner();
             client_tls
@@ -624,6 +721,11 @@ impl ProxyServer {
             Some(gw) => match self.evaluate_mcp_request(gw, &req, host).await {
                 McpEvalOutcome::Forward(call, args_bytes) => Some((call, args_bytes)),
                 McpEvalOutcome::Deny(resp) => {
+                    tracing::info!(
+                        %host,
+                        transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
+                        "MCP call refused; answering the client instead of dialling upstream",
+                    );
                     let mut client_tls = client_reader.into_inner();
                     client_tls.write_all(resp.as_bytes()).await?;
                     let _ = client_tls.shutdown().await;
@@ -647,8 +749,15 @@ impl ProxyServer {
                 findings = verdict.findings.len(),
                 "credential_action=Block on non-LLM MitM host: refusing forward, returning 403",
             );
-            self.emit_audit_entry(host, &req, &verdict, ProxyAuditDecision::Blocked)
-                .await;
+            self.emit_audit_entry(
+                host,
+                &req.method,
+                &req.target,
+                &verdict,
+                ProxyAuditDecision::Blocked,
+                transmission_evidence::not_forwarded(verdict.decision, self.config.credential_action),
+            )
+            .await;
             let mut client_tls = client_reader.into_inner();
             client_tls
                 .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
@@ -657,25 +766,42 @@ impl ProxyServer {
             return Ok(());
         }
 
+        // AAASM-5358: name the observation before anything can reach the wire.
+        // `authorized` is the only key to `dial_upstream_tls`.
+        let (execution, authorized) = self.observe_forwarding(&verdict);
         let forward_body: &[u8] = match verdict.decision {
             VerdictDecision::ForwardRedacted => {
-                self.emit_audit_entry(host, &req, &verdict, ProxyAuditDecision::ForwardedRedacted)
-                    .await;
+                self.emit_audit_entry(
+                    host,
+                    &req.method,
+                    &req.target,
+                    &verdict,
+                    ProxyAuditDecision::ForwardedRedacted,
+                    execution,
+                )
+                .await;
                 verdict
                     .redacted_body
                     .as_deref()
                     .expect("ForwardRedacted always carries redacted_body")
             }
             VerdictDecision::AlertAndForward => {
-                self.emit_audit_entry(host, &req, &verdict, ProxyAuditDecision::Forwarded)
-                    .await;
+                self.emit_audit_entry(
+                    host,
+                    &req.method,
+                    &req.target,
+                    &verdict,
+                    ProxyAuditDecision::Forwarded,
+                    execution,
+                )
+                .await;
                 &req.body
             }
             _ => &req.body,
         };
 
         // Forward the (consumed, DLP-scanned) request body to upstream.
-        let upstream_tls = self.dial_upstream_tls(host, target).await?;
+        let upstream_tls = self.dial_upstream_tls(host, target, authorized).await?;
         let outgoing = serialize_http_request(&req, forward_body);
         let mut client_tls = client_reader.into_inner();
         let (upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
@@ -822,7 +948,12 @@ impl ProxyServer {
         // `Host: evil.attacker.com` is rejected here, before any upstream dial.
         if let Some(reason) = self.in_tunnel_deny_reason(&req) {
             let in_host = Self::effective_request_host(&req).unwrap_or(host);
-            tracing::info!(connect_host = %host, in_tunnel_host = %in_host, "in-tunnel egress denied: {reason}");
+            tracing::info!(
+                connect_host = %host,
+                in_tunnel_host = %in_host,
+                transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
+                "in-tunnel egress denied: {reason}",
+            );
             self.interceptor.emit_policy_decision(in_host, true).await;
             let mut client_tls = client_reader.into_inner();
             client_tls
@@ -879,13 +1010,16 @@ impl ProxyServer {
                 ),
             };
             let adjudication = ProbeAdjudication::new(&correlation, &verdict, forwarded_is_clean);
+            let execution = self.probe_execution_evidence(&verdict);
             tracing::info!(
                 %host,
                 correlation = %correlation.as_str(),
                 decision = ?adjudication.decision,
+                transmission = execution.transmission.as_str(),
                 "adjudicated a protection probe request; answering it instead of forwarding upstream",
             );
-            self.emit_audit_entry(host, &req, &verdict, audit_decision).await;
+            self.emit_audit_entry(host, &req.method, &req.target, &verdict, audit_decision, execution)
+                .await;
             let mut client_tls = client_reader.into_inner();
             client_tls.write_all(&adjudication.http_response()).await?;
             let _ = client_tls.shutdown().await;
@@ -898,8 +1032,15 @@ impl ProxyServer {
                 findings = verdict.findings.len(),
                 "credential_action=Block: refusing forward, returning 403",
             );
-            self.emit_audit_entry(host, &req, &verdict, ProxyAuditDecision::Blocked)
-                .await;
+            self.emit_audit_entry(
+                host,
+                &req.method,
+                &req.target,
+                &verdict,
+                ProxyAuditDecision::Blocked,
+                transmission_evidence::not_forwarded(verdict.decision, self.config.credential_action),
+            )
+            .await;
             let mut client_tls = client_reader.into_inner();
             client_tls
                 .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
@@ -908,8 +1049,41 @@ impl ProxyServer {
             return Ok(());
         }
 
+        // AAASM-5358: the audit entry for a forwarding branch used to be emitted
+        // *after* the dial, so a request whose dial failed left no record at
+        // all. It is now emitted here, before the dial, and `authorized` is the
+        // only key to `dial_upstream_tls`.
+        let (execution, authorized) = self.observe_forwarding(&verdict);
+        match verdict.decision {
+            VerdictDecision::ForwardRedacted => {
+                self.emit_audit_entry(
+                    host,
+                    &req.method,
+                    &req.target,
+                    &verdict,
+                    ProxyAuditDecision::ForwardedRedacted,
+                    execution,
+                )
+                .await;
+            }
+            // Emit an audit entry so operators can see the alert-mode decision
+            // (findings are still recorded, body is not).
+            VerdictDecision::AlertAndForward => {
+                self.emit_audit_entry(
+                    host,
+                    &req.method,
+                    &req.target,
+                    &verdict,
+                    ProxyAuditDecision::Forwarded,
+                    execution,
+                )
+                .await;
+            }
+            _ => {}
+        }
+
         // Dial upstream only after we have decided not to block.
-        let upstream_tls = self.dial_upstream_tls(host, target).await?;
+        let upstream_tls = self.dial_upstream_tls(host, target, authorized).await?;
 
         // AAASM-3578: credential injection. When a real, non-expired provider
         // key is configured for this host the store builds the egress
@@ -930,18 +1104,7 @@ impl ProxyServer {
                     .redacted_body
                     .as_deref()
                     .expect("ForwardRedacted always carries redacted_body");
-                let bytes = serialize_http_request_with_auth(&req, body, injected_auth_ref);
-                self.emit_audit_entry(host, &req, &verdict, ProxyAuditDecision::ForwardedRedacted)
-                    .await;
-                bytes
-            }
-            VerdictDecision::AlertAndForward => {
-                let bytes = serialize_http_request_with_auth(&req, &req.body, injected_auth_ref);
-                // Emit an audit entry so operators can see the alert-mode
-                // decision (findings are still recorded, body is not).
-                self.emit_audit_entry(host, &req, &verdict, ProxyAuditDecision::Forwarded)
-                    .await;
-                bytes
+                serialize_http_request_with_auth(&req, body, injected_auth_ref)
             }
             _ => serialize_http_request_with_auth(&req, &req.body, injected_auth_ref),
         };
@@ -1187,7 +1350,11 @@ impl ProxyServer {
         // (before any upstream dial), mirroring the CONNECT path's 403.
         let deny_host = strip_host_port(&host);
         if let Some(reason) = self.connect_deny_reason(deny_host) {
-            tracing::info!(host = %deny_host, "plain-HTTP egress denied: {reason}");
+            tracing::info!(
+                host = %deny_host,
+                transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
+                "plain-HTTP egress denied: {reason}",
+            );
             self.interceptor.emit_policy_decision(deny_host, true).await;
             let mut stream = reader.into_inner();
             stream
@@ -1211,6 +1378,7 @@ impl ProxyServer {
         if detect_api(deny_host) != LlmApiPattern::Unknown {
             tracing::info!(
                 host = %deny_host,
+                transmission = transmission_evidence::not_forwarded_by_rule().transmission.as_str(),
                 "plain-HTTP egress to LLM host refused: cleartext downgrade bypasses DLP",
             );
             self.interceptor.emit_policy_decision(deny_host, true).await;
@@ -1247,20 +1415,35 @@ impl ProxyServer {
         // request (GET) has nothing to scan. Either way the forward path below
         // now forces `Connection: close` and relays only the upstream response,
         // so exactly one request/response crosses this connection (AAASM-4934).
+        let mut verdict: Option<InterceptVerdict> = None;
         let scanned_body: Option<Vec<u8>> = if content_length > 0 {
             let mut body = vec![0u8; content_length];
             reader.read_exact(&mut body).await?;
 
             let content_encoding = plain_http_header_value(&headers, "content-encoding");
-            let verdict =
+            let scanned =
                 self.interceptor
                     .intercept_request(&body, content_encoding.as_deref(), self.config.credential_action);
-            if verdict.decision == VerdictDecision::Block {
+            if scanned.decision == VerdictDecision::Block {
+                // AAASM-5358: this refusal is as pre-transmission as the MitM
+                // path's — the 403 is written and no dial follows — but it
+                // persisted nothing at all before now.
+                let execution = transmission_evidence::not_forwarded(scanned.decision, self.config.credential_action);
                 tracing::info!(
                     host = %deny_host,
-                    findings = verdict.findings.len(),
+                    findings = scanned.findings.len(),
+                    transmission = execution.transmission.as_str(),
                     "plain-HTTP credential_action=Block: refusing forward, returning 403",
                 );
+                self.emit_audit_entry(
+                    deny_host,
+                    method,
+                    target,
+                    &scanned,
+                    ProxyAuditDecision::Blocked,
+                    execution,
+                )
+                .await;
                 self.interceptor.emit_policy_decision(deny_host, true).await;
                 let mut stream = reader.into_inner();
                 stream
@@ -1269,9 +1452,9 @@ impl ProxyServer {
                 let _ = stream.shutdown().await;
                 return Ok(());
             }
-            match verdict.decision {
+            let forwarded = match scanned.decision {
                 VerdictDecision::ForwardRedacted => {
-                    let redacted = verdict
+                    let redacted = scanned
                         .redacted_body
                         .as_deref()
                         .expect("ForwardRedacted always carries redacted_body")
@@ -1282,10 +1465,33 @@ impl ProxyServer {
                     Some(redacted)
                 }
                 _ => Some(body),
-            }
+            };
+            verdict = Some(scanned);
+            forwarded
         } else {
             None
         };
+
+        // AAASM-5358: state what is about to go before the dial can happen.
+        // A bodyless request had nothing to inspect, which is reported as
+        // "forwarded, not inspected" — never as clean.
+        let (execution, authorized) = match verdict.as_ref() {
+            Some(verdict) => self.observe_forwarding(verdict),
+            None => transmission_evidence::forwarded(VerdictDecision::Forward, self.config.credential_action, None),
+        };
+        if let Some(verdict) = verdict.as_ref() {
+            if verdict.decision == VerdictDecision::ForwardRedacted {
+                self.emit_audit_entry(
+                    deny_host,
+                    method,
+                    target,
+                    verdict,
+                    ProxyAuditDecision::ForwardedRedacted,
+                    execution,
+                )
+                .await;
+            }
+        }
 
         // Connect to upstream via plain TCP.
         let upstream_addr = if host.contains(':') {
@@ -1298,10 +1504,7 @@ impl ProxyServer {
         // paths. Without this, a steered agent making a plain `http://`
         // request could reach loopback / RFC-1918 / `169.254.169.254` after
         // DNS resolution, bypassing the AAASM-3130 hardening.
-        let mut upstream = match self.config.upstream_override {
-            Some(addr) => TcpStream::connect(addr).await?,
-            None => self.connect_revalidated(&upstream_addr).await?,
-        };
+        let mut upstream = self.dial_upstream_plain(&upstream_addr, authorized).await?;
 
         // Re-serialise and forward the request, forcing `Connection: close`.
         //
@@ -2045,8 +2248,16 @@ mod tests {
             findings: Vec::new(),
             redacted_body: None,
         };
+        let (execution, _authorized) = server.observe_forwarding(&verdict);
         server
-            .emit_audit_entry("api.example.com", &req, &verdict, ProxyAuditDecision::Forwarded)
+            .emit_audit_entry(
+                "api.example.com",
+                &req.method,
+                &req.target,
+                &verdict,
+                ProxyAuditDecision::Forwarded,
+                execution,
+            )
             .await;
 
         // Drop the last server reference so its audit sender closes and the
@@ -2063,5 +2274,327 @@ mod tests {
             on_disk.contains("[REDACTED:AwsAccessKey]"),
             "JSONL must carry the [REDACTED:AwsAccessKey] marker for the target secret, got: {on_disk}",
         );
+    }
+
+    // ── AAASM-5358: execution evidence on the real data path ────────────────
+
+    /// Synthetic OpenAI-style key the default scanner detects. Not a real
+    /// credential.
+    const EVIDENCE_TEST_SECRET: &str = "sk-TESTONLY-NOT-REAL-1234567890abcdef1234567890ab";
+
+    /// A proxy with a live audit sink, so a test observes the record the data
+    /// path actually persists rather than a value it recomputes for itself.
+    async fn server_with_audit(
+        action: crate::config::CredentialAction,
+        upstream_override: Option<std::net::SocketAddr>,
+    ) -> (Arc<ProxyServer>, mpsc::Receiver<ProxyAuditEntry>) {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let config = ProxyConfig {
+            bind_addr: ([127, 0, 0, 1], 0).into(),
+            ca_dir: dir.path().to_path_buf(),
+            cert_cache_capacity: 8,
+            llm_only: true,
+            mitm_hosts: Vec::new(),
+            denied_hosts: Vec::new(),
+            network_allowlist: Vec::new(),
+            skip_upstream_tls_verify: false,
+            credential_action: action,
+            upstream_override,
+            gateway_endpoint: None,
+            mcp_fail_open: false,
+            allow_private_connect_targets: false,
+        };
+        let (tx, _rx) = broadcast::channel(8);
+        let (audit_tx, audit_rx) = mpsc::channel(8);
+        (
+            ProxyServer::new_with_audit_sink(config, ca, tx, Some(audit_tx)),
+            audit_rx,
+        )
+    }
+
+    /// Drive one plain-HTTP request through the real `handle_connection` entry
+    /// point and hand back whatever the client received.
+    async fn drive_plain_http(server: &Arc<ProxyServer>, request: &str) -> String {
+        use tokio::io::AsyncReadExt as _;
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        let (server_stream, _) = listener.accept().await.unwrap();
+        client.write_all(request.as_bytes()).await.unwrap();
+        // The dial-failure case returns Err; the test asserts on the audit
+        // record either way, so the result is deliberately not unwrapped.
+        let _ = server.handle_connection(server_stream).await;
+        let mut buf = String::new();
+        let _ = client.read_to_string(&mut buf).await;
+        buf
+    }
+
+    /// A body whose redaction re-inspects **clean** — the ordinary successful
+    /// scrub.
+    fn scrubbable_body() -> String {
+        format!("leaking {EVIDENCE_TEST_SECRET} here")
+    }
+
+    /// A body whose redaction re-inspects **dirty**: the scanner's generic
+    /// high-entropy recognizer matches the `[REDACTED:GenericHighEntropy]`
+    /// marker it just wrote. Whether that is a false positive is not this
+    /// ticket's question — what matters is that the evidence reports what
+    /// re-inspection actually said, not what the decision intended.
+    fn unscrubbable_body() -> String {
+        format!("{{\"token\":\"{EVIDENCE_TEST_SECRET}\"}}")
+    }
+
+    fn credential_post(target: &str, host: &str) -> String {
+        credential_post_with(target, host, &unscrubbable_body())
+    }
+
+    fn credential_post_with(target: &str, host: &str, body: &str) -> String {
+        format!(
+            "POST {target} HTTP/1.1\r\nHost: {host}\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body,
+        )
+    }
+
+    /// The one observation this product can make truthfully, made on the real
+    /// data path: a refused request never reached a dial, and the record says
+    /// so.
+    ///
+    /// The record is asserted non-empty *first* — a "no raw secret" assertion
+    /// over an absent or empty entry passes for the wrong reason.
+    #[tokio::test]
+    async fn a_refused_plain_http_request_persists_non_transmission_evidence() {
+        let (server, mut audit_rx) = server_with_audit(crate::config::CredentialAction::Block, None).await;
+        let response = drive_plain_http(&server, &credential_post("http://example.com/v1/ingest", "example.com")).await;
+        assert!(
+            response.contains("403"),
+            "the request must be refused, got: {response:?}"
+        );
+
+        let entry = audit_rx.try_recv().expect("the refusal persisted a decision record");
+
+        // Non-vacuity: this record has content, so the security assertions
+        // below are being made about something.
+        assert_eq!(entry.decision, ProxyAuditDecision::Blocked);
+        assert_eq!(entry.host, "example.com");
+        assert!(
+            !entry.credential_findings.is_empty(),
+            "a blocked credential body must carry its findings, else the assertions below are vacuous"
+        );
+
+        assert!(
+            entry.execution.establishes_non_transmission(),
+            "a pre-transmission refusal is the only shape that may support a prevention claim, got {:?}",
+            entry.execution
+        );
+        assert_eq!(entry.execution.transmission.as_str(), "not_forwarded");
+
+        let serialized = serde_json::to_string(&entry).expect("the record serializes");
+        assert!(
+            !serialized.contains(EVIDENCE_TEST_SECRET),
+            "SECURITY INVARIANT VIOLATED: raw value in the persisted record: {serialized}"
+        );
+    }
+
+    /// Redaction **forwards** the scrubbed bytes. The record must say
+    /// transmitted, never prevented — the mistake the `CredentialLeakBlocked`
+    /// name made, asserted here against the real path rather than the type.
+    #[tokio::test]
+    async fn a_redacted_plain_http_request_records_a_transmission_not_a_prevention() {
+        use tokio::io::AsyncReadExt as _;
+        let upstream = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let upstream_task = tokio::spawn(async move {
+            let (mut sock, _) = upstream.accept().await.unwrap();
+            let mut chunk = [0u8; 4096];
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(500), sock.read(&mut chunk)).await;
+            let _ = sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+            let _ = sock.shutdown().await;
+        });
+
+        let (server, mut audit_rx) =
+            server_with_audit(crate::config::CredentialAction::RedactOnly, Some(upstream_addr)).await;
+        drive_plain_http(
+            &server,
+            &credential_post_with("http://example.com/v1/ingest", "example.com", &scrubbable_body()),
+        )
+        .await;
+        let _ = upstream_task.await;
+
+        let entry = audit_rx.try_recv().expect("the redaction persisted a decision record");
+        assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
+        assert!(
+            !entry.credential_findings.is_empty(),
+            "a redacted body must carry its findings, else the assertions below are vacuous"
+        );
+        assert_eq!(entry.execution.transmission.as_str(), "forwarded_clean");
+        assert!(entry.execution.transmission.proves_transmission());
+        assert!(
+            !entry.execution.establishes_non_transmission(),
+            "a successful redaction is a transformed transmission, not a prevented one"
+        );
+    }
+
+    /// The other half of the same rule: the evidence is about the **bytes**. A
+    /// redaction whose output still re-inspects as carrying a value is recorded
+    /// as exactly that, not smoothed into `forwarded_clean` because the
+    /// decision was "redact".
+    #[tokio::test]
+    async fn a_redaction_whose_bytes_still_reinspect_dirty_says_so() {
+        use tokio::io::AsyncReadExt as _;
+        let upstream = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let upstream_task = tokio::spawn(async move {
+            let (mut sock, _) = upstream.accept().await.unwrap();
+            let mut chunk = [0u8; 4096];
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(500), sock.read(&mut chunk)).await;
+            let _ = sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+            let _ = sock.shutdown().await;
+        });
+
+        let (server, mut audit_rx) =
+            server_with_audit(crate::config::CredentialAction::RedactOnly, Some(upstream_addr)).await;
+        drive_plain_http(
+            &server,
+            &credential_post_with("http://example.com/v1/ingest", "example.com", &unscrubbable_body()),
+        )
+        .await;
+        let _ = upstream_task.await;
+
+        let entry = audit_rx.try_recv().expect("the redaction persisted a decision record");
+        assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+        assert_eq!(
+            entry.execution.transmission.as_str(),
+            "forwarded_carrying_sensitive_value"
+        );
+        assert!(!entry.execution.establishes_non_transmission());
+    }
+
+    /// The ordering claim, tested where it can actually fail: the upstream is a
+    /// closed port, so the dial errors out. The record must already exist — if
+    /// the emission ever moves back after the dial, this request leaves no
+    /// trace and the test fails.
+    #[tokio::test]
+    async fn the_record_exists_even_when_the_upstream_dial_fails() {
+        // Bind then drop, so the address is real and nothing is listening on it.
+        let dead = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let dead_addr = dead.local_addr().unwrap();
+        drop(dead);
+
+        let (server, mut audit_rx) =
+            server_with_audit(crate::config::CredentialAction::RedactOnly, Some(dead_addr)).await;
+        drive_plain_http(&server, &credential_post("http://example.com/v1/ingest", "example.com")).await;
+
+        let entry = audit_rx
+            .try_recv()
+            .expect("the observation must be recorded before the dial, not after it");
+        assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
+        assert!(entry.execution.transmission.proves_transmission());
+    }
+
+    /// A bodyless request has nothing to inspect. "Not inspected" is the honest
+    /// answer; "clean" would be a claim no scan supports.
+    #[tokio::test]
+    async fn a_bodyless_forward_is_recorded_as_uninspected_not_clean() {
+        let (server, _audit_rx) = server_with_audit(crate::config::CredentialAction::RedactOnly, None).await;
+        let (evidence, _authorized) =
+            transmission_evidence::forwarded(VerdictDecision::Forward, server.config.credential_action, None);
+        assert_eq!(evidence.transmission.as_str(), "forwarded_not_inspected");
+        assert!(!evidence.transmission.proves_non_transmission());
+    }
+
+    /// The probe branch. Only a genuine block is attributed to the policy; every
+    /// other verdict says "not recorded", because the probe protocol — not the
+    /// decision — is why those bytes stayed here.
+    #[tokio::test]
+    async fn a_probe_request_only_claims_non_transmission_when_the_policy_blocked_it() {
+        let (server, _audit_rx) = server_with_audit(crate::config::CredentialAction::RedactOnly, None).await;
+
+        let blocked = InterceptVerdict {
+            decision: VerdictDecision::Block,
+            findings: Vec::new(),
+            redacted_body: None,
+        };
+        assert!(
+            server.probe_execution_evidence(&blocked).establishes_non_transmission(),
+            "a policy block during a probe really did withhold the payload"
+        );
+
+        for decision in [
+            VerdictDecision::Forward,
+            VerdictDecision::ForwardRedacted,
+            VerdictDecision::AlertAndForward,
+        ] {
+            let verdict = InterceptVerdict {
+                decision,
+                findings: Vec::new(),
+                redacted_body: Some(bytes::Bytes::from_static(b"redacted")),
+            };
+            let evidence = server.probe_execution_evidence(&verdict);
+            assert_eq!(
+                evidence.transmission.as_str(),
+                "not_recorded",
+                "{decision:?}: the probe protocol withheld these bytes, not the policy"
+            );
+            assert!(
+                !evidence.establishes_non_transmission(),
+                "{decision:?}: a probe must not manufacture a prevented transmission"
+            );
+        }
+    }
+
+    /// Every branch that can reach a dial reports transmission. Stated over the
+    /// server's own observer rather than the pure function, so a call site that
+    /// starts feeding it the wrong re-inspection is caught here.
+    #[tokio::test]
+    async fn no_forwarding_observation_ever_claims_the_payload_stayed_here() {
+        let (server, _audit_rx) = server_with_audit(crate::config::CredentialAction::RedactOnly, None).await;
+        let verdicts = [
+            InterceptVerdict {
+                decision: VerdictDecision::Forward,
+                findings: Vec::new(),
+                redacted_body: None,
+            },
+            InterceptVerdict {
+                decision: VerdictDecision::ForwardRedacted,
+                findings: Vec::new(),
+                redacted_body: Some(bytes::Bytes::from_static(b"[REDACTED:OpenAiKey]")),
+            },
+            InterceptVerdict {
+                decision: VerdictDecision::AlertAndForward,
+                findings: Vec::new(),
+                redacted_body: None,
+            },
+        ];
+        for verdict in verdicts {
+            let (evidence, _authorized) = server.observe_forwarding(&verdict);
+            assert!(
+                evidence.transmission.proves_transmission(),
+                "{:?} authorized a dial without recording that bytes went",
+                verdict.decision
+            );
+            assert!(
+                !evidence.establishes_non_transmission(),
+                "{:?} would have counted as a prevented transmission",
+                verdict.decision
+            );
+        }
+    }
+
+    /// `alert_only` computes a decision and applies nothing, so its forwards are
+    /// dry-run and can never be counted as prevention.
+    #[tokio::test]
+    async fn an_alert_only_forward_is_recorded_as_observed_not_enforced() {
+        let (server, mut audit_rx) = server_with_audit(crate::config::CredentialAction::AlertOnly, None).await;
+        let verdict = InterceptVerdict {
+            decision: VerdictDecision::AlertAndForward,
+            findings: Vec::new(),
+            redacted_body: None,
+        };
+        let (evidence, _authorized) = server.observe_forwarding(&verdict);
+        assert_eq!(evidence.mode, aa_core::policy::EnforcementMode::Observe);
+        assert!(!evidence.establishes_non_transmission());
+        assert!(audit_rx.try_recv().is_err(), "observing a verdict must not persist one");
     }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -83,6 +83,23 @@ impl ServerCertVerifier for NoCertVerifier {
     }
 }
 
+/// Which request a decision record is about.
+///
+/// Bundled rather than passed as three loose `&str`s: the recorders take the
+/// identity, the verdict, the outcome and the evidence, and threading the
+/// probe correlation through pushed every one of them past clippy's argument
+/// limit. It also stops `host`/`method`/`target` being transposed at a call
+/// site, which no test would have caught.
+#[derive(Clone, Copy)]
+struct RequestIdentity<'a> {
+    /// Target host, no port.
+    host: &'a str,
+    /// HTTP method of the intercepted request.
+    method: &'a str,
+    /// Raw request target; redacted before it reaches the record.
+    target: &'a str,
+}
+
 /// The observation shared by every rule that refuses a request before a
 /// credential verdict exists (AAASM-5358).
 ///
@@ -319,14 +336,13 @@ impl ProxyServer {
     /// the only source of a [`ForwardAuthorized`] (AAASM-5358).
     async fn emit_audit_entry(
         self: &Arc<Self>,
-        host: &str,
-        method: &str,
-        target: &str,
+        id: RequestIdentity<'_>,
         verdict: &InterceptVerdict,
         decision: ProxyAuditDecision,
         execution: ExecutionEvidence,
+        probe_correlation: Option<String>,
     ) {
-        self.decision_record(host, method, target, verdict, decision, execution, None)
+        self.decision_record(id, verdict, decision, execution, probe_correlation)
             .send(self.audit_jsonl_tx.as_ref(), execution);
     }
 
@@ -337,12 +353,9 @@ impl ProxyServer {
     /// value on disk" guarantee would otherwise be exactly as strong as the
     /// scrubber, in the one branch where the proxy itself says the scrubber did
     /// not hold.
-    #[allow(clippy::too_many_arguments)]
     fn decision_record(
         &self,
-        host: &str,
-        method: &str,
-        target: &str,
+        id: RequestIdentity<'_>,
         verdict: &InterceptVerdict,
         decision: ProxyAuditDecision,
         execution: ExecutionEvidence,
@@ -357,13 +370,13 @@ impl ProxyServer {
                 .and_then(|b| std::str::from_utf8(b).ok().map(|s| bound_persisted_body(s.to_owned())))
         };
         DecisionRecord {
-            host: host.to_owned(),
-            method: method.to_owned(),
+            host: id.host.to_owned(),
+            method: id.method.to_owned(),
             // The target can carry a secret in its query string (`?key=…`,
             // `?token=…`, a presigned `?X-Amz-Signature=…`), so it is redacted
             // through the same scanner as the body before being persisted — the
             // body-only redaction left target secrets in cleartext (AAASM-4738).
-            path: self.interceptor.redact_target(target),
+            path: self.interceptor.redact_target(id.target),
             decision,
             findings: verdict.findings.clone(),
             redacted_body,
@@ -384,16 +397,38 @@ impl ProxyServer {
     async fn record_forwarding(
         self: &Arc<Self>,
         observation: ForwardObservation,
-        host: &str,
-        method: &str,
-        target: &str,
+        id: RequestIdentity<'_>,
         verdict: &InterceptVerdict,
         decision: Option<ProxyAuditDecision>,
+        probe_correlation: Option<String>,
     ) -> ForwardAuthorized {
-        let record = decision.map(|decision| {
-            self.decision_record(host, method, target, verdict, decision, observation.evidence(), None)
-        });
+        let record = decision
+            .map(|decision| self.decision_record(id, verdict, decision, observation.evidence(), probe_correlation));
         observation.persist(self.audit_jsonl_tx.as_ref(), record)
+    }
+
+    /// The probe correlation id on an in-tunnel request, when it carries a
+    /// well-formed one.
+    ///
+    /// Only `handle_llm_mitm` *adjudicates* a probe, but every handler can
+    /// *receive* one, and the record has to say so wherever it lands: under
+    /// `credential_action=block` a probe's request is refused before any dial
+    /// on the non-LLM MitM and plain-HTTP paths too, producing a record that
+    /// satisfies every ADR 0032 §8 condition. Unmarked, each of those is a
+    /// synthetic prevention indistinguishable from a real one (AAASM-5358).
+    fn probe_correlation(req: &HttpRequest) -> Option<String> {
+        req.header(PROBE_CORRELATION_HEADER)
+            .and_then(ProbeCorrelation::parse)
+            .map(|c| c.as_str().to_owned())
+    }
+
+    /// The plain-HTTP form of [`Self::probe_correlation`], reading the raw
+    /// header lines that path buffers instead of an [`HttpRequest`].
+    fn probe_correlation_plain(headers: &[String]) -> Option<String> {
+        plain_http_header_value(headers, PROBE_CORRELATION_HEADER)
+            .as_deref()
+            .and_then(ProbeCorrelation::parse)
+            .map(|c| c.as_str().to_owned())
     }
 
     /// Which decision event, if any, a forwarding verdict writes.
@@ -828,12 +863,15 @@ impl ProxyServer {
                 "credential_action=Block on non-LLM MitM host: refusing forward, returning 403",
             );
             self.emit_audit_entry(
-                host,
-                &req.method,
-                &req.target,
+                RequestIdentity {
+                    host,
+                    method: &req.method,
+                    target: &req.target,
+                },
                 &verdict,
                 ProxyAuditDecision::Blocked,
                 transmission_evidence::not_forwarded(verdict.decision, self.config.credential_action),
+                Self::probe_correlation(&req),
             )
             .await;
             let mut client_tls = client_reader.into_inner();
@@ -850,11 +888,14 @@ impl ProxyServer {
         let authorized = self
             .record_forwarding(
                 self.observe_forwarding(&verdict),
-                host,
-                &req.method,
-                &req.target,
+                RequestIdentity {
+                    host,
+                    method: &req.method,
+                    target: &req.target,
+                },
                 &verdict,
                 Self::forwarding_audit_decision(verdict.decision),
+                Self::probe_correlation(&req),
             )
             .await;
         let forward_body: &[u8] = match verdict.decision {
@@ -1056,9 +1097,13 @@ impl ProxyServer {
         // path would forward it to the real provider.
         //
         // Only this (LLM-pattern) handler speaks the protocol. A probe request
-        // that lands anywhere else is forwarded like any other request, so a
+        // that lands anywhere else is *handled* like any other request — which
+        // under `credential_action=block` means refused, not forwarded — so a
         // probe must establish that it is talking to an adjudicating proxy
-        // *before* it sends anything sensitive.
+        // before it sends anything sensitive. Those other handlers still mark
+        // the record with the correlation id (AAASM-5358), because a refusal
+        // there is a real refusal of synthetic traffic and a consumer has to be
+        // able to exclude it.
         if let Some(correlation) = req.header(PROBE_CORRELATION_HEADER).and_then(ProbeCorrelation::parse) {
             let (audit_decision, forwarded_is_clean) = match verdict.decision {
                 VerdictDecision::Block => (ProxyAuditDecision::Blocked, None),
@@ -1088,9 +1133,11 @@ impl ProxyServer {
             // marker each probe run would contribute a prevented transmission
             // indistinguishable from a real leak that was stopped.
             self.decision_record(
-                host,
-                &req.method,
-                &req.target,
+                RequestIdentity {
+                    host,
+                    method: &req.method,
+                    target: &req.target,
+                },
                 &verdict,
                 audit_decision,
                 execution,
@@ -1110,12 +1157,15 @@ impl ProxyServer {
                 "credential_action=Block: refusing forward, returning 403",
             );
             self.emit_audit_entry(
-                host,
-                &req.method,
-                &req.target,
+                RequestIdentity {
+                    host,
+                    method: &req.method,
+                    target: &req.target,
+                },
                 &verdict,
                 ProxyAuditDecision::Blocked,
                 transmission_evidence::not_forwarded(verdict.decision, self.config.credential_action),
+                Self::probe_correlation(&req),
             )
             .await;
             let mut client_tls = client_reader.into_inner();
@@ -1133,11 +1183,14 @@ impl ProxyServer {
         let authorized = self
             .record_forwarding(
                 self.observe_forwarding(&verdict),
-                host,
-                &req.method,
-                &req.target,
+                RequestIdentity {
+                    host,
+                    method: &req.method,
+                    target: &req.target,
+                },
                 &verdict,
                 Self::forwarding_audit_decision(verdict.decision),
+                Self::probe_correlation(&req),
             )
             .await;
 
@@ -1506,12 +1559,15 @@ impl ProxyServer {
                     "plain-HTTP credential_action=Block: refusing forward, returning 403",
                 );
                 self.emit_audit_entry(
-                    deny_host,
-                    method,
-                    target,
+                    RequestIdentity {
+                        host: deny_host,
+                        method,
+                        target,
+                    },
                     &scanned,
                     ProxyAuditDecision::Blocked,
                     execution,
+                    Self::probe_correlation_plain(&headers),
                 )
                 .await;
                 self.interceptor.emit_policy_decision(deny_host, true).await;
@@ -1554,11 +1610,14 @@ impl ProxyServer {
             Some(verdict) => {
                 self.record_forwarding(
                     self.observe_forwarding(verdict),
-                    deny_host,
-                    method,
-                    target,
+                    RequestIdentity {
+                        host: deny_host,
+                        method,
+                        target,
+                    },
                     verdict,
                     Self::forwarding_audit_decision(verdict.decision),
+                    Self::probe_correlation_plain(&headers),
                 )
                 .await
             }
@@ -2324,12 +2383,15 @@ mod tests {
         let execution = server.observe_forwarding(&verdict).evidence();
         server
             .emit_audit_entry(
-                "api.example.com",
-                &req.method,
-                &req.target,
+                RequestIdentity {
+                    host: "api.example.com",
+                    method: &req.method,
+                    target: &req.target,
+                },
                 &verdict,
                 ProxyAuditDecision::Forwarded,
                 execution,
+                None,
             )
             .await;
 

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -2626,7 +2626,12 @@ mod tests {
         .await;
         let _ = upstream_task.await;
 
-        let entry = audit_rx.try_recv().expect("the redaction persisted a decision record");
+        // A redaction *forwards* the scrubbed bytes, so this is a forwarding
+        // case and the count belongs here too. Reading the first entry would
+        // leave a false `NotForwarded` on this path invisible to it — and
+        // "the count is covered by four siblings on the same path" is exactly
+        // the reasoning that has already failed on this PR.
+        let entry = take_single_forwarding_record(&mut audit_rx).await;
         assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
         assert_eq!(
             entry.execution.transmission.as_str(),

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -508,25 +508,24 @@ impl ProxyServer {
     /// integration tests to redirect the dial to a local mock without
     /// hijacking DNS or modifying the client's CONNECT line.
     ///
-    /// `_authorized` is the AAASM-5358 invariant, not a parameter this function
-    /// reads: a [`ForwardAuthorized`] can only be obtained from
-    /// [`transmission_evidence::forwarded`], which issues it together with
-    /// evidence that the bytes went. A branch that recorded non-transmission
-    /// has no way to produce one, so the ordering "evidence first, wire second"
-    /// is a property of the call graph rather than of where a line happens to
-    /// sit.
+    /// `authorized` is the AAASM-5358 invariant rather than an input: it is
+    /// passed straight down to [`Self::connect_revalidated`], which is the
+    /// shared bottom of every route to the wire. A [`ForwardAuthorized`] can
+    /// only come from [`ForwardObservation::persist`], so reaching this
+    /// function at all means the observation it was minted with has already
+    /// been recorded.
     async fn dial_upstream_tls(
         self: &Arc<Self>,
         host: &str,
         target: &str,
-        _authorized: ForwardAuthorized,
+        authorized: ForwardAuthorized,
     ) -> Result<tokio_rustls::client::TlsStream<TcpStream>, ProxyError> {
         let upstream_tcp = match self.config.upstream_override {
             // Integration-test path: the dial is redirected to a trusted local
             // mock, so the SSRF re-validation below would (correctly) reject it.
             // Skip it here; the override is never set in production.
             Some(addr) => TcpStream::connect(addr).await?,
-            None => self.connect_revalidated(target, _authorized).await?,
+            None => self.connect_revalidated(target, authorized).await?,
         };
         let client_config = if self.config.skip_upstream_tls_verify {
             // Integration-test-only path: skip certificate verification so tests
@@ -566,11 +565,11 @@ impl ProxyServer {
     async fn dial_upstream_plain(
         &self,
         upstream_addr: &str,
-        _authorized: ForwardAuthorized,
+        authorized: ForwardAuthorized,
     ) -> Result<TcpStream, ProxyError> {
         match self.config.upstream_override {
             Some(addr) => Ok(TcpStream::connect(addr).await?),
-            None => self.connect_revalidated(upstream_addr, _authorized).await,
+            None => self.connect_revalidated(upstream_addr, authorized).await,
         }
     }
 

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -2480,6 +2480,35 @@ mod tests {
         format!("{{\"token\":\"{EVIDENCE_TEST_SECRET}\"}}")
     }
 
+    /// Take the one decision record a forwarded request must leave, asserting
+    /// there is exactly one.
+    ///
+    /// `try_recv` on its own reads only the *first* entry, so a false
+    /// `NotForwarded` line emitted alongside the true record — the additive
+    /// drift, and the one that corrupts the metric because consumers count
+    /// lines rather than first-lines — passed unnoticed. These tests run
+    /// against a live upstream, so the count is asserted where the bytes
+    /// genuinely went.
+    async fn take_single_forwarding_record(rx: &mut mpsc::Receiver<ProxyAuditEntry>) -> ProxyAuditEntry {
+        let first = rx.try_recv().expect("the forward persisted a decision record");
+        // Let any additional emission land before concluding there is none.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        let mut extra = Vec::new();
+        while let Ok(entry) = rx.try_recv() {
+            extra.push(entry);
+        }
+        assert!(
+            extra.is_empty(),
+            "a forwarded request wrote {} extra record(s): {extra:#?}",
+            extra.len()
+        );
+        assert!(
+            !first.execution.establishes_non_transmission(),
+            "a forwarded request left a record claiming the payload was withheld: {first:#?}"
+        );
+        first
+    }
+
     fn credential_post(target: &str, host: &str) -> String {
         credential_post_with(target, host, &unscrubbable_body())
     }
@@ -2557,7 +2586,7 @@ mod tests {
         .await;
         let _ = upstream_task.await;
 
-        let entry = audit_rx.try_recv().expect("the redaction persisted a decision record");
+        let entry = take_single_forwarding_record(&mut audit_rx).await;
         assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
         assert!(
             !entry.credential_findings.is_empty(),
@@ -2748,9 +2777,7 @@ mod tests {
         .await;
         let _ = upstream_task.await;
 
-        let entry = audit_rx
-            .try_recv()
-            .expect("an alert-mode detection that was forwarded must still be recorded");
+        let entry = take_single_forwarding_record(&mut audit_rx).await;
         assert_eq!(entry.decision, ProxyAuditDecision::Forwarded);
         assert!(
             !entry.credential_findings.is_empty(),
@@ -2790,7 +2817,7 @@ mod tests {
         .await;
         let _ = upstream_task.await;
 
-        let entry = audit_rx.try_recv().expect("the redaction persisted a decision record");
+        let entry = take_single_forwarding_record(&mut audit_rx).await;
         // Non-vacuity: this is the dirty branch, and the record has content.
         assert_eq!(
             entry.execution.transmission.as_str(),
@@ -2828,7 +2855,7 @@ mod tests {
         .await;
         let _ = upstream_task.await;
 
-        let entry = audit_rx.try_recv().expect("the redaction persisted a decision record");
+        let entry = take_single_forwarding_record(&mut audit_rx).await;
         assert_eq!(entry.execution.transmission.as_str(), "forwarded_clean");
         let body = entry.redacted_body.expect("a clean scrub is persisted");
         assert!(body.contains("[REDACTED:"), "got {body}");

--- a/aa-proxy/src/transmission_evidence.rs
+++ b/aa-proxy/src/transmission_evidence.rs
@@ -13,13 +13,27 @@
 //!
 //! # The invariant this module exists to make structural
 //!
-//! [`ForwardAuthorized`] has a private field and is minted by exactly one
-//! function — [`forwarded`]. [`ProxyServer::dial_upstream_tls`] and the
-//! plain-HTTP dial take one by value. So **no code path can reach the wire
-//! while holding evidence that says the payload was withheld**: the key to the
-//! dial is only issued together with evidence that says the opposite. That is a
-//! compile-time property of the call graph, not a timing coincidence a test has
-//! to chase.
+//! Every route to the wire — [`ProxyServer::dial_upstream_tls`], the plain-HTTP
+//! dial, and the transparent tunnel — takes a [`ForwardAuthorized`] by value.
+//! That token has a private field and is minted in exactly one place:
+//! [`ForwardObservation::persist`], **after** the observation it was created
+//! with has been handed to the sink.
+//!
+//! The binding matters more than the unforgeability. An earlier shape issued
+//! the token alongside the evidence and left the two separable, so a branch
+//! could hold a genuine token, persist some *other* evidence — say a
+//! hand-built `NotForwarded` — and still dial: a manufactured prevented
+//! transmission for bytes that went on the wire, with nothing to catch it.
+//! `persist` closes that by never taking evidence as a parameter. The caller
+//! supplies the identifying fields of the record; the evidence written is the
+//! observation's own. So the record that reaches the sink and the
+//! authorization that reaches the dial necessarily describe the same
+//! observation.
+//!
+//! What this does **not** claim: it does not stop a branch from writing an
+//! unrelated second record through [`ProxyServer::emit_audit_entry`], which the
+//! refusal branches still need. It guarantees that *the record a dial was
+//! authorized by* says the bytes went.
 //!
 //! # Naming rule
 //!
@@ -31,21 +45,133 @@
 //! attribute its non-transmission to the policy.
 //!
 //! [`ProxyServer::dial_upstream_tls`]: crate::proxy::ProxyServer
+//! [`ProxyServer::emit_audit_entry`]: crate::proxy::ProxyServer
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::sync::mpsc;
 
 use aa_core::policy::EnforcementMode;
 use aa_core::types::sensitive_data::{EnforcementPoint, ExecutionEvidence, TransmissionEvidence};
+use aa_security::CredentialFinding;
 
+use crate::audit_jsonl::{record_dropped_entry, ProxyAuditDecision, ProxyAuditEntry};
 use crate::config::CredentialAction;
 use crate::intercept::VerdictDecision;
 
 /// Permission to dial upstream for one request.
 ///
 /// Carries no data: its whole value is that it cannot be constructed outside
-/// this module, and the only function that produces one — [`forwarded`] — also
-/// produces evidence that the bytes were forwarded. A branch that observed
-/// non-transmission therefore has no way to obtain one.
+/// this module, and the only place that produces one is
+/// [`ForwardObservation::persist`], after that observation has been handed to
+/// the sink. A branch that observed non-transmission has no way to obtain one,
+/// and a branch that persisted a *different* observation has no way to obtain
+/// one either.
 #[must_use = "a dial authorization exists only to be handed to the dial it authorizes"]
 pub struct ForwardAuthorized(());
+
+/// The identifying half of a decision record: everything a
+/// [`ProxyAuditEntry`] carries **except** the execution evidence.
+///
+/// The evidence is deliberately absent. It is supplied by the observation that
+/// persists the record, so no caller is in a position to pair one observation's
+/// authorization with another observation's evidence.
+pub struct DecisionRecord {
+    /// Target host, no port.
+    pub host: String,
+    /// HTTP method of the intercepted request.
+    pub method: String,
+    /// Request target, **already redacted** by the caller (AAASM-4738).
+    pub path: String,
+    /// What the proxy resolved to do.
+    pub decision: ProxyAuditDecision,
+    /// Per-match scanner output.
+    pub findings: Vec<CredentialFinding>,
+    /// Post-scan body, when the caller has one it is willing to persist.
+    pub redacted_body: Option<String>,
+    /// Correlation id when this request was a protection probe's own traffic.
+    ///
+    /// Probe traffic is synthetic: its refusals are real refusals of a request
+    /// that was never going to be a leak. A consumer computing a prevention
+    /// rate has to be able to exclude it, and can only do that if the record
+    /// says so (AAASM-5359/5360).
+    pub probe_correlation: Option<String>,
+}
+
+impl DecisionRecord {
+    /// Attach `execution` and hand the finished entry to the sink.
+    ///
+    /// `try_send` rather than `send`: a slow JSONL writer must not stall an
+    /// intercepted request. Drops are counted so a lossy period is visible
+    /// rather than inferred from a gap.
+    pub(crate) fn send(self, sink: Option<&mpsc::Sender<ProxyAuditEntry>>, execution: ExecutionEvidence) {
+        let Some(tx) = sink else { return };
+        let ts_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        let entry = ProxyAuditEntry {
+            ts_ms,
+            agent_id: None,
+            host: self.host,
+            method: self.method,
+            path: self.path,
+            decision: self.decision,
+            execution,
+            probe_correlation: self.probe_correlation,
+            credential_findings: self.findings,
+            redacted_body: self.redacted_body,
+        };
+        if let Err(e) = tx.try_send(entry) {
+            let dropped = record_dropped_entry();
+            tracing::warn!(
+                error = %e,
+                dropped_total = dropped,
+                "proxy audit jsonl channel full or closed, dropping entry",
+            );
+        }
+    }
+}
+
+/// An observation that the proxy resolved to forward these bytes, not yet
+/// recorded.
+///
+/// Produced only by [`forwarded`]. Holds its evidence privately and offers no
+/// way to extract the dial authorization except through
+/// [`persist`](Self::persist).
+#[must_use = "an unpersisted forwarding observation is an unrecorded decision, and yields no dial key"]
+pub struct ForwardObservation {
+    evidence: ExecutionEvidence,
+}
+
+impl ForwardObservation {
+    /// What was observed. Read-only — for logging and assertions, never as an
+    /// input to the record.
+    pub fn evidence(&self) -> ExecutionEvidence {
+        self.evidence
+    }
+
+    /// Persist this observation and take the key to the wire.
+    ///
+    /// `record` is `None` for a branch with no decision event to write — a
+    /// clean body decided nothing, and inventing an event for it would change
+    /// what the audit trail counts. The key is issued either way, because the
+    /// invariant is about *what a persisted record says*, not about forcing a
+    /// record to exist for traffic there was no decision about.
+    ///
+    /// The evidence written is [`self.evidence`](Self::evidence). It is not a
+    /// parameter, and that is the whole point.
+    pub fn persist(
+        self,
+        sink: Option<&mpsc::Sender<ProxyAuditEntry>>,
+        record: Option<DecisionRecord>,
+    ) -> ForwardAuthorized {
+        if let Some(record) = record {
+            record.send(sink, self.evidence);
+        }
+        ForwardAuthorized(())
+    }
+}
 
 /// The enforcement mode the observed decision was actually taken under.
 ///
@@ -129,8 +255,11 @@ pub const fn terminated_by_probe_protocol(decision: VerdictDecision, action: Cre
     )
 }
 
-/// Evidence for bytes the proxy resolved to forward, plus the authorization to
-/// dial.
+/// Observe that the proxy resolved to forward these bytes.
+///
+/// Returns the observation, not a dial key: the key comes from
+/// [`ForwardObservation::persist`], so the only route to the wire runs through
+/// having recorded this observation.
 ///
 /// `reinspection` is `Some(true)` when the bytes that will go were re-scanned
 /// and found free of credentials, `Some(false)` when they still carry one, and
@@ -146,23 +275,23 @@ pub const fn terminated_by_probe_protocol(decision: VerdictDecision, action: Cre
 /// that is the only direction that is safe: an over-stated transmission can
 /// never turn a forwarded action into a prevented one, whereas the converse
 /// would invent a block that never happened.
-#[must_use = "the authorization is the only key to the dial this evidence describes"]
 pub fn forwarded(
     decision: VerdictDecision,
     action: CredentialAction,
     reinspection: Option<bool>,
-) -> (ExecutionEvidence, ForwardAuthorized) {
+) -> ForwardObservation {
     let transmission = match reinspection {
         Some(true) => TransmissionEvidence::ForwardedClean,
         Some(false) => TransmissionEvidence::ForwardedCarryingSensitiveValue,
         None => TransmissionEvidence::ForwardedNotInspected,
     };
-    let evidence = ExecutionEvidence::new(
-        EnforcementPoint::PreTransmission,
-        transmission,
-        observed_mode(decision, action),
-    );
-    (evidence, ForwardAuthorized(()))
+    ForwardObservation {
+        evidence: ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            transmission,
+            observed_mode(decision, action),
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -191,7 +320,7 @@ mod tests {
         for decision in DECISIONS {
             for action in ACTIONS {
                 for reinspection in [Some(true), Some(false), None] {
-                    let (evidence, _authorized) = forwarded(decision, action, reinspection);
+                    let evidence = forwarded(decision, action, reinspection).evidence();
                     assert!(
                         !evidence.transmission.proves_non_transmission(),
                         "{decision:?}/{action:?}/{reinspection:?} authorized a dial while claiming the payload was withheld"
@@ -214,11 +343,12 @@ mod tests {
     /// a transformed transmission.
     #[test]
     fn a_clean_redaction_records_transmitted_not_prevented() {
-        let (evidence, _authorized) = forwarded(
+        let evidence = forwarded(
             VerdictDecision::ForwardRedacted,
             CredentialAction::RedactOnly,
             Some(true),
-        );
+        )
+        .evidence();
         assert_eq!(evidence.transmission, TransmissionEvidence::ForwardedClean);
         assert!(evidence.transmission.proves_transmission());
         assert!(!evidence.establishes_non_transmission());
@@ -228,11 +358,12 @@ mod tests {
     /// evidence is about the bytes, not about what the decision meant to do.
     #[test]
     fn a_redaction_that_did_not_scrub_records_the_payload_still_carrying_a_value() {
-        let (evidence, _authorized) = forwarded(
+        let evidence = forwarded(
             VerdictDecision::ForwardRedacted,
             CredentialAction::RedactOnly,
             Some(false),
-        );
+        )
+        .evidence();
         assert_eq!(
             evidence.transmission,
             TransmissionEvidence::ForwardedCarryingSensitiveValue
@@ -243,7 +374,7 @@ mod tests {
     /// An uninspected payload must never read as clean.
     #[test]
     fn an_uninspected_forward_says_so() {
-        let (evidence, _authorized) = forwarded(VerdictDecision::Forward, CredentialAction::RedactOnly, None);
+        let evidence = forwarded(VerdictDecision::Forward, CredentialAction::RedactOnly, None).evidence();
         assert_eq!(evidence.transmission, TransmissionEvidence::ForwardedNotInspected);
     }
 
@@ -344,7 +475,7 @@ mod tests {
             for action in ACTIONS {
                 out.push(not_forwarded(decision, action).enforcement_point);
                 out.push(terminated_by_probe_protocol(decision, action).enforcement_point);
-                out.push(forwarded(decision, action, Some(true)).0.enforcement_point);
+                out.push(forwarded(decision, action, Some(true)).evidence().enforcement_point);
             }
         }
         out

--- a/aa-proxy/src/transmission_evidence.rs
+++ b/aa-proxy/src/transmission_evidence.rs
@@ -34,8 +34,12 @@
 //!   was no decision about would change what the audit trail counts.
 //! * It does not stop a branch writing an *additional* record through
 //!   [`ProxyServer::emit_audit_entry`], which the refusal branches need. That
-//!   gap is covered by tests asserting one record per forwarded request, not by
-//!   the type system.
+//!   gap is covered by tests, not by the type system — and the tests have to
+//!   count records on a **successful** forward as well as a failed dial. A
+//!   first draft of them asserted the count only where the upstream dial
+//!   failed, so a false record emitted after the dial sat outside the window
+//!   entirely: the assertion was right and the fixture had scoped it to the
+//!   case where no bytes went.
 //! * The earlier shape it replaces issued the token alongside the evidence and
 //!   left the two separable, so a branch could hold a genuine token, persist a
 //!   hand-built `NotForwarded`, and still dial — a manufactured prevented

--- a/aa-proxy/src/transmission_evidence.rs
+++ b/aa-proxy/src/transmission_evidence.rs
@@ -16,24 +16,30 @@
 //! Every route to the wire — [`ProxyServer::dial_upstream_tls`], the plain-HTTP
 //! dial, and the transparent tunnel — takes a [`ForwardAuthorized`] by value.
 //! That token has a private field and is minted in exactly one place:
-//! [`ForwardObservation::persist`], **after** the observation it was created
-//! with has been handed to the sink.
+//! [`ForwardObservation::persist`].
 //!
-//! The binding matters more than the unforgeability. An earlier shape issued
-//! the token alongside the evidence and left the two separable, so a branch
-//! could hold a genuine token, persist some *other* evidence — say a
-//! hand-built `NotForwarded` — and still dial: a manufactured prevented
-//! transmission for bytes that went on the wire, with nothing to catch it.
-//! `persist` closes that by never taking evidence as a parameter. The caller
-//! supplies the identifying fields of the record; the evidence written is the
-//! observation's own. So the record that reaches the sink and the
-//! authorization that reaches the dial necessarily describe the same
-//! observation.
+//! Stated precisely, because an earlier draft of this paragraph bound the
+//! guarantee one step earlier than the code does: **when a decision record is
+//! written for a forwarded request, it carries that observation's own
+//! evidence.** `persist` never takes evidence as a parameter — the caller
+//! supplies the identifying fields and the evidence comes from `self` — so a
+//! branch cannot record one observation and authorize a dial with another.
 //!
-//! What this does **not** claim: it does not stop a branch from writing an
-//! unrelated second record through [`ProxyServer::emit_audit_entry`], which the
-//! refusal branches still need. It guarantees that *the record a dial was
-//! authorized by* says the bytes went.
+//! Three things this deliberately does **not** say:
+//!
+//! * `persist` mints the token even when no record is written
+//!   (`record: None`), and that is the *common* path, not an edge case: a clean
+//!   `Forward` decides nothing, and the transparent tunnel and bodyless
+//!   plain-HTTP requests inspect nothing. Inventing an event for traffic there
+//!   was no decision about would change what the audit trail counts.
+//! * It does not stop a branch writing an *additional* record through
+//!   [`ProxyServer::emit_audit_entry`], which the refusal branches need. That
+//!   gap is covered by tests asserting one record per forwarded request, not by
+//!   the type system.
+//! * The earlier shape it replaces issued the token alongside the evidence and
+//!   left the two separable, so a branch could hold a genuine token, persist a
+//!   hand-built `NotForwarded`, and still dial — a manufactured prevented
+//!   transmission for bytes that went on the wire.
 //!
 //! # Naming rule
 //!
@@ -55,7 +61,7 @@ use aa_core::policy::EnforcementMode;
 use aa_core::types::sensitive_data::{EnforcementPoint, ExecutionEvidence, TransmissionEvidence};
 use aa_security::CredentialFinding;
 
-use crate::audit_jsonl::{record_dropped_entry, ProxyAuditDecision, ProxyAuditEntry};
+use crate::audit_jsonl::{bound_persisted_findings, record_dropped_entry, ProxyAuditDecision, ProxyAuditEntry};
 use crate::config::CredentialAction;
 use crate::intercept::VerdictDecision;
 
@@ -63,10 +69,12 @@ use crate::intercept::VerdictDecision;
 ///
 /// Carries no data: its whole value is that it cannot be constructed outside
 /// this module, and the only place that produces one is
-/// [`ForwardObservation::persist`], after that observation has been handed to
-/// the sink. A branch that observed non-transmission has no way to obtain one,
-/// and a branch that persisted a *different* observation has no way to obtain
-/// one either.
+/// [`ForwardObservation::persist`]. A branch that observed non-transmission has
+/// no way to obtain one, and a branch that writes a record through `persist`
+/// cannot choose evidence other than the observation's own.
+///
+/// It does **not** follow that holding one implies a record exists: `persist`
+/// issues the token whether or not a record accompanies the observation.
 #[must_use = "a dial authorization exists only to be handed to the dial it authorizes"]
 pub struct ForwardAuthorized(());
 
@@ -110,6 +118,10 @@ impl DecisionRecord {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as i64;
+        // ADR 0032 §9: byte offsets belong to the tamper-evident tier, which
+        // this sink is not. The projection drops them, and the cap keeps one
+        // pathological body from becoming a line of hundreds of megabytes.
+        let (credential_findings, findings_omitted) = bound_persisted_findings(&self.findings);
         let entry = ProxyAuditEntry {
             ts_ms,
             agent_id: None,
@@ -119,7 +131,8 @@ impl DecisionRecord {
             decision: self.decision,
             execution,
             probe_correlation: self.probe_correlation,
-            credential_findings: self.findings,
+            credential_findings,
+            findings_omitted,
             redacted_body: self.redacted_body,
         };
         if let Err(e) = tx.try_send(entry) {
@@ -297,6 +310,53 @@ pub fn forwarded(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::audit_jsonl::dropped_entries;
+
+    fn record(host: &str) -> DecisionRecord {
+        DecisionRecord {
+            host: host.to_owned(),
+            method: "POST".to_owned(),
+            path: "/v1/do".to_owned(),
+            decision: ProxyAuditDecision::ForwardedRedacted,
+            findings: Vec::new(),
+            redacted_body: None,
+            probe_correlation: None,
+        }
+    }
+
+    /// A record lost to a full channel has to be countable, not merely logged —
+    /// a prevention rate computed over a silently lossy window is not
+    /// authoritative. Exercised through a **real** drop rather than by calling
+    /// the counter, so the wiring between `send` and the counter is what is
+    /// under test.
+    #[tokio::test]
+    async fn a_record_lost_to_a_full_channel_increments_the_counter() {
+        let (tx, _rx) = mpsc::channel(1);
+        let evidence = forwarded(VerdictDecision::Forward, CredentialAction::RedactOnly, Some(true));
+
+        let before = dropped_entries();
+        // First fills the single slot and is *not* a drop.
+        record("first.example").send(Some(&tx), evidence.evidence());
+        assert_eq!(
+            dropped_entries(),
+            before,
+            "a record that fit in the channel must not count as dropped"
+        );
+
+        // Second has nowhere to go.
+        record("second.example").send(Some(&tx), evidence.evidence());
+        assert_eq!(dropped_entries(), before + 1, "a dropped record must be counted");
+    }
+
+    /// No sink configured is not a drop: there was never a record to lose.
+    #[test]
+    fn an_unconfigured_sink_is_not_counted_as_loss() {
+        let before = dropped_entries();
+        let evidence = forwarded(VerdictDecision::Forward, CredentialAction::RedactOnly, Some(true));
+        record("nowhere.example").send(None, evidence.evidence());
+        assert_eq!(dropped_entries(), before);
+    }
 
     const DECISIONS: [VerdictDecision; 4] = [
         VerdictDecision::Forward,

--- a/aa-proxy/src/transmission_evidence.rs
+++ b/aa-proxy/src/transmission_evidence.rs
@@ -1,0 +1,352 @@
+//! What this proxy *observed* about whether an inspected payload left the
+//! process — recorded as evidence, never as a claim.
+//!
+//! # Why the proxy is one of only two places this can honestly originate
+//!
+//! Across the product "prevented" is almost never provable. The runtime's
+//! `CredentialLeakBlocked` means *redact*, and redaction **forwards** the
+//! scrubbed bytes; its scanner runs on an already-reported event, so it is
+//! post-transmission by construction. The gateway and this proxy are the only
+//! layers that decide **before** the bytes can leave, so they are the only two
+//! that can produce [`TransmissionEvidence::NotForwarded`] truthfully
+//! (ADR 0032 §8).
+//!
+//! # The invariant this module exists to make structural
+//!
+//! [`ForwardAuthorized`] has a private field and is minted by exactly one
+//! function — [`forwarded`]. [`ProxyServer::dial_upstream_tls`] and the
+//! plain-HTTP dial take one by value. So **no code path can reach the wire
+//! while holding evidence that says the payload was withheld**: the key to the
+//! dial is only issued together with evidence that says the opposite. That is a
+//! compile-time property of the call graph, not a timing coincidence a test has
+//! to chase.
+//!
+//! # Naming rule
+//!
+//! Every constructor here is named after what was *observed*, never after what
+//! policy intended. `not_forwarded` says bytes did not go; it does not say the
+//! request was "blocked", because a request can fail to go for reasons that
+//! have nothing to do with a security decision — see
+//! [`terminated_by_probe_protocol`], which is exactly that case and refuses to
+//! attribute its non-transmission to the policy.
+//!
+//! [`ProxyServer::dial_upstream_tls`]: crate::proxy::ProxyServer
+
+use aa_core::policy::EnforcementMode;
+use aa_core::types::sensitive_data::{EnforcementPoint, ExecutionEvidence, TransmissionEvidence};
+
+use crate::config::CredentialAction;
+use crate::intercept::VerdictDecision;
+
+/// Permission to dial upstream for one request.
+///
+/// Carries no data: its whole value is that it cannot be constructed outside
+/// this module, and the only function that produces one — [`forwarded`] — also
+/// produces evidence that the bytes were forwarded. A branch that observed
+/// non-transmission therefore has no way to obtain one.
+#[must_use = "a dial authorization exists only to be handed to the dial it authorizes"]
+pub struct ForwardAuthorized(());
+
+/// The enforcement mode the observed decision was actually taken under.
+///
+/// Derived from the decision rather than read off the configured action,
+/// because the configured action is an intent and the decision is the
+/// observation. The two diverge in both directions:
+///
+/// * `credential_action=alert_only` still yields
+///   [`VerdictDecision::Block`] when a body's `Content-Encoding` cannot be
+///   decoded — the refusal really was applied, so that is `Enforce`, and
+///   reading `Observe` off the configured action would have thrown away a
+///   genuine prevention.
+/// * [`VerdictDecision::AlertAndForward`] is the definition of dry-run: a
+///   finding was recorded and nothing was applied to the payload.
+pub const fn observed_mode(decision: VerdictDecision, action: CredentialAction) -> EnforcementMode {
+    match decision {
+        // The refusal and the rewrite were both applied to the real payload.
+        VerdictDecision::Block | VerdictDecision::ForwardRedacted => EnforcementMode::Enforce,
+        // Findings recorded, payload untouched.
+        VerdictDecision::AlertAndForward => EnforcementMode::Observe,
+        // Nothing was found, so nothing was applied; the regime is whatever the
+        // operator configured.
+        VerdictDecision::Forward => match action {
+            CredentialAction::Block | CredentialAction::RedactOnly => EnforcementMode::Enforce,
+            CredentialAction::AlertOnly => EnforcementMode::Observe,
+        },
+    }
+}
+
+/// Evidence for a branch that returns to the client **without** dialling
+/// upstream.
+///
+/// The strongest observation this product can make: the bytes are still here.
+/// It is sound only because the branches that use it have no dial after them —
+/// and [`ForwardAuthorized`] is what keeps that true as the code changes.
+pub const fn not_forwarded(decision: VerdictDecision, action: CredentialAction) -> ExecutionEvidence {
+    ExecutionEvidence::new(
+        EnforcementPoint::PreTransmission,
+        TransmissionEvidence::NotForwarded,
+        observed_mode(decision, action),
+    )
+}
+
+/// Evidence for a rule that refused the request before any credential verdict
+/// existed: the egress denylist or network allowlist, an in-tunnel forged
+/// `Host`, a plaintext downgrade to an LLM host, or a gateway `tools/call`
+/// deny.
+///
+/// [`EnforcementMode::Enforce`] unconditionally: none of these rules has an
+/// observe mode in this proxy — one that matches is applied, and the 403 (or
+/// JSON-RPC error envelope) written instead of a dial is the proof.
+pub const fn not_forwarded_by_rule() -> ExecutionEvidence {
+    ExecutionEvidence::new(
+        EnforcementPoint::PreTransmission,
+        TransmissionEvidence::NotForwarded,
+        EnforcementMode::Enforce,
+    )
+}
+
+/// Evidence for a request the **probe protocol** terminated, rather than the
+/// policy.
+///
+/// A protection probe's request is answered here and never relayed, whatever
+/// the verdict (see [`crate::probe_adjudication`]). Recording that as
+/// [`TransmissionEvidence::NotForwarded`] would be true about the bytes and a
+/// lie about the cause: under `redact_only` the verdict is transforming, so the
+/// four conditions of ADR 0032 §8 would all hold and a probe would manufacture
+/// a "prevented transmission" for traffic the policy would in fact have
+/// forwarded in redacted form. Every probe run would inflate the one metric the
+/// probe exists to measure.
+///
+/// [`TransmissionEvidence::NotRecorded`] is the honest answer: this path proves
+/// nothing in either direction, and `NotRecorded` is defined so that it never
+/// can. The enforcement point is still recorded, because that part *was*
+/// observed.
+pub const fn terminated_by_probe_protocol(decision: VerdictDecision, action: CredentialAction) -> ExecutionEvidence {
+    ExecutionEvidence::new(
+        EnforcementPoint::PreTransmission,
+        TransmissionEvidence::NotRecorded,
+        observed_mode(decision, action),
+    )
+}
+
+/// Evidence for bytes the proxy resolved to forward, plus the authorization to
+/// dial.
+///
+/// `reinspection` is `Some(true)` when the bytes that will go were re-scanned
+/// and found free of credentials, `Some(false)` when they still carry one, and
+/// `None` when this proxy has no scanner and therefore cannot say. It mirrors
+/// [`Interceptor::forwarded_payload_is_clean`](crate::intercept::Interceptor::forwarded_payload_is_clean)
+/// exactly, and like it is about **bytes, not about the decision**: a redaction
+/// that failed to scrub reports `ForwardedCarryingSensitiveValue` and must not
+/// read as protection.
+///
+/// Recorded at the moment the proxy resolves to forward, which is before the
+/// dial and therefore before transmission is strictly observable. If the dial
+/// or the write then fails, this over-states transmission — deliberately, since
+/// that is the only direction that is safe: an over-stated transmission can
+/// never turn a forwarded action into a prevented one, whereas the converse
+/// would invent a block that never happened.
+#[must_use = "the authorization is the only key to the dial this evidence describes"]
+pub fn forwarded(
+    decision: VerdictDecision,
+    action: CredentialAction,
+    reinspection: Option<bool>,
+) -> (ExecutionEvidence, ForwardAuthorized) {
+    let transmission = match reinspection {
+        Some(true) => TransmissionEvidence::ForwardedClean,
+        Some(false) => TransmissionEvidence::ForwardedCarryingSensitiveValue,
+        None => TransmissionEvidence::ForwardedNotInspected,
+    };
+    let evidence = ExecutionEvidence::new(
+        EnforcementPoint::PreTransmission,
+        transmission,
+        observed_mode(decision, action),
+    );
+    (evidence, ForwardAuthorized(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DECISIONS: [VerdictDecision; 4] = [
+        VerdictDecision::Forward,
+        VerdictDecision::ForwardRedacted,
+        VerdictDecision::Block,
+        VerdictDecision::AlertAndForward,
+    ];
+    const ACTIONS: [CredentialAction; 3] = [
+        CredentialAction::Block,
+        CredentialAction::RedactOnly,
+        CredentialAction::AlertOnly,
+    ];
+
+    /// The invariant the whole module exists for, stated as a sweep: the only
+    /// function that mints a dial authorization can never hand back evidence of
+    /// non-transmission. Because that function is the *only* way to obtain a
+    /// [`ForwardAuthorized`], and the dials take one by value, this is
+    /// equivalent to "no dial happens while claiming the bytes stayed here".
+    #[test]
+    fn authorizing_a_dial_never_yields_non_transmission_evidence() {
+        for decision in DECISIONS {
+            for action in ACTIONS {
+                for reinspection in [Some(true), Some(false), None] {
+                    let (evidence, _authorized) = forwarded(decision, action, reinspection);
+                    assert!(
+                        !evidence.transmission.proves_non_transmission(),
+                        "{decision:?}/{action:?}/{reinspection:?} authorized a dial while claiming the payload was withheld"
+                    );
+                    assert!(
+                        evidence.transmission.proves_transmission(),
+                        "{decision:?}/{action:?}/{reinspection:?} authorized a dial without recording that bytes went"
+                    );
+                    assert!(
+                        !evidence.establishes_non_transmission(),
+                        "{decision:?}/{action:?}/{reinspection:?} would have counted as a prevented transmission"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A successful redaction is the case the `CredentialLeakBlocked` name got
+    /// wrong. The scrubbed bytes *are* forwarded, so the evidence must read as
+    /// a transformed transmission.
+    #[test]
+    fn a_clean_redaction_records_transmitted_not_prevented() {
+        let (evidence, _authorized) = forwarded(
+            VerdictDecision::ForwardRedacted,
+            CredentialAction::RedactOnly,
+            Some(true),
+        );
+        assert_eq!(evidence.transmission, TransmissionEvidence::ForwardedClean);
+        assert!(evidence.transmission.proves_transmission());
+        assert!(!evidence.establishes_non_transmission());
+    }
+
+    /// A redaction that failed to scrub is not protection either — the
+    /// evidence is about the bytes, not about what the decision meant to do.
+    #[test]
+    fn a_redaction_that_did_not_scrub_records_the_payload_still_carrying_a_value() {
+        let (evidence, _authorized) = forwarded(
+            VerdictDecision::ForwardRedacted,
+            CredentialAction::RedactOnly,
+            Some(false),
+        );
+        assert_eq!(
+            evidence.transmission,
+            TransmissionEvidence::ForwardedCarryingSensitiveValue
+        );
+        assert!(!evidence.establishes_non_transmission());
+    }
+
+    /// An uninspected payload must never read as clean.
+    #[test]
+    fn an_uninspected_forward_says_so() {
+        let (evidence, _authorized) = forwarded(VerdictDecision::Forward, CredentialAction::RedactOnly, None);
+        assert_eq!(evidence.transmission, TransmissionEvidence::ForwardedNotInspected);
+    }
+
+    /// The single positive case in the crate: an applied refusal, decided
+    /// before the dial.
+    #[test]
+    fn an_enforced_refusal_is_the_only_shape_that_establishes_non_transmission() {
+        let evidence = not_forwarded(VerdictDecision::Block, CredentialAction::Block);
+        assert_eq!(evidence.transmission, TransmissionEvidence::NotForwarded);
+        assert_eq!(evidence.enforcement_point, EnforcementPoint::PreTransmission);
+        assert!(evidence.establishes_non_transmission());
+    }
+
+    /// A fail-closed refusal under `alert_only` really was applied, so it must
+    /// still count. Reading the mode off the configured action instead of the
+    /// observed decision would have silently discarded this prevention.
+    #[test]
+    fn a_fail_closed_refusal_under_alert_only_is_still_an_applied_refusal() {
+        assert_eq!(
+            observed_mode(VerdictDecision::Block, CredentialAction::AlertOnly),
+            EnforcementMode::Enforce
+        );
+        assert!(not_forwarded(VerdictDecision::Block, CredentialAction::AlertOnly).establishes_non_transmission());
+    }
+
+    /// Dry-run must never produce prevention evidence. `AlertAndForward` is
+    /// the dry-run decision, and it stays `Observe` under every configured
+    /// action — so even if a future branch withheld such a request, the
+    /// evidence could not be counted.
+    #[test]
+    fn an_observed_decision_never_establishes_non_transmission() {
+        for action in ACTIONS {
+            assert_eq!(
+                observed_mode(VerdictDecision::AlertAndForward, action),
+                EnforcementMode::Observe,
+                "a recorded-but-unapplied decision is dry-run whatever the configured action"
+            );
+            assert!(
+                !not_forwarded(VerdictDecision::AlertAndForward, action).establishes_non_transmission(),
+                "a dry-run decision produced prevention evidence under {action:?}"
+            );
+        }
+        assert_eq!(
+            observed_mode(VerdictDecision::Forward, CredentialAction::AlertOnly),
+            EnforcementMode::Observe
+        );
+        assert!(!not_forwarded(VerdictDecision::Forward, CredentialAction::AlertOnly).establishes_non_transmission());
+    }
+
+    /// An egress refusal is applied unconditionally — there is no observe mode
+    /// for the denylist — so it is genuine prevention evidence.
+    #[test]
+    fn a_rule_refusal_establishes_non_transmission() {
+        assert!(not_forwarded_by_rule().establishes_non_transmission());
+    }
+
+    /// The trap this module was written to avoid: a probe under `redact_only`
+    /// satisfies every other condition of ADR 0032 §8, so attributing its
+    /// non-transmission to the policy would let a measurement tool inflate the
+    /// very metric it measures.
+    #[test]
+    fn a_probe_terminated_request_proves_nothing_in_either_direction() {
+        for action in ACTIONS {
+            for decision in DECISIONS {
+                let evidence = terminated_by_probe_protocol(decision, action);
+                assert!(
+                    !evidence.establishes_non_transmission(),
+                    "{decision:?}/{action:?}: the probe protocol, not the policy, withheld these bytes"
+                );
+                assert!(
+                    !evidence.transmission.proves_transmission(),
+                    "{decision:?}/{action:?}: nothing was forwarded either"
+                );
+            }
+        }
+        // Specifically the redacting case, which is the one that would have
+        // passed all four conditions had `NotForwarded` been used.
+        let evidence = terminated_by_probe_protocol(VerdictDecision::ForwardRedacted, CredentialAction::RedactOnly);
+        assert_eq!(evidence.transmission, TransmissionEvidence::NotRecorded);
+        assert_eq!(evidence.mode, EnforcementMode::Enforce);
+    }
+
+    /// Every decision point in this crate is pre-transmission — the proxy
+    /// decides before its own dial, by definition of where it sits. If a
+    /// constructor ever reported otherwise, condition 1 would fail silently.
+    #[test]
+    fn every_constructor_records_a_pre_transmission_decision() {
+        let mut points = alloc_points();
+        points.push(not_forwarded_by_rule().enforcement_point);
+        for point in points {
+            assert_eq!(point, EnforcementPoint::PreTransmission);
+        }
+    }
+
+    fn alloc_points() -> Vec<EnforcementPoint> {
+        let mut out = Vec::new();
+        for decision in DECISIONS {
+            for action in ACTIONS {
+                out.push(not_forwarded(decision, action).enforcement_point);
+                out.push(terminated_by_probe_protocol(decision, action).enforcement_point);
+                out.push(forwarded(decision, action, Some(true)).0.enforcement_point);
+            }
+        }
+        out
+    }
+}

--- a/aa-proxy/tests/mitm_execution_evidence.rs
+++ b/aa-proxy/tests/mitm_execution_evidence.rs
@@ -84,12 +84,51 @@ fn install_crypto() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
-/// An address nothing is listening on: bound to claim it, then dropped.
-async fn dead_upstream() -> SocketAddr {
+/// An upstream that accepts the TCP connection and then closes it, so the
+/// proxy's TLS handshake fails.
+///
+/// Deliberately *not* a bound-then-dropped port: that leaves the address free
+/// for the OS to re-hand to the proxy's own listener, which would point
+/// `upstream_override` at the proxy itself and let the dial succeed — silently
+/// inverting what these tests measure. Holding the listener keeps the address
+/// exclusively ours, and refusing at the TLS layer makes the dial failure
+/// deterministic.
+async fn refusing_upstream() -> SocketAddr {
     let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
     let addr = listener.local_addr().unwrap();
-    drop(listener);
+    tokio::spawn(async move {
+        while let Ok((sock, _)) = listener.accept().await {
+            drop(sock);
+        }
+    });
     addr
+}
+
+/// Drain everything the sink received and assert the request left exactly one
+/// decision record, none of which claims the payload was withheld.
+///
+/// A forwarded request that also produced a `NotForwarded` line is B1's outcome
+/// reached additively — the natural drift, and the one that actually corrupts
+/// the metric, because consumers count lines rather than first-lines. Asserting
+/// only on the first entry cannot see it.
+async fn assert_one_forwarding_record(rx: &mut mpsc::Receiver<ProxyAuditEntry>) -> ProxyAuditEntry {
+    let first = next_entry(rx).await;
+    // Give any additional emission time to land before concluding there is none.
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    let mut extra = Vec::new();
+    while let Ok(entry) = rx.try_recv() {
+        extra.push(entry);
+    }
+    assert!(
+        extra.is_empty(),
+        "a forwarded request wrote {} extra record(s): {extra:#?}",
+        extra.len()
+    );
+    assert!(
+        !first.execution.establishes_non_transmission(),
+        "a forwarded request must not leave a record claiming the payload was withheld: {first:#?}"
+    );
+    first
 }
 
 /// Start a proxy with a live audit sink, and hand back its address plus the
@@ -234,12 +273,12 @@ async fn llm_mitm_refusal_persists_non_transmission_evidence() {
 #[tokio::test]
 async fn llm_mitm_redaction_records_a_transmission_not_a_prevention() {
     let dir = tempfile::tempdir().unwrap();
-    let dead = dead_upstream().await;
+    let dead = refusing_upstream().await;
     let (proxy, mut audit) = start_proxy(CredentialAction::RedactOnly, Some(dead), Vec::new(), dir.path()).await;
 
     let _ = mitm_roundtrip(proxy, LLM_HOST, &post(LLM_HOST, &scrubbable_body())).await;
 
-    let entry = next_entry(&mut audit).await;
+    let entry = assert_one_forwarding_record(&mut audit).await;
     assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
     assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
     assert_eq!(entry.execution.transmission.as_str(), "forwarded_clean");
@@ -256,12 +295,12 @@ async fn llm_mitm_redaction_records_a_transmission_not_a_prevention() {
 #[tokio::test]
 async fn llm_mitm_records_the_forward_before_the_dial_that_fails() {
     let dir = tempfile::tempdir().unwrap();
-    let dead = dead_upstream().await;
+    let dead = refusing_upstream().await;
     let (proxy, mut audit) = start_proxy(CredentialAction::RedactOnly, Some(dead), Vec::new(), dir.path()).await;
 
     let _ = mitm_roundtrip(proxy, LLM_HOST, &post(LLM_HOST, &scrubbable_body())).await;
 
-    let entry = next_entry(&mut audit).await;
+    let entry = assert_one_forwarding_record(&mut audit).await;
     assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
     assert!(
         entry.execution.transmission.proves_transmission(),
@@ -274,12 +313,12 @@ async fn llm_mitm_records_the_forward_before_the_dial_that_fails() {
 #[tokio::test]
 async fn llm_mitm_alert_only_records_an_observed_transmission() {
     let dir = tempfile::tempdir().unwrap();
-    let dead = dead_upstream().await;
+    let dead = refusing_upstream().await;
     let (proxy, mut audit) = start_proxy(CredentialAction::AlertOnly, Some(dead), Vec::new(), dir.path()).await;
 
     let _ = mitm_roundtrip(proxy, LLM_HOST, &post(LLM_HOST, &scrubbable_body())).await;
 
-    let entry = next_entry(&mut audit).await;
+    let entry = assert_one_forwarding_record(&mut audit).await;
     assert_eq!(entry.decision, ProxyAuditDecision::Forwarded);
     assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
     assert_eq!(entry.execution.mode, aa_core::policy::EnforcementMode::Observe);
@@ -384,7 +423,7 @@ async fn non_llm_mitm_refusal_persists_non_transmission_evidence() {
 #[tokio::test]
 async fn non_llm_mitm_records_the_forward_before_the_dial_that_fails() {
     let dir = tempfile::tempdir().unwrap();
-    let dead = dead_upstream().await;
+    let dead = refusing_upstream().await;
     let (proxy, mut audit) = start_proxy(
         CredentialAction::RedactOnly,
         Some(dead),
@@ -395,7 +434,7 @@ async fn non_llm_mitm_records_the_forward_before_the_dial_that_fails() {
 
     let _ = mitm_roundtrip(proxy, MITM_HOST, &post(MITM_HOST, &scrubbable_body())).await;
 
-    let entry = next_entry(&mut audit).await;
+    let entry = assert_one_forwarding_record(&mut audit).await;
     assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
     assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
     assert_eq!(entry.execution.transmission.as_str(), "forwarded_clean");
@@ -407,7 +446,7 @@ async fn non_llm_mitm_records_the_forward_before_the_dial_that_fails() {
 #[tokio::test]
 async fn non_llm_mitm_alert_only_records_an_observed_transmission() {
     let dir = tempfile::tempdir().unwrap();
-    let dead = dead_upstream().await;
+    let dead = refusing_upstream().await;
     let (proxy, mut audit) = start_proxy(
         CredentialAction::AlertOnly,
         Some(dead),
@@ -418,9 +457,131 @@ async fn non_llm_mitm_alert_only_records_an_observed_transmission() {
 
     let _ = mitm_roundtrip(proxy, MITM_HOST, &post(MITM_HOST, &scrubbable_body())).await;
 
-    let entry = next_entry(&mut audit).await;
+    let entry = assert_one_forwarding_record(&mut audit).await;
     assert_eq!(entry.decision, ProxyAuditDecision::Forwarded);
     assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
     assert_eq!(entry.execution.mode, aa_core::policy::EnforcementMode::Observe);
     assert!(!entry.execution.establishes_non_transmission());
+}
+
+// ── the probe marker on the handlers that do not adjudicate ────────────────
+
+/// `handle_non_llm_mitm` never speaks the probe protocol, but it can still
+/// *receive* a probe — and under `block` it refuses it before any dial,
+/// producing a record that satisfies every ADR 0032 §8 condition. Unmarked,
+/// that is a synthetic prevention indistinguishable from a real one.
+#[tokio::test]
+async fn a_probe_refused_by_the_non_llm_handler_is_marked_synthetic() {
+    let dir = tempfile::tempdir().unwrap();
+    let (proxy, mut audit) = start_proxy(CredentialAction::Block, None, vec![MITM_HOST.to_string()], dir.path()).await;
+
+    let body = scrubbable_body();
+    let correlation = "0123456789abcdef0123456789abcdef";
+    let request = format!(
+        "POST /ingest HTTP/1.1\r\nHost: {MITM_HOST}\r\n\
+         x-agent-assembly-probe: {correlation}\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+    let _ = mitm_roundtrip(proxy, MITM_HOST, &request).await;
+
+    let entry = next_entry(&mut audit).await;
+    // Non-vacuity: this really is the refusal branch, with content.
+    assert_eq!(entry.decision, ProxyAuditDecision::Blocked);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert!(
+        entry.execution.establishes_non_transmission(),
+        "the refusal is genuine — the marker is what makes it excludable"
+    );
+    assert_eq!(
+        entry.probe_correlation.as_deref(),
+        Some(correlation),
+        "a probe refused by the non-LLM handler must still be identifiable as synthetic"
+    );
+}
+
+/// The same gap on the plain-HTTP path.
+#[tokio::test]
+async fn a_probe_refused_by_the_plain_http_handler_is_marked_synthetic() {
+    let dir = tempfile::tempdir().unwrap();
+    let (proxy, mut audit) = start_proxy(CredentialAction::Block, None, Vec::new(), dir.path()).await;
+
+    let body = scrubbable_body();
+    let correlation = "abcdef0123456789abcdef0123456789";
+    let request = format!(
+        "POST http://plain.example.com/ingest HTTP/1.1\r\nHost: plain.example.com\r\n\
+         x-agent-assembly-probe: {correlation}\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+    let mut client = TcpStream::connect(proxy).await.unwrap();
+    client.write_all(request.as_bytes()).await.unwrap();
+    let mut out = Vec::new();
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(3), client.read_to_end(&mut out)).await;
+    assert!(
+        String::from_utf8_lossy(&out).contains("403"),
+        "the probe body must be refused: {:?}",
+        String::from_utf8_lossy(&out)
+    );
+
+    let entry = next_entry(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::Blocked);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert_eq!(entry.probe_correlation.as_deref(), Some(correlation));
+}
+
+// ── the transparent tunnel, the third route to the wire ────────────────────
+
+/// Under the default `llm_only: true` this path carries every non-LLM
+/// connection, and it was the route S6 found ungated. It inspects nothing, so
+/// the honest outcome is that it writes **no** decision event — inventing one
+/// would change what the audit trail counts. Pinned here because nothing
+/// persisted means no other test can catch a regression in it.
+#[tokio::test]
+async fn the_transparent_tunnel_relays_and_records_no_decision_event() {
+    // A plain TCP echo-ish upstream: the tunnel is a raw byte relay, so no TLS.
+    let upstream = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let upstream_addr = upstream.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut sock, _) = upstream.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        let n = sock.read(&mut buf).await.unwrap_or(0);
+        assert!(n > 0, "the tunnel relayed nothing upstream");
+        let _ = sock.write_all(b"pong").await;
+        let _ = sock.shutdown().await;
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    // `llm_only: true` with no `mitm_hosts` entry ⇒ a non-LLM CONNECT is
+    // transparently tunnelled rather than MitM'd.
+    let (proxy, mut audit) = start_proxy(CredentialAction::Block, Some(upstream_addr), Vec::new(), dir.path()).await;
+
+    let mut stream = TcpStream::connect(proxy).await.unwrap();
+    stream
+        .write_all(b"CONNECT plain.example.com:443 HTTP/1.1\r\nHost: plain.example.com:443\r\n\r\n")
+        .await
+        .unwrap();
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.contains("200"), "tunnel not established: {line}");
+    loop {
+        let mut header = String::new();
+        reader.read_line(&mut header).await.unwrap();
+        if header.trim().is_empty() {
+            break;
+        }
+    }
+    // Raw bytes through the tunnel — no TLS, no inspection.
+    let mut stream = reader.into_inner();
+    stream.write_all(b"ping").await.unwrap();
+    let mut out = Vec::new();
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), stream.read_to_end(&mut out)).await;
+    assert_eq!(&out, b"pong", "the tunnel must relay the upstream response");
+
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    assert!(
+        audit.try_recv().is_err(),
+        "the transparent tunnel took no decision, so it must invent no decision event"
+    );
 }

--- a/aa-proxy/tests/mitm_execution_evidence.rs
+++ b/aa-proxy/tests/mitm_execution_evidence.rs
@@ -1,0 +1,426 @@
+//! AAASM-5358: execution evidence on the **HTTPS MitM** paths.
+//!
+//! The unit tests in `proxy::tests` drive `handle_plain_http`, which is the
+//! easiest path to exercise and the one that carries the least traffic. Under
+//! the default `llm_only: true` every real agent request arrives as a CONNECT
+//! tunnel and is handled by `handle_llm_mitm` (LLM patterns) or
+//! `handle_non_llm_mitm` (operator-MitM'd hosts). Those two were previously
+//! pinned by nothing: moving their audit emission back after the dial, or
+//! swapping the evidence they persist, passed the whole suite.
+//!
+//! These tests close that. They need no mock upstream: the refusal cases never
+//! dial, and the forwarding cases deliberately point `upstream_override` at a
+//! bound-then-dropped port so the dial genuinely fails — which is precisely the
+//! condition that distinguishes "recorded before the dial" from "recorded
+//! after".
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{broadcast, mpsc};
+use tokio_rustls::TlsConnector;
+
+use aa_proxy::audit_jsonl::{ProxyAuditDecision, ProxyAuditEntry};
+use aa_proxy::config::{CredentialAction, ProxyConfig};
+use aa_proxy::tls::CaStore;
+use aa_runtime::pipeline::PipelineEvent;
+
+/// Synthetic OpenAI-style key the default scanner detects. Not a real
+/// credential.
+const SECRET: &str = "sk-TESTONLY-NOT-REAL-1234567890abcdef1234567890ab";
+
+/// An LLM-pattern host, so the CONNECT routes to `handle_llm_mitm`.
+const LLM_HOST: &str = "api.openai.com";
+
+/// A non-LLM host the operator has asked to MitM, so the CONNECT routes to
+/// `handle_non_llm_mitm`.
+const MITM_HOST: &str = "hooks.example.com";
+
+/// The test client trusts whatever cert the proxy's MitM presents; cert
+/// validity is covered elsewhere and is not what these tests are about.
+#[derive(Debug)]
+struct AcceptAnyCert;
+
+impl ServerCertVerifier for AcceptAnyCert {
+    fn verify_server_cert(
+        &self,
+        _e: &CertificateDer<'_>,
+        _i: &[CertificateDer<'_>],
+        _n: &ServerName<'_>,
+        _o: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+    fn verify_tls12_signature(
+        &self,
+        _m: &[u8],
+        _c: &CertificateDer<'_>,
+        _d: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+    fn verify_tls13_signature(
+        &self,
+        _m: &[u8],
+        _c: &CertificateDer<'_>,
+        _d: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+fn install_crypto() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+/// An address nothing is listening on: bound to claim it, then dropped.
+async fn dead_upstream() -> SocketAddr {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr
+}
+
+/// Start a proxy with a live audit sink, and hand back its address plus the
+/// receiving end of the sink.
+async fn start_proxy(
+    action: CredentialAction,
+    upstream_override: Option<SocketAddr>,
+    mitm_hosts: Vec<String>,
+    ca_dir: &std::path::Path,
+) -> (SocketAddr, mpsc::Receiver<ProxyAuditEntry>) {
+    install_crypto();
+    let ca = CaStore::load_or_create(ca_dir).await.unwrap();
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let config = ProxyConfig {
+        bind_addr: addr,
+        ca_dir: ca_dir.to_path_buf(),
+        cert_cache_capacity: 8,
+        llm_only: true,
+        mitm_hosts,
+        denied_hosts: Vec::new(),
+        network_allowlist: Vec::new(),
+        skip_upstream_tls_verify: true,
+        credential_action: action,
+        upstream_override,
+        gateway_endpoint: None,
+        mcp_fail_open: false,
+        // The mock/dead upstreams are on loopback, which the SSRF guard would
+        // (correctly) refuse in production.
+        allow_private_connect_targets: true,
+    };
+
+    let (event_tx, _event_rx) = broadcast::channel::<PipelineEvent>(16);
+    let (audit_tx, audit_rx) = mpsc::channel(16);
+    let server = aa_proxy::proxy::ProxyServer::new_with_audit_sink(config, ca, event_tx, Some(audit_tx));
+    tokio::spawn(async move {
+        let _ = server.run().await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+    (addr, audit_rx)
+}
+
+/// Open a CONNECT tunnel, complete the MitM TLS handshake, send `request`, and
+/// return whatever the client saw.
+async fn mitm_roundtrip(proxy: SocketAddr, host: &str, request: &str) -> String {
+    let mut stream = TcpStream::connect(proxy).await.unwrap();
+    let connect = format!("CONNECT {host}:443 HTTP/1.1\r\nHost: {host}:443\r\n\r\n");
+    stream.write_all(connect.as_bytes()).await.unwrap();
+
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.contains("200"), "tunnel not established: {line}");
+    loop {
+        let mut header = String::new();
+        reader.read_line(&mut header).await.unwrap();
+        if header.trim().is_empty() {
+            break;
+        }
+    }
+
+    let client_config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(AcceptAnyCert))
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(client_config));
+    let server_name = ServerName::try_from(host.to_string()).unwrap();
+    let mut tls = connector.connect(server_name, reader.into_inner()).await.unwrap();
+
+    tls.write_all(request.as_bytes()).await.unwrap();
+    let mut out = Vec::new();
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(3), tls.read_to_end(&mut out)).await;
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// A body whose redaction re-inspects clean.
+fn scrubbable_body() -> String {
+    format!("leaking {SECRET} here")
+}
+
+fn post(host: &str, body: &str) -> String {
+    format!(
+        "POST /v1/chat/completions HTTP/1.1\r\nHost: {host}\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body,
+    )
+}
+
+/// Wait briefly for the record: the handler runs in a spawned connection task,
+/// so `try_recv` immediately after the client read can race it.
+async fn next_entry(rx: &mut mpsc::Receiver<ProxyAuditEntry>) -> ProxyAuditEntry {
+    tokio::time::timeout(std::time::Duration::from_secs(3), rx.recv())
+        .await
+        .expect("timed out waiting for the decision record")
+        .expect("the audit sink closed without producing a record")
+}
+
+// ── handle_llm_mitm — the path that carries real agent traffic ──────────────
+
+#[tokio::test]
+async fn llm_mitm_refusal_persists_non_transmission_evidence() {
+    let dir = tempfile::tempdir().unwrap();
+    let (proxy, mut audit) = start_proxy(CredentialAction::Block, None, Vec::new(), dir.path()).await;
+
+    let response = mitm_roundtrip(proxy, LLM_HOST, &post(LLM_HOST, &scrubbable_body())).await;
+    assert!(
+        response.contains("403"),
+        "the request must be refused, got: {response:?}"
+    );
+
+    let entry = next_entry(&mut audit).await;
+    // Non-vacuity first: the record has content, so the assertions below are
+    // being made about something.
+    assert_eq!(entry.decision, ProxyAuditDecision::Blocked);
+    assert_eq!(entry.host, LLM_HOST);
+    assert!(
+        !entry.credential_findings.is_empty(),
+        "a blocked credential body must carry its findings"
+    );
+
+    assert!(
+        entry.execution.establishes_non_transmission(),
+        "a pre-transmission refusal is the only shape that may support a prevention claim, got {:?}",
+        entry.execution
+    );
+    assert_eq!(entry.execution.transmission.as_str(), "not_forwarded");
+    assert!(
+        entry.probe_correlation.is_none(),
+        "ordinary traffic must not look synthetic"
+    );
+
+    let serialized = serde_json::to_string(&entry).unwrap();
+    assert!(
+        !serialized.contains(SECRET),
+        "SECURITY INVARIANT VIOLATED: raw value in the persisted record: {serialized}"
+    );
+}
+
+#[tokio::test]
+async fn llm_mitm_redaction_records_a_transmission_not_a_prevention() {
+    let dir = tempfile::tempdir().unwrap();
+    let dead = dead_upstream().await;
+    let (proxy, mut audit) = start_proxy(CredentialAction::RedactOnly, Some(dead), Vec::new(), dir.path()).await;
+
+    let _ = mitm_roundtrip(proxy, LLM_HOST, &post(LLM_HOST, &scrubbable_body())).await;
+
+    let entry = next_entry(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert_eq!(entry.execution.transmission.as_str(), "forwarded_clean");
+    assert!(entry.execution.transmission.proves_transmission());
+    assert!(
+        !entry.execution.establishes_non_transmission(),
+        "a successful redaction is a transformed transmission, not a prevented one"
+    );
+}
+
+/// The ordering claim on the path that matters. The upstream is a dead port, so
+/// the dial fails — the record must already exist. Moving the emission back
+/// after `dial_upstream_tls` makes this the only test that notices.
+#[tokio::test]
+async fn llm_mitm_records_the_forward_before_the_dial_that_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let dead = dead_upstream().await;
+    let (proxy, mut audit) = start_proxy(CredentialAction::RedactOnly, Some(dead), Vec::new(), dir.path()).await;
+
+    let _ = mitm_roundtrip(proxy, LLM_HOST, &post(LLM_HOST, &scrubbable_body())).await;
+
+    let entry = next_entry(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
+    assert!(
+        entry.execution.transmission.proves_transmission(),
+        "the observation that unlocked the dial must say the bytes went"
+    );
+}
+
+/// `alert_only` on the LLM path: detected, forwarded unchanged, and recorded as
+/// a dry-run transmission that can never be counted as prevention.
+#[tokio::test]
+async fn llm_mitm_alert_only_records_an_observed_transmission() {
+    let dir = tempfile::tempdir().unwrap();
+    let dead = dead_upstream().await;
+    let (proxy, mut audit) = start_proxy(CredentialAction::AlertOnly, Some(dead), Vec::new(), dir.path()).await;
+
+    let _ = mitm_roundtrip(proxy, LLM_HOST, &post(LLM_HOST, &scrubbable_body())).await;
+
+    let entry = next_entry(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::Forwarded);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert_eq!(entry.execution.mode, aa_core::policy::EnforcementMode::Observe);
+    assert!(!entry.execution.establishes_non_transmission());
+    // The unmodified body carried the value, and the proxy says so.
+    assert_eq!(
+        entry.execution.transmission.as_str(),
+        "forwarded_carrying_sensitive_value"
+    );
+}
+
+/// A protection probe's own refusal is real, but synthetic. Without the
+/// correlation marker every probe run under `block` would contribute a
+/// prevented transmission indistinguishable from a real one.
+#[tokio::test]
+async fn a_probe_refusal_is_marked_as_synthetic_traffic() {
+    let dir = tempfile::tempdir().unwrap();
+    let (proxy, mut audit) = start_proxy(CredentialAction::Block, None, Vec::new(), dir.path()).await;
+
+    let body = scrubbable_body();
+    let correlation = "0123456789abcdef0123456789abcdef";
+    let request = format!(
+        "POST /v1/chat/completions HTTP/1.1\r\nHost: {LLM_HOST}\r\n\
+         x-agent-assembly-probe: {correlation}\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+    let _ = mitm_roundtrip(proxy, LLM_HOST, &request).await;
+
+    let entry = next_entry(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::Blocked);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert_eq!(
+        entry.probe_correlation.as_deref(),
+        Some(correlation),
+        "a probe's record must be identifiable as synthetic"
+    );
+    // A real block during a probe is genuinely a refusal, so the evidence is
+    // not weakened — the marker is what lets a consumer exclude it.
+    assert!(entry.execution.establishes_non_transmission());
+}
+
+/// The other probe branches: withheld by the probe protocol, not by policy, so
+/// they claim nothing in either direction.
+#[tokio::test]
+async fn a_probe_under_redact_only_claims_no_prevention() {
+    let dir = tempfile::tempdir().unwrap();
+    let (proxy, mut audit) = start_proxy(CredentialAction::RedactOnly, None, Vec::new(), dir.path()).await;
+
+    let body = scrubbable_body();
+    let correlation = "abcdef0123456789abcdef0123456789";
+    let request = format!(
+        "POST /v1/chat/completions HTTP/1.1\r\nHost: {LLM_HOST}\r\n\
+         x-agent-assembly-probe: {correlation}\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+    let _ = mitm_roundtrip(proxy, LLM_HOST, &request).await;
+
+    let entry = next_entry(&mut audit).await;
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert_eq!(
+        entry.execution.transmission.as_str(),
+        "not_recorded",
+        "the probe protocol withheld these bytes, not the policy"
+    );
+    assert!(
+        !entry.execution.establishes_non_transmission(),
+        "a probe under redact_only must not manufacture a prevented transmission"
+    );
+    assert_eq!(entry.probe_correlation.as_deref(), Some(correlation));
+}
+
+// ── handle_non_llm_mitm — operator-MitM'd hosts ────────────────────────────
+
+#[tokio::test]
+async fn non_llm_mitm_refusal_persists_non_transmission_evidence() {
+    let dir = tempfile::tempdir().unwrap();
+    let (proxy, mut audit) = start_proxy(CredentialAction::Block, None, vec![MITM_HOST.to_string()], dir.path()).await;
+
+    let response = mitm_roundtrip(proxy, MITM_HOST, &post(MITM_HOST, &scrubbable_body())).await;
+    assert!(
+        response.contains("403"),
+        "the request must be refused, got: {response:?}"
+    );
+
+    let entry = next_entry(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::Blocked);
+    assert_eq!(entry.host, MITM_HOST);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert!(entry.execution.establishes_non_transmission());
+    assert_eq!(entry.execution.transmission.as_str(), "not_forwarded");
+
+    let serialized = serde_json::to_string(&entry).unwrap();
+    assert!(
+        !serialized.contains(SECRET),
+        "SECURITY INVARIANT VIOLATED: raw value in the persisted record: {serialized}"
+    );
+}
+
+/// The ordering claim on the non-LLM MitM path.
+#[tokio::test]
+async fn non_llm_mitm_records_the_forward_before_the_dial_that_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let dead = dead_upstream().await;
+    let (proxy, mut audit) = start_proxy(
+        CredentialAction::RedactOnly,
+        Some(dead),
+        vec![MITM_HOST.to_string()],
+        dir.path(),
+    )
+    .await;
+
+    let _ = mitm_roundtrip(proxy, MITM_HOST, &post(MITM_HOST, &scrubbable_body())).await;
+
+    let entry = next_entry(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert_eq!(entry.execution.transmission.as_str(), "forwarded_clean");
+    assert!(!entry.execution.establishes_non_transmission());
+}
+
+/// `alert_only` on the non-LLM MitM path, which is the other place the
+/// detected-but-forwarded numerator comes from.
+#[tokio::test]
+async fn non_llm_mitm_alert_only_records_an_observed_transmission() {
+    let dir = tempfile::tempdir().unwrap();
+    let dead = dead_upstream().await;
+    let (proxy, mut audit) = start_proxy(
+        CredentialAction::AlertOnly,
+        Some(dead),
+        vec![MITM_HOST.to_string()],
+        dir.path(),
+    )
+    .await;
+
+    let _ = mitm_roundtrip(proxy, MITM_HOST, &post(MITM_HOST, &scrubbable_body())).await;
+
+    let entry = next_entry(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::Forwarded);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert_eq!(entry.execution.mode, aa_core::policy::EnforcementMode::Observe);
+    assert!(!entry.execution.establishes_non_transmission());
+}

--- a/aa-proxy/tests/mitm_execution_evidence.rs
+++ b/aa-proxy/tests/mitm_execution_evidence.rs
@@ -18,12 +18,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-use rustls::{DigitallySignedStruct, SignatureScheme};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, ServerConfig, SignatureScheme};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{broadcast, mpsc};
-use tokio_rustls::TlsConnector;
+use tokio_rustls::{TlsAcceptor, TlsConnector};
 
 use aa_proxy::audit_jsonl::{ProxyAuditDecision, ProxyAuditEntry};
 use aa_proxy::config::{CredentialAction, ProxyConfig};
@@ -99,6 +99,50 @@ async fn refusing_upstream() -> SocketAddr {
     tokio::spawn(async move {
         while let Ok((sock, _)) = listener.accept().await {
             drop(sock);
+        }
+    });
+    addr
+}
+
+/// A TLS upstream that completes the handshake and answers 200.
+///
+/// The counterpart to [`refusing_upstream`], and the one the round-2 fix was
+/// missing: every call site of [`assert_one_forwarding_record`] used a failing
+/// dial, so "one record per forwarded request" was only ever asserted for
+/// requests where **no bytes went**. A false record emitted *after* a
+/// successful dial sat outside that window entirely.
+async fn live_tls_upstream() -> SocketAddr {
+    // The upstream builds a rustls `ServerConfig`, which needs the process
+    // crypto provider. It is called before `start_proxy`, which is the other
+    // place that installs it.
+    install_crypto();
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Self-signed leaf; the proxy dials with `skip_upstream_tls_verify`.
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+    let cert_der = CertificateDer::from(cert.cert.der().to_vec());
+    let key_der = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der()));
+    let server_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .unwrap();
+    let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let acceptor = acceptor.clone();
+            tokio::spawn(async move {
+                let Ok(mut tls) = acceptor.accept(stream).await else {
+                    return;
+                };
+                let mut chunk = [0u8; 8192];
+                let _ = tokio::time::timeout(std::time::Duration::from_millis(500), tls.read(&mut chunk)).await;
+                let _ = tls
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                    .await;
+                let _ = tls.shutdown().await;
+            });
         }
     });
     addr
@@ -545,8 +589,10 @@ async fn the_transparent_tunnel_relays_and_records_no_decision_event() {
     tokio::spawn(async move {
         let (mut sock, _) = upstream.accept().await.unwrap();
         let mut buf = [0u8; 1024];
-        let n = sock.read(&mut buf).await.unwrap_or(0);
-        assert!(n > 0, "the tunnel relayed nothing upstream");
+        // No assertion here: this task's handle is never awaited, so a failure
+        // inside it could not fail the test. The `pong` round-trip below is
+        // what proves the relay worked.
+        let _ = sock.read(&mut buf).await;
         let _ = sock.write_all(b"pong").await;
         let _ = sock.shutdown().await;
     });
@@ -584,4 +630,56 @@ async fn the_transparent_tunnel_relays_and_records_no_decision_event() {
         audit.try_recv().is_err(),
         "the transparent tunnel took no decision, so it must invent no decision event"
     );
+}
+
+/// The case the round-2 fix could not reach: a **successful** MitM forward with
+/// a live sink, counted.
+///
+/// Every other `assert_one_forwarding_record` call site uses
+/// [`refusing_upstream`], so the one-record property was only ever asserted
+/// where the dial failed — leaving a false record emitted *after*
+/// `dial_upstream_tls` outside the assertion window. Nothing in the repo drove
+/// a successful MitM forward with an audit sink attached.
+#[tokio::test]
+async fn a_successful_llm_mitm_forward_writes_exactly_one_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let upstream = live_tls_upstream().await;
+    let (proxy, mut audit) = start_proxy(CredentialAction::RedactOnly, Some(upstream), Vec::new(), dir.path()).await;
+
+    let response = mitm_roundtrip(proxy, LLM_HOST, &post(LLM_HOST, &scrubbable_body())).await;
+    // Non-vacuity: the bytes genuinely went and the upstream genuinely answered.
+    assert!(
+        response.contains("200 OK"),
+        "the request must have reached a live upstream, got: {response:?}"
+    );
+
+    let entry = assert_one_forwarding_record(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::ForwardedRedacted);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert!(entry.execution.transmission.proves_transmission());
+}
+
+/// The same, on the non-LLM MitM handler.
+#[tokio::test]
+async fn a_successful_non_llm_mitm_forward_writes_exactly_one_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let upstream = live_tls_upstream().await;
+    let (proxy, mut audit) = start_proxy(
+        CredentialAction::AlertOnly,
+        Some(upstream),
+        vec![MITM_HOST.to_string()],
+        dir.path(),
+    )
+    .await;
+
+    let response = mitm_roundtrip(proxy, MITM_HOST, &post(MITM_HOST, &scrubbable_body())).await;
+    assert!(
+        response.contains("200 OK"),
+        "the request must have reached a live upstream, got: {response:?}"
+    );
+
+    let entry = assert_one_forwarding_record(&mut audit).await;
+    assert_eq!(entry.decision, ProxyAuditDecision::Forwarded);
+    assert!(!entry.credential_findings.is_empty(), "otherwise this asserts nothing");
+    assert_eq!(entry.execution.mode, aa_core::policy::EnforcementMode::Observe);
 }


### PR DESCRIPTION
## Description

`ForwardedPayload::NotForwarded` was the one place in this product where non-transmission is genuinely provable — it is produced in `probe_adjudication.rs` strictly before the sole `dial_upstream_tls` call — and it was computed and thrown away. This PR generalises that observation to every pre-transmission decision point in `aa-proxy` and persists it, in `aa_core`'s `TransmissionEvidence` vocabulary (AAASM-5355, merged `e4297575`), on the proxy's decision record.

Why this matters, restated from the ticket: across the product "prevented" is almost never provable. `CredentialLeakBlocked` means *redact*, and redaction **forwards** the scrubbed bytes. A hard block records as `PolicyViolation`, `alert_only` as `ToolCallIntercepted`. `aa-runtime`'s scanner runs on an already-reported event and is post-transmission by construction. The gateway and this proxy are the only two layers that decide before the bytes can leave, so they are the only two that can produce `NotForwarded` truthfully.

> **Review round 1 changed the shape of this PR.** The first version's headline guarantee was weaker than claimed, and its end-to-end tests covered only the secondary path. Both are fixed here; the sections below state what is guaranteed and what is not. Details in **What review found**, at the end.

### What was added

**`aa-proxy/src/transmission_evidence.rs`** — the observation vocabulary. Every constructor is named after what was *observed*, never after what policy intended:

| Constructor | Records | Establishes non-transmission |
|---|---|---|
| `not_forwarded(decision, action)` | `NotForwarded` | yes, when the decision was applied |
| `not_forwarded_by_rule()` | `NotForwarded` + `Enforce` | yes |
| `forwarded(decision, action, reinspection)` → `ForwardObservation` | `ForwardedClean` / `ForwardedCarryingSensitiveValue` / `ForwardedNotInspected` | never |
| `terminated_by_probe_protocol(decision, action)` | `NotRecorded` | never |

**The structural guarantee, stated precisely.** All three routes to the wire — `dial_upstream_tls`, the plain-HTTP dial, and the transparent tunnel, which share `connect_revalidated` — take a `ForwardAuthorized` by value. That token is minted in exactly one place: `ForwardObservation::persist`, **after** the observation it was created with has been handed to the sink. `persist` takes no evidence parameter; the caller supplies the identifying half of the record (`DecisionRecord`) and the evidence written is the observation's own.

So: **when a decision record is written for a forwarded request, it carries that observation's own evidence.**

Three things that deliberately does *not* say, because an earlier draft of this paragraph bound the guarantee one step earlier than the code does:

- `persist` mints the token even when no record is written (`record: None`), and that is the **common** path, not an edge case — a clean `Forward` decides nothing, and the transparent tunnel and bodyless plain-HTTP inspect nothing. Inventing an event for traffic there was no decision about would change what the audit trail counts.
- It does not stop a branch writing an *additional* record through `emit_audit_entry`, which the refusal branches need. That gap is covered by tests asserting **one record per forwarded request**, counted on a *successful* forward as well as a failed dial (R1c, V3a, V3b) — not by the type system.
- Holding a token does not imply a record exists.

**Decision points now covered** (previously: the probe branch only, and even there discarded)

- `handle_llm_mitm` — in-tunnel egress deny, probe adjudication, credential `Block`, `ForwardRedacted`, `AlertAndForward`, clean `Forward`
- `handle_non_llm_mitm` — in-tunnel egress deny, MCP `tools/call` deny, and the same four credential branches
- `handle_plain_http` — egress deny, plaintext-downgrade-to-LLM refusal, credential `Block`, `ForwardRedacted`, `AlertAndForward`, bodyless forward
- `transparent_tunnel` — relays bytes it never inspected, and now says so before it dials

Credential decisions persist the evidence on `ProxyAuditEntry.execution`, a **required** field with no default.

Egress and MCP refusals are **logged and not persisted** — they refuse before `intercept_request` runs, so there is no sensitive-data decision event to attach evidence to, and synthesising one would invent events the audit trail has never counted. The consequence is real and worth stating plainly rather than glossing: these are the *most* provable preventions the proxy makes, and until a producer exists for them the §8 metric cannot see them. Follow-up work, not something this PR achieves.

### Three judgement calls a reviewer should check

**1. A probe-terminated request records `NotRecorded`, not `NotForwarded`.** A probe's request is answered here and never relayed *whatever the verdict*. Recording that as `NotForwarded` would be true about the bytes and a lie about the cause: under `redact_only` the verdict is transforming, the enforcement point is pre-transmission and the mode is enforce — all four §8 conditions would hold, and every probe run would manufacture a "prevented transmission" for traffic the policy would in fact have forwarded in redacted form. Only a genuine `Block` during a probe is attributed to the policy, and even that record now carries `probe_correlation` so a consumer can exclude synthetic traffic.

**2. `EnforcementMode` is derived from the observed decision, not the configured action.** `intercept_request` returns `Block` for `ScanSource::Uninspectable` regardless of action, so `credential_action=alert_only` still produces a real fail-closed refusal; reading `Observe` off the configured action would have discarded a genuine prevention. Conversely `AlertAndForward` is dry-run whatever the action, and can never establish non-transmission.

**3. `redacted_body` is withheld when re-inspection says the bytes still carry a value.** That branch is exactly where the proxy itself reports the scrubber did not hold, so persisting its output would rest the "no raw value on disk" guarantee on the thing it just distrusted.

**4. `credential_findings` is projected, not stored raw.** `aa_security::CredentialFinding` carries a `pub offset`, and ADR 0032 §9 permits offsets only in the tamper-evident tier — which `audit_jsonl`'s own header says it is not. Since this PR is what first constructs the writer in production, it is what would first put those offsets on disk. `PersistedFinding` carries category and redaction label only. `aa-security` had already drawn this line half-way: `end` is private and `#[serde(skip)]` citing §9, while `offset` stays public and serializes.

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

**Called out explicitly per the ticket's compatibility note, not slipped in.**

**1. The proxy's JSONL audit sink is now constructible in production — opt-in.** The Spike's finding still held on current `main`: `lib.rs:70` called `ProxyServer::new`, which passes `None`, and `new_with_audit_sink` had call sites only in `aa-integration-tests` and unit tests. The standalone binary also drops its `PipelineEvent` broadcast receiver immediately (`main.rs:52`). Every finding, block and redaction the proxy recorded was discarded on process exit, and persisting evidence into that sink would have been vacuous.

`run()` now builds the writer when `AA_PROXY_AUDIT_JSONL_PATH` is set. **Unset reproduces today's behaviour** — no writer, no file, and the data path is untouched because the sink is `None` exactly as before. A configured-but-unopenable path is a hard startup error, raised before the server is constructed: an operator who believes an audit trail exists and has none is the failure mode this work stream is about. The path is deliberately not a `ProxyConfig` field — the sink is a process-lifetime resource (`ProxyServer` is handed a channel `Sender`, never a path).

The file is `0600`, re-asserted on an existing file — the default `0644` would have been world-readable. **File permissions are access control, not ADR 0032 §9's constraint**, so the offsets are additionally kept out of the record entirely (see judgement call 4). Bodies are capped at 8 KiB and the findings list at 256 entries with the remainder counted — `redacted_body` alone does not bound a line, since a densely-matching 64 MiB body yields on the order of a million findings. Entries dropped by `try_send` are counted; **scope stated honestly: the only surfacing today is the running total on each `warn!`, and nothing in the repo reads `dropped_entries()` outside its tests**, so a consumer cannot yet gate a published rate on it. Putting it on the proxy's metrics output is follow-up work. `try_send` plus a spawned writer keeps blocking I/O off the request path.

**2. `ProxyAuditEntry` changes shape**: it gains `execution`, `probe_correlation` and `findings_omitted`, and `credential_findings` becomes `Vec<PersistedFinding>` (category + redaction label, no byte offset). Additive on the write side; a JSONL line written by an older build will not deserialize into the new struct. No in-repo reader parses historical files, and no default was invented because every candidate default would itself be a claim about a record we know nothing about.

**3. Audit entries for forwarding branches are emitted before the dial rather than after it.** A request whose upstream dial fails now leaves a record where it previously left none.

**4. The plain-HTTP path now records alert-mode detections.** It previously wrote a record only for `ForwardedRedacted`, so a cleartext `alert_only` deployment detected a credential, forwarded it, and persisted nothing.

**No change to what the proxy forwards or blocks.** This PR records; it does not enforce.

## Related Issues

- Related Jira ticket: [AAASM-5358](https://lightning-dust-mite.atlassian.net/browse/AAASM-5358) (Wave 4 of Epic [AAASM-5270](https://lightning-dust-mite.atlassian.net/browse/AAASM-5270))
- Builds on AAASM-5355 (`aa_core::types::sensitive_data::TransmissionEvidence`), merged as `e4297575`
- Related GitHub issues: N/A

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

`cargo nextest run -p aa-proxy -p aa-core` — **790 passed, 0 failed, 3 skipped** (the 3 skips are pre-existing `#[ignore]` macOS-keychain tests). All new tests run in the **default** profile; none is behind a feature flag.

`aa-proxy/tests/mitm_execution_evidence.rs` is new: fourteen end-to-end tests driving CONNECT → TLS MitM → in-tunnel HTTP against `handle_llm_mitm` and `handle_non_llm_mitm`. The dial-failure cases point `upstream_override` at a **TLS-refusing upstream** so the dial genuinely fails — the condition that distinguishes "recorded before the dial" from "recorded after" — and two further cases use a **live TLS upstream so the dial completes**, which is where the record *count* has to be asserted.

### Mutation evidence

Every assertion was watched fail. Each mutation was applied to the source, the suite run, and the file restored byte-for-byte.

| # | Mutation | Tests that failed |
|---|---|---|
| **R1** | **the review's B1 attack** — pass hand-built `NotForwarded` evidence to the recorder while dialling with a genuine key | **does not compile** — `record_forwarding` has no evidence parameter (`E0061`) |
| **R1b** | the *replacing* residual — bypass the recorder entirely: write a false `NotForwarded` record via `emit_audit_entry`, take the key from a bare `persist(…, None)` | 3 LLM-MitM tests |
| **R1c** | the ***additive*** residual — production recorder untouched, one extra false `emit_audit_entry(…, not_forwarded(…))` before the dial. **This passed 291/291 before the delta review**: the tests read only the first entry, and this is the more natural drift, since consumers count lines not first-lines | 3 LLM-MitM tests, via the new one-record assertion |
| **R2** | **the review's B2 mutation** — move `handle_llm_mitm`'s emission to after `dial_upstream_tls` | the same three LLM-MitM tests |
| M1 | `terminated_by_probe_protocol` records `NotForwarded` | 3, incl. `a_probe_under_redact_only_claims_no_prevention` |
| M2 | `forwarded()` maps a clean re-inspection to `NotForwarded` | 8, incl. both MitM dial-failure tests |
| M3 | `observed_mode` treats `alert_only` as `Enforce` | 4, incl. both MitM alert-mode tests |
| M4 | `not_forwarded()` records `ForwardedClean` — *the ticket's required "must not pass when the adjudication returns a forwarded variant"* | 7, incl. both MitM refusal tests |
| M5 | **persistence severed** — `DecisionRecord::send` never reaches the sink | **17** |
| M6 | `inspects()` answers `true` even with no scanner | `inspects_distinguishes_a_configured_scanner_from_a_disabled_one` |
| M7 | the plain-HTTP emission moved to after `dial_upstream_plain` | `the_record_exists_even_when_the_upstream_dial_fails` |
| S1 | `forwarding_audit_decision` drops `alert_only` — *the pre-review plain-HTTP bug, reintroduced across all paths* | `an_alert_only_plain_http_detection_…`, `llm_mitm_alert_only_…`, `non_llm_mitm_alert_only_…` |
| S2 | probe records carry no correlation marker | `a_probe_refusal_is_marked_as_synthetic_traffic`, `a_probe_under_redact_only_claims_no_prevention` |
| S4 | `redacted_body` persisted even when re-inspection says it is dirty | `a_body_that_reinspects_dirty_is_not_persisted` |
| S5a | audit file left at the default `0644` | `the_audit_file_is_not_world_readable`, `an_existing_loose_audit_file_is_tightened_on_open` |
| S5b | persisted bodies unbounded | `an_oversized_body_is_truncated_on_a_character_boundary_and_marked` |
| S5c | dropped entries not counted | `dropped_entries_are_counted` |
| **N1** | `PersistedFinding` carries the byte offset again (ADR 0032 §9) | `a_persisted_finding_carries_no_byte_offset` |
| **N2** | the non-LLM MitM handler drops the probe marker — *the pre-review gap* | `a_probe_refused_by_the_non_llm_handler_is_marked_synthetic` |
| **N3** | plain-HTTP drops the probe marker | `a_probe_refused_by_the_plain_http_handler_is_marked_synthetic` |
| **N4** | the findings vector is unbounded again | `an_oversized_finding_list_is_capped_and_the_remainder_counted` |
| **N5** | a real drop does not increment the counter | `a_record_lost_to_a_full_channel_increments_the_counter` |
| **N6** | persistence severed, re-run after the rework | **20** |
| **V3a** | a false `NotForwarded` emitted **after a successful `dial_upstream_tls`** — outside the window the round-2 fix closed. **This passed 791/791**: every one-record call site used a failing dial, so the property was only ever checked where no bytes went | `a_successful_llm_mitm_forward_writes_exactly_one_record` (LLM dial site) / `a_successful_non_llm_mitm_forward_writes_exactly_one_record` (non-LLM) |
| **V3b** | the same on the plain-HTTP forward path, which had **no count assertion at all** and a live upstream. Also passed 791/791 | **5** in-crate plain-HTTP evidence tests |

**Forging the token**, for completeness — the review's correction is exact, all three forms verified:

| Attempt | Error |
|---|---|
| `ForwardAuthorized(())` (type imported) | `E0423` |
| `ForwardAuthorized { 0: () }` | `E0451` |
| `crate::transmission_evidence::ForwardAuthorized(())` | `E0603` |

### Anti-vacuity

Each end-to-end test asserts the record is **non-empty first** — decision, host, non-empty `credential_findings` — and only then makes its security assertion. `M5` re-derives that: with persistence severed, 17 tests fail rather than pass over an empty sink. `a_body_that_reinspects_dirty_is_not_persisted` is paired with `a_body_that_reinspects_clean_is_persisted` as its control, so "not persisted" cannot pass merely because no body is ever persisted.

### Out-of-scope findings (not fixed here — no ticket opened yet)

1. **Re-inspecting a redacted body can flag the redaction marker itself.** `aa-security`'s `GenericHighEntropy` recognizer matches `[REDACTED:GenericHighEntropy]`, so `Interceptor::forwarded_payload_is_clean` returns `Some(false)` for a *correctly* scrubbed payload, depending on the surrounding bytes. This predates the PR and already affects AAASM-5300's probe reply: a well-behaved redacting proxy can report `ForwardedPayload::CarriesCredential` and read as non-protective. Here it surfaces as `forwarded_carrying_sensitive_value` — still transmission, still never prevention, so no metric is inflated — and it now also suppresses `redacted_body`. Both shapes are pinned by test so a future fix has to update them deliberately.
2. **The probe branch's `ProxyAuditDecision` is counterfactual.** It records `Forwarded`/`ForwardedRedacted` for a request that was never relayed. Renaming it is a record-schema change, out of scope; `execution` and `probe_correlation` now carry the truth alongside it.
3. **The proxy binary drops its `PipelineEvent` receiver** (`main.rs:52`), so even the broadcast path has no production subscriber.
4. **Egress/MCP refusals are not persisted** (above) — the proxy's strongest preventions remain invisible to the §8 metric.
5. **The JSONL sink has no rotation or retention.** Bodies are capped per line, but the file grows without bound.

## What review found

Recorded so the fixes are traceable, and because two of the findings generalise.

- **B1 — the token bound the wrong step.** It bound the *call to* `forwarded()`, not the persisted evidence, so a branch could hold a genuine key and persist whatever it liked. Fixed by inverting: the record mints the key. The lesson worth carrying — when a guarantee is called "structural", state precisely which step it binds.
- **B2 — the primary production path was untested.** Every evidence test drove plain HTTP; the HTTPS/LLM path that carries all real traffic was pinned by nothing, and the mutation that mattered compiled and passed the whole suite. Fixed by `mitm_execution_evidence.rs`. The lesson — put the end-to-end assertion on the path that carries the traffic, not the one that is easiest to drive.
- S1, S2, S4, S5, S6, S7 and the nits (test names that said "recorded" while recording nothing, the wrong error code, the wrong test count) are all addressed above.

### Delta review (round 2)

- **B-1 — this PR is what first puts §9 offsets on disk.** Correct, and the mitigation I had reached for (mode 0600) is access control, not the ADR's constraint. Fixed by projection.
- **B-2 — the probe marker covered one handler of three.** `emit_audit_entry` hardcoded `None` and the header was read only in `handle_llm_mitm`. Fixed on all three, and the stale comment claiming a probe elsewhere is "forwarded" is corrected — under `block` it is refused.
- **S-1 — the residual was not closed by test.** The additive variant passed 291/291. This was the second time a coverage claim of mine was stronger than the tests; the fix asserts one record per forwarded request rather than inspecting the first.
- **S-2 — two more doc overclaims binding one step earlier than the code.** `persist(sink, None)` mints a token and writes nothing, and that is the common path. Both the module doc and the token docstring are restated.
- **S-3, S-4** — findings list capped and counted; the counter's reach documented as "counted and logged", not "exported".
- **Nits** — `refusing_upstream` removes the freed-port reuse hazard; the transparent tunnel now has its own test.

### Round-3 delta review

- **V3a / V3b — the one-record assertion was correct and the *fixture* scoped it.** Every call site handed it a failing dial, so a property about *forwarded* requests was only ever checked where nothing was forwarded — and nothing in the repo drove a successful MitM forward with a sink attached. Fixed with `live_tls_upstream` (two new cases, one per handler) and by moving the plain-HTTP tests off `try_recv`. Both variants now fail.
- **Two docstrings still justified `0600` with `CredentialFinding.offset` being on disk** — a fact this PR deleted, and contradicted by `PersistedFinding`'s own docstring. Restated from what the record actually carries.
- **Nit** — an `assert!` inside a never-awaited spawned task could not fail its test; removed.
- **Residual, round 3b** — one forwarding-path test (`a_redaction_whose_bytes_still_reinspect_dirty_says_so`) still read the first entry. A redaction forwards, so it was blind to the same false record V3b plants. Leaving it because four siblings already counted is the "covered elsewhere" reasoning that failed three times here; fixed, and V3b now fails **5** tests rather than 4. Every remaining first-entry read was audited and is a refusal, a failed dial, or a probe-termination — cases where nothing was forwarded and first-entry is correct.

The reviewer's five verification probes (B-1 offset-on-real-file × 3, V3b record-count × 2) pass unmodified against this head.

**A process note, since it is the same class of error.** The delta review's clippy findings were caught by the pre-commit hook, not by me: I had run `cargo clippy -p aa-proxy -p aa-core --all-targets --all-features` and grepped for `^error`, but without `-- -D warnings` the lint was a *warning* and my filter never saw it. Two real lints (`too_many_arguments`, `while_let_loop`) were sitting there. I now run the hook's exact command and check its exit code rather than grepping its output.

Round 3 added a sharper form of the same shape, worth writing down: **the assertion was right and the fixture made it vacuous.** A helper named `assert_one_forwarding_record` that is only ever handed a request which never forwarded is the same category of defect as a `compile_fail` doctest that never runs. The check to apply when adding an assertion is not "is this assertion correct" but *"what has the fixture already made true before it runs?"*

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` clean)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module docs state the invariant *and* its limits; `AA_PROXY_AUDIT_JSONL_PATH` documented on the resolver)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)


[AAASM-5358]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ