### PR TITLE
[AAASM-5325] 📝 (adr): Repair ADR 0030's stale citations of plugins.md

### DIFF
--- a/docs/src/adr/0030-developer-integration-boundaries-and-trust-model.md
+++ b/docs/src/adr/0030-developer-integration-boundaries-and-trust-model.md
@@ -4,6 +4,22 @@
 **Date**: 2026-07
 **Ticket**: [AAASM-5275](https://lightning-dust-mite.atlassian.net/browse/AAASM-5275)
 
+---
+
+> **Amendment (AAASM-5325, 2026-08)** — **citations only; no decision changes.**
+> This ADR quoted `docs/src/devtools/plugins.md` in two places, and
+> [AAASM-5322](https://lightning-dust-mite.atlassian.net/browse/AAASM-5322)
+> rewrote that file afterwards, so both quotations named text their cited source
+> no longer contained. One was load-bearing: §7.2's backward-compatibility
+> argument rested on a pinning rule scoped to `aa-core`, which the rewrite
+> withdrew *because it was wrong* — adapters depend on `aa-devtool-contract` and
+> never on `aa-core` directly. The guarantee always held in substance; only the
+> citation was broken, and it now quotes the rule that exists. §7.2's deferral of
+> the migration section ("owned by a parallel branch") has also expired — that
+> commitment now lives in `plugins.md` itself.
+>
+> Every decision, forbidden design and consequence below is unchanged.
+
 This ADR fixes the architectural boundaries and the trust model for **Developer
 Integrations** — the machinery by which AASM installs, verifies, repairs and removes
 governance for a developer's AI coding tool (Claude Code, Codex, Copilot, Windsurf, a
@@ -102,15 +118,23 @@ problems follow directly from that shape:
 
 ### The registration model is build-time linking, and that is not an accident
 
-`docs/src/devtools/plugins.md` is explicit:
+[`docs/src/devtools/plugins.md` §"How adapters get loaded — build-time linking, by
+decision"](../devtools/plugins.md#how-adapters-get-loaded--build-time-linking-by-decision)
+is explicit:
 
-> Right now Agent Assembly uses **build-time linking**… There is **no**
-> `inventory::submit!`-style runtime registration in `aa-core` today, and there is no
-> dynamic shared-library loading. Both were proposed in early designs but neither has
-> been implemented; do not write code that assumes either exists.
+> Agent Assembly links adapters **at build time**. An adapter is loaded by linking
+> its crate into a binary that constructs it explicitly and registers it in an
+> in-memory registry at startup.
+>
+> There is **no** `inventory::submit!`-style runtime registration and **no**
+> dynamic shared-library loading.
 
-This ADR turns that observation into a decision: build-time linking is the *chosen*
-model, not a temporary gap (see Decision 6).
+This ADR is what makes that a decision rather than an observation: build-time linking
+is the *chosen* model, and dynamic loading is forbidden rather than merely absent (see
+Decision 6). The wording above already reflects that — when this ADR was written the
+same file described dynamic loading as an unimplemented gap, and it was rewritten by
+[AAASM-5322](https://lightning-dust-mite.atlassian.net/browse/AAASM-5322) once this
+ADR settled the question.
 
 ### Known current-state divergence (not fixed here)
 
@@ -736,11 +760,25 @@ lifecycle. No third-party adapter breaks.
 
 `DevToolAdapter` is removed only in a **major `aa-core` bump**, with `LegacyAdapterShim`
 retained for at least one minor release after the last in-tree consumer migrates, and a
-migration section added to `docs/src/devtools/plugins.md` — a file this ADR deliberately does
-not edit (it is owned by a parallel branch); updating it is a follow-up on the
-implementing ticket. `docs/src/devtools/plugins.md` already states the pinning rule that makes
-this safe for third parties: *"Adapters are tightly coupled to the `aa-core` major version
-they were built against. Pin `aa-core` exactly."*
+migration section added to [`docs/src/devtools/plugins.md`](../devtools/plugins.md#if-this-contract-breaks),
+which now carries that commitment in the file third parties actually read rather than only
+here.
+
+What makes this safe for third parties is the coupling rule that file states under
+[§Versioning](../devtools/plugins.md#versioning) — scoped to **`aa-devtool-contract`**, not
+to `aa-core`:
+
+> An adapter is coupled to the `aa-devtool-contract` / `aa-core` version it was
+> built against, and the core distributes as **one versioned unit** (runtime +
+> gateway + the linked adapters), so a git or path dependency pinned to a tag is
+> the practical form of that coupling.
+
+The distinction is not cosmetic. Adapters depend on `aa-devtool-contract` and never on
+`aa-core` directly — that facade is the security boundary Decision 4 establishes — so an
+argument resting on third parties pinning `aa-core` would be resting on a dependency they
+are forbidden to have. The guarantee holds either way, but only the `aa-devtool-contract`
+form is one an adapter author can act on. Every adapter crate is also `publish = false`,
+so the pin is a git or path dependency on a tag, not a crates.io version requirement.
 
 #### 7.3 Sequencing
 

--- a/docs/src/adr/README.md
+++ b/docs/src/adr/README.md
@@ -39,6 +39,6 @@ An ADR records **only** durable product or system decisions — product and busi
 | [0026](0026-open-dashboard-product-semantics.md) | Seven Open Dashboard Product-Semantics Decisions | Proposed (Decision 2 Accepted) |
 | [0027](0027-accessibility-floor-overrides-visual-spec.md) | The Accessibility Floor Overrides the Visual Specification | Accepted |
 | [0029](0029-capability-over-permission-derivation.md) | Capability Over-Permission Derivation | Proposed |
-| [0030](0030-developer-integration-boundaries-and-trust-model.md) | Developer Integration Boundaries, Capability Model & Local Trust Model | Proposed |
+| [0030](0030-developer-integration-boundaries-and-trust-model.md) | Developer Integration Boundaries, Capability Model & Local Trust Model | Accepted |
 | [0031](0031-oss-native-account-authentication.md) | OSS Native Account Authentication | Accepted |
 | [0032](0032-local-first-sensitive-data-provider-architecture.md) | Local-First Sensitive-Data Provider Architecture | Accepted |

--- a/docs/src/devtools/plugins.md
+++ b/docs/src/devtools/plugins.md
@@ -289,6 +289,24 @@ the practical form of that coupling. When a breaking change lands on
 `AdapterError` and `IntegrationCapability` are `#[non_exhaustive]` — adding
 variants is not a breaking change, so do not match exhaustively on either.
 
+### If this contract breaks
+
+The older `DevToolAdapter` trait still exists, and `LegacyAdapterShim` adapts
+any implementation of it to `DevToolIntegration`. If `DevToolAdapter` is ever
+removed, [ADR 0030 §7.2](../adr/0030-developer-integration-boundaries-and-trust-model.md#72-if-a-break-becomes-unavoidable)
+binds that removal to three conditions:
+
+1. it happens only in a **major `aa-core` bump**;
+2. `LegacyAdapterShim` is retained for **at least one minor release** after the
+   last in-tree consumer migrates;
+3. a migration section is added **here**, before the removal ships.
+
+No such removal is scheduled. This section states the commitment rather than
+the migration steps deliberately: the steps depend on what `DevToolIntegration`
+looks like at that time, and writing them against a break that has not happened
+would produce guidance that is wrong by the time anyone needs it. What you can
+rely on now is the notice period and that the guidance will be here.
+
 ---
 
 ## What is and is not in scope


### PR DESCRIPTION
## Description

**AAASM-5325.** AAASM-5322 rewrote `docs/src/devtools/plugins.md`; ADR 0030 quotes that file in two places, and both quotations named text the source no longer contains. This repairs the citations. **No decision changes.**

## The one that mattered

The first misquote is harmless in substance — the file still says build-time linking with no `inventory::submit!` registration and no dynamic loading, in different words, because it now frames dynamic loading as *forbidden by Decision 6* rather than as an unimplemented gap. This ADR caused that reframing, so the passage now quotes the current text and says so.

The second was **load-bearing**. §7.2's backward-compatibility argument — the reason removing `DevToolAdapter` is safe for third parties — rested on:

> "Adapters are tightly coupled to the `aa-core` major version they were built against. Pin `aa-core` exactly."

That sentence was withdrawn from the source **because it was wrong**. Adapters depend on `aa-devtool-contract` and never on `aa-core` directly; that facade is the security boundary Decision 4 establishes. So the ADR's safety argument rested on third parties holding a dependency they are *forbidden to have*.

The guarantee itself always held — the rewrite states an equivalent rule scoped to `aa-devtool-contract`. Only the citation was broken, and it now quotes the rule that exists, with the `publish = false` consequence stated, since the pin is a git or path dependency on a tag rather than a version requirement.

## The migration section §7.2 promised

Its deferral ("owned by a parallel branch") has expired. Rather than delete the promise, the **commitment moves into `plugins.md`** — the file an adapter author actually reads — stating the three conditions binding a `DevToolAdapter` removal: major `aa-core` bump, shim retained ≥1 minor release, migration section written before removal ships.

The migration **steps** deliberately are not written. No removal is scheduled, the steps depend on what `DevToolIntegration` looks like at that time, and writing them against a break that has not happened produces guidance that is wrong by the time anyone needs it. What can be relied on now is the notice period.

## Also fixed: a status drift found on the way

ADR 0030's own header has said **Accepted** since ratification (§7.3: "ratified when 5277 lands"; AAASM-5277 is Done), while the index row said **Proposed**. The index is where a reader checks whether a decision binds, so the drift understated a ratified, implemented decision. Corrected here because this ADR was already being amended.

**Two others drift the same way** — 0020 and 0022, both ratified in-file, both Proposed in the index. Filed as **AAASM-5445** rather than folded in, since neither is this ticket. That ticket also records that nothing detects this class of drift.

## Governance

ADR 0030 is Accepted, and the ADR README says decisions are *"never rewritten"*. Recorded as an **amendment header** per the existing ADR 0002 / 0007 precedent, stating explicitly that every decision, forbidden design and consequence is unchanged (AC 4).

## Type of Change

- [x] 📝 Documentation

## Breaking Changes

- [x] No. Citations and one index cell; no decision, forbidden design or consequence altered.

## Related Issues

- Jira: **AAASM-5325**
- Caused by: **AAASM-5322** (the plugins.md rewrite) · Governs: **ADR 0030** (AAASM-5275)
- Filed from this work: **AAASM-5445** (ADR index drift on 0020 / 0022)

## Testing

All four cross-document anchors were **verified to resolve**, not assumed:

| Link | Target |
|---|---|
| `plugins.md#how-adapters-get-loaded--build-time-linking-by-decision` | OK |
| `plugins.md#versioning` | OK |
| `plugins.md#if-this-contract-breaks` | OK |
| `0030…#72-if-a-break-becomes-unavoidable` | OK |

The first anchor check I wrote reported that link MISSING. The **checker** was wrong, not the link — it substituted a space for the em dash where mdBook strips it. Caught by calibrating against an anchor that already ships and works (`infra-overview.md#architecture-at-a-glance--components-layers--relations`); the corrected checker passes calibration and all four targets.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
