### PR TITLE
[AAASM-5357] ✨ (aa-gateway): Add the durable sensitive-data projection

### DIFF
--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -40,6 +40,7 @@ pub mod retention;
 pub mod retention_boot;
 pub mod retention_config;
 pub mod retention_engine;
+pub mod sensitive_data;
 pub mod sqlite;
 pub mod timescale;
 
@@ -61,5 +62,10 @@ pub use retention::{ColdAction, RetentionPolicy, RetentionStats};
 pub use retention_boot::spawn_retention_engine;
 pub use retention_config::{RetentionConfig, RetentionConfigError};
 pub use retention_engine::RetentionEngine;
+pub use sensitive_data::{
+    CategoryFindingAggregate, CategoryTally, ProjectionError, SensitiveDataEventFilter, SensitiveDataEventRow,
+    SensitiveDataFindingRow, SensitiveDataProjection, SensitiveDataProjectionConfig, SensitiveDataProjectionWriter,
+    TenantScope, WriteOutcome,
+};
 pub use sqlite::{SqliteBackend, SqliteConfig};
 pub use timescale::TimescaleStats;

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -289,6 +289,17 @@ impl PostgresBackend {
         })
     }
 
+    /// Borrow the connection pool.
+    ///
+    /// Crate-internal so a sibling module can implement a trait against this
+    /// backend without opening a second pool to the same cluster — used by
+    /// `storage::sensitive_data::postgres` (AAASM-5357), which persists a
+    /// projection that is deliberately not part of
+    /// [`StorageBackend`](super::backend::StorageBackend).
+    pub(crate) fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
     /// Gate the TimescaleDB hypertable setup based on `config.enabled` and
     /// the presence of the `timescaledb` extension on the cluster.
     ///

--- a/aa-gateway/src/storage/sensitive_data/mod.rs
+++ b/aa-gateway/src/storage/sensitive_data/mod.rs
@@ -1,0 +1,86 @@
+//! The durable sensitive-data projection (ADR 0032 §8, AAASM-5357).
+//!
+//! # Why this exists next to the audit bridge rather than inside it
+//!
+//! [`audit_entry_to_storage_event`](crate::storage::audit_entry_to_storage_event)
+//! is lossy in fourteen distinct ways — it keeps no finding, no lineage beyond
+//! `team_id`, no hash-chain metadata, persists the **raw** payload rather than
+//! the redacted one, sets `action` and `decision` from the same source, and
+//! hardcodes `dry_run: false`, `shadow_decision: None`, `matched_rule_id:
+//! None`. ADR 0032 §8 forbids repairing it field by field (forbidden design
+//! #15) and requires the replacement be written *beside* it. Nothing in this
+//! module reads, writes or alters `audit_events`, `audit_bridge.rs`, or the
+//! JSONL hash chain.
+//!
+//! # Tiering — the one rule that shapes every type here
+//!
+//! ADR 0032 §9 permits byte offsets and lengths **only** in the tamper-evident
+//! audit tier: a length plus a category can identify a value in a small
+//! domain. This projection is the other tier — it feeds dashboards, analytics
+//! and metric labels — so it may carry category, severity, confidence,
+//! outcome, method, recognizer and **field paths**, and no offset or length.
+//!
+//! That is enforced in two independent ways, because a `pub(crate)` accessor in
+//! Rust means nothing once a row is published as JSON:
+//!
+//! 1. the write path accepts only
+//!    [`SensitiveDataFindingRecord`](aa_core::types::sensitive_data::SensitiveDataFindingRecord),
+//!    which is span-free by construction — it is built *from* a
+//!    `CanonicalFinding` and discards the
+//!    [`ByteSpan`](aa_security::canonical::ByteSpan); and
+//! 2. neither [`SensitiveDataEventRow`] nor [`SensitiveDataFindingRow`] has a
+//!    field to put one in, and `tests/sensitive_data_projection_test.rs`
+//!    asserts the exact serialized key set and the exact SQL column set of
+//!    both from *outside* this module's privacy.
+//!
+//! # Counting
+//!
+//! Event counts and finding counts are different measures and are never
+//! collapsed (ADR 0032 §8, forbidden design #11). The event row carries
+//! [`blocked_event_count`](SensitiveDataEventRow::blocked_event_count) and
+//! [`blocked_finding_count`](SensitiveDataEventRow::blocked_finding_count) as
+//! separate columns, and
+//! [`CategoryFindingAggregate`](store::CategoryFindingAggregate) reports both
+//! `event_count` and `finding_count` per category so a reader cannot pick one
+//! and call it the other.
+//!
+//! # Prevention
+//!
+//! There is no `prevented` column. Redaction *forwards* the scrubbed bytes, so
+//! a redacted action is a transformed transmission; the only proof of
+//! non-transmission is explicit evidence. The row stores the three components
+//! of that evidence — `enforcement_point`, `transmission_evidence`,
+//! `enforcement_mode` — and
+//! [`counts_as_prevented_transmission`](SensitiveDataEventRow::counts_as_prevented_transmission)
+//! derives the metric from them, so no stored field can imply a block that did
+//! not happen.
+//!
+//! # Tenancy
+//!
+//! `org_id` and `tenant_id` are `NOT NULL` columns on **both** tables and every
+//! query takes a non-optional [`TenantScope`]. A findings query is therefore
+//! scoped without joining the events table, and there is no way to spell an
+//! unscoped read: the isolation is in the type, not in a convention the next
+//! caller has to remember.
+//!
+//! # Retention tiering — deferred, with the reason
+//!
+//! Not implemented here. [`RetentionEngine`](crate::storage::RetentionEngine)
+//! drives tiering from [`RetentionPolicy`](crate::storage::RetentionPolicy),
+//! whose warm/cold windows are expressed per *backend*, not per table, and
+//! whose SQLite path already downgrades `Archive` to a drop. Wiring a
+//! second-class table into it would either apply the audit tier's retention to
+//! a projection with different legal characteristics, or require a per-table
+//! policy shape that is its own change. Until that is decided the projection
+//! has **no** retention tier, so nothing is silently dropped — the failure mode
+//! of deferring is unbounded growth, which is visible, rather than data
+//! disappearing, which is not.
+
+mod rows;
+mod store;
+
+pub use rows::{CategoryTally, ProjectionError, SensitiveDataEventRow, SensitiveDataFindingRow, TenantScope};
+pub use store::{
+    CategoryFindingAggregate, SensitiveDataEventFilter, SensitiveDataProjection, SensitiveDataProjectionConfig,
+    SensitiveDataProjectionWriter, WriteOutcome,
+};

--- a/aa-gateway/src/storage/sensitive_data/mod.rs
+++ b/aa-gateway/src/storage/sensitive_data/mod.rs
@@ -77,6 +77,7 @@
 //! disappearing, which is not.
 
 mod rows;
+mod sqlite;
 mod store;
 
 pub use rows::{CategoryTally, ProjectionError, SensitiveDataEventRow, SensitiveDataFindingRow, TenantScope};

--- a/aa-gateway/src/storage/sensitive_data/mod.rs
+++ b/aa-gateway/src/storage/sensitive_data/mod.rs
@@ -29,7 +29,7 @@
 //!    `CanonicalFinding` and discards the
 //!    [`ByteSpan`](aa_security::canonical::ByteSpan); and
 //! 2. neither [`SensitiveDataEventRow`] nor [`SensitiveDataFindingRow`] has a
-//!    field to put one in, and `tests/sensitive_data_projection_test.rs`
+//!    field to put one in, and `tests/sensitive_data_contract/`
 //!    asserts the exact serialized key set and the exact SQL column set of
 //!    both from *outside* this module's privacy.
 //!

--- a/aa-gateway/src/storage/sensitive_data/mod.rs
+++ b/aa-gateway/src/storage/sensitive_data/mod.rs
@@ -76,6 +76,7 @@
 //! of deferring is unbounded growth, which is visible, rather than data
 //! disappearing, which is not.
 
+mod postgres;
 mod rows;
 mod sqlite;
 mod store;

--- a/aa-gateway/src/storage/sensitive_data/mod.rs
+++ b/aa-gateway/src/storage/sensitive_data/mod.rs
@@ -63,6 +63,21 @@
 //! unscoped read: the isolation is in the type, not in a convention the next
 //! caller has to remember.
 //!
+//! # Authorised access and audit-access logging — deferred, with the reason
+//!
+//! ADR 0032 §9 requires reads of this tier to be authorised and themselves
+//! audited. Neither is implemented here and neither belongs here: this module
+//! has no caller-identity concept and no request surface — the only way to
+//! reach it is a Rust method call from inside the gateway process.
+//! Authorisation and access logging attach where a *request* exists, which is
+//! the HTTP layer (AAASM-5359's endpoints) and the wiring in AAASM-5440.
+//! Implementing a second, weaker check here would produce an authorisation
+//! decision made without a principal, which is worse than none: it reads as
+//! coverage.
+//!
+//! What this module does owe that layer is a read API that cannot be called
+//! without a tenant, which [`TenantScope`] is.
+//!
 //! # Retention tiering — deferred, with the reason
 //!
 //! Not implemented here. [`RetentionEngine`](crate::storage::RetentionEngine)

--- a/aa-gateway/src/storage/sensitive_data/postgres.rs
+++ b/aa-gateway/src/storage/sensitive_data/postgres.rs
@@ -453,12 +453,24 @@ impl SensitiveDataProjection for PostgresBackend {
     async fn sensitive_data_projection_columns(&self) -> StorageResult<Vec<(String, String)>> {
         // `information_schema` reports what the cluster actually has, for the
         // same reason SQLite's impl reads `PRAGMA table_info`.
-        // Schema-qualified. Without `table_schema` this reports columns from
-        // *any* schema on the search path — and `information_schema.columns`
-        // additionally hides columns the connecting role has no privilege on,
-        // so an unqualified read both over- and under-reports. This query is
-        // the mechanism the whole "no offset column" claim rests on, so it has
-        // to describe exactly the tables this backend created.
+        // `table_schema = current_schema()` closes the **over**-reporting half:
+        // without it, a same-named table in any other schema on the search path
+        // is reported as if it were ours, and the contract test's exact-set
+        // assertion would fail — or, worse, pass while describing the wrong
+        // table. `the_projection_contract_holds_on_postgres` plants a decoy
+        // schema carrying a `span_start` column to prove that filter is load-
+        // bearing.
+        //
+        // The **under**-reporting half stays open and is worth naming, because
+        // this query is the mechanism the whole "no offset column" claim rests
+        // on: `information_schema.columns` is a privilege-filtered view, so a
+        // role without privilege on a column simply does not see it. A caller
+        // reading this catalogue with a restricted role would be told a column
+        // does not exist when it does. The claim is therefore "no offset column
+        // is visible to the role that created these tables" — which is the role
+        // the migration runs as, and the one the tests use. A stronger
+        // guarantee needs `pg_catalog.pg_attribute`, which is not
+        // privilege-filtered.
         let rows = sqlx::query(
             "SELECT table_name, column_name FROM information_schema.columns \
              WHERE table_schema = current_schema() \

--- a/aa-gateway/src/storage/sensitive_data/postgres.rs
+++ b/aa-gateway/src/storage/sensitive_data/postgres.rs
@@ -1,0 +1,468 @@
+//! PostgreSQL implementation of the sensitive-data projection.
+//!
+//! Deliberately **not** added to `migrations/postgres/`. That directory is the
+//! audit/registry schema's migrator, applied unconditionally by
+//! [`StorageBackend::migrate`](crate::storage::StorageBackend::migrate); putting
+//! the projection there would create its tables on every deployment including
+//! the ones that leave the flag off, and would make "roll the projection back"
+//! mean "roll a shared migration back". The projection owns its own up and down
+//! statements instead, and both are executed in tests.
+//!
+//! No TimescaleDB hypertable and no compression policy: those belong with a
+//! retention decision, and retention tiering is explicitly deferred (see the
+//! module doc). Plain tables grow visibly; a half-configured tier drops rows.
+
+use async_trait::async_trait;
+use sqlx::{PgPool, Row};
+
+use crate::storage::error::{StorageError, StorageResult};
+use crate::storage::postgres::PostgresBackend;
+
+use super::rows::{CategoryTally, SensitiveDataEventRow, SensitiveDataFindingRow};
+use super::store::{CategoryFindingAggregate, SensitiveDataEventFilter, SensitiveDataProjection};
+
+/// The projection's DDL. Mirrors the SQLite shape column for column so a row
+/// written by one backend means the same thing when read from the other.
+const PROJECTION_SCHEMA: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS sensitive_data_events (
+        schema_version_major      INTEGER     NOT NULL,
+        schema_version_minor      INTEGER     NOT NULL,
+        event_id                  TEXT        NOT NULL PRIMARY KEY,
+        occurred_at_ns            BIGINT      NOT NULL,
+        ingested_at_ns            BIGINT      NOT NULL,
+        org_id                    TEXT        NOT NULL,
+        tenant_id                 TEXT        NOT NULL,
+        team_id                   TEXT,
+        acting_agent_id           TEXT        NOT NULL,
+        root_agent_id             TEXT        NOT NULL,
+        parent_agent_id           TEXT,
+        delegation_depth          INTEGER     NOT NULL,
+        session_id                TEXT,
+        trace_id                  TEXT,
+        request_id                TEXT,
+        correlation_id            TEXT,
+        operation                 TEXT        NOT NULL,
+        destination_kind          TEXT        NOT NULL,
+        destination_id            TEXT        NOT NULL,
+        trust_zone                TEXT        NOT NULL,
+        direction                 TEXT        NOT NULL,
+        policy_document_id        TEXT,
+        policy_version            BIGINT,
+        matched_rule_ids          TEXT        NOT NULL,
+        inspected_field_paths     TEXT        NOT NULL,
+        verdict                   TEXT        NOT NULL,
+        enforcement_point         TEXT        NOT NULL,
+        transmission_evidence     TEXT        NOT NULL,
+        enforcement_mode          TEXT        NOT NULL,
+        inspection_failure_path   TEXT        NOT NULL,
+        severity                  TEXT,
+        confidence                TEXT,
+        method                    TEXT,
+        status                    TEXT,
+        event_count               INTEGER     NOT NULL,
+        blocked_event_count       INTEGER     NOT NULL,
+        finding_count             INTEGER     NOT NULL,
+        blocked_finding_count     INTEGER     NOT NULL,
+        transformed_finding_count INTEGER     NOT NULL,
+        finding_count_by_category TEXT        NOT NULL,
+        reason_codes              TEXT        NOT NULL
+    )",
+    "CREATE INDEX IF NOT EXISTS idx_sd_events_scope_ts
+        ON sensitive_data_events(org_id, tenant_id, occurred_at_ns)",
+    "CREATE INDEX IF NOT EXISTS idx_sd_events_scope_verdict
+        ON sensitive_data_events(org_id, tenant_id, verdict)",
+    "CREATE TABLE IF NOT EXISTS sensitive_data_findings (
+        schema_version_major INTEGER NOT NULL,
+        schema_version_minor INTEGER NOT NULL,
+        event_id             TEXT    NOT NULL,
+        finding_ordinal      INTEGER NOT NULL,
+        org_id               TEXT    NOT NULL,
+        tenant_id            TEXT    NOT NULL,
+        occurred_at_ns       BIGINT  NOT NULL,
+        category             TEXT    NOT NULL,
+        severity             TEXT    NOT NULL,
+        confidence           TEXT    NOT NULL,
+        method               TEXT    NOT NULL,
+        status               TEXT    NOT NULL,
+        recognizer           TEXT    NOT NULL,
+        recognizer_version   TEXT    NOT NULL,
+        field_path           TEXT    NOT NULL,
+        redaction_label      TEXT    NOT NULL,
+        aggregate_key        TEXT    NOT NULL,
+        PRIMARY KEY (event_id, finding_ordinal)
+    )",
+    "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_category
+        ON sensitive_data_findings(org_id, tenant_id, category)",
+    "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_ts
+        ON sensitive_data_findings(org_id, tenant_id, occurred_at_ns)",
+];
+
+/// The inverse of [`PROJECTION_SCHEMA`].
+const PROJECTION_ROLLBACK: &[&str] = &[
+    "DROP TABLE IF EXISTS sensitive_data_findings",
+    "DROP TABLE IF EXISTS sensitive_data_events",
+];
+
+/// The event columns, in the order the row struct declares them.
+const EVENT_COLUMNS: &str = "schema_version_major, schema_version_minor, event_id, occurred_at_ns, \
+     ingested_at_ns, org_id, tenant_id, team_id, acting_agent_id, root_agent_id, parent_agent_id, \
+     delegation_depth, session_id, trace_id, request_id, correlation_id, operation, destination_kind, \
+     destination_id, trust_zone, direction, policy_document_id, policy_version, matched_rule_ids, \
+     inspected_field_paths, verdict, enforcement_point, transmission_evidence, enforcement_mode, \
+     inspection_failure_path, severity, confidence, method, status, event_count, blocked_event_count, \
+     finding_count, blocked_finding_count, transformed_finding_count, finding_count_by_category, reason_codes";
+
+/// The finding columns, in the order the row struct declares them.
+const FINDING_COLUMNS: &str = "schema_version_major, schema_version_minor, event_id, finding_ordinal, \
+     org_id, tenant_id, occurred_at_ns, category, severity, confidence, method, status, recognizer, \
+     recognizer_version, field_path, redaction_label, aggregate_key";
+
+fn encode_json<T: serde::Serialize>(value: &T, column: &'static str) -> StorageResult<String> {
+    serde_json::to_string(value).map_err(|e| StorageError::QueryFailed(format!("encode {column}: {e}")))
+}
+
+fn decode_json<T: serde::de::DeserializeOwned>(raw: &str, column: &'static str) -> StorageResult<T> {
+    serde_json::from_str(raw).map_err(|e| StorageError::QueryFailed(format!("decode {column}: {e}")))
+}
+
+fn column<'r, T>(row: &'r sqlx::postgres::PgRow, name: &'static str) -> StorageResult<T>
+where
+    T: sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>,
+{
+    row.try_get(name)
+        .map_err(|e| StorageError::QueryFailed(format!("{name} column: {e}")))
+}
+
+fn row_to_event(row: &sqlx::postgres::PgRow) -> StorageResult<SensitiveDataEventRow> {
+    let matched_rule_ids: String = column(row, "matched_rule_ids")?;
+    let inspected_field_paths: String = column(row, "inspected_field_paths")?;
+    let by_category: String = column(row, "finding_count_by_category")?;
+    let reason_codes: String = column(row, "reason_codes")?;
+
+    Ok(SensitiveDataEventRow {
+        schema_version_major: column::<i32>(row, "schema_version_major")? as u16,
+        schema_version_minor: column::<i32>(row, "schema_version_minor")? as u16,
+        event_id: column(row, "event_id")?,
+        occurred_at_ns: column::<i64>(row, "occurred_at_ns")? as u64,
+        ingested_at_ns: column::<i64>(row, "ingested_at_ns")? as u64,
+        org_id: column(row, "org_id")?,
+        tenant_id: column(row, "tenant_id")?,
+        team_id: column(row, "team_id")?,
+        acting_agent_id: column(row, "acting_agent_id")?,
+        root_agent_id: column(row, "root_agent_id")?,
+        parent_agent_id: column(row, "parent_agent_id")?,
+        delegation_depth: column::<i32>(row, "delegation_depth")? as u32,
+        session_id: column(row, "session_id")?,
+        trace_id: column(row, "trace_id")?,
+        request_id: column(row, "request_id")?,
+        correlation_id: column(row, "correlation_id")?,
+        operation: column(row, "operation")?,
+        destination_kind: column(row, "destination_kind")?,
+        destination_id: column(row, "destination_id")?,
+        trust_zone: column(row, "trust_zone")?,
+        direction: column(row, "direction")?,
+        policy_document_id: column(row, "policy_document_id")?,
+        policy_version: column::<Option<i64>>(row, "policy_version")?.map(|v| v as u64),
+        matched_rule_ids: decode_json(&matched_rule_ids, "matched_rule_ids")?,
+        inspected_field_paths: decode_json(&inspected_field_paths, "inspected_field_paths")?,
+        verdict: column(row, "verdict")?,
+        enforcement_point: column(row, "enforcement_point")?,
+        transmission_evidence: column(row, "transmission_evidence")?,
+        enforcement_mode: column(row, "enforcement_mode")?,
+        inspection_failure_path: column(row, "inspection_failure_path")?,
+        severity: column(row, "severity")?,
+        confidence: column(row, "confidence")?,
+        method: column(row, "method")?,
+        status: column(row, "status")?,
+        event_count: column::<i32>(row, "event_count")? as u32,
+        blocked_event_count: column::<i32>(row, "blocked_event_count")? as u32,
+        finding_count: column::<i32>(row, "finding_count")? as u32,
+        blocked_finding_count: column::<i32>(row, "blocked_finding_count")? as u32,
+        transformed_finding_count: column::<i32>(row, "transformed_finding_count")? as u32,
+        finding_count_by_category: decode_json::<Vec<CategoryTally>>(&by_category, "finding_count_by_category")?,
+        reason_codes: decode_json(&reason_codes, "reason_codes")?,
+    })
+}
+
+fn row_to_finding(row: &sqlx::postgres::PgRow) -> StorageResult<SensitiveDataFindingRow> {
+    Ok(SensitiveDataFindingRow {
+        schema_version_major: column::<i32>(row, "schema_version_major")? as u16,
+        schema_version_minor: column::<i32>(row, "schema_version_minor")? as u16,
+        event_id: column(row, "event_id")?,
+        finding_ordinal: column::<i32>(row, "finding_ordinal")? as u32,
+        org_id: column(row, "org_id")?,
+        tenant_id: column(row, "tenant_id")?,
+        occurred_at_ns: column::<i64>(row, "occurred_at_ns")? as u64,
+        category: column(row, "category")?,
+        severity: column(row, "severity")?,
+        confidence: column(row, "confidence")?,
+        method: column(row, "method")?,
+        status: column(row, "status")?,
+        recognizer: column(row, "recognizer")?,
+        recognizer_version: column(row, "recognizer_version")?,
+        field_path: column(row, "field_path")?,
+        redaction_label: column(row, "redaction_label")?,
+        aggregate_key: column(row, "aggregate_key")?,
+    })
+}
+
+/// Append the tenant predicate and the optional narrowings.
+///
+/// As on SQLite: the tenant keys are pushed unconditionally and first, so no
+/// path through this function yields an unscoped `WHERE`.
+fn push_scope<'a>(
+    qb: &mut sqlx::QueryBuilder<'a, sqlx::Postgres>,
+    filter: &'a SensitiveDataEventFilter,
+    with_verdict: bool,
+) {
+    qb.push(" WHERE org_id = ").push_bind(filter.scope().org_id());
+    qb.push(" AND tenant_id = ").push_bind(filter.scope().tenant_id());
+    if let Some(from) = filter.from {
+        qb.push(" AND occurred_at_ns >= ").push_bind(from.as_nanos() as i64);
+    }
+    if let Some(to) = filter.to {
+        qb.push(" AND occurred_at_ns < ").push_bind(to.as_nanos() as i64);
+    }
+    if with_verdict {
+        if let Some(verdict) = filter.verdict.as_deref() {
+            qb.push(" AND verdict = ").push_bind(verdict);
+        }
+    }
+}
+
+/// `$1, $2, … $n`.
+fn placeholders(count: usize) -> String {
+    (1..=count).map(|n| format!("${n}")).collect::<Vec<_>>().join(", ")
+}
+
+#[async_trait]
+impl SensitiveDataProjection for PostgresBackend {
+    async fn migrate_sensitive_data_projection(&self) -> StorageResult<()> {
+        apply_statements(self.pool(), PROJECTION_SCHEMA).await
+    }
+
+    async fn rollback_sensitive_data_projection(&self) -> StorageResult<()> {
+        apply_statements(self.pool(), PROJECTION_ROLLBACK).await
+    }
+
+    async fn append_sensitive_data_decision(
+        &self,
+        event: &SensitiveDataEventRow,
+        findings: &[SensitiveDataFindingRow],
+    ) -> StorageResult<()> {
+        let matched_rule_ids = encode_json(&event.matched_rule_ids, "matched_rule_ids")?;
+        let inspected_field_paths = encode_json(&event.inspected_field_paths, "inspected_field_paths")?;
+        let by_category = encode_json(&event.finding_count_by_category, "finding_count_by_category")?;
+        let reason_codes = encode_json(&event.reason_codes, "reason_codes")?;
+
+        let mut tx = self
+            .pool()
+            .begin()
+            .await
+            .map_err(|e| StorageError::QueryFailed(format!("begin: {e}")))?;
+
+        // `ON CONFLICT DO NOTHING` is the idempotency rule: first write wins,
+        // so a replayed event cannot double-count and a late duplicate cannot
+        // rewrite tallies a reader may already have seen.
+        let event_placeholders = placeholders(41);
+        sqlx::query(&format!(
+            "INSERT INTO sensitive_data_events ({EVENT_COLUMNS}) VALUES ({event_placeholders}) \
+             ON CONFLICT (event_id) DO NOTHING"
+        ))
+        .bind(i32::from(event.schema_version_major))
+        .bind(i32::from(event.schema_version_minor))
+        .bind(&event.event_id)
+        .bind(event.occurred_at_ns as i64)
+        .bind(event.ingested_at_ns as i64)
+        .bind(&event.org_id)
+        .bind(&event.tenant_id)
+        .bind(event.team_id.as_deref())
+        .bind(&event.acting_agent_id)
+        .bind(&event.root_agent_id)
+        .bind(event.parent_agent_id.as_deref())
+        .bind(event.delegation_depth as i32)
+        .bind(event.session_id.as_deref())
+        .bind(event.trace_id.as_deref())
+        .bind(event.request_id.as_deref())
+        .bind(event.correlation_id.as_deref())
+        .bind(&event.operation)
+        .bind(&event.destination_kind)
+        .bind(&event.destination_id)
+        .bind(&event.trust_zone)
+        .bind(&event.direction)
+        .bind(event.policy_document_id.as_deref())
+        .bind(event.policy_version.map(|v| v as i64))
+        .bind(&matched_rule_ids)
+        .bind(&inspected_field_paths)
+        .bind(&event.verdict)
+        .bind(&event.enforcement_point)
+        .bind(&event.transmission_evidence)
+        .bind(&event.enforcement_mode)
+        .bind(&event.inspection_failure_path)
+        .bind(event.severity.as_deref())
+        .bind(event.confidence.as_deref())
+        .bind(event.method.as_deref())
+        .bind(event.status.as_deref())
+        .bind(event.event_count as i32)
+        .bind(event.blocked_event_count as i32)
+        .bind(event.finding_count as i32)
+        .bind(event.blocked_finding_count as i32)
+        .bind(event.transformed_finding_count as i32)
+        .bind(&by_category)
+        .bind(&reason_codes)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| StorageError::QueryFailed(format!("insert event: {e}")))?;
+
+        let finding_placeholders = placeholders(17);
+        for finding in findings {
+            sqlx::query(&format!(
+                "INSERT INTO sensitive_data_findings ({FINDING_COLUMNS}) VALUES ({finding_placeholders}) \
+                 ON CONFLICT (event_id, finding_ordinal) DO NOTHING"
+            ))
+            .bind(i32::from(finding.schema_version_major))
+            .bind(i32::from(finding.schema_version_minor))
+            .bind(&finding.event_id)
+            .bind(finding.finding_ordinal as i32)
+            .bind(&finding.org_id)
+            .bind(&finding.tenant_id)
+            .bind(finding.occurred_at_ns as i64)
+            .bind(&finding.category)
+            .bind(&finding.severity)
+            .bind(&finding.confidence)
+            .bind(&finding.method)
+            .bind(&finding.status)
+            .bind(&finding.recognizer)
+            .bind(&finding.recognizer_version)
+            .bind(&finding.field_path)
+            .bind(&finding.redaction_label)
+            .bind(&finding.aggregate_key)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::QueryFailed(format!("insert finding: {e}")))?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::QueryFailed(format!("commit: {e}")))
+    }
+
+    async fn query_sensitive_data_events(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<SensitiveDataEventRow>> {
+        let mut qb =
+            sqlx::QueryBuilder::<sqlx::Postgres>::new(format!("SELECT {EVENT_COLUMNS} FROM sensitive_data_events"));
+        push_scope(&mut qb, filter, true);
+        qb.push(" ORDER BY occurred_at_ns DESC, event_id ASC");
+        if let Some(limit) = filter.limit {
+            qb.push(" LIMIT ").push_bind(i64::from(limit));
+        }
+        let rows = qb
+            .build()
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        rows.iter().map(row_to_event).collect()
+    }
+
+    async fn query_sensitive_data_findings(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<SensitiveDataFindingRow>> {
+        let mut qb =
+            sqlx::QueryBuilder::<sqlx::Postgres>::new(format!("SELECT {FINDING_COLUMNS} FROM sensitive_data_findings"));
+        push_scope(&mut qb, filter, false);
+        qb.push(" ORDER BY occurred_at_ns DESC, event_id ASC, finding_ordinal ASC");
+        if let Some(limit) = filter.limit {
+            qb.push(" LIMIT ").push_bind(i64::from(limit));
+        }
+        let rows = qb
+            .build()
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        rows.iter().map(row_to_finding).collect()
+    }
+
+    async fn count_sensitive_data_events(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
+        let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new("SELECT COUNT(*) FROM sensitive_data_events");
+        push_scope(&mut qb, filter, true);
+        let count: i64 = qb
+            .build_query_scalar()
+            .fetch_one(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        Ok(count.max(0) as u64)
+    }
+
+    async fn count_sensitive_data_findings(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
+        let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new("SELECT COUNT(*) FROM sensitive_data_findings");
+        push_scope(&mut qb, filter, false);
+        let count: i64 = qb
+            .build_query_scalar()
+            .fetch_one(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        Ok(count.max(0) as u64)
+    }
+
+    async fn sensitive_data_projection_columns(&self) -> StorageResult<Vec<(String, String)>> {
+        // `information_schema` reports what the cluster actually has, for the
+        // same reason SQLite's impl reads `PRAGMA table_info`.
+        let rows = sqlx::query(
+            "SELECT table_name, column_name FROM information_schema.columns \
+             WHERE table_name IN ('sensitive_data_events', 'sensitive_data_findings') \
+             ORDER BY table_name, ordinal_position",
+        )
+        .fetch_all(self.pool())
+        .await
+        .map_err(|e| StorageError::QueryFailed(format!("information_schema: {e}")))?;
+
+        rows.iter()
+            .map(|row| {
+                Ok((
+                    column::<String>(row, "table_name")?,
+                    column::<String>(row, "column_name")?,
+                ))
+            })
+            .collect()
+    }
+
+    async fn aggregate_sensitive_data_by_category(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<CategoryFindingAggregate>> {
+        let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
+            "SELECT category, COUNT(*) AS finding_count, COUNT(DISTINCT event_id) AS event_count \
+             FROM sensitive_data_findings",
+        );
+        push_scope(&mut qb, filter, false);
+        qb.push(" GROUP BY category ORDER BY category ASC");
+        let rows = qb
+            .build()
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+
+        rows.iter()
+            .map(|row| {
+                Ok(CategoryFindingAggregate {
+                    category: column(row, "category")?,
+                    finding_count: column::<i64>(row, "finding_count")?.max(0) as u64,
+                    event_count: column::<i64>(row, "event_count")?.max(0) as u64,
+                })
+            })
+            .collect()
+    }
+}
+
+async fn apply_statements(pool: &PgPool, statements: &[&str]) -> StorageResult<()> {
+    for stmt in statements {
+        sqlx::query(stmt)
+            .execute(pool)
+            .await
+            .map_err(|e| StorageError::MigrationFailed(e.to_string()))?;
+    }
+    Ok(())
+}

--- a/aa-gateway/src/storage/sensitive_data/postgres.rs
+++ b/aa-gateway/src/storage/sensitive_data/postgres.rs
@@ -18,7 +18,7 @@ use sqlx::{PgPool, Row};
 use crate::storage::error::{StorageError, StorageResult};
 use crate::storage::postgres::PostgresBackend;
 
-use super::rows::{CategoryTally, SensitiveDataEventRow, SensitiveDataFindingRow};
+use super::rows::{check_readable, narrow, CategoryTally, SensitiveDataEventRow, SensitiveDataFindingRow};
 use super::store::{CategoryFindingAggregate, SensitiveDataEventFilter, SensitiveDataProjection};
 
 /// The projection's DDL. Mirrors the SQLite shape column for column so a row
@@ -79,6 +79,7 @@ const PROJECTION_SCHEMA: &[&str] = &[
         org_id               TEXT    NOT NULL,
         tenant_id            TEXT    NOT NULL,
         occurred_at_ns       BIGINT  NOT NULL,
+        verdict              TEXT    NOT NULL,
         category             TEXT    NOT NULL,
         severity             TEXT    NOT NULL,
         confidence           TEXT    NOT NULL,
@@ -92,7 +93,7 @@ const PROJECTION_SCHEMA: &[&str] = &[
         PRIMARY KEY (event_id, finding_ordinal)
     )",
     "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_category
-        ON sensitive_data_findings(org_id, tenant_id, category)",
+        ON sensitive_data_findings(org_id, tenant_id, verdict, category)",
     "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_ts
         ON sensitive_data_findings(org_id, tenant_id, occurred_at_ns)",
 ];
@@ -114,7 +115,7 @@ const EVENT_COLUMNS: &str = "schema_version_major, schema_version_minor, event_i
 
 /// The finding columns, in the order the row struct declares them.
 const FINDING_COLUMNS: &str = "schema_version_major, schema_version_minor, event_id, finding_ordinal, \
-     org_id, tenant_id, occurred_at_ns, category, severity, confidence, method, status, recognizer, \
+     org_id, tenant_id, occurred_at_ns, verdict, category, severity, confidence, method, status, recognizer, \
      recognizer_version, field_path, redaction_label, aggregate_key";
 
 fn encode_json<T: serde::Serialize>(value: &T, column: &'static str) -> StorageResult<String> {
@@ -134,24 +135,34 @@ where
 }
 
 fn row_to_event(row: &sqlx::postgres::PgRow) -> StorageResult<SensitiveDataEventRow> {
+    let event_id: String = column(row, "event_id")?;
+    let schema_version_major: u16 = narrow(
+        i64::from(column::<i32>(row, "schema_version_major")?),
+        "schema_version_major",
+    )?;
+    check_readable(&event_id, schema_version_major)?;
+
     let matched_rule_ids: String = column(row, "matched_rule_ids")?;
     let inspected_field_paths: String = column(row, "inspected_field_paths")?;
     let by_category: String = column(row, "finding_count_by_category")?;
     let reason_codes: String = column(row, "reason_codes")?;
 
     Ok(SensitiveDataEventRow {
-        schema_version_major: column::<i32>(row, "schema_version_major")? as u16,
-        schema_version_minor: column::<i32>(row, "schema_version_minor")? as u16,
-        event_id: column(row, "event_id")?,
-        occurred_at_ns: column::<i64>(row, "occurred_at_ns")? as u64,
-        ingested_at_ns: column::<i64>(row, "ingested_at_ns")? as u64,
+        schema_version_major,
+        schema_version_minor: narrow(
+            i64::from(column::<i32>(row, "schema_version_minor")?),
+            "schema_version_minor",
+        )?,
+        event_id,
+        occurred_at_ns: narrow(column::<i64>(row, "occurred_at_ns")?, "occurred_at_ns")?,
+        ingested_at_ns: narrow(column::<i64>(row, "ingested_at_ns")?, "ingested_at_ns")?,
         org_id: column(row, "org_id")?,
         tenant_id: column(row, "tenant_id")?,
         team_id: column(row, "team_id")?,
         acting_agent_id: column(row, "acting_agent_id")?,
         root_agent_id: column(row, "root_agent_id")?,
         parent_agent_id: column(row, "parent_agent_id")?,
-        delegation_depth: column::<i32>(row, "delegation_depth")? as u32,
+        delegation_depth: narrow(i64::from(column::<i32>(row, "delegation_depth")?), "delegation_depth")?,
         session_id: column(row, "session_id")?,
         trace_id: column(row, "trace_id")?,
         request_id: column(row, "request_id")?,
@@ -162,7 +173,9 @@ fn row_to_event(row: &sqlx::postgres::PgRow) -> StorageResult<SensitiveDataEvent
         trust_zone: column(row, "trust_zone")?,
         direction: column(row, "direction")?,
         policy_document_id: column(row, "policy_document_id")?,
-        policy_version: column::<Option<i64>>(row, "policy_version")?.map(|v| v as u64),
+        policy_version: column::<Option<i64>>(row, "policy_version")?
+            .map(|v| narrow(v, "policy_version"))
+            .transpose()?,
         matched_rule_ids: decode_json(&matched_rule_ids, "matched_rule_ids")?,
         inspected_field_paths: decode_json(&inspected_field_paths, "inspected_field_paths")?,
         verdict: column(row, "verdict")?,
@@ -174,25 +187,45 @@ fn row_to_event(row: &sqlx::postgres::PgRow) -> StorageResult<SensitiveDataEvent
         confidence: column(row, "confidence")?,
         method: column(row, "method")?,
         status: column(row, "status")?,
-        event_count: column::<i32>(row, "event_count")? as u32,
-        blocked_event_count: column::<i32>(row, "blocked_event_count")? as u32,
-        finding_count: column::<i32>(row, "finding_count")? as u32,
-        blocked_finding_count: column::<i32>(row, "blocked_finding_count")? as u32,
-        transformed_finding_count: column::<i32>(row, "transformed_finding_count")? as u32,
+        event_count: narrow(i64::from(column::<i32>(row, "event_count")?), "event_count")?,
+        blocked_event_count: narrow(
+            i64::from(column::<i32>(row, "blocked_event_count")?),
+            "blocked_event_count",
+        )?,
+        finding_count: narrow(i64::from(column::<i32>(row, "finding_count")?), "finding_count")?,
+        blocked_finding_count: narrow(
+            i64::from(column::<i32>(row, "blocked_finding_count")?),
+            "blocked_finding_count",
+        )?,
+        transformed_finding_count: narrow(
+            i64::from(column::<i32>(row, "transformed_finding_count")?),
+            "transformed_finding_count",
+        )?,
         finding_count_by_category: decode_json::<Vec<CategoryTally>>(&by_category, "finding_count_by_category")?,
         reason_codes: decode_json(&reason_codes, "reason_codes")?,
     })
 }
 
 fn row_to_finding(row: &sqlx::postgres::PgRow) -> StorageResult<SensitiveDataFindingRow> {
+    let event_id: String = column(row, "event_id")?;
+    let schema_version_major: u16 = narrow(
+        i64::from(column::<i32>(row, "schema_version_major")?),
+        "schema_version_major",
+    )?;
+    check_readable(&event_id, schema_version_major)?;
+
     Ok(SensitiveDataFindingRow {
-        schema_version_major: column::<i32>(row, "schema_version_major")? as u16,
-        schema_version_minor: column::<i32>(row, "schema_version_minor")? as u16,
-        event_id: column(row, "event_id")?,
-        finding_ordinal: column::<i32>(row, "finding_ordinal")? as u32,
+        schema_version_major,
+        schema_version_minor: narrow(
+            i64::from(column::<i32>(row, "schema_version_minor")?),
+            "schema_version_minor",
+        )?,
+        event_id,
+        finding_ordinal: narrow(i64::from(column::<i32>(row, "finding_ordinal")?), "finding_ordinal")?,
         org_id: column(row, "org_id")?,
         tenant_id: column(row, "tenant_id")?,
-        occurred_at_ns: column::<i64>(row, "occurred_at_ns")? as u64,
+        occurred_at_ns: narrow(column::<i64>(row, "occurred_at_ns")?, "occurred_at_ns")?,
+        verdict: column(row, "verdict")?,
         category: column(row, "category")?,
         severity: column(row, "severity")?,
         confidence: column(row, "confidence")?,
@@ -210,11 +243,7 @@ fn row_to_finding(row: &sqlx::postgres::PgRow) -> StorageResult<SensitiveDataFin
 ///
 /// As on SQLite: the tenant keys are pushed unconditionally and first, so no
 /// path through this function yields an unscoped `WHERE`.
-fn push_scope<'a>(
-    qb: &mut sqlx::QueryBuilder<'a, sqlx::Postgres>,
-    filter: &'a SensitiveDataEventFilter,
-    with_verdict: bool,
-) {
+fn push_scope<'a>(qb: &mut sqlx::QueryBuilder<'a, sqlx::Postgres>, filter: &'a SensitiveDataEventFilter) {
     qb.push(" WHERE org_id = ").push_bind(filter.scope().org_id());
     qb.push(" AND tenant_id = ").push_bind(filter.scope().tenant_id());
     if let Some(from) = filter.from {
@@ -223,10 +252,9 @@ fn push_scope<'a>(
     if let Some(to) = filter.to {
         qb.push(" AND occurred_at_ns < ").push_bind(to.as_nanos() as i64);
     }
-    if with_verdict {
-        if let Some(verdict) = filter.verdict.as_deref() {
-            qb.push(" AND verdict = ").push_bind(verdict);
-        }
+    // As on SQLite: no switch, because both tables carry the column.
+    if let Some(verdict) = filter.verdict.as_deref() {
+        qb.push(" AND verdict = ").push_bind(verdict);
     }
 }
 
@@ -265,7 +293,7 @@ impl SensitiveDataProjection for PostgresBackend {
         // so a replayed event cannot double-count and a late duplicate cannot
         // rewrite tallies a reader may already have seen.
         let event_placeholders = placeholders(41);
-        sqlx::query(&format!(
+        let inserted = sqlx::query(&format!(
             "INSERT INTO sensitive_data_events ({EVENT_COLUMNS}) VALUES ({event_placeholders}) \
              ON CONFLICT (event_id) DO NOTHING"
         ))
@@ -314,7 +342,21 @@ impl SensitiveDataProjection for PostgresBackend {
         .await
         .map_err(|e| StorageError::QueryFailed(format!("insert event: {e}")))?;
 
-        let finding_placeholders = placeholders(17);
+        // See the SQLite backend: `DO NOTHING` on the children alone is
+        // additive, so a replay carrying more findings would desynchronise the
+        // parent's `finding_count` from the rows beneath it.
+        if inserted.rows_affected() == 0 {
+            tracing::debug!(
+                event_id = %event.event_id,
+                "sensitive-data projection: event already stored, ignoring replay"
+            );
+            return tx
+                .commit()
+                .await
+                .map_err(|e| StorageError::QueryFailed(format!("commit: {e}")));
+        }
+
+        let finding_placeholders = placeholders(18);
         for finding in findings {
             sqlx::query(&format!(
                 "INSERT INTO sensitive_data_findings ({FINDING_COLUMNS}) VALUES ({finding_placeholders}) \
@@ -327,6 +369,7 @@ impl SensitiveDataProjection for PostgresBackend {
             .bind(&finding.org_id)
             .bind(&finding.tenant_id)
             .bind(finding.occurred_at_ns as i64)
+            .bind(&finding.verdict)
             .bind(&finding.category)
             .bind(&finding.severity)
             .bind(&finding.confidence)
@@ -353,7 +396,7 @@ impl SensitiveDataProjection for PostgresBackend {
     ) -> StorageResult<Vec<SensitiveDataEventRow>> {
         let mut qb =
             sqlx::QueryBuilder::<sqlx::Postgres>::new(format!("SELECT {EVENT_COLUMNS} FROM sensitive_data_events"));
-        push_scope(&mut qb, filter, true);
+        push_scope(&mut qb, filter);
         qb.push(" ORDER BY occurred_at_ns DESC, event_id ASC");
         if let Some(limit) = filter.limit {
             qb.push(" LIMIT ").push_bind(i64::from(limit));
@@ -372,7 +415,7 @@ impl SensitiveDataProjection for PostgresBackend {
     ) -> StorageResult<Vec<SensitiveDataFindingRow>> {
         let mut qb =
             sqlx::QueryBuilder::<sqlx::Postgres>::new(format!("SELECT {FINDING_COLUMNS} FROM sensitive_data_findings"));
-        push_scope(&mut qb, filter, false);
+        push_scope(&mut qb, filter);
         qb.push(" ORDER BY occurred_at_ns DESC, event_id ASC, finding_ordinal ASC");
         if let Some(limit) = filter.limit {
             qb.push(" LIMIT ").push_bind(i64::from(limit));
@@ -387,7 +430,7 @@ impl SensitiveDataProjection for PostgresBackend {
 
     async fn count_sensitive_data_events(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
         let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new("SELECT COUNT(*) FROM sensitive_data_events");
-        push_scope(&mut qb, filter, true);
+        push_scope(&mut qb, filter);
         let count: i64 = qb
             .build_query_scalar()
             .fetch_one(self.pool())
@@ -398,7 +441,7 @@ impl SensitiveDataProjection for PostgresBackend {
 
     async fn count_sensitive_data_findings(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
         let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new("SELECT COUNT(*) FROM sensitive_data_findings");
-        push_scope(&mut qb, filter, false);
+        push_scope(&mut qb, filter);
         let count: i64 = qb
             .build_query_scalar()
             .fetch_one(self.pool())
@@ -410,9 +453,16 @@ impl SensitiveDataProjection for PostgresBackend {
     async fn sensitive_data_projection_columns(&self) -> StorageResult<Vec<(String, String)>> {
         // `information_schema` reports what the cluster actually has, for the
         // same reason SQLite's impl reads `PRAGMA table_info`.
+        // Schema-qualified. Without `table_schema` this reports columns from
+        // *any* schema on the search path — and `information_schema.columns`
+        // additionally hides columns the connecting role has no privilege on,
+        // so an unqualified read both over- and under-reports. This query is
+        // the mechanism the whole "no offset column" claim rests on, so it has
+        // to describe exactly the tables this backend created.
         let rows = sqlx::query(
             "SELECT table_name, column_name FROM information_schema.columns \
-             WHERE table_name IN ('sensitive_data_events', 'sensitive_data_findings') \
+             WHERE table_schema = current_schema() \
+               AND table_name IN ('sensitive_data_events', 'sensitive_data_findings') \
              ORDER BY table_name, ordinal_position",
         )
         .fetch_all(self.pool())
@@ -437,8 +487,12 @@ impl SensitiveDataProjection for PostgresBackend {
             "SELECT category, COUNT(*) AS finding_count, COUNT(DISTINCT event_id) AS event_count \
              FROM sensitive_data_findings",
         );
-        push_scope(&mut qb, filter, false);
+        push_scope(&mut qb, filter);
         qb.push(" GROUP BY category ORDER BY category ASC");
+        // As on SQLite: the row cap is also the group cap.
+        if let Some(limit) = filter.limit {
+            qb.push(" LIMIT ").push_bind(i64::from(limit));
+        }
         let rows = qb
             .build()
             .fetch_all(self.pool())
@@ -457,12 +511,21 @@ impl SensitiveDataProjection for PostgresBackend {
     }
 }
 
+/// Apply a DDL set atomically — PostgreSQL has transactional DDL, so a
+/// migration that fails partway leaves no tables rather than a half-created
+/// schema the next `IF NOT EXISTS` run would accept as complete.
 async fn apply_statements(pool: &PgPool, statements: &[&str]) -> StorageResult<()> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| StorageError::MigrationFailed(format!("begin: {e}")))?;
     for stmt in statements {
         sqlx::query(stmt)
-            .execute(pool)
+            .execute(&mut *tx)
             .await
             .map_err(|e| StorageError::MigrationFailed(e.to_string()))?;
     }
-    Ok(())
+    tx.commit()
+        .await
+        .map_err(|e| StorageError::MigrationFailed(format!("commit: {e}")))
 }

--- a/aa-gateway/src/storage/sensitive_data/rows.rs
+++ b/aa-gateway/src/storage/sensitive_data/rows.rs
@@ -1,0 +1,506 @@
+//! The persisted shapes of the sensitive-data projection.
+//!
+//! Gateway-owned value types, per the storage layer's standing rule that the
+//! schema does not move whenever a runtime type grows a field. They are
+//! projected *from* `aa-core`'s
+//! [`SensitiveDataDecisionEvent`] and [`SensitiveDataFindingRecord`]; nothing
+//! constructs them from anything else, which is what makes the span-freedom
+//! argument in the module doc hold end to end.
+
+use aa_core::policy::EnforcementMode;
+use aa_core::time::Timestamp;
+use aa_core::types::sensitive_data::{
+    EnforcementPoint, RuntimeVerdictLabel, SensitiveDataDecisionEvent, SensitiveDataFindingRecord,
+    TransmissionEvidence, SENSITIVE_DATA_SCHEMA_VERSION,
+};
+
+use crate::storage::error::StorageError;
+
+/// Why a decision event could not be projected into storable rows.
+///
+/// Every variant is a state that would produce a row a reader could not trust.
+/// Refusing the write is the point: a projection that accepts an event whose
+/// finding rows disagree with its own tallies is exactly the "prevention
+/// dashboard reporting more blocked findings than there were findings" that
+/// `aa-core`'s [`CountsError`](aa_core::types::sensitive_data::CountsError)
+/// exists to prevent, arriving one layer down.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ProjectionError {
+    /// `org_id` or `tenant_id` was blank.
+    ///
+    /// A blank tenant is not a narrower scope, it is a scope that matches
+    /// whatever the next writer also leaves blank — so it is refused at
+    /// construction rather than stored and filtered around later.
+    #[error("tenancy field `{0}` must not be empty")]
+    EmptyTenancy(&'static str),
+    /// A finding row named a different event than the one being written.
+    #[error("finding {ordinal} belongs to event `{finding_event_id}`, not `{event_id}`")]
+    FindingEventIdMismatch {
+        /// Position of the offending record in the supplied slice.
+        ordinal: usize,
+        /// The event the projection is writing.
+        event_id: String,
+        /// The event the record claims to belong to.
+        finding_event_id: String,
+    },
+    /// The number of finding rows disagreed with the event's own total.
+    ///
+    /// The load-bearing check against collapsing event and finding counts: an
+    /// event that says it carried one finding while three rows are handed over
+    /// is one of the two numbers being written into the other's column.
+    #[error("event `{event_id}` declares {declared} findings but {supplied} rows were supplied")]
+    FindingCountMismatch {
+        /// The event being written.
+        event_id: String,
+        /// `finding_counts.total` as the producer computed it.
+        declared: u32,
+        /// How many rows were actually handed over.
+        supplied: usize,
+    },
+    /// The event's own tallies were internally inconsistent.
+    ///
+    /// `FindingCounts` only enforces this in
+    /// [`tally`](aa_core::types::sensitive_data::FindingCounts::tally);
+    /// deserializing one runs no invariant at all, so an event that reached the
+    /// gateway over the wire can carry `blocked: 99` against `total: 1`. The
+    /// read-path checks `aa-core` provides for exactly this are run here,
+    /// before the row is durable rather than after.
+    #[error("event `{event_id}` carries inconsistent finding tallies: {detail}")]
+    InconsistentCounts {
+        /// The event being written.
+        event_id: String,
+        /// Which invariant failed.
+        detail: &'static str,
+    },
+    /// A JSON-encoded column could not be built.
+    #[error("failed to encode column `{column}`: {source_message}")]
+    Encode {
+        /// The column that failed to encode.
+        column: &'static str,
+        /// The serializer's message.
+        source_message: String,
+    },
+    /// The store rejected an otherwise well-formed write.
+    ///
+    /// Carries the message rather than the [`StorageError`] so this type stays
+    /// `Clone` and `PartialEq` — a test asserting *which* projection error
+    /// occurred should not have to reconstruct a driver error to do it.
+    #[error("projection write failed: {0}")]
+    Storage(String),
+}
+
+impl From<ProjectionError> for StorageError {
+    fn from(err: ProjectionError) -> Self {
+        StorageError::QueryFailed(err.to_string())
+    }
+}
+
+/// The organisation and tenant every projection read and write is scoped to.
+///
+/// Exists as a distinct type so that "scoped by tenant" is a signature, not a
+/// convention. [`SensitiveDataEventFilter`](super::SensitiveDataEventFilter)
+/// takes one by value and offers no way to omit it, so there is no spelling of
+/// an unscoped query to review for.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TenantScope {
+    org_id: String,
+    tenant_id: String,
+}
+
+impl TenantScope {
+    /// Name an organisation and tenant.
+    ///
+    /// # Errors
+    ///
+    /// [`ProjectionError::EmptyTenancy`] if either identifier is empty or
+    /// whitespace-only.
+    pub fn new(org_id: impl Into<String>, tenant_id: impl Into<String>) -> Result<Self, ProjectionError> {
+        let org_id = org_id.into();
+        let tenant_id = tenant_id.into();
+        if org_id.trim().is_empty() {
+            return Err(ProjectionError::EmptyTenancy("org_id"));
+        }
+        if tenant_id.trim().is_empty() {
+            return Err(ProjectionError::EmptyTenancy("tenant_id"));
+        }
+        Ok(Self { org_id, tenant_id })
+    }
+
+    /// The owning organisation.
+    pub fn org_id(&self) -> &str {
+        &self.org_id
+    }
+
+    /// The owning tenant within that organisation.
+    pub fn tenant_id(&self) -> &str {
+        &self.tenant_id
+    }
+}
+
+/// How many findings of one category an event carried.
+///
+/// Denormalized onto the event row so the common dashboard query — "what
+/// classes of data did this action carry?" — needs no join. The normalized
+/// findings table remains the source of truth for grouping *across* events.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CategoryTally {
+    /// The category, as the writing build spelled it.
+    pub category: String,
+    /// How many findings of it this event carried.
+    pub count: u32,
+}
+
+/// One inspected action, as it is persisted.
+///
+/// # What is not here
+///
+/// No byte offset, no length, no raw or redacted payload, and no `prevented`
+/// flag. The first two are the audit tier's alone (ADR 0032 §9); the payload is
+/// the mistake the existing audit bridge already makes and is not repeated;
+/// the last is derived from evidence by
+/// [`counts_as_prevented_transmission`](Self::counts_as_prevented_transmission)
+/// so it cannot disagree with the evidence it is drawn from.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SensitiveDataEventRow {
+    /// Major of the schema the row was written against. A reader of a
+    /// different major must refuse the row.
+    pub schema_version_major: u16,
+    /// Minor of that schema. Additive only; never a reason to refuse a row.
+    pub schema_version_minor: u16,
+    /// The event's identity, and the projection's idempotency key.
+    pub event_id: String,
+    /// When the action was inspected, in nanoseconds since the Unix epoch.
+    pub occurred_at_ns: u64,
+    /// When the projection wrote the row.
+    ///
+    /// Distinct from `occurred_at_ns` so a late arrival is visible as such
+    /// rather than being silently backdated — see the late-arrival rule on
+    /// [`SensitiveDataProjection::append_sensitive_data_decision`](super::SensitiveDataProjection::append_sensitive_data_decision).
+    pub ingested_at_ns: u64,
+    /// Owning organisation.
+    pub org_id: String,
+    /// Owning tenant.
+    pub tenant_id: String,
+    /// Owning team, when the action is attributable to one.
+    pub team_id: Option<String>,
+    /// The agent that performed the action.
+    pub acting_agent_id: String,
+    /// The agent at the root of the delegation chain.
+    pub root_agent_id: String,
+    /// The agent that delegated to the actor, if any.
+    pub parent_agent_id: Option<String>,
+    /// Delegation hops from the root.
+    pub delegation_depth: u32,
+    /// The agent session the action belongs to.
+    pub session_id: Option<String>,
+    /// Distributed-trace id.
+    pub trace_id: Option<String>,
+    /// Id of the individual request.
+    pub request_id: Option<String>,
+    /// Caller-chosen correlation id.
+    pub correlation_id: Option<String>,
+    /// What kind of operation it was.
+    pub operation: String,
+    /// What kind of thing the destination is.
+    pub destination_kind: String,
+    /// The destination's name. Unbounded cardinality — a drill-down dimension,
+    /// never a metric label.
+    pub destination_id: String,
+    /// How far outside the boundary the destination sits.
+    pub trust_zone: String,
+    /// Which way the payload was travelling.
+    pub direction: String,
+    /// Identifier of the policy document in force.
+    pub policy_document_id: Option<String>,
+    /// Version of that document.
+    pub policy_version: Option<u64>,
+    /// Ids of the rules that matched. The audit bridge hardcodes this to
+    /// `None`; here it is what the engine actually reported.
+    pub matched_rule_ids: Vec<String>,
+    /// Names of the fields that were inspected — the drill-down granularity
+    /// ADR 0032 §9 grants in place of offsets.
+    pub inspected_field_paths: Vec<String>,
+    /// The enforcement outcome, as ADR 0018's frozen verdict.
+    pub verdict: String,
+    /// Where the decision was applied. Prevention condition 1.
+    pub enforcement_point: String,
+    /// What was observed about the forwarded bytes. Prevention condition 3.
+    pub transmission_evidence: String,
+    /// Whether enforcement was applied or merely computed. Prevention
+    /// condition 4, and the honest replacement for the audit bridge's
+    /// hardcoded `dry_run: false`.
+    pub enforcement_mode: String,
+    /// How the detection pass itself terminated. Never a synonym for "nothing
+    /// found".
+    pub inspection_failure_path: String,
+    /// Severity representing the action's findings, absent when there were none.
+    pub severity: Option<String>,
+    /// Confidence band representing the action's findings.
+    pub confidence: Option<String>,
+    /// Detection technique representing the action's findings.
+    pub method: Option<String>,
+    /// Triage state representing the action's findings.
+    pub status: Option<String>,
+    /// Always `1`. Stored so that `SUM(event_count)` is spellable next to
+    /// `SUM(finding_count)` and the two cannot be silently interchanged.
+    pub event_count: u32,
+    /// `1` when the action itself was refused, `0` otherwise. An **event**
+    /// count, and never the same number as `blocked_finding_count`.
+    pub blocked_event_count: u32,
+    /// How many findings the action carried in total.
+    pub finding_count: u32,
+    /// How many **findings** were refused. ADR 0032 §8's worked example: three
+    /// findings in one blocked action gives `blocked_event_count = 1` and
+    /// `blocked_finding_count = 3`.
+    pub blocked_finding_count: u32,
+    /// How many **findings** were rewritten and then forwarded. A transformed
+    /// finding is not a prevented one.
+    pub transformed_finding_count: u32,
+    /// Per-category finding tallies, denormalized for the join-free dashboard
+    /// query.
+    pub finding_count_by_category: Vec<CategoryTally>,
+    /// Machine-aggregatable reasons for the decision.
+    pub reason_codes: Vec<String>,
+}
+
+impl SensitiveDataEventRow {
+    /// Project a decision event into its storable row.
+    ///
+    /// `findings` is taken only to validate it against the event's own tallies
+    /// — the rows themselves are produced by
+    /// [`SensitiveDataFindingRow::project`]. Validating here rather than at the
+    /// SQL layer means an inconsistent event never reaches a transaction.
+    ///
+    /// # Errors
+    ///
+    /// [`ProjectionError::EmptyTenancy`], [`ProjectionError::FindingCountMismatch`]
+    /// and [`ProjectionError::InconsistentCounts`], per their documentation.
+    pub fn project(
+        event: &SensitiveDataDecisionEvent,
+        findings: &[SensitiveDataFindingRecord],
+        ingested_at: Timestamp,
+    ) -> Result<Self, ProjectionError> {
+        let event_id = event.event_id.as_str().to_string();
+        let scope = TenantScope::new(event.tenancy.org_id.as_str(), event.tenancy.tenant_id.as_str())?;
+
+        if findings.len() != event.total_finding_count() as usize {
+            return Err(ProjectionError::FindingCountMismatch {
+                event_id,
+                declared: event.total_finding_count(),
+                supplied: findings.len(),
+            });
+        }
+        if !event.finding_counts.breakdown_is_complete() {
+            return Err(ProjectionError::InconsistentCounts {
+                event_id,
+                detail: "per-category breakdown does not sum to the total finding count",
+            });
+        }
+        if !event.finding_counts.disposition_counts_are_consistent() {
+            return Err(ProjectionError::InconsistentCounts {
+                event_id,
+                detail: "transformed + blocked finding counts exceed the total finding count",
+            });
+        }
+
+        let classification = event.classification.as_ref();
+        Ok(Self {
+            schema_version_major: event.schema_version.major,
+            schema_version_minor: event.schema_version.minor,
+            event_id,
+            occurred_at_ns: event.occurred_at.as_nanos(),
+            ingested_at_ns: ingested_at.as_nanos(),
+            org_id: scope.org_id().to_string(),
+            tenant_id: scope.tenant_id().to_string(),
+            team_id: event.tenancy.team_id.as_ref().map(|l| l.as_str().to_string()),
+            acting_agent_id: event.lineage.acting_agent.as_str().to_string(),
+            root_agent_id: event.lineage.root_agent.as_str().to_string(),
+            parent_agent_id: event.lineage.parent_agent.as_ref().map(|a| a.as_str().to_string()),
+            delegation_depth: event.lineage.delegation_depth,
+            session_id: event.correlation.session_id.as_ref().map(|l| l.as_str().to_string()),
+            trace_id: event.correlation.trace_id.as_ref().map(|l| l.as_str().to_string()),
+            request_id: event.correlation.request_id.as_ref().map(|l| l.as_str().to_string()),
+            correlation_id: event
+                .correlation
+                .correlation_id
+                .as_ref()
+                .map(|l| l.as_str().to_string()),
+            operation: event.action.operation.as_str().to_string(),
+            destination_kind: event.action.destination.kind.as_str().to_string(),
+            destination_id: event.action.destination.identifier().to_string(),
+            trust_zone: event.action.trust_zone.as_str().to_string(),
+            direction: event.action.direction.as_str().to_string(),
+            policy_document_id: event.policy.document_id.as_ref().map(|l| l.as_str().to_string()),
+            policy_version: event.policy.version,
+            matched_rule_ids: event
+                .policy
+                .matched_rule_ids
+                .iter()
+                .map(|l| l.as_str().to_string())
+                .collect(),
+            inspected_field_paths: event.inspected_fields.iter().map(|p| p.as_str().to_string()).collect(),
+            verdict: event.verdict.as_str().to_string(),
+            enforcement_point: event.execution.enforcement_point.as_str().to_string(),
+            transmission_evidence: event.execution.transmission.as_str().to_string(),
+            enforcement_mode: event.execution.mode.as_wire().to_string(),
+            inspection_failure_path: event.inspection_failure_path.as_str().to_string(),
+            severity: classification.map(|c| c.severity.as_str().to_string()),
+            confidence: classification.map(|c| c.confidence.as_str().to_string()),
+            method: classification.map(|c| c.method.as_str().to_string()),
+            status: classification.map(|c| c.status.as_str().to_string()),
+            event_count: event.event_count(),
+            blocked_event_count: event.blocked_event_count(),
+            finding_count: event.total_finding_count(),
+            blocked_finding_count: event.blocked_finding_count(),
+            transformed_finding_count: event.transformed_finding_count(),
+            finding_count_by_category: event
+                .finding_counts
+                .by_category
+                .iter()
+                .map(|entry| CategoryTally {
+                    category: entry.category.as_str().to_string(),
+                    count: entry.count,
+                })
+                .collect(),
+            reason_codes: event.reason_codes.iter().map(|c| c.as_str().to_string()).collect(),
+        })
+    }
+
+    /// Whether this row may be counted as prevented transmission.
+    ///
+    /// Recomputed from the three stored evidence columns plus the verdict —
+    /// ADR 0032 §8's four conditions — rather than read from a column, so a
+    /// stored row can never claim a block that the evidence does not support.
+    /// A `scrub` verdict satisfies condition 2 but redaction *forwards* the
+    /// scrubbed bytes, so it reaches `true` only when the evidence separately
+    /// records that the payload did not leave.
+    ///
+    /// Each clause is compared against the `aa-core` vocabulary rather than a
+    /// literal, so a renamed variant is a compile-time change here instead of a
+    /// silently-never-true predicate. `narrow` is excluded because it scopes
+    /// the action without transforming the payload — asking
+    /// [`RuntimeVerdictLabel::is_deny_or_transforming`] rather than listing
+    /// verdicts is what keeps that decision in one place.
+    pub fn counts_as_prevented_transmission(&self) -> bool {
+        self.enforcement_point == EnforcementPoint::PreTransmission.as_str()
+            && self.transmission_evidence == TransmissionEvidence::NotForwarded.as_str()
+            && self.enforcement_mode == EnforcementMode::Enforce.as_wire()
+            && RuntimeVerdictLabel::from_wire(&self.verdict).is_some_and(|v| v.is_deny_or_transforming())
+    }
+}
+
+/// One normalized finding, as it is persisted beneath its event.
+///
+/// # Span-free by construction, twice over
+///
+/// It is projected only from [`SensitiveDataFindingRecord`], which discards the
+/// [`ByteSpan`](aa_security::canonical::ByteSpan) when it is built from a
+/// `CanonicalFinding`, and it has no field that could hold one if a caller had
+/// it. The struct is deliberately *not* `#[non_exhaustive]`: an added field is
+/// meant to be a visible, reviewable diff here, and the integration test pins
+/// the exact key set so adding one fails the suite rather than silently
+/// publishing an offset.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SensitiveDataFindingRow {
+    /// Major of the schema the row was written against.
+    pub schema_version_major: u16,
+    /// Minor of that schema.
+    pub schema_version_minor: u16,
+    /// The event this finding belongs to.
+    pub event_id: String,
+    /// Position within its event, and the other half of the row's primary key.
+    ///
+    /// Not the [`AggregateKey`](aa_core::types::sensitive_data::AggregateKey):
+    /// two findings of the same category at the same path share an aggregate
+    /// key, so keying on it would deduplicate them and quietly lower the
+    /// finding count. The ordinal is stable across a replay of the same event,
+    /// which is what idempotency actually needs.
+    pub finding_ordinal: u32,
+    /// Owning organisation. Replicated from the event so a findings query is
+    /// tenant-scoped without a join.
+    pub org_id: String,
+    /// Owning tenant. Replicated for the same reason.
+    pub tenant_id: String,
+    /// When the parent action was inspected. Replicated so a time-windowed
+    /// finding aggregate needs no join either.
+    pub occurred_at_ns: u64,
+    /// What was found, in provider-neutral terms.
+    pub category: String,
+    /// How damaging its exposure would be.
+    pub severity: String,
+    /// How much the recognizer trusts the finding. Never an authorisation input.
+    pub confidence: String,
+    /// The technique that produced it.
+    pub method: String,
+    /// Its triage state. Nothing in this vocabulary means "clean".
+    pub status: String,
+    /// Which recognizer claims to have produced it.
+    pub recognizer: String,
+    /// The version of that recognizer. Descriptive, not a trust signal.
+    pub recognizer_version: String,
+    /// The name of the inspected field.
+    pub field_path: String,
+    /// The `[REDACTED:…]` label this finding redacts to, as the writing build
+    /// emitted it.
+    pub redaction_label: String,
+    /// `category|field_path|method|recognizer`, stored so grouping does not
+    /// have to reassemble it in SQL.
+    pub aggregate_key: String,
+}
+
+impl SensitiveDataFindingRow {
+    /// Project one finding record into its storable child row.
+    ///
+    /// The scope and `occurred_at` come from the parent event rather than the
+    /// record, because the record carries neither and inventing them per-row
+    /// would let a child disagree with its parent about which tenant it belongs
+    /// to.
+    ///
+    /// # Errors
+    ///
+    /// [`ProjectionError::FindingEventIdMismatch`] when the record names an
+    /// event other than `event_id`.
+    pub fn project(
+        record: &SensitiveDataFindingRecord,
+        event_id: &str,
+        scope: &TenantScope,
+        occurred_at: Timestamp,
+        ordinal: u32,
+    ) -> Result<Self, ProjectionError> {
+        if record.event_id.as_str() != event_id {
+            return Err(ProjectionError::FindingEventIdMismatch {
+                ordinal: ordinal as usize,
+                event_id: event_id.to_string(),
+                finding_event_id: record.event_id.as_str().to_string(),
+            });
+        }
+
+        Ok(Self {
+            schema_version_major: record.schema_version.major,
+            schema_version_minor: record.schema_version.minor,
+            event_id: event_id.to_string(),
+            finding_ordinal: ordinal,
+            org_id: scope.org_id().to_string(),
+            tenant_id: scope.tenant_id().to_string(),
+            occurred_at_ns: occurred_at.as_nanos(),
+            category: record.category.as_str().to_string(),
+            severity: record.severity.as_str().to_string(),
+            confidence: record.confidence.as_str().to_string(),
+            method: record.method.as_str().to_string(),
+            status: record.status.as_str().to_string(),
+            recognizer: record.provenance.recognizer.as_str().to_string(),
+            recognizer_version: record.provenance.version.as_str().to_string(),
+            field_path: record.field_path.as_str().to_string(),
+            redaction_label: record.redaction_label.as_str().to_string(),
+            aggregate_key: record.aggregate_key().as_str().to_string(),
+        })
+    }
+
+    /// Whether this build can interpret the row.
+    ///
+    /// Majors must agree; a newer minor only adds fields and is readable.
+    pub fn is_readable(&self) -> bool {
+        self.schema_version_major == SENSITIVE_DATA_SCHEMA_VERSION.major
+    }
+}

--- a/aa-gateway/src/storage/sensitive_data/rows.rs
+++ b/aa-gateway/src/storage/sensitive_data/rows.rs
@@ -10,7 +10,7 @@
 use aa_core::policy::EnforcementMode;
 use aa_core::time::Timestamp;
 use aa_core::types::sensitive_data::{
-    EnforcementPoint, RuntimeVerdictLabel, SensitiveDataDecisionEvent, SensitiveDataFindingRecord,
+    EnforcementPoint, ExecutionEvidence, RuntimeVerdictLabel, SensitiveDataDecisionEvent, SensitiveDataFindingRecord,
     TransmissionEvidence, SENSITIVE_DATA_SCHEMA_VERSION,
 };
 
@@ -81,6 +81,33 @@ pub enum ProjectionError {
         /// The serializer's message.
         source_message: String,
     },
+    /// A stored row was written against a schema major this build cannot read.
+    ///
+    /// The refusal [`SchemaVersion`](aa_core::types::sensitive_data::SchemaVersion)
+    /// documents as mandatory. Returned on the *read* path rather than silently
+    /// decoding: a major bump means a field this build would misinterpret, and
+    /// a misinterpreted governance row is worse than a missing one.
+    #[error("row `{event_id}` was written against schema major {found}, this build reads {expected}")]
+    UnreadableSchemaVersion {
+        /// The row that could not be read.
+        event_id: String,
+        /// The major the row carries.
+        found: u16,
+        /// The major this build reads.
+        expected: u16,
+    },
+    /// A stored integer column did not fit the field it decodes into.
+    ///
+    /// A silent `as` truncation here would turn a corrupt count into a
+    /// plausible one, which is the failure mode this projection exists to make
+    /// impossible.
+    #[error("column `{column}` value {value} does not fit its field")]
+    ColumnOutOfRange {
+        /// The column that did not fit.
+        column: &'static str,
+        /// The value read.
+        value: i64,
+    },
     /// The store rejected an otherwise well-formed write.
     ///
     /// Carries the message rather than the [`StorageError`] so this type stays
@@ -124,7 +151,14 @@ impl TenantScope {
         if tenant_id.trim().is_empty() {
             return Err(ProjectionError::EmptyTenancy("tenant_id"));
         }
-        Ok(Self { org_id, tenant_id })
+        // Store what was validated, not what was passed. Validating the trimmed
+        // form and storing the untrimmed one makes `" acme "` a scope that
+        // passes construction and then matches no row — an isolation bug that
+        // presents as an empty dashboard rather than as an error.
+        Ok(Self {
+            org_id: org_id.trim().to_string(),
+            tenant_id: tenant_id.trim().to_string(),
+        })
     }
 
     /// The owning organisation.
@@ -161,7 +195,14 @@ pub struct CategoryTally {
 /// the last is derived from evidence by
 /// [`counts_as_prevented_transmission`](Self::counts_as_prevented_transmission)
 /// so it cannot disagree with the evidence it is drawn from.
+///
+/// `#[non_exhaustive]` so a downstream crate cannot mint one by struct literal
+/// and hand it to
+/// [`append_sensitive_data_decision`](super::SensitiveDataProjection::append_sensitive_data_decision),
+/// which is a `pub` trait method taking rows directly. That closes the door the
+/// writer's type signature alone does not.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub struct SensitiveDataEventRow {
     /// Major of the schema the row was written against. A reader of a
     /// different major must refuse the row.
@@ -376,32 +417,63 @@ impl SensitiveDataEventRow {
     /// scrubbed bytes, so it reaches `true` only when the evidence separately
     /// records that the payload did not leave.
     ///
-    /// Each clause is compared against the `aa-core` vocabulary rather than a
-    /// literal, so a renamed variant is a compile-time change here instead of a
-    /// silently-never-true predicate. `narrow` is excluded because it scopes
-    /// the action without transforming the payload — asking
-    /// [`RuntimeVerdictLabel::is_deny_or_transforming`] rather than listing
-    /// verdicts is what keeps that decision in one place.
+    /// The three evidence columns are parsed back into their `aa-core` enums and
+    /// handed to [`ExecutionEvidence::establishes_non_transmission`], rather
+    /// than compared against strings here. That matters because both enums are
+    /// `#[non_exhaustive]`: a future `EnforcementPoint` that also establishes
+    /// non-transmission would be handled by `aa-core` and silently missed by a
+    /// string copy of its logic. Condition 2 comes from the verdict, which is
+    /// the one clause `ExecutionEvidence` deliberately does not hold.
+    ///
+    /// An unparseable column yields `false` — a row this build cannot interpret
+    /// has not proved prevention, and guessing in the permissive direction is
+    /// how an unwired producer ends up claiming a block it never made.
     pub fn counts_as_prevented_transmission(&self) -> bool {
-        self.enforcement_point == EnforcementPoint::PreTransmission.as_str()
-            && self.transmission_evidence == TransmissionEvidence::NotForwarded.as_str()
-            && self.enforcement_mode == EnforcementMode::Enforce.as_wire()
-            && RuntimeVerdictLabel::from_wire(&self.verdict).is_some_and(|v| v.is_deny_or_transforming())
+        let Some(evidence) = self.execution_evidence() else {
+            return false;
+        };
+        let Some(verdict) = RuntimeVerdictLabel::from_wire(&self.verdict) else {
+            return false;
+        };
+        evidence.establishes_non_transmission() && verdict.is_deny_or_transforming()
+    }
+
+    /// Reassemble the stored evidence columns into `aa-core`'s record.
+    ///
+    /// `None` when any of the three does not name a variant this build knows —
+    /// see [`counts_as_prevented_transmission`](Self::counts_as_prevented_transmission)
+    /// for why that is not treated as "no objection".
+    pub fn execution_evidence(&self) -> Option<ExecutionEvidence> {
+        let enforcement_point = from_wire_enum::<EnforcementPoint>(&self.enforcement_point)?;
+        let transmission = from_wire_enum::<TransmissionEvidence>(&self.transmission_evidence)?;
+        let mode = from_wire_enum::<EnforcementMode>(&self.enforcement_mode)?;
+        Some(ExecutionEvidence::new(enforcement_point, transmission, mode))
     }
 }
 
 /// One normalized finding, as it is persisted beneath its event.
 ///
-/// # Span-free by construction, twice over
+/// # What is actually true about spans here
 ///
-/// It is projected only from [`SensitiveDataFindingRecord`], which discards the
-/// [`ByteSpan`](aa_security::canonical::ByteSpan) when it is built from a
-/// `CanonicalFinding`, and it has no field that could hold one if a caller had
-/// it. The struct is deliberately *not* `#[non_exhaustive]`: an added field is
-/// meant to be a visible, reviewable diff here, and the integration test pins
-/// the exact key set so adding one fails the suite rather than silently
-/// publishing an offset.
+/// Stated narrowly, because "span-free by construction" has been overclaimed on
+/// this Epic before and the honest version is still strong enough:
+///
+/// * **This type has no offset, length or span field**, and neither does the
+///   table behind it — asserted from `tests/` against the live SQL catalogue and
+///   against the serialized key set, not against the DDL constant.
+/// * **The writer accepts only [`SensitiveDataFindingRecord`]**, which discards
+///   the [`ByteSpan`](aa_security::canonical::ByteSpan) when it is built from a
+///   `CanonicalFinding`, so the production path has nothing to leak.
+/// * `#[non_exhaustive]` stops a downstream crate minting a row by struct
+///   literal, so [`append_sensitive_data_decision`](super::SensitiveDataProjection::append_sensitive_data_decision)
+///   cannot be handed one assembled outside this module.
+///
+/// What that does **not** say: the fields are `pub`, `Deserialize` rebuilds a
+/// row from whatever bytes it is given, and `field_path` is a string that an
+/// in-crate caller could put an offset into. A row in hand is evidence about
+/// the writer, not an unrepresentable state.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub struct SensitiveDataFindingRow {
     /// Major of the schema the row was written against.
     pub schema_version_major: u16,
@@ -425,6 +497,16 @@ pub struct SensitiveDataFindingRow {
     /// When the parent action was inspected. Replicated so a time-windowed
     /// finding aggregate needs no join either.
     pub occurred_at_ns: u64,
+    /// The parent action's enforcement outcome.
+    ///
+    /// Replicated for the same reason `org_id` and `occurred_at_ns` are: a
+    /// "blocked findings by category" read is the headline query, and without
+    /// this column the verdict predicate on
+    /// [`SensitiveDataEventFilter`](super::SensitiveDataEventFilter) is
+    /// inapplicable to the findings table. Ignoring it silently — which is what
+    /// the first cut did — makes a "denied" dashboard return *every* finding,
+    /// over-reporting by exactly the factor forbidden design #11 is about.
+    pub verdict: String,
     /// What was found, in provider-neutral terms.
     pub category: String,
     /// How damaging its exposure would be.
@@ -460,14 +542,13 @@ impl SensitiveDataFindingRow {
     /// # Errors
     ///
     /// [`ProjectionError::FindingEventIdMismatch`] when the record names an
-    /// event other than `event_id`.
+    /// event other than the parent row's.
     pub fn project(
         record: &SensitiveDataFindingRecord,
-        event_id: &str,
-        scope: &TenantScope,
-        occurred_at: Timestamp,
+        event: &SensitiveDataEventRow,
         ordinal: u32,
     ) -> Result<Self, ProjectionError> {
+        let event_id = event.event_id.as_str();
         if record.event_id.as_str() != event_id {
             return Err(ProjectionError::FindingEventIdMismatch {
                 ordinal: ordinal as usize,
@@ -481,9 +562,10 @@ impl SensitiveDataFindingRow {
             schema_version_minor: record.schema_version.minor,
             event_id: event_id.to_string(),
             finding_ordinal: ordinal,
-            org_id: scope.org_id().to_string(),
-            tenant_id: scope.tenant_id().to_string(),
-            occurred_at_ns: occurred_at.as_nanos(),
+            org_id: event.org_id.clone(),
+            tenant_id: event.tenant_id.clone(),
+            occurred_at_ns: event.occurred_at_ns,
+            verdict: event.verdict.clone(),
             category: record.category.as_str().to_string(),
             severity: record.severity.as_str().to_string(),
             confidence: record.confidence.as_str().to_string(),
@@ -496,11 +578,44 @@ impl SensitiveDataFindingRow {
             aggregate_key: record.aggregate_key().as_str().to_string(),
         })
     }
+}
 
-    /// Whether this build can interpret the row.
-    ///
-    /// Majors must agree; a newer minor only adds fields and is readable.
-    pub fn is_readable(&self) -> bool {
-        self.schema_version_major == SENSITIVE_DATA_SCHEMA_VERSION.major
+/// Refuse a row whose schema major this build does not read.
+///
+/// Called by both backends' decoders. Centralised rather than duplicated so
+/// there is one place the rule lives, and so a backend that forgets to call it
+/// is a visible omission rather than a silently permissive read path.
+///
+/// # Errors
+///
+/// [`ProjectionError::UnreadableSchemaVersion`] when the majors differ. The
+/// minor is deliberately not compared — a newer minor only adds fields, and
+/// refusing it would make an additive change breaking.
+pub(super) fn check_readable(event_id: &str, major: u16) -> Result<(), ProjectionError> {
+    if major == SENSITIVE_DATA_SCHEMA_VERSION.major {
+        return Ok(());
     }
+    Err(ProjectionError::UnreadableSchemaVersion {
+        event_id: event_id.to_string(),
+        found: major,
+        expected: SENSITIVE_DATA_SCHEMA_VERSION.major,
+    })
+}
+
+/// Narrow a stored integer column, refusing rather than truncating.
+///
+/// # Errors
+///
+/// [`ProjectionError::ColumnOutOfRange`] when the stored value does not fit.
+pub(super) fn narrow<T: TryFrom<i64>>(value: i64, column: &'static str) -> Result<T, ProjectionError> {
+    T::try_from(value).map_err(|_| ProjectionError::ColumnOutOfRange { column, value })
+}
+
+/// Parse a stored column back into the `aa-core` enum it was rendered from.
+///
+/// Goes through serde because every one of these enums is `#[non_exhaustive]`
+/// with a `snake_case` representation and no `FromStr` — and because a
+/// hand-written match would be a second copy of a vocabulary `aa-core` owns.
+fn from_wire_enum<T: serde::de::DeserializeOwned>(wire: &str) -> Option<T> {
+    serde_json::from_value(serde_json::Value::String(wire.to_string())).ok()
 }

--- a/aa-gateway/src/storage/sensitive_data/rows.rs
+++ b/aa-gateway/src/storage/sensitive_data/rows.rs
@@ -1,11 +1,17 @@
 //! The persisted shapes of the sensitive-data projection.
 //!
 //! Gateway-owned value types, per the storage layer's standing rule that the
-//! schema does not move whenever a runtime type grows a field. They are
-//! projected *from* `aa-core`'s
-//! [`SensitiveDataDecisionEvent`] and [`SensitiveDataFindingRecord`]; nothing
-//! constructs them from anything else, which is what makes the span-freedom
-//! argument in the module doc hold end to end.
+//! schema does not move whenever a runtime type grows a field. The *writer*
+//! projects them from `aa-core`'s [`SensitiveDataDecisionEvent`] and
+//! [`SensitiveDataFindingRecord`].
+//!
+//! That is a statement about the writer and not about the types: `Deserialize`
+//! rebuilds either row from arbitrary bytes, and the `pub` fields let a row
+//! that was legitimately read be mutated and written back. Both routes reach
+//! [`append_sensitive_data_decision`](super::SensitiveDataProjection::append_sensitive_data_decision),
+//! and an earlier draft of this paragraph claimed otherwise while the type doc
+//! 400 lines below said the opposite. See
+//! [`SensitiveDataFindingRow`] for the version that holds.
 
 use aa_core::policy::EnforcementMode;
 use aa_core::time::Timestamp;
@@ -199,8 +205,16 @@ pub struct CategoryTally {
 /// `#[non_exhaustive]` so a downstream crate cannot mint one by struct literal
 /// and hand it to
 /// [`append_sensitive_data_decision`](super::SensitiveDataProjection::append_sensitive_data_decision),
-/// which is a `pub` trait method taking rows directly. That closes the door the
-/// writer's type signature alone does not.
+/// which is a `pub` trait method taking rows directly.
+///
+/// That narrows one door, it does not close the room — the same caveat
+/// [`SensitiveDataFindingRow`] carries applies here and for the same reasons.
+/// `Deserialize` rebuilds this row from arbitrary bytes, and its fields are
+/// `pub`, so a row read from storage can be mutated and written back.
+/// `destination_id` and `inspected_field_paths` are free-form strings and are
+/// exactly as capable of holding an offset as `field_path` is. What is
+/// structural is the absence of an offset *column*; everything else is a
+/// property of the writer.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 pub struct SensitiveDataEventRow {

--- a/aa-gateway/src/storage/sensitive_data/sqlite.rs
+++ b/aa-gateway/src/storage/sensitive_data/sqlite.rs
@@ -1,0 +1,471 @@
+//! SQLite implementation of the sensitive-data projection.
+//!
+//! Local-mode's backing store, and the one the property tests run against —
+//! it needs no container, so the invariants that matter (span-freedom, count
+//! separation, tenant isolation, idempotency, rollback) are exercised on every
+//! `cargo nextest run -p aa-gateway` rather than only where Docker is present.
+
+use async_trait::async_trait;
+use sqlx::{Row, SqlitePool};
+
+use crate::storage::error::{StorageError, StorageResult};
+use crate::storage::sqlite::SqliteBackend;
+
+use super::rows::{CategoryTally, SensitiveDataEventRow, SensitiveDataFindingRow};
+use super::store::{CategoryFindingAggregate, SensitiveDataEventFilter, SensitiveDataProjection};
+
+/// The projection's DDL, applied by
+/// [`migrate_sensitive_data_projection`](SensitiveDataProjection::migrate_sensitive_data_projection).
+///
+/// Every statement is `IF NOT EXISTS`, so the slice is safe against a fresh
+/// file or an already-migrated one. There is no offset, length, start, end or
+/// payload column in either table — ADR 0032 §9 confines those to the
+/// tamper-evident tier, and `tests/sensitive_data_projection_test.rs` asserts
+/// the column sets from outside this module so the omission cannot be undone
+/// quietly.
+const PROJECTION_SCHEMA: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS sensitive_data_events (
+        schema_version_major      INTEGER NOT NULL,
+        schema_version_minor      INTEGER NOT NULL,
+        event_id                  TEXT    NOT NULL PRIMARY KEY,
+        occurred_at_ns            INTEGER NOT NULL,
+        ingested_at_ns            INTEGER NOT NULL,
+        org_id                    TEXT    NOT NULL,
+        tenant_id                 TEXT    NOT NULL,
+        team_id                   TEXT,
+        acting_agent_id           TEXT    NOT NULL,
+        root_agent_id             TEXT    NOT NULL,
+        parent_agent_id           TEXT,
+        delegation_depth          INTEGER NOT NULL,
+        session_id                TEXT,
+        trace_id                  TEXT,
+        request_id                TEXT,
+        correlation_id            TEXT,
+        operation                 TEXT    NOT NULL,
+        destination_kind          TEXT    NOT NULL,
+        destination_id            TEXT    NOT NULL,
+        trust_zone                TEXT    NOT NULL,
+        direction                 TEXT    NOT NULL,
+        policy_document_id        TEXT,
+        policy_version            INTEGER,
+        matched_rule_ids          TEXT    NOT NULL,
+        inspected_field_paths     TEXT    NOT NULL,
+        verdict                   TEXT    NOT NULL,
+        enforcement_point         TEXT    NOT NULL,
+        transmission_evidence     TEXT    NOT NULL,
+        enforcement_mode          TEXT    NOT NULL,
+        inspection_failure_path   TEXT    NOT NULL,
+        severity                  TEXT,
+        confidence                TEXT,
+        method                    TEXT,
+        status                    TEXT,
+        event_count               INTEGER NOT NULL,
+        blocked_event_count       INTEGER NOT NULL,
+        finding_count             INTEGER NOT NULL,
+        blocked_finding_count     INTEGER NOT NULL,
+        transformed_finding_count INTEGER NOT NULL,
+        finding_count_by_category TEXT    NOT NULL,
+        reason_codes              TEXT    NOT NULL
+    )",
+    // Every read is tenant-scoped, so every index leads with the tenant keys.
+    "CREATE INDEX IF NOT EXISTS idx_sd_events_scope_ts
+        ON sensitive_data_events(org_id, tenant_id, occurred_at_ns)",
+    "CREATE INDEX IF NOT EXISTS idx_sd_events_scope_verdict
+        ON sensitive_data_events(org_id, tenant_id, verdict)",
+    "CREATE TABLE IF NOT EXISTS sensitive_data_findings (
+        schema_version_major INTEGER NOT NULL,
+        schema_version_minor INTEGER NOT NULL,
+        event_id             TEXT    NOT NULL,
+        finding_ordinal      INTEGER NOT NULL,
+        org_id               TEXT    NOT NULL,
+        tenant_id            TEXT    NOT NULL,
+        occurred_at_ns       INTEGER NOT NULL,
+        category             TEXT    NOT NULL,
+        severity             TEXT    NOT NULL,
+        confidence           TEXT    NOT NULL,
+        method               TEXT    NOT NULL,
+        status               TEXT    NOT NULL,
+        recognizer           TEXT    NOT NULL,
+        recognizer_version   TEXT    NOT NULL,
+        field_path           TEXT    NOT NULL,
+        redaction_label      TEXT    NOT NULL,
+        aggregate_key        TEXT    NOT NULL,
+        PRIMARY KEY (event_id, finding_ordinal)
+    )",
+    "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_category
+        ON sensitive_data_findings(org_id, tenant_id, category)",
+    "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_ts
+        ON sensitive_data_findings(org_id, tenant_id, occurred_at_ns)",
+];
+
+/// The inverse of [`PROJECTION_SCHEMA`].
+///
+/// Dropping the table drops its indexes with it, so naming only the tables is
+/// the whole undo. Ordered children-first purely so the statements read in the
+/// reverse of the order they were created.
+const PROJECTION_ROLLBACK: &[&str] = &[
+    "DROP TABLE IF EXISTS sensitive_data_findings",
+    "DROP TABLE IF EXISTS sensitive_data_events",
+];
+
+/// The event columns, in the order the row struct declares them.
+const EVENT_COLUMNS: &str = "schema_version_major, schema_version_minor, event_id, occurred_at_ns, \
+     ingested_at_ns, org_id, tenant_id, team_id, acting_agent_id, root_agent_id, parent_agent_id, \
+     delegation_depth, session_id, trace_id, request_id, correlation_id, operation, destination_kind, \
+     destination_id, trust_zone, direction, policy_document_id, policy_version, matched_rule_ids, \
+     inspected_field_paths, verdict, enforcement_point, transmission_evidence, enforcement_mode, \
+     inspection_failure_path, severity, confidence, method, status, event_count, blocked_event_count, \
+     finding_count, blocked_finding_count, transformed_finding_count, finding_count_by_category, reason_codes";
+
+/// The finding columns, in the order the row struct declares them.
+const FINDING_COLUMNS: &str = "schema_version_major, schema_version_minor, event_id, finding_ordinal, \
+     org_id, tenant_id, occurred_at_ns, category, severity, confidence, method, status, recognizer, \
+     recognizer_version, field_path, redaction_label, aggregate_key";
+
+/// Encode a list column as a JSON array.
+///
+/// The list columns (`matched_rule_ids`, `inspected_field_paths`,
+/// `reason_codes`, `finding_count_by_category`) are never grouped by — grouping
+/// by category goes through the normalized findings table, which is why the
+/// findings are normalized at all — so a JSON column costs nothing and keeps
+/// the event row one row.
+fn encode_json<T: serde::Serialize>(value: &T, column: &'static str) -> StorageResult<String> {
+    serde_json::to_string(value).map_err(|e| StorageError::QueryFailed(format!("encode {column}: {e}")))
+}
+
+fn decode_json<T: serde::de::DeserializeOwned>(raw: &str, column: &'static str) -> StorageResult<T> {
+    serde_json::from_str(raw).map_err(|e| StorageError::QueryFailed(format!("decode {column}: {e}")))
+}
+
+fn column<'r, T>(row: &'r sqlx::sqlite::SqliteRow, name: &'static str) -> StorageResult<T>
+where
+    T: sqlx::Decode<'r, sqlx::Sqlite> + sqlx::Type<sqlx::Sqlite>,
+{
+    row.try_get(name)
+        .map_err(|e| StorageError::QueryFailed(format!("{name} column: {e}")))
+}
+
+fn row_to_event(row: &sqlx::sqlite::SqliteRow) -> StorageResult<SensitiveDataEventRow> {
+    let matched_rule_ids: String = column(row, "matched_rule_ids")?;
+    let inspected_field_paths: String = column(row, "inspected_field_paths")?;
+    let by_category: String = column(row, "finding_count_by_category")?;
+    let reason_codes: String = column(row, "reason_codes")?;
+
+    Ok(SensitiveDataEventRow {
+        schema_version_major: column::<i64>(row, "schema_version_major")? as u16,
+        schema_version_minor: column::<i64>(row, "schema_version_minor")? as u16,
+        event_id: column(row, "event_id")?,
+        occurred_at_ns: column::<i64>(row, "occurred_at_ns")? as u64,
+        ingested_at_ns: column::<i64>(row, "ingested_at_ns")? as u64,
+        org_id: column(row, "org_id")?,
+        tenant_id: column(row, "tenant_id")?,
+        team_id: column(row, "team_id")?,
+        acting_agent_id: column(row, "acting_agent_id")?,
+        root_agent_id: column(row, "root_agent_id")?,
+        parent_agent_id: column(row, "parent_agent_id")?,
+        delegation_depth: column::<i64>(row, "delegation_depth")? as u32,
+        session_id: column(row, "session_id")?,
+        trace_id: column(row, "trace_id")?,
+        request_id: column(row, "request_id")?,
+        correlation_id: column(row, "correlation_id")?,
+        operation: column(row, "operation")?,
+        destination_kind: column(row, "destination_kind")?,
+        destination_id: column(row, "destination_id")?,
+        trust_zone: column(row, "trust_zone")?,
+        direction: column(row, "direction")?,
+        policy_document_id: column(row, "policy_document_id")?,
+        policy_version: column::<Option<i64>>(row, "policy_version")?.map(|v| v as u64),
+        matched_rule_ids: decode_json(&matched_rule_ids, "matched_rule_ids")?,
+        inspected_field_paths: decode_json(&inspected_field_paths, "inspected_field_paths")?,
+        verdict: column(row, "verdict")?,
+        enforcement_point: column(row, "enforcement_point")?,
+        transmission_evidence: column(row, "transmission_evidence")?,
+        enforcement_mode: column(row, "enforcement_mode")?,
+        inspection_failure_path: column(row, "inspection_failure_path")?,
+        severity: column(row, "severity")?,
+        confidence: column(row, "confidence")?,
+        method: column(row, "method")?,
+        status: column(row, "status")?,
+        event_count: column::<i64>(row, "event_count")? as u32,
+        blocked_event_count: column::<i64>(row, "blocked_event_count")? as u32,
+        finding_count: column::<i64>(row, "finding_count")? as u32,
+        blocked_finding_count: column::<i64>(row, "blocked_finding_count")? as u32,
+        transformed_finding_count: column::<i64>(row, "transformed_finding_count")? as u32,
+        finding_count_by_category: decode_json::<Vec<CategoryTally>>(&by_category, "finding_count_by_category")?,
+        reason_codes: decode_json(&reason_codes, "reason_codes")?,
+    })
+}
+
+fn row_to_finding(row: &sqlx::sqlite::SqliteRow) -> StorageResult<SensitiveDataFindingRow> {
+    Ok(SensitiveDataFindingRow {
+        schema_version_major: column::<i64>(row, "schema_version_major")? as u16,
+        schema_version_minor: column::<i64>(row, "schema_version_minor")? as u16,
+        event_id: column(row, "event_id")?,
+        finding_ordinal: column::<i64>(row, "finding_ordinal")? as u32,
+        org_id: column(row, "org_id")?,
+        tenant_id: column(row, "tenant_id")?,
+        occurred_at_ns: column::<i64>(row, "occurred_at_ns")? as u64,
+        category: column(row, "category")?,
+        severity: column(row, "severity")?,
+        confidence: column(row, "confidence")?,
+        method: column(row, "method")?,
+        status: column(row, "status")?,
+        recognizer: column(row, "recognizer")?,
+        recognizer_version: column(row, "recognizer_version")?,
+        field_path: column(row, "field_path")?,
+        redaction_label: column(row, "redaction_label")?,
+        aggregate_key: column(row, "aggregate_key")?,
+    })
+}
+
+/// Append the tenant predicate and the optional narrowings.
+///
+/// `org_id` and `tenant_id` are pushed unconditionally and first, so there is
+/// no code path through this function that produces an unscoped `WHERE`.
+fn push_scope<'a>(
+    qb: &mut sqlx::QueryBuilder<'a, sqlx::Sqlite>,
+    filter: &'a SensitiveDataEventFilter,
+    with_verdict: bool,
+) {
+    qb.push(" WHERE org_id = ").push_bind(filter.scope().org_id());
+    qb.push(" AND tenant_id = ").push_bind(filter.scope().tenant_id());
+    if let Some(from) = filter.from {
+        qb.push(" AND occurred_at_ns >= ").push_bind(from.as_nanos() as i64);
+    }
+    if let Some(to) = filter.to {
+        qb.push(" AND occurred_at_ns < ").push_bind(to.as_nanos() as i64);
+    }
+    if with_verdict {
+        if let Some(verdict) = filter.verdict.as_deref() {
+            qb.push(" AND verdict = ").push_bind(verdict);
+        }
+    }
+}
+
+#[async_trait]
+impl SensitiveDataProjection for SqliteBackend {
+    async fn migrate_sensitive_data_projection(&self) -> StorageResult<()> {
+        apply_statements(self.pool(), PROJECTION_SCHEMA).await
+    }
+
+    async fn rollback_sensitive_data_projection(&self) -> StorageResult<()> {
+        apply_statements(self.pool(), PROJECTION_ROLLBACK).await
+    }
+
+    async fn append_sensitive_data_decision(
+        &self,
+        event: &SensitiveDataEventRow,
+        findings: &[SensitiveDataFindingRow],
+    ) -> StorageResult<()> {
+        let matched_rule_ids = encode_json(&event.matched_rule_ids, "matched_rule_ids")?;
+        let inspected_field_paths = encode_json(&event.inspected_field_paths, "inspected_field_paths")?;
+        let by_category = encode_json(&event.finding_count_by_category, "finding_count_by_category")?;
+        let reason_codes = encode_json(&event.reason_codes, "reason_codes")?;
+
+        let mut tx = self
+            .pool()
+            .begin()
+            .await
+            .map_err(|e| StorageError::QueryFailed(format!("begin: {e}")))?;
+
+        // `OR IGNORE` is the idempotency rule: a replayed event is a no-op, so
+        // a retried publish cannot double-count. First write wins.
+        let placeholders = vec!["?"; 41].join(", ");
+        sqlx::query(&format!(
+            "INSERT OR IGNORE INTO sensitive_data_events ({EVENT_COLUMNS}) VALUES ({placeholders})"
+        ))
+        .bind(i64::from(event.schema_version_major))
+        .bind(i64::from(event.schema_version_minor))
+        .bind(&event.event_id)
+        .bind(event.occurred_at_ns as i64)
+        .bind(event.ingested_at_ns as i64)
+        .bind(&event.org_id)
+        .bind(&event.tenant_id)
+        .bind(event.team_id.as_deref())
+        .bind(&event.acting_agent_id)
+        .bind(&event.root_agent_id)
+        .bind(event.parent_agent_id.as_deref())
+        .bind(i64::from(event.delegation_depth))
+        .bind(event.session_id.as_deref())
+        .bind(event.trace_id.as_deref())
+        .bind(event.request_id.as_deref())
+        .bind(event.correlation_id.as_deref())
+        .bind(&event.operation)
+        .bind(&event.destination_kind)
+        .bind(&event.destination_id)
+        .bind(&event.trust_zone)
+        .bind(&event.direction)
+        .bind(event.policy_document_id.as_deref())
+        .bind(event.policy_version.map(|v| v as i64))
+        .bind(&matched_rule_ids)
+        .bind(&inspected_field_paths)
+        .bind(&event.verdict)
+        .bind(&event.enforcement_point)
+        .bind(&event.transmission_evidence)
+        .bind(&event.enforcement_mode)
+        .bind(&event.inspection_failure_path)
+        .bind(event.severity.as_deref())
+        .bind(event.confidence.as_deref())
+        .bind(event.method.as_deref())
+        .bind(event.status.as_deref())
+        .bind(i64::from(event.event_count))
+        .bind(i64::from(event.blocked_event_count))
+        .bind(i64::from(event.finding_count))
+        .bind(i64::from(event.blocked_finding_count))
+        .bind(i64::from(event.transformed_finding_count))
+        .bind(&by_category)
+        .bind(&reason_codes)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| StorageError::QueryFailed(format!("insert event: {e}")))?;
+
+        let finding_placeholders = vec!["?"; 17].join(", ");
+        for finding in findings {
+            sqlx::query(&format!(
+                "INSERT OR IGNORE INTO sensitive_data_findings ({FINDING_COLUMNS}) \
+                 VALUES ({finding_placeholders})"
+            ))
+            .bind(i64::from(finding.schema_version_major))
+            .bind(i64::from(finding.schema_version_minor))
+            .bind(&finding.event_id)
+            .bind(i64::from(finding.finding_ordinal))
+            .bind(&finding.org_id)
+            .bind(&finding.tenant_id)
+            .bind(finding.occurred_at_ns as i64)
+            .bind(&finding.category)
+            .bind(&finding.severity)
+            .bind(&finding.confidence)
+            .bind(&finding.method)
+            .bind(&finding.status)
+            .bind(&finding.recognizer)
+            .bind(&finding.recognizer_version)
+            .bind(&finding.field_path)
+            .bind(&finding.redaction_label)
+            .bind(&finding.aggregate_key)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::QueryFailed(format!("insert finding: {e}")))?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::QueryFailed(format!("commit: {e}")))
+    }
+
+    async fn query_sensitive_data_events(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<SensitiveDataEventRow>> {
+        let mut qb =
+            sqlx::QueryBuilder::<sqlx::Sqlite>::new(format!("SELECT {EVENT_COLUMNS} FROM sensitive_data_events"));
+        push_scope(&mut qb, filter, true);
+        qb.push(" ORDER BY occurred_at_ns DESC, event_id ASC");
+        if let Some(limit) = filter.limit {
+            qb.push(" LIMIT ").push_bind(i64::from(limit));
+        }
+        let rows = qb
+            .build()
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        rows.iter().map(row_to_event).collect()
+    }
+
+    async fn query_sensitive_data_findings(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<SensitiveDataFindingRow>> {
+        let mut qb =
+            sqlx::QueryBuilder::<sqlx::Sqlite>::new(format!("SELECT {FINDING_COLUMNS} FROM sensitive_data_findings"));
+        push_scope(&mut qb, filter, false);
+        qb.push(" ORDER BY occurred_at_ns DESC, event_id ASC, finding_ordinal ASC");
+        if let Some(limit) = filter.limit {
+            qb.push(" LIMIT ").push_bind(i64::from(limit));
+        }
+        let rows = qb
+            .build()
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        rows.iter().map(row_to_finding).collect()
+    }
+
+    async fn count_sensitive_data_events(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
+        let mut qb = sqlx::QueryBuilder::<sqlx::Sqlite>::new("SELECT COUNT(*) FROM sensitive_data_events");
+        push_scope(&mut qb, filter, true);
+        let count: i64 = qb
+            .build_query_scalar()
+            .fetch_one(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        Ok(count.max(0) as u64)
+    }
+
+    async fn count_sensitive_data_findings(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
+        let mut qb = sqlx::QueryBuilder::<sqlx::Sqlite>::new("SELECT COUNT(*) FROM sensitive_data_findings");
+        push_scope(&mut qb, filter, false);
+        let count: i64 = qb
+            .build_query_scalar()
+            .fetch_one(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        Ok(count.max(0) as u64)
+    }
+
+    async fn sensitive_data_projection_columns(&self) -> StorageResult<Vec<(String, String)>> {
+        let mut out = Vec::new();
+        for table in ["sensitive_data_events", "sensitive_data_findings"] {
+            // `PRAGMA table_info` reports what the file actually has, which is
+            // the point — a test reading PROJECTION_SCHEMA back would only
+            // prove the constant agrees with itself.
+            let rows = sqlx::query(&format!("PRAGMA table_info({table})"))
+                .fetch_all(self.pool())
+                .await
+                .map_err(|e| StorageError::QueryFailed(format!("table_info {table}: {e}")))?;
+            for row in &rows {
+                out.push((table.to_string(), column::<String>(row, "name")?));
+            }
+        }
+        Ok(out)
+    }
+
+    async fn aggregate_sensitive_data_by_category(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<CategoryFindingAggregate>> {
+        // COUNT(*) counts findings; COUNT(DISTINCT event_id) counts events.
+        // Both are selected because they are different measures — collapsing
+        // them is ADR 0032 forbidden design #11.
+        let mut qb = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+            "SELECT category, COUNT(*) AS finding_count, COUNT(DISTINCT event_id) AS event_count \
+             FROM sensitive_data_findings",
+        );
+        push_scope(&mut qb, filter, false);
+        qb.push(" GROUP BY category ORDER BY category ASC");
+        let rows = qb
+            .build()
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+
+        rows.iter()
+            .map(|row| {
+                Ok(CategoryFindingAggregate {
+                    category: column(row, "category")?,
+                    finding_count: column::<i64>(row, "finding_count")?.max(0) as u64,
+                    event_count: column::<i64>(row, "event_count")?.max(0) as u64,
+                })
+            })
+            .collect()
+    }
+}
+
+async fn apply_statements(pool: &SqlitePool, statements: &[&str]) -> StorageResult<()> {
+    for stmt in statements {
+        sqlx::query(stmt)
+            .execute(pool)
+            .await
+            .map_err(|e| StorageError::MigrationFailed(e.to_string()))?;
+    }
+    Ok(())
+}

--- a/aa-gateway/src/storage/sensitive_data/sqlite.rs
+++ b/aa-gateway/src/storage/sensitive_data/sqlite.rs
@@ -11,7 +11,7 @@ use sqlx::{Row, SqlitePool};
 use crate::storage::error::{StorageError, StorageResult};
 use crate::storage::sqlite::SqliteBackend;
 
-use super::rows::{CategoryTally, SensitiveDataEventRow, SensitiveDataFindingRow};
+use super::rows::{check_readable, narrow, CategoryTally, SensitiveDataEventRow, SensitiveDataFindingRow};
 use super::store::{CategoryFindingAggregate, SensitiveDataEventFilter, SensitiveDataProjection};
 
 /// The projection's DDL, applied by
@@ -80,6 +80,7 @@ const PROJECTION_SCHEMA: &[&str] = &[
         org_id               TEXT    NOT NULL,
         tenant_id            TEXT    NOT NULL,
         occurred_at_ns       INTEGER NOT NULL,
+        verdict              TEXT    NOT NULL,
         category             TEXT    NOT NULL,
         severity             TEXT    NOT NULL,
         confidence           TEXT    NOT NULL,
@@ -93,7 +94,7 @@ const PROJECTION_SCHEMA: &[&str] = &[
         PRIMARY KEY (event_id, finding_ordinal)
     )",
     "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_category
-        ON sensitive_data_findings(org_id, tenant_id, category)",
+        ON sensitive_data_findings(org_id, tenant_id, verdict, category)",
     "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_ts
         ON sensitive_data_findings(org_id, tenant_id, occurred_at_ns)",
 ];
@@ -119,7 +120,7 @@ const EVENT_COLUMNS: &str = "schema_version_major, schema_version_minor, event_i
 
 /// The finding columns, in the order the row struct declares them.
 const FINDING_COLUMNS: &str = "schema_version_major, schema_version_minor, event_id, finding_ordinal, \
-     org_id, tenant_id, occurred_at_ns, category, severity, confidence, method, status, recognizer, \
+     org_id, tenant_id, occurred_at_ns, verdict, category, severity, confidence, method, status, recognizer, \
      recognizer_version, field_path, redaction_label, aggregate_key";
 
 /// Encode a list column as a JSON array.
@@ -146,24 +147,28 @@ where
 }
 
 fn row_to_event(row: &sqlx::sqlite::SqliteRow) -> StorageResult<SensitiveDataEventRow> {
+    let event_id: String = column(row, "event_id")?;
+    let schema_version_major: u16 = narrow(column::<i64>(row, "schema_version_major")?, "schema_version_major")?;
+    check_readable(&event_id, schema_version_major)?;
+
     let matched_rule_ids: String = column(row, "matched_rule_ids")?;
     let inspected_field_paths: String = column(row, "inspected_field_paths")?;
     let by_category: String = column(row, "finding_count_by_category")?;
     let reason_codes: String = column(row, "reason_codes")?;
 
     Ok(SensitiveDataEventRow {
-        schema_version_major: column::<i64>(row, "schema_version_major")? as u16,
-        schema_version_minor: column::<i64>(row, "schema_version_minor")? as u16,
-        event_id: column(row, "event_id")?,
-        occurred_at_ns: column::<i64>(row, "occurred_at_ns")? as u64,
-        ingested_at_ns: column::<i64>(row, "ingested_at_ns")? as u64,
+        schema_version_major,
+        schema_version_minor: narrow(column::<i64>(row, "schema_version_minor")?, "schema_version_minor")?,
+        event_id,
+        occurred_at_ns: narrow(column::<i64>(row, "occurred_at_ns")?, "occurred_at_ns")?,
+        ingested_at_ns: narrow(column::<i64>(row, "ingested_at_ns")?, "ingested_at_ns")?,
         org_id: column(row, "org_id")?,
         tenant_id: column(row, "tenant_id")?,
         team_id: column(row, "team_id")?,
         acting_agent_id: column(row, "acting_agent_id")?,
         root_agent_id: column(row, "root_agent_id")?,
         parent_agent_id: column(row, "parent_agent_id")?,
-        delegation_depth: column::<i64>(row, "delegation_depth")? as u32,
+        delegation_depth: narrow(column::<i64>(row, "delegation_depth")?, "delegation_depth")?,
         session_id: column(row, "session_id")?,
         trace_id: column(row, "trace_id")?,
         request_id: column(row, "request_id")?,
@@ -174,7 +179,9 @@ fn row_to_event(row: &sqlx::sqlite::SqliteRow) -> StorageResult<SensitiveDataEve
         trust_zone: column(row, "trust_zone")?,
         direction: column(row, "direction")?,
         policy_document_id: column(row, "policy_document_id")?,
-        policy_version: column::<Option<i64>>(row, "policy_version")?.map(|v| v as u64),
+        policy_version: column::<Option<i64>>(row, "policy_version")?
+            .map(|v| narrow(v, "policy_version"))
+            .transpose()?,
         matched_rule_ids: decode_json(&matched_rule_ids, "matched_rule_ids")?,
         inspected_field_paths: decode_json(&inspected_field_paths, "inspected_field_paths")?,
         verdict: column(row, "verdict")?,
@@ -186,25 +193,33 @@ fn row_to_event(row: &sqlx::sqlite::SqliteRow) -> StorageResult<SensitiveDataEve
         confidence: column(row, "confidence")?,
         method: column(row, "method")?,
         status: column(row, "status")?,
-        event_count: column::<i64>(row, "event_count")? as u32,
-        blocked_event_count: column::<i64>(row, "blocked_event_count")? as u32,
-        finding_count: column::<i64>(row, "finding_count")? as u32,
-        blocked_finding_count: column::<i64>(row, "blocked_finding_count")? as u32,
-        transformed_finding_count: column::<i64>(row, "transformed_finding_count")? as u32,
+        event_count: narrow(column::<i64>(row, "event_count")?, "event_count")?,
+        blocked_event_count: narrow(column::<i64>(row, "blocked_event_count")?, "blocked_event_count")?,
+        finding_count: narrow(column::<i64>(row, "finding_count")?, "finding_count")?,
+        blocked_finding_count: narrow(column::<i64>(row, "blocked_finding_count")?, "blocked_finding_count")?,
+        transformed_finding_count: narrow(
+            column::<i64>(row, "transformed_finding_count")?,
+            "transformed_finding_count",
+        )?,
         finding_count_by_category: decode_json::<Vec<CategoryTally>>(&by_category, "finding_count_by_category")?,
         reason_codes: decode_json(&reason_codes, "reason_codes")?,
     })
 }
 
 fn row_to_finding(row: &sqlx::sqlite::SqliteRow) -> StorageResult<SensitiveDataFindingRow> {
+    let event_id: String = column(row, "event_id")?;
+    let schema_version_major: u16 = narrow(column::<i64>(row, "schema_version_major")?, "schema_version_major")?;
+    check_readable(&event_id, schema_version_major)?;
+
     Ok(SensitiveDataFindingRow {
-        schema_version_major: column::<i64>(row, "schema_version_major")? as u16,
-        schema_version_minor: column::<i64>(row, "schema_version_minor")? as u16,
-        event_id: column(row, "event_id")?,
-        finding_ordinal: column::<i64>(row, "finding_ordinal")? as u32,
+        schema_version_major,
+        schema_version_minor: narrow(column::<i64>(row, "schema_version_minor")?, "schema_version_minor")?,
+        event_id,
+        finding_ordinal: narrow(column::<i64>(row, "finding_ordinal")?, "finding_ordinal")?,
         org_id: column(row, "org_id")?,
         tenant_id: column(row, "tenant_id")?,
-        occurred_at_ns: column::<i64>(row, "occurred_at_ns")? as u64,
+        occurred_at_ns: narrow(column::<i64>(row, "occurred_at_ns")?, "occurred_at_ns")?,
+        verdict: column(row, "verdict")?,
         category: column(row, "category")?,
         severity: column(row, "severity")?,
         confidence: column(row, "confidence")?,
@@ -222,11 +237,7 @@ fn row_to_finding(row: &sqlx::sqlite::SqliteRow) -> StorageResult<SensitiveDataF
 ///
 /// `org_id` and `tenant_id` are pushed unconditionally and first, so there is
 /// no code path through this function that produces an unscoped `WHERE`.
-fn push_scope<'a>(
-    qb: &mut sqlx::QueryBuilder<'a, sqlx::Sqlite>,
-    filter: &'a SensitiveDataEventFilter,
-    with_verdict: bool,
-) {
+fn push_scope<'a>(qb: &mut sqlx::QueryBuilder<'a, sqlx::Sqlite>, filter: &'a SensitiveDataEventFilter) {
     qb.push(" WHERE org_id = ").push_bind(filter.scope().org_id());
     qb.push(" AND tenant_id = ").push_bind(filter.scope().tenant_id());
     if let Some(from) = filter.from {
@@ -235,10 +246,10 @@ fn push_scope<'a>(
     if let Some(to) = filter.to {
         qb.push(" AND occurred_at_ns < ").push_bind(to.as_nanos() as i64);
     }
-    if with_verdict {
-        if let Some(verdict) = filter.verdict.as_deref() {
-            qb.push(" AND verdict = ").push_bind(verdict);
-        }
+    // No `with_verdict` switch: both tables carry the column, so there is no
+    // caller that can be handed a filter whose verdict is quietly dropped.
+    if let Some(verdict) = filter.verdict.as_deref() {
+        qb.push(" AND verdict = ").push_bind(verdict);
     }
 }
 
@@ -271,7 +282,7 @@ impl SensitiveDataProjection for SqliteBackend {
         // `OR IGNORE` is the idempotency rule: a replayed event is a no-op, so
         // a retried publish cannot double-count. First write wins.
         let placeholders = vec!["?"; 41].join(", ");
-        sqlx::query(&format!(
+        let inserted = sqlx::query(&format!(
             "INSERT OR IGNORE INTO sensitive_data_events ({EVENT_COLUMNS}) VALUES ({placeholders})"
         ))
         .bind(i64::from(event.schema_version_major))
@@ -319,7 +330,25 @@ impl SensitiveDataProjection for SqliteBackend {
         .await
         .map_err(|e| StorageError::QueryFailed(format!("insert event: {e}")))?;
 
-        let finding_placeholders = vec!["?"; 17].join(", ");
+        // First-write-wins has to cover the children, not just the parent.
+        // `OR IGNORE` on the child rows alone is *additive*: a replay carrying
+        // more findings than the stored event would insert the new ordinals
+        // while the parent's `finding_count` stayed frozen, leaving the tally
+        // disagreeing with the rows it describes — and the per-category
+        // aggregate, which reads the child table, over-reporting against it.
+        // A no-op parent insert therefore ends the transaction here.
+        if inserted.rows_affected() == 0 {
+            tracing::debug!(
+                event_id = %event.event_id,
+                "sensitive-data projection: event already stored, ignoring replay"
+            );
+            return tx
+                .commit()
+                .await
+                .map_err(|e| StorageError::QueryFailed(format!("commit: {e}")));
+        }
+
+        let finding_placeholders = vec!["?"; 18].join(", ");
         for finding in findings {
             sqlx::query(&format!(
                 "INSERT OR IGNORE INTO sensitive_data_findings ({FINDING_COLUMNS}) \
@@ -332,6 +361,7 @@ impl SensitiveDataProjection for SqliteBackend {
             .bind(&finding.org_id)
             .bind(&finding.tenant_id)
             .bind(finding.occurred_at_ns as i64)
+            .bind(&finding.verdict)
             .bind(&finding.category)
             .bind(&finding.severity)
             .bind(&finding.confidence)
@@ -358,7 +388,7 @@ impl SensitiveDataProjection for SqliteBackend {
     ) -> StorageResult<Vec<SensitiveDataEventRow>> {
         let mut qb =
             sqlx::QueryBuilder::<sqlx::Sqlite>::new(format!("SELECT {EVENT_COLUMNS} FROM sensitive_data_events"));
-        push_scope(&mut qb, filter, true);
+        push_scope(&mut qb, filter);
         qb.push(" ORDER BY occurred_at_ns DESC, event_id ASC");
         if let Some(limit) = filter.limit {
             qb.push(" LIMIT ").push_bind(i64::from(limit));
@@ -377,7 +407,7 @@ impl SensitiveDataProjection for SqliteBackend {
     ) -> StorageResult<Vec<SensitiveDataFindingRow>> {
         let mut qb =
             sqlx::QueryBuilder::<sqlx::Sqlite>::new(format!("SELECT {FINDING_COLUMNS} FROM sensitive_data_findings"));
-        push_scope(&mut qb, filter, false);
+        push_scope(&mut qb, filter);
         qb.push(" ORDER BY occurred_at_ns DESC, event_id ASC, finding_ordinal ASC");
         if let Some(limit) = filter.limit {
             qb.push(" LIMIT ").push_bind(i64::from(limit));
@@ -392,7 +422,7 @@ impl SensitiveDataProjection for SqliteBackend {
 
     async fn count_sensitive_data_events(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
         let mut qb = sqlx::QueryBuilder::<sqlx::Sqlite>::new("SELECT COUNT(*) FROM sensitive_data_events");
-        push_scope(&mut qb, filter, true);
+        push_scope(&mut qb, filter);
         let count: i64 = qb
             .build_query_scalar()
             .fetch_one(self.pool())
@@ -403,7 +433,7 @@ impl SensitiveDataProjection for SqliteBackend {
 
     async fn count_sensitive_data_findings(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
         let mut qb = sqlx::QueryBuilder::<sqlx::Sqlite>::new("SELECT COUNT(*) FROM sensitive_data_findings");
-        push_scope(&mut qb, filter, false);
+        push_scope(&mut qb, filter);
         let count: i64 = qb
             .build_query_scalar()
             .fetch_one(self.pool())
@@ -440,8 +470,14 @@ impl SensitiveDataProjection for SqliteBackend {
             "SELECT category, COUNT(*) AS finding_count, COUNT(DISTINCT event_id) AS event_count \
              FROM sensitive_data_findings",
         );
-        push_scope(&mut qb, filter, false);
+        push_scope(&mut qb, filter);
         qb.push(" GROUP BY category ORDER BY category ASC");
+        // The category vocabulary is not closed (see `CategoryFindingAggregate`),
+        // so the row cap is also the group cap — the only bound available
+        // against an attacker-influenced grouping value.
+        if let Some(limit) = filter.limit {
+            qb.push(" LIMIT ").push_bind(i64::from(limit));
+        }
         let rows = qb
             .build()
             .fetch_all(self.pool())
@@ -460,12 +496,24 @@ impl SensitiveDataProjection for SqliteBackend {
     }
 }
 
+/// Apply a DDL set atomically.
+///
+/// In one transaction because both SQLite and PostgreSQL support transactional
+/// DDL: a migration that fails on its fourth statement should leave no tables
+/// at all, rather than a half-created schema that the next `IF NOT EXISTS` run
+/// would silently accept as complete.
 async fn apply_statements(pool: &SqlitePool, statements: &[&str]) -> StorageResult<()> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| StorageError::MigrationFailed(format!("begin: {e}")))?;
     for stmt in statements {
         sqlx::query(stmt)
-            .execute(pool)
+            .execute(&mut *tx)
             .await
             .map_err(|e| StorageError::MigrationFailed(e.to_string()))?;
     }
-    Ok(())
+    tx.commit()
+        .await
+        .map_err(|e| StorageError::MigrationFailed(format!("commit: {e}")))
 }

--- a/aa-gateway/src/storage/sensitive_data/sqlite.rs
+++ b/aa-gateway/src/storage/sensitive_data/sqlite.rs
@@ -20,7 +20,7 @@ use super::store::{CategoryFindingAggregate, SensitiveDataEventFilter, Sensitive
 /// Every statement is `IF NOT EXISTS`, so the slice is safe against a fresh
 /// file or an already-migrated one. There is no offset, length, start, end or
 /// payload column in either table — ADR 0032 §9 confines those to the
-/// tamper-evident tier, and `tests/sensitive_data_projection_test.rs` asserts
+/// tamper-evident tier, and `tests/sensitive_data_contract/` asserts
 /// the column sets from outside this module so the omission cannot be undone
 /// quietly.
 const PROJECTION_SCHEMA: &[&str] = &[
@@ -279,11 +279,22 @@ impl SensitiveDataProjection for SqliteBackend {
             .await
             .map_err(|e| StorageError::QueryFailed(format!("begin: {e}")))?;
 
-        // `OR IGNORE` is the idempotency rule: a replayed event is a no-op, so
-        // a retried publish cannot double-count. First write wins.
+        // `ON CONFLICT(event_id) DO NOTHING` is the idempotency rule: a
+        // replayed event is a no-op, so a retried publish cannot double-count.
+        // First write wins.
+        //
+        // Targeted, not `INSERT OR IGNORE`, and the difference matters now that
+        // the child inserts are gated on `rows_affected()`. `OR IGNORE` skips
+        // on *any* constraint violation, so a NOT NULL or CHECK failure would
+        // become a successful-looking no-op that also silently skipped every
+        // child row — while PostgreSQL's targeted `DO NOTHING` raises. Backends
+        // whose failure semantics diverge is how a divergence gets found in
+        // production rather than in CI. (AAASM-5447 carries the matching
+        // primary-key change; this is the conflict-clause alignment only.)
         let placeholders = vec!["?"; 41].join(", ");
         let inserted = sqlx::query(&format!(
-            "INSERT OR IGNORE INTO sensitive_data_events ({EVENT_COLUMNS}) VALUES ({placeholders})"
+            "INSERT INTO sensitive_data_events ({EVENT_COLUMNS}) VALUES ({placeholders}) \
+             ON CONFLICT(event_id) DO NOTHING"
         ))
         .bind(i64::from(event.schema_version_major))
         .bind(i64::from(event.schema_version_minor))
@@ -331,7 +342,8 @@ impl SensitiveDataProjection for SqliteBackend {
         .map_err(|e| StorageError::QueryFailed(format!("insert event: {e}")))?;
 
         // First-write-wins has to cover the children, not just the parent.
-        // `OR IGNORE` on the child rows alone is *additive*: a replay carrying
+        // A conflict-ignoring insert on the child rows alone is *additive*: a
+        // replay carrying
         // more findings than the stored event would insert the new ordinals
         // while the parent's `finding_count` stayed frozen, leaving the tally
         // disagreeing with the rows it describes — and the per-category
@@ -351,8 +363,9 @@ impl SensitiveDataProjection for SqliteBackend {
         let finding_placeholders = vec!["?"; 18].join(", ");
         for finding in findings {
             sqlx::query(&format!(
-                "INSERT OR IGNORE INTO sensitive_data_findings ({FINDING_COLUMNS}) \
-                 VALUES ({finding_placeholders})"
+                "INSERT INTO sensitive_data_findings ({FINDING_COLUMNS}) \
+                 VALUES ({finding_placeholders}) \
+                 ON CONFLICT(event_id, finding_ordinal) DO NOTHING"
             ))
             .bind(i64::from(finding.schema_version_major))
             .bind(i64::from(finding.schema_version_minor))

--- a/aa-gateway/src/storage/sensitive_data/store.rs
+++ b/aa-gateway/src/storage/sensitive_data/store.rs
@@ -31,12 +31,26 @@ pub struct SensitiveDataEventFilter {
     /// "blocked findings by category" read returned every finding under a
     /// "denied" label.
     pub verdict: Option<String>,
-    /// Maximum rows to return — groups, for
+    /// Maximum rows to return from the two **list** reads
+    /// ([`query_sensitive_data_events`](SensitiveDataProjection::query_sensitive_data_events),
+    /// [`query_sensitive_data_findings`](SensitiveDataProjection::query_sensitive_data_findings))
+    /// and the maximum **groups** from
     /// [`aggregate_sensitive_data_by_category`](SensitiveDataProjection::aggregate_sensitive_data_by_category).
     ///
-    /// Applies to every read. On the aggregate it is the cap on how many
-    /// distinct categories a caller can be handed, which is the one bound
-    /// available against a category vocabulary that is not closed.
+    /// **Not applied to the two count reads**, which always report the true
+    /// total for the filter. That is deliberate — a count that stopped at the
+    /// cap would answer "how many did you show me?", which the caller already
+    /// knows — but it does mean a UI pairing a capped list with its count is
+    /// pairing 1 row with a count of 3 by design, and must label the count as
+    /// the total rather than as the list's length. An earlier draft of this doc
+    /// said "applies to every read", which was false for exactly those two.
+    ///
+    /// On the aggregate the cap is the one bound available against a category
+    /// vocabulary that is not closed. Note it interacts with the fixed
+    /// `ORDER BY category ASC`: the groups returned are the alphabetically
+    /// first N, **not** the top N by count. A "top categories" consumer needs
+    /// to sort client-side over an uncapped read, or wait for a ranking
+    /// parameter this filter does not yet have.
     pub limit: Option<u32>,
 }
 
@@ -231,7 +245,7 @@ pub trait SensitiveDataProjection: Send + Sync + 'static {
     /// Exists so the tiering obligation can be *checked* rather than asserted:
     /// ADR 0032 §9's ban on offsets and lengths is a property of what is
     /// durably stored, and reading the DDL constant back would only prove the
-    /// test and the constant agree. `tests/sensitive_data_projection_test.rs`
+    /// test and the constant agree. `tests/sensitive_data_contract/`
     /// pins the exact set from outside this module, which is the only vantage
     /// point from which "there is no offset column" is a real claim.
     ///

--- a/aa-gateway/src/storage/sensitive_data/store.rs
+++ b/aa-gateway/src/storage/sensitive_data/store.rs
@@ -1,0 +1,330 @@
+//! The projection's persistence contract, its query scope, and the flag that
+//! gates writing it at all.
+
+use async_trait::async_trait;
+
+use aa_core::time::Timestamp;
+use aa_core::types::sensitive_data::{SensitiveDataDecisionEvent, SensitiveDataFindingRecord};
+
+use crate::storage::error::StorageResult;
+
+use super::rows::{ProjectionError, SensitiveDataEventRow, SensitiveDataFindingRow, TenantScope};
+
+/// Everything a projection read may be narrowed by.
+///
+/// The scope is a constructor argument rather than an `Option` field: there is
+/// no way to build a filter that reads across tenants, so tenant isolation
+/// survives a caller who forgets, which is the failure mode "scope it by
+/// convention" has.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SensitiveDataEventFilter {
+    scope: TenantScope,
+    /// Inclusive lower bound on `occurred_at`.
+    pub from: Option<Timestamp>,
+    /// Exclusive upper bound on `occurred_at`.
+    pub to: Option<Timestamp>,
+    /// Restrict to one enforcement outcome.
+    pub verdict: Option<String>,
+    /// Maximum rows to return. Applies to whichever table is being read.
+    pub limit: Option<u32>,
+}
+
+impl SensitiveDataEventFilter {
+    /// Read everything within one tenant.
+    pub fn new(scope: TenantScope) -> Self {
+        Self {
+            scope,
+            from: None,
+            to: None,
+            verdict: None,
+            limit: None,
+        }
+    }
+
+    /// The tenant this filter is pinned to.
+    pub fn scope(&self) -> &TenantScope {
+        &self.scope
+    }
+
+    /// Narrow to a half-open `occurred_at` window.
+    #[must_use]
+    pub fn between(mut self, from: Timestamp, to: Timestamp) -> Self {
+        self.from = Some(from);
+        self.to = Some(to);
+        self
+    }
+
+    /// Narrow to one enforcement outcome.
+    #[must_use]
+    pub fn with_verdict(mut self, verdict: impl Into<String>) -> Self {
+        self.verdict = Some(verdict.into());
+        self
+    }
+
+    /// Cap the number of rows returned.
+    #[must_use]
+    pub fn with_limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+/// Findings of one category within a tenant and window, counted two ways.
+///
+/// Both counts are reported because they answer different questions — "how much
+/// sensitive data of this class did we see?" and "how many actions carried
+/// any?" — and ADR 0032 forbidden design #11 is precisely about a dashboard
+/// that picks one and labels it the other. A consumer wanting only one still
+/// has to name which.
+///
+/// `category` is the only grouping dimension this aggregate offers, and that is
+/// deliberate: it is bounded by `aa-security`'s compiled-in catalogue, whereas
+/// the destination, the agent id and the tenant id are not. ADR 0032 §9
+/// restricts metric labels to bounded-cardinality values, so an aggregate that
+/// grouped by destination would hand a caller a ready-made unbounded label set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CategoryFindingAggregate {
+    /// The category, as the writing build spelled it. Not guaranteed to
+    /// resolve against *this* build's catalogue — a consumer minting a metric
+    /// label must resolve it through
+    /// [`SensitiveDataMetricLabels`](aa_core::types::sensitive_data::SensitiveDataMetricLabels)
+    /// rather than trusting the string.
+    pub category: String,
+    /// How many **findings** of this category the window contains.
+    pub finding_count: u64,
+    /// How many distinct **events** carried at least one. Never the same
+    /// measure as `finding_count`, and frequently a smaller number.
+    pub event_count: u64,
+}
+
+/// Durable persistence for the sensitive-data projection.
+///
+/// Deliberately **not** part of [`StorageBackend`](crate::storage::StorageBackend):
+/// the projection is additive and optional, and folding it into the backend
+/// trait would force every existing implementor and test double to grow methods
+/// it will never call. Backends opt in by implementing this alongside.
+#[async_trait]
+pub trait SensitiveDataProjection: Send + Sync + 'static {
+    /// Create the projection's tables and indexes.
+    ///
+    /// Idempotent — safe on an already-migrated database. Separate from
+    /// [`StorageBackend::migrate`](crate::storage::StorageBackend::migrate) so
+    /// that a deployment which never enables the projection never grows its
+    /// tables, and so that the rollback below is a real inverse rather than a
+    /// partial undo of a shared migration.
+    ///
+    /// # Errors
+    ///
+    /// `StorageError::MigrationFailed` when any statement is rejected.
+    async fn migrate_sensitive_data_projection(&self) -> StorageResult<()>;
+
+    /// Drop the projection's tables and indexes — the documented rollback.
+    ///
+    /// The whole rollback story for this feature: turn the flag off, drop the
+    /// tables. Nothing else in the schema references them, and the audit path
+    /// never wrote to them, so no other data can be lost by running this.
+    ///
+    /// # Errors
+    ///
+    /// `StorageError::MigrationFailed` when a drop is rejected.
+    async fn rollback_sensitive_data_projection(&self) -> StorageResult<()>;
+
+    /// Persist one event and its normalized finding rows atomically.
+    ///
+    /// **Idempotency and the late-arrival rule.** The write is keyed on
+    /// `event_id` (and `(event_id, finding_ordinal)` for the children) and
+    /// ignores a conflict, so replaying an event — a retried publish, a
+    /// restarted consumer, a duplicate delivery — does not double-count. The
+    /// consequence is that **first write wins**: an event that arrives late,
+    /// after a row with the same id is already durable, is discarded rather
+    /// than allowed to rewrite the tallies a reader may already have seen. An
+    /// event arriving late but *for the first time* is stored normally and
+    /// lands in its own `occurred_at` bucket, with `ingested_at` recording that
+    /// it was late; a window already reported on can therefore gain rows, which
+    /// is why `ingested_at` is stored rather than inferred.
+    ///
+    /// # Errors
+    ///
+    /// `StorageError::QueryFailed` when the transaction cannot be committed.
+    async fn append_sensitive_data_decision(
+        &self,
+        event: &SensitiveDataEventRow,
+        findings: &[SensitiveDataFindingRow],
+    ) -> StorageResult<()>;
+
+    /// Events within the filter's tenant, newest first.
+    ///
+    /// # Errors
+    ///
+    /// `StorageError::QueryFailed` on driver failure or an undecodable column.
+    async fn query_sensitive_data_events(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<SensitiveDataEventRow>>;
+
+    /// Finding rows within the filter's tenant, newest event first.
+    ///
+    /// Scoped by the findings table's own `org_id`/`tenant_id` columns, not by
+    /// a join onto the events table — a join is a place isolation can be
+    /// dropped by a later query rewrite.
+    ///
+    /// # Errors
+    ///
+    /// As [`query_sensitive_data_events`](Self::query_sensitive_data_events).
+    async fn query_sensitive_data_findings(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<SensitiveDataFindingRow>>;
+
+    /// How many **events** match. Not the finding count.
+    ///
+    /// # Errors
+    ///
+    /// As [`query_sensitive_data_events`](Self::query_sensitive_data_events).
+    async fn count_sensitive_data_events(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64>;
+
+    /// How many **findings** match. Not the event count.
+    ///
+    /// # Errors
+    ///
+    /// As [`query_sensitive_data_events`](Self::query_sensitive_data_events).
+    async fn count_sensitive_data_findings(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64>;
+
+    /// Findings grouped by category, with both counts.
+    ///
+    /// # Errors
+    ///
+    /// As [`query_sensitive_data_events`](Self::query_sensitive_data_events).
+    async fn aggregate_sensitive_data_by_category(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<CategoryFindingAggregate>>;
+}
+
+/// Whether the projection is written at all.
+///
+/// Off by default. ADR 0032 §8 requires the new projection to be switchable
+/// without touching existing audit behaviour, and defaulting it on would make
+/// the safe state the one an operator has to opt into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SensitiveDataProjectionConfig {
+    /// `true` to persist decision events and their findings.
+    pub enabled: bool,
+}
+
+impl SensitiveDataProjectionConfig {
+    /// A configuration that writes the projection.
+    pub const fn enabled() -> Self {
+        Self { enabled: true }
+    }
+
+    /// A configuration that writes nothing.
+    pub const fn disabled() -> Self {
+        Self { enabled: false }
+    }
+}
+
+/// What a [`SensitiveDataProjectionWriter::write`] call did.
+///
+/// A distinct type rather than `()` so a caller can tell "the flag is off" from
+/// "the rows are durable" — otherwise a disabled projection is indistinguishable
+/// from a working one at the call site, and the first sign of a
+/// misconfiguration is an empty dashboard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteOutcome {
+    /// Rows were persisted (or were already present — see the idempotency rule).
+    Written,
+    /// The flag is off; nothing was written and nothing was validated.
+    Disabled,
+}
+
+/// Projects decision events into rows and writes them, subject to the flag.
+///
+/// The flag lives here rather than in the store so that the persistence
+/// contract stays purely about persistence, and so the gate is exercised by a
+/// test that needs no database at all.
+#[derive(Debug, Clone)]
+pub struct SensitiveDataProjectionWriter<S> {
+    store: S,
+    config: SensitiveDataProjectionConfig,
+}
+
+impl<S: SensitiveDataProjection> SensitiveDataProjectionWriter<S> {
+    /// Wrap a store with a configuration.
+    pub fn new(store: S, config: SensitiveDataProjectionConfig) -> Self {
+        Self { store, config }
+    }
+
+    /// Whether writes are enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    /// The underlying store, for reads — which the flag does not gate.
+    ///
+    /// Turning the projection off stops new rows being written; it does not
+    /// make the rows already written unreadable.
+    pub fn store(&self) -> &S {
+        &self.store
+    }
+
+    /// Ensure the projection's schema exists, if writing is enabled.
+    ///
+    /// A disabled projection creates no tables — the flag is the whole
+    /// deployment decision, not just a write switch.
+    ///
+    /// # Errors
+    ///
+    /// As [`SensitiveDataProjection::migrate_sensitive_data_projection`].
+    pub async fn migrate(&self) -> StorageResult<WriteOutcome> {
+        if !self.config.enabled {
+            return Ok(WriteOutcome::Disabled);
+        }
+        self.store.migrate_sensitive_data_projection().await?;
+        Ok(WriteOutcome::Written)
+    }
+
+    /// Project and persist one decision and its findings.
+    ///
+    /// `findings` must be the same set the event's tallies were computed from;
+    /// a mismatch is
+    /// [`ProjectionError::FindingCountMismatch`](super::ProjectionError::FindingCountMismatch)
+    /// rather than a silently wrong row.
+    ///
+    /// # Errors
+    ///
+    /// [`ProjectionError`](super::ProjectionError) for an event that cannot be
+    /// projected, and whatever the store returns for a write failure.
+    pub async fn write(
+        &self,
+        event: &SensitiveDataDecisionEvent,
+        findings: &[SensitiveDataFindingRecord],
+        ingested_at: Timestamp,
+    ) -> Result<WriteOutcome, ProjectionError> {
+        if !self.config.enabled {
+            return Ok(WriteOutcome::Disabled);
+        }
+
+        let event_row = SensitiveDataEventRow::project(event, findings, ingested_at)?;
+        let scope = TenantScope::new(&event_row.org_id, &event_row.tenant_id)?;
+        let finding_rows = findings
+            .iter()
+            .enumerate()
+            .map(|(ordinal, record)| {
+                SensitiveDataFindingRow::project(
+                    record,
+                    &event_row.event_id,
+                    &scope,
+                    event.occurred_at,
+                    u32::try_from(ordinal).unwrap_or(u32::MAX),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        self.store
+            .append_sensitive_data_decision(&event_row, &finding_rows)
+            .await
+            .map_err(|e| ProjectionError::Storage(e.to_string()))?;
+        Ok(WriteOutcome::Written)
+    }
+}

--- a/aa-gateway/src/storage/sensitive_data/store.rs
+++ b/aa-gateway/src/storage/sensitive_data/store.rs
@@ -199,6 +199,21 @@ pub trait SensitiveDataProjection: Send + Sync + 'static {
         &self,
         filter: &SensitiveDataEventFilter,
     ) -> StorageResult<Vec<CategoryFindingAggregate>>;
+
+    /// `(table, column)` pairs for the projection's tables, read from the live
+    /// database catalogue.
+    ///
+    /// Exists so the tiering obligation can be *checked* rather than asserted:
+    /// ADR 0032 §9's ban on offsets and lengths is a property of what is
+    /// durably stored, and reading the DDL constant back would only prove the
+    /// test and the constant agree. `tests/sensitive_data_projection_test.rs`
+    /// pins the exact set from outside this module, which is the only vantage
+    /// point from which "there is no offset column" is a real claim.
+    ///
+    /// # Errors
+    ///
+    /// `StorageError::QueryFailed` when the catalogue cannot be read.
+    async fn sensitive_data_projection_columns(&self) -> StorageResult<Vec<(String, String)>>;
 }
 
 /// Whether the projection is written at all.

--- a/aa-gateway/src/storage/sensitive_data/store.rs
+++ b/aa-gateway/src/storage/sensitive_data/store.rs
@@ -24,8 +24,19 @@ pub struct SensitiveDataEventFilter {
     /// Exclusive upper bound on `occurred_at`.
     pub to: Option<Timestamp>,
     /// Restrict to one enforcement outcome.
+    ///
+    /// Honoured on **every** read, findings included — `sensitive_data_findings`
+    /// replicates the parent's verdict for exactly this. It previously applied
+    /// only to the events table and was silently dropped elsewhere, so a
+    /// "blocked findings by category" read returned every finding under a
+    /// "denied" label.
     pub verdict: Option<String>,
-    /// Maximum rows to return. Applies to whichever table is being read.
+    /// Maximum rows to return — groups, for
+    /// [`aggregate_sensitive_data_by_category`](SensitiveDataProjection::aggregate_sensitive_data_by_category).
+    ///
+    /// Applies to every read. On the aggregate it is the cap on how many
+    /// distinct categories a caller can be handed, which is the one bound
+    /// available against a category vocabulary that is not closed.
     pub limit: Option<u32>,
 }
 
@@ -77,11 +88,21 @@ impl SensitiveDataEventFilter {
 /// that picks one and labels it the other. A consumer wanting only one still
 /// has to name which.
 ///
-/// `category` is the only grouping dimension this aggregate offers, and that is
-/// deliberate: it is bounded by `aa-security`'s compiled-in catalogue, whereas
-/// the destination, the agent id and the tenant id are not. ADR 0032 §9
-/// restricts metric labels to bounded-cardinality values, so an aggregate that
-/// grouped by destination would hand a caller a ready-made unbounded label set.
+/// `category` is the only grouping dimension this aggregate offers. That is
+/// deliberate but it is **not** a bounded-cardinality guarantee, and an earlier
+/// draft of this doc claimed it was: `CategoryLabel::new` is a shape check, so a
+/// stored category is whatever the writing build put there — the projection's
+/// own tests persist `acme_internal_customer_ssn_v3_9f2c1b` on purpose. Three
+/// unknown categories are three groups.
+///
+/// What the single dimension does buy is that the *other* dimensions — the
+/// destination, the agent id, the tenant id — cannot be grouped by at all, and
+/// those are unbounded by nature rather than by accident. The remaining risk is
+/// bounded two ways: [`SensitiveDataEventFilter::limit`] caps the number of
+/// groups returned, and a caller minting a metric series from a group must
+/// resolve the category through
+/// [`SensitiveDataMetricLabels`](aa_core::types::sensitive_data::SensitiveDataMetricLabels),
+/// which returns `None` for anything this build cannot name.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CategoryFindingAggregate {
     /// The category, as the writing build spelled it. Not guaranteed to
@@ -137,7 +158,11 @@ pub trait SensitiveDataProjection: Send + Sync + 'static {
     /// restarted consumer, a duplicate delivery — does not double-count. The
     /// consequence is that **first write wins**: an event that arrives late,
     /// after a row with the same id is already durable, is discarded rather
-    /// than allowed to rewrite the tallies a reader may already have seen. An
+    /// than allowed to rewrite the tallies a reader may already have seen.
+    /// First-write-wins covers the children too — an implementation must not
+    /// insert child rows when the parent insert was a no-op, or a replay
+    /// carrying *more* findings would add ordinals beneath a frozen
+    /// `finding_count` and desynchronise the parent from its own rows. An
     /// event arriving late but *for the first time* is stored normally and
     /// lands in its own `occurred_at` bucket, with `ingested_at` recording that
     /// it was late; a window already reported on can therefore gain rows, which
@@ -214,6 +239,64 @@ pub trait SensitiveDataProjection: Send + Sync + 'static {
     ///
     /// `StorageError::QueryFailed` when the catalogue cannot be read.
     async fn sensitive_data_projection_columns(&self) -> StorageResult<Vec<(String, String)>>;
+}
+
+/// Delegates to the wrapped store.
+///
+/// Exists so a single store can back several
+/// [`SensitiveDataProjectionWriter`]s — which the writer's by-value `store`
+/// otherwise prevents — and so the shared cross-backend contract test can hand
+/// the same handle to a writer and to a direct reader.
+#[async_trait]
+impl<T: SensitiveDataProjection> SensitiveDataProjection for std::sync::Arc<T> {
+    async fn migrate_sensitive_data_projection(&self) -> StorageResult<()> {
+        (**self).migrate_sensitive_data_projection().await
+    }
+
+    async fn rollback_sensitive_data_projection(&self) -> StorageResult<()> {
+        (**self).rollback_sensitive_data_projection().await
+    }
+
+    async fn append_sensitive_data_decision(
+        &self,
+        event: &SensitiveDataEventRow,
+        findings: &[SensitiveDataFindingRow],
+    ) -> StorageResult<()> {
+        (**self).append_sensitive_data_decision(event, findings).await
+    }
+
+    async fn query_sensitive_data_events(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<SensitiveDataEventRow>> {
+        (**self).query_sensitive_data_events(filter).await
+    }
+
+    async fn query_sensitive_data_findings(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<SensitiveDataFindingRow>> {
+        (**self).query_sensitive_data_findings(filter).await
+    }
+
+    async fn count_sensitive_data_events(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
+        (**self).count_sensitive_data_events(filter).await
+    }
+
+    async fn count_sensitive_data_findings(&self, filter: &SensitiveDataEventFilter) -> StorageResult<u64> {
+        (**self).count_sensitive_data_findings(filter).await
+    }
+
+    async fn aggregate_sensitive_data_by_category(
+        &self,
+        filter: &SensitiveDataEventFilter,
+    ) -> StorageResult<Vec<CategoryFindingAggregate>> {
+        (**self).aggregate_sensitive_data_by_category(filter).await
+    }
+
+    async fn sensitive_data_projection_columns(&self) -> StorageResult<Vec<(String, String)>> {
+        (**self).sensitive_data_projection_columns().await
+    }
 }
 
 /// Whether the projection is written at all.
@@ -321,18 +404,14 @@ impl<S: SensitiveDataProjection> SensitiveDataProjectionWriter<S> {
         }
 
         let event_row = SensitiveDataEventRow::project(event, findings, ingested_at)?;
-        let scope = TenantScope::new(&event_row.org_id, &event_row.tenant_id)?;
+        // Children are projected from the parent *row*, not from the event and a
+        // separately-derived scope: it is the only way a child cannot disagree
+        // with its parent about tenant, timestamp or verdict.
         let finding_rows = findings
             .iter()
             .enumerate()
             .map(|(ordinal, record)| {
-                SensitiveDataFindingRow::project(
-                    record,
-                    &event_row.event_id,
-                    &scope,
-                    event.occurred_at,
-                    u32::try_from(ordinal).unwrap_or(u32::MAX),
-                )
+                SensitiveDataFindingRow::project(record, &event_row, u32::try_from(ordinal).unwrap_or(u32::MAX))
             })
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/aa-gateway/src/storage/sqlite.rs
+++ b/aa-gateway/src/storage/sqlite.rs
@@ -144,9 +144,13 @@ impl SqliteBackend {
         Ok(Self { pool })
     }
 
-    /// Borrow the connection pool. Crate-internal helper for trait-impl
-    /// sub-modules that land in subsequent S-B sub-tasks.
-    #[allow(dead_code)] // first non-test consumer arrives with the trait impl methods
+    /// Borrow the connection pool.
+    ///
+    /// Crate-internal so a sibling module can implement a trait against this
+    /// backend without opening a second pool to the same file — used by
+    /// `storage::sensitive_data::sqlite` (AAASM-5357), which persists a
+    /// projection that is deliberately not part of
+    /// [`StorageBackend`](super::backend::StorageBackend).
     pub(crate) fn pool(&self) -> &SqlitePool {
         &self.pool
     }

--- a/aa-gateway/tests/sensitive_data_contract/mod.rs
+++ b/aa-gateway/tests/sensitive_data_contract/mod.rs
@@ -1,0 +1,1140 @@
+//! The backend-independent contract of the sensitive-data projection.
+//!
+//! Every assertion in here is about the *projection*, not about SQLite or
+//! PostgreSQL, so it belongs to both. It lives in a shared module because the
+//! first cut asserted the exact column set, the per-category aggregate, the
+//! prevention truth table, the flag and the count-mismatch refusal on SQLite
+//! only — which meant a mutation to the PostgreSQL copy of the same SQL would
+//! not have failed anything. "Two backends, one contract" has to be executed on
+//! both backends or it is a comment.
+//!
+//! Each function takes an `Arc<S>` and uses its own tenant, so the whole set
+//! can run sequentially against one database — which is what the PostgreSQL
+//! test does, since a container per assertion would be minutes of startup for
+//! no extra coverage.
+//!
+//! ADR 0032 §9 is the source of the tiering rules; §8 of the counting rules.
+
+#![allow(dead_code)] // each backend's test file uses a subset; the module is shared
+
+use std::sync::Arc;
+
+use aa_core::policy::EnforcementMode;
+use aa_core::time::Timestamp;
+use aa_core::types::sensitive_data::{
+    AgentLineage, AuditLabel, CategoryLabel, Endpoint, EndpointKind, EnforcementPoint, ExecutionEvidence, FieldPath,
+    FindingClassification, FindingCounts, InspectedAction, InspectionLatency, OperationKind, PolicyAttribution,
+    PolicyReasonCode, RequestDirection, RuntimeVerdictLabel, SensitiveDataDecisionEvent, SensitiveDataFindingRecord,
+    SensitiveDataMetricLabels, Tenancy, TransmissionEvidence, TrustZone,
+};
+use aa_core::types::AgentId;
+use aa_security::canonical::{
+    ByteSpan, CanonicalCategory, CanonicalFinding, CategoryBase, ConfidenceBand, DetectionMethod, FindingStatus,
+    Provenance, Recognizer, Severity,
+};
+
+use aa_gateway::storage::sensitive_data::{
+    CategoryFindingAggregate, ProjectionError, SensitiveDataEventFilter, SensitiveDataProjection,
+    SensitiveDataProjectionConfig, SensitiveDataProjectionWriter, TenantScope, WriteOutcome,
+};
+
+/// A byte span whose numbers appear nowhere else in this repository, in the
+/// schema, or in any vocabulary the projection stores.
+///
+/// The point of six odd digits rather than the `(4, 44)` the `aa-core` fixtures
+/// use: searching a serialized row for "4" finds a schema version, a delegation
+/// depth and a latency. Searching for `760913` finds a leak or nothing.
+pub const SPAN_START: usize = 760_913;
+pub const SPAN_END: usize = 760_931;
+
+/// A marker standing in for the sensitive value itself. No real credential is
+/// constructed anywhere in these tests.
+pub const SECRET_MARKER: &str = "ZZ-synthetic-secret-value-do-not-store-ZZ";
+
+/// A well-formed category that this build's catalogue does not contain — the
+/// shape an attacker-influenced or newer-build category would have.
+pub const UNRESOLVABLE_CATEGORY: &str = "acme_internal_customer_ssn_v3_9f2c1b";
+
+pub const ORG: &str = "acme";
+
+pub fn synthetic_finding(category: CanonicalCategory) -> CanonicalFinding {
+    CanonicalFinding::new(
+        category,
+        Severity::Critical,
+        ConfidenceBand::High,
+        ByteSpan::new(SPAN_START, SPAN_END),
+        DetectionMethod::Deterministic,
+        Provenance::new(Recognizer::BuiltinScanner, "0.0.0-test"),
+        FindingStatus::Confirmed,
+    )
+    .expect("well-formed span")
+}
+
+pub fn record(event_id: &str, category: CanonicalCategory, path: &str) -> SensitiveDataFindingRecord {
+    SensitiveDataFindingRecord::from_finding(
+        AuditLabel::new(event_id).expect("well-formed event id"),
+        &synthetic_finding(category),
+        FieldPath::parse(path).expect("well-formed field path"),
+    )
+    .expect("record projects")
+}
+
+pub fn email() -> CanonicalCategory {
+    CanonicalCategory::unqualified(CategoryBase::EmailAddress)
+}
+
+pub fn token() -> CanonicalCategory {
+    CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access")
+}
+
+/// The rendered form of a category, taken from the catalogue rather than spelled
+/// out, so a rename is a lookup failure here instead of a silently
+/// never-matching `find` that makes the assertions after it unreachable.
+pub fn rendered(category: CanonicalCategory) -> String {
+    CategoryLabel::from(category).as_str().to_string()
+}
+
+pub fn tenancy(tenant: &str) -> Tenancy {
+    Tenancy {
+        org_id: AuditLabel::new(ORG).expect("org label"),
+        tenant_id: AuditLabel::new(tenant).expect("tenant label"),
+        team_id: Some(AuditLabel::new("billing").expect("team label")),
+    }
+}
+
+pub fn lineage() -> AgentLineage {
+    AgentLineage {
+        acting_agent: AgentId::parse("acme/billing-bot").expect("agent id"),
+        root_agent: AgentId::parse("acme/orchestrator").expect("agent id"),
+        parent_agent: Some(AgentId::parse("acme/orchestrator").expect("agent id")),
+        delegation_depth: 1,
+    }
+}
+
+pub fn action() -> InspectedAction {
+    InspectedAction {
+        operation: OperationKind::ToolCall,
+        source: None,
+        destination: Endpoint::new(EndpointKind::HttpHost, "api.example.com").expect("endpoint"),
+        trust_zone: TrustZone::Public,
+        direction: RequestDirection::Outbound,
+    }
+}
+
+/// ADR 0032 §8's worked example: three findings in one action, blocked before
+/// transmission while enforcing. Two share a category, so the per-category event
+/// count and finding count differ as well.
+pub fn blocked_action_with_three_findings(
+    event_id: &str,
+    tenant: &str,
+) -> (SensitiveDataDecisionEvent, Vec<SensitiveDataFindingRecord>) {
+    let records = vec![
+        record(event_id, email(), "body.customer.email"),
+        record(event_id, email(), "body.contact.email"),
+        record(event_id, token(), "headers.authorization"),
+    ];
+    let counts = FindingCounts::tally(&records, 0, 3).expect("tally");
+
+    let event = SensitiveDataDecisionEvent::builder(
+        AuditLabel::new(event_id).expect("event id"),
+        Timestamp::from_nanos(1_700_000_000_000_000_000),
+        tenancy(tenant),
+        lineage(),
+        action(),
+        RuntimeVerdictLabel::DENY,
+        ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+        ),
+    )
+    .finding_counts(counts)
+    .classification(FindingClassification {
+        severity: Severity::Critical,
+        confidence: ConfidenceBand::High,
+        method: DetectionMethod::Deterministic,
+        status: FindingStatus::Confirmed,
+    })
+    .inspected_fields(vec![
+        FieldPath::parse("body.customer.email").expect("path"),
+        FieldPath::parse("body.contact.email").expect("path"),
+        FieldPath::parse("headers.authorization").expect("path"),
+    ])
+    .policy(PolicyAttribution {
+        document_id: Some(AuditLabel::new("sha256:abc123").expect("doc id")),
+        version: Some(7),
+        matched_rule_ids: vec![AuditLabel::new("no-pii-to-public-hosts").expect("rule id")],
+    })
+    .reason_codes(vec![PolicyReasonCode::SensitiveDataDetected])
+    .latency(InspectionLatency {
+        provider_us: None,
+        total_us: 6,
+    })
+    .build();
+
+    (event, records)
+}
+
+/// A one-finding allowed action, for filter tests that need a second verdict.
+pub fn allowed_action_with_one_finding(
+    event_id: &str,
+    tenant: &str,
+    occurred_at_ns: u64,
+) -> (SensitiveDataDecisionEvent, Vec<SensitiveDataFindingRecord>) {
+    let records = vec![record(event_id, email(), "body.customer.email")];
+    let counts = FindingCounts::tally(&records, 0, 0).expect("tally");
+    let event = SensitiveDataDecisionEvent::builder(
+        AuditLabel::new(event_id).expect("event id"),
+        Timestamp::from_nanos(occurred_at_ns),
+        tenancy(tenant),
+        lineage(),
+        action(),
+        RuntimeVerdictLabel::ALLOW,
+        ExecutionEvidence::unrecorded(EnforcementMode::Enforce),
+    )
+    .finding_counts(counts)
+    .build();
+    (event, records)
+}
+
+pub fn scope(tenant: &str) -> TenantScope {
+    TenantScope::new(ORG, tenant).expect("scope")
+}
+
+pub fn filter(tenant: &str) -> SensitiveDataEventFilter {
+    SensitiveDataEventFilter::new(scope(tenant))
+}
+
+pub fn writer<S: SensitiveDataProjection>(store: &Arc<S>) -> SensitiveDataProjectionWriter<Arc<S>> {
+    SensitiveDataProjectionWriter::new(Arc::clone(store), SensitiveDataProjectionConfig::enabled())
+}
+
+const INGESTED: u64 = 1_700_000_000_100_000_000;
+
+// ---------------------------------------------------------------------------
+// ADR 0032 §9 — offsets and lengths belong to the audit tier only
+// ---------------------------------------------------------------------------
+
+/// The exact column set of both tables, read from the live database catalogue.
+///
+/// Pinned exactly rather than checked against a list of bad names: a substring
+/// check knows only the leaks someone thought of, whereas an exact set fails on
+/// any column at all that is not on the reviewed list.
+pub async fn columns_are_exactly_the_reviewed_set<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let mut actual = store
+        .sensitive_data_projection_columns()
+        .await
+        .expect("read catalogue")
+        .into_iter()
+        .map(|(table, column)| format!("{table}.{column}"))
+        .collect::<Vec<_>>();
+    actual.sort();
+
+    let mut expected = expected_qualified_columns();
+    expected.sort();
+
+    assert_eq!(
+        actual, expected,
+        "the projection's persisted columns changed; ADR 0032 §9 confines offsets and \
+         lengths to the tamper-evident tier, so any new column here needs review"
+    );
+
+    for entry in &actual {
+        let name = entry.split('.').next_back().expect("qualified name");
+        for banned in ["offset", "length", "span", "byte", "payload", "raw"] {
+            assert!(
+                !name.contains(banned),
+                "column `{entry}` contains `{banned}` — offsets, lengths and payloads are \
+                 audit-tier only (ADR 0032 §9)"
+            );
+        }
+    }
+}
+
+/// The end-to-end attack: a finding carrying a distinctive span goes in, and
+/// neither of its numbers comes back out of storage in any form.
+///
+/// The assertion the type-level argument is meant to make unnecessary, written
+/// anyway — "span-free by construction" is a property of construction paths,
+/// not an unrepresentable state.
+pub async fn a_byte_span_reaches_no_part_of_the_projection<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-span";
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNSPAN01", tenant);
+
+    // The span really is on the finding that was scanned — otherwise this would
+    // pass by testing nothing, which is how a span-leak test fails.
+    assert_eq!(
+        synthetic_finding(email()).span().start(),
+        SPAN_START,
+        "fixture must carry the span"
+    );
+
+    writer(store)
+        .write(&event, &findings, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("write");
+
+    let f = filter(tenant);
+    let events = store.query_sensitive_data_events(&f).await.expect("events");
+    let rows = store.query_sensitive_data_findings(&f).await.expect("findings");
+
+    let dump = format!(
+        "{}{}",
+        serde_json::to_string(&events).expect("serialize events"),
+        serde_json::to_string(&rows).expect("serialize findings"),
+    );
+
+    for needle in [SPAN_START.to_string(), SPAN_END.to_string()] {
+        assert!(
+            !dump.contains(&needle),
+            "byte offset {needle} reached the non-audit projection; ADR 0032 §9 permits \
+             offsets only in the tamper-evident tier"
+        );
+    }
+    assert!(
+        !dump.contains(SECRET_MARKER),
+        "a sensitive value reached the projection; it stores redacted and derived data only"
+    );
+    // The drill-down granularity §9 grants *in place of* offsets did survive —
+    // otherwise the absence above would just mean nothing was stored.
+    assert!(
+        dump.contains("headers.authorization"),
+        "field paths are the drill-down granularity and must be persisted"
+    );
+}
+
+/// Every column of a fully-populated event row and finding row, asserted against
+/// literals.
+///
+/// The gap this closes: pinning column *names* cannot detect a wrong *value*.
+/// Five simultaneous mutations — blanking `destination_id`, blanking
+/// `matched_rule_ids` back to the audit bridge's hardcoded `None`, blanking
+/// `acting_agent_id`, collapsing `transformed_finding_count` into
+/// `blocked_finding_count`, and backdating `ingested_at_ns` to `occurred_at_ns`
+/// — passed the entire suite before this existed. Those five are the point of
+/// the whole ticket, so they are asserted one by one.
+pub async fn every_projected_value_round_trips<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-roundtrip";
+    let event_id = "01HZX9V8ABCDEFGHJKMNROUND1";
+    let (event, findings) = blocked_action_with_three_findings(event_id, tenant);
+    writer(store)
+        .write(&event, &findings, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("write");
+
+    let rows = store
+        .query_sensitive_data_events(&filter(tenant))
+        .await
+        .expect("events");
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+
+    assert_eq!(row.schema_version_major, 1);
+    assert_eq!(row.schema_version_minor, 0);
+    assert_eq!(row.event_id, event_id);
+    assert_eq!(row.occurred_at_ns, 1_700_000_000_000_000_000);
+    assert_eq!(
+        row.ingested_at_ns, INGESTED,
+        "ingested_at is stored, not inferred — backdating it to occurred_at kills late-arrival visibility"
+    );
+    assert_eq!(row.org_id, ORG);
+    assert_eq!(row.tenant_id, tenant);
+    assert_eq!(row.team_id.as_deref(), Some("billing"));
+    assert_eq!(
+        row.acting_agent_id, "acme/billing-bot",
+        "lineage is loss #3 of the audit bridge's fourteen"
+    );
+    assert_eq!(row.root_agent_id, "acme/orchestrator");
+    assert_eq!(row.parent_agent_id.as_deref(), Some("acme/orchestrator"));
+    assert_eq!(row.delegation_depth, 1);
+    assert_eq!(row.session_id, None);
+    assert_eq!(row.trace_id, None);
+    assert_eq!(row.request_id, None);
+    assert_eq!(row.correlation_id, None);
+    assert_eq!(row.operation, "tool_call");
+    assert_eq!(row.destination_kind, "http_host");
+    assert_eq!(
+        row.destination_id, "api.example.com",
+        "the destination is not a dimension of the audit event at all — it is why this Epic exists"
+    );
+    assert_eq!(row.trust_zone, "public");
+    assert_eq!(row.direction, "outbound");
+    assert_eq!(row.policy_document_id.as_deref(), Some("sha256:abc123"));
+    assert_eq!(row.policy_version, Some(7));
+    assert_eq!(
+        row.matched_rule_ids,
+        vec!["no-pii-to-public-hosts".to_string()],
+        "the audit bridge hardcodes matched_rule_id to None; this is the field that fixes it"
+    );
+    assert_eq!(
+        row.inspected_field_paths,
+        vec![
+            "body.customer.email".to_string(),
+            "body.contact.email".to_string(),
+            "headers.authorization".to_string(),
+        ]
+    );
+    assert_eq!(row.verdict, "deny");
+    assert_eq!(row.enforcement_point, "pre_transmission");
+    assert_eq!(row.transmission_evidence, "not_forwarded");
+    assert_eq!(
+        row.enforcement_mode, "enforce",
+        "the honest replacement for the bridge's hardcoded dry_run: false"
+    );
+    assert_eq!(row.inspection_failure_path, "completed");
+    assert_eq!(row.severity.as_deref(), Some("critical"));
+    assert_eq!(row.confidence.as_deref(), Some("high"));
+    assert_eq!(row.method.as_deref(), Some("deterministic"));
+    assert_eq!(row.status.as_deref(), Some("confirmed"));
+    assert_eq!(row.event_count, 1);
+    assert_eq!(row.blocked_event_count, 1);
+    assert_eq!(row.finding_count, 3);
+    assert_eq!(row.blocked_finding_count, 3);
+    assert_eq!(
+        row.transformed_finding_count, 0,
+        "nothing was redacted; collapsing this into blocked_finding_count is forbidden design #11"
+    );
+    let by_category = row
+        .finding_count_by_category
+        .iter()
+        .map(|t| (t.category.clone(), t.count))
+        .collect::<Vec<_>>();
+    assert_eq!(by_category, vec![(rendered(email()), 2), (rendered(token()), 1)]);
+    assert_eq!(row.reason_codes, vec!["sensitive_data_detected".to_string()]);
+
+    // The child rows, in ordinal order.
+    let mut children = store
+        .query_sensitive_data_findings(&filter(tenant))
+        .await
+        .expect("findings");
+    children.sort_by_key(|r| r.finding_ordinal);
+    assert_eq!(children.len(), 3);
+
+    let first = &children[0];
+    assert_eq!(first.schema_version_major, 1);
+    assert_eq!(first.schema_version_minor, 0);
+    assert_eq!(first.event_id, event_id);
+    assert_eq!(first.finding_ordinal, 0);
+    assert_eq!(first.org_id, ORG);
+    assert_eq!(first.tenant_id, tenant);
+    assert_eq!(first.occurred_at_ns, 1_700_000_000_000_000_000);
+    assert_eq!(
+        first.verdict, "deny",
+        "replicated from the parent so it can be filtered on"
+    );
+    assert_eq!(first.category, rendered(email()));
+    assert_eq!(first.severity, "critical");
+    assert_eq!(first.confidence, "high");
+    assert_eq!(first.method, "deterministic");
+    assert_eq!(first.status, "confirmed");
+    assert_eq!(first.recognizer, "aa-security::scanner");
+    assert_eq!(first.recognizer_version, "0.0.0-test");
+    assert_eq!(first.field_path, "body.customer.email");
+    assert_eq!(first.redaction_label, email().redaction_label());
+    assert_eq!(
+        first.aggregate_key,
+        format!(
+            "{}|body.customer.email|deterministic|aa-security::scanner",
+            rendered(email())
+        )
+    );
+
+    assert_eq!(children[1].field_path, "body.contact.email");
+    assert_eq!(children[1].category, rendered(email()));
+    assert_eq!(children[2].field_path, "headers.authorization");
+    assert_eq!(children[2].category, rendered(token()));
+
+    // The serialized shape a consumer receives, pinned the same way as the
+    // columns — a struct field with no column would still be published.
+    let mut event_keys = serde_json::to_value(row)
+        .expect("serialize event row")
+        .as_object()
+        .expect("object")
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    event_keys.sort();
+    let mut expected_event = EXPECTED_EVENT_COLUMNS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect::<Vec<_>>();
+    expected_event.sort();
+    assert_eq!(event_keys, expected_event);
+
+    let mut finding_keys = serde_json::to_value(first)
+        .expect("serialize finding row")
+        .as_object()
+        .expect("object")
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    finding_keys.sort();
+    let mut expected_finding = EXPECTED_FINDING_COLUMNS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect::<Vec<_>>();
+    expected_finding.sort();
+    assert_eq!(finding_keys, expected_finding);
+}
+
+// ---------------------------------------------------------------------------
+// ADR 0032 §8 — event counts and finding counts are different numbers
+// ---------------------------------------------------------------------------
+
+/// The §8 worked example, read back from the database rather than from the
+/// in-memory event, because the collapse this guards against is a writer
+/// putting one number in the other's column.
+pub async fn one_blocked_action_with_three_findings_stays_one_event<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-counts";
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNCOUNT1", tenant);
+    writer(store)
+        .write(&event, &findings, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("write");
+
+    let f = filter(tenant);
+    assert_eq!(store.count_sensitive_data_events(&f).await.expect("count"), 1);
+    assert_eq!(store.count_sensitive_data_findings(&f).await.expect("count"), 3);
+
+    let row = &store.query_sensitive_data_events(&f).await.expect("events")[0];
+    assert_eq!(row.event_count, 1, "one action is one event");
+    assert_eq!(row.blocked_event_count, 1, "the action was refused");
+    assert_eq!(row.finding_count, 3);
+    assert_eq!(row.blocked_finding_count, 3);
+    assert_ne!(
+        row.blocked_event_count, row.blocked_finding_count,
+        "the two are different measures and must not be interchangeable"
+    );
+
+    let aggregates = store
+        .aggregate_sensitive_data_by_category(&f)
+        .await
+        .expect("aggregate by category");
+    let email_label = rendered(email());
+    let agg = aggregates
+        .iter()
+        .find(|a| a.category == email_label)
+        .unwrap_or_else(|| panic!("email category present; got {aggregates:?}"));
+    assert_eq!(agg.finding_count, 2, "two email findings");
+    assert_eq!(agg.event_count, 1, "in one event");
+    assert_ne!(
+        agg.finding_count, agg.event_count,
+        "an aggregate reporting one of these as the other would be wrong by a factor \
+         that varies per action (forbidden design #11)"
+    );
+
+    // Structural as well as numeric: adding a grouping dimension stops the
+    // suite compiling, which is what keeps an unbounded label out of it.
+    let CategoryFindingAggregate {
+        category: _,
+        finding_count: _,
+        event_count: _,
+    } = aggregates[0].clone();
+}
+
+/// A producer whose finding rows disagree with its own tallies is refused before
+/// anything becomes durable.
+pub async fn a_row_count_disagreeing_with_the_tally_is_refused<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-mismatch";
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNMISM01", tenant);
+
+    let err = writer(store)
+        .write(&event, &findings[..2], Timestamp::from_nanos(INGESTED))
+        .await
+        .expect_err("two rows against a three-finding tally must be refused");
+    assert!(
+        matches!(
+            err,
+            ProjectionError::FindingCountMismatch {
+                declared: 3,
+                supplied: 2,
+                ..
+            }
+        ),
+        "expected FindingCountMismatch, got {err:?}"
+    );
+    assert_eq!(
+        store.count_sensitive_data_events(&filter(tenant)).await.expect("count"),
+        0,
+        "a refused projection must leave nothing behind"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tenant isolation
+// ---------------------------------------------------------------------------
+
+/// One tenant's rows are invisible under another tenant's scope on every read
+/// path — including the findings table, scoped by its own columns rather than by
+/// joining the events table.
+pub async fn a_neighbouring_tenant_sees_none_of_it<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-isolation";
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNISOL01", tenant);
+    writer(store)
+        .write(&event, &findings, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("write");
+
+    let owner = filter(tenant);
+    let same_org_other_tenant = filter("t-isolation-staging");
+    let other_org_same_tenant_name = SensitiveDataEventFilter::new(TenantScope::new("globex", tenant).expect("scope"));
+
+    assert_eq!(store.count_sensitive_data_events(&owner).await.expect("count"), 1);
+
+    for intruder in [&same_org_other_tenant, &other_org_same_tenant_name] {
+        assert_eq!(
+            store.count_sensitive_data_events(intruder).await.expect("count"),
+            0,
+            "events leaked across a tenant boundary"
+        );
+        assert_eq!(
+            store.count_sensitive_data_findings(intruder).await.expect("count"),
+            0,
+            "findings leaked across a tenant boundary"
+        );
+        assert!(
+            store
+                .query_sensitive_data_events(intruder)
+                .await
+                .expect("query")
+                .is_empty(),
+            "event rows leaked across a tenant boundary"
+        );
+        assert!(
+            store
+                .query_sensitive_data_findings(intruder)
+                .await
+                .expect("query")
+                .is_empty(),
+            "finding rows leaked across a tenant boundary"
+        );
+        assert!(
+            store
+                .aggregate_sensitive_data_by_category(intruder)
+                .await
+                .expect("aggregate")
+                .is_empty(),
+            "an aggregate leaked across a tenant boundary — the failure mode that is a \
+             smaller-looking answer rather than an error"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency and late arrivals
+// ---------------------------------------------------------------------------
+
+/// A replayed event does not double-count, on either table.
+pub async fn a_replayed_event_does_not_double_count<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-replay";
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNREPL01", tenant);
+    let w = writer(store);
+    for attempt in 0..3 {
+        w.write(&event, &findings, Timestamp::from_nanos(INGESTED + attempt))
+            .await
+            .expect("replay must be accepted, not rejected");
+    }
+
+    let f = filter(tenant);
+    assert_eq!(store.count_sensitive_data_events(&f).await.expect("count"), 1);
+    assert_eq!(
+        store.count_sensitive_data_findings(&f).await.expect("count"),
+        3,
+        "three replays of a three-finding event is still three findings"
+    );
+}
+
+/// A replay carrying **more** findings must not add child rows beneath a frozen
+/// parent tally.
+///
+/// The case the smaller-replay test could not reach: `OR IGNORE` /
+/// `DO NOTHING` is first-write-wins for the parent but purely *additive* for the
+/// children, so without gating the child inserts on the parent insert actually
+/// happening, `finding_count = 1` would sit above three rows and the
+/// per-category aggregate — which reads the child table — would over-report
+/// against the event's own number.
+pub async fn a_divergent_replay_cannot_desynchronise_parent_from_children<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-divergent";
+    let event_id = "01HZX9V8ABCDEFGHJKMNDIVG01";
+    let w = writer(store);
+
+    // First: a one-finding event.
+    let (small, small_findings) = allowed_action_with_one_finding(event_id, tenant, 1_700_000_000_000_000_000);
+    w.write(&small, &small_findings, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("first write");
+
+    // Then a replay of the same id carrying three.
+    let (big, big_findings) = blocked_action_with_three_findings(event_id, tenant);
+    w.write(&big, &big_findings, Timestamp::from_nanos(INGESTED + 5))
+        .await
+        .expect("a divergent replay is ignored, not an error");
+
+    let f = filter(tenant);
+    let row = &store.query_sensitive_data_events(&f).await.expect("events")[0];
+    assert_eq!(row.finding_count, 1, "first write wins for the parent");
+    assert_eq!(row.verdict, "allow", "first write wins for the verdict too");
+    assert_eq!(
+        store.count_sensitive_data_findings(&f).await.expect("count"),
+        u64::from(row.finding_count),
+        "the child rows must agree with the parent's own tally; an additive child insert \
+         leaves finding_count describing rows that are no longer there"
+    );
+
+    let total_in_aggregate: u64 = store
+        .aggregate_sensitive_data_by_category(&f)
+        .await
+        .expect("aggregate")
+        .iter()
+        .map(|a| a.finding_count)
+        .sum();
+    assert_eq!(
+        total_in_aggregate,
+        u64::from(row.finding_count),
+        "the per-category aggregate reads the child table and must not over-report \
+         against the event it belongs to"
+    );
+}
+
+/// The documented late-arrival rule: first write wins, so a duplicate arriving
+/// after the fact cannot move numbers a reader has already acted on.
+pub async fn a_late_duplicate_cannot_rewrite_stored_tallies<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-late";
+    let event_id = "01HZX9V8ABCDEFGHJKMNLATE01";
+    let w = writer(store);
+    let (first, findings) = blocked_action_with_three_findings(event_id, tenant);
+    w.write(&first, &findings, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("first write");
+
+    let (contradicting, single) = allowed_action_with_one_finding(event_id, tenant, 1_700_000_000_000_000_000);
+    w.write(
+        &contradicting,
+        &single,
+        Timestamp::from_nanos(1_700_000_999_000_000_000),
+    )
+    .await
+    .expect("a late duplicate is ignored, not an error");
+
+    let f = filter(tenant);
+    let row = &store.query_sensitive_data_events(&f).await.expect("events")[0];
+    assert_eq!(row.verdict, "deny", "first write wins");
+    assert_eq!(row.blocked_finding_count, 3, "the stored tallies did not move");
+    assert_eq!(
+        store.count_sensitive_data_findings(&f).await.expect("count"),
+        3,
+        "the late duplicate added no finding rows"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The filter's narrowings
+// ---------------------------------------------------------------------------
+
+/// `verdict`, `between` and `limit` are honoured on every read path.
+///
+/// The gap this closes: no test called any of the three builder methods, and
+/// `verdict` was silently dropped on the findings query, the findings count and
+/// the aggregate — so a "blocked findings by category" dashboard returned every
+/// finding under a "denied" label.
+pub async fn the_filters_narrowings_are_honoured_on_every_read<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-filters";
+    let w = writer(store);
+
+    let (denied, denied_findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNFILT01", tenant);
+    w.write(&denied, &denied_findings, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("write denied");
+
+    // Two allowed events, one of them outside the window used below.
+    for (id, occurred) in [
+        ("01HZX9V8ABCDEFGHJKMNFILT02", 1_700_000_000_000_000_001_u64),
+        ("01HZX9V8ABCDEFGHJKMNFILT03", 1_900_000_000_000_000_000_u64),
+    ] {
+        let (allowed, allowed_findings) = allowed_action_with_one_finding(id, tenant, occurred);
+        w.write(&allowed, &allowed_findings, Timestamp::from_nanos(INGESTED))
+            .await
+            .expect("write allowed");
+    }
+
+    let all = filter(tenant);
+    assert_eq!(store.count_sensitive_data_events(&all).await.expect("count"), 3);
+    assert_eq!(store.count_sensitive_data_findings(&all).await.expect("count"), 5);
+
+    // --- verdict, on all four data reads ---
+    let denied_only = filter(tenant).with_verdict("deny");
+    assert_eq!(store.count_sensitive_data_events(&denied_only).await.expect("count"), 1);
+    assert_eq!(
+        store.count_sensitive_data_findings(&denied_only).await.expect("count"),
+        3,
+        "the verdict predicate must reach the findings table, not be silently dropped"
+    );
+    assert!(store
+        .query_sensitive_data_findings(&denied_only)
+        .await
+        .expect("query")
+        .iter()
+        .all(|r| r.verdict == "deny"));
+    let denied_total: u64 = store
+        .aggregate_sensitive_data_by_category(&denied_only)
+        .await
+        .expect("aggregate")
+        .iter()
+        .map(|a| a.finding_count)
+        .sum();
+    assert_eq!(
+        denied_total, 3,
+        "an aggregate that ignores the verdict over-reports a 'blocked by category' read"
+    );
+
+    // --- between ---
+    let window = filter(tenant).between(
+        Timestamp::from_nanos(1_700_000_000_000_000_000),
+        Timestamp::from_nanos(1_700_000_000_000_000_002),
+    );
+    assert_eq!(
+        store.count_sensitive_data_events(&window).await.expect("count"),
+        2,
+        "the half-open window excludes the far-future event"
+    );
+    assert_eq!(store.count_sensitive_data_findings(&window).await.expect("count"), 4);
+
+    // --- limit, including on the aggregate, whose groups are not a closed set ---
+    assert_eq!(
+        store
+            .query_sensitive_data_events(&filter(tenant).with_limit(1))
+            .await
+            .expect("query")
+            .len(),
+        1
+    );
+    assert_eq!(
+        store
+            .query_sensitive_data_findings(&filter(tenant).with_limit(2))
+            .await
+            .expect("query")
+            .len(),
+        2
+    );
+    let capped = store
+        .aggregate_sensitive_data_by_category(&filter(tenant).with_limit(1))
+        .await
+        .expect("aggregate");
+    assert_eq!(
+        capped.len(),
+        1,
+        "the aggregate must honour the limit — it is the only bound available against a \
+         category vocabulary that is not closed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Prevention requires evidence
+// ---------------------------------------------------------------------------
+
+type PreventionCase = (
+    &'static str,
+    RuntimeVerdictLabel,
+    EnforcementPoint,
+    TransmissionEvidence,
+    EnforcementMode,
+    bool,
+);
+
+/// Only a deny-or-transforming verdict, applied pre-transmission, while
+/// enforcing, with the bytes observed not to have gone, counts as prevention.
+///
+/// The negative cases are the point. `scrub` with `forwarded_clean` is what a
+/// successful redaction looks like — a *transformed transmission* — and it is
+/// the case the `CredentialLeakBlocked` event name already got wrong once.
+pub async fn prevention_is_claimed_only_where_evidence_supports_it<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-prevention";
+    let cases: [PreventionCase; 7] = [
+        (
+            "01HZX9V8ABCDEFGHJKMNPREV01",
+            RuntimeVerdictLabel::DENY,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+            true,
+        ),
+        (
+            // Redaction forwards the scrubbed bytes. Detected, not prevented.
+            "01HZX9V8ABCDEFGHJKMNPREV02",
+            RuntimeVerdictLabel::SCRUB,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::ForwardedClean,
+            EnforcementMode::Enforce,
+            false,
+        ),
+        (
+            // `narrow` scopes the action without transforming the payload.
+            "01HZX9V8ABCDEFGHJKMNPREV03",
+            RuntimeVerdictLabel::NARROW,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+            false,
+        ),
+        (
+            // Observe mode computed the decision and applied nothing.
+            "01HZX9V8ABCDEFGHJKMNPREV04",
+            RuntimeVerdictLabel::DENY,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Observe,
+            false,
+        ),
+        (
+            // Decided after the bytes left.
+            "01HZX9V8ABCDEFGHJKMNPREV05",
+            RuntimeVerdictLabel::DENY,
+            EnforcementPoint::PostTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+            false,
+        ),
+        (
+            // An unwired producer must not claim prevention by saying nothing.
+            "01HZX9V8ABCDEFGHJKMNPREV06",
+            RuntimeVerdictLabel::DENY,
+            EnforcementPoint::NotRecorded,
+            TransmissionEvidence::NotRecorded,
+            EnforcementMode::Enforce,
+            false,
+        ),
+        (
+            // The layer decided to redact and emitted the credential anyway.
+            "01HZX9V8ABCDEFGHJKMNPREV07",
+            RuntimeVerdictLabel::SCRUB,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::ForwardedCarryingSensitiveValue,
+            EnforcementMode::Enforce,
+            false,
+        ),
+    ];
+
+    let w = writer(store);
+    for (event_id, verdict, point, transmission, mode, _) in cases {
+        let event = SensitiveDataDecisionEvent::builder(
+            AuditLabel::new(event_id).expect("event id"),
+            Timestamp::from_nanos(1_700_000_000_000_000_000),
+            tenancy(tenant),
+            lineage(),
+            action(),
+            verdict,
+            ExecutionEvidence::new(point, transmission, mode),
+        )
+        .build();
+        w.write(&event, &[], Timestamp::from_nanos(INGESTED))
+            .await
+            .expect("write");
+    }
+
+    let rows = store
+        .query_sensitive_data_events(&filter(tenant))
+        .await
+        .expect("events");
+
+    for (event_id, _, _, _, _, expected) in cases {
+        let row = rows.iter().find(|r| r.event_id == event_id).expect("row present");
+        assert_eq!(
+            row.counts_as_prevented_transmission(),
+            expected,
+            "prevention verdict wrong for {event_id} \
+             (verdict={}, point={}, transmission={}, mode={})",
+            row.verdict,
+            row.enforcement_point,
+            row.transmission_evidence,
+            row.enforcement_mode
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metric labels stay bounded
+// ---------------------------------------------------------------------------
+
+/// A category this build cannot resolve is stored for drill-down and refused as
+/// a metric label.
+///
+/// Both directions in one function on purpose: a test that only walked the
+/// catalogue's own members could never reach the unbounded case and would pass
+/// while the guard did nothing.
+pub async fn an_unresolvable_category_is_stored_but_never_labelled<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let tenant = "t-unbounded";
+    let event_id = "01HZX9V8ABCDEFGHJKMNUNBD01";
+
+    let mut arbitrary = record(event_id, email(), "body.customer.email");
+    arbitrary.category = CategoryLabel::new(UNRESOLVABLE_CATEGORY).expect("well-formed label");
+    assert!(
+        SensitiveDataMetricLabels::from_finding(&arbitrary, RuntimeVerdictLabel::DENY).is_none(),
+        "an unresolvable category must not become a metric label — it is an unbounded \
+         series, which ADR 0032 §9 forbids"
+    );
+
+    let catalogued = record(event_id, email(), "body.customer.email");
+    let labels = SensitiveDataMetricLabels::from_finding(&catalogued, RuntimeVerdictLabel::DENY)
+        .expect("a catalogue category must resolve — otherwise the None above proves nothing");
+    let names = labels.as_pairs().map(|(name, _)| name);
+    for banned in ["destination", "tenant", "org", "agent", "field_path", "event_id"] {
+        assert!(
+            !names.contains(&banned),
+            "`{banned}` is unbounded cardinality and must never be a metric label"
+        );
+    }
+
+    // Stored anyway, so refusing the label does not lose the drill-down that
+    // ADR 0032 §9 grants in place of the offset.
+    let mut findings = vec![arbitrary];
+    findings[0].event_id = AuditLabel::new(event_id).expect("event id");
+    let event = SensitiveDataDecisionEvent::builder(
+        AuditLabel::new(event_id).expect("event id"),
+        Timestamp::from_nanos(1_700_000_000_000_000_000),
+        tenancy(tenant),
+        lineage(),
+        action(),
+        RuntimeVerdictLabel::DENY,
+        ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+        ),
+    )
+    .finding_counts(FindingCounts::tally(&findings, 0, 1).expect("tally"))
+    .build();
+
+    writer(store)
+        .write(&event, &findings, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("write");
+
+    let stored = store
+        .query_sensitive_data_findings(&filter(tenant))
+        .await
+        .expect("findings");
+    assert!(
+        stored.iter().any(|r| r.category == UNRESOLVABLE_CATEGORY),
+        "an unresolvable category must still be persisted for drill-down"
+    );
+
+    // And it is its own aggregate group — the unboundedness the docstring now
+    // admits to, bounded only by the limit.
+    let groups = store
+        .aggregate_sensitive_data_by_category(&filter(tenant))
+        .await
+        .expect("aggregate");
+    assert!(groups.iter().any(|g| g.category == UNRESOLVABLE_CATEGORY));
+}
+
+// ---------------------------------------------------------------------------
+// The flag
+// ---------------------------------------------------------------------------
+
+/// With the flag off nothing is written and no tables are created.
+///
+/// Takes an un-migrated store, so it must be run before the schema exists.
+pub async fn a_disabled_projection_writes_nothing<S: SensitiveDataProjection>(store: &Arc<S>) {
+    let w = SensitiveDataProjectionWriter::new(Arc::clone(store), SensitiveDataProjectionConfig::disabled());
+    assert!(!w.is_enabled());
+    assert_eq!(w.migrate().await.expect("migrate"), WriteOutcome::Disabled);
+
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNFLAG01", "t-flag");
+    assert_eq!(
+        w.write(&event, &findings, Timestamp::from_nanos(INGESTED))
+            .await
+            .expect("a disabled write is a no-op, not an error"),
+        WriteOutcome::Disabled
+    );
+    assert!(
+        store
+            .sensitive_data_projection_columns()
+            .await
+            .expect("columns")
+            .is_empty(),
+        "a disabled projection must not create its tables"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The reviewed column lists
+// ---------------------------------------------------------------------------
+
+pub fn expected_qualified_columns() -> Vec<String> {
+    EXPECTED_EVENT_COLUMNS
+        .iter()
+        .map(|c| format!("sensitive_data_events.{c}"))
+        .chain(
+            EXPECTED_FINDING_COLUMNS
+                .iter()
+                .map(|c| format!("sensitive_data_findings.{c}")),
+        )
+        .collect()
+}
+
+/// Every column of `sensitive_data_events`, reviewed against ADR 0032 §9.
+pub const EXPECTED_EVENT_COLUMNS: &[&str] = &[
+    "schema_version_major",
+    "schema_version_minor",
+    "event_id",
+    "occurred_at_ns",
+    "ingested_at_ns",
+    "org_id",
+    "tenant_id",
+    "team_id",
+    "acting_agent_id",
+    "root_agent_id",
+    "parent_agent_id",
+    "delegation_depth",
+    "session_id",
+    "trace_id",
+    "request_id",
+    "correlation_id",
+    "operation",
+    "destination_kind",
+    "destination_id",
+    "trust_zone",
+    "direction",
+    "policy_document_id",
+    "policy_version",
+    "matched_rule_ids",
+    "inspected_field_paths",
+    "verdict",
+    "enforcement_point",
+    "transmission_evidence",
+    "enforcement_mode",
+    "inspection_failure_path",
+    "severity",
+    "confidence",
+    "method",
+    "status",
+    "event_count",
+    "blocked_event_count",
+    "finding_count",
+    "blocked_finding_count",
+    "transformed_finding_count",
+    "finding_count_by_category",
+    "reason_codes",
+];
+
+/// Every column of `sensitive_data_findings`, reviewed the same way.
+pub const EXPECTED_FINDING_COLUMNS: &[&str] = &[
+    "schema_version_major",
+    "schema_version_minor",
+    "event_id",
+    "finding_ordinal",
+    "org_id",
+    "tenant_id",
+    "occurred_at_ns",
+    "verdict",
+    "category",
+    "severity",
+    "confidence",
+    "method",
+    "status",
+    "recognizer",
+    "recognizer_version",
+    "field_path",
+    "redaction_label",
+    "aggregate_key",
+];

--- a/aa-gateway/tests/sensitive_data_contract/mod.rs
+++ b/aa-gateway/tests/sensitive_data_contract/mod.rs
@@ -430,7 +430,14 @@ pub async fn every_projected_value_round_trips<S: SensitiveDataProjection>(store
     assert_eq!(first.recognizer, "aa-security::scanner");
     assert_eq!(first.recognizer_version, "0.0.0-test");
     assert_eq!(first.field_path, "body.customer.email");
-    assert_eq!(first.redaction_label, email().redaction_label());
+    // Pinned as a literal, not as `email().redaction_label()` — both sides of
+    // that comparison resolve through the same function, so it would hold
+    // however wrong the function was. Worth doing: the literal caught an
+    // assumption that `EmailAddress` had no `CredentialKind` and so redacted to
+    // the opaque `[REDACTED]` sentinel. It does have one, so the writing build
+    // emits the qualified form, and this is the value a reader will actually
+    // see in the column.
+    assert_eq!(first.redaction_label, "[REDACTED:EmailAddress]");
     assert_eq!(
         first.aggregate_key,
         format!(
@@ -825,6 +832,27 @@ pub async fn the_filters_narrowings_are_honoured_on_every_read<S: SensitiveDataP
         1,
         "the aggregate must honour the limit — it is the only bound available against a \
          category vocabulary that is not closed"
+    );
+
+    // The two counts deliberately ignore the cap and report the true total.
+    // Asserted rather than left to the docstring, because the pairing a UI
+    // will actually build — a capped list beside its count — then shows 1 row
+    // against a count of 3, and that has to be a documented, tested choice
+    // rather than a surprise. An earlier docstring claimed `limit` applied to
+    // every read, which was false for exactly these two.
+    let capped_filter = filter(tenant).with_limit(1);
+    assert_eq!(
+        store.count_sensitive_data_events(&capped_filter).await.expect("count"),
+        3,
+        "a count reports the total for the filter, not the length of a capped page"
+    );
+    assert_eq!(
+        store
+            .count_sensitive_data_findings(&capped_filter)
+            .await
+            .expect("count"),
+        5,
+        "a count reports the total for the filter, not the length of a capped page"
     );
 }
 

--- a/aa-gateway/tests/sensitive_data_projection_postgres_test.rs
+++ b/aa-gateway/tests/sensitive_data_projection_postgres_test.rs
@@ -1,116 +1,33 @@
-//! PostgreSQL integration test for the sensitive-data projection (AAASM-5357).
+//! The sensitive-data projection's contract, on PostgreSQL (AAASM-5357).
 //!
-//! Same properties as the SQLite suite, against the backend that actually
-//! serves production: the migration applies and is idempotent, the rollback is
-//! executed rather than merely written, the schema carries no offset or length
-//! column, tenant scoping holds, and a replayed event does not double-count.
+//! The *same* assertions the SQLite suite runs, from `sensitive_data_contract`.
+//! The first cut of this file checked a handful of properties by hand, which
+//! left the exact column set, the per-category aggregate, the prevention truth
+//! table, the flag and the count-mismatch refusal asserted on one backend only —
+//! so a mutation to the PostgreSQL copy of the same SQL would not have failed
+//! anything. Two backends, one contract, executed on both.
 //!
-//! Driven by `testcontainers-modules` per the repo pattern, so it needs Docker
-//! on the host. It deliberately calls only the projection's own migration and
-//! not `StorageBackend::migrate`: the projection owns its up and down
+//! Driven by `testcontainers-modules` per the repo pattern, so it needs Docker.
+//! One container for the whole file: each contract assertion uses its own
+//! tenant, so they compose on a single database, and a container per assertion
+//! would be minutes of startup for no extra coverage.
+//!
+//! It calls only the projection's own migration and never
+//! `StorageBackend::migrate` — the projection owns separate up and down
 //! statements precisely so it can be applied and rolled back on its own.
 
-use aa_core::policy::EnforcementMode;
-use aa_core::time::Timestamp;
-use aa_core::types::sensitive_data::{
-    AgentLineage, AuditLabel, Endpoint, EndpointKind, EnforcementPoint, ExecutionEvidence, FieldPath, FindingCounts,
-    InspectedAction, OperationKind, RequestDirection, RuntimeVerdictLabel, SensitiveDataDecisionEvent,
-    SensitiveDataFindingRecord, Tenancy, TransmissionEvidence, TrustZone,
-};
-use aa_core::types::AgentId;
-use aa_security::canonical::{
-    ByteSpan, CanonicalCategory, CanonicalFinding, CategoryBase, ConfidenceBand, DetectionMethod, FindingStatus,
-    Provenance, Recognizer, Severity,
-};
+use std::sync::Arc;
 
-use aa_gateway::storage::sensitive_data::{
-    SensitiveDataEventFilter, SensitiveDataProjection, SensitiveDataProjectionConfig, SensitiveDataProjectionWriter,
-    TenantScope,
-};
+use aa_core::time::Timestamp;
+use aa_gateway::storage::sensitive_data::SensitiveDataProjection;
 use aa_gateway::storage::{PostgresBackend, PostgresConfig};
 
-const SPAN_START: usize = 760_913;
-const SPAN_END: usize = 760_931;
+#[path = "sensitive_data_contract/mod.rs"]
+mod contract;
 
-fn record(event_id: &str, category: CanonicalCategory, path: &str) -> SensitiveDataFindingRecord {
-    let finding = CanonicalFinding::new(
-        category,
-        Severity::Critical,
-        ConfidenceBand::High,
-        ByteSpan::new(SPAN_START, SPAN_END),
-        DetectionMethod::Deterministic,
-        Provenance::new(Recognizer::BuiltinScanner, "0.0.0-test"),
-        FindingStatus::Confirmed,
-    )
-    .expect("well-formed span");
-    SensitiveDataFindingRecord::from_finding(
-        AuditLabel::new(event_id).expect("event id"),
-        &finding,
-        FieldPath::parse(path).expect("field path"),
-    )
-    .expect("record projects")
-}
-
-/// ADR 0032 §8's worked example: three findings, one blocked action.
-fn blocked_action_with_three_findings(
-    event_id: &str,
-    org: &str,
-    tenant: &str,
-) -> (SensitiveDataDecisionEvent, Vec<SensitiveDataFindingRecord>) {
-    let email = CanonicalCategory::unqualified(CategoryBase::EmailAddress);
-    let token = CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access");
-    let records = vec![
-        record(event_id, email, "body.customer.email"),
-        record(event_id, email, "body.contact.email"),
-        record(event_id, token, "headers.authorization"),
-    ];
-    let counts = FindingCounts::tally(&records, 0, 3).expect("tally");
-
-    let event = SensitiveDataDecisionEvent::builder(
-        AuditLabel::new(event_id).expect("event id"),
-        Timestamp::from_nanos(1_700_000_000_000_000_000),
-        Tenancy {
-            org_id: AuditLabel::new(org).expect("org"),
-            tenant_id: AuditLabel::new(tenant).expect("tenant"),
-            team_id: Some(AuditLabel::new("billing").expect("team")),
-        },
-        AgentLineage {
-            acting_agent: AgentId::parse("acme/billing-bot").expect("agent"),
-            root_agent: AgentId::parse("acme/orchestrator").expect("agent"),
-            parent_agent: None,
-            delegation_depth: 0,
-        },
-        InspectedAction {
-            operation: OperationKind::ToolCall,
-            source: None,
-            destination: Endpoint::new(EndpointKind::HttpHost, "api.example.com").expect("endpoint"),
-            trust_zone: TrustZone::Public,
-            direction: RequestDirection::Outbound,
-        },
-        RuntimeVerdictLabel::DENY,
-        ExecutionEvidence::new(
-            EnforcementPoint::PreTransmission,
-            TransmissionEvidence::NotForwarded,
-            EnforcementMode::Enforce,
-        ),
-    )
-    .finding_counts(counts)
-    .build();
-
-    (event, records)
-}
-
-fn filter(org: &str, tenant: &str) -> SensitiveDataEventFilter {
-    SensitiveDataEventFilter::new(TenantScope::new(org, tenant).expect("scope"))
-}
-
-/// The whole projection lifecycle on a real PostgreSQL cluster.
-///
-/// One test rather than several because each would otherwise pay for its own
-/// container start; the assertions are independent and each names what it
-/// checks.
+/// The whole contract on a real PostgreSQL cluster.
 #[tokio::test]
-async fn projection_migrates_persists_isolates_and_rolls_back_on_postgres() {
+async fn the_projection_contract_holds_on_postgres() {
     use testcontainers_modules::postgres::Postgres;
     use testcontainers_modules::testcontainers::runners::AsyncRunner;
 
@@ -120,84 +37,47 @@ async fn projection_migrates_persists_isolates_and_rolls_back_on_postgres() {
         .expect("failed to start postgres testcontainer (is Docker running?)");
     let host = container.get_host().await.expect("container host");
     let port = container.get_host_port_ipv4(5432).await.expect("container port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
 
-    let backend = PostgresBackend::connect(&PostgresConfig {
-        database_url: Some(format!("postgres://postgres:postgres@{host}:{port}/postgres")),
-        max_connections: 4,
-        min_connections: 1,
-        ..PostgresConfig::default()
-    })
-    .await
-    .expect("connect to postgres container");
+    let store = Arc::new(
+        PostgresBackend::connect(&PostgresConfig {
+            database_url: Some(url.clone()),
+            max_connections: 4,
+            min_connections: 1,
+            ..PostgresConfig::default()
+        })
+        .await
+        .expect("connect to postgres container"),
+    );
 
-    backend
+    // Before the migration: a disabled writer must create nothing.
+    contract::a_disabled_projection_writes_nothing(&store).await;
+
+    store
         .migrate_sensitive_data_projection()
         .await
         .expect("projection migration applies to a fresh cluster");
-    backend
+    store
         .migrate_sensitive_data_projection()
         .await
         .expect("re-migrating must be a no-op");
 
-    // ADR 0032 §9: no offset, length, span or payload column reaches this tier.
-    let columns = backend
-        .sensitive_data_projection_columns()
-        .await
-        .expect("read information_schema");
-    assert!(!columns.is_empty(), "the migration created no columns");
-    for (table, name) in &columns {
-        for banned in ["offset", "length", "span", "byte", "payload", "raw"] {
-            assert!(
-                !name.contains(banned),
-                "{table}.{name} contains `{banned}` — audit-tier only (ADR 0032 §9)"
-            );
-        }
-    }
+    contract::columns_are_exactly_the_reviewed_set(&store).await;
+    contract::a_byte_span_reaches_no_part_of_the_projection(&store).await;
+    contract::every_projected_value_round_trips(&store).await;
+    contract::one_blocked_action_with_three_findings_stays_one_event(&store).await;
+    contract::a_row_count_disagreeing_with_the_tally_is_refused(&store).await;
+    contract::a_neighbouring_tenant_sees_none_of_it(&store).await;
+    contract::a_replayed_event_does_not_double_count(&store).await;
+    contract::a_divergent_replay_cannot_desynchronise_parent_from_children(&store).await;
+    contract::a_late_duplicate_cannot_rewrite_stored_tallies(&store).await;
+    contract::the_filters_narrowings_are_honoured_on_every_read(&store).await;
+    contract::prevention_is_claimed_only_where_evidence_supports_it(&store).await;
+    contract::an_unresolvable_category_is_stored_but_never_labelled(&store).await;
 
-    let writer = SensitiveDataProjectionWriter::new(backend, SensitiveDataProjectionConfig::enabled());
-    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-    for attempt in 0..2 {
-        writer
-            .write(
-                &event,
-                &findings,
-                Timestamp::from_nanos(1_700_000_000_100_000_000 + attempt),
-            )
-            .await
-            .expect("write (and replay) must be accepted");
-    }
+    unreadable_schema_major_is_refused(&store, &url).await;
 
-    let owner = filter("acme", "acme-prod");
-    let store = writer.store();
-    assert_eq!(
-        store.count_sensitive_data_events(&owner).await.expect("count"),
-        1,
-        "a replayed event must not double-count"
-    );
-    assert_eq!(
-        store.count_sensitive_data_findings(&owner).await.expect("count"),
-        3,
-        "finding rows are a different count from event rows and must survive the replay"
-    );
-
-    let row = &store.query_sensitive_data_events(&owner).await.expect("events")[0];
-    assert_eq!(row.blocked_event_count, 1);
-    assert_eq!(row.blocked_finding_count, 3);
-    assert!(
-        row.counts_as_prevented_transmission(),
-        "denied pre-transmission with the bytes observed not to have gone"
-    );
-
-    let intruder = filter("acme", "acme-staging");
-    assert_eq!(store.count_sensitive_data_events(&intruder).await.expect("count"), 0);
-    assert_eq!(store.count_sensitive_data_findings(&intruder).await.expect("count"), 0);
-    assert!(store
-        .aggregate_sensitive_data_by_category(&intruder)
-        .await
-        .expect("aggregate")
-        .is_empty());
-
-    // The rollback is executed, not merely written.
+    // The rollback is executed, not merely written, and re-applying works.
     store
         .rollback_sensitive_data_projection()
         .await
@@ -211,7 +91,55 @@ async fn projection_migrates_persists_isolates_and_rolls_back_on_postgres() {
         "rollback must remove the projection's tables"
     );
     store
+        .rollback_sensitive_data_projection()
+        .await
+        .expect("rollback must itself be idempotent");
+    store
         .migrate_sensitive_data_projection()
         .await
         .expect("re-applying after a rollback must work");
+}
+
+/// The PostgreSQL decoder refuses a foreign schema major, as the SQLite one
+/// does. Driven through a second connection because no in-crate path can
+/// produce one — which is why the read path has to defend against it.
+async fn unreadable_schema_major_is_refused(store: &Arc<PostgresBackend>, url: &str) {
+    let tenant = "t-schema";
+    let (event, findings) = contract::blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNSCHM01", tenant);
+    contract::writer(store)
+        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
+        .await
+        .expect("write");
+
+    store
+        .query_sensitive_data_events(&contract::filter(tenant))
+        .await
+        .expect("readable at the current major");
+
+    let pool = sqlx::PgPool::connect(url).await.expect("second connection");
+    for table in ["sensitive_data_events", "sensitive_data_findings"] {
+        sqlx::query(&format!(
+            "UPDATE {table} SET schema_version_major = 99 WHERE tenant_id = $1"
+        ))
+        .bind(tenant)
+        .execute(&pool)
+        .await
+        .expect("bump major");
+    }
+
+    for err in [
+        store
+            .query_sensitive_data_events(&contract::filter(tenant))
+            .await
+            .expect_err("a foreign major must be refused, not decoded"),
+        store
+            .query_sensitive_data_findings(&contract::filter(tenant))
+            .await
+            .expect_err("the finding decoder must refuse it too"),
+    ] {
+        assert!(
+            err.to_string().contains("schema major 99"),
+            "expected an unreadable-schema error, got: {err}"
+        );
+    }
 }

--- a/aa-gateway/tests/sensitive_data_projection_postgres_test.rs
+++ b/aa-gateway/tests/sensitive_data_projection_postgres_test.rs
@@ -1,0 +1,217 @@
+//! PostgreSQL integration test for the sensitive-data projection (AAASM-5357).
+//!
+//! Same properties as the SQLite suite, against the backend that actually
+//! serves production: the migration applies and is idempotent, the rollback is
+//! executed rather than merely written, the schema carries no offset or length
+//! column, tenant scoping holds, and a replayed event does not double-count.
+//!
+//! Driven by `testcontainers-modules` per the repo pattern, so it needs Docker
+//! on the host. It deliberately calls only the projection's own migration and
+//! not `StorageBackend::migrate`: the projection owns its up and down
+//! statements precisely so it can be applied and rolled back on its own.
+
+use aa_core::policy::EnforcementMode;
+use aa_core::time::Timestamp;
+use aa_core::types::sensitive_data::{
+    AgentLineage, AuditLabel, Endpoint, EndpointKind, EnforcementPoint, ExecutionEvidence, FieldPath, FindingCounts,
+    InspectedAction, OperationKind, RequestDirection, RuntimeVerdictLabel, SensitiveDataDecisionEvent,
+    SensitiveDataFindingRecord, Tenancy, TransmissionEvidence, TrustZone,
+};
+use aa_core::types::AgentId;
+use aa_security::canonical::{
+    ByteSpan, CanonicalCategory, CanonicalFinding, CategoryBase, ConfidenceBand, DetectionMethod, FindingStatus,
+    Provenance, Recognizer, Severity,
+};
+
+use aa_gateway::storage::sensitive_data::{
+    SensitiveDataEventFilter, SensitiveDataProjection, SensitiveDataProjectionConfig, SensitiveDataProjectionWriter,
+    TenantScope,
+};
+use aa_gateway::storage::{PostgresBackend, PostgresConfig};
+
+const SPAN_START: usize = 760_913;
+const SPAN_END: usize = 760_931;
+
+fn record(event_id: &str, category: CanonicalCategory, path: &str) -> SensitiveDataFindingRecord {
+    let finding = CanonicalFinding::new(
+        category,
+        Severity::Critical,
+        ConfidenceBand::High,
+        ByteSpan::new(SPAN_START, SPAN_END),
+        DetectionMethod::Deterministic,
+        Provenance::new(Recognizer::BuiltinScanner, "0.0.0-test"),
+        FindingStatus::Confirmed,
+    )
+    .expect("well-formed span");
+    SensitiveDataFindingRecord::from_finding(
+        AuditLabel::new(event_id).expect("event id"),
+        &finding,
+        FieldPath::parse(path).expect("field path"),
+    )
+    .expect("record projects")
+}
+
+/// ADR 0032 §8's worked example: three findings, one blocked action.
+fn blocked_action_with_three_findings(
+    event_id: &str,
+    org: &str,
+    tenant: &str,
+) -> (SensitiveDataDecisionEvent, Vec<SensitiveDataFindingRecord>) {
+    let email = CanonicalCategory::unqualified(CategoryBase::EmailAddress);
+    let token = CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access");
+    let records = vec![
+        record(event_id, email, "body.customer.email"),
+        record(event_id, email, "body.contact.email"),
+        record(event_id, token, "headers.authorization"),
+    ];
+    let counts = FindingCounts::tally(&records, 0, 3).expect("tally");
+
+    let event = SensitiveDataDecisionEvent::builder(
+        AuditLabel::new(event_id).expect("event id"),
+        Timestamp::from_nanos(1_700_000_000_000_000_000),
+        Tenancy {
+            org_id: AuditLabel::new(org).expect("org"),
+            tenant_id: AuditLabel::new(tenant).expect("tenant"),
+            team_id: Some(AuditLabel::new("billing").expect("team")),
+        },
+        AgentLineage {
+            acting_agent: AgentId::parse("acme/billing-bot").expect("agent"),
+            root_agent: AgentId::parse("acme/orchestrator").expect("agent"),
+            parent_agent: None,
+            delegation_depth: 0,
+        },
+        InspectedAction {
+            operation: OperationKind::ToolCall,
+            source: None,
+            destination: Endpoint::new(EndpointKind::HttpHost, "api.example.com").expect("endpoint"),
+            trust_zone: TrustZone::Public,
+            direction: RequestDirection::Outbound,
+        },
+        RuntimeVerdictLabel::DENY,
+        ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+        ),
+    )
+    .finding_counts(counts)
+    .build();
+
+    (event, records)
+}
+
+fn filter(org: &str, tenant: &str) -> SensitiveDataEventFilter {
+    SensitiveDataEventFilter::new(TenantScope::new(org, tenant).expect("scope"))
+}
+
+/// The whole projection lifecycle on a real PostgreSQL cluster.
+///
+/// One test rather than several because each would otherwise pay for its own
+/// container start; the assertions are independent and each names what it
+/// checks.
+#[tokio::test]
+async fn projection_migrates_persists_isolates_and_rolls_back_on_postgres() {
+    use testcontainers_modules::postgres::Postgres;
+    use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start postgres testcontainer (is Docker running?)");
+    let host = container.get_host().await.expect("container host");
+    let port = container.get_host_port_ipv4(5432).await.expect("container port");
+
+    let backend = PostgresBackend::connect(&PostgresConfig {
+        database_url: Some(format!("postgres://postgres:postgres@{host}:{port}/postgres")),
+        max_connections: 4,
+        min_connections: 1,
+        ..PostgresConfig::default()
+    })
+    .await
+    .expect("connect to postgres container");
+
+    backend
+        .migrate_sensitive_data_projection()
+        .await
+        .expect("projection migration applies to a fresh cluster");
+    backend
+        .migrate_sensitive_data_projection()
+        .await
+        .expect("re-migrating must be a no-op");
+
+    // ADR 0032 §9: no offset, length, span or payload column reaches this tier.
+    let columns = backend
+        .sensitive_data_projection_columns()
+        .await
+        .expect("read information_schema");
+    assert!(!columns.is_empty(), "the migration created no columns");
+    for (table, name) in &columns {
+        for banned in ["offset", "length", "span", "byte", "payload", "raw"] {
+            assert!(
+                !name.contains(banned),
+                "{table}.{name} contains `{banned}` — audit-tier only (ADR 0032 §9)"
+            );
+        }
+    }
+
+    let writer = SensitiveDataProjectionWriter::new(backend, SensitiveDataProjectionConfig::enabled());
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+    for attempt in 0..2 {
+        writer
+            .write(
+                &event,
+                &findings,
+                Timestamp::from_nanos(1_700_000_000_100_000_000 + attempt),
+            )
+            .await
+            .expect("write (and replay) must be accepted");
+    }
+
+    let owner = filter("acme", "acme-prod");
+    let store = writer.store();
+    assert_eq!(
+        store.count_sensitive_data_events(&owner).await.expect("count"),
+        1,
+        "a replayed event must not double-count"
+    );
+    assert_eq!(
+        store.count_sensitive_data_findings(&owner).await.expect("count"),
+        3,
+        "finding rows are a different count from event rows and must survive the replay"
+    );
+
+    let row = &store.query_sensitive_data_events(&owner).await.expect("events")[0];
+    assert_eq!(row.blocked_event_count, 1);
+    assert_eq!(row.blocked_finding_count, 3);
+    assert!(
+        row.counts_as_prevented_transmission(),
+        "denied pre-transmission with the bytes observed not to have gone"
+    );
+
+    let intruder = filter("acme", "acme-staging");
+    assert_eq!(store.count_sensitive_data_events(&intruder).await.expect("count"), 0);
+    assert_eq!(store.count_sensitive_data_findings(&intruder).await.expect("count"), 0);
+    assert!(store
+        .aggregate_sensitive_data_by_category(&intruder)
+        .await
+        .expect("aggregate")
+        .is_empty());
+
+    // The rollback is executed, not merely written.
+    store
+        .rollback_sensitive_data_projection()
+        .await
+        .expect("rollback applies");
+    assert!(
+        store
+            .sensitive_data_projection_columns()
+            .await
+            .expect("read information_schema")
+            .is_empty(),
+        "rollback must remove the projection's tables"
+    );
+    store
+        .migrate_sensitive_data_projection()
+        .await
+        .expect("re-applying after a rollback must work");
+}

--- a/aa-gateway/tests/sensitive_data_projection_postgres_test.rs
+++ b/aa-gateway/tests/sensitive_data_projection_postgres_test.rs
@@ -63,6 +63,7 @@ async fn the_projection_contract_holds_on_postgres() {
         .expect("re-migrating must be a no-op");
 
     contract::columns_are_exactly_the_reviewed_set(&store).await;
+    a_same_named_table_in_another_schema_is_not_reported(&store, &url).await;
     contract::a_byte_span_reaches_no_part_of_the_projection(&store).await;
     contract::every_projected_value_round_trips(&store).await;
     contract::one_blocked_action_with_three_findings_stays_one_event(&store).await;
@@ -98,6 +99,49 @@ async fn the_projection_contract_holds_on_postgres() {
         .migrate_sensitive_data_projection()
         .await
         .expect("re-applying after a rollback must work");
+}
+
+/// A same-named table in another schema must not be reported as ours.
+///
+/// `sensitive_data_projection_columns` is the mechanism the entire "no offset
+/// column" claim rests on, and on PostgreSQL it reads a catalogue view rather
+/// than a per-table pragma. Without `table_schema = current_schema()` that view
+/// answers for every schema on the search path, so a `decoy.sensitive_data_findings`
+/// carrying a `span_start` column would be reported under the projection's own
+/// name — the exact-set assertion would then either fail for the wrong reason
+/// or, if the decoy happened to match, pass while describing the wrong table.
+///
+/// The decoy is planted and removed here so the filter is proved load-bearing
+/// rather than assumed. This closes the over-reporting half only; the
+/// under-reporting half — `information_schema` hides columns the connecting
+/// role lacks privilege on — is named in the implementation and stays open.
+async fn a_same_named_table_in_another_schema_is_not_reported(store: &Arc<PostgresBackend>, url: &str) {
+    let pool = sqlx::PgPool::connect(url).await.expect("second connection");
+    sqlx::query("CREATE SCHEMA IF NOT EXISTS decoy")
+        .execute(&pool)
+        .await
+        .expect("create decoy schema");
+    sqlx::query("CREATE TABLE IF NOT EXISTS decoy.sensitive_data_findings (span_start INTEGER NOT NULL)")
+        .execute(&pool)
+        .await
+        .expect("create decoy table");
+
+    let columns = store
+        .sensitive_data_projection_columns()
+        .await
+        .expect("read information_schema");
+    assert!(
+        !columns.iter().any(|(_, name)| name == "span_start"),
+        "a same-named table in another schema was reported as the projection's own; \
+         ADR 0032 §9 evidence must describe the tables this backend created"
+    );
+    // And the reviewed set is still exactly right with the decoy in place.
+    contract::columns_are_exactly_the_reviewed_set(store).await;
+
+    sqlx::query("DROP SCHEMA decoy CASCADE")
+        .execute(&pool)
+        .await
+        .expect("drop decoy schema");
 }
 
 /// The PostgreSQL decoder refuses a foreign schema major, as the SQLite one

--- a/aa-gateway/tests/sensitive_data_projection_test.rs
+++ b/aa-gateway/tests/sensitive_data_projection_test.rs
@@ -1,0 +1,1007 @@
+//! Adversarial tests for the durable sensitive-data projection (AAASM-5357).
+//!
+//! These live in `tests/` on purpose. Every claim this file makes is about
+//! something a *consumer* of the projection can or cannot observe — an offset
+//! in a column, a span in a serialized row, one tenant's rows under another
+//! tenant's scope — and a unit test inside `storage::sensitive_data` would
+//! share that module's privacy and could therefore assert the claim by
+//! inspecting things no consumer can reach. From out here the only available
+//! surface is the public one, which is the surface the claim is about.
+//!
+//! ADR 0032 §9 is the source of the tiering rules; §8 of the counting rules.
+
+use aa_core::policy::EnforcementMode;
+use aa_core::time::Timestamp;
+use aa_core::types::sensitive_data::{
+    AgentLineage, AuditLabel, CategoryLabel, EndpointKind, EnforcementPoint, ExecutionEvidence, FieldPath,
+    FindingClassification, FindingCounts, InspectedAction, InspectionLatency, OperationKind, PolicyAttribution,
+    PolicyReasonCode, RequestDirection, RuntimeVerdictLabel, SensitiveDataDecisionEvent, SensitiveDataFindingRecord,
+    SensitiveDataMetricLabels, Tenancy, TransmissionEvidence, TrustZone,
+};
+use aa_core::types::AgentId;
+use aa_security::canonical::{
+    ByteSpan, CanonicalCategory, CanonicalFinding, CategoryBase, ConfidenceBand, DetectionMethod, FindingStatus,
+    Provenance, Recognizer, Severity,
+};
+
+use aa_gateway::storage::sensitive_data::{
+    CategoryFindingAggregate, ProjectionError, SensitiveDataEventFilter, SensitiveDataProjection,
+    SensitiveDataProjectionConfig, SensitiveDataProjectionWriter, TenantScope, WriteOutcome,
+};
+use aa_gateway::storage::{SqliteBackend, SqliteConfig, StorageBackend};
+
+/// A byte span whose numbers appear nowhere else in this file, in the schema,
+/// or in any vocabulary the projection stores.
+///
+/// The point of picking odd six-digit values rather than the `(4, 44)` the
+/// `aa-core` fixtures use: a search for "4" in a serialized row finds a schema
+/// version, a delegation depth and a latency. A search for `760913` finds a
+/// leak or nothing.
+const SPAN_START: usize = 760_913;
+const SPAN_END: usize = 760_931;
+
+/// A marker standing in for the sensitive value itself.
+///
+/// No real credential is constructed anywhere here. The projection's write path
+/// never receives a payload at all, so this is a regression guard rather than a
+/// live risk: if a payload column is ever added, this marker is what proves it.
+const SECRET_MARKER: &str = "ZZ-synthetic-secret-value-do-not-store-ZZ";
+
+fn synthetic_finding(category: CanonicalCategory) -> CanonicalFinding {
+    CanonicalFinding::new(
+        category,
+        Severity::Critical,
+        ConfidenceBand::High,
+        ByteSpan::new(SPAN_START, SPAN_END),
+        DetectionMethod::Deterministic,
+        Provenance::new(Recognizer::BuiltinScanner, "0.0.0-test"),
+        FindingStatus::Confirmed,
+    )
+    .expect("well-formed span")
+}
+
+fn record(event_id: &str, category: CanonicalCategory, path: &str) -> SensitiveDataFindingRecord {
+    SensitiveDataFindingRecord::from_finding(
+        AuditLabel::new(event_id).expect("well-formed event id"),
+        &synthetic_finding(category),
+        FieldPath::parse(path).expect("well-formed field path"),
+    )
+    .expect("record projects")
+}
+
+fn tenancy(org: &str, tenant: &str) -> Tenancy {
+    Tenancy {
+        org_id: AuditLabel::new(org).expect("org label"),
+        tenant_id: AuditLabel::new(tenant).expect("tenant label"),
+        team_id: Some(AuditLabel::new("billing").expect("team label")),
+    }
+}
+
+fn lineage() -> AgentLineage {
+    AgentLineage {
+        acting_agent: AgentId::parse("acme/billing-bot").expect("agent id"),
+        root_agent: AgentId::parse("acme/orchestrator").expect("agent id"),
+        parent_agent: Some(AgentId::parse("acme/orchestrator").expect("agent id")),
+        delegation_depth: 1,
+    }
+}
+
+fn action() -> InspectedAction {
+    InspectedAction {
+        operation: OperationKind::ToolCall,
+        source: None,
+        destination: aa_core::types::sensitive_data::Endpoint::new(EndpointKind::HttpHost, "api.example.com")
+            .expect("endpoint"),
+        trust_zone: TrustZone::Public,
+        direction: RequestDirection::Outbound,
+    }
+}
+
+/// ADR 0032 §8's worked example: three findings in one action, blocked before
+/// transmission while enforcing. Two of the findings share a category, so the
+/// per-category event count and finding count differ as well.
+fn blocked_action_with_three_findings(
+    event_id: &str,
+    org: &str,
+    tenant: &str,
+) -> (SensitiveDataDecisionEvent, Vec<SensitiveDataFindingRecord>) {
+    let email = CanonicalCategory::unqualified(CategoryBase::EmailAddress);
+    let token = CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access");
+    let records = vec![
+        record(event_id, email, "body.customer.email"),
+        record(event_id, email, "body.contact.email"),
+        record(event_id, token, "headers.authorization"),
+    ];
+    let counts = FindingCounts::tally(&records, 0, 3).expect("tally");
+
+    let event = SensitiveDataDecisionEvent::builder(
+        AuditLabel::new(event_id).expect("event id"),
+        Timestamp::from_nanos(1_700_000_000_000_000_000),
+        tenancy(org, tenant),
+        lineage(),
+        action(),
+        RuntimeVerdictLabel::DENY,
+        ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+        ),
+    )
+    .finding_counts(counts)
+    .classification(FindingClassification {
+        severity: Severity::Critical,
+        confidence: ConfidenceBand::High,
+        method: DetectionMethod::Deterministic,
+        status: FindingStatus::Confirmed,
+    })
+    .inspected_fields(vec![
+        FieldPath::parse("body.customer.email").expect("path"),
+        FieldPath::parse("body.contact.email").expect("path"),
+        FieldPath::parse("headers.authorization").expect("path"),
+    ])
+    .policy(PolicyAttribution {
+        document_id: Some(AuditLabel::new("sha256:abc123").expect("doc id")),
+        version: Some(7),
+        matched_rule_ids: vec![AuditLabel::new("no-pii-to-public-hosts").expect("rule id")],
+    })
+    .reason_codes(vec![PolicyReasonCode::SensitiveDataDetected])
+    .latency(InspectionLatency {
+        provider_us: None,
+        total_us: 6,
+    })
+    .build();
+
+    (event, records)
+}
+
+async fn migrated_backend() -> (tempfile::TempDir, SqliteBackend) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let backend = SqliteBackend::open(&SqliteConfig {
+        path: dir.path().join("projection.db"),
+    })
+    .await
+    .expect("open sqlite");
+    backend.migrate().await.expect("base migrate");
+    backend
+        .migrate_sensitive_data_projection()
+        .await
+        .expect("projection migrate");
+    (dir, backend)
+}
+
+fn scope(org: &str, tenant: &str) -> TenantScope {
+    TenantScope::new(org, tenant).expect("scope")
+}
+
+fn filter(org: &str, tenant: &str) -> SensitiveDataEventFilter {
+    SensitiveDataEventFilter::new(scope(org, tenant))
+}
+
+fn writer(backend: SqliteBackend) -> SensitiveDataProjectionWriter<SqliteBackend> {
+    SensitiveDataProjectionWriter::new(backend, SensitiveDataProjectionConfig::enabled())
+}
+
+// ---------------------------------------------------------------------------
+// ADR 0032 §9 — offsets and lengths belong to the audit tier only
+// ---------------------------------------------------------------------------
+
+/// The exact column set of both tables, read from the live SQLite catalogue.
+///
+/// Pinned exactly rather than checked for the absence of a list of bad names:
+/// a substring check knows only the leaks someone thought of, whereas an exact
+/// set fails on any column at all that is not on the reviewed list — which is
+/// the property ADR 0032 §9 actually needs.
+#[tokio::test]
+async fn projection_tables_have_exactly_the_reviewed_columns_and_no_offset() {
+    let (_dir, backend) = migrated_backend().await;
+
+    let mut actual = backend
+        .sensitive_data_projection_columns()
+        .await
+        .expect("read catalogue")
+        .into_iter()
+        .map(|(table, column)| format!("{table}.{column}"))
+        .collect::<Vec<_>>();
+    actual.sort();
+
+    let mut expected = EXPECTED_EVENT_COLUMNS
+        .iter()
+        .map(|c| format!("sensitive_data_events.{c}"))
+        .chain(
+            EXPECTED_FINDING_COLUMNS
+                .iter()
+                .map(|c| format!("sensitive_data_findings.{c}")),
+        )
+        .collect::<Vec<_>>();
+    expected.sort();
+
+    assert_eq!(
+        actual, expected,
+        "the projection's persisted columns changed; ADR 0032 §9 confines offsets and \
+         lengths to the tamper-evident tier, so any new column here needs review"
+    );
+
+    // Belt as well as braces: the exact-set assertion above is the real guard,
+    // but naming the forbidden shapes documents *why* the list is closed.
+    for entry in &actual {
+        let name = entry.split('.').next_back().expect("qualified name");
+        for banned in ["offset", "length", "span", "byte", "payload", "raw"] {
+            assert!(
+                !name.contains(banned),
+                "column `{entry}` contains `{banned}` — offsets, lengths and payloads are \
+                 audit-tier only (ADR 0032 §9)"
+            );
+        }
+    }
+}
+
+/// The serialized shape a consumer receives, pinned the same way.
+///
+/// Separate from the column test because they can diverge: a struct field with
+/// no column would still be published to any consumer that serializes a row.
+#[tokio::test]
+async fn serialized_rows_expose_exactly_the_reviewed_keys_and_no_span() {
+    let (_dir, backend) = migrated_backend().await;
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+    let writer = writer(backend);
+    writer
+        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
+        .await
+        .expect("write");
+
+    let events = writer
+        .store()
+        .query_sensitive_data_events(&filter("acme", "acme-prod"))
+        .await
+        .expect("query events");
+    let rows = writer
+        .store()
+        .query_sensitive_data_findings(&filter("acme", "acme-prod"))
+        .await
+        .expect("query findings");
+
+    let event_json = serde_json::to_value(&events[0]).expect("serialize event row");
+    let finding_json = serde_json::to_value(&rows[0]).expect("serialize finding row");
+
+    let mut event_keys = event_json
+        .as_object()
+        .expect("object")
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    event_keys.sort();
+    let mut expected_event = EXPECTED_EVENT_COLUMNS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect::<Vec<_>>();
+    expected_event.sort();
+    assert_eq!(
+        event_keys, expected_event,
+        "the event row's serialized keys must match its columns exactly"
+    );
+
+    let mut finding_keys = finding_json
+        .as_object()
+        .expect("object")
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    finding_keys.sort();
+    let mut expected_finding = EXPECTED_FINDING_COLUMNS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect::<Vec<_>>();
+    expected_finding.sort();
+    assert_eq!(
+        finding_keys, expected_finding,
+        "the finding row's serialized keys must match its columns exactly"
+    );
+}
+
+/// The end-to-end attack: a finding carrying a distinctive span goes in, and
+/// neither of its numbers comes back out of storage in any form.
+///
+/// This is the assertion the type-level argument is supposed to make
+/// unnecessary — and the reason it is written anyway. "Span-free by
+/// construction" is a claim about construction paths, not an unrepresentable
+/// state; the fields are `pub` and `Deserialize` rebuilds a record from bytes.
+/// So the claim is checked against what is actually durable.
+#[tokio::test]
+async fn a_findings_byte_span_reaches_no_part_of_the_persisted_projection() {
+    let (_dir, backend) = migrated_backend().await;
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+
+    // The span really is on the finding that was scanned — otherwise this test
+    // would pass by testing nothing, which is how a span-leak test fails.
+    let scanned = synthetic_finding(CanonicalCategory::unqualified(CategoryBase::EmailAddress));
+    assert_eq!(scanned.span().start(), SPAN_START, "fixture must carry the span");
+
+    let writer = writer(backend);
+    writer
+        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
+        .await
+        .expect("write");
+
+    let f = filter("acme", "acme-prod");
+    let events = writer.store().query_sensitive_data_events(&f).await.expect("events");
+    let rows = writer
+        .store()
+        .query_sensitive_data_findings(&f)
+        .await
+        .expect("findings");
+
+    let dump = format!(
+        "{}{}",
+        serde_json::to_string(&events).expect("serialize events"),
+        serde_json::to_string(&rows).expect("serialize findings"),
+    );
+
+    for needle in [SPAN_START.to_string(), SPAN_END.to_string()] {
+        assert!(
+            !dump.contains(&needle),
+            "byte offset {needle} reached the non-audit projection; ADR 0032 §9 permits \
+             offsets only in the tamper-evident tier"
+        );
+    }
+    assert!(
+        !dump.contains(SECRET_MARKER),
+        "a sensitive value reached the projection; it stores redacted and derived data only"
+    );
+    // The drill-down granularity §9 grants *in place of* offsets did survive —
+    // otherwise the absence above would just mean nothing was stored.
+    assert!(
+        dump.contains("headers.authorization"),
+        "field paths are the drill-down granularity and must be persisted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ADR 0032 §8 — event counts and finding counts are different numbers
+// ---------------------------------------------------------------------------
+
+/// The §8 worked example, carried all the way through storage.
+///
+/// Three findings in one blocked action: one blocked *event*, three blocked
+/// *findings*. Both numbers are read back from the database rather than from
+/// the in-memory event, because the collapse this guards against is a writer
+/// putting one of them in the other's column.
+#[tokio::test]
+async fn one_blocked_action_with_three_findings_persists_as_one_event_and_three_findings() {
+    let (_dir, backend) = migrated_backend().await;
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+    let writer = writer(backend);
+    writer
+        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
+        .await
+        .expect("write");
+
+    let f = filter("acme", "acme-prod");
+    let store = writer.store();
+
+    assert_eq!(store.count_sensitive_data_events(&f).await.expect("count"), 1);
+    assert_eq!(store.count_sensitive_data_findings(&f).await.expect("count"), 3);
+
+    let row = &store.query_sensitive_data_events(&f).await.expect("events")[0];
+    assert_eq!(row.event_count, 1, "one action is one event");
+    assert_eq!(row.blocked_event_count, 1, "the action was refused");
+    assert_eq!(row.finding_count, 3);
+    assert_eq!(row.blocked_finding_count, 3);
+    assert_ne!(
+        row.blocked_event_count, row.blocked_finding_count,
+        "the two are different measures and must not be interchangeable"
+    );
+
+    // The per-category aggregate reports both, and for the doubled category
+    // they differ — two email findings inside a single event.
+    let aggregates = store
+        .aggregate_sensitive_data_by_category(&f)
+        .await
+        .expect("aggregate by category");
+    // Rendered from the catalogue rather than spelled out, so a renamed
+    // category is a compile-or-lookup failure here instead of a silently
+    // never-matching `find` that makes the assertions below unreachable.
+    let email_label = CategoryLabel::from(CanonicalCategory::unqualified(CategoryBase::EmailAddress));
+    let email = aggregates
+        .iter()
+        .find(|a| a.category == email_label.as_str())
+        .unwrap_or_else(|| panic!("email category present; got {aggregates:?}"));
+    assert_eq!(email.finding_count, 2, "two email findings");
+    assert_eq!(email.event_count, 1, "in one event");
+    assert_ne!(
+        email.finding_count, email.event_count,
+        "an aggregate that reported one of these as the other would be wrong by a \
+         factor that varies per action (forbidden design #11)"
+    );
+
+    // A structural guard as well as a numeric one: adding a grouping dimension
+    // to this aggregate stops the suite compiling, which is what keeps an
+    // unbounded label — a destination, an agent id — out of it.
+    let CategoryFindingAggregate {
+        category: _,
+        finding_count: _,
+        event_count: _,
+    } = aggregates[0].clone();
+}
+
+/// A producer whose finding rows disagree with its own tallies is refused
+/// before anything becomes durable.
+#[tokio::test]
+async fn a_row_count_that_disagrees_with_the_events_tally_is_refused() {
+    let (_dir, backend) = migrated_backend().await;
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+    let writer = writer(backend);
+
+    let err = writer
+        .write(&event, &findings[..2], Timestamp::from_nanos(1_700_000_000_100_000_000))
+        .await
+        .expect_err("two rows against a three-finding tally must be refused");
+    assert!(
+        matches!(
+            err,
+            ProjectionError::FindingCountMismatch {
+                declared: 3,
+                supplied: 2,
+                ..
+            }
+        ),
+        "expected FindingCountMismatch, got {err:?}"
+    );
+
+    let f = filter("acme", "acme-prod");
+    assert_eq!(
+        writer.store().count_sensitive_data_events(&f).await.expect("count"),
+        0,
+        "a refused projection must leave nothing behind"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tenant isolation
+// ---------------------------------------------------------------------------
+
+/// One tenant's rows are invisible under another tenant's scope, on every read
+/// path — including the findings table, which is scoped by its own columns
+/// rather than by joining the events table.
+#[tokio::test]
+async fn a_neighbouring_tenant_sees_none_of_it() {
+    let (_dir, backend) = migrated_backend().await;
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+    let writer = writer(backend);
+    writer
+        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
+        .await
+        .expect("write");
+
+    let store = writer.store();
+    let owner = filter("acme", "acme-prod");
+    let same_org_other_tenant = filter("acme", "acme-staging");
+    let other_org_same_tenant_name = filter("globex", "acme-prod");
+
+    assert_eq!(store.count_sensitive_data_events(&owner).await.expect("count"), 1);
+
+    for intruder in [&same_org_other_tenant, &other_org_same_tenant_name] {
+        assert_eq!(
+            store.count_sensitive_data_events(intruder).await.expect("count"),
+            0,
+            "events leaked across a tenant boundary"
+        );
+        assert_eq!(
+            store.count_sensitive_data_findings(intruder).await.expect("count"),
+            0,
+            "findings leaked across a tenant boundary"
+        );
+        assert!(
+            store
+                .query_sensitive_data_events(intruder)
+                .await
+                .expect("query")
+                .is_empty(),
+            "event rows leaked across a tenant boundary"
+        );
+        assert!(
+            store
+                .query_sensitive_data_findings(intruder)
+                .await
+                .expect("query")
+                .is_empty(),
+            "finding rows leaked across a tenant boundary"
+        );
+        assert!(
+            store
+                .aggregate_sensitive_data_by_category(intruder)
+                .await
+                .expect("aggregate")
+                .is_empty(),
+            "an aggregate leaked across a tenant boundary — the failure mode that is a \
+             smaller-looking answer rather than an error"
+        );
+    }
+}
+
+/// A blank tenant is not a narrower scope, so it cannot be constructed.
+#[test]
+fn an_empty_tenancy_cannot_be_scoped() {
+    assert!(matches!(
+        TenantScope::new("", "acme-prod"),
+        Err(ProjectionError::EmptyTenancy("org_id"))
+    ));
+    assert!(matches!(
+        TenantScope::new("acme", "   "),
+        Err(ProjectionError::EmptyTenancy("tenant_id"))
+    ));
+    assert!(TenantScope::new("acme", "acme-prod").is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency and late arrivals
+// ---------------------------------------------------------------------------
+
+/// A replayed event does not double-count, on either table.
+#[tokio::test]
+async fn a_replayed_event_does_not_double_count() {
+    let (_dir, backend) = migrated_backend().await;
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+    let writer = writer(backend);
+
+    for attempt in 0..3 {
+        writer
+            .write(
+                &event,
+                &findings,
+                Timestamp::from_nanos(1_700_000_000_100_000_000 + attempt),
+            )
+            .await
+            .expect("replay must be accepted, not rejected");
+    }
+
+    let f = filter("acme", "acme-prod");
+    assert_eq!(writer.store().count_sensitive_data_events(&f).await.expect("count"), 1);
+    assert_eq!(
+        writer.store().count_sensitive_data_findings(&f).await.expect("count"),
+        3,
+        "three replays of a three-finding event is still three findings"
+    );
+}
+
+/// The documented late-arrival rule: first write wins.
+///
+/// A duplicate arriving after the fact cannot rewrite tallies a reader may
+/// already have acted on, so a dashboard's numbers do not move under it.
+#[tokio::test]
+async fn a_late_duplicate_cannot_rewrite_the_stored_tallies() {
+    let (_dir, backend) = migrated_backend().await;
+    let (first, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+    let writer = writer(backend);
+    writer
+        .write(&first, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
+        .await
+        .expect("first write");
+
+    // Same event id, a different verdict and different tallies — the shape a
+    // corrupted or re-decided replay would have.
+    let single = vec![record(
+        "01HZX9V8ABCDEFGHJKMNPQRSTV",
+        CanonicalCategory::unqualified(CategoryBase::EmailAddress),
+        "body.customer.email",
+    )];
+    let contradicting = SensitiveDataDecisionEvent::builder(
+        AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").expect("event id"),
+        Timestamp::from_nanos(1_700_000_000_000_000_000),
+        tenancy("acme", "acme-prod"),
+        lineage(),
+        action(),
+        RuntimeVerdictLabel::ALLOW,
+        ExecutionEvidence::unrecorded(EnforcementMode::Observe),
+    )
+    .finding_counts(FindingCounts::tally(&single, 0, 0).expect("tally"))
+    .build();
+
+    writer
+        .write(
+            &contradicting,
+            &single,
+            Timestamp::from_nanos(1_700_000_999_000_000_000),
+        )
+        .await
+        .expect("a late duplicate is ignored, not an error");
+
+    let f = filter("acme", "acme-prod");
+    let row = &writer.store().query_sensitive_data_events(&f).await.expect("events")[0];
+    assert_eq!(row.verdict, "deny", "first write wins");
+    assert_eq!(row.blocked_finding_count, 3, "the stored tallies did not move");
+    assert_eq!(
+        writer.store().count_sensitive_data_findings(&f).await.expect("count"),
+        3,
+        "the late duplicate added no finding rows"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Migration and rollback
+// ---------------------------------------------------------------------------
+
+/// The migration is idempotent and the rollback is executed, not merely
+/// written — and running it leaves the audit tables untouched.
+#[tokio::test]
+async fn the_migration_is_idempotent_and_the_rollback_is_a_real_inverse() {
+    let (_dir, backend) = migrated_backend().await;
+
+    backend
+        .migrate_sensitive_data_projection()
+        .await
+        .expect("re-migrating must be a no-op");
+    assert_eq!(
+        backend
+            .sensitive_data_projection_columns()
+            .await
+            .expect("columns")
+            .len(),
+        EXPECTED_EVENT_COLUMNS.len() + EXPECTED_FINDING_COLUMNS.len()
+    );
+
+    backend
+        .rollback_sensitive_data_projection()
+        .await
+        .expect("rollback must apply");
+    assert!(
+        backend
+            .sensitive_data_projection_columns()
+            .await
+            .expect("columns")
+            .is_empty(),
+        "rollback must remove the projection's tables"
+    );
+
+    // The audit path is unaffected by the rollback — which is the whole reason
+    // the projection owns its own up/down rather than joining the shared
+    // migrator.
+    backend
+        .count_audit_events(Default::default())
+        .await
+        .expect("the audit tables must survive a projection rollback");
+
+    backend
+        .rollback_sensitive_data_projection()
+        .await
+        .expect("rollback must itself be idempotent");
+    backend
+        .migrate_sensitive_data_projection()
+        .await
+        .expect("re-applying after a rollback must work");
+    assert_eq!(
+        backend
+            .sensitive_data_projection_columns()
+            .await
+            .expect("columns")
+            .len(),
+        EXPECTED_EVENT_COLUMNS.len() + EXPECTED_FINDING_COLUMNS.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The flag
+// ---------------------------------------------------------------------------
+
+/// With the flag off nothing is written, no tables are created, and the
+/// existing audit path is unaffected.
+#[tokio::test]
+async fn a_disabled_projection_writes_nothing_and_leaves_the_audit_path_alone() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let backend = SqliteBackend::open(&SqliteConfig {
+        path: dir.path().join("projection.db"),
+    })
+    .await
+    .expect("open sqlite");
+    backend.migrate().await.expect("base migrate");
+
+    let writer = SensitiveDataProjectionWriter::new(backend, SensitiveDataProjectionConfig::disabled());
+    assert!(!writer.is_enabled());
+    assert_eq!(writer.migrate().await.expect("migrate"), WriteOutcome::Disabled);
+
+    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+    assert_eq!(
+        writer
+            .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
+            .await
+            .expect("a disabled write is a no-op, not an error"),
+        WriteOutcome::Disabled
+    );
+
+    assert!(
+        writer
+            .store()
+            .sensitive_data_projection_columns()
+            .await
+            .expect("columns")
+            .is_empty(),
+        "a disabled projection must not create its tables"
+    );
+    // The audit path still works with the projection off, which is what
+    // "turned off without affecting existing audit behaviour" means.
+    writer
+        .store()
+        .count_audit_events(Default::default())
+        .await
+        .expect("audit path unaffected");
+}
+
+// ---------------------------------------------------------------------------
+// Prevention requires evidence
+// ---------------------------------------------------------------------------
+
+/// Only a deny-or-transforming verdict, applied pre-transmission, while
+/// enforcing, with the bytes observed not to have gone, counts as prevention.
+///
+/// The negative cases are the point. `scrub` with `forwarded_clean` is what a
+/// successful redaction looks like — a *transformed transmission* — and it is
+/// the case the `CredentialLeakBlocked` event name already got wrong once.
+#[tokio::test]
+async fn prevention_is_claimed_only_where_the_evidence_supports_it() {
+    let (_dir, backend) = migrated_backend().await;
+    let writer = writer(backend);
+
+    let cases: [(
+        &str,
+        RuntimeVerdictLabel,
+        EnforcementPoint,
+        TransmissionEvidence,
+        EnforcementMode,
+        bool,
+    ); 7] = [
+        (
+            "01HZX9V8ABCDEFGHJKMNPQRS01",
+            RuntimeVerdictLabel::DENY,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+            true,
+        ),
+        (
+            // Redaction forwards the scrubbed bytes. Detected, not prevented.
+            "01HZX9V8ABCDEFGHJKMNPQRS02",
+            RuntimeVerdictLabel::SCRUB,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::ForwardedClean,
+            EnforcementMode::Enforce,
+            false,
+        ),
+        (
+            // `narrow` scopes the action without transforming the payload.
+            "01HZX9V8ABCDEFGHJKMNPQRS03",
+            RuntimeVerdictLabel::NARROW,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+            false,
+        ),
+        (
+            // Observe mode computed the decision and applied nothing.
+            "01HZX9V8ABCDEFGHJKMNPQRS04",
+            RuntimeVerdictLabel::DENY,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Observe,
+            false,
+        ),
+        (
+            // Decided after the bytes left.
+            "01HZX9V8ABCDEFGHJKMNPQRS05",
+            RuntimeVerdictLabel::DENY,
+            EnforcementPoint::PostTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+            false,
+        ),
+        (
+            // An unwired producer must not claim prevention by saying nothing.
+            "01HZX9V8ABCDEFGHJKMNPQRS06",
+            RuntimeVerdictLabel::DENY,
+            EnforcementPoint::NotRecorded,
+            TransmissionEvidence::NotRecorded,
+            EnforcementMode::Enforce,
+            false,
+        ),
+        (
+            // The layer decided to redact and emitted the credential anyway.
+            "01HZX9V8ABCDEFGHJKMNPQRS07",
+            RuntimeVerdictLabel::SCRUB,
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::ForwardedCarryingSensitiveValue,
+            EnforcementMode::Enforce,
+            false,
+        ),
+    ];
+
+    for (event_id, verdict, point, transmission, mode, _expected) in cases {
+        let event = SensitiveDataDecisionEvent::builder(
+            AuditLabel::new(event_id).expect("event id"),
+            Timestamp::from_nanos(1_700_000_000_000_000_000),
+            tenancy("acme", "acme-prod"),
+            lineage(),
+            action(),
+            verdict,
+            ExecutionEvidence::new(point, transmission, mode),
+        )
+        .build();
+        writer
+            .write(&event, &[], Timestamp::from_nanos(1_700_000_000_100_000_000))
+            .await
+            .expect("write");
+    }
+
+    let rows = writer
+        .store()
+        .query_sensitive_data_events(&filter("acme", "acme-prod"))
+        .await
+        .expect("events");
+
+    for (event_id, _, _, _, _, expected) in cases {
+        let row = rows.iter().find(|r| r.event_id == event_id).expect("row present");
+        assert_eq!(
+            row.counts_as_prevented_transmission(),
+            expected,
+            "prevention verdict wrong for {event_id} \
+             (verdict={}, point={}, transmission={}, mode={})",
+            row.verdict,
+            row.enforcement_point,
+            row.transmission_evidence,
+            row.enforcement_mode
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metric labels stay bounded
+// ---------------------------------------------------------------------------
+
+/// A category this build cannot resolve is stored for drill-down but refused as
+/// a metric label.
+///
+/// Both directions are asserted in one test on purpose. A test that only walked
+/// the catalogue's own members could never reach the unbounded case and would
+/// pass while the guard did nothing — the precedent this is written against.
+/// The positive control is what proves the negative is not vacuous.
+#[tokio::test]
+async fn an_unresolvable_category_is_stored_for_drill_down_but_refused_as_a_label() {
+    let mut arbitrary = record(
+        "01HZX9V8ABCDEFGHJKMNPQRSTV",
+        CanonicalCategory::unqualified(CategoryBase::EmailAddress),
+        "body.customer.email",
+    );
+    // The shape an attacker-influenced or newer-build category would have:
+    // well-formed, unbounded, and not in this build's catalogue.
+    arbitrary.category = CategoryLabel::new("acme_internal_customer_ssn_v3_9f2c1b").expect("well-formed label");
+
+    assert!(
+        SensitiveDataMetricLabels::from_finding(&arbitrary, RuntimeVerdictLabel::DENY).is_none(),
+        "an unresolvable category must not become a metric label — it is an unbounded \
+         series, which ADR 0032 §9 forbids"
+    );
+
+    let catalogued = record(
+        "01HZX9V8ABCDEFGHJKMNPQRSTV",
+        CanonicalCategory::unqualified(CategoryBase::EmailAddress),
+        "body.customer.email",
+    );
+    let labels = SensitiveDataMetricLabels::from_finding(&catalogued, RuntimeVerdictLabel::DENY)
+        .expect("a catalogue category must resolve — otherwise the None above proves nothing");
+
+    let names = labels.as_pairs().map(|(name, _)| name);
+    assert_eq!(names, SensitiveDataMetricLabels::LABEL_NAMES);
+    for banned in ["destination", "tenant", "org", "agent", "field_path", "event_id"] {
+        assert!(
+            !names.contains(&banned),
+            "`{banned}` is unbounded cardinality and must never be a metric label"
+        );
+    }
+
+    // The unresolvable category is still durable, so the drill-down that
+    // replaces the offset is not lost by refusing the label.
+    let (_dir, backend) = migrated_backend().await;
+    let (event, mut findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
+    findings[0].category = CategoryLabel::new("acme_internal_customer_ssn_v3_9f2c1b").expect("label");
+    let counts = FindingCounts::tally(&findings, 0, 3).expect("tally");
+    let event = SensitiveDataDecisionEvent::builder(
+        AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").expect("event id"),
+        Timestamp::from_nanos(1_700_000_000_000_000_000),
+        tenancy("acme", "acme-prod"),
+        lineage(),
+        action(),
+        event.verdict,
+        ExecutionEvidence::new(
+            EnforcementPoint::PreTransmission,
+            TransmissionEvidence::NotForwarded,
+            EnforcementMode::Enforce,
+        ),
+    )
+    .finding_counts(counts)
+    .build();
+
+    let writer = writer(backend);
+    writer
+        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
+        .await
+        .expect("write");
+
+    let stored = writer
+        .store()
+        .query_sensitive_data_findings(&filter("acme", "acme-prod"))
+        .await
+        .expect("findings");
+    assert!(
+        stored
+            .iter()
+            .any(|r| r.category == "acme_internal_customer_ssn_v3_9f2c1b"),
+        "an unresolvable category must still be persisted for drill-down"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The reviewed column lists
+// ---------------------------------------------------------------------------
+
+/// Every column of `sensitive_data_events`, reviewed against ADR 0032 §9.
+const EXPECTED_EVENT_COLUMNS: &[&str] = &[
+    "schema_version_major",
+    "schema_version_minor",
+    "event_id",
+    "occurred_at_ns",
+    "ingested_at_ns",
+    "org_id",
+    "tenant_id",
+    "team_id",
+    "acting_agent_id",
+    "root_agent_id",
+    "parent_agent_id",
+    "delegation_depth",
+    "session_id",
+    "trace_id",
+    "request_id",
+    "correlation_id",
+    "operation",
+    "destination_kind",
+    "destination_id",
+    "trust_zone",
+    "direction",
+    "policy_document_id",
+    "policy_version",
+    "matched_rule_ids",
+    "inspected_field_paths",
+    "verdict",
+    "enforcement_point",
+    "transmission_evidence",
+    "enforcement_mode",
+    "inspection_failure_path",
+    "severity",
+    "confidence",
+    "method",
+    "status",
+    "event_count",
+    "blocked_event_count",
+    "finding_count",
+    "blocked_finding_count",
+    "transformed_finding_count",
+    "finding_count_by_category",
+    "reason_codes",
+];
+
+/// Every column of `sensitive_data_findings`, reviewed the same way.
+const EXPECTED_FINDING_COLUMNS: &[&str] = &[
+    "schema_version_major",
+    "schema_version_minor",
+    "event_id",
+    "finding_ordinal",
+    "org_id",
+    "tenant_id",
+    "occurred_at_ns",
+    "category",
+    "severity",
+    "confidence",
+    "method",
+    "status",
+    "recognizer",
+    "recognizer_version",
+    "field_path",
+    "redaction_label",
+    "aggregate_key",
+];

--- a/aa-gateway/tests/sensitive_data_projection_test.rs
+++ b/aa-gateway/tests/sensitive_data_projection_test.rs
@@ -1,160 +1,30 @@
-//! Adversarial tests for the durable sensitive-data projection (AAASM-5357).
+//! The sensitive-data projection's contract, on SQLite (AAASM-5357).
 //!
-//! These live in `tests/` on purpose. Every claim this file makes is about
-//! something a *consumer* of the projection can or cannot observe — an offset
-//! in a column, a span in a serialized row, one tenant's rows under another
-//! tenant's scope — and a unit test inside `storage::sensitive_data` would
-//! share that module's privacy and could therefore assert the claim by
-//! inspecting things no consumer can reach. From out here the only available
-//! surface is the public one, which is the surface the claim is about.
+//! The assertions themselves live in `sensitive_data_contract`, shared with the
+//! PostgreSQL suite, because they are properties of the *projection* rather than
+//! of a backend — see that module's header for why sharing them is not
+//! optional. This file supplies a SQLite store, plus the checks that are about
+//! schema lifecycle and so cannot share a database with anything else.
+//!
+//! They are in `tests/` rather than in the module because every claim is about
+//! what a *consumer* can observe, and a unit test sharing
+//! `storage::sensitive_data`'s privacy could satisfy the claim by inspecting
+//! things no consumer can reach.
 //!
 //! ADR 0032 §9 is the source of the tiering rules; §8 of the counting rules.
 
-use aa_core::policy::EnforcementMode;
-use aa_core::time::Timestamp;
-use aa_core::types::sensitive_data::{
-    AgentLineage, AuditLabel, CategoryLabel, EndpointKind, EnforcementPoint, ExecutionEvidence, FieldPath,
-    FindingClassification, FindingCounts, InspectedAction, InspectionLatency, OperationKind, PolicyAttribution,
-    PolicyReasonCode, RequestDirection, RuntimeVerdictLabel, SensitiveDataDecisionEvent, SensitiveDataFindingRecord,
-    SensitiveDataMetricLabels, Tenancy, TransmissionEvidence, TrustZone,
-};
-use aa_core::types::AgentId;
-use aa_security::canonical::{
-    ByteSpan, CanonicalCategory, CanonicalFinding, CategoryBase, ConfidenceBand, DetectionMethod, FindingStatus,
-    Provenance, Recognizer, Severity,
-};
+use std::path::Path;
+use std::sync::Arc;
 
-use aa_gateway::storage::sensitive_data::{
-    CategoryFindingAggregate, ProjectionError, SensitiveDataEventFilter, SensitiveDataProjection,
-    SensitiveDataProjectionConfig, SensitiveDataProjectionWriter, TenantScope, WriteOutcome,
-};
+use aa_core::time::Timestamp;
+use aa_gateway::storage::sensitive_data::{ProjectionError, SensitiveDataProjection, TenantScope};
 use aa_gateway::storage::{SqliteBackend, SqliteConfig, StorageBackend};
 
-/// A byte span whose numbers appear nowhere else in this file, in the schema,
-/// or in any vocabulary the projection stores.
-///
-/// The point of picking odd six-digit values rather than the `(4, 44)` the
-/// `aa-core` fixtures use: a search for "4" in a serialized row finds a schema
-/// version, a delegation depth and a latency. A search for `760913` finds a
-/// leak or nothing.
-const SPAN_START: usize = 760_913;
-const SPAN_END: usize = 760_931;
+#[path = "sensitive_data_contract/mod.rs"]
+mod contract;
 
-/// A marker standing in for the sensitive value itself.
-///
-/// No real credential is constructed anywhere here. The projection's write path
-/// never receives a payload at all, so this is a regression guard rather than a
-/// live risk: if a payload column is ever added, this marker is what proves it.
-const SECRET_MARKER: &str = "ZZ-synthetic-secret-value-do-not-store-ZZ";
-
-fn synthetic_finding(category: CanonicalCategory) -> CanonicalFinding {
-    CanonicalFinding::new(
-        category,
-        Severity::Critical,
-        ConfidenceBand::High,
-        ByteSpan::new(SPAN_START, SPAN_END),
-        DetectionMethod::Deterministic,
-        Provenance::new(Recognizer::BuiltinScanner, "0.0.0-test"),
-        FindingStatus::Confirmed,
-    )
-    .expect("well-formed span")
-}
-
-fn record(event_id: &str, category: CanonicalCategory, path: &str) -> SensitiveDataFindingRecord {
-    SensitiveDataFindingRecord::from_finding(
-        AuditLabel::new(event_id).expect("well-formed event id"),
-        &synthetic_finding(category),
-        FieldPath::parse(path).expect("well-formed field path"),
-    )
-    .expect("record projects")
-}
-
-fn tenancy(org: &str, tenant: &str) -> Tenancy {
-    Tenancy {
-        org_id: AuditLabel::new(org).expect("org label"),
-        tenant_id: AuditLabel::new(tenant).expect("tenant label"),
-        team_id: Some(AuditLabel::new("billing").expect("team label")),
-    }
-}
-
-fn lineage() -> AgentLineage {
-    AgentLineage {
-        acting_agent: AgentId::parse("acme/billing-bot").expect("agent id"),
-        root_agent: AgentId::parse("acme/orchestrator").expect("agent id"),
-        parent_agent: Some(AgentId::parse("acme/orchestrator").expect("agent id")),
-        delegation_depth: 1,
-    }
-}
-
-fn action() -> InspectedAction {
-    InspectedAction {
-        operation: OperationKind::ToolCall,
-        source: None,
-        destination: aa_core::types::sensitive_data::Endpoint::new(EndpointKind::HttpHost, "api.example.com")
-            .expect("endpoint"),
-        trust_zone: TrustZone::Public,
-        direction: RequestDirection::Outbound,
-    }
-}
-
-/// ADR 0032 §8's worked example: three findings in one action, blocked before
-/// transmission while enforcing. Two of the findings share a category, so the
-/// per-category event count and finding count differ as well.
-fn blocked_action_with_three_findings(
-    event_id: &str,
-    org: &str,
-    tenant: &str,
-) -> (SensitiveDataDecisionEvent, Vec<SensitiveDataFindingRecord>) {
-    let email = CanonicalCategory::unqualified(CategoryBase::EmailAddress);
-    let token = CanonicalCategory::with_scheme(CategoryBase::AccessToken, "github", "personal_access");
-    let records = vec![
-        record(event_id, email, "body.customer.email"),
-        record(event_id, email, "body.contact.email"),
-        record(event_id, token, "headers.authorization"),
-    ];
-    let counts = FindingCounts::tally(&records, 0, 3).expect("tally");
-
-    let event = SensitiveDataDecisionEvent::builder(
-        AuditLabel::new(event_id).expect("event id"),
-        Timestamp::from_nanos(1_700_000_000_000_000_000),
-        tenancy(org, tenant),
-        lineage(),
-        action(),
-        RuntimeVerdictLabel::DENY,
-        ExecutionEvidence::new(
-            EnforcementPoint::PreTransmission,
-            TransmissionEvidence::NotForwarded,
-            EnforcementMode::Enforce,
-        ),
-    )
-    .finding_counts(counts)
-    .classification(FindingClassification {
-        severity: Severity::Critical,
-        confidence: ConfidenceBand::High,
-        method: DetectionMethod::Deterministic,
-        status: FindingStatus::Confirmed,
-    })
-    .inspected_fields(vec![
-        FieldPath::parse("body.customer.email").expect("path"),
-        FieldPath::parse("body.contact.email").expect("path"),
-        FieldPath::parse("headers.authorization").expect("path"),
-    ])
-    .policy(PolicyAttribution {
-        document_id: Some(AuditLabel::new("sha256:abc123").expect("doc id")),
-        version: Some(7),
-        matched_rule_ids: vec![AuditLabel::new("no-pii-to-public-hosts").expect("rule id")],
-    })
-    .reason_codes(vec![PolicyReasonCode::SensitiveDataDetected])
-    .latency(InspectionLatency {
-        provider_us: None,
-        total_us: 6,
-    })
-    .build();
-
-    (event, records)
-}
-
-async fn migrated_backend() -> (tempfile::TempDir, SqliteBackend) {
+/// A store with the base schema only — no projection tables.
+async fn bare() -> (tempfile::TempDir, Arc<SqliteBackend>) {
     let dir = tempfile::tempdir().expect("temp dir");
     let backend = SqliteBackend::open(&SqliteConfig {
         path: dir.path().join("projection.db"),
@@ -162,6 +32,12 @@ async fn migrated_backend() -> (tempfile::TempDir, SqliteBackend) {
     .await
     .expect("open sqlite");
     backend.migrate().await.expect("base migrate");
+    (dir, Arc::new(backend))
+}
+
+/// A store with the base schema and the projection applied.
+async fn migrated() -> (tempfile::TempDir, Arc<SqliteBackend>) {
+    let (dir, backend) = bare().await;
     backend
         .migrate_sensitive_data_projection()
         .await
@@ -169,358 +45,50 @@ async fn migrated_backend() -> (tempfile::TempDir, SqliteBackend) {
     (dir, backend)
 }
 
-fn scope(org: &str, tenant: &str) -> TenantScope {
-    TenantScope::new(org, tenant).expect("scope")
-}
-
-fn filter(org: &str, tenant: &str) -> SensitiveDataEventFilter {
-    SensitiveDataEventFilter::new(scope(org, tenant))
-}
-
-fn writer(backend: SqliteBackend) -> SensitiveDataProjectionWriter<SqliteBackend> {
-    SensitiveDataProjectionWriter::new(backend, SensitiveDataProjectionConfig::enabled())
-}
-
-// ---------------------------------------------------------------------------
-// ADR 0032 §9 — offsets and lengths belong to the audit tier only
-// ---------------------------------------------------------------------------
-
-/// The exact column set of both tables, read from the live SQLite catalogue.
-///
-/// Pinned exactly rather than checked for the absence of a list of bad names:
-/// a substring check knows only the leaks someone thought of, whereas an exact
-/// set fails on any column at all that is not on the reviewed list — which is
-/// the property ADR 0032 §9 actually needs.
-#[tokio::test]
-async fn projection_tables_have_exactly_the_reviewed_columns_and_no_offset() {
-    let (_dir, backend) = migrated_backend().await;
-
-    let mut actual = backend
-        .sensitive_data_projection_columns()
-        .await
-        .expect("read catalogue")
-        .into_iter()
-        .map(|(table, column)| format!("{table}.{column}"))
-        .collect::<Vec<_>>();
-    actual.sort();
-
-    let mut expected = EXPECTED_EVENT_COLUMNS
-        .iter()
-        .map(|c| format!("sensitive_data_events.{c}"))
-        .chain(
-            EXPECTED_FINDING_COLUMNS
-                .iter()
-                .map(|c| format!("sensitive_data_findings.{c}")),
-        )
-        .collect::<Vec<_>>();
-    expected.sort();
-
-    assert_eq!(
-        actual, expected,
-        "the projection's persisted columns changed; ADR 0032 §9 confines offsets and \
-         lengths to the tamper-evident tier, so any new column here needs review"
-    );
-
-    // Belt as well as braces: the exact-set assertion above is the real guard,
-    // but naming the forbidden shapes documents *why* the list is closed.
-    for entry in &actual {
-        let name = entry.split('.').next_back().expect("qualified name");
-        for banned in ["offset", "length", "span", "byte", "payload", "raw"] {
-            assert!(
-                !name.contains(banned),
-                "column `{entry}` contains `{banned}` — offsets, lengths and payloads are \
-                 audit-tier only (ADR 0032 §9)"
-            );
+/// Bind one shared contract assertion to a fresh SQLite database.
+macro_rules! contract_test {
+    ($name:ident) => {
+        #[tokio::test]
+        async fn $name() {
+            let (_dir, store) = migrated().await;
+            contract::$name(&store).await;
         }
-    }
+    };
 }
 
-/// The serialized shape a consumer receives, pinned the same way.
-///
-/// Separate from the column test because they can diverge: a struct field with
-/// no column would still be published to any consumer that serializes a row.
+contract_test!(columns_are_exactly_the_reviewed_set);
+contract_test!(a_byte_span_reaches_no_part_of_the_projection);
+contract_test!(every_projected_value_round_trips);
+contract_test!(one_blocked_action_with_three_findings_stays_one_event);
+contract_test!(a_row_count_disagreeing_with_the_tally_is_refused);
+contract_test!(a_neighbouring_tenant_sees_none_of_it);
+contract_test!(a_replayed_event_does_not_double_count);
+contract_test!(a_divergent_replay_cannot_desynchronise_parent_from_children);
+contract_test!(a_late_duplicate_cannot_rewrite_stored_tallies);
+contract_test!(the_filters_narrowings_are_honoured_on_every_read);
+contract_test!(prevention_is_claimed_only_where_evidence_supports_it);
+contract_test!(an_unresolvable_category_is_stored_but_never_labelled);
+
+/// The flag test needs a store whose projection has *not* been migrated, since
+/// what it asserts is that a disabled writer creates nothing.
 #[tokio::test]
-async fn serialized_rows_expose_exactly_the_reviewed_keys_and_no_span() {
-    let (_dir, backend) = migrated_backend().await;
-    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-    let writer = writer(backend);
-    writer
-        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
+async fn a_disabled_projection_writes_nothing_and_leaves_the_audit_path_alone() {
+    let (_dir, store) = bare().await;
+    contract::a_disabled_projection_writes_nothing(&store).await;
+
+    // The audit path still works with the projection off, which is what
+    // "turned off without affecting existing audit behaviour" means.
+    store
+        .count_audit_events(Default::default())
         .await
-        .expect("write");
-
-    let events = writer
-        .store()
-        .query_sensitive_data_events(&filter("acme", "acme-prod"))
-        .await
-        .expect("query events");
-    let rows = writer
-        .store()
-        .query_sensitive_data_findings(&filter("acme", "acme-prod"))
-        .await
-        .expect("query findings");
-
-    let event_json = serde_json::to_value(&events[0]).expect("serialize event row");
-    let finding_json = serde_json::to_value(&rows[0]).expect("serialize finding row");
-
-    let mut event_keys = event_json
-        .as_object()
-        .expect("object")
-        .keys()
-        .cloned()
-        .collect::<Vec<_>>();
-    event_keys.sort();
-    let mut expected_event = EXPECTED_EVENT_COLUMNS
-        .iter()
-        .map(|s| (*s).to_string())
-        .collect::<Vec<_>>();
-    expected_event.sort();
-    assert_eq!(
-        event_keys, expected_event,
-        "the event row's serialized keys must match its columns exactly"
-    );
-
-    let mut finding_keys = finding_json
-        .as_object()
-        .expect("object")
-        .keys()
-        .cloned()
-        .collect::<Vec<_>>();
-    finding_keys.sort();
-    let mut expected_finding = EXPECTED_FINDING_COLUMNS
-        .iter()
-        .map(|s| (*s).to_string())
-        .collect::<Vec<_>>();
-    expected_finding.sort();
-    assert_eq!(
-        finding_keys, expected_finding,
-        "the finding row's serialized keys must match its columns exactly"
-    );
+        .expect("audit path unaffected");
 }
 
-/// The end-to-end attack: a finding carrying a distinctive span goes in, and
-/// neither of its numbers comes back out of storage in any form.
-///
-/// This is the assertion the type-level argument is supposed to make
-/// unnecessary — and the reason it is written anyway. "Span-free by
-/// construction" is a claim about construction paths, not an unrepresentable
-/// state; the fields are `pub` and `Deserialize` rebuilds a record from bytes.
-/// So the claim is checked against what is actually durable.
-#[tokio::test]
-async fn a_findings_byte_span_reaches_no_part_of_the_persisted_projection() {
-    let (_dir, backend) = migrated_backend().await;
-    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-
-    // The span really is on the finding that was scanned — otherwise this test
-    // would pass by testing nothing, which is how a span-leak test fails.
-    let scanned = synthetic_finding(CanonicalCategory::unqualified(CategoryBase::EmailAddress));
-    assert_eq!(scanned.span().start(), SPAN_START, "fixture must carry the span");
-
-    let writer = writer(backend);
-    writer
-        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
-        .await
-        .expect("write");
-
-    let f = filter("acme", "acme-prod");
-    let events = writer.store().query_sensitive_data_events(&f).await.expect("events");
-    let rows = writer
-        .store()
-        .query_sensitive_data_findings(&f)
-        .await
-        .expect("findings");
-
-    let dump = format!(
-        "{}{}",
-        serde_json::to_string(&events).expect("serialize events"),
-        serde_json::to_string(&rows).expect("serialize findings"),
-    );
-
-    for needle in [SPAN_START.to_string(), SPAN_END.to_string()] {
-        assert!(
-            !dump.contains(&needle),
-            "byte offset {needle} reached the non-audit projection; ADR 0032 §9 permits \
-             offsets only in the tamper-evident tier"
-        );
-    }
-    assert!(
-        !dump.contains(SECRET_MARKER),
-        "a sensitive value reached the projection; it stores redacted and derived data only"
-    );
-    // The drill-down granularity §9 grants *in place of* offsets did survive —
-    // otherwise the absence above would just mean nothing was stored.
-    assert!(
-        dump.contains("headers.authorization"),
-        "field paths are the drill-down granularity and must be persisted"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// ADR 0032 §8 — event counts and finding counts are different numbers
-// ---------------------------------------------------------------------------
-
-/// The §8 worked example, carried all the way through storage.
-///
-/// Three findings in one blocked action: one blocked *event*, three blocked
-/// *findings*. Both numbers are read back from the database rather than from
-/// the in-memory event, because the collapse this guards against is a writer
-/// putting one of them in the other's column.
-#[tokio::test]
-async fn one_blocked_action_with_three_findings_persists_as_one_event_and_three_findings() {
-    let (_dir, backend) = migrated_backend().await;
-    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-    let writer = writer(backend);
-    writer
-        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
-        .await
-        .expect("write");
-
-    let f = filter("acme", "acme-prod");
-    let store = writer.store();
-
-    assert_eq!(store.count_sensitive_data_events(&f).await.expect("count"), 1);
-    assert_eq!(store.count_sensitive_data_findings(&f).await.expect("count"), 3);
-
-    let row = &store.query_sensitive_data_events(&f).await.expect("events")[0];
-    assert_eq!(row.event_count, 1, "one action is one event");
-    assert_eq!(row.blocked_event_count, 1, "the action was refused");
-    assert_eq!(row.finding_count, 3);
-    assert_eq!(row.blocked_finding_count, 3);
-    assert_ne!(
-        row.blocked_event_count, row.blocked_finding_count,
-        "the two are different measures and must not be interchangeable"
-    );
-
-    // The per-category aggregate reports both, and for the doubled category
-    // they differ — two email findings inside a single event.
-    let aggregates = store
-        .aggregate_sensitive_data_by_category(&f)
-        .await
-        .expect("aggregate by category");
-    // Rendered from the catalogue rather than spelled out, so a renamed
-    // category is a compile-or-lookup failure here instead of a silently
-    // never-matching `find` that makes the assertions below unreachable.
-    let email_label = CategoryLabel::from(CanonicalCategory::unqualified(CategoryBase::EmailAddress));
-    let email = aggregates
-        .iter()
-        .find(|a| a.category == email_label.as_str())
-        .unwrap_or_else(|| panic!("email category present; got {aggregates:?}"));
-    assert_eq!(email.finding_count, 2, "two email findings");
-    assert_eq!(email.event_count, 1, "in one event");
-    assert_ne!(
-        email.finding_count, email.event_count,
-        "an aggregate that reported one of these as the other would be wrong by a \
-         factor that varies per action (forbidden design #11)"
-    );
-
-    // A structural guard as well as a numeric one: adding a grouping dimension
-    // to this aggregate stops the suite compiling, which is what keeps an
-    // unbounded label — a destination, an agent id — out of it.
-    let CategoryFindingAggregate {
-        category: _,
-        finding_count: _,
-        event_count: _,
-    } = aggregates[0].clone();
-}
-
-/// A producer whose finding rows disagree with its own tallies is refused
-/// before anything becomes durable.
-#[tokio::test]
-async fn a_row_count_that_disagrees_with_the_events_tally_is_refused() {
-    let (_dir, backend) = migrated_backend().await;
-    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-    let writer = writer(backend);
-
-    let err = writer
-        .write(&event, &findings[..2], Timestamp::from_nanos(1_700_000_000_100_000_000))
-        .await
-        .expect_err("two rows against a three-finding tally must be refused");
-    assert!(
-        matches!(
-            err,
-            ProjectionError::FindingCountMismatch {
-                declared: 3,
-                supplied: 2,
-                ..
-            }
-        ),
-        "expected FindingCountMismatch, got {err:?}"
-    );
-
-    let f = filter("acme", "acme-prod");
-    assert_eq!(
-        writer.store().count_sensitive_data_events(&f).await.expect("count"),
-        0,
-        "a refused projection must leave nothing behind"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Tenant isolation
-// ---------------------------------------------------------------------------
-
-/// One tenant's rows are invisible under another tenant's scope, on every read
-/// path — including the findings table, which is scoped by its own columns
-/// rather than by joining the events table.
-#[tokio::test]
-async fn a_neighbouring_tenant_sees_none_of_it() {
-    let (_dir, backend) = migrated_backend().await;
-    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-    let writer = writer(backend);
-    writer
-        .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
-        .await
-        .expect("write");
-
-    let store = writer.store();
-    let owner = filter("acme", "acme-prod");
-    let same_org_other_tenant = filter("acme", "acme-staging");
-    let other_org_same_tenant_name = filter("globex", "acme-prod");
-
-    assert_eq!(store.count_sensitive_data_events(&owner).await.expect("count"), 1);
-
-    for intruder in [&same_org_other_tenant, &other_org_same_tenant_name] {
-        assert_eq!(
-            store.count_sensitive_data_events(intruder).await.expect("count"),
-            0,
-            "events leaked across a tenant boundary"
-        );
-        assert_eq!(
-            store.count_sensitive_data_findings(intruder).await.expect("count"),
-            0,
-            "findings leaked across a tenant boundary"
-        );
-        assert!(
-            store
-                .query_sensitive_data_events(intruder)
-                .await
-                .expect("query")
-                .is_empty(),
-            "event rows leaked across a tenant boundary"
-        );
-        assert!(
-            store
-                .query_sensitive_data_findings(intruder)
-                .await
-                .expect("query")
-                .is_empty(),
-            "finding rows leaked across a tenant boundary"
-        );
-        assert!(
-            store
-                .aggregate_sensitive_data_by_category(intruder)
-                .await
-                .expect("aggregate")
-                .is_empty(),
-            "an aggregate leaked across a tenant boundary — the failure mode that is a \
-             smaller-looking answer rather than an error"
-        );
-    }
-}
-
-/// A blank tenant is not a narrower scope, so it cannot be constructed.
+/// A blank tenant is not a narrower scope, so it cannot be constructed — and a
+/// scope stores what it validated, so a padded identifier cannot become one
+/// that silently matches nothing.
 #[test]
-fn an_empty_tenancy_cannot_be_scoped() {
+fn an_empty_tenancy_cannot_be_scoped_and_a_padded_one_is_normalised() {
     assert!(matches!(
         TenantScope::new("", "acme-prod"),
         Err(ProjectionError::EmptyTenancy("org_id"))
@@ -529,122 +97,38 @@ fn an_empty_tenancy_cannot_be_scoped() {
         TenantScope::new("acme", "   "),
         Err(ProjectionError::EmptyTenancy("tenant_id"))
     ));
-    assert!(TenantScope::new("acme", "acme-prod").is_ok());
-}
 
-// ---------------------------------------------------------------------------
-// Idempotency and late arrivals
-// ---------------------------------------------------------------------------
-
-/// A replayed event does not double-count, on either table.
-#[tokio::test]
-async fn a_replayed_event_does_not_double_count() {
-    let (_dir, backend) = migrated_backend().await;
-    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-    let writer = writer(backend);
-
-    for attempt in 0..3 {
-        writer
-            .write(
-                &event,
-                &findings,
-                Timestamp::from_nanos(1_700_000_000_100_000_000 + attempt),
-            )
-            .await
-            .expect("replay must be accepted, not rejected");
-    }
-
-    let f = filter("acme", "acme-prod");
-    assert_eq!(writer.store().count_sensitive_data_events(&f).await.expect("count"), 1);
+    let padded = TenantScope::new("  acme  ", " acme-prod ").expect("padded identifiers are accepted");
     assert_eq!(
-        writer.store().count_sensitive_data_findings(&f).await.expect("count"),
-        3,
-        "three replays of a three-finding event is still three findings"
+        padded,
+        TenantScope::new("acme", "acme-prod").expect("scope"),
+        "validating the trimmed form and storing the untrimmed one would make this a \
+         scope that passes construction and then matches no row"
     );
 }
 
-/// The documented late-arrival rule: first write wins.
-///
-/// A duplicate arriving after the fact cannot rewrite tallies a reader may
-/// already have acted on, so a dashboard's numbers do not move under it.
-#[tokio::test]
-async fn a_late_duplicate_cannot_rewrite_the_stored_tallies() {
-    let (_dir, backend) = migrated_backend().await;
-    let (first, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-    let writer = writer(backend);
-    writer
-        .write(&first, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
-        .await
-        .expect("first write");
-
-    // Same event id, a different verdict and different tallies — the shape a
-    // corrupted or re-decided replay would have.
-    let single = vec![record(
-        "01HZX9V8ABCDEFGHJKMNPQRSTV",
-        CanonicalCategory::unqualified(CategoryBase::EmailAddress),
-        "body.customer.email",
-    )];
-    let contradicting = SensitiveDataDecisionEvent::builder(
-        AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").expect("event id"),
-        Timestamp::from_nanos(1_700_000_000_000_000_000),
-        tenancy("acme", "acme-prod"),
-        lineage(),
-        action(),
-        RuntimeVerdictLabel::ALLOW,
-        ExecutionEvidence::unrecorded(EnforcementMode::Observe),
-    )
-    .finding_counts(FindingCounts::tally(&single, 0, 0).expect("tally"))
-    .build();
-
-    writer
-        .write(
-            &contradicting,
-            &single,
-            Timestamp::from_nanos(1_700_000_999_000_000_000),
-        )
-        .await
-        .expect("a late duplicate is ignored, not an error");
-
-    let f = filter("acme", "acme-prod");
-    let row = &writer.store().query_sensitive_data_events(&f).await.expect("events")[0];
-    assert_eq!(row.verdict, "deny", "first write wins");
-    assert_eq!(row.blocked_finding_count, 3, "the stored tallies did not move");
-    assert_eq!(
-        writer.store().count_sensitive_data_findings(&f).await.expect("count"),
-        3,
-        "the late duplicate added no finding rows"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Migration and rollback
-// ---------------------------------------------------------------------------
-
-/// The migration is idempotent and the rollback is executed, not merely
-/// written — and running it leaves the audit tables untouched.
+/// The migration is idempotent and the rollback is executed, not merely written
+/// — and running it leaves the audit tables intact.
 #[tokio::test]
 async fn the_migration_is_idempotent_and_the_rollback_is_a_real_inverse() {
-    let (_dir, backend) = migrated_backend().await;
+    let (_dir, store) = migrated().await;
+    let expected = contract::expected_qualified_columns().len();
 
-    backend
+    store
         .migrate_sensitive_data_projection()
         .await
         .expect("re-migrating must be a no-op");
     assert_eq!(
-        backend
-            .sensitive_data_projection_columns()
-            .await
-            .expect("columns")
-            .len(),
-        EXPECTED_EVENT_COLUMNS.len() + EXPECTED_FINDING_COLUMNS.len()
+        store.sensitive_data_projection_columns().await.expect("columns").len(),
+        expected
     );
 
-    backend
+    store
         .rollback_sensitive_data_projection()
         .await
         .expect("rollback must apply");
     assert!(
-        backend
+        store
             .sensitive_data_projection_columns()
             .await
             .expect("columns")
@@ -652,356 +136,87 @@ async fn the_migration_is_idempotent_and_the_rollback_is_a_real_inverse() {
         "rollback must remove the projection's tables"
     );
 
-    // The audit path is unaffected by the rollback — which is the whole reason
-    // the projection owns its own up/down rather than joining the shared
-    // migrator.
-    backend
+    // Unaffected by the rollback — the whole reason the projection owns its own
+    // up and down statements rather than joining the shared migrator.
+    store
         .count_audit_events(Default::default())
         .await
         .expect("the audit tables must survive a projection rollback");
 
-    backend
+    store
         .rollback_sensitive_data_projection()
         .await
         .expect("rollback must itself be idempotent");
-    backend
+    store
         .migrate_sensitive_data_projection()
         .await
         .expect("re-applying after a rollback must work");
     assert_eq!(
-        backend
-            .sensitive_data_projection_columns()
-            .await
-            .expect("columns")
-            .len(),
-        EXPECTED_EVENT_COLUMNS.len() + EXPECTED_FINDING_COLUMNS.len()
+        store.sensitive_data_projection_columns().await.expect("columns").len(),
+        expected
     );
 }
 
-// ---------------------------------------------------------------------------
-// The flag
-// ---------------------------------------------------------------------------
-
-/// With the flag off nothing is written, no tables are created, and the
-/// existing audit path is unaffected.
-#[tokio::test]
-async fn a_disabled_projection_writes_nothing_and_leaves_the_audit_path_alone() {
-    let dir = tempfile::tempdir().expect("temp dir");
-    let backend = SqliteBackend::open(&SqliteConfig {
-        path: dir.path().join("projection.db"),
-    })
-    .await
-    .expect("open sqlite");
-    backend.migrate().await.expect("base migrate");
-
-    let writer = SensitiveDataProjectionWriter::new(backend, SensitiveDataProjectionConfig::disabled());
-    assert!(!writer.is_enabled());
-    assert_eq!(writer.migrate().await.expect("migrate"), WriteOutcome::Disabled);
-
-    let (event, findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-    assert_eq!(
-        writer
-            .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
-            .await
-            .expect("a disabled write is a no-op, not an error"),
-        WriteOutcome::Disabled
-    );
-
-    assert!(
-        writer
-            .store()
-            .sensitive_data_projection_columns()
-            .await
-            .expect("columns")
-            .is_empty(),
-        "a disabled projection must not create its tables"
-    );
-    // The audit path still works with the projection off, which is what
-    // "turned off without affecting existing audit behaviour" means.
-    writer
-        .store()
-        .count_audit_events(Default::default())
-        .await
-        .expect("audit path unaffected");
-}
-
-// ---------------------------------------------------------------------------
-// Prevention requires evidence
-// ---------------------------------------------------------------------------
-
-/// Only a deny-or-transforming verdict, applied pre-transmission, while
-/// enforcing, with the bytes observed not to have gone, counts as prevention.
+/// A row written against a schema major this build does not read is refused on
+/// the way out, not silently decoded.
 ///
-/// The negative cases are the point. `scrub` with `forwarded_clean` is what a
-/// successful redaction looks like — a *transformed transmission* — and it is
-/// the case the `CredentialLeakBlocked` event name already got wrong once.
+/// `SchemaVersion` documents this as mandatory — "a reader of a different major
+/// **must** refuse the record" — and the first cut shipped an `is_readable`
+/// helper with no callers, which is a comment rather than a rule. Driven
+/// through raw SQL against the same file because no in-crate path can produce a
+/// foreign major, which is precisely why the read path has to defend against
+/// one.
 #[tokio::test]
-async fn prevention_is_claimed_only_where_the_evidence_supports_it() {
-    let (_dir, backend) = migrated_backend().await;
-    let writer = writer(backend);
-
-    let cases: [(
-        &str,
-        RuntimeVerdictLabel,
-        EnforcementPoint,
-        TransmissionEvidence,
-        EnforcementMode,
-        bool,
-    ); 7] = [
-        (
-            "01HZX9V8ABCDEFGHJKMNPQRS01",
-            RuntimeVerdictLabel::DENY,
-            EnforcementPoint::PreTransmission,
-            TransmissionEvidence::NotForwarded,
-            EnforcementMode::Enforce,
-            true,
-        ),
-        (
-            // Redaction forwards the scrubbed bytes. Detected, not prevented.
-            "01HZX9V8ABCDEFGHJKMNPQRS02",
-            RuntimeVerdictLabel::SCRUB,
-            EnforcementPoint::PreTransmission,
-            TransmissionEvidence::ForwardedClean,
-            EnforcementMode::Enforce,
-            false,
-        ),
-        (
-            // `narrow` scopes the action without transforming the payload.
-            "01HZX9V8ABCDEFGHJKMNPQRS03",
-            RuntimeVerdictLabel::NARROW,
-            EnforcementPoint::PreTransmission,
-            TransmissionEvidence::NotForwarded,
-            EnforcementMode::Enforce,
-            false,
-        ),
-        (
-            // Observe mode computed the decision and applied nothing.
-            "01HZX9V8ABCDEFGHJKMNPQRS04",
-            RuntimeVerdictLabel::DENY,
-            EnforcementPoint::PreTransmission,
-            TransmissionEvidence::NotForwarded,
-            EnforcementMode::Observe,
-            false,
-        ),
-        (
-            // Decided after the bytes left.
-            "01HZX9V8ABCDEFGHJKMNPQRS05",
-            RuntimeVerdictLabel::DENY,
-            EnforcementPoint::PostTransmission,
-            TransmissionEvidence::NotForwarded,
-            EnforcementMode::Enforce,
-            false,
-        ),
-        (
-            // An unwired producer must not claim prevention by saying nothing.
-            "01HZX9V8ABCDEFGHJKMNPQRS06",
-            RuntimeVerdictLabel::DENY,
-            EnforcementPoint::NotRecorded,
-            TransmissionEvidence::NotRecorded,
-            EnforcementMode::Enforce,
-            false,
-        ),
-        (
-            // The layer decided to redact and emitted the credential anyway.
-            "01HZX9V8ABCDEFGHJKMNPQRS07",
-            RuntimeVerdictLabel::SCRUB,
-            EnforcementPoint::PreTransmission,
-            TransmissionEvidence::ForwardedCarryingSensitiveValue,
-            EnforcementMode::Enforce,
-            false,
-        ),
-    ];
-
-    for (event_id, verdict, point, transmission, mode, _expected) in cases {
-        let event = SensitiveDataDecisionEvent::builder(
-            AuditLabel::new(event_id).expect("event id"),
-            Timestamp::from_nanos(1_700_000_000_000_000_000),
-            tenancy("acme", "acme-prod"),
-            lineage(),
-            action(),
-            verdict,
-            ExecutionEvidence::new(point, transmission, mode),
-        )
-        .build();
-        writer
-            .write(&event, &[], Timestamp::from_nanos(1_700_000_000_100_000_000))
-            .await
-            .expect("write");
-    }
-
-    let rows = writer
-        .store()
-        .query_sensitive_data_events(&filter("acme", "acme-prod"))
-        .await
-        .expect("events");
-
-    for (event_id, _, _, _, _, expected) in cases {
-        let row = rows.iter().find(|r| r.event_id == event_id).expect("row present");
-        assert_eq!(
-            row.counts_as_prevented_transmission(),
-            expected,
-            "prevention verdict wrong for {event_id} \
-             (verdict={}, point={}, transmission={}, mode={})",
-            row.verdict,
-            row.enforcement_point,
-            row.transmission_evidence,
-            row.enforcement_mode
-        );
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Metric labels stay bounded
-// ---------------------------------------------------------------------------
-
-/// A category this build cannot resolve is stored for drill-down but refused as
-/// a metric label.
-///
-/// Both directions are asserted in one test on purpose. A test that only walked
-/// the catalogue's own members could never reach the unbounded case and would
-/// pass while the guard did nothing — the precedent this is written against.
-/// The positive control is what proves the negative is not vacuous.
-#[tokio::test]
-async fn an_unresolvable_category_is_stored_for_drill_down_but_refused_as_a_label() {
-    let mut arbitrary = record(
-        "01HZX9V8ABCDEFGHJKMNPQRSTV",
-        CanonicalCategory::unqualified(CategoryBase::EmailAddress),
-        "body.customer.email",
-    );
-    // The shape an attacker-influenced or newer-build category would have:
-    // well-formed, unbounded, and not in this build's catalogue.
-    arbitrary.category = CategoryLabel::new("acme_internal_customer_ssn_v3_9f2c1b").expect("well-formed label");
-
-    assert!(
-        SensitiveDataMetricLabels::from_finding(&arbitrary, RuntimeVerdictLabel::DENY).is_none(),
-        "an unresolvable category must not become a metric label — it is an unbounded \
-         series, which ADR 0032 §9 forbids"
-    );
-
-    let catalogued = record(
-        "01HZX9V8ABCDEFGHJKMNPQRSTV",
-        CanonicalCategory::unqualified(CategoryBase::EmailAddress),
-        "body.customer.email",
-    );
-    let labels = SensitiveDataMetricLabels::from_finding(&catalogued, RuntimeVerdictLabel::DENY)
-        .expect("a catalogue category must resolve — otherwise the None above proves nothing");
-
-    let names = labels.as_pairs().map(|(name, _)| name);
-    assert_eq!(names, SensitiveDataMetricLabels::LABEL_NAMES);
-    for banned in ["destination", "tenant", "org", "agent", "field_path", "event_id"] {
-        assert!(
-            !names.contains(&banned),
-            "`{banned}` is unbounded cardinality and must never be a metric label"
-        );
-    }
-
-    // The unresolvable category is still durable, so the drill-down that
-    // replaces the offset is not lost by refusing the label.
-    let (_dir, backend) = migrated_backend().await;
-    let (event, mut findings) = blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNPQRSTV", "acme", "acme-prod");
-    findings[0].category = CategoryLabel::new("acme_internal_customer_ssn_v3_9f2c1b").expect("label");
-    let counts = FindingCounts::tally(&findings, 0, 3).expect("tally");
-    let event = SensitiveDataDecisionEvent::builder(
-        AuditLabel::new("01HZX9V8ABCDEFGHJKMNPQRSTV").expect("event id"),
-        Timestamp::from_nanos(1_700_000_000_000_000_000),
-        tenancy("acme", "acme-prod"),
-        lineage(),
-        action(),
-        event.verdict,
-        ExecutionEvidence::new(
-            EnforcementPoint::PreTransmission,
-            TransmissionEvidence::NotForwarded,
-            EnforcementMode::Enforce,
-        ),
-    )
-    .finding_counts(counts)
-    .build();
-
-    let writer = writer(backend);
-    writer
+async fn a_row_from_an_unreadable_schema_major_is_refused_not_decoded() {
+    let (dir, store) = migrated().await;
+    let tenant = "t-schema";
+    let (event, findings) = contract::blocked_action_with_three_findings("01HZX9V8ABCDEFGHJKMNSCHM01", tenant);
+    contract::writer(&store)
         .write(&event, &findings, Timestamp::from_nanos(1_700_000_000_100_000_000))
         .await
         .expect("write");
 
-    let stored = writer
-        .store()
-        .query_sensitive_data_findings(&filter("acme", "acme-prod"))
+    // Readable before the bump, so the refusal below is the bump's doing and
+    // not a query that was broken all along.
+    store
+        .query_sensitive_data_events(&contract::filter(tenant))
         .await
-        .expect("findings");
-    assert!(
-        stored
-            .iter()
-            .any(|r| r.category == "acme_internal_customer_ssn_v3_9f2c1b"),
-        "an unresolvable category must still be persisted for drill-down"
-    );
+        .expect("readable at the current major");
+    store
+        .query_sensitive_data_findings(&contract::filter(tenant))
+        .await
+        .expect("readable at the current major");
+
+    bump_schema_major(&dir.path().join("projection.db"), 99).await;
+
+    for err in [
+        store
+            .query_sensitive_data_events(&contract::filter(tenant))
+            .await
+            .expect_err("a foreign major must be refused, not decoded"),
+        store
+            .query_sensitive_data_findings(&contract::filter(tenant))
+            .await
+            .expect_err("the finding decoder must refuse it too"),
+    ] {
+        assert!(
+            err.to_string().contains("schema major 99"),
+            "expected an unreadable-schema error, got: {err}"
+        );
+    }
 }
 
-// ---------------------------------------------------------------------------
-// The reviewed column lists
-// ---------------------------------------------------------------------------
-
-/// Every column of `sensitive_data_events`, reviewed against ADR 0032 §9.
-const EXPECTED_EVENT_COLUMNS: &[&str] = &[
-    "schema_version_major",
-    "schema_version_minor",
-    "event_id",
-    "occurred_at_ns",
-    "ingested_at_ns",
-    "org_id",
-    "tenant_id",
-    "team_id",
-    "acting_agent_id",
-    "root_agent_id",
-    "parent_agent_id",
-    "delegation_depth",
-    "session_id",
-    "trace_id",
-    "request_id",
-    "correlation_id",
-    "operation",
-    "destination_kind",
-    "destination_id",
-    "trust_zone",
-    "direction",
-    "policy_document_id",
-    "policy_version",
-    "matched_rule_ids",
-    "inspected_field_paths",
-    "verdict",
-    "enforcement_point",
-    "transmission_evidence",
-    "enforcement_mode",
-    "inspection_failure_path",
-    "severity",
-    "confidence",
-    "method",
-    "status",
-    "event_count",
-    "blocked_event_count",
-    "finding_count",
-    "blocked_finding_count",
-    "transformed_finding_count",
-    "finding_count_by_category",
-    "reason_codes",
-];
-
-/// Every column of `sensitive_data_findings`, reviewed the same way.
-const EXPECTED_FINDING_COLUMNS: &[&str] = &[
-    "schema_version_major",
-    "schema_version_minor",
-    "event_id",
-    "finding_ordinal",
-    "org_id",
-    "tenant_id",
-    "occurred_at_ns",
-    "category",
-    "severity",
-    "confidence",
-    "method",
-    "status",
-    "recognizer",
-    "recognizer_version",
-    "field_path",
-    "redaction_label",
-    "aggregate_key",
-];
+/// Rewrite the stored schema major through a second connection, bypassing every
+/// in-crate write path.
+async fn bump_schema_major(path: &Path, major: i64) {
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", path.display()))
+        .await
+        .expect("second connection to the same file");
+    for table in ["sensitive_data_events", "sensitive_data_findings"] {
+        sqlx::query(&format!("UPDATE {table} SET schema_version_major = ?"))
+            .bind(major)
+            .execute(&pool)
+            .await
+            .expect("bump major");
+    }
+}


### PR DESCRIPTION
## Description

Adds `aa-gateway/src/storage/sensitive_data/` — the durable sensitive-data projection ADR 0032 §8 requires be written **alongside** `audit_entry_to_storage_event` rather than by extending it (forbidden design #15). Two new tables, `sensitive_data_events` and normalized `sensitive_data_findings` child rows, on both SQLite and PostgreSQL, behind a flag that is off by default.

`audit_bridge.rs`, the `audit_events` table, and the JSONL hash chain are untouched.

**What the projection stores that the bridge loses.** The bridge is lossy in fourteen ways; this closes eleven. Lineage (`acting_agent`, `root_agent`, `parent_agent`, `delegation_depth`), org and tenant, session/trace/request/correlation ids, `policy_document_id` and `policy_version`, `matched_rule_ids` (the bridge hardcodes `None`), the enforcement mode (the honest replacement for the bridge's hardcoded `dry_run: false`), every finding as a normalized row, and — the one the Epic exists for — the destination, which is not a dimension of the audit event at all. `action` and `decision` are no longer the same source: `operation`, `destination_*` and `verdict` are separate columns. Three losses are deliberately left: the hash chain stays the JSONL writer's job, the raw payload is not persisted *anywhere* in this projection by design, and `shadow_decision` awaits a producer.

**Byte offsets.** ADR 0032 §9 confines offsets and lengths to the tamper-evident tier. The write path accepts only `SensitiveDataFindingRecord`, which is span-free by construction (AAASM-5355); neither row type nor either table has a column that could hold one; and both row types are `#[non_exhaustive]`, so a downstream crate cannot mint one by struct literal and hand it to the `pub` `append_sensitive_data_decision`. The docs claim exactly that and no more — the fields are `pub` and `Deserialize` rebuilds a row from whatever bytes it is given, so a row in hand is evidence about the writer, not an unrepresentable state.

**Counting.** Event counts and finding counts never collapse. `event_count` / `blocked_event_count` and `finding_count` / `blocked_finding_count` / `transformed_finding_count` are separate columns, and `CategoryFindingAggregate` reports both `event_count` and `finding_count` per category. `SensitiveDataEventRow::project` refuses an event whose supplied finding rows disagree with its own tally, and re-runs `aa-core`'s two read-path consistency checks before the row is durable.

**Prevention.** There is no `prevented` column. Redaction *forwards* the scrubbed bytes, so a redacted action is a transformed transmission. The row stores the three evidence components — `enforcement_point`, `transmission_evidence`, `enforcement_mode` — and `counts_as_prevented_transmission()` parses them back into their `aa-core` enums and delegates to `ExecutionEvidence::establishes_non_transmission`, so a future variant that also establishes non-transmission is handled rather than silently missed by a string copy.

**Tenancy.** `TenantScope` is a constructor argument on every filter, rejects a blank identifier and stores the identifier it validated. `org_id` and `tenant_id` are `NOT NULL` on **both** tables, so a findings query is scoped without joining the events table.

**Idempotency and late arrivals.** `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` inside one transaction, with the child inserts gated on the parent insert having actually happened: first write wins for the parent *and* its children, so a replay carrying more findings cannot add ordinals beneath a frozen `finding_count`. Finding rows are keyed `(event_id, finding_ordinal)`, not the aggregate key — two findings of the same category at the same path share one, so keying on it would deduplicate them and lower the finding count. `ingested_at_ns` is stored separately from `occurred_at_ns` so a late arrival is visible as such.

**Migration and rollback.** The projection owns its own up and down statement sets rather than joining `migrations/postgres/`, which is applied unconditionally by `StorageBackend::migrate` — putting it there would create the tables on deployments that leave the flag off and would make rolling the projection back mean rolling a shared migration back. DDL runs in a transaction. Both directions are executed in tests on both backends.

### Three explicit deferrals

* **Retention tiering.** `RetentionEngine` expresses warm/cold windows per *backend*, not per table, and its SQLite path already downgrades `Archive` to a drop. The projection ships with no tier, so the failure mode is visible growth rather than silent loss.
* **Authorised access and audit-access logging** (ADR 0032 §9). This module has no caller-identity concept and no request surface — the only way to reach it is a Rust method call inside the gateway process. Authorisation attaches where a request exists: AAASM-5359's endpoints and the AAASM-5440 wiring. A second, weaker check here would be an authorisation decision made without a principal, which reads as coverage.
* **Cross-tenant `event_id` collision (AAASM-5447).** `event_id` is the sole primary key while both tables are multi-tenant and every read is tenant-scoped, so two tenants writing the same event id means the second is silently discarded — both get `WriteOutcome::Written`, the second reads back nothing. Pre-existing (the child key collided identically before the child-gating change), inert while nothing writes, and filed to land before AAASM-5440 wires a producer. The fix is keying on `(org_id, tenant_id, event_id)`. The SQLite conflict-clause alignment that ticket also covers is done here, since the file was already open.
* **Wiring to a producer.** Nothing calls `SensitiveDataProjectionWriter::write`, the trait, or the migration, and `SensitiveDataProjectionConfig` is not plumbed into `GatewayConfig` or env — so an operator cannot currently turn the flag on. **AAASM-5440** owns both seams (`EvaluationResult::canonical_findings` from AAASM-5354, and the execution-evidence producer) and should carry the config plumbing with it. With the flag off the tables are never created and rollback is a tested drop, so this is dead schema behind an off-by-default seam, not a third write-only table.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Purely additive. Two new tables created only when the flag is on, and one new module. The edits to **existing** files are: `storage/mod.rs` gains `pub mod sensitive_data;` and an eleven-name `pub use` re-export, and `storage/sqlite.rs` / `storage/postgres.rs` each gain a `pub(crate) fn pool()` accessor. No existing schema, wire, OpenAPI or SDK change; `StorageBackend` is unchanged, so no existing implementor or test double grows a method.

## Related Issues

- Related Jira ticket: [AAASM-5357](https://lightning-dust-mite.atlassian.net/browse/AAASM-5357)
- Depends on AAASM-5355 (`e4297575`) and AAASM-5354 (`2239336f`), both merged.
- Followed by **AAASM-5440** — wires both producer seams and the config plumbing.
- Related GitHub issues: N/A

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

`aa-gateway/tests/sensitive_data_contract/` holds the backend-independent assertions. `sensitive_data_projection_test.rs` runs them on SQLite — **16 tests**: 12 shared contract assertions bound one-per-database, plus the flag, the scope constructor, migration/rollback and the schema-major refusal. `sensitive_data_projection_postgres_test.rs` is one container test invoking **all 13** shared assertions plus two PostgreSQL-specific probes (a decoy schema, and the foreign schema major). Both in the **default** nextest profile — no `--all-features`.

They are in `tests/` rather than in the module because every claim is about what a *consumer* can observe, and a unit test sharing the module's privacy could satisfy the claim by inspecting things no consumer can reach.

`cargo nextest run -p aa-gateway -p aa-core` → **1721 passed, 0 failed**, no flakes on the final run. (`cascade_hot_reload_*` flaked on earlier runs; they are pre-existing file-watcher timing under parallel load, pass in isolation, and nothing here touches `engine/`.)

### Mutation evidence

Every assertion was watched fail. Eighteen mutations plus three PostgreSQL parity checks, each reverted after.

**Tiering and counting**

| # | Mutation | Fails |
|---|---|---|
| 1 | Add a `span_start` column + field carrying the offset | `a_byte_span_reaches_no_part_of_the_projection` — *byte offset 760913 reached the non-audit projection* — plus the column-set, key-set and migration assertions |
| 2 | `blocked_event_count: event.blocked_finding_count()` | *the action was refused: left 3, right 1* |
| 3 | Aggregate `COUNT(DISTINCT event_id)` → `COUNT(*)` | *in one event: left 2, right 1* |
| 8 | Skip the finding-count-vs-tally check | count-mismatch refusal fails at `expect_err` |

**Values, not just names** — five mutations the first cut's suite passed *simultaneously*

| # | Mutation | Fails |
|---|---|---|
| 9 | `destination_id: String::new()` | *the destination is not a dimension of the audit event at all* |
| 10 | `matched_rule_ids: Vec::new()` (verbatim the bridge's `None`) | *the audit bridge hardcodes matched_rule_id to None* |
| 11 | `acting_agent_id: String::new()` | *lineage is loss #3 of the audit bridge's fourteen* |
| 12 | `transformed_finding_count: event.blocked_finding_count()` | *collapsing this into blocked_finding_count is forbidden design #11* |
| 13 | `ingested_at_ns: event.occurred_at.as_nanos()` | *ingested_at is stored, not inferred* |

**Replay, reads and scope**

| # | Mutation | Fails |
|---|---|---|
| 4 | Drop `AND tenant_id = …` | *events leaked across a tenant boundary* |
| 5 | `INSERT OR IGNORE` → `OR REPLACE` | *first write wins: left "allow", right "deny"* |
| 14 | Insert children regardless of the parent | *the child rows must agree with the parent's own tally: left 3, right 1* |
| 15 | Drop the verdict predicate | verdict-scoped finding count returns 3 instead of 1 |
| 16 | Ignore `limit` on the aggregate | *the aggregate must honour the limit: left 2, right 1* |
| 17 | Decode a foreign schema major instead of refusing it | schema-major refusal fails at `expect_err` |
| 18 | Store the untrimmed tenant identifier | *…would make this a scope that passes construction and then matches no row* |

**Honesty and the flag**

| # | Mutation | Fails |
|---|---|---|
| 6 | Count `narrow` as prevention | *prevention verdict wrong for …03 (verdict=narrow, point=pre_transmission, transmission=not_forwarded, mode=enforce)* |
| 7 | Ignore the flag in `write` | disabled-projection test fails at "must not create its tables" |

**PostgreSQL parity.** The same three mutations applied to the *PostgreSQL* copies of the SQL now fail the PostgreSQL suite — `COUNT(DISTINCT)` → `COUNT(*)`, dropped verdict predicate, ungated child inserts. Before the shared contract module they would have failed nothing.

Mutation 1 injects the offset as a literal because the production write path has no way to obtain one — that is the primary defence, and the column/key pins are the second.

Two guards are structural and fail the *build* rather than an assertion: destructuring `CategoryFindingAggregate` by name stops compiling if a grouping dimension is added (`E0027`), and `#[non_exhaustive]` stops an out-of-crate struct literal.

`an_unresolvable_category_is_stored_but_never_labelled` asserts **both** directions — an out-of-catalogue category returns `None` from `SensitiveDataMetricLabels::from_finding` while a catalogue one returns `Some`, and the unresolvable one is still persisted for drill-down and still forms its own aggregate group. A metric-label test that only walks the catalogue's own members can never reach the unbounded case.

| 19 | Drop `table_schema = current_schema()` | *a same-named table in another schema was reported as the projection's own* |
| 20 | Cap the count reads at `limit` | *a count reports the total for the filter, not the length of a capped page: left 1, right 5* |

Mutation 19 is the gap the previous round called untestable: the PostgreSQL suite now plants a `decoy.sensitive_data_findings` carrying a `span_start` column, which makes the `table_schema` filter load-bearing and provable. That closes the **over**-reporting half only. The **under**-reporting half stays open and is named in the code: `information_schema.columns` is privilege-filtered, so the claim is "no offset column is visible to the role that created these tables" — the role the migration and the tests run as. A stronger guarantee needs `pg_catalog.pg_attribute`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)


[AAASM-5357]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ