### PR TITLE
[AAASM-5447] 🐛 (aa-gateway): Key the sensitive-data projection by tenant scope

### DIFF
--- a/aa-gateway/src/storage/sensitive_data/postgres.rs
+++ b/aa-gateway/src/storage/sensitive_data/postgres.rs
@@ -23,11 +23,18 @@ use super::store::{CategoryFindingAggregate, SensitiveDataEventFilter, Sensitive
 
 /// The projection's DDL. Mirrors the SQLite shape column for column so a row
 /// written by one backend means the same thing when read from the other.
+///
+/// That mirroring extends to the primary key and to every `ON CONFLICT` target:
+/// see the SQLite module's schema documentation for why the key carries
+/// `(org_id, tenant_id, event_id)` rather than `event_id` alone (AAASM-5447),
+/// and for the migration position. The two backends must be changed together —
+/// a key that matches on one and not the other reintroduces the defect on
+/// whichever deployment uses the unfixed one.
 const PROJECTION_SCHEMA: &[&str] = &[
     "CREATE TABLE IF NOT EXISTS sensitive_data_events (
         schema_version_major      INTEGER     NOT NULL,
         schema_version_minor      INTEGER     NOT NULL,
-        event_id                  TEXT        NOT NULL PRIMARY KEY,
+        event_id                  TEXT        NOT NULL,
         occurred_at_ns            BIGINT      NOT NULL,
         ingested_at_ns            BIGINT      NOT NULL,
         org_id                    TEXT        NOT NULL,
@@ -65,7 +72,8 @@ const PROJECTION_SCHEMA: &[&str] = &[
         blocked_finding_count     INTEGER     NOT NULL,
         transformed_finding_count INTEGER     NOT NULL,
         finding_count_by_category TEXT        NOT NULL,
-        reason_codes              TEXT        NOT NULL
+        reason_codes              TEXT        NOT NULL,
+        PRIMARY KEY (org_id, tenant_id, event_id)
     )",
     "CREATE INDEX IF NOT EXISTS idx_sd_events_scope_ts
         ON sensitive_data_events(org_id, tenant_id, occurred_at_ns)",
@@ -90,7 +98,7 @@ const PROJECTION_SCHEMA: &[&str] = &[
         field_path           TEXT    NOT NULL,
         redaction_label      TEXT    NOT NULL,
         aggregate_key        TEXT    NOT NULL,
-        PRIMARY KEY (event_id, finding_ordinal)
+        PRIMARY KEY (org_id, tenant_id, event_id, finding_ordinal)
     )",
     "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_category
         ON sensitive_data_findings(org_id, tenant_id, verdict, category)",
@@ -295,7 +303,7 @@ impl SensitiveDataProjection for PostgresBackend {
         let event_placeholders = placeholders(41);
         let inserted = sqlx::query(&format!(
             "INSERT INTO sensitive_data_events ({EVENT_COLUMNS}) VALUES ({event_placeholders}) \
-             ON CONFLICT (event_id) DO NOTHING"
+             ON CONFLICT (org_id, tenant_id, event_id) DO NOTHING"
         ))
         .bind(i32::from(event.schema_version_major))
         .bind(i32::from(event.schema_version_minor))
@@ -360,7 +368,7 @@ impl SensitiveDataProjection for PostgresBackend {
         for finding in findings {
             sqlx::query(&format!(
                 "INSERT INTO sensitive_data_findings ({FINDING_COLUMNS}) VALUES ({finding_placeholders}) \
-                 ON CONFLICT (event_id, finding_ordinal) DO NOTHING"
+                 ON CONFLICT (org_id, tenant_id, event_id, finding_ordinal) DO NOTHING"
             ))
             .bind(i32::from(finding.schema_version_major))
             .bind(i32::from(finding.schema_version_minor))

--- a/aa-gateway/src/storage/sensitive_data/sqlite.rs
+++ b/aa-gateway/src/storage/sensitive_data/sqlite.rs
@@ -23,11 +23,40 @@ use super::store::{CategoryFindingAggregate, SensitiveDataEventFilter, Sensitive
 /// tamper-evident tier, and `tests/sensitive_data_contract/` asserts
 /// the column sets from outside this module so the omission cannot be undone
 /// quietly.
+///
+/// # Why the primary key carries the tenant keys
+///
+/// AAASM-5447: `event_id` alone was the key on a table every read scopes by
+/// `(org_id, tenant_id)`. Uniqueness that is narrower than the read scope is a
+/// cross-tenant denial-of-recording: a second tenant writing an `event_id` the
+/// first had already used had its insert skipped as a duplicate, its child rows
+/// skipped with it, and its write still returned `Written`. The tenant then read
+/// its own data and saw nothing — and on a governance surface a missing record
+/// reads as "nothing happened".
+///
+/// `event_id` is producer-supplied, so the collision is available to anyone able
+/// to influence their own id and arrives by accident across a large enough
+/// tenant population. Keying on `(org_id, tenant_id, event_id)` makes the
+/// uniqueness scope and the read scope the same thing, which is the invariant
+/// that was actually wanted; first-write-wins is preserved *within* a tenant.
+///
+/// Every `ON CONFLICT` target names exactly these columns. A conflict target
+/// that drifts from the key silently stops matching, so the two must be changed
+/// together.
+///
+/// # Migration position
+///
+/// These statements are `CREATE TABLE IF NOT EXISTS`, so they do **not** alter
+/// the key of a table that already exists. That is acceptable only because this
+/// tier is off by default and has no producer: nothing writes to it until
+/// AAASM-5440 lands, so there is no deployed data to migrate today. That is a
+/// statement about right now, not a property of the design — once a producer
+/// exists, changing this key needs a real migration that recreates the tables.
 const PROJECTION_SCHEMA: &[&str] = &[
     "CREATE TABLE IF NOT EXISTS sensitive_data_events (
         schema_version_major      INTEGER NOT NULL,
         schema_version_minor      INTEGER NOT NULL,
-        event_id                  TEXT    NOT NULL PRIMARY KEY,
+        event_id                  TEXT    NOT NULL,
         occurred_at_ns            INTEGER NOT NULL,
         ingested_at_ns            INTEGER NOT NULL,
         org_id                    TEXT    NOT NULL,
@@ -65,7 +94,8 @@ const PROJECTION_SCHEMA: &[&str] = &[
         blocked_finding_count     INTEGER NOT NULL,
         transformed_finding_count INTEGER NOT NULL,
         finding_count_by_category TEXT    NOT NULL,
-        reason_codes              TEXT    NOT NULL
+        reason_codes              TEXT    NOT NULL,
+        PRIMARY KEY (org_id, tenant_id, event_id)
     )",
     // Every read is tenant-scoped, so every index leads with the tenant keys.
     "CREATE INDEX IF NOT EXISTS idx_sd_events_scope_ts
@@ -91,7 +121,7 @@ const PROJECTION_SCHEMA: &[&str] = &[
         field_path           TEXT    NOT NULL,
         redaction_label      TEXT    NOT NULL,
         aggregate_key        TEXT    NOT NULL,
-        PRIMARY KEY (event_id, finding_ordinal)
+        PRIMARY KEY (org_id, tenant_id, event_id, finding_ordinal)
     )",
     "CREATE INDEX IF NOT EXISTS idx_sd_findings_scope_category
         ON sensitive_data_findings(org_id, tenant_id, verdict, category)",
@@ -279,7 +309,7 @@ impl SensitiveDataProjection for SqliteBackend {
             .await
             .map_err(|e| StorageError::QueryFailed(format!("begin: {e}")))?;
 
-        // `ON CONFLICT(event_id) DO NOTHING` is the idempotency rule: a
+        // `ON CONFLICT(org_id, tenant_id, event_id) DO NOTHING` is the idempotency rule: a
         // replayed event is a no-op, so a retried publish cannot double-count.
         // First write wins.
         //
@@ -294,7 +324,7 @@ impl SensitiveDataProjection for SqliteBackend {
         let placeholders = vec!["?"; 41].join(", ");
         let inserted = sqlx::query(&format!(
             "INSERT INTO sensitive_data_events ({EVENT_COLUMNS}) VALUES ({placeholders}) \
-             ON CONFLICT(event_id) DO NOTHING"
+             ON CONFLICT(org_id, tenant_id, event_id) DO NOTHING"
         ))
         .bind(i64::from(event.schema_version_major))
         .bind(i64::from(event.schema_version_minor))
@@ -365,7 +395,7 @@ impl SensitiveDataProjection for SqliteBackend {
             sqlx::query(&format!(
                 "INSERT INTO sensitive_data_findings ({FINDING_COLUMNS}) \
                  VALUES ({finding_placeholders}) \
-                 ON CONFLICT(event_id, finding_ordinal) DO NOTHING"
+                 ON CONFLICT(org_id, tenant_id, event_id, finding_ordinal) DO NOTHING"
             ))
             .bind(i64::from(finding.schema_version_major))
             .bind(i64::from(finding.schema_version_minor))

--- a/aa-gateway/tests/sensitive_data_contract/mod.rs
+++ b/aa-gateway/tests/sensitive_data_contract/mod.rs
@@ -1166,3 +1166,72 @@ pub const EXPECTED_FINDING_COLUMNS: &[&str] = &[
     "redaction_label",
     "aggregate_key",
 ];
+
+/// Two tenants writing the **same** `event_id` must each read back their own
+/// event and their own findings.
+///
+/// AAASM-5447: `event_id` was the sole primary key on a table every read scopes
+/// by `(org_id, tenant_id)`. The uniqueness scope did not match the read scope,
+/// so the second tenant's insert was skipped as a duplicate, its child rows were
+/// skipped with it, and the write still reported `Written`. The tenant then
+/// queried its own data and saw nothing.
+///
+/// `a_neighbouring_tenant_sees_none_of_it` does not cover this: it gives each
+/// tenant a distinct `event_id`, so it passes while the collision is live. The
+/// shared id here is the whole point — `event_id` is producer-supplied, so a
+/// collision is available to anyone who can influence their own id and arrives
+/// by accident across a large enough tenant population.
+pub async fn two_tenants_sharing_an_event_id_keep_their_own_rows<S: SensitiveDataProjection>(store: &Arc<S>) {
+    const SHARED: &str = "01HZX9V8ABCDEFGHJKMNSHARE1";
+
+    let (event_a, findings_a) = blocked_action_with_three_findings(SHARED, "t-alpha");
+    let (event_b, findings_b) = allowed_action_with_one_finding(SHARED, "t-beta", 1_700_000_000_000_000_000);
+
+    writer(store)
+        .write(&event_a, &findings_a, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("tenant A write");
+    writer(store)
+        .write(&event_b, &findings_b, Timestamp::from_nanos(INGESTED))
+        .await
+        .expect("tenant B write");
+
+    // Tenant B's write reported success, so its record must exist. A governance
+    // surface that returns zero here is indistinguishable from "nothing
+    // happened", which is the failure mode this Epic exists to eliminate.
+    let fb = filter("t-beta");
+    assert_eq!(
+        store.count_sensitive_data_events(&fb).await.expect("count B events"),
+        1,
+        "tenant B's event was discarded by a cross-tenant key collision while its \
+         write returned Written — a silent denial-of-recording"
+    );
+    assert_eq!(
+        store
+            .count_sensitive_data_findings(&fb)
+            .await
+            .expect("count B findings"),
+        1,
+        "tenant B's findings were skipped along with its parent event"
+    );
+
+    // And tenant A must be untouched by B's write — first-write-wins must not
+    // become first-tenant-wins.
+    let fa = filter("t-alpha");
+    assert_eq!(store.count_sensitive_data_events(&fa).await.expect("count A events"), 1);
+    assert_eq!(
+        store
+            .count_sensitive_data_findings(&fa)
+            .await
+            .expect("count A findings"),
+        3
+    );
+
+    let a = &store.query_sensitive_data_events(&fa).await.expect("A events")[0];
+    let b = &store.query_sensitive_data_events(&fb).await.expect("B events")[0];
+    assert_eq!(a.finding_count, 3, "tenant A keeps its own tallies");
+    assert_eq!(
+        b.finding_count, 1,
+        "tenant B keeps its own tallies rather than inheriting tenant A's"
+    );
+}

--- a/aa-gateway/tests/sensitive_data_projection_postgres_test.rs
+++ b/aa-gateway/tests/sensitive_data_projection_postgres_test.rs
@@ -69,6 +69,7 @@ async fn the_projection_contract_holds_on_postgres() {
     contract::one_blocked_action_with_three_findings_stays_one_event(&store).await;
     contract::a_row_count_disagreeing_with_the_tally_is_refused(&store).await;
     contract::a_neighbouring_tenant_sees_none_of_it(&store).await;
+    contract::two_tenants_sharing_an_event_id_keep_their_own_rows(&store).await;
     contract::a_replayed_event_does_not_double_count(&store).await;
     contract::a_divergent_replay_cannot_desynchronise_parent_from_children(&store).await;
     contract::a_late_duplicate_cannot_rewrite_stored_tallies(&store).await;

--- a/aa-gateway/tests/sensitive_data_projection_test.rs
+++ b/aa-gateway/tests/sensitive_data_projection_test.rs
@@ -62,6 +62,7 @@ contract_test!(every_projected_value_round_trips);
 contract_test!(one_blocked_action_with_three_findings_stays_one_event);
 contract_test!(a_row_count_disagreeing_with_the_tally_is_refused);
 contract_test!(a_neighbouring_tenant_sees_none_of_it);
+contract_test!(two_tenants_sharing_an_event_id_keep_their_own_rows);
 contract_test!(a_replayed_event_does_not_double_count);
 contract_test!(a_divergent_replay_cannot_desynchronise_parent_from_children);
 contract_test!(a_late_duplicate_cannot_rewrite_stored_tallies);


### PR DESCRIPTION
## Description

`event_id` was the **sole** primary key on `sensitive_data_events`, and `(event_id, finding_ordinal)` on the findings table — but every read scopes by `(org_id, tenant_id)`.

Uniqueness narrower than the read scope is a **cross-tenant denial-of-recording**:

1. Tenant A writes event `X`. Stored.
2. Tenant B writes event `X`. `ON CONFLICT DO NOTHING` skips it — and the `rows_affected` gate then skips every child row too.
3. **Both writes return `WriteOutcome::Written`.**
4. Tenant B queries its own data and sees **0 events, 0 findings**.

No error, no warning. On a governance surface a missing record reads as *"nothing happened"* — the exact failure mode this Epic exists to eliminate.

`event_id` is producer-supplied, so the collision is reachable by anyone able to influence their own id, and arrives by accident across a large enough tenant population.

The idempotency design was correct; **the uniqueness scope simply did not match the read scope.** Both keys now carry the tenant columns, and every `ON CONFLICT` target names exactly the key columns — a target that drifts from its key silently stops matching, so the two must move together. First-write-wins is preserved **within** a tenant, and AAASM-5357's child-gating fix is unaffected.

### Landing before AAASM-5440, deliberately

While nothing writes to this tier the defect is inert. AAASM-5440 wires the producer, so this lands first.

Note the interaction the ticket calls out: AAASM-5440's per-seam falsification writes and reads back **within one tenant**, which passes cleanly while this defect is live.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

`CREATE TABLE IF NOT EXISTS` does **not** alter an existing table's key. That is acceptable **only** because this tier is off by default and has no producer — there is no deployed data to migrate today. That is a statement about right now, not a property of the design, and it is recorded as such in the schema documentation: once a producer exists, changing this key needs a real migration that recreates the tables.

## Related Issues

- Related Jira ticket: AAASM-5447
- Related GitHub issues: N/A

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`two_tenants_sharing_an_event_id_keep_their_own_rows` was written **first and confirmed red** against the current schema, per the ticket's AC2:

```
FAIL two_tenants_sharing_an_event_id_keep_their_own_rows
  assertion `left == right` failed: tenant B's event was discarded by a
  cross-tenant key collision while its write returned Written —
  a silent denial-of-recording
    left: 0
   right: 1
```

After the fix:

- **SQLite** — `17 tests run: 17 passed`
- **PostgreSQL** — `the_projection_contract_holds_on_postgres ... PASS`
- **Full `aa-gateway`** — `1232 tests run: 1232 passed`

### Why the existing tenant-isolation test did not catch this

`a_neighbouring_tenant_sees_none_of_it` gives each tenant a **distinct** `event_id`, so it passed throughout. The shared id is the entire mechanism, which is why a new test was needed rather than an extension of that one.

### Falsification — the Postgres run is real, not a skip

The Postgres test finished in 1.6 s, which is fast enough to suspect a silent skip. Reverting **only** the Postgres key while leaving SQLite fixed:

```
FAIL the_projection_contract_holds_on_postgres
  ... a silent denial-of-recording
```

So the assertion genuinely executes against a real PostgreSQL server, and the two backends are independently covered rather than one standing in for both.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012To43UU7TLdNaxaiQq1aes