### PR TITLE
[AAASM-5444] 🔧 (ci): Classify aa-api-server-pg-qa as intentionally unreleased

### DIFF
--- a/scripts/check-release-completeness.sh
+++ b/scripts/check-release-completeness.sh
@@ -50,7 +50,12 @@ pkg_of() {
 #                             security tests run against the real boundary
 #                             rather than a mock. Test-only, never shipped
 #                             (AAASM-5282).
-UNRELEASED_BINARIES="generate_openapi generate_policy_rbac_doc generate_golden aa-ebpf-loaderd aa-devint-harness"
+# `aa-api-server-pg-qa` is a QA-only entrypoint (AAASM-5444). Its own module
+# docs say so: "This is NOT a shipped binary — it exists so QA can exercise the
+# Postgres happy-path that the SQLite `aa-api-server` intentionally degrades."
+# It needs a live `AAASM_DATABASE_URL`, so shipping it would hand users a binary
+# that cannot start.
+UNRELEASED_BINARIES="generate_openapi generate_policy_rbac_doc generate_golden aa-ebpf-loaderd aa-devint-harness aa-api-server-pg-qa"
 
 fail=0
 err() { echo "::error::$*" >&2; fail=1; }


### PR DESCRIPTION
## Description

The `Release-artifact completeness gate` has been failing on every PR opened since **#1905** (AAASM-5439), which added the `aa-api-server-pg-qa` workspace binary. The gate requires each workspace binary to be **explicitly** classified as released or intentionally unreleased, so an unclassified one is a correct failure — that is the whole point of the check.

## The classification is not a guess

The harness declares its own disposition, in its own module docs:

> **QA-ONLY** entrypoint … This is **NOT a shipped binary** — it exists so QA can exercise the Postgres happy-path that the SQLite `aa-api-server` intentionally degrades.

It also requires a live `AAASM_DATABASE_URL`, so shipping it would hand users a binary that cannot start. `UNRELEASED_BINARIES` is the right side, and no judgement about another author's intent had to be inferred.

## Why main went red without anyone noticing

**The gate runs on `pull_request` only**, and is path-filtered. It therefore never ran on the merge that introduced the binary. `main` has been failing it silently since, and the next PR to trigger it inherits a failure it did not cause — here **#1909** (AAASM-5350), which touches nothing near this.

Third instance of one shape this programme keeps meeting: **AAASM-5375** (an unparseable workflow yields zero check runs, so CI reads green), **AAASM-5432** (a packaging gate that could not have passed for a new crate), and now a gate consulted at one point in the lifecycle while the defect enters at another.

Whether this gate and the packaging gate should **also run on `main` pushes** — so a breaking merge is attributed to the merge rather than to the next unrelated contributor — is recorded on AAASM-5444 as a separate question, not decided here.

## Type of Change

- [x] 🐛 Bug fix (CI is red on main)

## Breaking Changes

- [x] No. `RELEASE_BINARIES` is untouched; the shipped set is exactly what it was.

## Related Issues

- Jira: **AAASM-5444**
- Introduced by: **AAASM-5439** (#1905) · Gate: **AAASM-4449**
- Unblocks: **#1909** (AAASM-5350)

## Testing

Run locally against the real workspace, not a fixture:

```
release-artifact completeness gate: OK
```

with all 11 workspace binaries enumerated and the 5 release binaries unchanged.

**Mutation-checked** — removing `aa-api-server-pg-qa` from the allowlist reproduces the exact CI failure:

```
::error::workspace binary 'aa-api-server-pg-qa' is neither in RELEASE_BINARIES nor
the intentionally-unreleased allowlist.
```

So the line is load-bearing, rather than a change that merely coincides with a passing gate.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (reason recorded inline, so the next reader need not re-derive it)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
