### PR TITLE
[AAASM-5356] ✨ (aa-api): Add the additive sensitive_data_disposition field

### DIFF
--- a/aa-api/src/models/disposition.rs
+++ b/aa-api/src/models/disposition.rs
@@ -187,6 +187,18 @@ impl SensitiveDataDisposition {
     /// `allow`-implying values) are ordered by declaration. The tie-break is
     /// arbitrary *and harmless*: either winner yields the same verdict, so no
     /// coarse reader can tell which was picked.
+    ///
+    /// # `require_approval` outranking `approval_granted`
+    ///
+    /// Taken on its own that pair looks like the mistake this module avoids
+    /// elsewhere: reporting `pending` for an action that completed is as wrong
+    /// as mapping `none` to `allow`. It is defused by the two values being
+    /// mutually exclusive on one record rather than by the ranking — a record
+    /// says the action was *held awaiting* a decision or that a human *made*
+    /// one, never both, because the second supersedes the first on the same
+    /// action. If a caller ever does hold both, the ordering here is the
+    /// deliberate one: `pending` over-reports restrictiveness, and
+    /// over-reporting is the safe direction for a reporting field.
     fn precedence(self) -> u8 {
         match self {
             // Adds nothing, so it loses to everything that does.
@@ -289,9 +301,23 @@ mod tests {
         }
     }
 
-    /// How restrictive a coarse verdict is, on ADR 0018's own
-    /// least-to-most-restrictive ordering, with "no verdict at all" below
+    /// How restrictive a coarse verdict is, with "no verdict at all" below
     /// `allow`.
+    ///
+    /// # This ranking is AAASM-5356's, not ADR 0018's
+    ///
+    /// ADR 0018 *lists* the five variants and calls them ordered
+    /// least-to-most restrictive, but it states no ranking this test could
+    /// inherit, and its declaration order carries no serialized meaning. The
+    /// numbers below are a judgment made here, and the debatable one is
+    /// `pending` (4) above `scrub` (3): a held action has not happened yet,
+    /// whereas a scrubbed one was carried out with a transformed payload, so
+    /// `pending` is treated as the more restrictive outcome.
+    ///
+    /// Nothing outside this test depends on it. It exists to check that
+    /// [`precedence`](SensitiveDataDisposition::precedence) is monotone in
+    /// restrictiveness — if the ranking here were wrong, the failure mode is a
+    /// property test that is too strict or too lax, never a wrong wire value.
     ///
     /// Wildcard-free on purpose: this is a second place a sixth `RuntimeVerdict`
     /// variant would stop the build, which matters because the disposition
@@ -358,12 +384,22 @@ mod tests {
         }
     }
 
-    /// An unrecognised spelling is refused rather than defaulted.
+    /// `Deserialize` refuses an unrecognised spelling rather than defaulting to
+    /// `none` — a fallback would turn a read error into a record that looks
+    /// like it had nothing to report.
     ///
-    /// A disposition that fell back to `none` on an unknown label would turn a
-    /// read error into a record that looks like it had nothing to report.
+    /// # What this does *not* say about the shipped read path
+    ///
+    /// This is a property of the impl, not of every caller. The audit-log
+    /// reader in `routes::agents::entry_to_decision_row` deliberately swallows
+    /// the error with `.ok()` and records the disposition as **absent**, so
+    /// after AAASM-5356 "absent" means *nothing was recorded* **or** *this
+    /// build could not parse what was*. That cost is bounded — the verdict is
+    /// parsed independently and stays authoritative — and it is pinned by
+    /// `an_unparseable_disposition_reads_as_absent_rather_than_failing_the_row`
+    /// rather than left to this test to imply.
     #[test]
-    fn an_unknown_spelling_is_refused() {
+    fn an_unknown_spelling_is_refused_by_deserialize() {
         assert!(serde_json::from_str::<SensitiveDataDisposition>(r#""quarantine""#).is_err());
         assert!(serde_json::from_str::<SensitiveDataDisposition>(r#""Redact""#).is_err());
         assert!(serde_json::from_str::<SensitiveDataDisposition>(r#""requireApproval""#).is_err());

--- a/aa-api/src/models/disposition.rs
+++ b/aa-api/src/models/disposition.rs
@@ -229,3 +229,285 @@ impl SensitiveDataDisposition {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every disposition ADR 0032 §10 D-2 defines, in the order it lists them.
+    ///
+    /// Spelled out because Rust has no variant reflection. On its own this array
+    /// is exactly the trap AAASM-5384 documented — a ninth variant would simply
+    /// not be *mentioned* here, the list would still be eight long, and every
+    /// assertion below would still pass. [`variant_index`] is what stops that.
+    const DISPOSITIONS_IN_ADR_0032_ORDER: [SensitiveDataDisposition; 8] = [
+        SensitiveDataDisposition::Redact,
+        SensitiveDataDisposition::Mask,
+        SensitiveDataDisposition::Tokenize,
+        SensitiveDataDisposition::RequireApproval,
+        SensitiveDataDisposition::ApprovalGranted,
+        SensitiveDataDisposition::ApprovalDenied,
+        SensitiveDataDisposition::ShadowOnly,
+        SensitiveDataDisposition::None,
+    ];
+
+    /// The wire spellings ADR 0032 §10 D-2 fixes, positionally aligned with
+    /// [`DISPOSITIONS_IN_ADR_0032_ORDER`].
+    ///
+    /// Written as literals rather than derived from the enum, so a `rename_all`
+    /// change or a variant rename is a test failure and not a silent respelling
+    /// of a published contract.
+    const WIRE_SPELLINGS_IN_ADR_0032_ORDER: [&str; 8] = [
+        "redact",
+        "mask",
+        "tokenize",
+        "require_approval",
+        "approval_granted",
+        "approval_denied",
+        "shadow_only",
+        "none",
+    ];
+
+    /// The position ADR 0032 §10 D-2 assigns each disposition.
+    ///
+    /// This exists for its `match`, not its return value. The arms are
+    /// exhaustive with no `_` fallback, so **adding** a variant stops this file
+    /// compiling, and **removing** one leaves both this match and
+    /// [`DISPOSITIONS_IN_ADR_0032_ORDER`] naming a variant that no longer
+    /// exists. It is the same mechanism `aa_core_label_contract` uses to keep
+    /// `RuntimeVerdict` honest, for the same reason.
+    fn variant_index(disposition: SensitiveDataDisposition) -> usize {
+        match disposition {
+            SensitiveDataDisposition::Redact => 0,
+            SensitiveDataDisposition::Mask => 1,
+            SensitiveDataDisposition::Tokenize => 2,
+            SensitiveDataDisposition::RequireApproval => 3,
+            SensitiveDataDisposition::ApprovalGranted => 4,
+            SensitiveDataDisposition::ApprovalDenied => 5,
+            SensitiveDataDisposition::ShadowOnly => 6,
+            SensitiveDataDisposition::None => 7,
+        }
+    }
+
+    /// How restrictive a coarse verdict is, on ADR 0018's own
+    /// least-to-most-restrictive ordering, with "no verdict at all" below
+    /// `allow`.
+    ///
+    /// Wildcard-free on purpose: this is a second place a sixth `RuntimeVerdict`
+    /// variant would stop the build, which matters because the disposition
+    /// mapping is only sound if every verdict has a known restrictiveness.
+    fn restrictiveness(verdict: Option<RuntimeVerdict>) -> u8 {
+        match verdict {
+            Option::None => 0,
+            Some(RuntimeVerdict::Allow) => 1,
+            Some(RuntimeVerdict::Narrow) => 2,
+            Some(RuntimeVerdict::Scrub) => 3,
+            Some(RuntimeVerdict::Pending) => 4,
+            Some(RuntimeVerdict::Deny) => 5,
+        }
+    }
+
+    /// The vocabulary is exactly ADR 0032 §10 D-2's eight values, with exactly
+    /// those spellings, in that order.
+    ///
+    /// Catches a removed value (the arrays stop being eight long, and the
+    /// removed variant stops existing), a renamed value (the literal no longer
+    /// matches what serde emits), and a reordered one (the comparison is
+    /// positional).
+    #[test]
+    fn the_vocabulary_is_exactly_adr_0032s_eight_values() {
+        assert_eq!(
+            DISPOSITIONS_IN_ADR_0032_ORDER.len(),
+            8,
+            "ADR 0032 §10 D-2 fixes eight dispositions",
+        );
+        // Checked before zipping, because `zip` truncates to the shorter side
+        // and would turn a dropped spelling into a pass.
+        assert_eq!(
+            DISPOSITIONS_IN_ADR_0032_ORDER.len(),
+            WIRE_SPELLINGS_IN_ADR_0032_ORDER.len(),
+        );
+
+        for (position, (disposition, expected)) in DISPOSITIONS_IN_ADR_0032_ORDER
+            .iter()
+            .zip(WIRE_SPELLINGS_IN_ADR_0032_ORDER)
+            .enumerate()
+        {
+            assert_eq!(
+                variant_index(*disposition),
+                position,
+                "DISPOSITIONS_IN_ADR_0032_ORDER is itself out of order at index {position}",
+            );
+
+            let json = serde_json::to_string(disposition).unwrap();
+            assert_eq!(
+                json,
+                format!("\"{expected}\""),
+                "{disposition:?} serializes as {json} but ADR 0032 §10 D-2 spells it {expected:?}",
+            );
+        }
+    }
+
+    /// Each spelling reads back as the value that wrote it.
+    #[test]
+    fn every_disposition_round_trips_through_its_wire_spelling() {
+        for disposition in DISPOSITIONS_IN_ADR_0032_ORDER {
+            let json = serde_json::to_string(&disposition).unwrap();
+            let restored: SensitiveDataDisposition = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored, disposition);
+        }
+    }
+
+    /// An unrecognised spelling is refused rather than defaulted.
+    ///
+    /// A disposition that fell back to `none` on an unknown label would turn a
+    /// read error into a record that looks like it had nothing to report.
+    #[test]
+    fn an_unknown_spelling_is_refused() {
+        assert!(serde_json::from_str::<SensitiveDataDisposition>(r#""quarantine""#).is_err());
+        assert!(serde_json::from_str::<SensitiveDataDisposition>(r#""Redact""#).is_err());
+        assert!(serde_json::from_str::<SensitiveDataDisposition>(r#""requireApproval""#).is_err());
+        assert!(serde_json::from_str::<SensitiveDataDisposition>(r#""""#).is_err());
+    }
+
+    /// ADR 0032 §10 D-2's mapping table, value by value.
+    ///
+    /// Written as eight explicit expectations rather than a loop over
+    /// [`implied_verdict`](SensitiveDataDisposition::implied_verdict), so that
+    /// changing one arm of that match fails here — a loop that re-derived the
+    /// expectation from the same match would pass whatever it was changed to.
+    #[test]
+    fn the_mapping_is_exactly_adr_0032s_table() {
+        use RuntimeVerdict::{Allow, Deny, Pending, Scrub};
+        use SensitiveDataDisposition as D;
+
+        assert_eq!(D::Redact.implied_verdict(), Some(Scrub));
+        assert_eq!(D::Mask.implied_verdict(), Some(Scrub));
+        assert_eq!(D::Tokenize.implied_verdict(), Some(Scrub));
+        assert_eq!(D::RequireApproval.implied_verdict(), Some(Pending));
+        assert_eq!(D::ApprovalGranted.implied_verdict(), Some(Allow));
+        assert_eq!(D::ApprovalDenied.implied_verdict(), Some(Deny));
+        assert_eq!(D::ShadowOnly.implied_verdict(), Some(Allow));
+        // Not `Allow`: `none` adds nothing and must not contradict the record's
+        // own verdict.
+        assert_eq!(D::None.implied_verdict(), Option::None);
+    }
+
+    /// Every disposition except `none` maps onto a verdict, so a coarse reader
+    /// always reaches a conclusion.
+    ///
+    /// The exhaustive `match` in [`variant_index`] is what keeps this from being
+    /// vacuous against a ninth value.
+    #[test]
+    fn only_none_declines_to_imply_a_verdict() {
+        for disposition in DISPOSITIONS_IN_ADR_0032_ORDER {
+            let implied = disposition.implied_verdict();
+            if disposition == SensitiveDataDisposition::None {
+                assert_eq!(implied, Option::None);
+            } else {
+                assert!(implied.is_some(), "{disposition:?} implies no verdict");
+            }
+        }
+    }
+
+    /// Precedence never lets the surviving disposition imply a *less*
+    /// restrictive verdict than one it displaced.
+    ///
+    /// This is the property that makes a single-valued field safe: collapsing
+    /// several true dispositions into one cannot under-report to a
+    /// `RuntimeVerdict`-only reader. Checked over all 64 ordered pairs rather
+    /// than by reading the rank literals.
+    #[test]
+    fn precedence_never_under_reports_the_verdict() {
+        for higher in DISPOSITIONS_IN_ADR_0032_ORDER {
+            for lower in DISPOSITIONS_IN_ADR_0032_ORDER {
+                if higher.precedence() <= lower.precedence() {
+                    continue;
+                }
+                assert!(
+                    restrictiveness(higher.implied_verdict()) >= restrictiveness(lower.implied_verdict()),
+                    "{higher:?} outranks {lower:?} but implies the less restrictive verdict \
+                     {:?} < {:?}",
+                    higher.implied_verdict(),
+                    lower.implied_verdict(),
+                );
+            }
+        }
+    }
+
+    /// No two dispositions share a rank, so [`SensitiveDataDisposition::reported`]
+    /// is deterministic regardless of the order the candidates arrive in.
+    #[test]
+    fn precedence_is_a_total_order() {
+        for (position, disposition) in DISPOSITIONS_IN_ADR_0032_ORDER.iter().enumerate() {
+            for other in &DISPOSITIONS_IN_ADR_0032_ORDER[position + 1..] {
+                assert_ne!(
+                    disposition.precedence(),
+                    other.precedence(),
+                    "{disposition:?} and {other:?} share a precedence rank",
+                );
+            }
+        }
+    }
+
+    /// The case ADR 0032 §10 names: an action that was both redacted and
+    /// approval-granted reports `redact`, so the verdict stays `scrub` instead
+    /// of under-reporting as `allow`.
+    #[test]
+    fn a_transformation_outranks_an_approval_grant() {
+        use SensitiveDataDisposition as D;
+
+        assert_eq!(D::reported([D::ApprovalGranted, D::Redact]), D::Redact);
+        // Order of arrival must not change the answer.
+        assert_eq!(D::reported([D::Redact, D::ApprovalGranted]), D::Redact);
+        assert_eq!(
+            D::reported([D::ApprovalGranted, D::Redact]).implied_verdict(),
+            Some(RuntimeVerdict::Scrub),
+        );
+    }
+
+    /// A refusal outranks a transformation: an action that was blocked did not
+    /// happen, whatever was done to its payload first.
+    #[test]
+    fn a_refusal_outranks_a_transformation() {
+        use SensitiveDataDisposition as D;
+
+        assert_eq!(D::reported([D::Redact, D::ApprovalDenied]), D::ApprovalDenied);
+        assert_eq!(
+            D::reported([D::Redact, D::ApprovalDenied]).implied_verdict(),
+            Some(RuntimeVerdict::Deny),
+        );
+    }
+
+    /// `none` loses to every other value, and an empty set of dispositions
+    /// resolves to `none` — the same statement as the field being absent.
+    #[test]
+    fn none_is_the_identity_of_the_precedence_fold() {
+        use SensitiveDataDisposition as D;
+
+        assert_eq!(D::reported([]), D::None);
+        assert_eq!(D::reported([D::None]), D::None);
+        for disposition in DISPOSITIONS_IN_ADR_0032_ORDER {
+            assert_eq!(
+                D::reported([D::None, disposition]),
+                disposition,
+                "`none` displaced {disposition:?}",
+            );
+        }
+    }
+
+    /// `shadow_only` carries no would-be verdict, which is what keeps it from
+    /// becoming a second representation of the audit event's `shadow_decision`.
+    ///
+    /// A unit variant has nowhere to put one. This test is the statement of that
+    /// ownership split in executable form: if someone ever gives `ShadowOnly` a
+    /// payload, the pattern below stops compiling.
+    #[test]
+    fn shadow_only_is_a_unit_variant_and_holds_no_shadow_decision() {
+        let disposition = SensitiveDataDisposition::ShadowOnly;
+        assert!(matches!(disposition, SensitiveDataDisposition::ShadowOnly));
+        // It reports only that inspection was observe-only; what the policy
+        // *would* have decided stays in the audit event's `shadow_decision`.
+        assert_eq!(disposition.implied_verdict(), Some(RuntimeVerdict::Allow));
+    }
+}

--- a/aa-api/src/models/disposition.rs
+++ b/aa-api/src/models/disposition.rs
@@ -1,0 +1,231 @@
+//! The additive `sensitive_data_disposition` vocabulary (AAASM-5356, ADR 0032 §10 D-2).
+//!
+//! # Why this is a second field and not five more verdicts
+//!
+//! ADR 0018 froze [`RuntimeVerdict`] at five variants and shipped it with zero
+//! new OpenAPI paths. ADR 0024 establishes that **adding an enum variant is not
+//! additive on the wire** — a reader that does not know the new spelling refuses
+//! the payload — so extending `RuntimeVerdict` to say *how* a payload was
+//! transformed would break a contract that was frozen on purpose. ADR 0032 D-2
+//! therefore puts the finer vocabulary in a separate, optional field, and this
+//! module is that field's type.
+//!
+//! # The three rules this module has to keep
+//!
+//! **1. Absence must keep meaning exactly what it means today.** The field is
+//! `Option<SensitiveDataDisposition>` and is `skip_serializing_if`-omitted when
+//! absent, so a response carrying no disposition is byte-identical to what the
+//! same response was before this type existed. A client that has never heard of
+//! the field reads the same object it read yesterday.
+//!
+//! **2. A `RuntimeVerdict`-only reader must still be right, just coarser.**
+//! [`SensitiveDataDisposition::implied_verdict`] is the full eight-value mapping
+//! from ADR 0032 §10 D-2, written as a wildcard-free `match` so neither
+//! vocabulary can grow a value whose coarse meaning nobody chose.
+//!
+//! **3. It is not a second authorisation channel.** See below — this one is
+//! structural, not a promise.
+//!
+//! # How "never an authorisation input" is enforced rather than asserted
+//!
+//! Three independent mechanisms, none of which is a comment:
+//!
+//! - **The crates that decide cannot name the type.** `aa-api` depends on
+//!   `aa-gateway` and `aa-runtime`; the dependency does not run the other way
+//!   (ADR 0018 put `RuntimeVerdict` here for the same reason — so it could carry
+//!   a `utoipa::ToSchema` derive). For the policy engine or the enforcement
+//!   pipeline to consult a `SensitiveDataDisposition` it would have to depend on
+//!   `aa-api`, which is a dependency cycle `cargo` refuses to build. The
+//!   authorisation decision is made in crates that structurally cannot see this
+//!   enum.
+//! - **It is never an input.** The type appears only in response bodies, never
+//!   in a request body or a query parameter, so no caller can supply one for the
+//!   server to act on. `the_disposition_is_never_a_request_input` in
+//!   `aa-api/tests/sensitive_data_disposition_contract.rs` asserts that against
+//!   the *generated* `openapi/v1.yaml`, which is the artifact clients build
+//!   from.
+//! - **It exposes no permission-shaped API.** There is no `is_allowed`, no
+//!   `From<SensitiveDataDisposition> for Decision`, and deliberately no
+//!   `PartialOrd`/`Ord` — an ordering is exactly the hook someone would reach
+//!   for to write "at least as permissive as", which is an authorisation
+//!   question. The one method that produces a verdict returns it for *reporting*
+//!   and is documented as such.
+//!
+//! # Shadow reporting: `shadow_decision` owns it, this field does not
+//!
+//! The proto audit event already has a `shadow_decision` string (`audit.proto`
+//! field 31) carrying **what the policy engine would have decided** had the
+//! agent not been in observe/dry-run mode, alongside the rule id that produced
+//! it. That field keeps sole ownership of shadow *decision* reporting; nothing
+//! here duplicates it, and nothing may populate
+//! [`ShadowOnly`](SensitiveDataDisposition::ShadowOnly) by copying it.
+//!
+//! `ShadowOnly` answers a different question — *what happened to the payload* —
+//! with the answer "nothing: the sensitive-data pipeline observed and reported
+//! only". That it cannot become a second copy of `shadow_decision` is
+//! structural rather than a rule to remember: it is a **unit variant**, with
+//! nowhere to put a would-be verdict. The two fields are read together, not
+//! instead of each other.
+//!
+//! # Precedence: one action, one disposition
+//!
+//! The field is single-valued, but an action can be both redacted *and*
+//! approval-granted. [`SensitiveDataDisposition::reported`] resolves that, and
+//! the rule is derived rather than invented: **the disposition whose implied
+//! verdict is more restrictive wins**, so collapsing to one value can never
+//! under-report to a `RuntimeVerdict`-only reader. Redacted-and-approved
+//! reports `redact` (verdict `scrub`), not `approval_granted` (verdict
+//! `allow`) — the outcome ADR 0032 §10 calls for.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::models::verdict::RuntimeVerdict;
+
+/// What the sensitive-data pipeline did to an action's payload and to the
+/// approval of the action, at a granularity the 5-way runtime verdict
+/// deliberately does not carry (ADR 0032 §10 D-2).
+///
+/// A **record of** a decision the gateway already made, never an input to one:
+/// the runtime verdict remains the authoritative outcome, and every disposition
+/// but `none` maps onto one, so a client that reads only the verdict still
+/// reaches a correct if coarser conclusion.
+///
+/// These eight values are a closed vocabulary. Adding a ninth is the same
+/// category of breaking wire change ADR 0024 forbids for the runtime verdict.
+///
+/// This doc comment is published as the schema description in `openapi/v1.yaml`;
+/// the implementation rationale — including how "never an authorisation input"
+/// is enforced rather than promised — is in the module documentation, which is
+/// not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SensitiveDataDisposition {
+    /// Findings were removed from the payload and the scrubbed bytes were
+    /// forwarded. A redacted action is a *transformed transmission*, never a
+    /// prevented one.
+    Redact,
+    /// Findings were replaced with a fixed-shape placeholder that preserves the
+    /// field's format, and the masked bytes were forwarded.
+    Mask,
+    /// Findings were replaced with a reversible token and the tokenized bytes
+    /// were forwarded.
+    Tokenize,
+    /// The action was held for a human approval decision that had not been made
+    /// when this record was written.
+    RequireApproval,
+    /// A human approved the action and it proceeded.
+    ApprovalGranted,
+    /// A human refused the action and it was blocked.
+    ApprovalDenied,
+    /// The sensitive-data pipeline observed and reported only; the payload was
+    /// neither transformed nor held. Distinct from
+    /// [`None`](Self::None) — this records that inspection ran in
+    /// observe-only mode, not that nothing was recorded.
+    ShadowOnly,
+    /// No sensitive-data disposition applies. Semantically identical to the
+    /// field being absent, which is what ADR 0032 §10 D-2 requires: the
+    /// [`RuntimeVerdict`] carries the whole meaning of the record.
+    None,
+}
+
+impl SensitiveDataDisposition {
+    /// The coarse [`RuntimeVerdict`] this disposition implies — ADR 0032 §10
+    /// D-2's mapping table, in code.
+    ///
+    /// | disposition | verdict |
+    /// |---|---|
+    /// | `redact` / `mask` / `tokenize` | `scrub` |
+    /// | `require_approval` | `pending` |
+    /// | `approval_granted` | `allow` |
+    /// | `approval_denied` | `deny` |
+    /// | `shadow_only` | `allow` |
+    /// | `none` | `None` — the verdict carries the whole meaning |
+    ///
+    /// # This is reporting, not authorisation
+    ///
+    /// It answers "what would a client that only understands `RuntimeVerdict`
+    /// conclude from this record?". It must not be called to decide whether an
+    /// action is permitted — that decision is `aa-gateway`'s and was made before
+    /// any disposition existed. See the module documentation for why the crates
+    /// that make it cannot reach this method at all.
+    ///
+    /// # Why `Option`
+    ///
+    /// [`None`](Self::None) maps to no verdict rather than to
+    /// [`RuntimeVerdict::Allow`], because it is not a claim that the action was
+    /// allowed — it is the statement that this field adds nothing and the
+    /// record's own verdict stands. Returning `Allow` here would let a
+    /// `none` disposition contradict a `deny` verdict.
+    ///
+    /// The arms are spelled out one per value with no `_` fallback, so a ninth
+    /// disposition cannot be added without someone choosing its coarse meaning.
+    pub fn implied_verdict(self) -> Option<RuntimeVerdict> {
+        match self {
+            Self::Redact => Some(RuntimeVerdict::Scrub),
+            Self::Mask => Some(RuntimeVerdict::Scrub),
+            Self::Tokenize => Some(RuntimeVerdict::Scrub),
+            Self::RequireApproval => Some(RuntimeVerdict::Pending),
+            Self::ApprovalGranted => Some(RuntimeVerdict::Allow),
+            Self::ApprovalDenied => Some(RuntimeVerdict::Deny),
+            Self::ShadowOnly => Some(RuntimeVerdict::Allow),
+            Self::None => Option::None,
+        }
+    }
+
+    /// Reporting rank: when several dispositions applied to one action, the
+    /// highest rank is the one the single-valued field carries.
+    ///
+    /// The ranks are not arbitrary — they ascend with the restrictiveness of
+    /// [`implied_verdict`](Self::implied_verdict), which is what makes
+    /// collapsing to one value safe for a `RuntimeVerdict`-only reader: the
+    /// surviving disposition never implies a *less* restrictive verdict than one
+    /// it displaced. `precedence_never_under_reports_the_verdict` proves that
+    /// over every pair rather than trusting the numbers below.
+    ///
+    /// Values sharing an implied verdict (the three transformations; the two
+    /// `allow`-implying values) are ordered by declaration. The tie-break is
+    /// arbitrary *and harmless*: either winner yields the same verdict, so no
+    /// coarse reader can tell which was picked.
+    fn precedence(self) -> u8 {
+        match self {
+            // Adds nothing, so it loses to everything that does.
+            Self::None => 0,
+            Self::ShadowOnly => 1,
+            Self::ApprovalGranted => 2,
+            Self::Redact => 3,
+            Self::Mask => 4,
+            Self::Tokenize => 5,
+            Self::RequireApproval => 6,
+            // The action did not happen; nothing said about the payload can
+            // outrank that.
+            Self::ApprovalDenied => 7,
+        }
+    }
+
+    /// The single disposition to report for an action that had several.
+    ///
+    /// Returns [`None`](Self::None) for an empty iterator, which is the same
+    /// statement as the field being absent.
+    ///
+    /// This resolves a *presentation* ambiguity — which of several true
+    /// statements to record in a one-valued field — and decides nothing about
+    /// whether the action was permitted.
+    ///
+    /// The worked case ADR 0032 §10 names — an action both redacted and
+    /// approval-granted reports `redact`, so a coarse reader still sees `scrub`
+    /// rather than being told the payload passed clean — is asserted by
+    /// `a_transformation_outranks_an_approval_grant` below. It is deliberately
+    /// *not* written as a doctest: CI runs `cargo test --doc` for `aa-gateway`
+    /// only (AAASM-5354), so an example here would document a property nothing
+    /// executes.
+    pub fn reported(dispositions: impl IntoIterator<Item = Self>) -> Self {
+        dispositions.into_iter().fold(Self::None, |winner, candidate| {
+            if candidate.precedence() > winner.precedence() {
+                candidate
+            } else {
+                winner
+            }
+        })
+    }
+}

--- a/aa-api/src/models/mod.rs
+++ b/aa-api/src/models/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod alert_ws_payloads;
 pub mod capability;
+pub mod disposition;
 pub mod event;
 pub mod event_type;
 pub mod retention;

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -197,6 +197,7 @@ use crate::routes::{
         agents::PermissionSourceResponse,
         agents::EffectivePermissionsResponse,
         crate::models::verdict::RuntimeVerdict,
+        crate::models::disposition::SensitiveDataDisposition,
         agents::DecisionLabel,
         agents::AgentDecisionResponse,
         agents::AgentDecisionsResponse,

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -2395,6 +2395,118 @@ mod tests {
         assert_eq!(row.session_id, "ee".repeat(16));
     }
 
+    // ── AAASM-5356: the sensitive-data disposition read path ──────────────
+    //
+    // `entry_to_decision_row` is the *only* code that ever populates
+    // `sensitive_data_disposition`. Without the four tests below the field
+    // could be permanently unpopulatable and nothing would notice: the wire
+    // contract tests assert the published *shape*, and the OpenAPI drift gate
+    // derives the spec from the struct rather than from this reader, so both
+    // stay green against a read path gutted to `let x = None;`.
+
+    /// A payload carrying a disposition surfaces it on the row.
+    ///
+    /// The case the writer AAASM-5357 will produce. Asserted against the real
+    /// audit-payload key (`sensitive_data_disposition`, snake_case like every
+    /// other payload key) rather than the camelCase wire name, because this is
+    /// the read side of the audit log, not the response.
+    #[test]
+    fn a_payload_carrying_a_disposition_surfaces_it_on_the_row() {
+        let entry = decision_entry(
+            r#"{"action_type":"TOOL_CALL","decision":4,"verdict":"scrub","sensitive_data_disposition":"redact","detail":{"kind":"tool_call","tool_name":"gmail.send"}}"#,
+        );
+        let row = entry_to_decision_row(&entry).expect("redact carries a decision");
+
+        assert_eq!(row.sensitive_data_disposition, Some(SensitiveDataDisposition::Redact));
+        // The coarse verdict a disposition-blind reader falls back to agrees
+        // with the finer field, which is the whole point of the mapping.
+        assert_eq!(row.verdict, Some(RuntimeVerdict::Scrub));
+        assert_eq!(
+            row.sensitive_data_disposition
+                .and_then(SensitiveDataDisposition::implied_verdict),
+            row.verdict,
+        );
+    }
+
+    /// Every one of the eight spellings survives the read path.
+    ///
+    /// A loop, but not a vacuous one: the expectations come from the wire
+    /// spellings the audit log would carry, and each is fed through
+    /// `entry_to_decision_row` rather than through `Deserialize` directly, so
+    /// this fails if the reader looks up the wrong payload key or parses the
+    /// wrong way.
+    #[test]
+    fn every_disposition_spelling_survives_the_read_path() {
+        use SensitiveDataDisposition as D;
+        let cases = [
+            ("redact", D::Redact),
+            ("mask", D::Mask),
+            ("tokenize", D::Tokenize),
+            ("require_approval", D::RequireApproval),
+            ("approval_granted", D::ApprovalGranted),
+            ("approval_denied", D::ApprovalDenied),
+            ("shadow_only", D::ShadowOnly),
+            ("none", D::None),
+        ];
+        assert_eq!(cases.len(), 8, "ADR 0032 §10 D-2 fixes eight dispositions");
+
+        for (spelling, expected) in cases {
+            let entry = decision_entry(&format!(
+                r#"{{"action_type":"TOOL_CALL","decision":1,"sensitive_data_disposition":"{spelling}"}}"#
+            ));
+            let row = entry_to_decision_row(&entry).expect("the payload carries a decision");
+            assert_eq!(
+                row.sensitive_data_disposition,
+                Some(expected),
+                "the read path lost {spelling:?}",
+            );
+        }
+    }
+
+    /// A payload omitting the key reads as absent — the legacy-row case, which
+    /// is every row today.
+    ///
+    /// This is ADR 0032 §10 D-2's first binding rule at the read boundary: an
+    /// absent key must not become a default that claims something happened.
+    #[test]
+    fn a_payload_omitting_the_disposition_reads_as_absent() {
+        let entry = decision_entry(
+            r#"{"action_type":"TOOL_CALL","decision":1,"detail":{"kind":"tool_call","tool_name":"pg.users"}}"#,
+        );
+        let row = entry_to_decision_row(&entry).expect("tool_call carries a decision");
+
+        assert_eq!(row.sensitive_data_disposition, None);
+        // And absence is invisible on the wire, not a null.
+        let json = serde_json::to_string(&row).unwrap();
+        assert!(
+            !json.contains("sensitiveDataDisposition"),
+            "an absent disposition leaked onto the wire: {json}",
+        );
+    }
+
+    /// An unparseable spelling reads as **absent**, not as an error and not as
+    /// a defaulted value.
+    ///
+    /// Pinned because it is a real semantic cost, not an accident: after this
+    /// change "absent" means *no disposition recorded* **or** *a disposition
+    /// this build could not parse*. It is bounded — `verdict` is parsed
+    /// independently on the line above and stays the authoritative outcome, so
+    /// a fallback reader is never misled about whether the action was permitted
+    /// — and it mirrors how the `verdict` read itself already degrades. The
+    /// alternative, failing the whole row, would hide a decision from the
+    /// operator over an optional reporting field.
+    #[test]
+    fn an_unparseable_disposition_reads_as_absent_rather_than_failing_the_row() {
+        let entry = decision_entry(
+            r#"{"action_type":"TOOL_CALL","decision":2,"verdict":"deny","sensitive_data_disposition":"quarantine"}"#,
+        );
+        let row = entry_to_decision_row(&entry).expect("the row survives an unknown disposition");
+
+        assert_eq!(row.sensitive_data_disposition, None);
+        // The bound on the cost: the authoritative outcome is untouched.
+        assert_eq!(row.verdict, Some(RuntimeVerdict::Deny));
+    }
+
     #[test]
     fn scrubbed_action_records_scrub_verdict_distinct_from_allow() {
         // AAASM-5100 item A — a DLP-scrubbed action is forwarded (proto Redact,

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -15,6 +15,7 @@ use aa_gateway::registry::{AgentStatus, OrphanMode};
 use crate::auth::scope::{RequireRead, RequireWrite, Scope};
 use crate::auth::AuthenticatedCaller;
 use crate::error::ProblemDetail;
+use crate::models::disposition::SensitiveDataDisposition;
 use crate::models::verdict::RuntimeVerdict;
 use crate::pagination::PaginationParams;
 use crate::state::AppState;
@@ -1716,6 +1717,34 @@ pub struct AgentDecisionResponse {
     /// fabricated. Wired through so the column lands the day a latency source is
     /// added, without another contract change.
     pub latency_ms: Option<u64>,
+    /// What the sensitive-data pipeline did to this action's payload and to the
+    /// approval of the action (AAASM-5356, ADR 0032 §10 D-2) — a finer
+    /// vocabulary than `verdict`, which stays the authoritative outcome and is
+    /// frozen at five values.
+    ///
+    /// **Additive and optional.** The key is *omitted entirely* when there is no
+    /// disposition to report, so a response for an action that has none is
+    /// byte-for-byte what this endpoint returned before the field existed. An
+    /// absent key and an explicit `"none"` say the same thing: this field adds
+    /// nothing and `verdict` carries the whole meaning. A client that has never
+    /// heard of the field reads exactly the object it read before.
+    ///
+    /// Declared last, so a response that *does* carry a disposition is a pure
+    /// suffix append to the object as it was.
+    ///
+    /// **Absent on every row today**: no writer populates the audit payload's
+    /// `sensitive_data_disposition` yet — that is AAASM-5357's projection. The
+    /// read is wired through now so the day it lands there is no second contract
+    /// change, which is the pattern `verdict` followed.
+    ///
+    /// **Reporting only.** Nothing consults this to decide whether an action is
+    /// permitted — `verdict` remains the authoritative outcome. It is a field of
+    /// this response like any other, so it inherits the endpoint's tenant
+    /// scoping unchanged: `authorize_agent_access` gates the whole row, so the
+    /// `approval_*` values it can carry are visible to exactly the callers
+    /// already entitled to the decision record.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sensitive_data_disposition: Option<SensitiveDataDisposition>,
 }
 
 /// Recent per-agent decision stream (AAASM-5058).
@@ -1838,6 +1867,21 @@ fn entry_to_decision_row(entry: &AuditEntry) -> Option<AgentDecisionResponse> {
     // the audit write path. Absent on legacy rows, which stay `null`.
     let latency_ms = payload.get("latency_ms").and_then(serde_json::Value::as_u64);
 
+    // AAASM-5356 / ADR 0032 §10 D-2 — the additive finer disposition. No writer
+    // emits this key yet (AAASM-5357 owns the projection), so it is absent on
+    // every row today and the field is omitted from the response entirely.
+    //
+    // An unrecognised spelling degrades to absent rather than failing the row.
+    // That can only under-report the *optional* field: `verdict` above is parsed
+    // independently and remains the authoritative outcome, so a reader falling
+    // back to it is never misled about whether the action was permitted.
+    let sensitive_data_disposition = payload
+        .get("sensitive_data_disposition")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| {
+            serde_json::from_value::<SensitiveDataDisposition>(serde_json::Value::String(s.to_string())).ok()
+        });
+
     Some(AgentDecisionResponse {
         timestamp,
         session_id: hex::encode(entry.session_id().as_bytes()),
@@ -1853,6 +1897,7 @@ fn entry_to_decision_row(entry: &AuditEntry) -> Option<AgentDecisionResponse> {
         // separate Phase 2 ticket. The audit write records no per-decision trace
         // id, so this stays null.
         trace_id: None,
+        sensitive_data_disposition,
     })
 }
 

--- a/aa-api/tests/sensitive_data_disposition_contract.rs
+++ b/aa-api/tests/sensitive_data_disposition_contract.rs
@@ -25,6 +25,23 @@ use aa_api::models::disposition::SensitiveDataDisposition;
 use aa_api::routes::agents::{AgentDecisionResponse, DecisionLabel};
 use serde_json::Value;
 
+/// ADR 0032 §10 D-2's eight wire spellings, written out rather than derived
+/// from the enum so a respelling is a failure and not a silent rename.
+const WIRE_SPELLINGS: [&str; 8] = [
+    "redact",
+    "mask",
+    "tokenize",
+    "require_approval",
+    "approval_granted",
+    "approval_denied",
+    "shadow_only",
+    "none",
+];
+
+/// OpenAPI 3.1 operation keys. Every other child of a path item (`parameters`,
+/// `summary`, `description`, `servers`, `$ref`) is not an operation.
+const HTTP_METHODS: [&str; 8] = ["get", "put", "post", "delete", "options", "head", "patch", "trace"];
+
 /// Exactly what `GET /api/v1/agents/{id}/decisions` emitted for this row before
 /// `sensitiveDataDisposition` existed.
 ///
@@ -220,32 +237,53 @@ fn the_disposition_is_never_a_request_input() {
     );
 
     let mut request_shapes_scanned = 0usize;
+    let mut check_input = |origin: &str, input_kind: &str, input: &Value| {
+        request_shapes_scanned += 1;
+
+        let mut refs = Vec::new();
+        referenced_schema_names(input, &mut refs);
+        for reference in &refs {
+            assert!(
+                !tainted.iter().any(|t| t == reference),
+                "{origin} accepts {reference} as a {input_kind}, which reaches \
+                 SensitiveDataDisposition — the disposition must never be an input \
+                 (ADR 0032 §10 D-2)",
+            );
+        }
+
+        // An inlined enum would have no `$ref` to catch. Counting spellings
+        // rather than looking for one: an inlined *subset* — say just the three
+        // transformations — would evade a single-needle grep, and a subset is
+        // still the vocabulary appearing on an input.
+        let inlined = WIRE_SPELLINGS.iter().filter(|s| contains_string(input, s)).count();
+        assert!(
+            inlined < 2,
+            "{origin} inlines {inlined} of the disposition's spellings into a {input_kind}",
+        );
+    };
+
     for (path, item) in spec["paths"].as_object().expect("the spec has paths") {
-        for (method, operation) in item.as_object().expect("a path item is a map") {
+        let item = item.as_object().expect("a path item is a map");
+
+        // A path item may carry `parameters` as a sibling of its methods,
+        // applying to every operation under it. Iterating only the method
+        // children would skip that shape entirely — zero occurrences today,
+        // which is exactly why it would go unnoticed if one were added.
+        if let Some(shared) = item.get("parameters") {
+            check_input(&format!("{path} (path-level)"), "parameters", shared);
+        }
+
+        for (method, operation) in item {
+            // Skip the path item's non-operation children (`parameters`,
+            // handled above; `summary`, `description`, `servers`, `$ref`), so
+            // the scan reads operations and nothing else.
+            if !HTTP_METHODS.contains(&method.as_str()) {
+                continue;
+            }
             for input_kind in ["requestBody", "parameters"] {
-                let Some(input) = operation.get(input_kind) else {
-                    continue;
-                };
-                request_shapes_scanned += 1;
-
-                let mut refs = Vec::new();
-                referenced_schema_names(input, &mut refs);
-                for reference in &refs {
-                    assert!(
-                        !tainted.iter().any(|t| t == reference),
-                        "{method} {path} accepts {reference} as a {input_kind}, which reaches \
-                         SensitiveDataDisposition — the disposition must never be an input \
-                         (ADR 0032 §10 D-2)",
-                    );
+                if let Some(input) = operation.get(input_kind) {
+                    check_input(&format!("{method} {path}"), input_kind, input);
                 }
-
-                // An inlined enum would have no $ref to catch. `require_approval`
-                // is unique to this vocabulary, so its presence in a request
-                // shape means the disposition was inlined into one.
-                assert!(
-                    !contains_string(input, "require_approval"),
-                    "{method} {path} inlines the disposition vocabulary into a {input_kind}",
-                );
             }
         }
     }
@@ -271,24 +309,36 @@ fn the_published_schema_is_optional_and_carries_the_eight_spellings() {
         .iter()
         .map(|v| v.as_str().expect("a string enum value"))
         .collect();
-    assert_eq!(
-        published,
-        [
-            "redact",
-            "mask",
-            "tokenize",
-            "require_approval",
-            "approval_granted",
-            "approval_denied",
-            "shadow_only",
-            "none",
-        ],
-    );
+    assert_eq!(published, WIRE_SPELLINGS);
 
     let decision_row = &spec["components"]["schemas"]["AgentDecisionResponse"];
+    let property = &decision_row["properties"]["sensitiveDataDisposition"];
     assert!(
-        decision_row["properties"].get("sensitiveDataDisposition").is_some(),
+        !property.is_null(),
         "AgentDecisionResponse does not publish sensitiveDataDisposition",
+    );
+
+    // Not merely "a property with that name exists" — it must resolve to the
+    // disposition schema. A property retyped to a bare `string` would keep the
+    // name and lose the closed vocabulary.
+    let mut refs = Vec::new();
+    referenced_schema_names(property, &mut refs);
+    assert!(
+        refs.iter().any(|r| r == "SensitiveDataDisposition"),
+        "sensitiveDataDisposition no longer resolves to the disposition schema: {property:?}",
+    );
+
+    // The published property is `oneOf: [null, $ref]` — utoipa's rendering of
+    // `Option<T>`. Recorded rather than glossed over, because it means the
+    // *contract* tolerates an explicit `null` that the *server* never sends:
+    // `skip_serializing_if` omits the key entirely, which
+    // `a_row_without_a_disposition_is_byte_identical_to_the_pre_change_response`
+    // proves at the byte level. Both readings are safe — absent and null both
+    // mean "no disposition" — but the stronger guarantee lives in the server,
+    // not in the artifact, and a reader of this file should know that.
+    assert!(
+        property.get("oneOf").is_some(),
+        "the disposition property is no longer nullable-optional in the spec: {property:?}",
     );
 
     // Optional: an existing client that does not send or expect it stays valid.

--- a/aa-api/tests/sensitive_data_disposition_contract.rs
+++ b/aa-api/tests/sensitive_data_disposition_contract.rs
@@ -1,0 +1,306 @@
+//! The wire contract for the additive `sensitiveDataDisposition` field
+//! (AAASM-5356, ADR 0032 §10 D-2).
+//!
+//! Two properties are asserted here that cannot be asserted inside
+//! `models::disposition`, because both are about the *published artifact* rather
+//! than the Rust type:
+//!
+//! 1. **Adding the field changed nothing for a client that ignores it.** A
+//!    decision row with no disposition serializes byte-for-byte as it did before
+//!    the field existed, and a pre-change payload still deserializes.
+//! 2. **The disposition is never an input.** It appears only in response bodies
+//!    of the generated `openapi/v1.yaml` — never in a request body or a query
+//!    parameter — so no caller can hand the server a disposition for it to act
+//!    on. This is the structural half of ADR 0032 §10 D-2's "not a second
+//!    authorisation channel"; the other half is that `aa-gateway` and
+//!    `aa-runtime` sit *below* `aa-api` in the dependency graph and so cannot
+//!    name the type at all.
+//!
+//! The spec is read from the committed `openapi/v1.yaml` on purpose, not from
+//! `ApiDoc::openapi()`: the committed file is what the dashboard's
+//! `openapi-typescript` codegen and every external client build from, and CI's
+//! drift gate already proves the two agree.
+
+use aa_api::models::disposition::SensitiveDataDisposition;
+use aa_api::routes::agents::{AgentDecisionResponse, DecisionLabel};
+use serde_json::Value;
+
+/// Exactly what `GET /api/v1/agents/{id}/decisions` emitted for this row before
+/// `sensitiveDataDisposition` existed.
+///
+/// A literal rather than a value derived from the current struct — deriving it
+/// would make the comparison below tautological, which is the whole failure mode
+/// this file exists to rule out. Regenerating this string from the post-change
+/// type would be the way to make the test pass while breaking the contract.
+const PRE_CHANGE_DECISION_ROW: &str = concat!(
+    r#"{"timestamp":"2026-08-01T09:15:00+00:00","sessionId":"0a0b","seq":7,"#,
+    r#""verb":"TOOL_CALL","resource":"api.example.test","decision":1,"#,
+    r#""decisionLabel":"allow","verdict":"allow","traceId":null,"#,
+    r#""matchedPolicy":"rule-egress-a","latencyMs":12}"#,
+);
+
+/// The same row as [`PRE_CHANGE_DECISION_ROW`], as the current type.
+fn decision_row(disposition: Option<SensitiveDataDisposition>) -> AgentDecisionResponse {
+    AgentDecisionResponse {
+        timestamp: "2026-08-01T09:15:00+00:00".to_string(),
+        session_id: "0a0b".to_string(),
+        seq: 7,
+        verb: Some("TOOL_CALL".to_string()),
+        resource: Some("api.example.test".to_string()),
+        decision: 1,
+        decision_label: DecisionLabel::Allow,
+        verdict: Some(aa_api::models::verdict::RuntimeVerdict::Allow),
+        trace_id: None,
+        matched_policy: Some("rule-egress-a".to_string()),
+        latency_ms: Some(12),
+        sensitive_data_disposition: disposition,
+    }
+}
+
+/// A row with no disposition serializes to the pre-change bytes — same keys,
+/// same order, no `"sensitiveDataDisposition": null` appended.
+///
+/// This is ADR 0032 §10 D-2's first binding rule in its strongest form: absence
+/// is not "a new key set to null", it is the key not being there. Byte equality
+/// rather than `serde_json::Value` equality, because a value comparison would
+/// pass with the key order changed and clients that parse incrementally, or diff
+/// recorded fixtures, would still see a changed response.
+#[test]
+fn a_row_without_a_disposition_is_byte_identical_to_the_pre_change_response() {
+    let serialized = serde_json::to_string(&decision_row(None)).unwrap();
+    assert_eq!(serialized, PRE_CHANGE_DECISION_ROW);
+}
+
+/// A payload written before the field existed still deserializes, and reads back
+/// as "no disposition".
+///
+/// The old-server half of the compatibility statement: a stored or replayed
+/// pre-change row must not become unreadable, and its missing key must mean
+/// absent — never a default that claims something happened.
+#[test]
+fn a_pre_change_payload_deserializes_with_the_disposition_absent() {
+    let row: AgentDecisionResponse = serde_json::from_str(PRE_CHANGE_DECISION_ROW).unwrap();
+
+    assert_eq!(row.sensitive_data_disposition, None);
+    // Everything a pre-change client reads is unchanged, above all the
+    // authoritative outcome.
+    assert_eq!(row.verdict, Some(aa_api::models::verdict::RuntimeVerdict::Allow));
+    assert_eq!(row.seq, 7);
+    assert_eq!(row.matched_policy.as_deref(), Some("rule-egress-a"));
+
+    // And it round-trips back to the same bytes it arrived as.
+    assert_eq!(serde_json::to_string(&row).unwrap(), PRE_CHANGE_DECISION_ROW);
+}
+
+/// When a disposition *is* present the response is the pre-change object with
+/// one key appended — nothing existing moves, changes name, or changes value.
+#[test]
+fn a_present_disposition_is_a_pure_suffix_append() {
+    let serialized = serde_json::to_string(&decision_row(Some(SensitiveDataDisposition::Redact))).unwrap();
+
+    let expected = format!(
+        "{}{}",
+        PRE_CHANGE_DECISION_ROW.strip_suffix('}').unwrap(),
+        r#","sensitiveDataDisposition":"redact"}"#,
+    );
+    assert_eq!(serialized, expected);
+
+    // A client that ignores the unknown key reads the pre-change object back.
+    let mut object: serde_json::Map<String, Value> = serde_json::from_str(&serialized).unwrap();
+    assert!(object.remove("sensitiveDataDisposition").is_some());
+    assert_eq!(
+        Value::Object(object),
+        serde_json::from_str::<Value>(PRE_CHANGE_DECISION_ROW).unwrap()
+    );
+}
+
+/// An explicit `"none"` and an absent key say the same thing about the record.
+///
+/// They are not the same *bytes* — `none` is a positive statement that the
+/// pipeline had nothing to report, absence is the field never having been
+/// written — but neither may change the conclusion a reader draws, which is that
+/// `verdict` carries the whole meaning.
+#[test]
+fn an_explicit_none_and_an_absent_key_imply_the_same_verdict() {
+    let absent = decision_row(None);
+    let explicit = decision_row(Some(SensitiveDataDisposition::None));
+
+    assert_eq!(absent.verdict, explicit.verdict);
+    assert_eq!(SensitiveDataDisposition::None.implied_verdict(), None);
+}
+
+/// The committed spec every client builds from.
+fn committed_spec() -> Value {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../openapi/v1.yaml");
+    let yaml = std::fs::read_to_string(path).expect("openapi/v1.yaml is committed");
+    serde_yaml::from_str(&yaml).expect("openapi/v1.yaml parses")
+}
+
+/// Every `$ref` target name anywhere under `node`.
+fn referenced_schema_names(node: &Value, out: &mut Vec<String>) {
+    match node {
+        Value::Object(map) => {
+            for (key, value) in map {
+                if key == "$ref" {
+                    if let Some(name) = value.as_str().and_then(|r| r.rsplit('/').next()) {
+                        out.push(name.to_string());
+                    }
+                }
+                referenced_schema_names(value, out);
+            }
+        }
+        Value::Array(items) => items.iter().for_each(|item| referenced_schema_names(item, out)),
+        _ => {}
+    }
+}
+
+/// Whether `node` contains the literal string `needle` anywhere.
+fn contains_string(node: &Value, needle: &str) -> bool {
+    match node {
+        Value::String(s) => s == needle,
+        Value::Object(map) => map.values().any(|v| contains_string(v, needle)),
+        Value::Array(items) => items.iter().any(|v| contains_string(v, needle)),
+        _ => false,
+    }
+}
+
+/// The disposition schema, and every schema that can reach it, appear in no
+/// request body and no parameter of the published spec.
+///
+/// This is the structural reason the field cannot become a second authorisation
+/// channel *from outside*: there is no request shape in which a caller can send
+/// one, so there is nothing for the server to consult. (The reason it cannot
+/// become one from inside is the dependency direction — `aa-gateway` and
+/// `aa-runtime` cannot import `aa-api`, so the code that decides cannot name the
+/// type.)
+///
+/// Both a named `$ref` and an inlined copy are checked: utoipa inlines some
+/// schemas, and an inlined enum would carry the eight spellings with no `$ref`
+/// to find.
+#[test]
+fn the_disposition_is_never_a_request_input() {
+    let spec = committed_spec();
+
+    // Which component schemas can reach SensitiveDataDisposition — computed
+    // rather than listed, so a new response type embedding it is covered the day
+    // it is added.
+    let schemas = spec["components"]["schemas"]
+        .as_object()
+        .expect("the spec has component schemas");
+    let mut tainted: Vec<String> = vec!["SensitiveDataDisposition".to_string()];
+    loop {
+        let mut grew = false;
+        for (name, schema) in schemas {
+            if tainted.iter().any(|t| t == name) {
+                continue;
+            }
+            let mut refs = Vec::new();
+            referenced_schema_names(schema, &mut refs);
+            if refs.iter().any(|r| tainted.iter().any(|t| t == r)) {
+                tainted.push(name.clone());
+                grew = true;
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
+
+    // Anti-vacuity: the closure must have found the response that carries the
+    // field. If the field were dropped from every response this test would
+    // otherwise pass by scanning for a type nothing uses.
+    assert!(
+        tainted.iter().any(|t| t == "AgentDecisionResponse"),
+        "AgentDecisionResponse no longer reaches SensitiveDataDisposition; the field \
+         is not on the response it is supposed to be on. Tainted set: {tainted:?}",
+    );
+    assert!(
+        tainted.iter().any(|t| t == "AgentDecisionsResponse"),
+        "AgentDecisionsResponse no longer reaches SensitiveDataDisposition",
+    );
+
+    let mut request_shapes_scanned = 0usize;
+    for (path, item) in spec["paths"].as_object().expect("the spec has paths") {
+        for (method, operation) in item.as_object().expect("a path item is a map") {
+            for input_kind in ["requestBody", "parameters"] {
+                let Some(input) = operation.get(input_kind) else {
+                    continue;
+                };
+                request_shapes_scanned += 1;
+
+                let mut refs = Vec::new();
+                referenced_schema_names(input, &mut refs);
+                for reference in &refs {
+                    assert!(
+                        !tainted.iter().any(|t| t == reference),
+                        "{method} {path} accepts {reference} as a {input_kind}, which reaches \
+                         SensitiveDataDisposition — the disposition must never be an input \
+                         (ADR 0032 §10 D-2)",
+                    );
+                }
+
+                // An inlined enum would have no $ref to catch. `require_approval`
+                // is unique to this vocabulary, so its presence in a request
+                // shape means the disposition was inlined into one.
+                assert!(
+                    !contains_string(input, "require_approval"),
+                    "{method} {path} inlines the disposition vocabulary into a {input_kind}",
+                );
+            }
+        }
+    }
+
+    // Anti-vacuity: the spec really does have request shapes, so the loop above
+    // asserted something.
+    assert!(
+        request_shapes_scanned > 50,
+        "only {request_shapes_scanned} request shapes scanned — the scan is not \
+         reaching the spec's inputs",
+    );
+}
+
+/// The published schema is optional, carries all eight spellings, and lives on
+/// the decision record.
+#[test]
+fn the_published_schema_is_optional_and_carries_the_eight_spellings() {
+    let spec = committed_spec();
+
+    let published: Vec<&str> = spec["components"]["schemas"]["SensitiveDataDisposition"]["enum"]
+        .as_array()
+        .expect("SensitiveDataDisposition is published as an enum schema")
+        .iter()
+        .map(|v| v.as_str().expect("a string enum value"))
+        .collect();
+    assert_eq!(
+        published,
+        [
+            "redact",
+            "mask",
+            "tokenize",
+            "require_approval",
+            "approval_granted",
+            "approval_denied",
+            "shadow_only",
+            "none",
+        ],
+    );
+
+    let decision_row = &spec["components"]["schemas"]["AgentDecisionResponse"];
+    assert!(
+        decision_row["properties"].get("sensitiveDataDisposition").is_some(),
+        "AgentDecisionResponse does not publish sensitiveDataDisposition",
+    );
+
+    // Optional: an existing client that does not send or expect it stays valid.
+    let required: Vec<&str> = decision_row["required"]
+        .as_array()
+        .map(|s| s.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    assert!(
+        !required.contains(&"sensitiveDataDisposition"),
+        "the disposition is a required property; it must be additive and optional",
+    );
+    // Anti-vacuity: this response does have required properties, so the check
+    // above is reading a real list.
+    assert!(required.contains(&"timestamp"), "required list not found: {required:?}");
+}

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -2727,6 +2727,7 @@ export interface components {
              *     `resource` column. `null` when the detail carries no resolvable target.
              */
             resource?: string | null;
+            sensitiveDataDisposition?: null | components["schemas"]["SensitiveDataDisposition"];
             /**
              * Format: int64
              * @description Per-session monotonic sequence of the audit entry. Combined with
@@ -5785,6 +5786,26 @@ export interface components {
             /** @description Fixed leak severity: `critical` | `high` | `medium` | `low`. */
             severity: string;
         };
+        /**
+         * @description What the sensitive-data pipeline did to an action's payload and to the
+         *     approval of the action, at a granularity the 5-way runtime verdict
+         *     deliberately does not carry (ADR 0032 §10 D-2).
+         *
+         *     A **record of** a decision the gateway already made, never an input to one:
+         *     the runtime verdict remains the authoritative outcome, and every disposition
+         *     but `none` maps onto one, so a client that reads only the verdict still
+         *     reaches a correct if coarser conclusion.
+         *
+         *     These eight values are a closed vocabulary. Adding a ninth is the same
+         *     category of breaking wire change ADR 0024 forbids for the runtime verdict.
+         *
+         *     This doc comment is published as the schema description in `openapi/v1.yaml`;
+         *     the implementation rationale — including how "never an authorisation input"
+         *     is enforced rather than promised — is in the module documentation, which is
+         *     not.
+         * @enum {string}
+         */
+        SensitiveDataDisposition: "redact" | "mask" | "tokenize" | "require_approval" | "approval_granted" | "approval_denied" | "shadow_only" | "none";
         /** @description A single time-series point: `t` is epoch milliseconds, `value` the count. */
         SeriesPoint: {
             /**

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -4409,6 +4409,37 @@ components:
             The action's primary target derived from the audit `detail` (tool name,
             file path, network host, process command, or LLM model). The design's
             `resource` column. `null` when the detail carries no resolvable target.
+        sensitiveDataDisposition:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/SensitiveDataDisposition'
+            description: |-
+              What the sensitive-data pipeline did to this action's payload and to the
+              approval of the action (AAASM-5356, ADR 0032 §10 D-2) — a finer
+              vocabulary than `verdict`, which stays the authoritative outcome and is
+              frozen at five values.
+
+              **Additive and optional.** The key is *omitted entirely* when there is no
+              disposition to report, so a response for an action that has none is
+              byte-for-byte what this endpoint returned before the field existed. An
+              absent key and an explicit `"none"` say the same thing: this field adds
+              nothing and `verdict` carries the whole meaning. A client that has never
+              heard of the field reads exactly the object it read before.
+
+              Declared last, so a response that *does* carry a disposition is a pure
+              suffix append to the object as it was.
+
+              **Absent on every row today**: no writer populates the audit payload's
+              `sensitive_data_disposition` yet — that is AAASM-5357's projection. The
+              read is wired through now so the day it lands there is no second contract
+              change, which is the pattern `verdict` followed.
+
+              **Reporting only.** Nothing consults this to decide whether an action is
+              permitted — `verdict` remains the authoritative outcome. It is a field of
+              this response like any other, so it inherits the endpoint's tenant
+              scoping unchanged: `authorize_agent_access` gates the whole row, so the
+              `approval_*` values it can carry are visible to exactly the callers
+              already entitled to the decision record.
         seq:
           type: integer
           format: int64
@@ -9097,6 +9128,34 @@ components:
         severity:
           type: string
           description: 'Fixed leak severity: `critical` | `high` | `medium` | `low`.'
+    SensitiveDataDisposition:
+      type: string
+      description: |-
+        What the sensitive-data pipeline did to an action's payload and to the
+        approval of the action, at a granularity the 5-way runtime verdict
+        deliberately does not carry (ADR 0032 §10 D-2).
+
+        A **record of** a decision the gateway already made, never an input to one:
+        the runtime verdict remains the authoritative outcome, and every disposition
+        but `none` maps onto one, so a client that reads only the verdict still
+        reaches a correct if coarser conclusion.
+
+        These eight values are a closed vocabulary. Adding a ninth is the same
+        category of breaking wire change ADR 0024 forbids for the runtime verdict.
+
+        This doc comment is published as the schema description in `openapi/v1.yaml`;
+        the implementation rationale — including how "never an authorisation input"
+        is enforced rather than promised — is in the module documentation, which is
+        not.
+      enum:
+      - redact
+      - mask
+      - tokenize
+      - require_approval
+      - approval_granted
+      - approval_denied
+      - shadow_only
+      - none
     SeriesPoint:
       type: object
       description: 'A single time-series point: `t` is epoch milliseconds, `value` the count.'


### PR DESCRIPTION
> **Review round 1 addressed** (commits `3e4d23fde`, `a63a3be78`). The blocker was correct and the criticism was the right one: **the only behavioural code in this PR was provably untested.** Replacing the whole read block with `let sensitive_data_disposition = None;` left all 1176 tests green and the drift gate passing, and not one of my eleven mutations attacked it — every one went at the vocabulary, the mapping, or the artifact. That is the same "bound one step earlier than its claim" shape as #1907 and #1908. Four read-path tests now close it, and three new mutations (M12–M14) prove them. SF1 and every nit are addressed below; nothing was pushed back on.

## Description

Implements ADR 0032 §10 **D-2** directly: `RuntimeVerdict` stays frozen, and the finer sensitive-data vocabulary lands in a separate optional field, `sensitive_data_disposition`, carrying the eight values `redact` · `mask` · `tokenize` · `require_approval` · `approval_granted` · `approval_denied` · `shadow_only` · `none`.

`RuntimeVerdict` is untouched — no variant added, renamed or reordered — because ADR 0024 establishes that adding an enum variant is not additive on the wire, and ADR 0018 froze that vocabulary on purpose. AAASM-5384's `aa_core_label_contract`, which pins `RuntimeVerdict` positionally against `aa_core::types::sensitive_data::RuntimeVerdictLabel::ALL`, is left exactly as merged and is the model the new vocabulary's pinning follows.

**The mapping** (ADR 0032 §10 D-2's table, implemented as a wildcard-free eight-arm `match` in `SensitiveDataDisposition::implied_verdict`):

| `sensitive_data_disposition` | `RuntimeVerdict` |
|---|---|
| `redact` | `scrub` |
| `mask` | `scrub` |
| `tokenize` | `scrub` |
| `require_approval` | `pending` |
| `approval_granted` | `allow` |
| `approval_denied` | `deny` |
| `shadow_only` | `allow` |
| `none` | *(none — the verdict carries the whole meaning)* |

`none` maps to no verdict rather than to `allow`, because it is not a claim that the action was allowed; returning `allow` would let a `none` disposition contradict a `deny` verdict.

### The two modelling gaps the ticket left open

**Shadow reporting ownership.** The audit event's `shadow_decision` string (`proto/audit.proto` field 31) keeps sole ownership of *what the policy engine would have decided* in observe/dry-run mode, alongside the rule id that produced it. `shadow_only` answers a different question — *what happened to the payload*, namely nothing, the pipeline observed and reported only. There is no competing representation, and that is structural rather than a rule to remember: `ShadowOnly` is a **unit variant**, so it has nowhere to put a would-be verdict even if someone tried to copy one in.

**Precedence for combined dispositions.** An action can be both redacted *and* approval-granted; the field is single-valued. The rule is derived from the mapping rather than invented: **the disposition implying the more restrictive verdict wins**, so collapsing to one value can never under-report to a `RuntimeVerdict`-only reader. Redacted-and-approval-granted reports `redact` (verdict `scrub`), not `approval_granted` (verdict `allow`) — the outcome §10 calls for. `approval_denied` outranks a transformation, because an action that was blocked did not happen whatever was done to its payload first. The property is asserted over all 64 ordered pairs, not by reading the rank literals back.

### Never an authorisation input — enforced, not promised

Three independent mechanisms, none of which is a comment:

1. **The crates that decide cannot name the type.** `aa-api` depends on `aa-gateway` and `aa-runtime`; the dependency does not run the other way (ADR 0018 put `RuntimeVerdict` here for the same reason — so it could carry a `utoipa::ToSchema` derive). For the policy engine or the enforcement pipeline to consult a `SensitiveDataDisposition` it would have to depend on `aa-api`, which is a dependency cycle `cargo` refuses to build. This needs no test; it is a build-graph property.
2. **It is never an input.** `the_disposition_is_never_a_request_input` asserts against the *committed* `openapi/v1.yaml` that the disposition schema — and every schema that transitively reaches it, computed by closure rather than listed — appears in no `requestBody` and no `parameters` entry. If a caller cannot send one, there is nothing for the server to consult. Both a named `$ref` and an inlined copy of the vocabulary are checked, since utoipa inlines some schemas.
3. **It exposes no permission-shaped API.** No `is_allowed`, no `From<SensitiveDataDisposition> for Decision`, and deliberately no `PartialOrd`/`Ord` — an ordering is exactly the hook someone would reach for to write "at least as permissive as", which is an authorisation question.

On the ticket's related security note: the `approval_*` values are a field of `AgentDecisionResponse` like any other, so they inherit the endpoint's scoping unchanged — `authorize_agent_access` gates the whole row, and the values are visible to exactly the callers already entitled to the decision record. No raw sensitive value can reach the field: it is a closed eight-value enum.

### Additivity

Stronger than "optional": `#[serde(skip_serializing_if = "Option::is_none")]` omits the key **entirely** rather than emitting `null`, so a decision row with no disposition is **byte-identical** to what `GET /api/v1/agents/{id}/decisions` returned before the field existed. The field is declared last, so a row that *does* carry one is a pure suffix append. No new OpenAPI path — the spec diff is 59 added lines and zero removed.

The field is absent on every row today: nothing writes `sensitive_data_disposition` into the audit payload yet (that projection is AAASM-5357's). The read is wired now so the day it lands there is no second contract change — the pattern `verdict` followed under AAASM-5100.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

Additive and optional only. Old clients ignore the new key; old servers omit it, which readers treat as `none`. No migration, no data backfill. `a_row_without_a_disposition_is_byte_identical_to_the_pre_change_response` asserts this against a frozen literal of the pre-change bytes rather than against a value derived from the current struct.

## Related Issues

- Related Jira ticket: [AAASM-5356](https://lightning-dust-mite.atlassian.net/browse/AAASM-5356) (Epic [AAASM-5270](https://lightning-dust-mite.atlassian.net/browse/AAASM-5270), Wave 4)
- Builds on merged contracts AAASM-5355 (`e4297575`) and AAASM-5384 (`7d6a2d64`) — neither is modified.
- Related GitHub issues: N/A

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

### SF1 — `.ok()` overloads absence

Accepted as stated. After this PR "absent" means *no disposition recorded* **or** *one this build could not parse*. Rather than add a counter (new behaviour, and this ticket is contract-only), the fix is to stop the docs claiming a refusal the shipped path does not perform:

- `an_unknown_spelling_is_refused` → renamed **`an_unknown_spelling_is_refused_by_deserialize`**, with a section saying explicitly that the audit-log reader swallows the error and records absence.
- The behaviour is now **pinned** by `an_unparseable_disposition_reads_as_absent_rather_than_failing_the_row` instead of implied, and M14 proves that test bites.
- The bound is asserted in the same test: `verdict` is parsed independently and stays authoritative, so a fallback reader is never misled about whether the action was permitted.

### Nits — all taken

- **ADR 0018 attribution dropped.** ADR 0018 lists the five variants and calls them ordered but states no ranking to inherit. The numbers are this ticket's judgment, now owned as such, with the debatable one named: `pending` (4) above `scrub` (3), because a held action has not happened while a scrubbed one was carried out. Noted that nothing outside the property test depends on it.
- **Path-level `parameters`** now scanned; non-operation keys of a path item are skipped explicitly against an `HTTP_METHODS` list rather than by asking every child for a `requestBody`. Proven by N1.
- **Inlined subset** now fails on **≥2** spellings rather than grepping for `require_approval` alone. Proven by N2.
- **`oneOf: [{type: 'null'}, {$ref}]`** — recorded in the test rather than glossed: the *contract* tolerates an explicit `null` the *server* never sends, because `skip_serializing_if` omits the key, which the byte-identical test proves. Generated by utoipa; not hand-editable without breaking the drift gate. A reader of the artifact should know the stronger guarantee lives in the server.
- **`require_approval` outranking `approval_granted`** — a sentence added. It is defused by the two being mutually exclusive on one record, not by the ranking; and if a caller ever holds both, `pending` over-reports restrictiveness, which is the safe direction for a reporting field.

21 new tests, all running in the **default** profile — no feature gate, no doctest — and all observed executing by name under a plain `cargo nextest run`. (AAASM-5354 found 19 `aa-security` tests that had gone unrun for months behind `#[cfg(feature = "serde")]`; CI also runs `cargo test --doc` for `aa-gateway` only, so a doctest here would have been dead weight and the one drafted was removed in favour of a real unit test.)

### Mutation evidence

Every assertion was watched failing before it was trusted. Restored to a clean tree between each.

| # | Mutation | What failed |
|---|---|---|
| M1 | Remove the `tokenize` value from the enum | **Compile error, exit 101** — `implied_verdict` and `precedence` are wildcard-free, so a removed value breaks the *library*, not merely its tests: `no variant … named Tokenize found for enum SensitiveDataDisposition` |
| M2 | Drop `tokenize` from the pinned arrays only, keeping the variant | `the_vocabulary_is_exactly_adr_0032s_eight_values` — `left: 7, right: 8` (the length check runs before the `zip`, which would otherwise truncate a dropped entry into a pass) |
| M3 | Rename the wire casing (`snake_case` → `camelCase`) | `…eight_values`: *RequireApproval serializes as `"requireApproval"` but ADR 0032 §10 D-2 spells it `"require_approval"`*; `an_unknown_spelling_is_refused` also fails |
| M4 | Rename one value (`mask` → `obscure`) | `…eight_values`: *Mask serializes as `"obscure"` but ADR 0032 §10 D-2 spells it `"mask"`* |
| M5 | Break the mapping (`approval_denied` → `Allow`) | `the_mapping_is_exactly_adr_0032s_table` — `left: Some(Allow), right: Some(Deny)`; `precedence_never_under_reports_the_verdict` and `a_refusal_outranks_a_transformation` fail with it |
| M6 | Break precedence (`approval_granted` outranks `require_approval`) | `a_transformation_outranks_an_approval_grant` — `left: ApprovalGranted, right: Redact`, plus the all-pairs property |
| M7 | Drop `skip_serializing_if` so absence emits `null` | `a_row_without_a_disposition_is_byte_identical_to_the_pre_change_response`, printing the exact regression: `…,"latencyMs":12,"sensitiveDataDisposition":null}` vs `…,"latencyMs":12}` |
| M8a | Point a real `requestBody` at a disposition-bearing schema | `the_disposition_is_never_a_request_input`: *put /api/v1/admin/retention-policy accepts AgentDecisionResponse as a requestBody, which reaches SensitiveDataDisposition* |
| M8b | Inline the eight spellings into a real `requestBody` (no `$ref` to find) | same test: *post /api/v1/admin/retention-policy/run inlines the disposition vocabulary into a requestBody* |
| M9 | Make the response stop referencing the disposition | The anti-vacuity guard fires rather than the scan passing on an unused type: *AgentDecisionResponse no longer reaches SensitiveDataDisposition … Tainted set: ["SensitiveDataDisposition"]* |
| M10 | Make the field `required` in the published schema | `the_published_schema_is_optional_and_carries_the_eight_spellings`: *the disposition is a required property; it must be additive and optional* |
| M11 | Drop a spelling from the published enum | same test, with the 7-vs-8 list diff |

**Round 2 — the mutations that should have been in round 1.** The reviewer's point stands: eleven mutations and none touched `entry_to_decision_row`, the only code that ever populates the field.

| # | Mutation | What failed |
|---|---|---|
| M12 | **Gut the read path** — replace the whole block with `let sensitive_data_disposition = None;` (the reviewer's own mutation) | `a_payload_carrying_a_disposition_surfaces_it_on_the_row` — `left: None, right: Some(Redact)`; `every_disposition_spelling_survives_the_read_path` — *the read path lost `"redact"`* |
| M13 | Read the wrong payload key — camelCase instead of the audit log's snake_case | Both of the above; catches the reader looking in the wrong place, which a shape-only test cannot |
| M14 | Default an unparseable spelling to `none` instead of absent | `an_unparseable_disposition_reads_as_absent_rather_than_failing_the_row` — `left: Some(None), right: None` |
| N1 | A **path-level** `parameters` array (sibling of the methods) accepting the disposition | Now caught: *`/api/v1/agents/{id}/decisions` (path-level) accepts SensitiveDataDisposition as a parameters* — this evaded the round-1 scan entirely |
| N2 | Inline a **subset** of the vocabulary (`redact`/`mask`/`tokenize` only, no `require_approval`) | Now caught: *inlines 3 of the disposition's spellings into a requestBody* — the round-1 single-needle grep would have missed this |
| N3 | Retype the published property to a bare `string` | Now caught: *sensitiveDataDisposition no longer resolves to the disposition schema*. **This is the escape M9 previously slipped through** — in round 1 `the_published_schema_…` passed under exactly this mutation |

**One round-1 attempt passed and should not have, and that is recorded rather than quietly rerun.** The first version of M8 injected a second `post:` key under an existing path item; YAML kept only the last, so the mutation never reached the parsed document and the test passed. M8a/M8b replace it by mutating a *real* `requestBody`. The lesson is the ticket's own: a mutation that fails to mutate looks exactly like a test that caught nothing.

### What layer 2 actually proved, restated honestly

The reviewer's framing is the correct one and worth keeping in the record: **layer 2 proved *provenance*, not *fidelity*.** It showed the published contract has the right shape and appears in no request input; it said nothing about whether the reader reads. Layers 1 (build graph) and 3 (no `is_allowed`, no `Ord`) were and remain genuine. The read-path tests are what make layer 2's claim behavioural rather than structural-only.

### Verification

| Check | Result |
|---|---|
| `cargo nextest run -p aa-api` (after review fixes) | **1180 passed, 0 failed** — all 21 new tests observed executing by name |
| `cargo nextest run -p aa-api -p aa-core` (round 1) | **1666 passed, 0 failed** |
| `cargo fmt` / `cargo clippy --all-targets -- -D warnings` | Green — enforced by the lefthook pre-commit hook on every one of the four commits, none bypassed |
| OpenAPI drift gate: `cargo run -p aa-api --bin generate_openapi` vs `openapi/v1.yaml` | **No diff** — the spec is regenerated, never hand-edited |
| `npx @stoplight/spectral-cli lint openapi/v1.yaml` | `No results with a severity of 'error' found!` |
| Dashboard codegen: `pnpm run generate:api` then `pnpm type-check` (`tsc --noEmit`) | Clean; `schema.d.ts` diff is +21 lines, 0 removed |
| Every commit builds (AAASM-5385): `cargo check -p aa-api --all-targets` at `14d5c9e4c`, `c79d3d5ef`, `76fb27a22`, `b03f31cb2`, `3e4d23fde`, `a63a3be78` | Exit 0 at all six |

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)


[AAASM-5356]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ