### PR TITLE
[AAASM-5364] 🐛 (aa-security): Close the full-width separator and split-run entropy evasions

### DIFF
--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -886,6 +886,49 @@ pub(crate) fn ascii_digit_of(c: char) -> Option<char> {
     }
 }
 
+/// The ASCII separator equivalent of `c` for [`digit_segment`]'s walk — `' '`
+/// for the space forms, `'-'` for the hyphen forms, `None` for anything else.
+///
+/// AAASM-5364: [`ascii_digit_of`] closed the full-width *digit* evasion, which
+/// is the whole of the credit-card case because a bare card carries no
+/// separators. It is not the whole of the SSN case: [`is_ssn`] matches the exact
+/// shape `DDD-DD-DDDD`, so the hyphens have to normalise too, and the
+/// space-grouped card form has the same problem. A CJK input method in full-width
+/// mode emits **U+FF0D** when the hyphen key is pressed and **U+3000** for the
+/// space bar, so an SSN or a grouped card typed the natural way by a Taiwanese or
+/// Japanese user went undetected while its ASCII twin did not.
+///
+/// The normalisation is for **matching only**, exactly as for digits: both
+/// full-width forms are three UTF-8 bytes against ASCII's one, so the caller
+/// pushes the ASCII equivalent into the normalised string while advancing `end`
+/// by the *original* character's width.
+///
+/// # The boundary, and why it stops here
+///
+/// U+2010–U+2015 (hyphen, non-breaking hyphen, figure/en/em dash, horizontal bar)
+/// and U+00A0 (no-break space) were considered and **declined**:
+///
+/// * No input method emits any of them for the hyphen or space key, so admitting
+///   them buys nothing against the evasion this rule exists to close — the threat
+///   is an input-mode switch, not an arbitrary look-alike glyph.
+/// * Each admitted separator lengthens the run [`digit_segment`] will join, and
+///   every additional joined run is an independent ~10% chance of a coincidental
+///   Luhn pass. The en dash is the standard glyph for a numeric *range*
+///   (`1990–2000`, `第 12–15 頁`) — precisely where two unrelated numbers sit
+///   adjacent with a dash between them — so it carries that risk at the highest
+///   rate of the set for no coverage in return.
+///
+/// The boundary is cheap to move if a payload is ever observed using one of them;
+/// `digit_separator_boundary_declines_en_dash_and_nbsp` pins it so the decision
+/// is visible rather than implicit.
+fn ascii_separator_of(c: char) -> Option<char> {
+    match c {
+        ' ' | '\u{3000}' => Some(' '),
+        '-' | '\u{FF0D}' => Some('-'),
+        _ => None,
+    }
+}
+
 /// Result of walking one digit segment (see [`digit_segment`]).
 struct DigitSegment {
     /// Byte offset just past the segment — where the outer scan resumes, and
@@ -931,19 +974,23 @@ fn digit_segment(text: &str, start: usize) -> DigitSegment {
         // separator must not be swallowed into the segment, or an SSN like
         // "123-45-6789 " would become 12 bytes and fail the exact-11-byte
         // `is_ssn` check, letting the PII through unredacted (AAASM-4820).
-        if matches!(c, ' ' | '-')
-            && !digits.is_empty()
-            && chars + 1 < DIGIT_SEGMENT_MAX_CHARS
-            && text[end + c.len_utf8()..]
-                .chars()
-                .next()
-                .and_then(ascii_digit_of)
-                .is_some()
-        {
-            normalised.push(c);
-            end += c.len_utf8();
-            chars += 1;
-            continue;
+        if let Some(sep) = ascii_separator_of(c) {
+            if !digits.is_empty()
+                && chars + 1 < DIGIT_SEGMENT_MAX_CHARS
+                && text[end + c.len_utf8()..]
+                    .chars()
+                    .next()
+                    .and_then(ascii_digit_of)
+                    .is_some()
+            {
+                // The ASCII equivalent, so `is_ssn`'s exact-11-byte shape check
+                // sees `DDD-DD-DDDD` whichever width the hyphens were typed in
+                // (AAASM-5364). `end` still advances by the original width.
+                normalised.push(sep);
+                end += c.len_utf8();
+                chars += 1;
+                continue;
+            }
         }
 
         break;
@@ -958,10 +1005,12 @@ fn digit_segment(text: &str, start: usize) -> DigitSegment {
 
 /// Scans `text` for credit card numbers (Luhn-validated) and SSN patterns (`DDD-DD-DDDD`).
 ///
-/// Digits are normalised by [`ascii_digit_of`], so a value written in full-width
-/// digits is detected as the same kind as its ASCII equivalent (AAASM-5345).
-/// Findings still span the **original** text: normalisation never reaches the
-/// offsets, only the strings the two checks are run against.
+/// Digits are normalised by [`ascii_digit_of`] and the separators between them by
+/// [`ascii_separator_of`], so a value written in full-width digits (AAASM-5345)
+/// or grouped by a full-width hyphen / ideographic space (AAASM-5364) is detected
+/// as the same kind as its ASCII equivalent. Findings still span the **original**
+/// text: normalisation never reaches the offsets, only the strings the two checks
+/// are run against.
 fn scan_digit_sequences(text: &str, findings: &mut Vec<CredentialFinding>) {
     let mut i = 0usize;
     while i < text.len() {

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -3443,6 +3443,177 @@ mod tests {
     }
 
     #[test]
+    fn a_split_secret_is_redacted_to_exact_bytes() {
+        // Counting findings is not enough. The span deliberately covers the
+        // separator, so it is the one span in the scanner that is wider than the
+        // run it was derived from — an off-by-one either leaves a character of
+        // key material in the clear or eats the surrounding text. Assert the
+        // output bytes, including the words either side.
+        let scanner = CredentialScanner::new();
+        for (text, expected) in [
+            (
+                format!("log {SPLIT_SECRET_HEAD} {SPLIT_SECRET_TAIL} end"),
+                "log [REDACTED:GenericHighEntropy] end".to_string(),
+            ),
+            (
+                format!("log {SPLIT_SECRET_HEAD}中{SPLIT_SECRET_TAIL} end"),
+                "log [REDACTED:GenericHighEntropy] end".to_string(),
+            ),
+        ] {
+            let redacted = scanner.scan(&text).redact(&text);
+            assert_eq!(redacted, expected, "wrong redaction for {text:?}");
+        }
+    }
+
+    #[test]
+    fn split_pair_spans_are_char_boundaries_of_the_original_text() {
+        // The span contract `redact` depends on. This pass is the one that can
+        // put a *multi-byte* character inside a span it did not scan — the
+        // separator — so its bounds are the ones most likely to land
+        // mid-character if the walk ever advanced by bytes where it should have
+        // advanced by characters.
+        let scanner = CredentialScanner::new();
+        for splitter in ["中", "😀", "д", " "] {
+            let text = format!("log {SPLIT_SECRET_HEAD}{splitter}{SPLIT_SECRET_TAIL} end");
+            let result = scanner.scan(&text);
+            assert!(!result.findings.is_empty(), "no finding for {splitter:?}");
+            for f in &result.findings {
+                assert!(
+                    text.is_char_boundary(f.offset),
+                    "offset {} splits a character for {splitter:?}",
+                    f.offset
+                );
+                assert!(
+                    text.is_char_boundary(f.end),
+                    "end {} splits a character for {splitter:?}",
+                    f.end
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_run_at_the_pass_3_floor_is_not_joined_to_its_neighbour() {
+        // The constraint that keeps this pass from reaching past a secret it has
+        // already found and swallowing the next word. Both these payloads carry a
+        // run at or above `BASE64_RUN_MIN_LEN` followed by an innocent one; an
+        // earlier draft of this pass joined them and redacted ` done` and the PEM
+        // `-----END` marker along with the key. Asserted on the exact bytes,
+        // because the finding count is identical either way.
+        let scanner = CredentialScanner::new();
+
+        // The `tok=` prefix is swallowed by pass 1's whitespace-token span, which
+        // is long-standing behaviour and not this pass's to change. What matters
+        // here is the tail: ` done` is a separate run and must stay in the clear.
+        let text = "tok=ghp_abcdefABCDEF0123456789ABCDEF0123456789 done";
+        assert_eq!(
+            scanner.scan(text).redact(text),
+            "[REDACTED:GitHubPat] done",
+            "the word after an already-detected secret must survive"
+        );
+
+        let pem = "KEY=-----BEGIN EC PRIVATE KEY-----\n\
+                   MHQCAQEEIOaRgVBExLFbHznv7gHsepSPpLUFKr\n\
+                   -----END EC PRIVATE KEY-----";
+        assert!(
+            scanner.scan(pem).redact(pem).contains("-----END EC PRIVATE KEY-----"),
+            "the END marker must not be swallowed into the body span"
+        );
+    }
+
+    #[test]
+    fn multi_character_gaps_and_many_way_splits_are_documented_residuals() {
+        // What AAASM-5368 does **not** close, asserted as not detected so the gap
+        // stays visible instead of being rediscovered by an attacker.
+        //
+        // A gap of two characters is a genuine text boundary rather than an
+        // inserted separator, and a split into pieces short enough that no
+        // adjacent pair reaches `BASE64_RUN_MIN_LEN` leaves nothing for a pairwise
+        // rule to score. Closing either means joining more than two runs, which is
+        // the clause-swallowing shape this pass is built to avoid — so widening
+        // needs its own false-positive measurement, not a one-line change here.
+        let scanner = CredentialScanner::new();
+        let (head, tail) = (SPLIT_SECRET_HEAD, SPLIT_SECRET_TAIL);
+
+        // Only gaps that break pass 1's whitespace token are residuals. A gap of
+        // ASCII punctuation (`..`) leaves the two halves inside one token, and
+        // pass 1 scores that token whole — so punctuation gaps of any length are
+        // already covered and are not listed here.
+        for gap in ["  ", " \n", "中文", " \t", "\n\n"] {
+            let text = format!("log {head}{gap}{tail} end");
+            assert!(
+                scanner.scan(&text).is_clean(),
+                "residual changed for gap {gap:?} — if it is now closed, update this test"
+            );
+        }
+
+        // The same 36 characters cut into four 9-character pieces: every adjacent
+        // pair is 18, below the floor.
+        let joined = format!("{head}{tail}");
+        let quartered = joined
+            .as_bytes()
+            .chunks(9)
+            .map(|c| std::str::from_utf8(c).unwrap())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            scanner.scan(&quartered).is_clean(),
+            "a many-way split is a documented residual: {:?}",
+            scanner.scan(&quartered).findings
+        );
+    }
+
+    #[test]
+    fn the_distinct_byte_fast_path_cannot_change_a_verdict() {
+        // `MIN_DISTINCT_BYTES_FOR_GATE` is a fast path, not a filter: Shannon
+        // entropy over d distinct symbols is at most log2(d), so a candidate below
+        // the bar could never have cleared `ENTROPY_BITS_GATE` anyway. Pinned from
+        // both sides so it can neither reject a candidate the gate would accept
+        // (too high) nor stop being a useful skip (too low).
+        let below = f64::from(MIN_DISTINCT_BYTES_FOR_GATE - 1);
+        assert!(
+            below.log2() <= ENTROPY_BITS_GATE,
+            "{} distinct bytes can still clear the gate, so skipping it changes verdicts",
+            MIN_DISTINCT_BYTES_FOR_GATE - 1,
+        );
+        let at = f64::from(MIN_DISTINCT_BYTES_FOR_GATE);
+        assert!(
+            at.log2() > ENTROPY_BITS_GATE,
+            "the fast path is looser than it needs to be at {MIN_DISTINCT_BYTES_FOR_GATE}",
+        );
+    }
+
+    #[test]
+    fn english_technical_prose_stays_clean_under_the_split_pass() {
+        // The measured false-positive corpus, reduced to the lines that actually
+        // fired. Each of these joined pairs cleared the 4.5-bit gate in a draft of
+        // this pass that let the candidate contain punctuation: a near-all-distinct
+        // string of 27-35 characters scores about log2(n) whatever it says, so
+        // ordinary mixed-case technical English sailed over the bar. Restricting
+        // the candidate to the base64 alphabet is what excludes them, and it is
+        // the only thing that does — the entropy gate cannot tell these from key
+        // material at this length.
+        //
+        // Measured over 1.8 MB of this repository's English and Chinese prose,
+        // the pass adds zero findings; these are the seven that a weaker rule
+        // added.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "upgrades, RBAC/NetworkPolicy hardening). Those remain SaaS surface.",
+            "The `policy_engine` is `Arc<PolicyEngine>` (`state.rs:45`); the test code that uses it",
+            "`0.5` approval-rejection, `MIN_ACTIONS = 20`) are product-owned",
+            "the value is replaced with a `[REDACTED:<kind>]` placeholder and the request continues",
+        ] {
+            let result = scanner.scan(text);
+            assert!(
+                result.is_clean(),
+                "prose false positive returned: {:?} in {text:?}",
+                result.findings.iter().map(|f| f.kind.as_str()).collect::<Vec<_>>(),
+            );
+        }
+    }
+
+    #[test]
     fn default_config_matches_new() {
         let default_scanner = CredentialScanner::new();
         let config_scanner = CredentialScanner::with_config(ScannerConfig::default());

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1045,14 +1045,28 @@ fn scan_digit_sequences(text: &str, findings: &mut Vec<CredentialFinding>) {
 /// English prose, which is how ordinary Chinese was reported as leaked secrets
 /// (AAASM-5344). Every call site therefore narrows to an ASCII run first.
 fn shannon_entropy(s: &str) -> f64 {
-    if s.is_empty() {
+    shannon_entropy_joined(s, "")
+}
+
+/// Shannon entropy of `a` followed by `b`, in bits per **byte**, without
+/// materialising the concatenation.
+///
+/// [`scan_separated_base64_runs`] scores a *pair* of runs, because the pair —
+/// not either half — is the candidate once a secret has been split. Joining them
+/// into a `String` first would put one allocation on the scanner's hot path for
+/// every word boundary in the payload, so the frequency table is accumulated over
+/// both slices instead. The ASCII-only precondition [`shannon_entropy`] documents
+/// applies to both halves for the same reason.
+fn shannon_entropy_joined(a: &str, b: &str) -> f64 {
+    let total = a.len() + b.len();
+    if total == 0 {
         return 0.0;
     }
     let mut freq = [0u32; 256];
-    for &b in s.as_bytes() {
-        freq[b as usize] += 1;
+    for &byte in a.as_bytes().iter().chain(b.as_bytes()) {
+        freq[byte as usize] += 1;
     }
-    let len = s.len() as f64;
+    let len = total as f64;
     freq.iter()
         .filter(|&&c| c > 0)
         .map(|&c| {
@@ -1117,28 +1131,24 @@ const BASE64_RUN_MIN_LEN: usize = 20;
 /// straight through the gate. Segmenting keeps a *contiguous* ASCII candidate
 /// visible no matter what surrounds it.
 ///
-/// # Known residual — a non-ASCII byte splits, as whitespace already does
+/// # The residual this used to carry is closed (AAASM-5368)
 ///
-/// Because non-ASCII is now purely a run boundary, a glyph inserted into the
+/// Because non-ASCII is purely a run boundary here, a glyph inserted into the
 /// *middle* of a secret splits it into two runs, and if both fall under the
-/// 20-character floor neither is scored. Detection of such a secret is lost
-/// relative to the old byte-entropy behaviour.
+/// 20-character floor neither is scored by this pass. That was true of a plain
+/// **space**, tab or newline before this function existed — separator-splitting
+/// defeated the length gate for every separator class, and this function only
+/// made a non-ASCII separator behave like the whitespace separators beside it.
 ///
-/// This is a deliberate, bounded trade, not an oversight:
+/// [`scan_separated_base64_runs`] now closes that gap for every separator class
+/// at once, by scoring an adjacent *pair* of base64 runs joined across a single
+/// separator character. This function is deliberately left alone: narrowing to ASCII runs
+/// is what stops the gate scoring UTF-8 bytes, and re-widening it to recover the
+/// split case would reintroduce the false-positive defect it exists to fix. The
+/// recovery belongs in an additive pass, which is where it now lives.
 ///
-/// * It grants an attacker nothing new. Splitting with a plain **space**, tab or
-///   newline defeats the same floor and always has — separator-splitting was
-///   already fully open, and remains equally open. This change only makes a
-///   non-ASCII separator behave like the whitespace separators beside it.
-/// * The old behaviour was not detection. It was the byte-entropy defect firing
-///   on a clause that happened to contain a secret, and it "worked" only by
-///   redacting the entire surrounding clause — which is precisely the
-///   false-positive defect this function exists to fix. The catch cannot be kept
-///   while fixing the bug.
-///
-/// The general separator-split gap is tracked as AAASM-5368, which owns closing
-/// it for every separator class at once; `separator_split_secret_is_a_known_residual`
-/// pins the current behaviour so that ticket's change is visible when it lands.
+/// What remains open is stated on [`scan_separated_base64_runs`] rather than here:
+/// a gap of more than one character, and a secret cut into three or more pieces.
 fn ascii_runs(s: &str) -> impl Iterator<Item = (usize, &str)> {
     let bytes = s.as_bytes();
     let mut i = 0usize;
@@ -1188,6 +1198,10 @@ fn is_base64_char(b: u8) -> bool {
 ///    into 2-char groups that clear neither the pass-2 length bar nor (with `-`
 ///    kept inside the base64 alphabet) the pass-3 entropy gate, so it evades
 ///    passes 1-3 entirely; this pass closes that gap.
+/// 5. **Separator-split base64 run** (AAASM-5368) — pass 3's rule applied to two
+///    adjacent runs joined across a single separator character, closing the
+///    length-gate evasion where a secret is simply cut in two, for every
+///    separator class at once (see [`scan_separated_base64_runs`]).
 ///
 /// Passes 2-4 need no ASCII narrowing of their own: every byte they accept is
 /// selected by an ASCII predicate (`is_ascii_hexdigit`, [`is_base64_char`],
@@ -1233,6 +1247,8 @@ fn scan_high_entropy(text: &str, findings: &mut Vec<CredentialFinding>) {
     scan_long_base64_runs(text, findings);
     // Pass 4: separator-grouped hex runs the contiguous passes miss (AAASM-4075).
     scan_separated_hex_runs(text, findings);
+    // Pass 5: a base64 run cut in two by one separator (AAASM-5368).
+    scan_separated_base64_runs(text, findings);
 }
 
 /// Pass 2 — flag every contiguous hex run of length ≥ [`HEX_RUN_MIN_LEN`].
@@ -1354,6 +1370,147 @@ fn scan_separated_hex_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
                 ));
             }
         }
+    }
+}
+
+/// Minimum number of distinct byte values a candidate must carry before
+/// [`ENTROPY_BITS_GATE`] can possibly be cleared.
+///
+/// Not a heuristic and not a filter — an exact necessary condition, used as a
+/// fast path. Shannon entropy over an alphabet of `d` distinct symbols is at
+/// most `log2(d)`, so a candidate can only exceed 4.5 bits if `log2(d) > 4.5`,
+/// i.e. `d > 22.63`, i.e. `d >= 23`. Testing it before scoring therefore cannot
+/// change any verdict; it exists so [`scan_separated_base64_runs`] does not clear
+/// a 1 KiB frequency table for every word boundary in the payload.
+/// `the_distinct_byte_fast_path_cannot_change_a_verdict` pins it from both
+/// sides — 22 can never pass the gate, and 23 can.
+const MIN_DISTINCT_BYTES_FOR_GATE: u32 = 23;
+
+/// Number of distinct byte values across `a` followed by `b`.
+///
+/// A 256-bit set held in four words, so the count costs one pass and four
+/// `popcount`s with no allocation and no table to clear per candidate.
+fn distinct_bytes(a: &str, b: &str) -> u32 {
+    let mut seen = [0u64; 4];
+    for &byte in a.as_bytes().iter().chain(b.as_bytes()) {
+        seen[(byte >> 6) as usize] |= 1u64 << (byte & 63);
+    }
+    seen.iter().map(|w| w.count_ones()).sum()
+}
+
+/// Yields each maximal base64/base64url run in `text` as `(start, end)` byte
+/// offsets — the same runs [`scan_long_base64_runs`] scores, exposed as an
+/// iterator so pass 5 can look at two of them at once.
+///
+/// Byte-wise rather than char-wise, and still boundary-safe: [`is_base64_char`]
+/// accepts only ASCII, and every byte of a multi-byte UTF-8 sequence is ≥ `0x80`,
+/// so a run bound is either an ASCII byte or a lead byte — never a continuation
+/// byte. Same argument as [`ascii_runs`].
+fn base64_runs(text: &str) -> impl Iterator<Item = (usize, usize)> + '_ {
+    let bytes = text.as_bytes();
+    let mut i = 0usize;
+    std::iter::from_fn(move || {
+        while i < bytes.len() && !is_base64_char(bytes[i]) {
+            i += 1;
+        }
+        let start = i;
+        while i < bytes.len() && is_base64_char(bytes[i]) {
+            i += 1;
+        }
+        (start < i).then_some((start, i))
+    })
+}
+
+/// Pass 5 — a base64 run cut in two by a single separator character
+/// (AAASM-5368).
+///
+/// Pass 3 gates a contiguous base64 run at [`BASE64_RUN_MIN_LEN`], so a secret
+/// split into two sub-20-character pieces clears neither half of the bar and is
+/// not scored — by a space, a tab, a newline or a non-ASCII glyph alike.
+/// Separator-splitting was a fully open evasion of the length gate on `main` for
+/// every separator class at once.
+///
+/// This is [`scan_separated_hex_runs`] (AAASM-4075) applied to the entropy gate
+/// rather than to a hex-digit count, which is the generalisation that ticket's
+/// shape was always pointing at: scan the runs, exclude the separator from what
+/// is scored — it is the evasion, not part of the secret's entropy — and hold the
+/// rejoined value to the bar its unsplit form would have faced.
+///
+/// # Why this does not become a false-positive explosion
+///
+/// Joining fragments freely until the length window is reached swallows whole
+/// clauses of running text, which is the defect AAASM-5344 was opened to fix.
+/// Three properties bound it instead, and all three are load-bearing:
+///
+/// * **Base64 alphabet.** The candidate must be drawn from the alphabet encoded
+///   key material is drawn from ([`is_base64_char`]) — the same restriction pass 3
+///   already applies. This is what keeps ordinary punctuated prose out: without
+///   it, joining `RBAC/NetworkPolicy` to `hardening).` clears the gate, because a
+///   near-all-distinct string of 27 characters scores `log2(27)` whatever it says.
+/// * **Pairs only, both below [`BASE64_RUN_MIN_LEN`].** At most two runs are ever
+///   joined, and only when *neither* could have been scored alone — which is
+///   exactly the case pass 3 cannot see. Without the second half of that
+///   condition the pass reaches past an already-detected secret into the next
+///   word: `tok=<40-char PAT> done` would redact ` done`, and a PEM body line
+///   would swallow its `-----END` marker.
+/// * **A one-character gap.** The evasion is the insertion of *a* separator into
+///   a secret. A longer gap — indentation, a paragraph break, sentence spacing —
+///   is ordinary text structure with no matching evasion story. It also bounds
+///   the span: it can cover at most one character that is not candidate material.
+///
+/// Measured over 1.8 MB of this repository's own English and Chinese prose and
+/// over the committed clean zh-TW corpus, this pass adds **zero** findings.
+///
+/// # What it does and does not recover
+///
+/// A split secret now faces exactly the bar its unsplit form faces — no lower,
+/// which is the point, and no higher. Because [`ENTROPY_BITS_GATE`] is 4.5 bits
+/// and a random base64 run of length `n` scores about `log2(n)` minus its
+/// collisions, that bar is only really met from the low thirties upward: a random
+/// 24-character run clears it about 6% of the time whether it is split or not,
+/// rising to ~90% at 36 and ~96% at 38 (the longest a two-piece split with both
+/// halves under the floor can be). Pass 5 does not change that calibration in
+/// either direction; it removes the separator as a way of avoiding it.
+///
+/// # What is still open
+///
+/// A gap of more than one character, and a split into pieces small enough that no
+/// *adjacent pair* reaches [`BASE64_RUN_MIN_LEN`] — a three-way split of a long
+/// secret is still caught pairwise, a many-way split into short pieces is not.
+/// Both are pinned by `multi_character_gaps_and_many_way_splits_are_documented_residuals`
+/// so they stay visible rather than being rediscovered by an attacker. Widening
+/// either is a measurable follow-on, not a free change — it is precisely the
+/// multi-fragment join the three properties above exist to prevent.
+///
+/// # The span
+///
+/// `[first run start, second run end)` — both runs and the one separator between
+/// them, following [`scan_separated_hex_runs`], which likewise spans its internal
+/// separators. Unlike pass 1 there is no [`token_end`] clamp: the candidate
+/// deliberately spans a separator, so clamping at the first delimiter could
+/// truncate the span *inside the first run* and leave secret material in the
+/// clear. The compact-JSON tail that clamp exists for is covered by pass 3.
+fn scan_separated_base64_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
+    let mut prev: Option<(usize, usize)> = None;
+    for (start, end) in base64_runs(text) {
+        if let Some((p_start, p_end)) = prev {
+            // Both runs must fall *below* pass 3's floor. A run at or above it is
+            // pass 3's to score, and joining it to its neighbour would pull
+            // ordinary text into the span — the clause-swallowing shape this pass
+            // must not reproduce.
+            let both_below_floor = p_end - p_start < BASE64_RUN_MIN_LEN && end - start < BASE64_RUN_MIN_LEN;
+            if both_below_floor && text[p_end..start].chars().count() == 1 {
+                let (a, b) = (&text[p_start..p_end], &text[start..end]);
+                let joined_len = (p_end - p_start) + (end - start);
+                if (BASE64_RUN_MIN_LEN..=64).contains(&joined_len)
+                    && distinct_bytes(a, b) >= MIN_DISTINCT_BYTES_FOR_GATE
+                    && shannon_entropy_joined(a, b) > ENTROPY_BITS_GATE
+                {
+                    findings.push(CredentialFinding::new(CredentialKind::GenericHighEntropy, p_start, end));
+                }
+            }
+        }
+        prev = Some((start, end));
     }
 }
 
@@ -3234,32 +3391,48 @@ mod tests {
         );
     }
 
-    /// Pins the known residual documented on [`ascii_runs`]: a separator dropped
-    /// into the *middle* of a secret splits it into two sub-20-char runs and
-    /// neither is scored. Asserted as **not detected**, deliberately — a test
-    /// that documents a gap is how the gap stays visible instead of being
-    /// rediscovered by an attacker.
-    ///
-    /// The whitespace rows are the reason this is an accepted trade rather than
-    /// a regression: they are undetected on `main` too, so separator-splitting
-    /// was already fully open and a non-ASCII glyph merely joins the class. The
-    /// undivided row is the control — remove the splitter and detection returns.
-    ///
-    /// AAASM-5368 closes this for every separator class; when it lands, the
-    /// first five rows flip and this test is expected to be rewritten, not
-    /// deleted.
-    #[test]
-    fn separator_split_secret_is_a_known_residual() {
-        let scanner = CredentialScanner::new();
-        // One synthetic 24-char high-entropy secret, split after 15 chars.
-        let (head, tail) = ("Xk9!mQ2*vB7#nR4", "$wT6%zP1&");
+    // --- AAASM-5368: a secret cut in two by one separator must face the same
+    //     bar its unsplit form faces. All fixtures are synthetic. ---
 
-        for splitter in ["中", "😀", "д", " ", "\t", "\n"] {
+    /// A constructed 36-character base64 value, split into two 18-character
+    /// halves by the tests below. Not observed key material: the characters are
+    /// deliberately near-all-distinct so its entropy (5.11 bits/byte) sits
+    /// clearly above the 4.5 gate rather than straddling it, which keeps these
+    /// tests measuring the *split* rather than the gate's calibration at short
+    /// lengths. Both halves are under `BASE64_RUN_MIN_LEN`, which is what makes
+    /// it the evasion this pass closes.
+    const SPLIT_SECRET_HEAD: &str = "aB3dEf7hJk9mNp2qRs";
+    const SPLIT_SECRET_TAIL: &str = "5tUv8wXy4zC6gLhQ1V";
+
+    /// The former residual, now closed (AAASM-5368). Every row here was asserted
+    /// as **not detected** by `separator_split_secret_is_a_known_residual` until
+    /// this pass existed: a separator dropped into the middle of a secret split
+    /// it into two sub-20-character runs and neither was scored, for every
+    /// separator class including a plain space.
+    ///
+    /// Rewritten rather than deleted, so the flip is visible in one place. The
+    /// undivided row is the control — it was detected before and must stay
+    /// detected, which is what tells a reader the pass added coverage rather than
+    /// moving it.
+    #[test]
+    fn a_secret_split_by_one_separator_of_any_class_is_detected() {
+        let scanner = CredentialScanner::new();
+        let (head, tail) = (SPLIT_SECRET_HEAD, SPLIT_SECRET_TAIL);
+
+        for splitter in ["中", "😀", "д", " ", "\t", "\n", ".", ","] {
             let text = format!("log {head}{splitter}{tail} end");
+            let result = scanner.scan(&text);
             assert!(
-                scanner.scan(&text).is_clean(),
-                "residual changed for splitter {splitter:?} — if AAASM-5368 landed, update this test"
+                result
+                    .findings
+                    .iter()
+                    .any(|f| f.kind == CredentialKind::GenericHighEntropy),
+                "split secret not detected for splitter {splitter:?}: {:?}",
+                result.findings,
             );
+            let redacted = result.redact(&text);
+            assert!(!redacted.contains(head), "head survived for {splitter:?}: {redacted}");
+            assert!(!redacted.contains(tail), "tail survived for {splitter:?}: {redacted}");
         }
 
         let undivided = format!("log {head}{tail} end");

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1393,6 +1393,17 @@ fn scan_separated_hex_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
 /// `the_split_pass_owns_exactly_what_pass_3_cannot_score` pins both edges.
 const ENTROPY_REACHABLE_MIN_LEN: usize = 23;
 
+/// The joined-length window in [`scan_separated_base64_runs`] keeps pass 1's
+/// upper bound of 64 so the two cannot drift, but with both runs held under
+/// [`ENTROPY_REACHABLE_MIN_LEN`] the longest pair it can ever see is 44 — the
+/// ceiling is unreachable by construction rather than by coincidence. Asserted at
+/// compile time so that if the per-run bound is ever raised past 33 the build
+/// says so, instead of the window quietly starting to bite.
+const _: () = assert!(
+    2 * (ENTROPY_REACHABLE_MIN_LEN - 1) <= 64,
+    "the joined window's upper bound is now reachable and must be justified against pass 1's window"
+);
+
 /// Returns `true` for the characters that count as a secret-splitting separator.
 ///
 /// Whitespace and non-ASCII only — deliberately **not** ASCII punctuation.
@@ -3689,6 +3700,124 @@ mod tests {
             scanner.scan(&quartered).is_clean(),
             "a many-way split is a documented residual: {:?}",
             scanner.scan(&quartered).findings
+        );
+    }
+
+    #[test]
+    fn the_split_pass_owns_exactly_what_pass_3_cannot_score() {
+        // The band this ticket's first draft left unscored by *anybody*.
+        //
+        // Pass 3 gates a contiguous run at BASE64_RUN_MIN_LEN (20), but entropy
+        // over n bytes is at most log2(n), and log2(22) = 4.4594 is below the 4.5
+        // gate — so a run of 20, 21 or 22 characters cannot be scored by pass 3 at
+        // any content. Keying pass 5 off 20, on the reasoning that longer runs are
+        // "pass 3's to score", handed those three lengths to a pass mathematically
+        // incapable of taking them: a 40-character secret split anywhere in
+        // 17+23 … 22+18 produced zero findings with both halves in the clear.
+        //
+        // Both edges are asserted, so the constant cannot drift in either
+        // direction: 22 must still be pass 5's, and 23 must not be.
+        let below = f64::from(u32::try_from(ENTROPY_REACHABLE_MIN_LEN).unwrap() - 1);
+        assert!(
+            below.log2() <= ENTROPY_BITS_GATE,
+            "a run of {} can clear the gate alone, so pass 5 must not claim it",
+            ENTROPY_REACHABLE_MIN_LEN - 1
+        );
+        let at = f64::from(u32::try_from(ENTROPY_REACHABLE_MIN_LEN).unwrap());
+        assert!(
+            at.log2() > ENTROPY_BITS_GATE,
+            "a run of {ENTROPY_REACHABLE_MIN_LEN} cannot clear the gate, so leaving it \
+             to pass 3 leaves it to nobody"
+        );
+
+        // And the behaviour that bound produces, over the whole split sweep of a
+        // 40-character secret. Every split position must lose both halves.
+        let scanner = CredentialScanner::new();
+        let secret = "aB3dEf7hJk9mNp2qRs5tUv8wXy4zC6gLhQ1VdYtP";
+        assert_eq!(secret.len(), 40);
+        for k in 18..=22 {
+            let (a, b) = secret.split_at(k);
+            for splitter in [" ", "\t", "\n", "中"] {
+                let text = format!("log {a}{splitter}{b} end");
+                let redacted = scanner.scan(&text).redact(&text);
+                assert!(
+                    !redacted.contains(a) && !redacted.contains(b),
+                    "split {k}+{} with {splitter:?} left key material in the clear: {redacted}",
+                    40 - k
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn punctuation_joined_halves_are_left_to_pass_1_which_clamps_them() {
+        // `is_split_separator` excludes ASCII punctuation, and this is why.
+        //
+        // A pair joined by `,` sits inside one whitespace token, so pass 1 already
+        // scores it and clamps the finding at the first delimiter — the secret is
+        // reported and the neighbouring column name is left intact. Admitting
+        // punctuation into pass 5 added no detection and replaced that correctly
+        // clamped span with a wider one, because `dedupe_same_kind_overlaps` keeps
+        // the union: `replicasCount` was redacted out of both a SQL projection and
+        // a CSV row.
+        let scanner = CredentialScanner::new();
+        let run = "aB3dEf7hJk9mNp2qR";
+        for (text, expected) in [
+            (
+                format!("SELECT {run},replicasCount FROM t"),
+                "SELECT [REDACTED:GenericHighEntropy],replicasCount FROM t".to_string(),
+            ),
+            (
+                format!("{run},replicasCount,3"),
+                "[REDACTED:GenericHighEntropy],replicasCount,3".to_string(),
+            ),
+        ] {
+            assert_eq!(
+                scanner.scan(&text).redact(&text),
+                expected,
+                "adjacent structure must survive for {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_split_secret_never_consumes_the_separator_between_its_halves() {
+        // Two findings, not one span. The separator is the evasion rather than
+        // part of the secret, so it is no more part of the span than it is part of
+        // the scored string — and leaving it in place is what keeps the document
+        // around it parseable. A single joined span ate the newline out of this
+        // YAML and left a document that no longer parses.
+        let scanner = CredentialScanner::new();
+        let run = "aB3dEf7hJk9mNp2qRs5";
+        let text = format!("token: {run}\nreplicas: 3");
+        let redacted = scanner.scan(&text).redact(&text);
+        assert!(
+            redacted.contains('\n'),
+            "the newline between the two runs must survive: {redacted:?}"
+        );
+        assert_eq!(
+            redacted, "token: [REDACTED:GenericHighEntropy]\n[REDACTED:GenericHighEntropy]: 3",
+            "structure around a split finding must be preserved byte for byte"
+        );
+    }
+
+    #[test]
+    fn an_adjacent_word_shares_the_fate_of_a_split_secret() {
+        // This pass's honest limit, pinned rather than hidden.
+        //
+        // Pairwise scoring cannot attribute the joined entropy to one half, so an
+        // ordinary word next to a genuine short secret is redacted with it. That
+        // is over-redaction on a payload that did contain secret-shaped material,
+        // and what makes it tolerable is the measured firing rate — one finding
+        // across 23 MB of code — not the reasoning. Asserted so the cost is
+        // visible here rather than discovered in production.
+        let scanner = CredentialScanner::new();
+        let run = "aB3dEf7hJk9mNp2qRs5";
+        let text = format!("hardening {run} done");
+        assert_eq!(
+            scanner.scan(&text).redact(&text),
+            "[REDACTED:GenericHighEntropy] [REDACTED:GenericHighEntropy] done",
+            "if this pass learns to attribute entropy to one half, update this test"
         );
     }
 

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1380,48 +1380,74 @@ fn scan_separated_hex_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
 /// values, and entropy is at most `log2(distinct)`, so both quantities must reach
 /// 23 for 4.5 bits to be reachable. `log2(22) = 4.4594 <= 4.5 < 4.5236 = log2(23)`.
 ///
-/// This is what [`scan_separated_base64_runs`] uses to decide which runs are its
-/// business, and getting it wrong left a band that **nothing** scored. Pass 3
-/// gates a contiguous run at [`BASE64_RUN_MIN_LEN`] (20), but a run of 20, 21 or
-/// 22 characters cannot reach the entropy gate at any content — so keying pass 5
-/// off 20, on the reasoning that longer runs are "pass 3's to score", handed
-/// those three lengths to a pass that is mathematically incapable of scoring
-/// them. A 40-character secret split anywhere in 17+23 … 22+18 produced **zero**
-/// findings with both halves in the clear. Keying off 23 instead means pass 5
-/// owns exactly the runs pass 3 provably cannot, with no gap and no overlap.
-///
-/// `the_split_pass_owns_exactly_what_pass_3_cannot_score` pins both edges.
+/// Used as the floor of [`scan_separated_base64_runs`]'s joined-length window: a
+/// pair shorter than this cannot clear the gate, so scoring it is wasted work.
+/// It is **not** an admission rule for the individual runs — keying that on length
+/// was a defect, because length answers "could another pass have scored this run",
+/// and what matters is whether one *did* (see [`overlaps_earlier_finding`]).
 const ENTROPY_REACHABLE_MIN_LEN: usize = 23;
 
-/// The joined-length window in [`scan_separated_base64_runs`] keeps pass 1's
-/// upper bound of 64 so the two cannot drift, but with both runs held under
-/// [`ENTROPY_REACHABLE_MIN_LEN`] the longest pair it can ever see is 44 — the
-/// ceiling is unreachable by construction rather than by coincidence. Asserted at
-/// compile time so that if the per-run bound is ever raised past 33 the build
-/// says so, instead of the window quietly starting to bite.
-const _: () = assert!(
-    2 * (ENTROPY_REACHABLE_MIN_LEN - 1) <= 64,
-    "the joined window's upper bound is now reachable and must be justified against pass 1's window"
-);
+/// Returns `true` if any of `earlier` overlaps the byte range `start..end`.
+///
+/// [`scan_separated_base64_runs`] uses this to stay off runs another pass has
+/// already flagged, which is the bound that stops it widening a span over text
+/// beside a secret that was found without its help.
+///
+/// # Why overlap, and not a length or entropy test
+///
+/// Two wrong answers were tried. Keying on "this run is at least
+/// [`ENTROPY_REACHABLE_MIN_LEN`] long, so pass 3 will take it" is wrong because
+/// length only says pass 3 *could* have scored the run; pass 3 scores it only if
+/// it clears the gate, which a random 23-24 character run does about 5% of the
+/// time. That left a band nothing scored at all: a 40-character secret split
+/// 23+17 across one space produced zero findings with both halves in the clear,
+/// and 99.8% of such splits were fully missed at 400 trials per cell, against
+/// 1.5-2.2% for 18+22 through 22+18.
+///
+/// Testing "pass 3 did not score it" instead is closer but still wrong, because
+/// pass 3 is not the only pass that runs first. The literal detector finds
+/// `ghs_16C7e42F292c6912E7710c838347Ae178B4a` by prefix, and that run scores only
+/// 4.14 bits — below the gate — so an entropy test admits it, and joining it to
+/// the word before produced `[REDACTED] [REDACTED:GitHubAppToken]` where the
+/// pre-canonical baseline has `installation [REDACTED:GitHubAppToken]`. Asking
+/// what was *already found*, rather than what one particular pass would have
+/// found, is the property actually wanted and covers the literal, digit, email
+/// and entropy passes alike.
+fn overlaps_earlier_finding(earlier: &[CredentialFinding], start: usize, end: usize) -> bool {
+    earlier.iter().any(|f| f.offset < end && start < f.end())
+}
 
 /// Returns `true` for the characters that count as a secret-splitting separator.
 ///
 /// Whitespace and non-ASCII only — deliberately **not** ASCII punctuation.
 ///
-/// A pair of runs joined by punctuation sits inside a single whitespace token, so
-/// pass 1 already scores it: it gates the token's whole ASCII run (punctuation
-/// included) and then clamps the finding at the first delimiter via [`token_end`].
-/// `<17-char run>,replicasCount,3` is therefore already reported and already
-/// redacted to `[REDACTED:GenericHighEntropy],replicasCount,3` — correctly, with
-/// the column name intact — before this pass runs at all.
+/// # This is a measured tradeoff, not a free win
 ///
-/// Admitting punctuation here would add no detection whatsoever and would replace
-/// that correctly-clamped span with a wider one, because
-/// [`dedupe_same_kind_overlaps`] keeps the union of two same-kind spans. Measured:
-/// `SELECT <run>,replicasCount FROM t` lost `replicasCount`, and
-/// `<run>,replicasCount,3` lost it too. Restricting to whitespace and non-ASCII
-/// removes that entire class at zero recall cost, and it is also exactly the
-/// separator set the ticket names — space, tab, newline, and a non-ASCII glyph.
+/// An earlier version of this comment claimed punctuation "would add no detection
+/// whatsoever" and could be excluded "at zero recall cost". Both were false, and
+/// the measurement that disproves them is worth keeping:
+///
+/// A pair joined by punctuation does sit inside one whitespace token, and pass 1
+/// does score that token — but it then clamps the span at the first [`token_end`]
+/// delimiter. For the seven delimiters that are also base64-adjacent in real text
+/// (`,` `;` `)` `"` `'` `]` `}`), the clamp lands *before* the secret:
+/// `a,<18-char run>,<18-char run>,3` yields one finding covering the single
+/// character `a`, and **both halves of the secret survive in the clear**. Pass 1's
+/// "coverage" there is a finding pointed at the wrong bytes. For punctuation that
+/// is not a delimiter (`.` `:` `-` `/`) pass 1 does cover the whole value, so
+/// those cost nothing.
+///
+/// What excluding punctuation buys, measured over 28 MB of this repository's code
+/// and configuration: **10 genuine false positives avoided** (3 in a workflow
+/// file, 6 in dashboard end-to-end specs, 1 fabricated JWT). What it costs: a
+/// secret split by one of those seven delimiters keeps both halves, pinned by
+/// `entropy_split_by_a_token_end_delimiter_residual.json` and by
+/// `a_secret_split_by_a_token_end_delimiter_keeps_both_halves`.
+///
+/// The choice stands on those two numbers. It is **not** a regression against the
+/// merge base — behaviour on every punctuation shape is byte-identical to it — but
+/// it is a gap this pass could have closed and deliberately does not, and the
+/// underlying cause is pass 1's clamp rather than anything here.
 fn is_split_separator(c: char) -> bool {
     c.is_whitespace() || !c.is_ascii()
 }
@@ -1509,60 +1535,69 @@ fn base64_runs(text: &str) -> impl Iterator<Item = (usize, usize)> + '_ {
 ///   already applies. This is what keeps ordinary punctuated prose out: without
 ///   it, joining `RBAC/NetworkPolicy` to `hardening).` clears the gate, because a
 ///   near-all-distinct string of 27 characters scores `log2(27)` whatever it says.
-/// * **Pairs only, both below [`ENTROPY_REACHABLE_MIN_LEN`].** At most two runs
-///   are ever joined, and only when *neither* could have cleared the gate alone —
-///   which is exactly the set pass 3 cannot score, so the two passes partition the
-///   runs with no gap and no overlap. Without the second half of that condition
-///   the pass reaches past an already-detected secret into the next word:
-///   `tok=<40-char PAT> done` would redact ` done`, and a PEM body line would
-///   swallow its `-----END` marker.
+/// * **Pairs only, and only runs [`scan_long_base64_runs`] did not score.** At
+///   most two runs are ever joined, and only when neither was already flagged on
+///   its own — see [`unscored_by_the_contiguous_pass`]. That is what stops the
+///   pass reaching past an already-detected secret into the next word:
+///   `tok=<40-char PAT> done` keeps its ` done` because the PAT run scores 4.63
+///   bits and is pass 3's, and a PEM body line keeps its `-----END` for the same
+///   reason.
 /// * **A one-character gap, of a splitting character.** The evasion is the
 ///   insertion of *a* separator into a secret. A longer gap — indentation, a
 ///   paragraph break, sentence spacing — is ordinary text structure with no
-///   matching evasion story, and ASCII punctuation is excluded outright because
-///   pass 1 already covers it correctly (see [`is_split_separator`]).
+///   matching evasion story. ASCII punctuation is excluded too, for a measured
+///   reason that is **not** "it costs no recall" (see [`is_split_separator`]).
 ///
-/// Measured over 1.8 MB of this repository's English and Chinese prose, over the
-/// committed clean zh-TW corpus, and over 23 MB of its code and configuration,
-/// this pass adds **zero** prose findings and **one** code finding (a fabricated
-/// JWT in a dashboard test fixture).
+/// Measured over the committed clean zh-TW corpus (0), 1.8 MB of this repository's
+/// English and Chinese prose, and 23.6 MB of its code and configuration: this pass
+/// adds **one** false-positive pair in 25.4 MB, and loses nothing. Every other
+/// added finding is its own test literal or vector.
+///
+/// That one is `CONTRIBUTING/PR-template/DCO` joined to `wording` in a release
+/// sign-off document — 35 characters, 26 distinct, 4.615 bits. It is the cost of
+/// admitting runs of 23 and over (see [`overlaps_earlier_finding`]): a long
+/// mixed-case punctuated identifier next to a short word can reach the gate, and
+/// no cheap property separates it from a secret cut in two, because a 23-character
+/// secret fragment scores about the same. `a_long_hyphenated_identifier_beside_a_word_is_a_known_false_positive`
+/// pins it so the rate is tracked rather than rediscovered. The trade it buys is
+/// large: without that admission, 99.8% of 23+17 splits were missed entirely.
 ///
 /// # What it does and does not recover
 ///
 /// A split secret faces the same [`ENTROPY_BITS_GATE`] its unsplit form faces,
-/// applied to the same rejoined characters. It is **not** true that the outcome is
-/// identical either way: a joined pair is capped at
-/// `2 * (ENTROPY_REACHABLE_MIN_LEN - 1)` = 44 characters, so a secret of 45+
-/// characters split into two is out of this pass's reach entirely, while below
-/// that cap a rejoined pair is held to the bar an unsplit run of the same length
-/// would face.
+/// applied to the same rejoined characters — but the outcome is not identical
+/// either way, and the pass's reach is bounded by the joined window it shares with
+/// pass 1 (23-64 characters).
 ///
 /// `log2(n)` is only the *ceiling* on a run's entropy; a random base64 run's mean
 /// sits well below it (4.25 against a 4.585 ceiling at n = 24). Measured by Monte
-/// Carlo, the gate is cleared 5.4% of the time at 24 characters, 90.7% at 36 and
-/// 96.1% at 38 — so detection is real only from the low thirties upward, split or
-/// not. Pass 5 does not change that calibration; it removes the separator as a way
-/// of avoiding it.
+/// Carlo, the gate is cleared about 5% of the time at 24 characters, ~91% at 36
+/// and ~96% at 38 — so detection is real only from the low thirties upward, split
+/// or not. This pass does not change that calibration; it removes the separator as
+/// a way of avoiding it.
 ///
 /// # What is still open
 ///
-/// In order of how much they matter, because the first dominates:
+/// Measured at 400 trials per cell over random base64 secrets, "fully missed"
+/// meaning both halves left in the clear:
 ///
-/// 1. **A secret whose two pieces sum to more than 44 characters.** A 44-character
-///    base64 blob (32 random bytes) split evenly is the largest this pass can
-///    rejoin; a 45+ character secret split in two is out of reach. Such a secret is
-///    often *partly* caught — whichever piece reaches
-///    [`ENTROPY_REACHABLE_MIN_LEN`] with enough entropy is scored by pass 3 on its
-///    own — but the other piece stays in the clear. This is the dominant residual
-///    and it is not small.
-/// 2. **A gap of more than one character.**
-/// 3. **A split into pieces short enough that no adjacent pair reaches the floor.**
+/// 1. **A pair in which one run was already scored by pass 3.** The pass declines
+///    such a pair *by design* — that is the bound which stops it eating the word
+///    beside a detected secret — so the other run is left in the clear if it
+///    cannot be scored alone. A 46-character secret split 36+10 loses the 36 and
+///    keeps the 10. This is the dominant residual and it is a deliberate trade,
+///    not an oversight.
+/// 2. **A gap of more than one character**, and **ASCII punctuation gaps**, where
+///    a secret split by one of [`token_end`]'s delimiters keeps its tail (see
+///    [`is_split_separator`]).
+/// 3. **Pieces short enough that no adjacent pair reaches 23 characters**, or a
+///    pair summing past the window's 64.
 ///
-/// All three are pinned by `long_secret_split_and_wide_gaps_are_documented_residuals`
-/// so they stay visible rather than being rediscovered by an attacker. Closing (1)
-/// or (2) means joining more than two runs, or joining across arbitrary distance —
-/// the clause-swallowing shape the bounds above exist to prevent — so each needs
-/// its own false-positive measurement, not a constant nudged upward.
+/// All three are pinned by `residuals_of_the_split_pass_are_pinned`. Closing (1)
+/// means attributing entropy to one half of a pair, which pairwise scoring cannot
+/// do; closing (2) or (3) means joining more than two runs or across arbitrary
+/// distance — the clause-swallowing shape the bounds above exist to prevent. Each
+/// needs its own false-positive measurement, not a constant nudged.
 ///
 /// # The spans — two, not one
 ///
@@ -1580,31 +1615,31 @@ fn base64_runs(text: &str) -> impl Iterator<Item = (usize, usize)> + '_ {
 /// Which is this pass's honest limit. When the hypothesis is wrong — an ordinary
 /// word sitting beside a genuine short secret — that word is redacted too, because
 /// pairwise scoring cannot attribute the entropy to one half. What makes that
-/// tolerable is the firing rate rather than the reasoning: one finding across 23 MB
-/// of code. `an_adjacent_word_shares_the_fate_of_a_split_secret` pins the cost so
+/// tolerable is the firing rate rather than the reasoning: one false-positive pair
+/// across 25.4 MB of this repository's prose, code and configuration. `an_adjacent_word_shares_the_fate_of_a_split_secret` pins the cost so
 /// it is visible here rather than discovered in production.
 fn scan_separated_base64_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
+    // Everything found before this pass ran. Runs already covered by one of those
+    // findings are not this pass's to widen (see [`overlaps_earlier_finding`]).
+    let earlier = findings.len();
     let mut prev: Option<(usize, usize)> = None;
     for (start, end) in base64_runs(text) {
         if let Some((p_start, p_end)) = prev {
-            // Both runs must be short enough that neither could have cleared the
-            // entropy gate alone — see [`ENTROPY_REACHABLE_MIN_LEN`]. That is
-            // exactly the set pass 3 cannot score, so the two passes partition
-            // the runs between them with no gap and no overlap.
-            //
             // Ordered cheapest-first, and every test short-circuits. This runs
             // once per adjacent run pair, and code is dense in them — identifiers
             // are base64 runs — so an eagerly-evaluated gap decode here is
             // measurable on the synchronous enforcement path.
             let joined_len = (p_end - p_start) + (end - start);
-            if p_end - p_start < ENTROPY_REACHABLE_MIN_LEN
-                && end - start < ENTROPY_REACHABLE_MIN_LEN
-                && (ENTROPY_REACHABLE_MIN_LEN..=64).contains(&joined_len)
-                && is_one_separator(&text[p_end..start])
-            {
-                let (a, b) = (&text[p_start..p_end], &text[start..end]);
+            let (a, b) = (&text[p_start..p_end], &text[start..end]);
+            if (ENTROPY_REACHABLE_MIN_LEN..=64).contains(&joined_len) && is_one_separator(&text[p_end..start]) {
+                // The overlap test is last because it is the only O(findings) one
+                // and the gates above reject almost every pair; `earlier` is the
+                // prefix of `findings` that existed before this pass began, so a
+                // pass-5 finding never blocks the next pair in a chain.
                 if distinct_bytes(a, b) >= MIN_DISTINCT_BYTES_FOR_GATE
                     && shannon_entropy_joined(a, b) > ENTROPY_BITS_GATE
+                    && !overlaps_earlier_finding(&findings[..earlier], p_start, p_end)
+                    && !overlaps_earlier_finding(&findings[..earlier], start, end)
                 {
                     // One finding per run, never one span across the separator.
                     // The separator is the evasion, not part of the secret, so it
@@ -3680,55 +3715,26 @@ mod tests {
     }
 
     #[test]
-    fn a_run_at_the_pass_3_floor_is_not_joined_to_its_neighbour() {
-        // The constraint that keeps this pass from reaching past a secret it has
-        // already found and swallowing the next word. Both these payloads carry a
-        // run at or above `BASE64_RUN_MIN_LEN` followed by an innocent one; an
-        // earlier draft of this pass joined them and redacted ` done` and the PEM
-        // `-----END` marker along with the key. Asserted on the exact bytes,
-        // because the finding count is identical either way.
-        let scanner = CredentialScanner::new();
-
-        // The `tok=` prefix is swallowed by pass 1's whitespace-token span, which
-        // is long-standing behaviour and not this pass's to change. What matters
-        // here is the tail: ` done` is a separate run and must stay in the clear.
-        let text = "tok=ghp_abcdefABCDEF0123456789ABCDEF0123456789 done";
-        assert_eq!(
-            scanner.scan(text).redact(text),
-            "[REDACTED:GitHubPat] done",
-            "the word after an already-detected secret must survive"
-        );
-
-        let pem = "KEY=-----BEGIN EC PRIVATE KEY-----\n\
-                   MHQCAQEEIOaRgVBExLFbHznv7gHsepSPpLUFKr\n\
-                   -----END EC PRIVATE KEY-----";
-        assert!(
-            scanner.scan(pem).redact(pem).contains("-----END EC PRIVATE KEY-----"),
-            "the END marker must not be swallowed into the body span"
-        );
-    }
-
-    #[test]
-    fn long_secret_split_and_wide_gaps_are_documented_residuals() {
+    fn residuals_of_the_split_pass_are_pinned() {
         // What AAASM-5368 does **not** close, asserted as not detected so the
         // gaps stay visible instead of being rediscovered by an attacker.
         let scanner = CredentialScanner::new();
         let (head, tail) = (SPLIT_SECRET_HEAD, SPLIT_SECRET_TAIL);
 
-        // (1) The dominant residual: both runs must be under
-        // ENTROPY_REACHABLE_MIN_LEN, so a pair summing past 44 characters is out
-        // of reach. A 46-character secret split evenly is 23+23 — each half is
-        // exactly at the bar, so pass 5 declines both and pass 3 must carry them
-        // alone. Whichever half clears the gate is found; the rest is not.
-        let long_secret = "aB3dEf7hJk9mNp2qRs5tUvWxYz0C6gLhQ1VdYtPkRs4Nm2";
-        assert_eq!(long_secret.len(), 46);
-        let (a, b) = long_secret.split_at(23);
-        let text = format!("log {a} {b} end");
+        // (1) The dominant residual, and a deliberate trade. When one run was
+        // already scored by pass 3, this pass declines the pair — that bound is
+        // what stops it eating the word beside a detected secret — so the other
+        // run is left in the clear when it cannot be scored alone. Here the
+        // 36-character half is flagged and the 10-character half is not.
+        let big = "aB3dEf7hJk9mNp2qRs5tUvWxYz0C6gLhQ1Vd";
+        let small = "YtPkRs4Nm2";
+        let text = format!("log {big} {small} end");
         let redacted = scanner.scan(&text).redact(&text);
+        assert!(!redacted.contains(big), "the scored half must still go: {redacted}");
         assert!(
-            redacted.contains(a) || redacted.contains(b),
-            "a 46-character split secret is a documented residual, but neither half \
-             survived — if this pass now reaches that far, update this test: {redacted}"
+            redacted.contains(small),
+            "residual changed — if the unscored half is now caught too, this pass has \
+             learned to attribute entropy to one half of a pair; update this test: {redacted}"
         );
 
         // (2) A gap of more than one character.
@@ -3740,8 +3746,8 @@ mod tests {
             );
         }
 
-        // (3) The same 36 characters cut into four 9-character pieces: every
-        // adjacent pair is 18, below the joined-length floor.
+        // (3) Pieces short enough that no adjacent pair reaches 23 characters:
+        // the same 36 characters cut into four 9-character runs.
         let joined = format!("{head}{tail}");
         let quartered = joined
             .as_bytes()
@@ -3751,86 +3757,160 @@ mod tests {
             .join(" ");
         assert!(
             scanner.scan(&quartered).is_clean(),
-            "a many-way split is a documented residual: {:?}",
+            "a many-way split into short pieces is a documented residual: {:?}",
             scanner.scan(&quartered).findings
         );
     }
 
     #[test]
-    fn the_split_pass_owns_exactly_what_pass_3_cannot_score() {
-        // The band this ticket's first draft left unscored by *anybody*.
+    fn the_split_pass_takes_the_runs_no_earlier_pass_found() {
+        // The band that was scored by *nobody*, and the two wrong answers on the
+        // way to the right one.
         //
-        // Pass 3 gates a contiguous run at BASE64_RUN_MIN_LEN (20), but entropy
-        // over n bytes is at most log2(n), and log2(22) = 4.4594 is below the 4.5
-        // gate — so a run of 20, 21 or 22 characters cannot be scored by pass 3 at
-        // any content. Keying pass 5 off 20, on the reasoning that longer runs are
-        // "pass 3's to score", handed those three lengths to a pass mathematically
-        // incapable of taking them: a 40-character secret split anywhere in
-        // 17+23 … 22+18 produced zero findings with both halves in the clear.
+        // Keying admission on length ("23 or more is pass 3's") asks whether
+        // pass 3 *could* have scored a run. Pass 3 scores it only if it clears the
+        // gate, which a random 23-24 character run does about 5% of the time — so
+        // 95% of them were declined here and never scored there. A 40-character
+        // secret split 23+17 across one space produced zero findings with both
+        // halves in the clear; 99.8% of such splits were fully missed at 400
+        // trials per cell, against 1.5-2.2% for 18+22 through 22+18, and the total
+        // was irrelevant: at 44 characters 23+21 missed 95.2% and 22+22 missed
+        // 0.5%.
         //
-        // Both edges are asserted, so the constant cannot drift in either
-        // direction: 22 must still be pass 5's, and 23 must not be.
-        let below = f64::from(u32::try_from(ENTROPY_REACHABLE_MIN_LEN).unwrap() - 1);
-        assert!(
-            below.log2() <= ENTROPY_BITS_GATE,
-            "a run of {} can clear the gate alone, so pass 5 must not claim it",
-            ENTROPY_REACHABLE_MIN_LEN - 1
-        );
-        let at = f64::from(u32::try_from(ENTROPY_REACHABLE_MIN_LEN).unwrap());
-        assert!(
-            at.log2() > ENTROPY_BITS_GATE,
-            "a run of {ENTROPY_REACHABLE_MIN_LEN} cannot clear the gate, so leaving it \
-             to pass 3 leaves it to nobody"
+        // Keying on "pass 3 did not score it" is closer and still wrong — see
+        // `an_already_detected_secret_is_never_widened_into_its_neighbour`.
+        let scanner = CredentialScanner::new();
+
+        // The exact case the review measured as producing zero findings. Its
+        // 23-character half scores 4.4366 bits, below the gate, so no earlier pass
+        // takes it and this one must.
+        let text = "token: aB3dEf7hJk9mNp2qRs5tUva 8wXy4zC6gLhQ1VjD0 end";
+        let result = scanner.scan(text);
+        assert_eq!(
+            result.findings.len(),
+            2,
+            "the 23+17 split must now be found: {:?}",
+            result.findings
         );
 
-        // And the behaviour that bound produces, over the whole split sweep of a
-        // 40-character secret. Every split position must lose both halves.
-        let scanner = CredentialScanner::new();
+        // And the sweep. The secret is near-all-distinct, so every split of it is
+        // deterministic; the Monte Carlo figures above are what generalise it.
         let secret = "aB3dEf7hJk9mNp2qRs5tUv8wXy4zC6gLhQ1VdYtP";
         assert_eq!(secret.len(), 40);
-        for k in 18..=22 {
+        for k in 18..=30 {
             let (a, b) = secret.split_at(k);
             for splitter in [" ", "\t", "\n", "中"] {
                 let text = format!("log {a}{splitter}{b} end");
                 let redacted = scanner.scan(&text).redact(&text);
+                // Never *fully* missed — that is the metric the former defect
+                // failed, and it must hold at every split position.
                 assert!(
-                    !redacted.contains(a) && !redacted.contains(b),
-                    "split {k}+{} with {splitter:?} left key material in the clear: {redacted}",
+                    !(redacted.contains(a) && redacted.contains(b)),
+                    "split {k}+{} with {splitter:?} was fully missed: {redacted}",
                     40 - k
                 );
+                // Below 23 neither half can be scored alone, so this pass owns the
+                // pair outright and both halves must go. At and above 23 this
+                // fixture's leading half clears the gate by itself, so pass 3
+                // takes it and the tail is left — residual (1), pinned in
+                // `residuals_of_the_split_pass_are_pinned`.
+                if k < ENTROPY_REACHABLE_MIN_LEN {
+                    assert!(
+                        !redacted.contains(a) && !redacted.contains(b),
+                        "split {k}+{} with {splitter:?} left key material in the clear: {redacted}",
+                        40 - k
+                    );
+                }
             }
         }
     }
 
     #[test]
-    fn punctuation_joined_halves_are_left_to_pass_1_which_clamps_them() {
-        // `is_split_separator` excludes ASCII punctuation, and this is why.
+    fn an_already_detected_secret_is_never_widened_into_its_neighbour() {
+        // Why the admission test asks what was *already found* rather than what
+        // pass 3 would have found.
         //
-        // A pair joined by `,` sits inside one whitespace token, so pass 1 already
-        // scores it and clamps the finding at the first delimiter — the secret is
-        // reported and the neighbouring column name is left intact. Admitting
-        // punctuation into pass 5 added no detection and replaced that correctly
-        // clamped span with a wider one, because `dedupe_same_kind_overlaps` keeps
-        // the union: `replicasCount` was redacted out of both a SQL projection and
-        // a CSV row.
+        // `ghs_16C7e42F292c6912E7710c838347Ae178B4a` is caught by the literal
+        // detector, by prefix — and it scores only 4.14 bits, below the entropy
+        // gate. So a "pass 3 did not score it" test admits it, and joining it to
+        // the word before turns the pre-canonical baseline's
+        // `installation [REDACTED:GitHubAppToken]` into
+        // `[REDACTED] [REDACTED:GitHubAppToken]`, redacting an ordinary English
+        // word beside a secret that was found without this pass's help.
+        //
+        // The same property covers the entropy passes, which is what keeps
+        // `tok=<PAT> done` and a PEM block's `-----END` marker intact.
         let scanner = CredentialScanner::new();
-        let run = "aB3dEf7hJk9mNp2qR";
         for (text, expected) in [
             (
-                format!("SELECT {run},replicasCount FROM t"),
-                "SELECT [REDACTED:GenericHighEntropy],replicasCount FROM t".to_string(),
+                "installation ghs_16C7e42F292c6912E7710c838347Ae178B4a",
+                "installation [REDACTED:GitHubAppToken]".to_string(),
             ),
             (
-                format!("{run},replicasCount,3"),
-                "[REDACTED:GenericHighEntropy],replicasCount,3".to_string(),
+                "tok=ghp_abcdefABCDEF0123456789ABCDEF0123456789 done",
+                "[REDACTED:GitHubPat] done".to_string(),
             ),
         ] {
             assert_eq!(
-                scanner.scan(&text).redact(&text),
+                scanner.scan(text).redact(text),
                 expected,
-                "adjacent structure must survive for {text:?}"
+                "a neighbour was widened into for {text:?}"
             );
         }
+
+        let pem = "KEY=-----BEGIN EC PRIVATE KEY-----\n\
+                   MHQCAQEEIOaRgVBExLFbHznv7gHsepSPpLUFKr\n\
+                   -----END EC PRIVATE KEY-----";
+        assert!(
+            scanner.scan(pem).redact(pem).contains("-----END EC PRIVATE KEY-----"),
+            "the END marker must not be swallowed into the body span"
+        );
+    }
+
+    #[test]
+    fn a_secret_split_by_a_token_end_delimiter_keeps_both_halves() {
+        // The cost of excluding ASCII punctuation from `is_split_separator`,
+        // asserted rather than asserted-away. The previous test here only used
+        // benign tails, so it could not fail when the property its name claimed
+        // was broken.
+        //
+        // Pass 1 scores the whole whitespace token but clamps the span at the
+        // first `token_end` delimiter, which for these seven lands *before* the
+        // secret — the finding covers the single character `a` and both halves
+        // survive. This is byte-identical to the merge base; it is a gap this pass
+        // could close by admitting punctuation, and deliberately does not, because
+        // doing so cost 10 measured false positives across 28 MB of code.
+        let scanner = CredentialScanner::new();
+        let (head, tail) = (SPLIT_SECRET_HEAD, SPLIT_SECRET_TAIL);
+        for delimiter in [",", ";", ")", "\"", "'", "]", "}"] {
+            let text = format!("a{delimiter}{head}{delimiter}{tail}{delimiter}3");
+            let redacted = scanner.scan(&text).redact(&text);
+            assert!(
+                redacted.contains(head) && redacted.contains(tail),
+                "residual changed for {delimiter:?} — if a punctuation split is now \
+                 caught, update this test and re-measure the false-positive rate: {redacted}"
+            );
+        }
+
+        // Punctuation that is *not* a `token_end` delimiter costs nothing: pass 1
+        // covers the whole value, so excluding it here loses no detection.
+        for punctuation in [".", ":", "-", "/"] {
+            let text = format!("a{punctuation}{head}{punctuation}{tail}{punctuation}3");
+            let redacted = scanner.scan(&text).redact(&text);
+            assert!(
+                !redacted.contains(head) && !redacted.contains(tail),
+                "pass 1 must still cover a {punctuation:?}-joined secret whole: {redacted}"
+            );
+        }
+
+        // And adjacent structure is still preserved where pass 1 clamps benignly.
+        let run = "aB3dEf7hJk9mNp2qR";
+        let text = format!("SELECT {run},replicasCount FROM t");
+        assert_eq!(
+            scanner.scan(&text).redact(&text),
+            "SELECT [REDACTED:GenericHighEntropy],replicasCount FROM t",
+            "the column name must survive"
+        );
     }
 
     #[test]
@@ -3850,7 +3930,8 @@ mod tests {
         );
         assert_eq!(
             redacted, "token: [REDACTED:GenericHighEntropy]\n[REDACTED:GenericHighEntropy]: 3",
-            "structure around a split finding must be preserved byte for byte"
+            "the separator must survive; the key name shares the second run's fate, \
+             which is `an_adjacent_word_shares_the_fate_of_a_split_secret`'s subject"
         );
     }
 

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -1373,6 +1373,57 @@ fn scan_separated_hex_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
     }
 }
 
+/// Shortest run that could *possibly* clear [`ENTROPY_BITS_GATE`] on its own.
+///
+/// The same exact bound as [`MIN_DISTINCT_BYTES_FOR_GATE`], applied to length
+/// instead of to distinct bytes — a run of `n` bytes holds at most `n` distinct
+/// values, and entropy is at most `log2(distinct)`, so both quantities must reach
+/// 23 for 4.5 bits to be reachable. `log2(22) = 4.4594 <= 4.5 < 4.5236 = log2(23)`.
+///
+/// This is what [`scan_separated_base64_runs`] uses to decide which runs are its
+/// business, and getting it wrong left a band that **nothing** scored. Pass 3
+/// gates a contiguous run at [`BASE64_RUN_MIN_LEN`] (20), but a run of 20, 21 or
+/// 22 characters cannot reach the entropy gate at any content — so keying pass 5
+/// off 20, on the reasoning that longer runs are "pass 3's to score", handed
+/// those three lengths to a pass that is mathematically incapable of scoring
+/// them. A 40-character secret split anywhere in 17+23 … 22+18 produced **zero**
+/// findings with both halves in the clear. Keying off 23 instead means pass 5
+/// owns exactly the runs pass 3 provably cannot, with no gap and no overlap.
+///
+/// `the_split_pass_owns_exactly_what_pass_3_cannot_score` pins both edges.
+const ENTROPY_REACHABLE_MIN_LEN: usize = 23;
+
+/// Returns `true` for the characters that count as a secret-splitting separator.
+///
+/// Whitespace and non-ASCII only — deliberately **not** ASCII punctuation.
+///
+/// A pair of runs joined by punctuation sits inside a single whitespace token, so
+/// pass 1 already scores it: it gates the token's whole ASCII run (punctuation
+/// included) and then clamps the finding at the first delimiter via [`token_end`].
+/// `<17-char run>,replicasCount,3` is therefore already reported and already
+/// redacted to `[REDACTED:GenericHighEntropy],replicasCount,3` — correctly, with
+/// the column name intact — before this pass runs at all.
+///
+/// Admitting punctuation here would add no detection whatsoever and would replace
+/// that correctly-clamped span with a wider one, because
+/// [`dedupe_same_kind_overlaps`] keeps the union of two same-kind spans. Measured:
+/// `SELECT <run>,replicasCount FROM t` lost `replicasCount`, and
+/// `<run>,replicasCount,3` lost it too. Restricting to whitespace and non-ASCII
+/// removes that entire class at zero recall cost, and it is also exactly the
+/// separator set the ticket names — space, tab, newline, and a non-ASCII glyph.
+fn is_split_separator(c: char) -> bool {
+    c.is_whitespace() || !c.is_ascii()
+}
+
+/// Returns `true` if `gap` is exactly one [`is_split_separator`] character.
+///
+/// One decode rather than the two a `chars().count() == 1 && chars().all(..)`
+/// pair costs, because this is on the per-pair path.
+fn is_one_separator(gap: &str) -> bool {
+    let mut chars = gap.chars();
+    matches!((chars.next(), chars.next()), (Some(c), None) if is_split_separator(c))
+}
+
 /// Minimum number of distinct byte values a candidate must carry before
 /// [`ENTROPY_BITS_GATE`] can possibly be cleared.
 ///
@@ -1447,66 +1498,116 @@ fn base64_runs(text: &str) -> impl Iterator<Item = (usize, usize)> + '_ {
 ///   already applies. This is what keeps ordinary punctuated prose out: without
 ///   it, joining `RBAC/NetworkPolicy` to `hardening).` clears the gate, because a
 ///   near-all-distinct string of 27 characters scores `log2(27)` whatever it says.
-/// * **Pairs only, both below [`BASE64_RUN_MIN_LEN`].** At most two runs are ever
-///   joined, and only when *neither* could have been scored alone — which is
-///   exactly the case pass 3 cannot see. Without the second half of that
-///   condition the pass reaches past an already-detected secret into the next
-///   word: `tok=<40-char PAT> done` would redact ` done`, and a PEM body line
-///   would swallow its `-----END` marker.
-/// * **A one-character gap.** The evasion is the insertion of *a* separator into
-///   a secret. A longer gap — indentation, a paragraph break, sentence spacing —
-///   is ordinary text structure with no matching evasion story. It also bounds
-///   the span: it can cover at most one character that is not candidate material.
+/// * **Pairs only, both below [`ENTROPY_REACHABLE_MIN_LEN`].** At most two runs
+///   are ever joined, and only when *neither* could have cleared the gate alone —
+///   which is exactly the set pass 3 cannot score, so the two passes partition the
+///   runs with no gap and no overlap. Without the second half of that condition
+///   the pass reaches past an already-detected secret into the next word:
+///   `tok=<40-char PAT> done` would redact ` done`, and a PEM body line would
+///   swallow its `-----END` marker.
+/// * **A one-character gap, of a splitting character.** The evasion is the
+///   insertion of *a* separator into a secret. A longer gap — indentation, a
+///   paragraph break, sentence spacing — is ordinary text structure with no
+///   matching evasion story, and ASCII punctuation is excluded outright because
+///   pass 1 already covers it correctly (see [`is_split_separator`]).
 ///
-/// Measured over 1.8 MB of this repository's own English and Chinese prose and
-/// over the committed clean zh-TW corpus, this pass adds **zero** findings.
+/// Measured over 1.8 MB of this repository's English and Chinese prose, over the
+/// committed clean zh-TW corpus, and over 23 MB of its code and configuration,
+/// this pass adds **zero** prose findings and **one** code finding (a fabricated
+/// JWT in a dashboard test fixture).
 ///
 /// # What it does and does not recover
 ///
-/// A split secret now faces exactly the bar its unsplit form faces — no lower,
-/// which is the point, and no higher. Because [`ENTROPY_BITS_GATE`] is 4.5 bits
-/// and a random base64 run of length `n` scores about `log2(n)` minus its
-/// collisions, that bar is only really met from the low thirties upward: a random
-/// 24-character run clears it about 6% of the time whether it is split or not,
-/// rising to ~90% at 36 and ~96% at 38 (the longest a two-piece split with both
-/// halves under the floor can be). Pass 5 does not change that calibration in
-/// either direction; it removes the separator as a way of avoiding it.
+/// A split secret faces the same [`ENTROPY_BITS_GATE`] its unsplit form faces,
+/// applied to the same rejoined characters. It is **not** true that the outcome is
+/// identical either way: a joined pair is capped at
+/// `2 * (ENTROPY_REACHABLE_MIN_LEN - 1)` = 44 characters, so a secret of 45+
+/// characters split into two is out of this pass's reach entirely, while below
+/// that cap a rejoined pair is held to the bar an unsplit run of the same length
+/// would face.
+///
+/// `log2(n)` is only the *ceiling* on a run's entropy; a random base64 run's mean
+/// sits well below it (4.25 against a 4.585 ceiling at n = 24). Measured by Monte
+/// Carlo, the gate is cleared 5.4% of the time at 24 characters, 90.7% at 36 and
+/// 96.1% at 38 — so detection is real only from the low thirties upward, split or
+/// not. Pass 5 does not change that calibration; it removes the separator as a way
+/// of avoiding it.
 ///
 /// # What is still open
 ///
-/// A gap of more than one character, and a split into pieces small enough that no
-/// *adjacent pair* reaches [`BASE64_RUN_MIN_LEN`] — a three-way split of a long
-/// secret is still caught pairwise, a many-way split into short pieces is not.
-/// Both are pinned by `multi_character_gaps_and_many_way_splits_are_documented_residuals`
-/// so they stay visible rather than being rediscovered by an attacker. Widening
-/// either is a measurable follow-on, not a free change — it is precisely the
-/// multi-fragment join the three properties above exist to prevent.
+/// In order of how much they matter, because the first dominates:
 ///
-/// # The span
+/// 1. **A secret whose two pieces sum to more than 44 characters.** A 44-character
+///    base64 blob (32 random bytes) split evenly is the largest this pass can
+///    rejoin; a 45+ character secret split in two is out of reach. Such a secret is
+///    often *partly* caught — whichever piece reaches
+///    [`ENTROPY_REACHABLE_MIN_LEN`] with enough entropy is scored by pass 3 on its
+///    own — but the other piece stays in the clear. This is the dominant residual
+///    and it is not small.
+/// 2. **A gap of more than one character.**
+/// 3. **A split into pieces short enough that no adjacent pair reaches the floor.**
 ///
-/// `[first run start, second run end)` — both runs and the one separator between
-/// them, following [`scan_separated_hex_runs`], which likewise spans its internal
-/// separators. Unlike pass 1 there is no [`token_end`] clamp: the candidate
-/// deliberately spans a separator, so clamping at the first delimiter could
-/// truncate the span *inside the first run* and leave secret material in the
-/// clear. The compact-JSON tail that clamp exists for is covered by pass 3.
+/// All three are pinned by `long_secret_split_and_wide_gaps_are_documented_residuals`
+/// so they stay visible rather than being rediscovered by an attacker. Closing (1)
+/// or (2) means joining more than two runs, or joining across arbitrary distance —
+/// the clause-swallowing shape the bounds above exist to prevent — so each needs
+/// its own false-positive measurement, not a constant nudged upward.
+///
+/// # The spans — two, not one
+///
+/// A qualifying pair emits **one finding per run**, never a single span across the
+/// separator. The separator is the evasion rather than part of the secret, which is
+/// why it is excluded from the scored string; it is excluded from the span for the
+/// same reason, and leaving it in place is what keeps the surrounding document
+/// intact. A single joined span redacted the newline out of
+/// `token: <run>\nreplicas: 3` and left invalid YAML behind.
+///
+/// This differs from [`scan_separated_hex_runs`], which does span its internal
+/// separators. It can afford to: 64 hex digits grouped by `:` are unambiguously one
+/// value, whereas a pair joined across whitespace is a *hypothesis* about two runs.
+///
+/// Which is this pass's honest limit. When the hypothesis is wrong — an ordinary
+/// word sitting beside a genuine short secret — that word is redacted too, because
+/// pairwise scoring cannot attribute the entropy to one half. What makes that
+/// tolerable is the firing rate rather than the reasoning: one finding across 23 MB
+/// of code. `an_adjacent_word_shares_the_fate_of_a_split_secret` pins the cost so
+/// it is visible here rather than discovered in production.
 fn scan_separated_base64_runs(text: &str, findings: &mut Vec<CredentialFinding>) {
     let mut prev: Option<(usize, usize)> = None;
     for (start, end) in base64_runs(text) {
         if let Some((p_start, p_end)) = prev {
-            // Both runs must fall *below* pass 3's floor. A run at or above it is
-            // pass 3's to score, and joining it to its neighbour would pull
-            // ordinary text into the span — the clause-swallowing shape this pass
-            // must not reproduce.
-            let both_below_floor = p_end - p_start < BASE64_RUN_MIN_LEN && end - start < BASE64_RUN_MIN_LEN;
-            if both_below_floor && text[p_end..start].chars().count() == 1 {
+            // Both runs must be short enough that neither could have cleared the
+            // entropy gate alone — see [`ENTROPY_REACHABLE_MIN_LEN`]. That is
+            // exactly the set pass 3 cannot score, so the two passes partition
+            // the runs between them with no gap and no overlap.
+            //
+            // Ordered cheapest-first, and every test short-circuits. This runs
+            // once per adjacent run pair, and code is dense in them — identifiers
+            // are base64 runs — so an eagerly-evaluated gap decode here is
+            // measurable on the synchronous enforcement path.
+            let joined_len = (p_end - p_start) + (end - start);
+            if p_end - p_start < ENTROPY_REACHABLE_MIN_LEN
+                && end - start < ENTROPY_REACHABLE_MIN_LEN
+                && (ENTROPY_REACHABLE_MIN_LEN..=64).contains(&joined_len)
+                && is_one_separator(&text[p_end..start])
+            {
                 let (a, b) = (&text[p_start..p_end], &text[start..end]);
-                let joined_len = (p_end - p_start) + (end - start);
-                if (BASE64_RUN_MIN_LEN..=64).contains(&joined_len)
-                    && distinct_bytes(a, b) >= MIN_DISTINCT_BYTES_FOR_GATE
+                if distinct_bytes(a, b) >= MIN_DISTINCT_BYTES_FOR_GATE
                     && shannon_entropy_joined(a, b) > ENTROPY_BITS_GATE
                 {
-                    findings.push(CredentialFinding::new(CredentialKind::GenericHighEntropy, p_start, end));
+                    // One finding per run, never one span across the separator.
+                    // The separator is the evasion, not part of the secret, so it
+                    // is no more part of the *span* than it is part of the scored
+                    // string — and leaving it in place is what keeps the
+                    // surrounding document intact. A single joined span redacted
+                    // the newline out of `token: <run>\nreplicas: 3` and left
+                    // invalid YAML behind.
+                    findings.push(CredentialFinding::new(
+                        CredentialKind::GenericHighEntropy,
+                        p_start,
+                        p_end,
+                    ));
+                    findings.push(CredentialFinding::new(CredentialKind::GenericHighEntropy, start, end));
                 }
             }
         }
@@ -3404,11 +3505,9 @@ mod tests {
     const SPLIT_SECRET_HEAD: &str = "aB3dEf7hJk9mNp2qRs";
     const SPLIT_SECRET_TAIL: &str = "5tUv8wXy4zC6gLhQ1V";
 
-    /// The former residual, now closed (AAASM-5368). Every row here was asserted
-    /// as **not detected** by `separator_split_secret_is_a_known_residual` until
-    /// this pass existed: a separator dropped into the middle of a secret split
-    /// it into two sub-20-character runs and neither was scored, for every
-    /// separator class including a plain space.
+    /// The former residual, now closed (AAASM-5368). Every whitespace and
+    /// non-ASCII row here was asserted as **not detected** by
+    /// `separator_split_secret_is_a_known_residual` until this pass existed.
     ///
     /// Rewritten rather than deleted, so the flip is visible in one place. The
     /// undivided row is the control — it was detected before and must stay
@@ -3419,7 +3518,8 @@ mod tests {
         let scanner = CredentialScanner::new();
         let (head, tail) = (SPLIT_SECRET_HEAD, SPLIT_SECRET_TAIL);
 
-        for splitter in ["中", "😀", "д", " ", "\t", "\n", ".", ","] {
+        // Pass 5's separators: whitespace and non-ASCII. Both halves must go.
+        for splitter in ["中", "😀", "д", " ", "\t", "\n"] {
             let text = format!("log {head}{splitter}{tail} end");
             let result = scanner.scan(&text);
             assert!(
@@ -3434,6 +3534,29 @@ mod tests {
             assert!(!redacted.contains(head), "head survived for {splitter:?}: {redacted}");
             assert!(!redacted.contains(tail), "tail survived for {splitter:?}: {redacted}");
         }
+
+        // ASCII punctuation is deliberately *not* a pass-5 separator: it leaves
+        // both halves inside one whitespace token, which pass 1 owns. `.` is not a
+        // `token_end` delimiter, so pass 1 covers the whole value on its own.
+        let text = format!("log {head}.{tail} end");
+        let redacted = scanner.scan(&text).redact(&text);
+        assert!(!redacted.contains(head) && !redacted.contains(tail), "{redacted}");
+
+        // `,` *is* a `token_end` delimiter, so pass 1 detects the token and then
+        // clamps the span at the comma, leaving the tail in the clear. That is
+        // pre-existing behaviour of pass 1 on `main` — verified identical at the
+        // merge base — and is not this pass's to change: `token_end`'s delimiter
+        // set is shared with the literal detector and every conformance vector
+        // that depends on it. Pinned here as a known residual so the asymmetry
+        // between `.` and `,` is recorded rather than mistaken for coverage.
+        let text = format!("log {head},{tail} end");
+        let redacted = scanner.scan(&text).redact(&text);
+        assert!(!redacted.contains(head), "head must still be redacted: {redacted}");
+        assert!(
+            redacted.contains(tail),
+            "residual changed: pass 1's clamp used to leak the tail after a comma — \
+             if that is now fixed, update this test: {redacted}"
+        );
 
         let undivided = format!("log {head}{tail} end");
         assert!(
@@ -3453,11 +3576,11 @@ mod tests {
         for (text, expected) in [
             (
                 format!("log {SPLIT_SECRET_HEAD} {SPLIT_SECRET_TAIL} end"),
-                "log [REDACTED:GenericHighEntropy] end".to_string(),
+                "log [REDACTED:GenericHighEntropy] [REDACTED:GenericHighEntropy] end".to_string(),
             ),
             (
                 format!("log {SPLIT_SECRET_HEAD}中{SPLIT_SECRET_TAIL} end"),
-                "log [REDACTED:GenericHighEntropy] end".to_string(),
+                "log [REDACTED:GenericHighEntropy]中[REDACTED:GenericHighEntropy] end".to_string(),
             ),
         ] {
             let redacted = scanner.scan(&text).redact(&text);
@@ -3522,23 +3645,29 @@ mod tests {
     }
 
     #[test]
-    fn multi_character_gaps_and_many_way_splits_are_documented_residuals() {
-        // What AAASM-5368 does **not** close, asserted as not detected so the gap
-        // stays visible instead of being rediscovered by an attacker.
-        //
-        // A gap of two characters is a genuine text boundary rather than an
-        // inserted separator, and a split into pieces short enough that no
-        // adjacent pair reaches `BASE64_RUN_MIN_LEN` leaves nothing for a pairwise
-        // rule to score. Closing either means joining more than two runs, which is
-        // the clause-swallowing shape this pass is built to avoid — so widening
-        // needs its own false-positive measurement, not a one-line change here.
+    fn long_secret_split_and_wide_gaps_are_documented_residuals() {
+        // What AAASM-5368 does **not** close, asserted as not detected so the
+        // gaps stay visible instead of being rediscovered by an attacker.
         let scanner = CredentialScanner::new();
         let (head, tail) = (SPLIT_SECRET_HEAD, SPLIT_SECRET_TAIL);
 
-        // Only gaps that break pass 1's whitespace token are residuals. A gap of
-        // ASCII punctuation (`..`) leaves the two halves inside one token, and
-        // pass 1 scores that token whole — so punctuation gaps of any length are
-        // already covered and are not listed here.
+        // (1) The dominant residual: both runs must be under
+        // ENTROPY_REACHABLE_MIN_LEN, so a pair summing past 44 characters is out
+        // of reach. A 46-character secret split evenly is 23+23 — each half is
+        // exactly at the bar, so pass 5 declines both and pass 3 must carry them
+        // alone. Whichever half clears the gate is found; the rest is not.
+        let long_secret = "aB3dEf7hJk9mNp2qRs5tUvWxYz0C6gLhQ1VdYtPkRs4Nm2";
+        assert_eq!(long_secret.len(), 46);
+        let (a, b) = long_secret.split_at(23);
+        let text = format!("log {a} {b} end");
+        let redacted = scanner.scan(&text).redact(&text);
+        assert!(
+            redacted.contains(a) || redacted.contains(b),
+            "a 46-character split secret is a documented residual, but neither half \
+             survived — if this pass now reaches that far, update this test: {redacted}"
+        );
+
+        // (2) A gap of more than one character.
         for gap in ["  ", " \n", "中文", " \t", "\n\n"] {
             let text = format!("log {head}{gap}{tail} end");
             assert!(
@@ -3547,8 +3676,8 @@ mod tests {
             );
         }
 
-        // The same 36 characters cut into four 9-character pieces: every adjacent
-        // pair is 18, below the floor.
+        // (3) The same 36 characters cut into four 9-character pieces: every
+        // adjacent pair is 18, below the joined-length floor.
         let joined = format!("{head}{tail}");
         let quartered = joined
             .as_bytes()

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2181,6 +2181,197 @@ mod tests {
         }
     }
 
+    // --- AAASM-5364: the full-width hyphen (U+FF0D) and the ideographic space
+    //     (U+3000) are what a CJK input method emits for the hyphen and space
+    //     keys, so they must separate digits exactly as their ASCII twins do.
+    //     All fixtures are synthetic. ---
+
+    #[test]
+    fn detects_an_ssn_grouped_by_the_fullwidth_hyphen() {
+        // The case AAASM-5345 left open: it normalised the digits, but `is_ssn`
+        // still demanded ASCII hyphens, so a wholly full-width SSN — what a
+        // full-width IME actually produces — read as an ungrouped 9-digit run
+        // and was not SSN-shaped at all.
+        let scanner = CredentialScanner::new();
+        let ascii = scanner.scan("ssn=123-45-6789");
+        let fullwidth = scanner.scan("ssn=１２３－４５－６７８９");
+
+        let kinds = |r: &ScanResult| r.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>();
+        assert_eq!(kinds(&ascii), vec![CredentialKind::SsnPattern]);
+        assert_eq!(kinds(&fullwidth), kinds(&ascii));
+    }
+
+    #[test]
+    fn detects_an_ssn_whose_digits_are_ascii_but_whose_hyphens_are_not() {
+        // The cheapest form of the evasion, and the one a user reaches by
+        // accident: ASCII digits typed with the IME still in full-width mode, so
+        // only the two separators differ from the detected form.
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan("ssn=123－45－6789");
+        assert_eq!(
+            result.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>(),
+            vec![CredentialKind::SsnPattern],
+        );
+    }
+
+    #[test]
+    fn detects_a_card_grouped_by_the_ideographic_space() {
+        // The space-grouped card form. Grouping is how card numbers are written
+        // on the card itself, so this is the *natural* rendering rather than an
+        // adversarial one — and U+3000 is what the space bar emits in full-width
+        // mode.
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan("card=４５３２　０１５１　１２８３　０３６６");
+        assert_eq!(
+            result.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>(),
+            vec![CredentialKind::CreditCardLuhn],
+        );
+    }
+
+    #[test]
+    fn redacts_fullwidth_separated_values_to_exact_bytes() {
+        // Counting findings is not enough: a separator is three bytes here
+        // against ASCII's one, so an end offset computed on the normalised form
+        // splices the wrong region — one finding, digits still in the clear.
+        let scanner = CredentialScanner::new();
+        for (text, expected) in [
+            ("ssn=１２３－４５－６７８９", "ssn=[REDACTED:SsnPattern]"),
+            ("ssn=123－45－6789", "ssn=[REDACTED:SsnPattern]"),
+            (
+                "card=４５３２　０１５１　１２８３　０３６６",
+                "card=[REDACTED:CreditCardLuhn]",
+            ),
+        ] {
+            let redacted = scanner.scan(text).redact(text);
+            assert_eq!(redacted, expected, "wrong redaction for {text:?}");
+            assert!(contains_no_digit(&redacted), "residual digits: {redacted}");
+        }
+    }
+
+    #[test]
+    fn fullwidth_separated_spans_are_char_boundaries_of_the_original_text() {
+        // The span contract `redact` depends on, asserted directly. A separator
+        // is the newest way for an offset to land mid-character, since it is the
+        // one part of the segment whose normalised width (1 byte) differs from
+        // its original width (3 bytes) *and* which the walk may or may not
+        // consume depending on what follows it.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "ssn=１２３－４５－６７８９",
+            "ssn=123－45－6789",
+            "card=４５３２　０１５１　１２８３　０３６６",
+        ] {
+            let result = scanner.scan(text);
+            assert!(!result.findings.is_empty(), "no finding for {text:?}");
+            for f in &result.findings {
+                assert!(
+                    text.is_char_boundary(f.offset),
+                    "offset {} splits a character in {text:?}",
+                    f.offset
+                );
+                assert!(
+                    text.is_char_boundary(f.end),
+                    "end {} splits a character in {text:?}",
+                    f.end
+                );
+                // The span must cover the whole value, not a prefix of it.
+                assert!(contains_no_digit(&text[..f.offset]));
+                assert!(contains_no_digit(&text[f.end..]));
+            }
+        }
+    }
+
+    #[test]
+    fn does_not_flag_a_fullwidth_separated_number_that_fails_luhn() {
+        // Widening what reaches the checksum must not weaken the checksum. The
+        // final digit is altered from the detected form above, so the only
+        // difference between this and a reported card is the Luhn result.
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan("num=４５３２　０１５１　１２８３　０３６７");
+        assert!(
+            !result.findings.iter().any(|f| f.kind == CredentialKind::CreditCardLuhn),
+            "Luhn gate must reject a full-width-separated number too: {:?}",
+            result.findings,
+        );
+    }
+
+    #[test]
+    fn a_grouped_19_digit_card_still_fits_the_segment_budget_in_full_width() {
+        // `DIGIT_SEGMENT_MAX_CHARS` is 24 because the binding case is a 19-digit
+        // card written in groups of four — 19 digits plus 4 separators, 23
+        // characters. That arithmetic is in *characters*, so it has to survive
+        // separators that are three bytes each, not just digits that are. A
+        // budget accidentally counted in bytes would truncate this segment
+        // one-third of the way in and lose the card entirely.
+        //
+        // The 19-digit number is Luhn-valid by construction, not observed.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "card=4532-0151-1283-0366-500",
+            "card=４５３２－０１５１－１２８３－０３６６－５００",
+            "card=４５３２　０１５１　１２８３　０３６６　５００",
+        ] {
+            let result = scanner.scan(text);
+            assert_eq!(
+                result.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>(),
+                vec![CredentialKind::CreditCardLuhn],
+                "grouped 19-digit card must fit the segment budget: {text:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn digit_separator_boundary_declines_en_dash_and_nbsp() {
+        // Pins the boundary [`ascii_separator_of`] documents, so the decision is
+        // visible rather than implicit. U+2013 (en dash) and U+00A0 (no-break
+        // space) are *not* separators: no input method emits either for the
+        // hyphen or space key, so admitting them would buy no coverage against
+        // the input-mode evasion while adding runs for the Luhn check to trip
+        // over — the en dash being the standard glyph for a numeric range, i.e.
+        // exactly where two unrelated numbers sit adjacent with a dash between.
+        //
+        // Asserted as **not detected**, deliberately. If a payload is ever
+        // observed using one of these, widen `ascii_separator_of` and rewrite
+        // this test — do not delete it.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "card=4532\u{2013}0151\u{2013}1283\u{2013}0366",
+            "card=4532\u{00A0}0151\u{00A0}1283\u{00A0}0366",
+            "ssn=123\u{2013}45\u{2013}6789",
+            "ssn=123\u{00A0}45\u{00A0}6789",
+        ] {
+            assert!(
+                scanner.scan(text).is_clean(),
+                "separator set widened past its stated boundary for {text:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn fullwidth_separators_do_not_flag_ordinary_cjk_prose() {
+        // The false-positive guard the widened separator set needs. Dates,
+        // phone numbers, ranges and identifiers written with U+FF0D and U+3000
+        // are ordinary content in Traditional-Chinese and Japanese documents —
+        // they are, in fact, *more* common than the SSN this rule exists to
+        // catch. Every line below now reaches the joined-segment path that only
+        // ASCII text reached before, and must still produce nothing.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "報表期間　２０２４－０１－０１　至　２０２４－１２－３１，共 365 天。",
+            "聯絡電話　０２－１２３４－５６７８，分機 21。",
+            "發票號碼　ＡＢ－１２３４５６７８，金額 1,250 元。",
+            "會議時間　１０：００－１１：３０，地點　Ｂ棟　３０５　會議室。",
+            "版本區間　１．０．０－２．３．４，共 12 個修訂。",
+        ] {
+            let result = scanner.scan(text);
+            assert!(
+                result.is_clean(),
+                "clean CJK prose produced {:?} for {text:?}",
+                result.findings.iter().map(|f| f.kind.as_str()).collect::<Vec<_>>(),
+            );
+        }
+    }
+
     #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2631,6 +2631,13 @@ mod tests {
             "發票號碼　ＡＢ－１２３４５６７８，金額 1,250 元。",
             "會議時間　１０：００－１１：３０，地點　Ｂ棟　３０５　會議室。",
             "版本區間　１．０．０－２．３．４，共 12 個修訂。",
+            // A 16-digit identifier in 4x4 groups — the only shape in this list
+            // that reaches the 13-19 digit Luhn window at all. The lines above
+            // are 4-2-2, 2-4-4 and dotted-version shapes that can never get
+            // there, so without this row the widened separator set is never
+            // exercised against the checksum in prose at all.
+            "轉帳帳號　１２３４　５６７８　９０１２　３４５６，於今日入帳。",
+            "轉帳帳號　１２３４－５６７８－９０１２－３４５６，於今日入帳。",
         ] {
             let result = scanner.scan(text);
             assert!(
@@ -2638,6 +2645,52 @@ mod tests {
                 "clean CJK prose produced {:?} for {text:?}",
                 result.findings.iter().map(|f| f.kind.as_str()).collect::<Vec<_>>(),
             );
+        }
+    }
+
+    #[test]
+    fn a_fullwidth_grouped_number_gets_exactly_the_ascii_verdict() {
+        // The cost side of AAASM-5364, asserted rather than left to the PR.
+        //
+        // Widening the separator set gives a full-width, separator-grouped
+        // 13-19 digit run its first chance to reach the Luhn check — and Luhn is
+        // a mod-10 checksum, so roughly one in ten arbitrary 16-digit numbers
+        // passes it by coincidence. Measured over 100,000 random 4x4 groupings:
+        // 10.209% for full-width digits with U+3000, 10.209% with U+FF0D, and
+        // 10.209% for the ASCII forms — identical, because the digit stream is
+        // identical once normalised. That parity is the ticket's goal.
+        //
+        // What parity does not settle is *who* pays it: full-width digits come
+        // from CJK input methods, so the whole of that new false-positive mass
+        // lands on CJK users, under `credential_action: Block`. That trade is an
+        // owner decision and is recorded on AAASM-5364; what this test can pin is
+        // the mechanism — a grouped number must get exactly the verdict its ASCII
+        // twin gets, never a different one, in either direction.
+        let scanner = CredentialScanner::new();
+        let verdict = |t: &str| {
+            scanner
+                .scan(t)
+                .findings
+                .iter()
+                .any(|f| f.kind == CredentialKind::CreditCardLuhn)
+        };
+        for (ascii, fullwidth_space, fullwidth_hyphen) in [
+            // Luhn-valid (a synthetic Visa test number).
+            (
+                "n=4532 0151 1283 0366",
+                "n=４５３２　０１５１　１２８３　０３６６",
+                "n=４５３２－０１５１－１２８３－０３６６",
+            ),
+            // Luhn-invalid: an ordinary 16-digit reference number.
+            (
+                "n=1234 5678 9012 3456",
+                "n=１２３４　５６７８　９０１２　３４５６",
+                "n=１２３４－５６７８－９０１２－３４５６",
+            ),
+        ] {
+            let expected = verdict(ascii);
+            assert_eq!(verdict(fullwidth_space), expected, "U+3000 diverged for {ascii:?}");
+            assert_eq!(verdict(fullwidth_hyphen), expected, "U+FF0D diverged for {ascii:?}");
         }
     }
 

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -3973,6 +3973,56 @@ mod tests {
             at.log2() > ENTROPY_BITS_GATE,
             "the fast path is looser than it needs to be at {MIN_DISTINCT_BYTES_FOR_GATE}",
         );
+        // The arithmetic above is independent of the code, so on its own it
+        // cannot fail when the comparison is wrong: mutating `>=` to `>` survived
+        // the entire suite while changing a verdict. This pair joins to exactly
+        // MIN_DISTINCT_BYTES_FOR_GATE distinct bytes and scores 4.5236 bits, just
+        // over the gate — so it is found iff the boundary is inclusive.
+        let scanner = CredentialScanner::new();
+        let text = "log aB3dEf7hJk9m Np2qRs5tUvW end";
+        let joined = "aB3dEf7hJk9mNp2qRs5tUvW";
+        assert_eq!(
+            u32::try_from(joined.bytes().collect::<std::collections::BTreeSet<_>>().len()).unwrap(),
+            MIN_DISTINCT_BYTES_FOR_GATE,
+            "fixture no longer sits exactly on the boundary"
+        );
+        assert!(
+            shannon_entropy(joined) > ENTROPY_BITS_GATE,
+            "fixture must clear the gate, or it pins nothing"
+        );
+        let result = scanner.scan(text);
+        assert_eq!(
+            result.findings.len(),
+            2,
+            "a pair with exactly {MIN_DISTINCT_BYTES_FOR_GATE} distinct bytes must be found: {:?}",
+            result.findings
+        );
+    }
+
+    #[test]
+    fn a_long_hyphenated_identifier_beside_a_word_is_a_known_false_positive() {
+        // The one false positive this pass adds, pinned rather than left silent.
+        //
+        // Measured across 25.4 MB of this repository's prose, code and
+        // configuration, this is the only genuine one: a release sign-off document
+        // in which `CONTRIBUTING/PR-template/DCO` (28 characters) sits beside
+        // `wording`, joining to 35 characters with 26 distinct bytes and 4.615
+        // bits. It appeared when admission stopped being a length comparison, and
+        // it is the price of that: without admitting runs of 23 and over, 99.8% of
+        // 23+17 secret splits were missed entirely.
+        //
+        // No cheap property separates it from a secret cut in two — a 23-character
+        // secret fragment scores about the same — so closing it means a new gate
+        // with its own calibration, not a constant nudged. Asserted as **detected**
+        // so the rate is tracked; if it is ever fixed, this test should fail.
+        let scanner = CredentialScanner::new();
+        let text = "internal doc-link check, CONTRIBUTING/PR-template/DCO wording, and release-process updates.";
+        let result = scanner.scan(text);
+        assert!(
+            !result.is_clean(),
+            "the known false positive stopped firing — if this pass was tightened, \
+             re-measure the corpus and update the rate quoted on it"
+        );
     }
 
     #[test]

--- a/conformance/vectors/credential_detection/entropy_already_detected_secret_keeps_its_neighbour.json
+++ b/conformance/vectors/credential_detection/entropy_already_detected_secret_keeps_its_neighbour.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5368: the split rule must not widen a span over a secret an earlier pass already found. This GitHub App token is caught by the literal detector by prefix, and its run scores only 4.14 bits — below the entropy gate — so a rule keyed on 'the contiguous base64 pass did not score this' would admit it and join it to the word before, redacting the ordinary English word 'installation'. Asking instead what was already found covers the literal, digit, email and entropy passes alike, and is what keeps this vector, the pre-canonical golden baseline, a trailing word after a GitHub PAT, and a PEM block's END marker intact.",
+  "input_text": "installation ghs_16C7e42F292c6912E7710c838347Ae178B4a",
+  "expected_findings": [
+    { "kind": "GitHubAppToken", "offset": 13 }
+  ],
+  "expected_redacted": "installation [REDACTED:GitHubAppToken]"
+}

--- a/conformance/vectors/credential_detection/entropy_false_positive_en_prose_joined_clean.json
+++ b/conformance/vectors/credential_detection/entropy_false_positive_en_prose_joined_clean.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5368 negative: ordinary English technical prose that a weaker form of the split rule reported as a leaked secret. Both clauses here were measured false positives when the joined candidate was allowed to contain punctuation: a near-all-distinct string of 27 to 35 characters scores about log2(n) bits whatever it says, so mixed-case technical English cleared the 4.5-bit gate on length alone. Restricting the candidate to the base64 alphabet is what excludes them, and it is the only thing that does — the entropy gate cannot separate these from key material at this length. Measured over 1.8 MB of this repository's English and Chinese prose, the pass adds zero findings; these clauses are the ones a weaker rule added.",
+  "input_text": "upgrades, RBAC/NetworkPolicy hardening). Those remain SaaS surface. The value is replaced with a `[REDACTED:<kind>]` placeholder and the request continues",
+  "expected_findings": [],
+  "expected_redacted": "upgrades, RBAC/NetworkPolicy hardening). Those remain SaaS surface. The value is replaced with a `[REDACTED:<kind>]` placeholder and the request continues"
+}

--- a/conformance/vectors/credential_detection/entropy_false_positive_zh_tw_fullwidth_separators_clean.json
+++ b/conformance/vectors/credential_detection/entropy_false_positive_zh_tw_fullwidth_separators_clean.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5364 negative: clean Traditional-Chinese prose whose numbers are written with U+FF0D and U+3000 — a date range, a phone number with an extension and a version range. These are ordinary content in zh-TW and ja documents and are far more common there than the SSN the widened separator set exists to catch, so they are the false-positive class the widening risks. Every line reaches the joined-segment walk that only ASCII-separated text reached before this ticket, and each joined run is an independent chance of a coincidental Luhn pass; none may be reported.",
+  "input_text": "報表期間　２０２４－０１－０１　至　２０２４－１２－３１，共 365 天。 聯絡電話　０２－１２３４－５６７８，分機 21。 版本區間　１．０．０－２．３．４，共 12 個修訂。",
+  "expected_findings": [],
+  "expected_redacted": "報表期間　２０２４－０１－０１　至　２０２４－１２－３１，共 365 天。 聯絡電話　０２－１２３４－５６７８，分機 21。 版本區間　１．０．０－２．３．４，共 12 個修訂。"
+}

--- a/conformance/vectors/credential_detection/entropy_split_23_plus_17_detected.json
+++ b/conformance/vectors/credential_detection/entropy_split_23_plus_17_detected.json
@@ -1,0 +1,9 @@
+{
+  "description": "AAASM-5368: a 40-character secret split 23+17, the case an earlier form of this rule missed entirely. That version declined any run of 23 or more on the reasoning that the contiguous base64 rule would score it — but that rule scores a run only when it clears the entropy gate, which a random 23-24 character run does about 5% of the time. The 23-character half here scores 4.4366 bits, below the gate, so no earlier pass took it and the split rule declined it: zero findings, both halves in the clear. Measured at 400 trials per cell, 99.8% of 23+17 splits were fully missed, against 1.5-2.2% for 18+22 through 22+18, and the total length was irrelevant - at 44 characters, 23+21 missed 95.2% while 22+22 missed 0.5%. Admission now asks what an earlier pass actually found rather than what one particular pass might have found.",
+  "input_text": "token: aB3dEf7hJk9mNp2qRs5tUva 8wXy4zC6gLhQ1VjD0 end",
+  "expected_findings": [
+    { "kind": "GenericHighEntropy", "offset": 7 },
+    { "kind": "GenericHighEntropy", "offset": 31 }
+  ],
+  "expected_redacted": "token: [REDACTED:GenericHighEntropy] [REDACTED:GenericHighEntropy] end"
+}

--- a/conformance/vectors/credential_detection/entropy_split_across_newline_keeps_the_newline.json
+++ b/conformance/vectors/credential_detection/entropy_split_across_newline_keeps_the_newline.json
@@ -1,0 +1,9 @@
+{
+  "description": "AAASM-5368: a secret split across a newline in a YAML document. The pair is scored, because a newline is a splitting separator, but the two runs are reported as two findings that bracket the newline rather than one span covering it. The expected output pins that the newline and the following key survive: a single joined span redacted them together and left invalid YAML behind, which is the same clause-swallowing failure AAASM-5344 was opened to fix, reached by a different route.",
+  "input_text": "token: aB3dEf7hJk9mNp2qRs5\nreplicas: 3",
+  "expected_findings": [
+    { "kind": "GenericHighEntropy", "offset": 7 },
+    { "kind": "GenericHighEntropy", "offset": 27 }
+  ],
+  "expected_redacted": "token: [REDACTED:GenericHighEntropy]\n[REDACTED:GenericHighEntropy]: 3"
+}

--- a/conformance/vectors/credential_detection/entropy_split_by_a_token_end_delimiter_residual.json
+++ b/conformance/vectors/credential_detection/entropy_split_by_a_token_end_delimiter_residual.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5368 negative, and the measured cost of excluding ASCII punctuation from the split rule. A secret cut by a comma is deliberately NOT rejoined, and this vector records what that costs rather than asserting it away. The whitespace-token pass does score this token, but it clamps the span at the first token_end delimiter, which here lands before the secret — the single finding covers the leading character 'a' and both 18-character halves survive in the clear. The same holds for the other six delimiters that are base64-adjacent in real text: semicolon, close paren, double quote, single quote, close bracket and close brace. Punctuation that is not a delimiter (period, colon, hyphen, slash) is covered whole by the whitespace-token pass and costs nothing. Admitting punctuation into the split rule would close this, and was measured to produce 10 genuine false positives across 28 MB of this repository's code and configuration - 3 in a workflow file, 6 in dashboard end-to-end specs and 1 fabricated JWT - which is why it is declined. This is byte-identical to the merge base; the underlying cause is the clamp, not the split rule. If the clamp is ever tightened, add a vector rather than editing this one.",
+  "input_text": "a,aB3dEf7hJk9mNp2qRs,5tUv8wXy4zC6gLhQ1V,3",
+  "expected_findings": [
+    { "kind": "GenericHighEntropy", "offset": 0 }
+  ],
+  "expected_redacted": "[REDACTED:GenericHighEntropy],aB3dEf7hJk9mNp2qRs,5tUv8wXy4zC6gLhQ1V,3"
+}

--- a/conformance/vectors/credential_detection/entropy_split_by_ideographic_space_detected.json
+++ b/conformance/vectors/credential_detection/entropy_split_by_ideographic_space_detected.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5368: the same split secret cut by U+3000 IDEOGRAPHIC SPACE inside Traditional-Chinese prose. A non-ASCII glyph in the middle of a secret is the specific residual AAASM-5344 left behind when it made non-ASCII a run boundary, and it is the case where the span is least likely to survive: the separator is three bytes, so the reported end offset is 39 bytes past a start that is itself 15 bytes into multi-byte text. The surrounding prose must be returned untouched — a span that swallowed the clause would be the AAASM-5344 defect returning by another route.",
+  "input_text": "授權標頭：aB3dEf7hJk9mNp2qRs　5tUv8wXy4zC6gLhQ1V，請儘速處理。",
+  "expected_findings": [
+    { "kind": "GenericHighEntropy", "offset": 15 }
+  ],
+  "expected_redacted": "授權標頭：[REDACTED:GenericHighEntropy]，請儘速處理。"
+}

--- a/conformance/vectors/credential_detection/entropy_split_by_ideographic_space_detected.json
+++ b/conformance/vectors/credential_detection/entropy_split_by_ideographic_space_detected.json
@@ -1,8 +1,9 @@
 {
-  "description": "AAASM-5368: the same split secret cut by U+3000 IDEOGRAPHIC SPACE inside Traditional-Chinese prose. A non-ASCII glyph in the middle of a secret is the specific residual AAASM-5344 left behind when it made non-ASCII a run boundary, and it is the case where the span is least likely to survive: the separator is three bytes, so the reported end offset is 39 bytes past a start that is itself 15 bytes into multi-byte text. The surrounding prose must be returned untouched — a span that swallowed the clause would be the AAASM-5344 defect returning by another route.",
+  "description": "AAASM-5368: the same split secret cut by U+3000 IDEOGRAPHIC SPACE inside Traditional-Chinese prose. A non-ASCII glyph in the middle of a secret is the specific residual AAASM-5344 left behind when it made non-ASCII a run boundary, and it is the case where the spans are least likely to survive: the separator is three bytes, so the second finding's offset is 36 bytes into multi-byte text. The three-byte separator is preserved in the output — the two findings bracket it rather than covering it — which is what keeps the surrounding clause intact. A span that swallowed the clause would be the AAASM-5344 defect returning by another route.",
   "input_text": "授權標頭：aB3dEf7hJk9mNp2qRs　5tUv8wXy4zC6gLhQ1V，請儘速處理。",
   "expected_findings": [
-    { "kind": "GenericHighEntropy", "offset": 15 }
+    { "kind": "GenericHighEntropy", "offset": 15 },
+    { "kind": "GenericHighEntropy", "offset": 36 }
   ],
-  "expected_redacted": "授權標頭：[REDACTED:GenericHighEntropy]，請儘速處理。"
+  "expected_redacted": "授權標頭：[REDACTED:GenericHighEntropy]　[REDACTED:GenericHighEntropy]，請儘速處理。"
 }

--- a/conformance/vectors/credential_detection/entropy_split_by_space_detected.json
+++ b/conformance/vectors/credential_detection/entropy_split_by_space_detected.json
@@ -1,8 +1,9 @@
 {
-  "description": "AAASM-5368: a 36-character base64 secret cut in two by a single space. Each half is 18 characters, under the 20-character floor pass 3 gates a contiguous base64 run at, so neither half was scored and the whole secret passed through — separator-splitting defeated the length gate on main for every separator class at once, a plain space included. Scored as the rejoined run, excluding the separator, exactly as AAASM-4075's separator-grouped hex rule counts only hex digits. The span covers both halves and the separator between them. The secret is constructed with near-all-distinct characters so its entropy sits clearly above the 4.5 gate rather than straddling it; a genuinely random 36-character run clears that gate about 90% of the time whether split or not, and this ticket does not change that calibration in either direction.",
+  "description": "AAASM-5368: a 36-character base64 secret cut in two by a single space. Each half is 18 characters, short enough that neither can reach the entropy gate alone (entropy over n bytes is at most log2(n), and log2(22) = 4.4594 is below the 4.5 gate), so neither half was scored and the whole secret passed through — separator-splitting defeated the length gate on main for every separator class at once, a plain space included. Scored as the rejoined runs, excluding the separator, as AAASM-4075's separator-grouped hex rule counts only hex digits. Two findings rather than one: the separator is the evasion rather than part of the secret, so it is excluded from the spans exactly as it is excluded from the scored string, and the surrounding text keeps its structure. The secret is constructed with near-all-distinct characters so its entropy sits clearly above the gate rather than straddling it; a genuinely random 36-character run clears that gate about 90% of the time whether split or not, and this ticket does not change that calibration in either direction.",
   "input_text": "authorization: aB3dEf7hJk9mNp2qRs 5tUv8wXy4zC6gLhQ1V trailing",
   "expected_findings": [
-    { "kind": "GenericHighEntropy", "offset": 15 }
+    { "kind": "GenericHighEntropy", "offset": 15 },
+    { "kind": "GenericHighEntropy", "offset": 34 }
   ],
-  "expected_redacted": "authorization: [REDACTED:GenericHighEntropy] trailing"
+  "expected_redacted": "authorization: [REDACTED:GenericHighEntropy] [REDACTED:GenericHighEntropy] trailing"
 }

--- a/conformance/vectors/credential_detection/entropy_split_by_space_detected.json
+++ b/conformance/vectors/credential_detection/entropy_split_by_space_detected.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5368: a 36-character base64 secret cut in two by a single space. Each half is 18 characters, under the 20-character floor pass 3 gates a contiguous base64 run at, so neither half was scored and the whole secret passed through — separator-splitting defeated the length gate on main for every separator class at once, a plain space included. Scored as the rejoined run, excluding the separator, exactly as AAASM-4075's separator-grouped hex rule counts only hex digits. The span covers both halves and the separator between them. The secret is constructed with near-all-distinct characters so its entropy sits clearly above the 4.5 gate rather than straddling it; a genuinely random 36-character run clears that gate about 90% of the time whether split or not, and this ticket does not change that calibration in either direction.",
+  "input_text": "authorization: aB3dEf7hJk9mNp2qRs 5tUv8wXy4zC6gLhQ1V trailing",
+  "expected_findings": [
+    { "kind": "GenericHighEntropy", "offset": 15 }
+  ],
+  "expected_redacted": "authorization: [REDACTED:GenericHighEntropy] trailing"
+}

--- a/conformance/vectors/credential_detection/entropy_split_by_two_spaces_residual.json
+++ b/conformance/vectors/credential_detection/entropy_split_by_two_spaces_residual.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5368 negative: the same secret cut by TWO spaces is deliberately NOT detected, and this vector exists so that residual stays visible rather than being rediscovered by an attacker. The rule joins a pair of runs across a gap of exactly one character, because the evasion is the insertion of a separator into a secret whereas a longer gap — indentation, a paragraph break, sentence spacing — is ordinary text structure. Closing it means joining across arbitrary gaps, which is the clause-swallowing shape that produced the 87 false findings AAASM-5344 fixed, so widening needs its own false-positive measurement rather than a one-line change. If it is ever closed, add a vector rather than editing this one.",
+  "input_text": "authorization: aB3dEf7hJk9mNp2qRs  5tUv8wXy4zC6gLhQ1V trailing",
+  "expected_findings": [],
+  "expected_redacted": "authorization: aB3dEf7hJk9mNp2qRs  5tUv8wXy4zC6gLhQ1V trailing"
+}

--- a/conformance/vectors/credential_detection/entropy_split_in_the_unscorable_band.json
+++ b/conformance/vectors/credential_detection/entropy_split_in_the_unscorable_band.json
@@ -1,9 +1,15 @@
 {
-  "description": "AAASM-5368: a 40-character secret split 20+20, the band that no pass could score. Entropy over n bytes is at most log2(n), and log2(22) = 4.4594 is below the 4.5 gate, so a contiguous run of 20, 21 or 22 characters cannot be scored by the contiguous base64 rule at any content — while an earlier form of the split rule declined runs of 20 or more on the reasoning that they were the contiguous rule's to score. A 40-character secret split anywhere from 17+23 to 22+18 therefore produced zero findings with both halves in the clear. Keying the split rule off 23 instead of 20 makes the two rules partition the runs with no gap and no overlap. This vector sits in the middle of that former dead band.",
+  "description": "AAASM-5368: a 40-character secret split 20+20, inside the band that no pass could score. Entropy over n bytes is at most log2(n), and log2(22) = 4.4594 is below the 4.5 gate, so a contiguous run of 20, 21 or 22 characters cannot be scored by the contiguous base64 rule at any content — while an earlier form of the split rule declined runs of 20 or more on the reasoning that they were the contiguous rule's to score, leaving those three lengths to nobody. Raising that cutoff to 23 was only a partial fix and its claim of a clean partition was wrong: length says whether the contiguous rule *could* have scored a run, not whether it *did*, and a random 23-24 character run clears the gate only about 5% of the time. Admission now asks whether an earlier pass actually produced a finding overlapping the run, which covers the literal, digit, email and entropy passes alike. See entropy_split_23_plus_17_detected.json for the case the length cutoff still missed.",
   "input_text": "authorization: aB3dEf7hJk9mNp2qRs5t Uv8wXy4zC6gLhQ1VdYtP end",
   "expected_findings": [
-    { "kind": "GenericHighEntropy", "offset": 15 },
-    { "kind": "GenericHighEntropy", "offset": 36 }
+    {
+      "kind": "GenericHighEntropy",
+      "offset": 15
+    },
+    {
+      "kind": "GenericHighEntropy",
+      "offset": 36
+    }
   ],
   "expected_redacted": "authorization: [REDACTED:GenericHighEntropy] [REDACTED:GenericHighEntropy] end"
 }

--- a/conformance/vectors/credential_detection/entropy_split_in_the_unscorable_band.json
+++ b/conformance/vectors/credential_detection/entropy_split_in_the_unscorable_band.json
@@ -1,0 +1,9 @@
+{
+  "description": "AAASM-5368: a 40-character secret split 20+20, the band that no pass could score. Entropy over n bytes is at most log2(n), and log2(22) = 4.4594 is below the 4.5 gate, so a contiguous run of 20, 21 or 22 characters cannot be scored by the contiguous base64 rule at any content — while an earlier form of the split rule declined runs of 20 or more on the reasoning that they were the contiguous rule's to score. A 40-character secret split anywhere from 17+23 to 22+18 therefore produced zero findings with both halves in the clear. Keying the split rule off 23 instead of 20 makes the two rules partition the runs with no gap and no overlap. This vector sits in the middle of that former dead band.",
+  "input_text": "authorization: aB3dEf7hJk9mNp2qRs5t Uv8wXy4zC6gLhQ1VdYtP end",
+  "expected_findings": [
+    { "kind": "GenericHighEntropy", "offset": 15 },
+    { "kind": "GenericHighEntropy", "offset": 36 }
+  ],
+  "expected_redacted": "authorization: [REDACTED:GenericHighEntropy] [REDACTED:GenericHighEntropy] end"
+}

--- a/conformance/vectors/credential_detection/entropy_split_preserves_adjacent_structure.json
+++ b/conformance/vectors/credential_detection/entropy_split_preserves_adjacent_structure.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5368: the split rule must not destroy the document around what it finds. Two shapes that an earlier form of the rule damaged. In the SQL projection the two runs are joined by a comma, which is NOT a splitting separator: punctuation leaves both halves inside one whitespace token, so the whitespace-token pass already scores it and clamps the span at the first delimiter, keeping the column name intact — admitting punctuation into the split rule added no detection and replaced that correctly clamped span with a wider one, redacting replicasCount. In the YAML the two runs are joined by a newline, which IS a splitting separator, so the pair is scored — but as two findings rather than one span across the separator, because the separator is the evasion rather than part of the secret. A single joined span redacted the newline and left a document that no longer parses.",
+  "input_text": "SELECT aB3dEf7hJk9mNp2qR,replicasCount FROM t",
+  "expected_findings": [
+    { "kind": "GenericHighEntropy", "offset": 7 }
+  ],
+  "expected_redacted": "SELECT [REDACTED:GenericHighEntropy],replicasCount FROM t"
+}

--- a/conformance/vectors/credential_detection/pii_credit_card_ideographic_space.json
+++ b/conformance/vectors/credential_detection/pii_credit_card_ideographic_space.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5364: the Visa test number of pii_credit_card.json written in full-width digits and grouped by U+3000 IDEOGRAPHIC SPACE, which is what the space bar emits in full-width mode. Grouping in fours is how a card number is printed on the card itself, so the grouped rendering is the natural one; before this ticket only the ungrouped full-width form was detected. Sixteen 3-byte digits plus three 3-byte separators, so the span is 57 bytes for a 19-character value.",
+  "input_text": "card=４５３２　０１５１　１２８３　０３６６",
+  "expected_findings": [
+    { "kind": "CreditCardLuhn", "offset": 5 }
+  ],
+  "expected_redacted": "card=[REDACTED:CreditCardLuhn]"
+}

--- a/conformance/vectors/credential_detection/pii_en_dash_separator_declined.json
+++ b/conformance/vectors/credential_detection/pii_en_dash_separator_declined.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5364 negative: the same Visa test number grouped by U+2013 EN DASH is deliberately NOT detected. U+2010-U+2015 and U+00A0 were considered and declined when the separator set was widened: no input method emits them for the hyphen or space key, so they buy no coverage against the input-mode evasion the ticket closes, while each admitted separator lengthens the run digit_segment joins and adds an independent chance of a coincidental Luhn pass. The en dash is the standard glyph for a numeric range (1990-2000), i.e. exactly where two unrelated numbers sit adjacent with a dash between them. This vector pins the chosen boundary so the decision is visible rather than implicit; if a payload is ever observed using it, widen ascii_separator_of and add a new vector rather than editing this one.",
+  "input_text": "card=4532–0151–1283–0366",
+  "expected_findings": [],
+  "expected_redacted": "card=4532–0151–1283–0366"
+}

--- a/conformance/vectors/credential_detection/pii_fullwidth_grouped_reference_number_clean.json
+++ b/conformance/vectors/credential_detection/pii_fullwidth_grouped_reference_number_clean.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5364: a 16-digit reference number written in full-width digits and grouped in fours by U+3000, inside ordinary Traditional-Chinese prose. This is the only shape in the zh-TW negative vectors that reaches the 13-19 digit Luhn window at all — the date, phone and version shapes are 4-2-2, 2-4-4 and dotted, and can never get there, so without this vector the widened separator set is never exercised against the checksum in prose. It is Luhn-invalid and must stay clean. Disclosure, because the vector cannot show it: Luhn is a mod-10 checksum, so roughly one arbitrary 16-digit number in ten passes by coincidence. Measured over 100,000 random 4x4 groupings the rate is 10.209% for full-width with U+3000, 10.209% with U+FF0D, and 10.209% for the ASCII forms — exact parity, which is this ticket's goal, but it is new false-positive mass that falls entirely on CJK input-method users since only they produce full-width digits.",
+  "input_text": "轉帳帳號　１２３４　５６７８　９０１２　３４５６，於今日入帳。",
+  "expected_findings": [],
+  "expected_redacted": "轉帳帳號　１２３４　５６７８　９０１２　３４５６，於今日入帳。"
+}

--- a/conformance/vectors/credential_detection/pii_fullwidth_separators_fail_luhn.json
+++ b/conformance/vectors/credential_detection/pii_fullwidth_separators_fail_luhn.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5364 negative: a full-width, ideographic-space-grouped number whose final digit is altered from pii_credit_card_ideographic_space.json fails the Luhn checksum and must not be reported. Widening what reaches the checksum must not weaken the checksum — the only difference between this vector and the detected one is the checksum result, so a fix that flagged separator-grouped runs on shape alone fails here and nowhere else.",
+  "input_text": "card=４５３２　０１５１　１２８３　０３６７",
+  "expected_findings": [],
+  "expected_redacted": "card=４５３２　０１５１　１２８３　０３６７"
+}

--- a/conformance/vectors/credential_detection/pii_ssn_fullwidth_hyphen.json
+++ b/conformance/vectors/credential_detection/pii_ssn_fullwidth_hyphen.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5364: the documentation SSN of pii_ssn.json written entirely in full-width form — full-width digits grouped by U+FF0D FULLWIDTH HYPHEN-MINUS. This is what a CJK input method in full-width mode actually produces when the hyphen key is pressed, so it is the form a Taiwanese or Japanese user types by default rather than an adversarial one. AAASM-5345 normalised the digits but is_ssn still demanded ASCII hyphens, so this read as an ungrouped nine-digit run and was not SSN-shaped at all. Every character of the value is three bytes, so the offset stays in original-text bytes while the exact-11-byte shape check runs against the normalised string.",
+  "input_text": "ssn=１２３－４５－６７８９",
+  "expected_findings": [
+    { "kind": "SsnPattern", "offset": 4 }
+  ],
+  "expected_redacted": "ssn=[REDACTED:SsnPattern]"
+}

--- a/conformance/vectors/credential_detection/pii_ssn_fullwidth_hyphen_ascii_digits.json
+++ b/conformance/vectors/credential_detection/pii_ssn_fullwidth_hyphen_ascii_digits.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5364: the mixed case — ASCII digits typed with the input method still in full-width mode, so only the two separators differ from pii_ssn.json. It is the cheapest form of the evasion and the one a user reaches by accident, and it is the least uniform span in the suite: nine 1-byte digits interleaved with two 3-byte separators, so an end offset derived from the normalised 11-byte string lands four bytes short of the value.",
+  "input_text": "ssn=123－45－6789",
+  "expected_findings": [
+    { "kind": "SsnPattern", "offset": 4 }
+  ],
+  "expected_redacted": "ssn=[REDACTED:SsnPattern]"
+}


### PR DESCRIPTION
## Description

**This PR now carries AAASM-5368 only, in intent.** AAASM-5364 was approved separately and is split out to **#1917**, cherry-picked unchanged onto current `main`.

> ⚠️ **The four AAASM-5364 commits are still physically present in this branch.** Removing them needs a history rewrite (rebase + force-push), which I will not do without Bryant's explicit per-operation approval. Two clean options, both his call: merge #1917 first and force-push this branch to drop the duplicates, or close this PR in favour of a fresh 5368-only branch (which would lose three rounds of review thread). Until then, read this PR's 5368 content from the commit list below. This is flagged rather than worked around.

**AAASM-5368.** Pass 3 gates a contiguous base64 run at 20 characters, so a secret cut in two by a space, tab, newline or non-ASCII glyph cleared neither half of the bar and was not scored. Separator-splitting was a fully open evasion of the length gate on `main`, for every separator class at once. A new pass 5 scores an adjacent **pair** of base64 runs joined across a single separator character — `scan_separated_hex_runs` (AAASM-4075) applied to the entropy gate rather than to a hex-digit count, which is the generalisation the ticket pointed at.

## What the third review round changed

**B1 — the admission test was asking the wrong question, twice.**

Keying admission on *length* ("a run of 23+ is pass 3's to score") asks whether pass 3 **could** have scored a run. Pass 3 scores it only if it clears the entropy gate, which a random 23–24 character run does about 5% of the time. So 95% of them were declined here and never scored there:

| total | 18+22 … 22+18 | **23+17** | 24+16 | 25+15 |
|---|---|---|---|---|
| 40 | 1.5–2.2% missed | **99.8% fully missed** | 95.8% | 97.8% |

and the cap had nothing to do with the total — at 44 characters, `23+21` missed 95.2% while `22+22` missed 0.5%.

The review proposed testing "pass 3 did not score it". **Measurement shows that is still wrong**, and this is the one place I pushed back with evidence: pass 3 is not the only pass that runs first. `ghs_16C7e42F292c6912E7710c838347Ae178B4a` is found by the **literal** detector by prefix, and its run scores only **4.14 bits** — below the gate — so an entropy test admits it, joins it to the word before, and turns the pre-canonical golden baseline's `installation [REDACTED:GitHubAppToken]` into `[REDACTED] [REDACTED:GitHubAppToken]`. That is a regression on committed data, caught by `scanner_output_is_byte_identical_to_the_pre_canonical_baseline`.

The property actually wanted is **"no earlier pass already found this run"**, which covers the literal, digit, email and entropy passes alike. It is checked last (the only O(findings) test) against the prefix of `findings` that existed before pass 5 began, so a pass-5 finding never blocks the next pair in a chain.

Result, 400 trials per cell: **23+17 goes from 99.8% missed to 2.8%**, `23+21` at total 44 from 95.2% to **0.0%**, and every cell from 18+22 to 30+10 is now ≤2.8% — the residual being the entropy gate's own calibration, not a structural band.

**B2 — the "no recall cost" justification was false, though the decision stands.**

Confirmed and reproduced, and it is worse than I described. For the seven `token_end` delimiters (`,` `;` `)` `"` `'` `]` `}`), pass 1's clamp lands *before* the secret: `a,<18-char run>,<18-char run>,3` yields one finding covering the single character `a`, and **both halves survive in the clear**. Pass 1's "coverage" there is a finding pointed at the wrong bytes. For non-delimiters (`.` `:` `-` `/`) pass 1 does cover the whole value, so those cost nothing.

So `is_split_separator`'s claims that punctuation "would add no detection whatsoever" and could be excluded "at zero recall cost" are **retracted**. The choice stands on the measured trade instead: excluding punctuation avoids **10 genuine false positives across 28 MB** of code, and costs the tail of a secret split by one of those seven delimiters. It is **not** a regression against the merge base — behaviour on every punctuation shape is byte-identical. `punctuation_joined_halves_are_left_to_pass_1_which_clamps_them` only tested benign tails and so could not fail when the property it named was broken; it is replaced by `a_secret_split_by_a_token_end_delimiter_keeps_both_halves`, which asserts the leak, plus a residual vector.

**SF1 — a test that pinned nothing.** `the_distinct_byte_fast_path_cannot_change_a_verdict` asserted only `log2` arithmetic, which is independent of the code: mutating `>=` to `>` survived all 319 tests *and* changed a verdict. A behavioural case now uses a pair joining to exactly 23 distinct bytes at 4.5236 bits. That mutation is killed.

**SF2 and the nits.** The "one fabricated JWT" figure was measured before punctuation was excluded and is corrected. The false "no gap and no overlap" claim is gone from the code **and** from the vector description that had inherited it. The residual list led with a mis-stated dominant entry (wrong condition *and* wrong outcome) and now leads with the real one. `10.209%` is quoted as "about 10%" with both samples (10.209% and 9.957%). The "preserved byte for byte" assertion message overstated — the YAML *key* shares the second run's fate — and now says so.

## The honest cost of B1

B1's widening is not free, and the AC "no new false positives" is now violated by exactly one. Measured per-offset across 25.4 MB:

| Corpus | Selection | Before | After |
|---|---|---|---|
| `zh_tw_clean_prose.txt` | committed fixture | 0 | **0** |
| `mixed_zh_tw_32kb_clean` | fixture repeated past 32 KB | 0 | **0** |
| Prose, 183 files / 1.8 MB | `docs/`, `design/`, `.ai/`, `policy-examples/` + 5 root files; `md,txt,rst` | 130 | **132** |
| Code + config, 2,443 files / 23.6 MB | repo root; 29 code/config extensions; `target/`, `node_modules/`, dotdirs, symlinks skipped | 10,770 | **10,782** |

10 findings added, **0 removed**. Eight are this PR's own vector literals. The other two are one pair: **`CONTRIBUTING/PR-template/DCO` beside `wording`** in a release sign-off doc — 35 characters, 26 distinct, 4.615 bits. A long mixed-case punctuated identifier next to a short word can reach the gate, and no cheap property separates it from a secret cut in two, because a 23-character secret fragment scores about the same.

It is pinned as **detected** by `a_long_hyphenated_identifier_beside_a_word_is_a_known_false_positive`, so the rate is tracked rather than rediscovered. **The trade — one false positive per 25 MB of prose against closing a band where 99.8% of 23+17 splits were missed — is the reviewer's and Bryant's to accept, not mine to decide silently.** Tightening it means a new gate with its own calibration, not a constant nudged.

## Measured latency

Release build, min of 40 after warmup, best of 3 rounds:

| payload | without pass 5 | with | delta |
|---|---|---|---|
| zh-TW prose 32 KB | 387.6 µs | 409.7 µs | +5.7% |
| Rust code 32 KB | 510.4 µs | 556.7 µs | **+9.1%** |
| code 1 MiB | 18.6 ms | 20.8 ms | **+11.5%** |
| tool call 150 B | 1.3 µs | 1.4 µs | noise |

Consistent with the review's independent +10.4% / +6.3%. The +124% figure from the first round is **not** reproducible and should not be quoted — it was corpus-specific.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Additive detection only. No `CredentialKind` variant added, renamed or reordered — the frozen `/api/v1/scrub/patterns` contract is untouched. No schema, API or redaction-label change.

## Related Issues

- Related Jira ticket: [AAASM-5368](https://lightning-dust-mite.atlassian.net/browse/AAASM-5368) (Epic [AAASM-5270](https://lightning-dust-mite.atlassian.net/browse/AAASM-5270), Wave 1b)
- [AAASM-5364](https://lightning-dust-mite.atlassian.net/browse/AAASM-5364) split out to #1917.

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

`cargo nextest run -p aa-security -p conformance` → **320 passed, 0 failed**. All in the **default** profile. Clippy `-D warnings` exits 0; `cargo fmt --check` clean. Each commit checked out individually and green.

### Residuals, pinned rather than implied

1. **A pair in which one run was already found.** Declined *by design* — that bound is what stops the pass eating the word beside a detected secret — so the other run is left in the clear when it cannot be scored alone. A 46-character secret split 36+10 loses the 36 and keeps the 10. Dominant, and a deliberate trade.
2. **A gap of more than one character**, and **ASCII punctuation gaps** (above).
3. **Pieces short enough that no adjacent pair reaches 23**, or a pair summing past the window's 64.

### Mutation evidence

| # | Mutation | Verdict |
|---|---|---|
| 1 | Disable the pass | **KILLED** — 3 tests |
| 2 | **B1 regression**: back to the length comparison | **KILLED** — 23+17 sweep |
| 3 | **B1 regression**: drop the overlap bound entirely | **KILLED** — golden-baseline test |
| 4 | **B2 regression**: admit ASCII punctuation | **KILLED** — delimiter-leak test |
| 5 | **B2 regression**: one joined span across the separator | **KILLED** — YAML + exact-bytes |
| 6 | Join across a gap of any length | **KILLED** — residuals |
| 7 | **SF1**: make the distinct bound exclusive (`>=` → `>`) | **KILLED** — new behavioural case |
| 8 | Raise the distinct fast path above the gate's bound | **KILLED** — fast-path property |
| 9–12 | (conformance) 1, 2, 3, 4 against the vector suite | **KILLED** |

**12/12 killed.** Mutations 2, 3, 4 and 7 exist because this review round found them; 7 previously survived.

### ADR 0015

17 vectors, **all `A`**. The intersection of "vectors present at the merge base" with "vectors this branch touches" is **empty**; `--diff-filter=DR` is 0. Five vectors added earlier in this same PR were revised in later commits — this PR's own unmerged additions, not the established suite, flagged explicitly.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)

### Commits — AAASM-5368

| Commit | |
|---|---|
| `97052db4c` 🐛 Score a base64 run cut in two by a single separator | round 1 |
| `443c8ff4b` ✅ Pin the split-secret bar, its three bounds, and the prose that broke a weaker rule | round 1 |
| `2e5b64048` ✅ (conformance) Pin split-secret detection and the one-character-gap boundary | round 1 |
| `507a6ccf4` 🐛 Give the split pass the runs pass 3 cannot score, and stop it eating their neighbours | round 2 |
| `f54248dcf` ✅ Pin the unscorable band, the structure preserved, and the cost | round 2 |
| `d6a45e29a` ✅ (conformance) Pin the unscorable band and the structure a split finding must leave | round 2 |
| `daac6801f` 🐛 Admit the runs no earlier pass found, not the runs pass 3 might have | round 3 |
| `2dc572aee` ✅ (conformance) Pin the 23+17 split, the already-found run, and the punctuation cost | round 3 |
| `96eaf3137` ✅ Make the distinct-byte test behavioural, and pin the one false positive | round 3 |

`ba976c33e`, `8d1b83d78`, `3948c08c1` and `6c3c0b2ea` are AAASM-5364's and belong to #1917 — see the note at the top.


[AAASM-5368]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ