### PR TITLE
[AAASM-5350] ✨ (aa-cli): Refuse --no-proxy under managed operation, and record unprotected launches as unprotected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ version = "0.0.1-rc.6"
 dependencies = [
  "aa-core",
  "aa-devtool",
+ "aa-devtool-claude-code",
  "aa-gateway",
  "aa-policy",
  "aa-proto",
@@ -204,6 +205,7 @@ dependencies = [
  "async-trait",
  "axum",
  "insta",
+ "libc",
  "rustls",
  "serde",
  "serde_json",

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -44,6 +44,10 @@ aa-security          = { path = "../aa-security", version = "0.0.1-rc.6", featur
 # `aasm tools` cannot resolve different adapters for the same tool. Adding
 # a tool therefore needs no change to this manifest.
 aa-devtool           = { path = "../aa-devtool", version = "0.0.1-rc.6" }
+# AAASM-5350: the endpoint managed-settings file is Claude Code's canonical
+# artifact, and its path plus validator live with that adapter. `aasm run` reads
+# it to decide whether --no-proxy is permitted.
+aa-devtool-claude-code = { path = "../aa-devtool-claude-code", version = "0.0.1-rc.6" }
 # strip-for-publish:end devtool
 aa-gateway           = { path = "../aa-gateway", version = "0.0.1-rc.6" }
 aa-policy            = { path = "../aa-policy", version = "0.0.1-rc.6" }

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -31,6 +31,7 @@ pub mod proxy;
 // strip-for-publish:begin devtool
 pub mod run;
 pub mod run_audit;
+pub mod run_no_proxy_guard;
 pub mod run_registration;
 // strip-for-publish:end devtool
 pub mod sandbox;

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -726,6 +726,7 @@ pub async fn execute_with_adapters(args: &RunArgs, adapters: &HashMap<&str, Box<
         &args.tool,
         &args.tool_args,
         &resolution.posture(),
+        args.no_proxy,
     )
     .await;
     let mut child_env = build_child_env(&handle, proxy.as_deref(), args.no_proxy, mode);

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -477,6 +477,7 @@ fn mask_value(key: &str, value: &str) -> String {
 fn format_dry_run_output(
     handle: &RegistrationHandle,
     policy: &run_policy::PolicyResolution,
+    no_proxy: bool,
     settings: &str,
     cmd: &std::process::Command,
     env: &HashMap<String, String>,
@@ -505,11 +506,18 @@ fn format_dry_run_output(
         .collect();
 
     format!(
-        "--- aasm run dry-run ---\nagent_id:    {}\nagent_did:   {}\ntrace_id:    {}\nsession_id:  {}\n\n--- policy ---\nstate:  {}\nsource: {}\ndetail: {}\n\n--- managed settings ---\n{}\n\n--- launch command ---\n{}\n\n--- environment ---\n{}",
+        "--- aasm run dry-run ---\nagent_id:    {}\nagent_did:   {}\ntrace_id:    {}\nsession_id:  {}\n\n--- protection ---\nstate:  {}\ndetail: {}\n\n--- policy ---\nstate:  {}\nsource: {}\ndetail: {}\n\n--- managed settings ---\n{}\n\n--- launch command ---\n{}\n\n--- environment ---\n{}",
         handle.agent_id,
         handle.registration_did,
         handle.trace_id,
         handle.session_id,
+        crate::commands::run_audit::protection_label(no_proxy),
+        if no_proxy {
+            "--no-proxy: nothing is intercepted, no egress policy applies, and nothing is inspected"
+        } else {
+            "a trusted proxy endpoint was resolved and injected; whether interception works is \
+             adjudicated later, not asserted here"
+        },
         policy.state_token(),
         policy.source().map_or("<none>".to_string(), |p| p.display().to_string()),
         policy.summary(),
@@ -668,7 +676,7 @@ pub async fn execute_with_adapters(args: &RunArgs, adapters: &HashMap<&str, Box<
         cmd.envs(&child_env);
         print!(
             "{}",
-            format_dry_run_output(&handle, &resolution, &settings, &cmd, &child_env)
+            format_dry_run_output(&handle, &resolution, args.no_proxy, &settings, &cmd, &child_env)
         );
         return Ok(0);
     }
@@ -1602,7 +1610,7 @@ mod tests {
         env.insert("MY_API_KEY".into(), "secret123".into());
         env.insert("NORMAL_VAR".into(), "hello".into());
 
-        let output = format_dry_run_output(&handle, &stub_resolution(), settings, &cmd, &env);
+        let output = format_dry_run_output(&handle, &stub_resolution(), false, settings, &cmd, &env);
 
         assert!(output.contains("agent_id:"), "missing identity section: {output}");
         assert!(output.contains("agent-xyz"), "missing agent_id value: {output}");
@@ -1688,7 +1696,7 @@ mod tests {
         let sections: Vec<String> = states
             .iter()
             .map(|state| {
-                let output = format_dry_run_output(&handle, state, "{}", &cmd, &env);
+                let output = format_dry_run_output(&handle, state, false, "{}", &cmd, &env);
                 let start = output
                     .find("--- policy ---")
                     .expect("receipt must carry a policy section");
@@ -1735,7 +1743,7 @@ mod tests {
         env.insert("AA_JWT_SECRET".into(), "super-secret-signing-key".into());
         env.insert("DATABASE_URL".into(), "postgresql://aasm:hunter2@db:5432/aasm".into());
 
-        let output = format_dry_run_output(&handle, &stub_resolution(), "{}", &cmd, &env);
+        let output = format_dry_run_output(&handle, &stub_resolution(), false, "{}", &cmd, &env);
 
         assert!(
             !output.contains("super-secret-signing-key"),
@@ -1774,7 +1782,7 @@ mod tests {
         let mut env = HashMap::new();
         env.insert("MONGODB_URI".into(), "mongodb://user:p4ss@host:27017/db".into());
 
-        let output = format_dry_run_output(&handle, &stub_resolution(), "{}", &cmd, &env);
+        let output = format_dry_run_output(&handle, &stub_resolution(), false, "{}", &cmd, &env);
 
         assert!(
             !output.contains("p4ss"),
@@ -1807,6 +1815,32 @@ mod tests {
         assert_eq!(
             mask_value("ENDPOINT", "https://api.example.com/v1"),
             "https://api.example.com/v1"
+        );
+    }
+
+    /// AAASM-5350 AC 2, receipt surface: a preview of an unprotected launch has
+    /// to *say* it is unprotected. Before this the reader had to notice that
+    /// `HTTPS_PROXY` was absent from the environment listing and infer the rest
+    /// — an inference, made by the person least placed to make it.
+    #[test]
+    fn the_dry_run_receipt_states_the_protection_it_previews() {
+        let handle = stub_handle(None);
+        let cmd = std::process::Command::new("claude");
+        let env = HashMap::new();
+
+        let unprotected = format_dry_run_output(&handle, &stub_resolution(), true, "{}", &cmd, &env);
+        assert!(unprotected.contains("--- protection ---"), "{unprotected}");
+        assert!(unprotected.contains("unprotected"), "{unprotected}");
+        assert!(
+            unprotected.contains("nothing is intercepted"),
+            "the consequence, not just the flag: {unprotected}"
+        );
+
+        let proxied = format_dry_run_output(&handle, &stub_resolution(), false, "{}", &cmd, &env);
+        assert!(proxied.contains("proxy_configured"), "{proxied}");
+        assert!(
+            !proxied.contains("gateway_protected") && !proxied.contains("host_enforced"),
+            "a preview must not claim an adjudicated rung: {proxied}"
         );
     }
 }

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -1843,4 +1843,42 @@ mod tests {
             "a preview must not claim an adjudicated rung: {proxied}"
         );
     }
+
+    /// AAASM-5350 AC 4: an operator-supplied `HTTPS_PROXY` is not AASM
+    /// interception, and no surface may report it as though it were.
+    ///
+    /// The property was documented on `build_child_env` and enforced there, but
+    /// never asserted — so nothing would have caught a later change that read
+    /// the ambient value back out as evidence of protection. The protection
+    /// label derives from what `aasm` resolved, so an ambient proxy cannot
+    /// produce `proxy_configured`.
+    #[test]
+    fn an_ambient_proxy_is_never_reported_as_aasm_interception() {
+        let _guard = crate::test_support::env_guard();
+        let prior = std::env::var("HTTPS_PROXY").ok();
+        std::env::set_var("HTTPS_PROXY", "http://corporate.example:3128");
+
+        // A `--no-proxy` launch with an ambient proxy set is still unprotected:
+        // the operator's own route is left alone, and it governs nothing.
+        assert_eq!(
+            crate::commands::run_audit::protection_label(true),
+            "unprotected",
+            "an ambient HTTPS_PROXY must not upgrade an unprotected launch"
+        );
+
+        // And the child keeps the operator's route rather than having it
+        // removed or overwritten — the documented opt-out behaviour.
+        let handle = stub_handle(None);
+        let env = build_child_env(&handle, None, true, aa_core::EnforcementMode::Enforce);
+        assert_eq!(
+            env.get("HTTPS_PROXY").map(String::as_str),
+            Some("http://corporate.example:3128"),
+            "--no-proxy leaves the operator's own proxy configuration alone"
+        );
+
+        match prior {
+            Some(v) => std::env::set_var("HTTPS_PROXY", v),
+            None => std::env::remove_var("HTTPS_PROXY"),
+        }
+    }
 }

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -341,6 +341,30 @@ fn build_child_env(
 /// outcome is either a vouched-for endpoint or a refusal: there is no path from
 /// "the proxy could not be verified" to "launch anyway", because that path is a
 /// direct, uninspected connection made by a session presenting as governed.
+/// The authoritative refusal, if any, for a `--no-proxy` launch of `tool`.
+///
+/// Reads both sources AC 1 names and lets
+/// [`crate::commands::run_no_proxy_guard::refusal_for`] decide, so the decision lives in one
+/// tested place rather than being spelled out at the call site.
+///
+/// A receipt that cannot be read is treated as **no receipt** rather than as a
+/// refusal: an unreadable receipt is not evidence that someone required managed
+/// operation, and refusing on it would turn a corrupt file into a policy. The
+/// managed-settings source is unaffected and still refuses on its own.
+fn no_proxy_refusal(tool: &str) -> Option<crate::commands::run_no_proxy_guard::RefusalSource> {
+    let kind = aa_devtool::registry::kind_for(tool)?;
+    let scope = aa_core::integration::step::SettingsScope::User;
+
+    let receipt_profile = aa_core::integration::ReceiptStore::default_location()
+        .ok()
+        .and_then(|store| store.load_receipt(&kind, scope).ok().flatten())
+        .map(|receipt| receipt.profile);
+
+    let managed = aa_devtool_claude_code::managed_settings::managed_installation_evidence().ok();
+
+    crate::commands::run_no_proxy_guard::refusal_for(&kind, scope, receipt_profile, managed)
+}
+
 fn resolve_launch_proxy(no_proxy: bool) -> Result<Option<String>> {
     if no_proxy {
         eprintln!(
@@ -664,6 +688,17 @@ pub async fn execute_with_adapters(args: &RunArgs, adapters: &HashMap<&str, Box<
     // Resolved before registration on purpose: a launch that is going to be
     // refused should not first create a gateway registration it then abandons.
     let proxy = resolve_launch_proxy(args.no_proxy)?;
+
+    // AAASM-5350 AC 1: `--no-proxy` is refused where a party other than the
+    // invoking user has already decided this host runs managed. Checked here,
+    // before the policy resolves and before anything is registered or started,
+    // for the same reason the policy refusal is: refusing after a launch has
+    // begun is not refusing.
+    if args.no_proxy {
+        if let Some(refusal) = no_proxy_refusal(&args.tool) {
+            anyhow::bail!("{refusal}");
+        }
+    }
 
     // Same reason, and the same ordering rule: a session with no effective
     // policy is refused here, before any registration exists, because a

--- a/aa-cli/src/commands/run_audit.rs
+++ b/aa-cli/src/commands/run_audit.rs
@@ -51,6 +51,10 @@ pub const LABEL_POLICY_SOURCE: &str = "aasm.policy_source";
 /// Label marking this exec as a governed launch rather than an arbitrary
 /// subprocess, so a query can separate the two.
 pub const LABEL_LAUNCH: &str = "aasm.launch";
+/// Label carrying whether this launch had interception configured at all
+/// (AAASM-5350). Separate from [`LABEL_LAUNCH`], which classifies the *event*,
+/// and from the policy labels, which describe a different dimension entirely.
+pub const LABEL_PROTECTION: &str = "aasm.protection";
 
 /// Build the labels describing the policy a launch ran under.
 ///
@@ -68,6 +72,32 @@ pub fn policy_labels(posture: &PolicyPosture) -> HashMap<String, String> {
         }
     }
     labels
+}
+
+/// What this launch can honestly say about interception, at the moment it
+/// starts (AAASM-5350 AC 2 / AC 3).
+///
+/// Two values, and deliberately **neither** of them is a ladder rung:
+///
+/// * `unprotected` — `--no-proxy`; nothing is intercepted, no egress policy
+///   applies, and no later reading may upgrade this session.
+/// * `proxy_configured` — a trusted proxy endpoint was resolved and injected.
+///
+/// It is **not** `gateway_protected`. That rung requires probe traffic to have
+/// been produced and adjudicated, and at launch time no traffic exists yet.
+/// Writing the rung here would be a claim about behaviour made before any
+/// behaviour occurred — the exact over-claim AC 3 forbids, and the reason this
+/// label names a *configuration* fact rather than a protection level.
+///
+/// An operator-supplied `HTTPS_PROXY` never produces `proxy_configured`: the
+/// value is derived from what `aasm` resolved and injected, not from the
+/// environment it inherited (AC 4).
+pub fn protection_label(no_proxy: bool) -> &'static str {
+    if no_proxy {
+        "unprotected"
+    } else {
+        "proxy_configured"
+    }
 }
 
 /// Whether a posture is one this module is able to record.
@@ -110,6 +140,10 @@ pub struct GovernedLaunchRecord<'a> {
     pub args: &'a [String],
     /// The policy the launch resolved, from the one shared mapping.
     pub posture: &'a PolicyPosture,
+    /// Whether the launch ran unprotected (`--no-proxy`). Carried explicitly
+    /// rather than inferred, so the audit record cannot disagree with what the
+    /// launch actually did.
+    pub no_proxy: bool,
     /// When the launch happened.
     pub occurred_at_unix_secs: u64,
 }
@@ -131,6 +165,7 @@ pub async fn report_governed_launch(record: GovernedLaunchRecord<'_>) -> Result<
         command,
         args,
         posture,
+        no_proxy,
         occurred_at_unix_secs,
     } = record;
     let event = AuditEvent {
@@ -145,7 +180,11 @@ pub async fn report_governed_launch(record: GovernedLaunchRecord<'_>) -> Result<
         decision: Decision::Allow as i32,
         trace_id,
         session_id,
-        labels: policy_labels(posture),
+        labels: {
+            let mut labels = policy_labels(posture);
+            labels.insert(LABEL_PROTECTION.to_string(), protection_label(no_proxy).to_string());
+            labels
+        },
         detail: Some(audit_event::Detail::Process(ProcessExecDetail {
             command: command.to_string(),
             args: args.to_vec(),
@@ -240,5 +279,35 @@ mod tests {
         });
         assert!(!labels.contains_key(LABEL_POLICY_STATE));
         assert_eq!(labels.get(LABEL_LAUNCH).map(String::as_str), Some("governed"));
+    }
+
+    /// AC 2: a `--no-proxy` session is recorded as unprotected. Without this
+    /// the audit trail says `governed` for a launch nothing intercepted.
+    #[test]
+    fn a_no_proxy_launch_is_labelled_unprotected() {
+        assert_eq!(protection_label(true), "unprotected");
+    }
+
+    /// AC 3: no launch-time label may name a ladder rung. `gateway_protected`
+    /// requires adjudicated traffic, and at launch no traffic exists — writing
+    /// it here would claim behaviour before any behaviour happened.
+    #[test]
+    fn no_protection_label_claims_a_ladder_rung() {
+        for no_proxy in [true, false] {
+            let label = protection_label(no_proxy);
+            assert_ne!(label, "gateway_protected");
+            assert_ne!(label, "host_enforced");
+            assert!(
+                !label.contains("protected") || label == "unprotected",
+                "a launch-time label must not imply a protection level: {label}"
+            );
+        }
+    }
+
+    /// A protected launch says only what is true at launch: the proxy was
+    /// configured. Whether it worked is a later, adjudicated question.
+    #[test]
+    fn a_proxied_launch_claims_configuration_not_adjudication() {
+        assert_eq!(protection_label(false), "proxy_configured");
     }
 }

--- a/aa-cli/src/commands/run_no_proxy_guard.rs
+++ b/aa-cli/src/commands/run_no_proxy_guard.rs
@@ -1,0 +1,239 @@
+//! When `--no-proxy` may be used, and when it may not (AAASM-5350 AC 1).
+//!
+//! # The two authoritative refusal sources, and why only these two
+//!
+//! `--no-proxy` launches a tool with **no interception, no egress policy and
+//! nothing inspected**. That is a legitimate thing to want on an unmanaged
+//! machine, and it stays available there. It is not legitimate where someone
+//! other than the invoking user has already decided this host runs managed.
+//!
+//! Two artifacts express that decision, and both are things a party *other than
+//! the flag's user* wrote:
+//!
+//! * **(a)** the integration receipt records [`ProtectionProfile::Strict`] — an
+//!   install-time choice, integrity-checked by the receipt store;
+//! * **(b)** a valid endpoint managed-settings file exists at the canonical
+//!   system path, root-owned — which takes administrator authorization to
+//!   create.
+//!
+//! **"A required protection level" is deliberately absent.** No runtime artifact
+//! expresses one, and a refusal inferred from local conditions with no
+//! authoritative representation would be this programme's own failure mode: a
+//! claim with nothing behind it. If such a requirement is introduced later, this
+//! contract is extended through that feature's work rather than anticipated
+//! here.
+//!
+//! # What a refusal never does
+//!
+//! It never silently downgrades. A launch under either source is refused
+//! outright, before anything starts — the alternative, quietly proceeding
+//! unprotected, is exactly what AC 1 exists to prevent.
+//!
+//! A permitted `--no-proxy` launch is still **Unprotected** and must never be
+//! reported as `Gateway Protected` or `Host Enforced`; that is AC 2 and AC 3,
+//! enforced elsewhere.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use aa_core::dev_tool::DevToolKind;
+use aa_core::integration::plan::ProtectionProfile;
+use aa_core::integration::step::SettingsScope;
+
+/// The authoritative source that refuses this `--no-proxy` launch.
+///
+/// Named individually because the operator's next step differs: a profile is
+/// something they chose and can re-install, a managed file is something an
+/// administrator installed and they may not be able to remove.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefusalSource {
+    /// (a) The integration receipt records a `Strict` profile.
+    StrictProfile {
+        /// The tool whose receipt says so.
+        tool: String,
+        /// The scope the receipt was read from.
+        scope: SettingsScope,
+    },
+    /// (b) A valid, root-owned managed-settings file is installed.
+    ManagedSettingsInstalled {
+        /// The canonical path it was found at.
+        path: PathBuf,
+    },
+}
+
+impl fmt::Display for RefusalSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StrictProfile { tool, scope } => write!(
+                f,
+                "refusing --no-proxy: the {tool} integration is installed with the strict profile \
+                 ({scope:?} scope), and strict exists precisely to say that this tool does not run \
+                 unprotected on this host.\n\
+                 \n\
+                 To run without interception, re-install the integration with a profile that permits \
+                 it:\n\
+                 \x20 aasm integrations install {tool} --profile recommended\n\
+                 Or run it without --no-proxy, which is what strict expects:\n\
+                 \x20 aasm proxy start && aasm run {tool}"
+            ),
+            Self::ManagedSettingsInstalled { path } => write!(
+                f,
+                "refusing --no-proxy: an endpoint managed-settings file is installed at {}, which \
+                 takes administrator authorization to create. Someone other than you decided this \
+                 host runs managed, and a per-launch flag does not override that.\n\
+                 \n\
+                 Run the tool through the managed path instead:\n\
+                 \x20 aasm proxy start && aasm run <tool>\n\
+                 If this host should no longer be managed, that is an administrator action — removing \
+                 the file requires the same authorization installing it did.",
+                path.display()
+            ),
+        }
+    }
+}
+
+/// Decide whether `--no-proxy` may be used for `tool`.
+///
+/// `receipt_profile` is the profile recorded in the authoritative integration
+/// receipt, or `None` when no receipt exists — an un-integrated tool is not a
+/// managed one.
+///
+/// Checked in order (a) then (b), and the **first** match is reported rather
+/// than a list: AC 1 requires naming the exact triggering condition, and "one of
+/// these two things" is not a condition an operator can act on.
+pub fn refusal_for(
+    tool: &DevToolKind,
+    scope: SettingsScope,
+    receipt_profile: Option<ProtectionProfile>,
+    managed_evidence: Option<PathBuf>,
+) -> Option<RefusalSource> {
+    if receipt_profile == Some(ProtectionProfile::Strict) {
+        return Some(RefusalSource::StrictProfile {
+            tool: tool_id(tool),
+            scope,
+        });
+    }
+    managed_evidence.map(|path| RefusalSource::ManagedSettingsInstalled { path })
+}
+
+fn tool_id(tool: &DevToolKind) -> String {
+    match tool {
+        DevToolKind::Custom(name) => name.clone(),
+        other => format!("{other:?}").to_lowercase(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn claude() -> DevToolKind {
+        DevToolKind::ClaudeCode
+    }
+
+    /// Strict is the install-time statement that this tool does not run
+    /// unprotected here, so the flag cannot override it.
+    #[test]
+    fn strict_profile_refuses() {
+        let refusal = refusal_for(&claude(), SettingsScope::User, Some(ProtectionProfile::Strict), None);
+        assert!(matches!(refusal, Some(RefusalSource::StrictProfile { .. })));
+    }
+
+    /// Recommended is guidance, not a mandate. `--no-proxy` stays available, and
+    /// narrowing that would remove a documented capability the AC preserves.
+    #[test]
+    fn recommended_permits() {
+        assert_eq!(
+            refusal_for(
+                &claude(),
+                SettingsScope::User,
+                Some(ProtectionProfile::Recommended),
+                None
+            ),
+            None
+        );
+    }
+
+    /// Observe-only applies no decision at all; refusing under it would be
+    /// stricter than the profile itself.
+    #[test]
+    fn observe_only_permits() {
+        assert_eq!(
+            refusal_for(
+                &claude(),
+                SettingsScope::User,
+                Some(ProtectionProfile::ObserveOnly),
+                None
+            ),
+            None
+        );
+    }
+
+    /// An un-integrated tool on an unmanaged host is the ordinary local case.
+    #[test]
+    fn no_receipt_and_no_managed_file_permits() {
+        assert_eq!(refusal_for(&claude(), SettingsScope::User, None, None), None);
+    }
+
+    /// A managed installation refuses even with no receipt at all: the
+    /// administrator's decision does not depend on this tool being integrated.
+    #[test]
+    fn managed_settings_refuse_without_any_receipt() {
+        let refusal = refusal_for(
+            &claude(),
+            SettingsScope::User,
+            None,
+            Some(PathBuf::from(
+                "/Library/Application Support/ClaudeCode/managed-settings.json",
+            )),
+        );
+        assert!(matches!(refusal, Some(RefusalSource::ManagedSettingsInstalled { .. })));
+    }
+
+    /// Both sources in force must name exactly one — the profile, checked first.
+    /// AC 1 requires the *exact* triggering condition, and a diagnostic listing
+    /// both leaves the operator guessing which to act on.
+    #[test]
+    fn both_sources_name_exactly_one_condition() {
+        let refusal = refusal_for(
+            &claude(),
+            SettingsScope::User,
+            Some(ProtectionProfile::Strict),
+            Some(PathBuf::from("/some/managed.json")),
+        )
+        .expect("refused");
+        assert!(matches!(refusal, RefusalSource::StrictProfile { .. }));
+        let text = refusal.to_string();
+        assert!(
+            !text.contains("/some/managed.json"),
+            "must name one condition, not both"
+        );
+    }
+
+    /// The diagnostic has to be actionable: it names the condition and what the
+    /// operator can do, or it is just a denial.
+    #[test]
+    fn each_diagnostic_names_the_condition_and_a_way_forward() {
+        let strict = RefusalSource::StrictProfile {
+            tool: "claude-code".into(),
+            scope: SettingsScope::User,
+        }
+        .to_string();
+        assert!(strict.contains("strict profile"), "names the condition: {strict}");
+        assert!(
+            strict.contains("aasm integrations install"),
+            "offers a way forward: {strict}"
+        );
+
+        let managed = RefusalSource::ManagedSettingsInstalled {
+            path: PathBuf::from("/Library/Application Support/ClaudeCode/managed-settings.json"),
+        }
+        .to_string();
+        assert!(managed.contains("managed-settings"), "names the condition: {managed}");
+        assert!(managed.contains("administrator"), "says who can change it: {managed}");
+        assert!(
+            managed.contains("/Library/Application Support/ClaudeCode/managed-settings.json"),
+            "names the exact path: {managed}"
+        );
+    }
+}

--- a/aa-cli/src/commands/run_registration.rs
+++ b/aa-cli/src/commands/run_registration.rs
@@ -405,6 +405,7 @@ pub async fn report_launch(
     command: &str,
     args: &[String],
     posture: &aa_core::integration::policy_posture::PolicyPosture,
+    no_proxy: bool,
 ) {
     let agent_id = ProtoAgentId {
         org_id: String::new(),
@@ -421,6 +422,7 @@ pub async fn report_launch(
         command,
         args,
         posture,
+        no_proxy,
         occurred_at_unix_secs: std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())

--- a/aa-devtool-claude-code/Cargo.toml
+++ b/aa-devtool-claude-code/Cargo.toml
@@ -8,6 +8,11 @@ repository.workspace = true
 description = "DevToolAdapter implementation for Anthropic Claude Code CLI"
 
 [dependencies]
+# AAASM-5350: `O_NOFOLLOW` when opening the managed-settings file. Refusing a
+# symlink atomically at open time is what avoids a check/use split; there is no
+# std equivalent that both rejects the symlink and hands back the descriptor.
+libc = { workspace = true }
+
 aa-devtool-contract = { path = "../aa-devtool-contract" }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/aa-devtool-claude-code/src/managed_settings.rs
+++ b/aa-devtool-claude-code/src/managed_settings.rs
@@ -1703,3 +1703,292 @@ mod tests {
         }
     }
 }
+
+/// Why an endpoint managed-settings file does not count as evidence that an
+/// administrator required managed operation.
+///
+/// Each variant is a *refusal to treat the file as authoritative*, never a
+/// refusal to launch — the caller decides what to do with the answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManagedEvidenceRejection {
+    /// Nothing is installed at the canonical path. The ordinary case on an
+    /// unmanaged host, and not a fault.
+    NotInstalled,
+    /// The path exists but is a symlink, or resolving it left the canonical
+    /// location. A file an unprivileged user can re-point is not evidence of
+    /// anything an administrator did.
+    NotARegularFile,
+    /// Owned by someone other than `root`. A file the invoking user owns is a
+    /// file the invoking user wrote.
+    NotRootOwned {
+        /// The uid that actually owns it.
+        uid: u32,
+    },
+    /// Writable by group or other, so an account other than the owner can
+    /// rewrite it between one launch and the next.
+    WritableByOthers {
+        /// The mode as found.
+        mode: u32,
+    },
+    /// Present, root-owned and correctly permissioned, but not a valid managed
+    /// document. An administrator did not install *this*.
+    InvalidContent {
+        /// What the validator objected to.
+        detail: String,
+    },
+    /// The file could not be read at all.
+    Unreadable {
+        /// The underlying error.
+        detail: String,
+    },
+}
+
+impl fmt::Display for ManagedEvidenceRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotInstalled => write!(f, "no endpoint managed-settings file is installed"),
+            Self::NotARegularFile => write!(
+                f,
+                "the path is not a regular file (a symlink or directory), so it is not evidence of a \
+                 privileged installation"
+            ),
+            Self::NotRootOwned { uid } => write!(
+                f,
+                "it is owned by uid {uid}, not root; a file the invoking user owns is a file the \
+                 invoking user wrote"
+            ),
+            Self::WritableByOthers { mode } => write!(
+                f,
+                "its mode is {mode:04o}, which lets an account other than the owner rewrite it"
+            ),
+            Self::InvalidContent { detail } => write!(f, "it is not a valid managed document: {detail}"),
+            Self::Unreadable { detail } => write!(f, "it could not be read: {detail}"),
+        }
+    }
+}
+
+/// Whether a valid endpoint managed-settings file is installed, meaning an
+/// administrator required managed operation on this host (AAASM-5350 AC 1b).
+///
+/// # Why this does not reuse [`ManagedSettingsInstaller::verify_read_back`]
+///
+/// That function answers "does the file still match what *this integration*
+/// installed", and reads the path twice — once for content, once for metadata.
+/// Two lookups of a path are two chances to resolve to different files, which is
+/// tolerable when the question is drift and **not** tolerable when the answer
+/// decides whether a launch may proceed unprotected.
+///
+/// Here the file is opened **once** and every subsequent question is asked of
+/// that descriptor: the metadata comes from the open handle, and the bytes come
+/// from the same handle. A file swapped after the open is not the file this
+/// answer describes.
+///
+/// # What it deliberately does not claim
+///
+/// `O_NOFOLLOW` refuses a symlink at the **final** path component only. A
+/// symlinked *parent* directory is not detected here; on macOS the canonical
+/// parent lives under `/Library/Application Support/`, which an unprivileged
+/// user cannot re-point, so the residual case needs root to set up and root can
+/// simply write the file instead. Stated rather than implied, because a reader
+/// should not infer full path-resolution hardening from this check.
+///
+/// Non-Unix targets always return [`ManagedEvidenceRejection::NotInstalled`]:
+/// the ownership and permission questions this rests on have no equivalent, and
+/// answering "installed" without them would be the over-claim.
+pub fn managed_installation_evidence() -> Result<PathBuf, ManagedEvidenceRejection> {
+    managed_installation_evidence_at(Path::new(MANAGED_SETTINGS_PATH), 0)
+}
+
+/// [`managed_installation_evidence`] against an explicit path and expected
+/// owner, so tests can exercise every rejection without being root.
+///
+/// Not public: production must never be able to name a path other than
+/// [`MANAGED_SETTINGS_PATH`], because "the canonical system path only" is half
+/// of what makes the answer mean anything.
+#[cfg(unix)]
+pub(crate) fn managed_installation_evidence_at(
+    path: &Path,
+    expected_uid: u32,
+) -> Result<PathBuf, ManagedEvidenceRejection> {
+    use std::io::Read as _;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    let mut file = match std::fs::OpenOptions::new()
+        .read(true)
+        // Refuses a symlink at the final component *atomically* — checking with
+        // `symlink_metadata` and then opening would be the check/use split this
+        // whole function exists to avoid.
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(ManagedEvidenceRejection::NotInstalled),
+        // ELOOP is what `O_NOFOLLOW` returns for a symlink.
+        Err(e) if e.raw_os_error() == Some(libc::ELOOP) => return Err(ManagedEvidenceRejection::NotARegularFile),
+        Err(e) => return Err(ManagedEvidenceRejection::Unreadable { detail: e.to_string() }),
+    };
+
+    // Every question below is asked of the open descriptor, never of the path.
+    let metadata = file
+        .metadata()
+        .map_err(|e| ManagedEvidenceRejection::Unreadable { detail: e.to_string() })?;
+    if !metadata.is_file() {
+        return Err(ManagedEvidenceRejection::NotARegularFile);
+    }
+    if metadata.uid() != expected_uid {
+        return Err(ManagedEvidenceRejection::NotRootOwned { uid: metadata.uid() });
+    }
+    let mode = metadata.mode() & 0o7777;
+    if mode & 0o022 != 0 {
+        return Err(ManagedEvidenceRejection::WritableByOthers { mode });
+    }
+
+    let mut raw = String::new();
+    file.read_to_string(&mut raw)
+        .map_err(|e| ManagedEvidenceRejection::Unreadable { detail: e.to_string() })?;
+    validate_managed_document(&raw).map_err(|e| ManagedEvidenceRejection::InvalidContent { detail: e.to_string() })?;
+
+    Ok(path.to_path_buf())
+}
+
+#[cfg(not(unix))]
+pub(crate) fn managed_installation_evidence_at(
+    _path: &Path,
+    _expected_uid: u32,
+) -> Result<PathBuf, ManagedEvidenceRejection> {
+    Err(ManagedEvidenceRejection::NotInstalled)
+}
+
+#[cfg(all(test, unix))]
+mod managed_evidence_tests {
+    use super::*;
+    use std::io::Write as _;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    /// A document that passes `validate_managed_document`, so these tests fail
+    /// on the property under test rather than on the content.
+    fn valid_doc() -> String {
+        managed_settings_document(ProtectionProfile::Strict).expect("strict document")
+    }
+
+    fn write(dir: &std::path::Path, name: &str, body: &str, mode: u32) -> PathBuf {
+        let path = dir.join(name);
+        let mut f = std::fs::File::create(&path).expect("create");
+        f.write_all(body.as_bytes()).expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)).expect("chmod");
+        path
+    }
+
+    fn me() -> u32 {
+        use std::os::unix::fs::MetadataExt as _;
+        std::fs::metadata(std::env::current_exe().expect("exe"))
+            .expect("meta")
+            .uid()
+    }
+
+    /// The permitting case, so the rejections below are known to be rejecting
+    /// something that would otherwise be accepted.
+    #[test]
+    fn a_valid_root_owned_document_is_evidence() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let path = write(dir.path(), "managed-settings.json", &valid_doc(), 0o644);
+        assert_eq!(managed_installation_evidence_at(&path, me()), Ok(path));
+    }
+
+    /// The ordinary unmanaged host. Not a fault, and must not be reported as one.
+    #[test]
+    fn an_absent_file_is_not_installed() {
+        let dir = tempfile::tempdir().expect("tmp");
+        assert_eq!(
+            managed_installation_evidence_at(&dir.path().join("nope.json"), me()),
+            Err(ManagedEvidenceRejection::NotInstalled)
+        );
+    }
+
+    /// A user pointing the canonical path at their own file is the whole reason
+    /// this check exists: it would otherwise let an unprivileged account
+    /// manufacture "an administrator required this".
+    #[test]
+    fn a_symlink_is_refused_even_when_its_target_is_valid() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let real = write(dir.path(), "real.json", &valid_doc(), 0o644);
+        let link = dir.path().join("managed-settings.json");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+        assert_eq!(
+            managed_installation_evidence_at(&link, me()),
+            Err(ManagedEvidenceRejection::NotARegularFile),
+            "a symlink must never be evidence, however valid its target"
+        );
+    }
+
+    /// A file the invoking user owns is a file the invoking user wrote.
+    #[test]
+    fn a_file_owned_by_someone_else_is_refused() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let path = write(dir.path(), "managed-settings.json", &valid_doc(), 0o644);
+        // Expect an owner this file cannot have, standing in for "expected root,
+        // found the user" without needing to be root to arrange it.
+        let wrong = me().wrapping_add(1);
+        assert!(matches!(
+            managed_installation_evidence_at(&path, wrong),
+            Err(ManagedEvidenceRejection::NotRootOwned { .. })
+        ));
+    }
+
+    /// Root-owned but group/world writable is not a privileged artifact: another
+    /// account can rewrite it between one launch and the next.
+    #[test]
+    fn a_world_writable_file_is_refused() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let path = write(dir.path(), "managed-settings.json", &valid_doc(), 0o666);
+        assert!(matches!(
+            managed_installation_evidence_at(&path, me()),
+            Err(ManagedEvidenceRejection::WritableByOthers { .. })
+        ));
+    }
+
+    /// Correct ownership and permissions do not make arbitrary content a managed
+    /// installation. An administrator did not install *this*.
+    #[test]
+    fn a_correctly_owned_file_with_wrong_content_is_refused() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let path = write(dir.path(), "managed-settings.json", "{\"unrelated\": true}", 0o644);
+        assert!(matches!(
+            managed_installation_evidence_at(&path, me()),
+            Err(ManagedEvidenceRejection::InvalidContent { .. })
+        ));
+    }
+
+    /// Unparseable content is refused for the same reason, and is reported as
+    /// invalid content rather than as absence.
+    #[test]
+    fn malformed_json_is_invalid_content_not_absence() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let path = write(dir.path(), "managed-settings.json", "{not json", 0o644);
+        assert!(matches!(
+            managed_installation_evidence_at(&path, me()),
+            Err(ManagedEvidenceRejection::InvalidContent { .. })
+        ));
+    }
+
+    /// A directory at the path is not a regular file, and must not read as one.
+    #[test]
+    fn a_directory_is_refused() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let path = dir.path().join("managed-settings.json");
+        std::fs::create_dir(&path).expect("mkdir");
+        assert!(matches!(
+            managed_installation_evidence_at(&path, me()),
+            Err(ManagedEvidenceRejection::NotARegularFile) | Err(ManagedEvidenceRejection::Unreadable { .. })
+        ));
+    }
+
+    /// Production must not be able to name any path but the canonical one.
+    #[test]
+    fn the_public_entry_point_uses_only_the_canonical_path() {
+        // Not an assertion about the host: on a developer machine the file is
+        // absent, which is exactly `NotInstalled`. The point is that the public
+        // function takes no path argument at all.
+        let _: Result<PathBuf, ManagedEvidenceRejection> = managed_installation_evidence();
+    }
+}


### PR DESCRIPTION
## Description

**AAASM-5350** against its criteria as revised by owner decision on 2026-08-03. `--no-proxy` is now refused where a party other than the invoking user has already decided this host runs managed, and a permitted unprotected launch is recorded as unprotected rather than as governed.

## The defect this found

The audit record added in AAASM-5349 set `aasm.launch = "governed"` **unconditionally**. A `--no-proxy` session — nothing intercepted, no egress policy, nothing inspected — was being written into the governance trail looking identical to a protected one.

That is the over-claim this ticket exists to prevent, already shipped, in the *record* rather than in the launch. Found by tracing whether `--no-proxy` actually reaches the emission rather than assuming it did not.

## AC 1 — refusal, and the two authoritative sources

Refused when **either** is in force:

* **(a)** the integration receipt records `ProtectionProfile::Strict` — integrity-checked by the receipt store;
* **(b)** a valid endpoint managed-settings file is installed at the canonical system path — which takes administrator authorization to create.

Both are written by someone other than the flag's user. `Recommended` and `ObserveOnly` still permit the flag: narrowing that would remove a capability the criterion preserves.

Refused **before** the policy resolves and before anything registers or starts, for the same reason the policy refusal is — refusing after a launch has begun is not refusing.

### Managed-settings evidence is read from one descriptor

`verify_read_back` could not be reused: it answers a different question ("does this still match what we installed") and reads the path **twice**, once for content and once for metadata. Two lookups of a path are two chances to resolve to different files — tolerable for drift, not tolerable when the answer decides whether a launch may proceed unprotected.

The new check opens the file **once** and asks everything of that descriptor:

| Requirement | How |
|---|---|
| canonical path only | the public entry point takes **no path argument** |
| regular file, symlink rejected | `O_NOFOLLOW` at open — atomic, not stat-then-open |
| root ownership | `fstat` on the open handle |
| permission boundary | `mode & 0o022` on the same handle |
| schema-conforming content | validated from bytes read via the same handle |
| no user-created file counts | ownership **and** content together |
| **no check/use split** | one descriptor throughout |

**Two things it does not claim.** `O_NOFOLLOW` covers the final path component only — a symlinked *parent* is undetected; on macOS that parent is under `/Library/Application Support/`, which needs root to re-point, and root could write the file directly. And non-Unix targets always report `NotInstalled`, because the ownership and permission questions have no equivalent there and answering "installed" without them would be the over-claim.

### The diagnostic names exactly one condition

A refusal listing both sources would satisfy "refuses" while failing the part that makes a refusal useful — an operator cannot act on a disjunction. A test asserts the single-condition property, and each diagnostic carries a concrete next command.

## AC 2a — audit and receipt

`aasm.protection` carries the interception dimension, separate from `aasm.launch` (which classifies the event) and from the policy labels (a different dimension again). The `--dry-run` receipt gains a `--- protection ---` block from the **same function**, so a preview and the record it predicts cannot disagree.

Two values, and **neither is a ladder rung**:

* `unprotected` — `--no-proxy`;
* `proxy_configured` — a trusted endpoint was resolved and injected.

It is not `gateway_protected`. That rung requires probe traffic to have been produced and adjudicated; at launch, no traffic exists. A launch-time surface states a *configuration* fact or it claims behaviour that has not happened.

## AC 2b — why `status` and `verify` are out of scope

`IntegrationStatus` carries **no session concept at all**. `status` and `verify` answer "what is installed and does it still verify", derived from receipts and evidence — not "what did session X do". A `--no-proxy` launch leaves no trace there by construction, and satisfying the original wording literally would mean introducing session tracking into the DI-API: a new concept with retention, restart and wire questions, not a wiring change.

Scoped by owner decision rather than quietly narrowed, and this PR does not claim otherwise.

## AC 3 — and why it holds structurally

No path reports `Gateway Protected`/`Host Enforced` for a `--no-proxy` session. This is stronger than the label tests: the ladder is derived **only** from adjudicated evidence, and such a session produces none, so it cannot raise the ladder regardless of what any label says.

## AC 4 — pinned, not merely documented

`build_child_env` already documented and enforced that an ambient `HTTPS_PROXY` is not AASM interception — but nothing asserted it, so a later change reading the ambient value back out as evidence of protection would have passed. Now tested in both halves: an ambient proxy does not upgrade an unprotected launch, and `--no-proxy` still leaves the operator's own route alone.

## AC 5 — deferred

`--no-proxy` remains the spelling for rc.7. Reasons recorded on the ticket; **AAASM-5437** evaluates `--unprotected` with a full migration contract. No rename implemented or announced here.

## Type of Change

- [x] ✨ New feature (the refusal)
- [x] 🐛 Bug fix (unprotected launches recorded as governed)

## Breaking Changes

- [x] Yes, narrowly: `aasm run --no-proxy` now **refuses** under a Strict profile or a valid managed-settings installation. Both are states where an unprotected launch was never intended to be available, and the refusal is explicit with a named condition and a way forward.

## Related Issues

- Jira: **AAASM-5350** (AC 1, 2a/2b, 5 revised by owner decision 2026-08-03)
- Follow-up: **AAASM-5437** (naming)
- Builds on AAASM-5349 (`cdb03b9e`)

## Testing

**1111/1111** across `aa-cli` and `aa-devtool-claude-code`; `clippy --all-targets -- -D warnings` clean; **both crates compile alone**.

**Six mutations killed**, each attacking a distinct guarantee:

| Mutation | Caught by |
|---|---|
| Drop `O_NOFOLLOW` (follow symlinks) | `a_symlink_is_refused_even_when_its_target_is_valid` |
| Skip the ownership check | `a_file_owned_by_someone_else_is_refused` |
| Remove the Strict-profile source | `strict_profile_refuses` + `both_sources_name_exactly_one_condition` |
| Remove the managed-settings source | `managed_settings_refuse_without_any_receipt` |
| Label a `--no-proxy` launch `gateway_protected` | three protection-label tests |
| Label it `proxy_configured` (silent downgrade) | `a_no_proxy_launch_is_labelled_unprotected` |

The last two are the AC 3 pair; the middle two are the falsification the AC requires — removal of **either** authoritative refusal source is detected.

Coverage: Strict / Recommended / ObserveOnly / no-receipt / valid managed installation / spoofed user file / symlink-with-valid-target / wrong owner / world-writable / invalid content / malformed JSON / directory / both-sources / diagnostics-are-actionable.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rationale at the point of use)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## One judgement made explicit in code

**An unreadable receipt is treated as no receipt, not as a refusal.** A corrupt file is not evidence that someone required managed operation, and refusing on it would turn corruption into policy. The managed-settings source is unaffected and still refuses on its own.
