### PR TITLE
[AAASM-5364] 🐛 (aa-security): Treat the full-width hyphen and ideographic space as digit separators

### DIFF
--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -886,6 +886,49 @@ pub(crate) fn ascii_digit_of(c: char) -> Option<char> {
     }
 }
 
+/// The ASCII separator equivalent of `c` for [`digit_segment`]'s walk — `' '`
+/// for the space forms, `'-'` for the hyphen forms, `None` for anything else.
+///
+/// AAASM-5364: [`ascii_digit_of`] closed the full-width *digit* evasion, which
+/// is the whole of the credit-card case because a bare card carries no
+/// separators. It is not the whole of the SSN case: [`is_ssn`] matches the exact
+/// shape `DDD-DD-DDDD`, so the hyphens have to normalise too, and the
+/// space-grouped card form has the same problem. A CJK input method in full-width
+/// mode emits **U+FF0D** when the hyphen key is pressed and **U+3000** for the
+/// space bar, so an SSN or a grouped card typed the natural way by a Taiwanese or
+/// Japanese user went undetected while its ASCII twin did not.
+///
+/// The normalisation is for **matching only**, exactly as for digits: both
+/// full-width forms are three UTF-8 bytes against ASCII's one, so the caller
+/// pushes the ASCII equivalent into the normalised string while advancing `end`
+/// by the *original* character's width.
+///
+/// # The boundary, and why it stops here
+///
+/// U+2010–U+2015 (hyphen, non-breaking hyphen, figure/en/em dash, horizontal bar)
+/// and U+00A0 (no-break space) were considered and **declined**:
+///
+/// * No input method emits any of them for the hyphen or space key, so admitting
+///   them buys nothing against the evasion this rule exists to close — the threat
+///   is an input-mode switch, not an arbitrary look-alike glyph.
+/// * Each admitted separator lengthens the run [`digit_segment`] will join, and
+///   every additional joined run is an independent ~10% chance of a coincidental
+///   Luhn pass. The en dash is the standard glyph for a numeric *range*
+///   (`1990–2000`, `第 12–15 頁`) — precisely where two unrelated numbers sit
+///   adjacent with a dash between them — so it carries that risk at the highest
+///   rate of the set for no coverage in return.
+///
+/// The boundary is cheap to move if a payload is ever observed using one of them;
+/// `digit_separator_boundary_declines_en_dash_and_nbsp` pins it so the decision
+/// is visible rather than implicit.
+fn ascii_separator_of(c: char) -> Option<char> {
+    match c {
+        ' ' | '\u{3000}' => Some(' '),
+        '-' | '\u{FF0D}' => Some('-'),
+        _ => None,
+    }
+}
+
 /// Result of walking one digit segment (see [`digit_segment`]).
 struct DigitSegment {
     /// Byte offset just past the segment — where the outer scan resumes, and
@@ -931,19 +974,23 @@ fn digit_segment(text: &str, start: usize) -> DigitSegment {
         // separator must not be swallowed into the segment, or an SSN like
         // "123-45-6789 " would become 12 bytes and fail the exact-11-byte
         // `is_ssn` check, letting the PII through unredacted (AAASM-4820).
-        if matches!(c, ' ' | '-')
-            && !digits.is_empty()
-            && chars + 1 < DIGIT_SEGMENT_MAX_CHARS
-            && text[end + c.len_utf8()..]
-                .chars()
-                .next()
-                .and_then(ascii_digit_of)
-                .is_some()
-        {
-            normalised.push(c);
-            end += c.len_utf8();
-            chars += 1;
-            continue;
+        if let Some(sep) = ascii_separator_of(c) {
+            if !digits.is_empty()
+                && chars + 1 < DIGIT_SEGMENT_MAX_CHARS
+                && text[end + c.len_utf8()..]
+                    .chars()
+                    .next()
+                    .and_then(ascii_digit_of)
+                    .is_some()
+            {
+                // The ASCII equivalent, so `is_ssn`'s exact-11-byte shape check
+                // sees `DDD-DD-DDDD` whichever width the hyphens were typed in
+                // (AAASM-5364). `end` still advances by the original width.
+                normalised.push(sep);
+                end += c.len_utf8();
+                chars += 1;
+                continue;
+            }
         }
 
         break;
@@ -958,10 +1005,12 @@ fn digit_segment(text: &str, start: usize) -> DigitSegment {
 
 /// Scans `text` for credit card numbers (Luhn-validated) and SSN patterns (`DDD-DD-DDDD`).
 ///
-/// Digits are normalised by [`ascii_digit_of`], so a value written in full-width
-/// digits is detected as the same kind as its ASCII equivalent (AAASM-5345).
-/// Findings still span the **original** text: normalisation never reaches the
-/// offsets, only the strings the two checks are run against.
+/// Digits are normalised by [`ascii_digit_of`] and the separators between them by
+/// [`ascii_separator_of`], so a value written in full-width digits (AAASM-5345)
+/// or grouped by a full-width hyphen / ideographic space (AAASM-5364) is detected
+/// as the same kind as its ASCII equivalent. Findings still span the **original**
+/// text: normalisation never reaches the offsets, only the strings the two checks
+/// are run against.
 fn scan_digit_sequences(text: &str, findings: &mut Vec<CredentialFinding>) {
     let mut i = 0usize;
     while i < text.len() {

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2362,6 +2362,13 @@ mod tests {
             "發票號碼　ＡＢ－１２３４５６７８，金額 1,250 元。",
             "會議時間　１０：００－１１：３０，地點　Ｂ棟　３０５　會議室。",
             "版本區間　１．０．０－２．３．４，共 12 個修訂。",
+            // A 16-digit identifier in 4x4 groups — the only shape in this list
+            // that reaches the 13-19 digit Luhn window at all. The lines above
+            // are 4-2-2, 2-4-4 and dotted-version shapes that can never get
+            // there, so without this row the widened separator set is never
+            // exercised against the checksum in prose at all.
+            "轉帳帳號　１２３４　５６７８　９０１２　３４５６，於今日入帳。",
+            "轉帳帳號　１２３４－５６７８－９０１２－３４５６，於今日入帳。",
         ] {
             let result = scanner.scan(text);
             assert!(
@@ -2369,6 +2376,52 @@ mod tests {
                 "clean CJK prose produced {:?} for {text:?}",
                 result.findings.iter().map(|f| f.kind.as_str()).collect::<Vec<_>>(),
             );
+        }
+    }
+
+    #[test]
+    fn a_fullwidth_grouped_number_gets_exactly_the_ascii_verdict() {
+        // The cost side of AAASM-5364, asserted rather than left to the PR.
+        //
+        // Widening the separator set gives a full-width, separator-grouped
+        // 13-19 digit run its first chance to reach the Luhn check — and Luhn is
+        // a mod-10 checksum, so roughly one in ten arbitrary 16-digit numbers
+        // passes it by coincidence. Measured over 100,000 random 4x4 groupings:
+        // 10.209% for full-width digits with U+3000, 10.209% with U+FF0D, and
+        // 10.209% for the ASCII forms — identical, because the digit stream is
+        // identical once normalised. That parity is the ticket's goal.
+        //
+        // What parity does not settle is *who* pays it: full-width digits come
+        // from CJK input methods, so the whole of that new false-positive mass
+        // lands on CJK users, under `credential_action: Block`. That trade is an
+        // owner decision and is recorded on AAASM-5364; what this test can pin is
+        // the mechanism — a grouped number must get exactly the verdict its ASCII
+        // twin gets, never a different one, in either direction.
+        let scanner = CredentialScanner::new();
+        let verdict = |t: &str| {
+            scanner
+                .scan(t)
+                .findings
+                .iter()
+                .any(|f| f.kind == CredentialKind::CreditCardLuhn)
+        };
+        for (ascii, fullwidth_space, fullwidth_hyphen) in [
+            // Luhn-valid (a synthetic Visa test number).
+            (
+                "n=4532 0151 1283 0366",
+                "n=４５３２　０１５１　１２８３　０３６６",
+                "n=４５３２－０１５１－１２８３－０３６６",
+            ),
+            // Luhn-invalid: an ordinary 16-digit reference number.
+            (
+                "n=1234 5678 9012 3456",
+                "n=１２３４　５６７８　９０１２　３４５６",
+                "n=１２３４－５６７８－９０１２－３４５６",
+            ),
+        ] {
+            let expected = verdict(ascii);
+            assert_eq!(verdict(fullwidth_space), expected, "U+3000 diverged for {ascii:?}");
+            assert_eq!(verdict(fullwidth_hyphen), expected, "U+FF0D diverged for {ascii:?}");
         }
     }
 

--- a/aa-security/src/scanner.rs
+++ b/aa-security/src/scanner.rs
@@ -2181,6 +2181,197 @@ mod tests {
         }
     }
 
+    // --- AAASM-5364: the full-width hyphen (U+FF0D) and the ideographic space
+    //     (U+3000) are what a CJK input method emits for the hyphen and space
+    //     keys, so they must separate digits exactly as their ASCII twins do.
+    //     All fixtures are synthetic. ---
+
+    #[test]
+    fn detects_an_ssn_grouped_by_the_fullwidth_hyphen() {
+        // The case AAASM-5345 left open: it normalised the digits, but `is_ssn`
+        // still demanded ASCII hyphens, so a wholly full-width SSN — what a
+        // full-width IME actually produces — read as an ungrouped 9-digit run
+        // and was not SSN-shaped at all.
+        let scanner = CredentialScanner::new();
+        let ascii = scanner.scan("ssn=123-45-6789");
+        let fullwidth = scanner.scan("ssn=１２３－４５－６７８９");
+
+        let kinds = |r: &ScanResult| r.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>();
+        assert_eq!(kinds(&ascii), vec![CredentialKind::SsnPattern]);
+        assert_eq!(kinds(&fullwidth), kinds(&ascii));
+    }
+
+    #[test]
+    fn detects_an_ssn_whose_digits_are_ascii_but_whose_hyphens_are_not() {
+        // The cheapest form of the evasion, and the one a user reaches by
+        // accident: ASCII digits typed with the IME still in full-width mode, so
+        // only the two separators differ from the detected form.
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan("ssn=123－45－6789");
+        assert_eq!(
+            result.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>(),
+            vec![CredentialKind::SsnPattern],
+        );
+    }
+
+    #[test]
+    fn detects_a_card_grouped_by_the_ideographic_space() {
+        // The space-grouped card form. Grouping is how card numbers are written
+        // on the card itself, so this is the *natural* rendering rather than an
+        // adversarial one — and U+3000 is what the space bar emits in full-width
+        // mode.
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan("card=４５３２　０１５１　１２８３　０３６６");
+        assert_eq!(
+            result.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>(),
+            vec![CredentialKind::CreditCardLuhn],
+        );
+    }
+
+    #[test]
+    fn redacts_fullwidth_separated_values_to_exact_bytes() {
+        // Counting findings is not enough: a separator is three bytes here
+        // against ASCII's one, so an end offset computed on the normalised form
+        // splices the wrong region — one finding, digits still in the clear.
+        let scanner = CredentialScanner::new();
+        for (text, expected) in [
+            ("ssn=１２３－４５－６７８９", "ssn=[REDACTED:SsnPattern]"),
+            ("ssn=123－45－6789", "ssn=[REDACTED:SsnPattern]"),
+            (
+                "card=４５３２　０１５１　１２８３　０３６６",
+                "card=[REDACTED:CreditCardLuhn]",
+            ),
+        ] {
+            let redacted = scanner.scan(text).redact(text);
+            assert_eq!(redacted, expected, "wrong redaction for {text:?}");
+            assert!(contains_no_digit(&redacted), "residual digits: {redacted}");
+        }
+    }
+
+    #[test]
+    fn fullwidth_separated_spans_are_char_boundaries_of_the_original_text() {
+        // The span contract `redact` depends on, asserted directly. A separator
+        // is the newest way for an offset to land mid-character, since it is the
+        // one part of the segment whose normalised width (1 byte) differs from
+        // its original width (3 bytes) *and* which the walk may or may not
+        // consume depending on what follows it.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "ssn=１２３－４５－６７８９",
+            "ssn=123－45－6789",
+            "card=４５３２　０１５１　１２８３　０３６６",
+        ] {
+            let result = scanner.scan(text);
+            assert!(!result.findings.is_empty(), "no finding for {text:?}");
+            for f in &result.findings {
+                assert!(
+                    text.is_char_boundary(f.offset),
+                    "offset {} splits a character in {text:?}",
+                    f.offset
+                );
+                assert!(
+                    text.is_char_boundary(f.end),
+                    "end {} splits a character in {text:?}",
+                    f.end
+                );
+                // The span must cover the whole value, not a prefix of it.
+                assert!(contains_no_digit(&text[..f.offset]));
+                assert!(contains_no_digit(&text[f.end..]));
+            }
+        }
+    }
+
+    #[test]
+    fn does_not_flag_a_fullwidth_separated_number_that_fails_luhn() {
+        // Widening what reaches the checksum must not weaken the checksum. The
+        // final digit is altered from the detected form above, so the only
+        // difference between this and a reported card is the Luhn result.
+        let scanner = CredentialScanner::new();
+        let result = scanner.scan("num=４５３２　０１５１　１２８３　０３６７");
+        assert!(
+            !result.findings.iter().any(|f| f.kind == CredentialKind::CreditCardLuhn),
+            "Luhn gate must reject a full-width-separated number too: {:?}",
+            result.findings,
+        );
+    }
+
+    #[test]
+    fn a_grouped_19_digit_card_still_fits_the_segment_budget_in_full_width() {
+        // `DIGIT_SEGMENT_MAX_CHARS` is 24 because the binding case is a 19-digit
+        // card written in groups of four — 19 digits plus 4 separators, 23
+        // characters. That arithmetic is in *characters*, so it has to survive
+        // separators that are three bytes each, not just digits that are. A
+        // budget accidentally counted in bytes would truncate this segment
+        // one-third of the way in and lose the card entirely.
+        //
+        // The 19-digit number is Luhn-valid by construction, not observed.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "card=4532-0151-1283-0366-500",
+            "card=４５３２－０１５１－１２８３－０３６６－５００",
+            "card=４５３２　０１５１　１２８３　０３６６　５００",
+        ] {
+            let result = scanner.scan(text);
+            assert_eq!(
+                result.findings.iter().map(|f| f.kind.clone()).collect::<Vec<_>>(),
+                vec![CredentialKind::CreditCardLuhn],
+                "grouped 19-digit card must fit the segment budget: {text:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn digit_separator_boundary_declines_en_dash_and_nbsp() {
+        // Pins the boundary [`ascii_separator_of`] documents, so the decision is
+        // visible rather than implicit. U+2013 (en dash) and U+00A0 (no-break
+        // space) are *not* separators: no input method emits either for the
+        // hyphen or space key, so admitting them would buy no coverage against
+        // the input-mode evasion while adding runs for the Luhn check to trip
+        // over — the en dash being the standard glyph for a numeric range, i.e.
+        // exactly where two unrelated numbers sit adjacent with a dash between.
+        //
+        // Asserted as **not detected**, deliberately. If a payload is ever
+        // observed using one of these, widen `ascii_separator_of` and rewrite
+        // this test — do not delete it.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "card=4532\u{2013}0151\u{2013}1283\u{2013}0366",
+            "card=4532\u{00A0}0151\u{00A0}1283\u{00A0}0366",
+            "ssn=123\u{2013}45\u{2013}6789",
+            "ssn=123\u{00A0}45\u{00A0}6789",
+        ] {
+            assert!(
+                scanner.scan(text).is_clean(),
+                "separator set widened past its stated boundary for {text:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn fullwidth_separators_do_not_flag_ordinary_cjk_prose() {
+        // The false-positive guard the widened separator set needs. Dates,
+        // phone numbers, ranges and identifiers written with U+FF0D and U+3000
+        // are ordinary content in Traditional-Chinese and Japanese documents —
+        // they are, in fact, *more* common than the SSN this rule exists to
+        // catch. Every line below now reaches the joined-segment path that only
+        // ASCII text reached before, and must still produce nothing.
+        let scanner = CredentialScanner::new();
+        for text in [
+            "報表期間　２０２４－０１－０１　至　２０２４－１２－３１，共 365 天。",
+            "聯絡電話　０２－１２３４－５６７８，分機 21。",
+            "發票號碼　ＡＢ－１２３４５６７８，金額 1,250 元。",
+            "會議時間　１０：００－１１：３０，地點　Ｂ棟　３０５　會議室。",
+            "版本區間　１．０．０－２．３．４，共 12 個修訂。",
+        ] {
+            let result = scanner.scan(text);
+            assert!(
+                result.is_clean(),
+                "clean CJK prose produced {:?} for {text:?}",
+                result.findings.iter().map(|f| f.kind.as_str()).collect::<Vec<_>>(),
+            );
+        }
+    }
+
     #[test]
     fn detects_email_address() {
         let scanner = CredentialScanner::new();

--- a/conformance/vectors/credential_detection/entropy_false_positive_zh_tw_fullwidth_separators_clean.json
+++ b/conformance/vectors/credential_detection/entropy_false_positive_zh_tw_fullwidth_separators_clean.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5364 negative: clean Traditional-Chinese prose whose numbers are written with U+FF0D and U+3000 — a date range, a phone number with an extension and a version range. These are ordinary content in zh-TW and ja documents and are far more common there than the SSN the widened separator set exists to catch, so they are the false-positive class the widening risks. Every line reaches the joined-segment walk that only ASCII-separated text reached before this ticket, and each joined run is an independent chance of a coincidental Luhn pass; none may be reported.",
+  "input_text": "報表期間　２０２４－０１－０１　至　２０２４－１２－３１，共 365 天。 聯絡電話　０２－１２３４－５６７８，分機 21。 版本區間　１．０．０－２．３．４，共 12 個修訂。",
+  "expected_findings": [],
+  "expected_redacted": "報表期間　２０２４－０１－０１　至　２０２４－１２－３１，共 365 天。 聯絡電話　０２－１２３４－５６７８，分機 21。 版本區間　１．０．０－２．３．４，共 12 個修訂。"
+}

--- a/conformance/vectors/credential_detection/pii_credit_card_ideographic_space.json
+++ b/conformance/vectors/credential_detection/pii_credit_card_ideographic_space.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5364: the Visa test number of pii_credit_card.json written in full-width digits and grouped by U+3000 IDEOGRAPHIC SPACE, which is what the space bar emits in full-width mode. Grouping in fours is how a card number is printed on the card itself, so the grouped rendering is the natural one; before this ticket only the ungrouped full-width form was detected. Sixteen 3-byte digits plus three 3-byte separators, so the span is 57 bytes for a 19-character value.",
+  "input_text": "card=４５３２　０１５１　１２８３　０３６６",
+  "expected_findings": [
+    { "kind": "CreditCardLuhn", "offset": 5 }
+  ],
+  "expected_redacted": "card=[REDACTED:CreditCardLuhn]"
+}

--- a/conformance/vectors/credential_detection/pii_en_dash_separator_declined.json
+++ b/conformance/vectors/credential_detection/pii_en_dash_separator_declined.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5364 negative: the same Visa test number grouped by U+2013 EN DASH is deliberately NOT detected. U+2010-U+2015 and U+00A0 were considered and declined when the separator set was widened: no input method emits them for the hyphen or space key, so they buy no coverage against the input-mode evasion the ticket closes, while each admitted separator lengthens the run digit_segment joins and adds an independent chance of a coincidental Luhn pass. The en dash is the standard glyph for a numeric range (1990-2000), i.e. exactly where two unrelated numbers sit adjacent with a dash between them. This vector pins the chosen boundary so the decision is visible rather than implicit; if a payload is ever observed using it, widen ascii_separator_of and add a new vector rather than editing this one.",
+  "input_text": "card=4532–0151–1283–0366",
+  "expected_findings": [],
+  "expected_redacted": "card=4532–0151–1283–0366"
+}

--- a/conformance/vectors/credential_detection/pii_fullwidth_grouped_reference_number_clean.json
+++ b/conformance/vectors/credential_detection/pii_fullwidth_grouped_reference_number_clean.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5364: a 16-digit reference number written in full-width digits and grouped in fours by U+3000, inside ordinary Traditional-Chinese prose. This is the only shape in the zh-TW negative vectors that reaches the 13-19 digit Luhn window at all — the date, phone and version shapes are 4-2-2, 2-4-4 and dotted, and can never get there, so without this vector the widened separator set is never exercised against the checksum in prose. It is Luhn-invalid and must stay clean. Disclosure, because the vector cannot show it: Luhn is a mod-10 checksum, so roughly one arbitrary 16-digit number in ten passes by coincidence. Measured over 100,000 random 4x4 groupings the rate is 10.209% for full-width with U+3000, 10.209% with U+FF0D, and 10.209% for the ASCII forms — exact parity, which is this ticket's goal, but it is new false-positive mass that falls entirely on CJK input-method users since only they produce full-width digits.",
+  "input_text": "轉帳帳號　１２３４　５６７８　９０１２　３４５６，於今日入帳。",
+  "expected_findings": [],
+  "expected_redacted": "轉帳帳號　１２３４　５６７８　９０１２　３４５６，於今日入帳。"
+}

--- a/conformance/vectors/credential_detection/pii_fullwidth_separators_fail_luhn.json
+++ b/conformance/vectors/credential_detection/pii_fullwidth_separators_fail_luhn.json
@@ -1,0 +1,6 @@
+{
+  "description": "AAASM-5364 negative: a full-width, ideographic-space-grouped number whose final digit is altered from pii_credit_card_ideographic_space.json fails the Luhn checksum and must not be reported. Widening what reaches the checksum must not weaken the checksum — the only difference between this vector and the detected one is the checksum result, so a fix that flagged separator-grouped runs on shape alone fails here and nowhere else.",
+  "input_text": "card=４５３２　０１５１　１２８３　０３６７",
+  "expected_findings": [],
+  "expected_redacted": "card=４５３２　０１５１　１２８３　０３６７"
+}

--- a/conformance/vectors/credential_detection/pii_ssn_fullwidth_hyphen.json
+++ b/conformance/vectors/credential_detection/pii_ssn_fullwidth_hyphen.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5364: the documentation SSN of pii_ssn.json written entirely in full-width form — full-width digits grouped by U+FF0D FULLWIDTH HYPHEN-MINUS. This is what a CJK input method in full-width mode actually produces when the hyphen key is pressed, so it is the form a Taiwanese or Japanese user types by default rather than an adversarial one. AAASM-5345 normalised the digits but is_ssn still demanded ASCII hyphens, so this read as an ungrouped nine-digit run and was not SSN-shaped at all. Every character of the value is three bytes, so the offset stays in original-text bytes while the exact-11-byte shape check runs against the normalised string.",
+  "input_text": "ssn=１２３－４５－６７８９",
+  "expected_findings": [
+    { "kind": "SsnPattern", "offset": 4 }
+  ],
+  "expected_redacted": "ssn=[REDACTED:SsnPattern]"
+}

--- a/conformance/vectors/credential_detection/pii_ssn_fullwidth_hyphen_ascii_digits.json
+++ b/conformance/vectors/credential_detection/pii_ssn_fullwidth_hyphen_ascii_digits.json
@@ -1,0 +1,8 @@
+{
+  "description": "AAASM-5364: the mixed case — ASCII digits typed with the input method still in full-width mode, so only the two separators differ from pii_ssn.json. It is the cheapest form of the evasion and the one a user reaches by accident, and it is the least uniform span in the suite: nine 1-byte digits interleaved with two 3-byte separators, so an end offset derived from the normalised 11-byte string lands four bytes short of the value.",
+  "input_text": "ssn=123－45－6789",
+  "expected_findings": [
+    { "kind": "SsnPattern", "offset": 4 }
+  ],
+  "expected_redacted": "ssn=[REDACTED:SsnPattern]"
+}


### PR DESCRIPTION
## Description

Split out of #1910 so it is not held behind AAASM-5368, which needs another review round. These four commits are cherry-picked unchanged onto current `main` (`-x`, so each carries its origin SHA); #1910 keeps the AAASM-5368 work.

AAASM-5345 normalised full-width **digits**, which closes the whole of the credit-card case because a bare card carries no separators. It does not close the SSN case: `is_ssn` matches the exact shape `DDD-DD-DDDD`, so the hyphens have to normalise too, and the space-grouped card form has the same problem. A CJK input method in full-width mode emits **U+FF0D** when the hyphen key is pressed and **U+3000** for the space bar, so an SSN or a grouped card typed the natural way by a Taiwanese or Japanese user went undetected while its ASCII twin did not. All four cases measured on the ticket are now detected.

### The boundary decision the ticket asked for

U+2010–U+2015 (hyphen, non-breaking hyphen, figure/en/em dash, horizontal bar) and U+00A0 were considered and **declined**. No input method emits any of them for the hyphen or space key, so they buy nothing against the evasion this rule exists to close — the threat is an input-mode switch, not an arbitrary look-alike glyph. Each admitted separator also lengthens the run `digit_segment` joins, and every additional joined run is an independent ~10% chance of a coincidental Luhn pass; the en dash is the standard glyph for a numeric *range* (`1990–2000`, `第 12–15 頁`), which is exactly where two unrelated numbers sit adjacent with a dash between them. Pinned as a unit test **and** a conformance vector, both asserting **not detected**, so the decision is visible rather than implicit and is cheap to revisit.

### Disclosure — a measured cost that needs an owner decision

Adversarial review found that this ticket's own false-positive evidence structurally could not see its cost, and that was correct.

Widening the separator set gives a full-width, separator-grouped 13–19 digit run its first chance to reach the Luhn check. Luhn is a mod-10 checksum, so roughly one arbitrary 16-digit number in ten passes by coincidence. Measured over 100,000 random 4×4 groupings per shape, ~**10%** for every accepted form — full-width with U+3000, full-width with U+FF0D, and both ASCII forms — and **0%** for the declined en dash and NBSP. Two independent 100k runs measured 10.209% and 9.957%; the substance is "about one in ten and identical across widths", not the third decimal.

That parity is the ticket's goal, and before this change the full-width rate was 0% only because the separator was not recognised at all. What parity does not settle is **who pays it**: full-width digits are produced only by CJK input methods, so all of that new false-positive mass falls on the population this Epic exists to protect, under `credential_action: Block`. That trade is Bryant's call and is raised on the ticket. If it is rejected, the lever is narrow — declining U+3000/U+FF0D for the **card** detector while keeping them for the SSN shape removes the Luhn exposure entirely while still closing the SSN evasion this ticket was opened for.

Why the original evidence was silent: both zh-TW corpora were curated before the widening and contain no full-width separator-grouped 13–19 digit run, and the prose negative test's shapes are 4-2-2, 2-4-4 and dotted — none can reach the Luhn window. Two 16-digit 4×4 rows and a matching vector were added so the class is represented, and `a_fullwidth_grouped_number_gets_exactly_the_ascii_verdict` pins the *mechanism* (a grouped number must get exactly its ASCII twin's verdict, never a different one in either direction), since the rate itself is not assertable.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Additive detection only. No `CredentialKind` variant added, renamed or reordered — the frozen `/api/v1/scrub/patterns` wire contract is untouched. No schema, API or redaction-label change. Payloads previously passed through may now be redacted; that is intended, and is the same class of change any detector improvement carries.

## Related Issues

- Related Jira ticket: [AAASM-5364](https://lightning-dust-mite.atlassian.net/browse/AAASM-5364) (Epic [AAASM-5270](https://lightning-dust-mite.atlassian.net/browse/AAASM-5270), Wave 1b)
- Split out of #1910, which retains AAASM-5368.

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

`cargo nextest run -p aa-security -p conformance` → **316 passed, 0 failed**. 8 new unit tests, 7 new conformance vectors, all executing in the **default** profile — none behind a feature flag CI does not enable. `cargo clippy -p aa-security --all-targets --all-features -- -D warnings` exits 0; `cargo fmt --check` clean.

### Acceptance criteria

| AC | Result |
|---|---|
| Each of the four measured cases detected | Yes — all four |
| Spans are valid char boundaries of the original text | `fullwidth_separated_spans_are_char_boundaries_of_the_original_text` |
| `redact()` byte-correct, no residual digits, no panic | `redacts_fullwidth_separated_values_to_exact_bytes` |
| Negative: full-width-separated run failing Luhn not reported | `does_not_flag_a_fullwidth_separated_number_that_fails_luhn` + vector |
| Negative: prose false positives from the widened set | `fullwidth_separators_do_not_flag_ordinary_cjk_prose` + 2 vectors |
| All existing vectors pass, none edited (ADR 0015) | 7 files, all `A`; `--diff-filter=DR` and `-M` both 0 |
| 24-character segment budget still holds | `a_grouped_19_digit_card_still_fits_the_segment_budget_in_full_width` |

### Mutation evidence

| Mutation | Verdict |
|---|---|
| Drop U+FF0D / U+3000 from the separator set | **KILLED** — 6 tests |
| Widen to the declined en dash + NBSP | **KILLED** — boundary test |
| Push the original separator, not its ASCII form | **KILLED** — both SSN tests |
| Break full-width/ASCII verdict parity | **KILLED** — parity test |
| (conformance) drop U+FF0D / U+3000 | **KILLED** — finding-count + redaction |
| (conformance) widen to en dash / NBSP | **KILLED** — finding-count + redaction |

**6/6 killed.** The harness reports ANCHOR-MISS (mutation never applied, or the named test never ran) distinctly from NO-BREAK, and refused to score several runs during development rather than reporting a false kill.

### D-3 — ASCII detection is not weakened

This change only widens what reaches the Luhn and SSN checks; neither check is relaxed. `does_not_flag_a_fullwidth_separated_number_that_fails_luhn` and the `pii_fullwidth_separators_fail_luhn` vector assert the checksum still rejects, and `ascii_secret_detection_survives_beside_the_locale_pack` covers the other direction. Independent verification against the 352 KB origin document of the original 87-finding incident found it byte-identical before and after, with hex-64, contiguous base64, compact-JSON base64, grouped hex, AWS/ghp/postgres/PEM/card/SSN positive controls all firing identically.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
- [x] Commits are signed off (`git commit -s`)

### Commits

| Commit | Origin in #1910 |
|---|---|
| `4adb463d2` 🐛 Treat the full-width hyphen and ideographic space as digit separators | `ba976c33e` |
| `5fe5930d4` ✅ Pin the full-width separator forms, and the boundary declined | `8d1b83d78` |
| `1982e1cea` ✅ (conformance) Pin the full-width-separated SSN and card, and the declined boundary | `3948c08c1` |
| `756214fda` ✅ Pin full-width/ASCII Luhn parity, and the prose shape that reaches it | `6c3c0b2ea` |

Each was verified green individually before the split, and all four cherry-picked onto current `main` without conflict.


[AAASM-5364]: https://lightning-dust-mite.atlassian.net/browse/AAASM-5364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ